### PR TITLE
Use npm trusted publishing, fix build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -58,13 +59,14 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
+
+      - name: Install latest npm (required for trusted publishing)
+        run: npm install -g npm@latest
 
       - name: Publish to npm
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           node -e "const p=require('./package.json'); p.version='$VERSION'; require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2)+'\n')"
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --access public --provenance

--- a/install.mjs
+++ b/install.mjs
@@ -6,8 +6,7 @@ import https from "https";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Skip when running in the source repo (dev install)
-const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
-if (pkg.dependencies) process.exit(0);
+if (existsSync(join(__dirname, "src"))) process.exit(0);
 const REPO = "vincelwt/gloomberb";
 
 const platform = process.platform;


### PR DESCRIPTION
## Summary
- Switch from NPM_TOKEN to OIDC trusted publishing (no secrets needed)
- Add `id-token: write` permission and `--provenance` flag
- Fix install.mjs dev detection (check for `src/` dir, not `dependencies`)
- Remove stale `npm/package.json` reference from build script

🤖 Generated with [Claude Code](https://claude.com/claude-code)