### PR TITLE
Upgrade Financials tab with sub-tabs, growth rates, and more metrics

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -105,7 +105,7 @@ function AppInner({ pluginRegistry, markdownStore, yahoo }: AppInnerProps) {
         type: "SET_ACTIVE_PANEL",
         panel: state.activePanel === "left" ? "right" : "left",
       });
-    } else if (event.name === "q") {
+    } else if (event.name === "q" && !(state.activePanel === "right" && state.activeRightTab === "financials")) {
       renderer.destroy();
     } else if (event.name === "r") {
       // Refresh selected ticker
@@ -145,6 +145,7 @@ export function App({ config, renderer }: AppProps) {
 
   const dbPath = join(config.dataDir, ".gloomberb-cache.db");
   const cache = new SqliteCache(dbPath);
+  cache.clearByType("full"); // Clear stale financials cache on startup
   const markdownStore = new MarkdownStore(config.dataDir);
   setMarkdownStore(markdownStore);
   const yahoo = new YahooFinanceClient(cache);

--- a/src/data/sqlite-cache.ts
+++ b/src/data/sqlite-cache.ts
@@ -106,6 +106,11 @@ export class SqliteCache {
       .run(pair, rate, Date.now());
   }
 
+  /** Clear cached entries by data type (e.g. "full" to force re-fetch of financials) */
+  clearByType(dataType: string): void {
+    this.db.query("DELETE FROM yahoo_cache WHERE data_type = ?").run(dataType);
+  }
+
   close(): void {
     this.db.close();
   }

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -5,7 +5,7 @@ import type { TabSelectRenderable, TextareaRenderable } from "@opentui/core";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
 import { useAppState, useSelectedTicker } from "../../state/app-context";
 import { colors, priceColor } from "../../theme/colors";
-import { formatCurrency, formatCompact, formatPercent, formatPercentRaw, formatNumber } from "../../utils/format";
+import { formatCurrency, formatCompact, formatPercent, formatPercentRaw, formatNumber, formatGrowthShort, pickUnit, formatWithDivisor } from "../../utils/format";
 import { StockChart } from "../../components/chart/stock-chart";
 import type { MarkdownStore } from "../../data/markdown-store";
 
@@ -113,49 +113,229 @@ function OverviewTab({ width }: { width?: number }) {
   );
 }
 
-function FinancialsTab() {
+type MetricDef = {
+  label: string;
+  key: keyof import("../../types/financials").FinancialStatement;
+  format: "compact" | "eps";
+};
+
+type FinancialSubTab = {
+  name: string;
+  key: string;
+  metrics: MetricDef[];
+};
+
+const FINANCIAL_SUB_TABS: FinancialSubTab[] = [
+  {
+    name: "Income",
+    key: "income",
+    metrics: [
+      { label: "Revenue", key: "totalRevenue", format: "compact" },
+      { label: "Cost of Revenue", key: "costOfRevenue", format: "compact" },
+      { label: "Gross Profit", key: "grossProfit", format: "compact" },
+      { label: "R&D", key: "researchAndDevelopment", format: "compact" },
+      { label: "SG&A", key: "sellingGeneralAndAdministration", format: "compact" },
+      { label: "Operating Exp", key: "operatingExpense", format: "compact" },
+      { label: "Operating Inc", key: "operatingIncome", format: "compact" },
+      { label: "Interest Exp", key: "interestExpense", format: "compact" },
+      { label: "Tax Provision", key: "taxProvision", format: "compact" },
+      { label: "Net Income", key: "netIncome", format: "compact" },
+      { label: "EBITDA", key: "ebitda", format: "compact" },
+      { label: "Basic EPS", key: "basicEps", format: "eps" },
+      { label: "Diluted EPS", key: "eps", format: "eps" },
+      { label: "Shares Out", key: "dilutedShares", format: "compact" },
+    ],
+  },
+  {
+    name: "Cash Flow",
+    key: "cashflow",
+    metrics: [
+      { label: "Operating CF", key: "operatingCashFlow", format: "compact" },
+      { label: "CapEx", key: "capitalExpenditure", format: "compact" },
+      { label: "Free Cash Flow", key: "freeCashFlow", format: "compact" },
+      { label: "Investing CF", key: "investingCashFlow", format: "compact" },
+      { label: "Financing CF", key: "financingCashFlow", format: "compact" },
+      { label: "Debt Issuance", key: "issuanceOfDebt", format: "compact" },
+      { label: "Buybacks", key: "repurchaseOfCapitalStock", format: "compact" },
+      { label: "Dividends Paid", key: "cashDividendsPaid", format: "compact" },
+    ],
+  },
+  {
+    name: "Balance Sheet",
+    key: "balance",
+    metrics: [
+      { label: "Total Assets", key: "totalAssets", format: "compact" },
+      { label: "Current Assets", key: "currentAssets", format: "compact" },
+      { label: "Cash & Equiv", key: "cashAndCashEquivalents", format: "compact" },
+      { label: "Total Liab", key: "totalLiabilities", format: "compact" },
+      { label: "Current Liab", key: "currentLiabilities", format: "compact" },
+      { label: "Long-Term Debt", key: "longTermDebt", format: "compact" },
+      { label: "Total Debt", key: "totalDebt", format: "compact" },
+      { label: "Equity", key: "totalEquity", format: "compact" },
+      { label: "Retained Earn", key: "retainedEarnings", format: "compact" },
+    ],
+  },
+];
+
+// Flow metrics are summed for TTM; balance sheet metrics use latest quarter value
+const FLOW_KEYS = new Set<string>([
+  "totalRevenue", "costOfRevenue", "grossProfit",
+  "sellingGeneralAndAdministration", "researchAndDevelopment",
+  "operatingExpense", "operatingIncome", "interestExpense", "taxProvision",
+  "netIncome", "ebitda", "basicEps", "eps",
+  "operatingCashFlow", "capitalExpenditure", "freeCashFlow",
+  "investingCashFlow", "financingCashFlow",
+  "issuanceOfDebt", "repurchaseOfCapitalStock", "cashDividendsPaid",
+]);
+
+const BALANCE_KEYS = new Set<string>([
+  "totalAssets", "currentAssets", "cashAndCashEquivalents",
+  "totalLiabilities", "currentLiabilities", "longTermDebt", "totalDebt",
+  "totalEquity", "retainedEarnings", "dilutedShares",
+]);
+
+function computeTTM(quarterlyStmts: import("../../types/financials").FinancialStatement[]): import("../../types/financials").FinancialStatement | null {
+  const last4 = quarterlyStmts.slice(-4);
+  if (last4.length < 4) return null;
+
+  const ttm: import("../../types/financials").FinancialStatement = { date: "TTM" };
+  for (const key of FLOW_KEYS) {
+    const values = last4.map((s) => (s as any)[key]).filter((v: any): v is number => v != null);
+    if (values.length === 4) {
+      (ttm as any)[key] = values.reduce((a: number, b: number) => a + b, 0);
+    }
+  }
+  const latest = last4[last4.length - 1]!;
+  for (const key of BALANCE_KEYS) {
+    if ((latest as any)[key] != null) (ttm as any)[key] = (latest as any)[key];
+  }
+
+  return ttm;
+}
+
+function computeGrowth(current: number | undefined, previous: number | undefined): number | undefined {
+  if (current == null || previous == null || previous === 0) return undefined;
+  return (current - previous) / Math.abs(previous);
+}
+
+function FinancialsTab({ focused }: { focused: boolean }) {
   const { financials } = useSelectedTicker();
+  const [period, setPeriod] = useState<"annual" | "quarterly">("annual");
+  const [subTabIdx, setSubTabIdx] = useState(0);
+
+  useKeyboard((event) => {
+    if (!focused) return;
+    if (event.name === "a") setPeriod("annual");
+    else if (event.name === "q") setPeriod("quarterly");
+    else if (event.name === "1") setSubTabIdx(0);
+    else if (event.name === "2") setSubTabIdx(1);
+    else if (event.name === "3") setSubTabIdx(2);
+  });
+
   if (!financials) return <text fg={colors.textDim}>No financial data available.</text>;
 
-  const stmts = financials.annualStatements.slice(-5).reverse();
+  const subTab = FINANCIAL_SUB_TABS[subTabIdx]!;
+  const isAnnual = period === "annual";
+  const rawStmts = isAnnual
+    ? financials.annualStatements.slice(-5).reverse()
+    : financials.quarterlyStatements.slice(-6).reverse();
+
+  const ttm = isAnnual ? computeTTM(financials.quarterlyStatements) : null;
+  const displayStmts = ttm ? [ttm, ...rawStmts] : rawStmts;
+
+  // Build previous-period lookup for growth rates
+  const allStmts = isAnnual ? financials.annualStatements : financials.quarterlyStatements;
+  const prevMap = new Map<string, import("../../types/financials").FinancialStatement>();
+  for (let i = 0; i < allStmts.length; i++) {
+    if (i > 0) prevMap.set(allStmts[i]!.date, allStmts[i - 1]!);
+  }
+  // TTM previous: compute from quarters 5-8 ago
+  if (ttm && allStmts.length >= 8) {
+    const prev4 = allStmts.slice(-8, -4);
+    const prevTtm: import("../../types/financials").FinancialStatement = { date: "prevTTM" };
+    for (const key of FLOW_KEYS) {
+      const values = prev4.map((s) => (s as any)[key]).filter((v: any): v is number => v != null);
+      if (values.length === 4) (prevTtm as any)[key] = values.reduce((a: number, b: number) => a + b, 0);
+    }
+    const prevLatest = prev4[prev4.length - 1]!;
+    for (const key of BALANCE_KEYS) {
+      if ((prevLatest as any)[key] != null) (prevTtm as any)[key] = (prevLatest as any)[key];
+    }
+    prevMap.set("TTM", prevTtm);
+  }
+
+  const COL_W = 18;
+  const LABEL_W = 20;
 
   return (
     <scrollbox flexGrow={1} scrollY>
-      <box flexDirection="column" paddingX={1} paddingY={1}>
-        <text attributes={TextAttributes.BOLD} fg={colors.textBright}>Annual Financials</text>
+      <box flexDirection="column" paddingX={2} paddingY={1}>
+        {/* Sub-tab selector + period toggle */}
+        <box flexDirection="row" height={1}>
+          {FINANCIAL_SUB_TABS.map((tab, i) => (
+            <box key={tab.key} flexDirection="row">
+              <text
+                fg={i === subTabIdx ? colors.textBright : colors.textDim}
+                attributes={i === subTabIdx ? TextAttributes.BOLD : 0}
+              >
+                {`${i + 1}:${tab.name}`}
+              </text>
+              {i < FINANCIAL_SUB_TABS.length - 1 && <text fg={colors.textMuted}>{" │ "}</text>}
+            </box>
+          ))}
+          <box flexGrow={1} />
+          <text fg={isAnnual ? colors.accent : colors.textDim} attributes={isAnnual ? TextAttributes.BOLD : 0}>a</text>
+          <text fg={colors.textMuted}>/</text>
+          <text fg={!isAnnual ? colors.accent : colors.textDim} attributes={!isAnnual ? TextAttributes.BOLD : 0}>q</text>
+        </box>
         <box height={1} />
 
-        {/* Header row */}
+        {/* Column headers */}
         <box flexDirection="row" height={1}>
-          <box width={14}><text attributes={TextAttributes.BOLD} fg={colors.textDim}>Metric</text></box>
-          {stmts.map((s) => (
-            <box key={s.date} width={14}>
-              <text attributes={TextAttributes.BOLD} fg={colors.textDim}>{s.date.slice(0, 7)}</text>
+          <box width={LABEL_W}><text attributes={TextAttributes.BOLD} fg={colors.textDim}>{isAnnual ? "Annual" : "Quarterly"}</text></box>
+          {displayStmts.map((s) => (
+            <box key={s.date} width={COL_W}>
+              <text attributes={TextAttributes.BOLD} fg={s.date === "TTM" ? colors.accent : colors.textDim}>
+                {s.date === "TTM" ? "TTM" : s.date.slice(0, 7)}
+              </text>
             </box>
           ))}
         </box>
+        <box height={1} />
 
-        {/* Data rows */}
-        {[
-          { label: "Revenue", key: "totalRevenue" as const },
-          { label: "Net Income", key: "netIncome" as const },
-          { label: "EBITDA", key: "ebitda" as const },
-          { label: "EPS", key: "eps" as const },
-          { label: "Total Debt", key: "totalDebt" as const },
-        ].map(({ label, key }) => (
-          <box key={key} flexDirection="row" height={1}>
-            <box width={14}><text fg={colors.textDim}>{label}</text></box>
-            {stmts.map((s) => (
-              <box key={s.date} width={14}>
-                <text fg={colors.text}>
-                  {s[key] != null
-                    ? key === "eps" ? formatNumber(s[key]!, 2) : formatCompact(s[key]!)
-                    : "—"}
-                </text>
+        {/* Metric rows */}
+        {subTab.metrics.map(({ label, key, format }, idx) => {
+          const isEps = format === "eps";
+          const allVals = displayStmts.map((s) => s[key] as number | undefined);
+          const { suffix, divisor } = isEps ? { suffix: "", divisor: 1 } : pickUnit(allVals);
+          const unitLabel = suffix ? `${label} (${suffix})` : label;
+
+          return (
+            <box key={key} flexDirection="column">
+              {idx > 0 && idx % 4 === 0 && <box height={1} />}
+              <box flexDirection="row" height={1}>
+              <box width={LABEL_W}><text fg={colors.textDim}>{unitLabel}</text></box>
+              {displayStmts.map((s) => {
+                const val = s[key] as number | undefined;
+                const prev = prevMap.get(s.date);
+                const prevVal = prev ? (prev[key] as number | undefined) : undefined;
+                const growth = computeGrowth(val, prevVal);
+                const formatted = val != null
+                  ? isEps ? formatNumber(val, 2) : formatWithDivisor(val, divisor)
+                  : "—";
+                const growthStr = growth != null ? " " + formatGrowthShort(growth) : "";
+                const isNeg = val != null && val < 0;
+                return (
+                  <box key={s.date} width={COL_W} flexDirection="row" marginLeft={isNeg ? -1 : 0}>
+                    <text fg={colors.text}>{formatted}</text>
+                    {growthStr ? <text fg={priceColor(growth!)}>{growthStr}</text> : null}
+                  </box>
+                );
+              })}
               </box>
-            ))}
-          </box>
-        ))}
+            </box>
+          );
+        })}
       </box>
     </scrollbox>
   );
@@ -318,7 +498,7 @@ function TickerDetailPane({ focused, width, height }: PaneProps) {
       />
 
       {state.activeRightTab === "overview" && <OverviewTab width={width} />}
-      {state.activeRightTab === "financials" && <FinancialsTab />}
+      {state.activeRightTab === "financials" && <FinancialsTab focused={focused} />}
       {state.activeRightTab === "chart" && <ChartTab width={width} height={height} focused={focused} interactive={chartInteractive} />}
       {state.activeRightTab === "notes" && <NotesTab markdownStore={_markdownStore} notesFocused={notesFocused} />}
     </box>

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -31,12 +31,40 @@ const RETRYABLE_ERROR = /429|403|401|Too Many Requests|Forbidden|Unauthorized|EC
 
 const TIMESERIES_TYPES = {
   annual: [
-    "annualTotalRevenue", "annualNetIncome", "annualEBITDA",
-    "annualDilutedEPS", "annualTotalDebt", "annualDilutedAverageShares",
+    // Income Statement
+    "annualTotalRevenue", "annualCostOfRevenue", "annualGrossProfit",
+    "annualSellingGeneralAndAdministration", "annualResearchAndDevelopment",
+    "annualOperatingExpense", "annualOperatingIncome",
+    "annualInterestExpense", "annualTaxProvision",
+    "annualNetIncome", "annualEBITDA",
+    "annualBasicEPS", "annualDilutedEPS", "annualDilutedAverageShares",
+    // Cash Flow
+    "annualOperatingCashFlow", "annualCapitalExpenditure", "annualFreeCashFlow",
+    "annualInvestingCashFlow", "annualFinancingCashFlow",
+    "annualIssuanceOfDebt", "annualRepurchaseOfCapitalStock", "annualCashDividendsPaid",
+    // Balance Sheet
+    "annualTotalAssets", "annualCurrentAssets", "annualCashAndCashEquivalents",
+    "annualTotalLiabilitiesNetMinorityInterest", "annualCurrentLiabilities",
+    "annualLongTermDebt", "annualTotalDebt",
+    "annualStockholdersEquity", "annualRetainedEarnings",
   ],
   quarterly: [
-    "quarterlyTotalRevenue", "quarterlyNetIncome", "quarterlyEBITDA",
-    "quarterlyDilutedEPS", "quarterlyTotalDebt", "quarterlyDilutedAverageShares",
+    // Income Statement
+    "quarterlyTotalRevenue", "quarterlyCostOfRevenue", "quarterlyGrossProfit",
+    "quarterlySellingGeneralAndAdministration", "quarterlyResearchAndDevelopment",
+    "quarterlyOperatingExpense", "quarterlyOperatingIncome",
+    "quarterlyInterestExpense", "quarterlyTaxProvision",
+    "quarterlyNetIncome", "quarterlyEBITDA",
+    "quarterlyBasicEPS", "quarterlyDilutedEPS", "quarterlyDilutedAverageShares",
+    // Cash Flow
+    "quarterlyOperatingCashFlow", "quarterlyCapitalExpenditure", "quarterlyFreeCashFlow",
+    "quarterlyInvestingCashFlow", "quarterlyFinancingCashFlow",
+    "quarterlyIssuanceOfDebt", "quarterlyRepurchaseOfCapitalStock", "quarterlyCashDividendsPaid",
+    // Balance Sheet
+    "quarterlyTotalAssets", "quarterlyCurrentAssets", "quarterlyCashAndCashEquivalents",
+    "quarterlyTotalLiabilitiesNetMinorityInterest", "quarterlyCurrentLiabilities",
+    "quarterlyLongTermDebt", "quarterlyTotalDebt",
+    "quarterlyStockholdersEquity", "quarterlyRetainedEarnings",
   ],
   trailing: [
     "trailingMarketCap", "trailingPeRatio", "trailingForwardPeRatio",
@@ -276,12 +304,40 @@ export class YahooFinanceClient {
           byDate.set(pt.asOfDate, row);
         }
       };
+      // Income Statement
       assign(`${prefix}TotalRevenue`, "totalRevenue");
+      assign(`${prefix}CostOfRevenue`, "costOfRevenue");
+      assign(`${prefix}GrossProfit`, "grossProfit");
+      assign(`${prefix}SellingGeneralAndAdministration`, "sellingGeneralAndAdministration");
+      assign(`${prefix}ResearchAndDevelopment`, "researchAndDevelopment");
+      assign(`${prefix}OperatingExpense`, "operatingExpense");
+      assign(`${prefix}OperatingIncome`, "operatingIncome");
+      assign(`${prefix}InterestExpense`, "interestExpense");
+      assign(`${prefix}TaxProvision`, "taxProvision");
       assign(`${prefix}NetIncome`, "netIncome");
       assign(`${prefix}EBITDA`, "ebitda");
+      assign(`${prefix}BasicEPS`, "basicEps");
       assign(`${prefix}DilutedEPS`, "eps");
-      assign(`${prefix}TotalDebt`, "totalDebt");
       assign(`${prefix}DilutedAverageShares`, "dilutedShares");
+      // Cash Flow
+      assign(`${prefix}OperatingCashFlow`, "operatingCashFlow");
+      assign(`${prefix}CapitalExpenditure`, "capitalExpenditure");
+      assign(`${prefix}FreeCashFlow`, "freeCashFlow");
+      assign(`${prefix}InvestingCashFlow`, "investingCashFlow");
+      assign(`${prefix}FinancingCashFlow`, "financingCashFlow");
+      assign(`${prefix}IssuanceOfDebt`, "issuanceOfDebt");
+      assign(`${prefix}RepurchaseOfCapitalStock`, "repurchaseOfCapitalStock");
+      assign(`${prefix}CashDividendsPaid`, "cashDividendsPaid");
+      // Balance Sheet
+      assign(`${prefix}TotalAssets`, "totalAssets");
+      assign(`${prefix}CurrentAssets`, "currentAssets");
+      assign(`${prefix}CashAndCashEquivalents`, "cashAndCashEquivalents");
+      assign(`${prefix}TotalLiabilitiesNetMinorityInterest`, "totalLiabilities");
+      assign(`${prefix}CurrentLiabilities`, "currentLiabilities");
+      assign(`${prefix}LongTermDebt`, "longTermDebt");
+      assign(`${prefix}TotalDebt`, "totalDebt");
+      assign(`${prefix}StockholdersEquity`, "totalEquity");
+      assign(`${prefix}RetainedEarnings`, "retainedEarnings");
       return Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date));
     };
 

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -35,12 +35,40 @@ export interface Fundamentals {
 
 export interface FinancialStatement {
   date: string;
+  // Income Statement
   totalRevenue?: number;
+  costOfRevenue?: number;
+  grossProfit?: number;
+  sellingGeneralAndAdministration?: number;
+  researchAndDevelopment?: number;
+  operatingExpense?: number;
+  operatingIncome?: number;
+  interestExpense?: number;
+  taxProvision?: number;
   netIncome?: number;
   ebitda?: number;
-  eps?: number;
-  totalDebt?: number;
+  basicEps?: number;
+  eps?: number; // diluted
   dilutedShares?: number;
+  // Cash Flow
+  operatingCashFlow?: number;
+  capitalExpenditure?: number;
+  freeCashFlow?: number;
+  investingCashFlow?: number;
+  financingCashFlow?: number;
+  issuanceOfDebt?: number;
+  repurchaseOfCapitalStock?: number;
+  cashDividendsPaid?: number;
+  // Balance Sheet
+  totalAssets?: number;
+  currentAssets?: number;
+  cashAndCashEquivalents?: number;
+  totalLiabilities?: number;
+  currentLiabilities?: number;
+  longTermDebt?: number;
+  totalDebt?: number;
+  totalEquity?: number;
+  retainedEarnings?: number;
 }
 
 export interface PricePoint {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -44,6 +44,36 @@ export function formatNumber(value: number | undefined, decimals = 2): string {
   });
 }
 
+/** Format a growth rate compactly (e.g., +12%, -5%) */
+export function formatGrowthShort(value: number): string {
+  const pct = value * 100;
+  const sign = pct > 0 ? "+" : "";
+  return Math.abs(pct) >= 10
+    ? `${sign}${Math.round(pct)}%`
+    : `${sign}${pct.toFixed(1)}%`;
+}
+
+/** Pick a common unit suffix for a set of numbers */
+export function pickUnit(values: (number | undefined)[]): { suffix: string; divisor: number } {
+  const defined = values.filter((v): v is number => v != null);
+  if (!defined.length) return { suffix: "", divisor: 1 };
+  const maxAbs = Math.max(...defined.map(Math.abs));
+  if (maxAbs >= 1e12) return { suffix: "T", divisor: 1e12 };
+  if (maxAbs >= 1e9) return { suffix: "B", divisor: 1e9 };
+  if (maxAbs >= 1e6) return { suffix: "M", divisor: 1e6 };
+  if (maxAbs >= 1e3) return { suffix: "K", divisor: 1e3 };
+  return { suffix: "", divisor: 1 };
+}
+
+/** Format a number using a pre-determined divisor (no unit suffix) */
+export function formatWithDivisor(value: number | undefined, divisor: number): string {
+  if (value === undefined || value === null) return "—";
+  const scaled = value / divisor;
+  const abs = Math.abs(scaled);
+  const decimals = abs >= 100 ? 1 : 2;
+  return scaled.toFixed(decimals);
+}
+
 /** Pad/truncate a string to a fixed width */
 export function padTo(str: string, width: number, align: "left" | "right" = "left"): string {
   if (str.length > width) return str.slice(0, width);


### PR DESCRIPTION
## Summary
- Splits the Financials tab into 3 navigable sub-tabs (1:Income, 2:Cash Flow, 3:Balance Sheet) with comprehensive metrics for each category
- Adds annual/quarterly toggle (a/q keys), TTM column computed from last 4 quarters, and inline YoY growth rates with green/red color coding
- Fetches 20+ new Yahoo Finance timeseries (gross profit, operating income, R&D, SG&A, cash flow breakdown, balance sheet items, etc.)
- Displays a common unit per row in the label (e.g. "Revenue (B)") for cleaner presentation, with negative values offset for alignment
- Clears stale financials cache on startup so new fields populate immediately

## Test plan
- [ ] Run the app and navigate to the Financials tab
- [ ] Press 1/2/3 to switch between Income, Cash Flow, and Balance Sheet sub-tabs
- [ ] Press a/q to toggle annual/quarterly views
- [ ] Verify TTM column appears in annual view
- [ ] Verify growth rates show inline with correct coloring
- [ ] Confirm q no longer quits the app when Financials tab is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)