### PR TITLE
Add theming system with 11 themes and live preview switcher

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,7 +11,7 @@ import { PluginRegistry } from "./plugins/registry";
 import { MarkdownStore } from "./data/markdown-store";
 import { SqliteCache } from "./data/sqlite-cache";
 import { YahooFinanceClient } from "./sources/yahoo-finance";
-import { colors } from "./theme/colors";
+import { colors, applyTheme } from "./theme/colors";
 import type { AppConfig } from "./types/config";
 import type { TickerFile } from "./types/ticker";
 
@@ -140,6 +140,9 @@ interface AppProps {
 }
 
 export function App({ config, renderer }: AppProps) {
+  // Apply saved theme before first render
+  if (config.theme) applyTheme(config.theme);
+
   const dbPath = join(config.dataDir, ".gloomberb-cache.db");
   const cache = new SqliteCache(dbPath);
   const markdownStore = new MarkdownStore(config.dataDir);

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -5,7 +5,9 @@ import type { InputRenderable } from "@opentui/core";
 import { colors } from "../../theme/colors";
 import { useAppState } from "../../state/app-context";
 import { fuzzyFilter } from "../../utils/fuzzy-search";
-import { commands, matchPrefix, type Command } from "./command-registry";
+import { commands, matchPrefix, getThemeOptions, type Command } from "./command-registry";
+import { getCurrentThemeId, applyTheme } from "../../theme/colors";
+import { saveConfig } from "../../data/config-store";
 import type { YahooFinanceClient } from "../../sources/yahoo-finance";
 import type { MarkdownStore } from "../../data/markdown-store";
 import type { TickerFrontmatter } from "../../types/ticker";
@@ -21,6 +23,7 @@ interface ResultItem {
   detail: string;
   right?: string;
   category: string;
+  themeId?: string; // for theme items — enables live preview
   action: () => void | Promise<void>;
 }
 
@@ -33,6 +36,7 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
   const [searching, setSearching] = useState(false);
   const inputRef = useRef<InputRenderable>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const originalThemeRef = useRef<string>(getCurrentThemeId());
 
   useEffect(() => {
     if (inputRef.current) inputRef.current.focus();
@@ -44,6 +48,12 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
     setResults([]);
     setSelectedIdx(0);
   }, [dispatch]);
+
+  // Revert theme on close without selection
+  const closeAndRevert = useCallback(() => {
+    dispatch({ type: "SET_THEME", theme: originalThemeRef.current });
+    close();
+  }, [dispatch, close]);
 
   // Handle prefix-based command execution
   const executeCommand = useCallback((cmd: Command, arg: string) => {
@@ -110,12 +120,43 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
     })();
   }, [markdownStore, dispatch, close]);
 
+  // Detect if we're in theme mode
+  const isThemeMode = matchPrefix(query)?.command.id === "theme";
+
   // Build results based on query and prefix matching
   useEffect(() => {
     const items: ResultItem[] = [];
     const match = matchPrefix(query);
 
-    if (match && match.command.id === "search-ticker") {
+    let initialIdx = 0;
+
+    if (match && match.command.id === "theme") {
+      // Theme selection mode
+      const themeOptions = getThemeOptions();
+      const savedThemeId = originalThemeRef.current;
+      const filtered = match.arg
+        ? themeOptions.filter((t) => t.name.toLowerCase().includes(match.arg.toLowerCase()) || t.id.includes(match.arg.toLowerCase()))
+        : themeOptions;
+      for (let i = 0; i < filtered.length; i++) {
+        const t = filtered[i]!;
+        const isSaved = t.id === savedThemeId;
+        if (isSaved) initialIdx = i;
+        items.push({
+          id: `theme:${t.id}`,
+          label: t.name,
+          detail: t.description,
+          right: isSaved ? "current" : undefined,
+          themeId: t.id,
+          category: "Themes",
+          action: () => {
+            originalThemeRef.current = t.id;
+            dispatch({ type: "SET_THEME", theme: t.id });
+            saveConfig({ ...state.config, theme: t.id }).catch(() => {});
+            close();
+          },
+        });
+      }
+    } else if (match && match.command.id === "search-ticker") {
       // Ticker search mode - show "Searching..." until results come in
       // Don't show anything else, just Yahoo results
       if (!match.arg) {
@@ -176,7 +217,7 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
     }
 
     setResults(items);
-    setSelectedIdx(0);
+    setSelectedIdx(initialIdx);
 
     // Yahoo search when in ticker search mode (prefix "T")
     if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
@@ -217,9 +258,24 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
     return () => { if (searchTimerRef.current) clearTimeout(searchTimerRef.current); };
   }, [query, state.tickers, state.selectedTicker]);
 
+  // Live preview: apply theme as user arrows through the list
+  useEffect(() => {
+    if (!isThemeMode) return;
+    const selected = results[selectedIdx];
+    if (selected?.themeId) {
+      applyTheme(selected.themeId);
+      // Force a re-render by dispatching a no-op-like action
+      dispatch({ type: "SET_THEME", theme: selected.themeId });
+    }
+  }, [selectedIdx, isThemeMode, results]);
+
   useKeyboard((event) => {
     if (event.name === "escape" || event.name === "`") {
-      close();
+      if (isThemeMode) {
+        closeAndRevert();
+      } else {
+        close();
+      }
     } else if (event.name === "down" || (event.name === "n" && event.ctrl)) {
       setSelectedIdx((i) => Math.min(i + 1, results.length - 1));
     } else if (event.name === "up" || (event.name === "p" && event.ctrl)) {
@@ -233,7 +289,7 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
   // Layout
   const barWidth = Math.min(Math.floor(termWidth * 0.6), 72);
   const barLeft = Math.floor((termWidth - barWidth) / 2);
-  const maxVisible = 10;
+  const maxVisible = 12;
   const visibleResults = results.slice(0, maxVisible);
 
   // Group by category
@@ -296,7 +352,7 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
       )}
 
       {/* Results */}
-      <scrollbox flexGrow={1} scrollY maxHeight={Math.min(gIdx + grouped.length * 2 + 2, 18)}>
+      <scrollbox flexGrow={1} scrollY maxHeight={Math.min(gIdx + grouped.length * 2 + 2, 20)}>
         {searching ? (
           <box paddingX={2} height={1}>
             <text fg={colors.textDim}>Searching Yahoo Finance...</text>
@@ -319,6 +375,7 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
               {/* Items */}
               {group.items.map((item) => {
                 const isSel = item.globalIdx === selectedIdx;
+                const isThemeItem = !!item.themeId;
                 return (
                   <box
                     key={item.id}
@@ -327,18 +384,26 @@ export function CommandBar({ yahoo, markdownStore }: CommandBarProps) {
                     paddingX={2}
                     backgroundColor={isSel ? colors.selected : colors.commandBg}
                   >
-                    {/* Prefix shortcut on the left */}
-                    <box width={5}>
-                      <text fg={colors.textMuted}>{item.right || ""}</text>
-                    </box>
+                    {/* Prefix shortcut column — hidden for theme items */}
+                    {!isThemeItem && (
+                      <box width={5}>
+                        <text fg={colors.textMuted}>{item.right || ""}</text>
+                      </box>
+                    )}
                     {/* Label */}
-                    <box width={Math.floor(barWidth * 0.3)}>
+                    <box width={isThemeItem ? Math.floor(barWidth * 0.35) : Math.floor(barWidth * 0.3)}>
                       <text fg={isSel ? colors.text : colors.textDim}>{item.label}</text>
                     </box>
                     {/* Description */}
                     <box flexGrow={1}>
                       <text fg={colors.textMuted}>{item.detail}</text>
                     </box>
+                    {/* Right-side tag for theme items */}
+                    {isThemeItem && item.right && (
+                      <box>
+                        <text fg={colors.textMuted}>{item.right}</text>
+                      </box>
+                    )}
                   </box>
                 );
               })}

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -1,4 +1,5 @@
 import type { AppAction } from "../../state/app-context";
+import { themes, getThemeIds } from "../../theme/themes";
 
 export type CommandExecutor = (dispatch: React.Dispatch<AppAction>, context: CommandContext) => void | Promise<void>;
 
@@ -124,7 +125,28 @@ export const commands: Command[] = [
       dispatch({ type: "TOGGLE_CONFIG" });
     },
   },
+
+  // Theme
+  {
+    id: "theme",
+    prefix: "TH",
+    label: "Change Theme",
+    description: "Switch color theme",
+    hasArg: true,
+    argPlaceholder: "theme name",
+    category: "Config",
+    execute: () => {}, // handled by command bar
+  },
 ];
+
+/** Get theme options for the command bar */
+export function getThemeOptions(): Array<{ id: string; name: string; description: string }> {
+  return getThemeIds().map((id) => ({
+    id,
+    name: themes[id]!.name,
+    description: themes[id]!.description,
+  }));
+}
 
 /** Find a command whose prefix matches the start of the input */
 export function matchPrefix(input: string): { command: Command; arg: string } | null {

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useReducer, type ReactNode } from "react";
 import type { AppConfig } from "../types/config";
 import type { TickerFile } from "../types/ticker";
 import type { TickerFinancials } from "../types/financials";
+import { applyTheme } from "../theme/colors";
 
 // --- State ---
 
@@ -39,7 +40,8 @@ export type AppAction =
   | { type: "SET_COMMAND_BAR"; open: boolean }
   | { type: "TOGGLE_CONFIG" }
   | { type: "SET_REFRESHING"; symbol: string; refreshing: boolean }
-  | { type: "SET_INITIALIZED" };
+  | { type: "SET_INITIALIZED" }
+  | { type: "SET_THEME"; theme: string };
 
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
@@ -104,6 +106,11 @@ function appReducer(state: AppState, action: AppAction): AppState {
 
     case "SET_INITIALIZED":
       return { ...state, initialized: true };
+
+    case "SET_THEME": {
+      applyTheme(action.theme);
+      return { ...state, config: { ...state.config, theme: action.theme } };
+    }
 
     default:
       return state;

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,27 +1,21 @@
-export const colors = {
-  bg: "#000000",
-  panel: "#0a0a14",
-  border: "#1a3a5c",
-  borderFocused: "#ff8800",
+import { getTheme, DEFAULT_THEME, type Theme } from "./themes";
 
-  text: "#ff8800", // amber primary
-  textDim: "#886622",
-  textBright: "#ffaa00",
-  textMuted: "#555555",
+// Mutable colors object — properties are updated in-place when the theme changes.
+// React components re-read these on each render triggered by the SET_THEME action.
+export const colors: Omit<Theme, "name" | "description"> = { ...getTheme(DEFAULT_THEME) };
 
-  positive: "#00cc66", // green for gains
-  negative: "#ff3333", // red for losses
-  neutral: "#888888",
+let currentThemeId = DEFAULT_THEME;
 
-  header: "#0044aa",
-  headerText: "#ffffff",
+export function getCurrentThemeId(): string {
+  return currentThemeId;
+}
 
-  selected: "#1a3a5c",
-  selectedText: "#ffaa00",
-
-  commandBg: "#111122",
-  commandBorder: "#ff8800",
-} as const;
+export function applyTheme(id: string): void {
+  const theme = getTheme(id);
+  currentThemeId = id;
+  // Mutate in-place so every existing import sees the new values
+  Object.assign(colors, theme);
+}
 
 export type ColorKey = keyof typeof colors;
 

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -1,0 +1,281 @@
+export interface Theme {
+  name: string;
+  description: string;
+
+  bg: string;
+  panel: string;
+  border: string;
+  borderFocused: string;
+
+  text: string;
+  textDim: string;
+  textBright: string;
+  textMuted: string;
+
+  positive: string;
+  negative: string;
+  neutral: string;
+
+  header: string;
+  headerText: string;
+
+  selected: string;
+  selectedText: string;
+
+  commandBg: string;
+  commandBorder: string;
+}
+
+export const themes: Record<string, Theme> = {
+  amber: {
+    name: "Amber",
+    description: "Classic amber-on-black terminal",
+    bg: "#000000",
+    panel: "#0a0a14",
+    border: "#1a3a5c",
+    borderFocused: "#ff8800",
+    text: "#ff8800",
+    textDim: "#886622",
+    textBright: "#ffaa00",
+    textMuted: "#555555",
+    positive: "#00cc66",
+    negative: "#ff3333",
+    neutral: "#888888",
+    header: "#0044aa",
+    headerText: "#ffffff",
+    selected: "#1a3a5c",
+    selectedText: "#ffaa00",
+    commandBg: "#111122",
+    commandBorder: "#ff8800",
+  },
+
+  green: {
+    name: "Green Phosphor",
+    description: "Retro green CRT monitor",
+    bg: "#000000",
+    panel: "#001100",
+    border: "#004400",
+    borderFocused: "#00ff00",
+    text: "#00cc00",
+    textDim: "#006600",
+    textBright: "#00ff00",
+    textMuted: "#444444",
+    positive: "#00ff66",
+    negative: "#ff4444",
+    neutral: "#666666",
+    header: "#003300",
+    headerText: "#00ff00",
+    selected: "#003300",
+    selectedText: "#00ff00",
+    commandBg: "#001100",
+    commandBorder: "#00cc00",
+  },
+
+  tokyo: {
+    name: "Tokyo Night",
+    description: "Cool blue-purple palette",
+    bg: "#1a1b26",
+    panel: "#16161e",
+    border: "#3b4261",
+    borderFocused: "#7aa2f7",
+    text: "#c0caf5",
+    textDim: "#565f89",
+    textBright: "#ffffff",
+    textMuted: "#444b6a",
+    positive: "#9ece6a",
+    negative: "#f7768e",
+    neutral: "#565f89",
+    header: "#24283b",
+    headerText: "#7aa2f7",
+    selected: "#283457",
+    selectedText: "#c0caf5",
+    commandBg: "#16161e",
+    commandBorder: "#7aa2f7",
+  },
+
+  solarized: {
+    name: "Solarized Dark",
+    description: "Ethan Schoonover's classic palette",
+    bg: "#002b36",
+    panel: "#073642",
+    border: "#586e75",
+    borderFocused: "#b58900",
+    text: "#839496",
+    textDim: "#586e75",
+    textBright: "#fdf6e3",
+    textMuted: "#657b83",
+    positive: "#859900",
+    negative: "#dc322f",
+    neutral: "#657b83",
+    header: "#073642",
+    headerText: "#268bd2",
+    selected: "#0a4a5c",
+    selectedText: "#b58900",
+    commandBg: "#002b36",
+    commandBorder: "#268bd2",
+  },
+
+  dracula: {
+    name: "Dracula",
+    description: "Popular dark theme with vivid colors",
+    bg: "#282a36",
+    panel: "#21222c",
+    border: "#44475a",
+    borderFocused: "#bd93f9",
+    text: "#f8f8f2",
+    textDim: "#6272a4",
+    textBright: "#ffffff",
+    textMuted: "#6272a4",
+    positive: "#50fa7b",
+    negative: "#ff5555",
+    neutral: "#6272a4",
+    header: "#44475a",
+    headerText: "#bd93f9",
+    selected: "#44475a",
+    selectedText: "#f8f8f2",
+    commandBg: "#21222c",
+    commandBorder: "#bd93f9",
+  },
+
+  nord: {
+    name: "Nord",
+    description: "Arctic, north-bluish palette",
+    bg: "#2e3440",
+    panel: "#3b4252",
+    border: "#4c566a",
+    borderFocused: "#88c0d0",
+    text: "#d8dee9",
+    textDim: "#4c566a",
+    textBright: "#eceff4",
+    textMuted: "#4c566a",
+    positive: "#a3be8c",
+    negative: "#bf616a",
+    neutral: "#4c566a",
+    header: "#3b4252",
+    headerText: "#88c0d0",
+    selected: "#4c566a",
+    selectedText: "#eceff4",
+    commandBg: "#2e3440",
+    commandBorder: "#88c0d0",
+  },
+
+  monokai: {
+    name: "Monokai",
+    description: "Warm, high-contrast classic",
+    bg: "#272822",
+    panel: "#1e1f1c",
+    border: "#49483e",
+    borderFocused: "#f92672",
+    text: "#f8f8f2",
+    textDim: "#75715e",
+    textBright: "#ffffff",
+    textMuted: "#75715e",
+    positive: "#a6e22e",
+    negative: "#f92672",
+    neutral: "#75715e",
+    header: "#49483e",
+    headerText: "#e6db74",
+    selected: "#49483e",
+    selectedText: "#f8f8f2",
+    commandBg: "#1e1f1c",
+    commandBorder: "#f92672",
+  },
+
+  catppuccin: {
+    name: "Catppuccin Mocha",
+    description: "Soothing pastel theme",
+    bg: "#1e1e2e",
+    panel: "#181825",
+    border: "#45475a",
+    borderFocused: "#cba6f7",
+    text: "#cdd6f4",
+    textDim: "#585b70",
+    textBright: "#ffffff",
+    textMuted: "#6c7086",
+    positive: "#a6e3a1",
+    negative: "#f38ba8",
+    neutral: "#6c7086",
+    header: "#313244",
+    headerText: "#cba6f7",
+    selected: "#3e3f56",
+    selectedText: "#cdd6f4",
+    commandBg: "#181825",
+    commandBorder: "#cba6f7",
+  },
+
+  gruvbox: {
+    name: "Gruvbox Dark",
+    description: "Retro earthy tones",
+    bg: "#282828",
+    panel: "#1d2021",
+    border: "#504945",
+    borderFocused: "#fe8019",
+    text: "#ebdbb2",
+    textDim: "#928374",
+    textBright: "#fbf1c7",
+    textMuted: "#665c54",
+    positive: "#b8bb26",
+    negative: "#fb4934",
+    neutral: "#928374",
+    header: "#3c3836",
+    headerText: "#fabd2f",
+    selected: "#3c3836",
+    selectedText: "#ebdbb2",
+    commandBg: "#1d2021",
+    commandBorder: "#fe8019",
+  },
+
+  rosepine: {
+    name: "Rose Pine",
+    description: "Muted, elegant dark theme",
+    bg: "#191724",
+    panel: "#1f1d2e",
+    border: "#403d52",
+    borderFocused: "#c4a7e7",
+    text: "#e0def4",
+    textDim: "#6e6a86",
+    textBright: "#ffffff",
+    textMuted: "#524f67",
+    positive: "#31748f",
+    negative: "#eb6f92",
+    neutral: "#6e6a86",
+    header: "#26233a",
+    headerText: "#c4a7e7",
+    selected: "#332f4a",
+    selectedText: "#e0def4",
+    commandBg: "#1f1d2e",
+    commandBorder: "#c4a7e7",
+  },
+
+  midnight: {
+    name: "Midnight Blue",
+    description: "Deep blue Bloomberg-inspired",
+    bg: "#000022",
+    panel: "#000033",
+    border: "#003366",
+    borderFocused: "#ff6600",
+    text: "#ccddff",
+    textDim: "#6688bb",
+    textBright: "#ffffff",
+    textMuted: "#445577",
+    positive: "#00cc66",
+    negative: "#ff3333",
+    neutral: "#6688bb",
+    header: "#001144",
+    headerText: "#ff6600",
+    selected: "#002255",
+    selectedText: "#ffffff",
+    commandBg: "#000033",
+    commandBorder: "#ff6600",
+  },
+};
+
+export const DEFAULT_THEME = "amber";
+
+export function getThemeIds(): string[] {
+  return Object.keys(themes);
+}
+
+export function getTheme(id: string): Theme {
+  return themes[id] ?? themes[DEFAULT_THEME]!;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -24,6 +24,7 @@ export interface AppConfig {
   layout: PaneLayoutEntry[];
   brokers: Record<string, Record<string, unknown>>;
   plugins: string[];
+  theme: string;
 }
 
 export const DEFAULT_COLUMNS: ColumnConfig[] = [
@@ -51,5 +52,6 @@ export function createDefaultConfig(dataDir: string): AppConfig {
     layout: DEFAULT_LAYOUT,
     brokers: {},
     plugins: ["portfolio-list", "ticker-detail", "manual-entry", "ibkr-flex"],
+    theme: "amber",
   };
 }


### PR DESCRIPTION
## Summary
- Adds a theming system with 11 built-in color themes: Amber, Green Phosphor, Tokyo Night, Solarized Dark, Dracula, Nord, Monokai, Catppuccin Mocha, Gruvbox Dark, Rose Pine, and Midnight Blue
- Themes are switchable from the command bar (`TH` prefix) with live preview as you arrow through options — escape reverts, enter commits
- The current theme is pre-selected when opening the picker, and the choice persists to `config.json`
- All themes have been tuned for adequate selection highlight contrast

## Test plan
- [ ] Open command bar, type `TH`, verify all 11 themes listed
- [ ] Arrow through themes and confirm live preview updates the full UI
- [ ] Press Escape and confirm it reverts to the original theme
- [ ] Select a theme with Enter, restart the app, confirm it persists
- [ ] Reopen theme picker and confirm the current theme is pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)