### PR TITLE
Fix news dates, expand exchange support, add auto-scroll & preview

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -182,7 +182,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
 
         // Select first ticker if any
         if (tickers.length > 0) {
-          dispatch({ type: "SELECT_TICKER", symbol: tickers[0]!.frontmatter.ticker });
+          dispatch({ type: "PREVIEW_TICKER", symbol: tickers[0]!.frontmatter.ticker });
         }
 
         dispatch({ type: "SET_INITIALIZED" });

--- a/src/components/config/config-page.tsx
+++ b/src/components/config/config-page.tsx
@@ -1,7 +1,7 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { useKeyboard } from "@opentui/react";
 import { TextAttributes } from "@opentui/core";
-import type { SelectRenderable } from "@opentui/core";
+import type { SelectRenderable, ScrollBoxRenderable } from "@opentui/core";
 import { colors } from "../../theme/colors";
 import { useAppState } from "../../state/app-context";
 import { saveConfig } from "../../data/config-store";
@@ -81,6 +81,19 @@ function ColumnsSection({ focused }: { focused: boolean }) {
   );
 
   const addSelectRef = useRef<SelectRenderable>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  // Auto-scroll to keep selected column visible
+  useEffect(() => {
+    const sb = scrollRef.current;
+    if (!sb) return;
+    const viewportH = sb.viewport.height;
+    if (selectedIdx < sb.scrollTop) {
+      sb.scrollTo(selectedIdx);
+    } else if (selectedIdx >= sb.scrollTop + viewportH) {
+      sb.scrollTo(selectedIdx - viewportH + 1);
+    }
+  }, [selectedIdx]);
 
   useKeyboard((event) => {
     if (!focused) return;
@@ -205,7 +218,7 @@ function ColumnsSection({ focused }: { focused: boolean }) {
       </box>
 
       {/* Column rows */}
-      <scrollbox flexGrow={1} scrollY>
+      <scrollbox ref={scrollRef} flexGrow={1} scrollY>
         {columns.map((col, idx) => {
           const isSel = idx === selectedIdx && mode === "list";
           return (

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -1,5 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { useKeyboard } from "@opentui/react";
+import type { ScrollBoxRenderable } from "@opentui/core";
 import { TextAttributes } from "@opentui/core";
 import { TabBar } from "../../components/tab-bar";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
@@ -107,6 +108,7 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
   const tickers = getActiveTabTickers(state);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
 
   const currentTabIdx = tabs.findIndex((t) => t.id === state.activeLeftTab);
 
@@ -117,11 +119,11 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
     if (key === "j" || key === "down") {
       const next = Math.min(selectedIdx + 1, tickers.length - 1);
       setSelectedIdx(next);
-      if (tickers[next]) dispatch({ type: "SELECT_TICKER", symbol: tickers[next]!.frontmatter.ticker });
+      if (tickers[next]) dispatch({ type: "PREVIEW_TICKER", symbol: tickers[next]!.frontmatter.ticker });
     } else if (key === "k" || key === "up") {
       const next = Math.max(selectedIdx - 1, 0);
       setSelectedIdx(next);
-      if (tickers[next]) dispatch({ type: "SELECT_TICKER", symbol: tickers[next]!.frontmatter.ticker });
+      if (tickers[next]) dispatch({ type: "PREVIEW_TICKER", symbol: tickers[next]!.frontmatter.ticker });
     } else if (key === "h" || key === "left") {
       const newIdx = Math.max(currentTabIdx - 1, 0);
       if (tabs[newIdx]) dispatch({ type: "SET_LEFT_TAB", tab: tabs[newIdx]!.id });
@@ -133,6 +135,18 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
       if (tickers[selectedIdx]) dispatch({ type: "SELECT_TICKER", symbol: tickers[selectedIdx]!.frontmatter.ticker });
     }
   });
+
+  // Auto-scroll to keep selected row visible
+  useEffect(() => {
+    const sb = scrollRef.current;
+    if (!sb) return;
+    const viewportH = sb.viewport.height;
+    if (selectedIdx < sb.scrollTop) {
+      sb.scrollTo(selectedIdx);
+    } else if (selectedIdx >= sb.scrollTop + viewportH) {
+      sb.scrollTo(selectedIdx - viewportH + 1);
+    }
+  }, [selectedIdx]);
 
   // Auto-select first ticker when list changes
   if (tickers.length > 0 && selectedIdx >= tickers.length) {
@@ -162,7 +176,7 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
       </box>
 
       {/* Ticker rows */}
-      <scrollbox flexGrow={1} scrollY>
+      <scrollbox ref={scrollRef} flexGrow={1} scrollY>
         {tickers.length === 0 ? (
           <box paddingX={1} paddingY={1}>
             <text fg={colors.textDim}>No tickers. Press Cmd+K to add one.</text>

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
 import { TextAttributes } from "@opentui/core";
-import type { TextareaRenderable } from "@opentui/core";
+import type { TextareaRenderable, ScrollBoxRenderable } from "@opentui/core";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
 import { useAppState, useSelectedTicker } from "../../state/app-context";
 import { colors, priceColor } from "../../theme/colors";
@@ -444,7 +444,7 @@ function formatTimeAgo(date: Date): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return date.toLocaleDateString();
+  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 }
 
 function NewsTab({ width, height, focused }: { width: number; height: number; focused: boolean }) {
@@ -452,6 +452,7 @@ function NewsTab({ width, height, focused }: { width: number; height: number; fo
   const [news, setNews] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const newsScrollRef = useRef<ScrollBoxRenderable>(null);
   const [summaryCache, setSummaryCache] = useState<Map<string, string>>(new Map());
   const [loadingSummary, setLoadingSummary] = useState(false);
   const summaryFetchRef = useRef(0);
@@ -462,7 +463,7 @@ function NewsTab({ width, height, focused }: { width: number; height: number; fo
     setLoading(true);
     setSelectedIdx(0);
     setSummaryCache(new Map());
-    _dataProvider.getNews(ticker.frontmatter.ticker, 15).then((items) => {
+    _dataProvider.getNews(ticker.frontmatter.ticker, 15, ticker.frontmatter.exchange).then((items) => {
       if (!cancelled) setNews(items);
     }).catch(() => {}).finally(() => {
       if (!cancelled) setLoading(false);
@@ -496,12 +497,24 @@ function NewsTab({ width, height, focused }: { width: number; height: number; fo
     }
   });
 
+  // Auto-scroll to keep selected news item visible
+  useEffect(() => {
+    const sb = newsScrollRef.current;
+    if (!sb) return;
+    const viewportH = sb.viewport.height;
+    if (selectedIdx < sb.scrollTop) {
+      sb.scrollTo(selectedIdx);
+    } else if (selectedIdx >= sb.scrollTop + viewportH) {
+      sb.scrollTo(selectedIdx - viewportH + 1);
+    }
+  }, [selectedIdx]);
+
   if (!ticker) return <text fg={colors.textDim}>Select a ticker to view news.</text>;
   if (loading && news.length === 0) return <text fg={colors.textDim}>Loading news...</text>;
   if (news.length === 0) return <text fg={colors.textDim}>No news available for {ticker.frontmatter.ticker}.</text>;
 
   const innerWidth = Math.max(width - 4, 40);
-  const timeColW = 7;
+  const timeColW = 9;
   const sourceColW = 16;
   const titleColW = Math.max(innerWidth - timeColW - sourceColW - 2, 10);
   const summary = selected ? summaryCache.get(selected.url) : undefined;
@@ -532,7 +545,7 @@ function NewsTab({ width, height, focused }: { width: number; height: number; fo
       </box>
 
       {/* News list */}
-      <scrollbox height={listHeight} scrollY>
+      <scrollbox ref={newsScrollRef} height={listHeight} scrollY>
         {news.map((item, i) => {
           const isSelected = i === selectedIdx;
           const title = item.title.length > titleColW

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -4,26 +4,69 @@ import type { DataProvider, NewsItem } from "../types/data-provider";
 import type { TimeRange } from "../components/chart/chart-types";
 
 // Exchange suffix mapping for Yahoo Finance ticker symbols
+// Includes both canonical codes and common IBKR listing exchange aliases
 const EXCHANGE_SUFFIX_MAP: Record<string, string> = {
-  NASDAQ: "", NYSE: "", AMEX: "",
-  TYO: ".T", HKEX: ".HK", SGX: ".SI", IDX: ".JK",
-  KRX: ".KS", KOSDAQ: ".KQ",
+  // US exchanges
+  NASDAQ: "", NMS: "", NYSE: "", AMEX: "", ARCA: "", NYSEArca: "", BATS: "", BYX: "", IEX: "", PINK: "", OTC: "",
+  // Canada
+  TSX: ".TO", VENTURE: ".V", CSE2: ".CN", CNSX: ".CN",
+  // Japan (note: TSE is ambiguous — handled via EXCHANGE_FALLBACKS)
+  TYO: ".T", JPX: ".T", TSEJ: ".T",
+  // Hong Kong
+  HKEX: ".HK", SEHK: ".HK", HKG: ".HK",
+  // China
+  SSE: ".SS", SHG: ".SS", SZSE: ".SZ", SHE: ".SZ",
+  // Taiwan
   TWSE: ".TW", TPE: ".TW",
-  SSE: ".SS", SZSE: ".SZ",
-  EURONEXT: ".AS", XETRA: ".DE",
-  LSE: ".L", ASX: ".AX", OSE: ".OL",
+  // Korea
+  KRX: ".KS", KSE: ".KS", KOSDAQ: ".KQ",
+  // Singapore
+  SGX: ".SI", SES: ".SI",
+  // Indonesia
+  IDX: ".JK",
+  // India
+  NSE: ".NS", BSE: ".BO",
+  // Australia & New Zealand
+  ASX: ".AX", NZE: ".NZ",
+  // Thailand, Malaysia, Philippines, Vietnam
+  SET: ".BK", BKK: ".BK", KLSE: ".KL", MYX: ".KL", PSE: ".PS", HOSE: ".VN", HNX: ".VN",
+  // UK
+  LSE: ".L", LSEETF: ".L",
+  // Germany
+  XETRA: ".DE", IBIS: ".DE", IBIS2: ".DE", FWB: ".F", FWB2: ".DE", GETTEX: ".DE", TGATE: ".DE", SWB: ".SG",
+  // France, Netherlands, Belgium, Portugal (Euronext)
+  EURONEXT: ".AS", AEB: ".AS", SBF: ".PA", "ENEXT.BE": ".BR", BVL: ".LS",
+  // Italy & Spain
+  BVME: ".MI", BM: ".MC",
+  // Switzerland
+  EBS: ".SW", SWX: ".SW",
+  // Nordics
+  SFB: ".ST", Stockholm: ".ST", OMX: ".ST", CPH: ".CO", HEX: ".HE", OSE: ".OL", OMXNO: ".OL", ICEX: ".IC",
+  // Central/Eastern Europe
+  VSE: ".VI", WSE: ".WA", PRA: ".PR", BUX: ".BD", ATHEX: ".AT", BVB: ".RO", BIST: ".IS",
+  // Israel
+  TASE: ".TA",
+  // South Africa
+  JSE: ".JO",
+  // Brazil & Latin America
+  BVMF: ".SA", MEXI: ".MX", BYMA: ".BA", BCS: ".SN",
+  // Middle East
+  TADAWUL: ".SAU", QSE: ".QA", DFM: ".AE",
 };
 
 const EXCHANGE_FALLBACKS: Record<string, string[]> = {
-  KRX: [".KS", ".KQ"],
-  TWSE: [".TW", ".TWO"],
-  TPE: [".TW", ".TWO"],
-  EURONEXT: [".AS", ".PA", ".BR"],
+  // TSE is ambiguous: Toronto (.TO) vs Tokyo (.T) — try both
+  TSE: [".TO", ".T"],
+  KRX: [".KS", ".KQ"], KSE: [".KS", ".KQ"],
+  TWSE: [".TW", ".TWO"], TPE: [".TW", ".TWO"],
+  EURONEXT: [".AS", ".PA", ".BR"], AEB: [".AS", ".PA", ".BR"], SBF: [".PA", ".AS", ".BR"],
 };
 
 const GENERIC_SUFFIX_FALLBACKS = [
-  "", ".HK", ".T", ".KS", ".KQ", ".TW", ".TWO", ".SS", ".SZ",
-  ".AS", ".PA", ".BR", ".DE", ".L", ".AX", ".SI", ".JK", ".OL", ".NS", ".BO", ".SA",
+  "", ".HK", ".T", ".TO", ".KS", ".KQ", ".TW", ".TWO", ".SS", ".SZ",
+  ".AS", ".PA", ".BR", ".DE", ".F", ".L", ".MI", ".MC", ".SW", ".AX",
+  ".SI", ".JK", ".OL", ".ST", ".CO", ".HE", ".NS", ".BO", ".SA",
+  ".BK", ".KL", ".NZ", ".JO", ".TA", ".WA", ".VI",
 ];
 
 const MAX_RETRIES = 3;
@@ -217,18 +260,54 @@ export class YahooFinanceClient implements DataProvider {
     });
   }
 
+  /** All known Yahoo Finance suffixes — used to detect tickers that already include one */
+  private static KNOWN_SUFFIXES = new Set(
+    Object.values(EXCHANGE_SUFFIX_MAP).filter(Boolean)
+      .concat(GENERIC_SUFFIX_FALLBACKS.filter(Boolean)),
+  );
+
+  /** Check if the ticker already ends with a known Yahoo suffix (e.g. "6324.T") */
+  private tickerHasSuffix(ticker: string): boolean {
+    const dot = ticker.indexOf(".");
+    if (dot < 0) return false;
+    return YahooFinanceClient.KNOWN_SUFFIXES.has(ticker.slice(dot));
+  }
+
+  private isHKExchange(exchange: string): boolean {
+    return exchange === "HKEX" || exchange === "SEHK" || exchange === "HKG";
+  }
+
+  private normalizeTicker(ticker: string, exchange: string): string {
+    // Hong Kong stocks need 4-digit codes with leading zeros
+    if (this.isHKExchange(exchange) && /^\d+$/.test(ticker)) {
+      return ticker.padStart(4, "0");
+    }
+    return ticker;
+  }
+
   private getSymbol(ticker: string, exchange: string): string {
+    // If ticker already contains a Yahoo suffix, use it as-is
+    if (this.tickerHasSuffix(ticker)) return ticker;
     const suffix = EXCHANGE_SUFFIX_MAP[exchange] ?? "";
-    const normalized = exchange === "HKEX" && /^\d+$/.test(ticker) ? ticker.padStart(4, "0") : ticker;
-    return `${normalized}${suffix}`;
+    return `${this.normalizeTicker(ticker, exchange)}${suffix}`;
   }
 
   private getSymbolsToTry(ticker: string, exchange: string): string[] {
-    const normalized = exchange === "HKEX" && /^\d+$/.test(ticker) ? ticker.padStart(4, "0") : ticker;
+    // If ticker already contains a Yahoo suffix, use it as-is
+    if (this.tickerHasSuffix(ticker)) return [ticker];
+
+    const normalized = this.normalizeTicker(ticker, exchange);
     const ex = (exchange || "").toUpperCase();
     if (!ex) {
       const symbols = new Set<string>();
-      for (const suffix of GENERIC_SUFFIX_FALLBACKS) symbols.add(`${normalized}${suffix}`);
+      // For numeric tickers with no exchange, also try HK-padded variant
+      const candidates = [normalized];
+      if (/^\d+$/.test(normalized) && normalized.length < 4) {
+        candidates.push(normalized.padStart(4, "0"));
+      }
+      for (const candidate of candidates) {
+        for (const suffix of GENERIC_SUFFIX_FALLBACKS) symbols.add(`${candidate}${suffix}`);
+      }
       return Array.from(symbols);
     }
     const fallbacks = EXCHANGE_FALLBACKS[exchange];
@@ -468,34 +547,43 @@ export class YahooFinanceClient implements DataProvider {
       if (cached) return cached;
     }
 
-    const symbol = this.getSymbol(ticker, exchange);
-    const { meta, history } = await this.fetchChart(symbol, "1mo");
-    const latest = history[history.length - 1]!;
-    const prev = history.length > 1 ? history[history.length - 2]!.close : meta.chartPreviousClose;
-    const price = meta.regularMarketPrice ?? latest.close;
-    const change = prev != null ? price - prev : 0;
+    const symbolsToTry = this.getSymbolsToTry(ticker, exchange);
+    let lastError: any;
 
-    const marketState = deriveMarketState(meta);
-    const extHours = await this.fetchExtendedHoursData(symbol, price, meta);
+    for (const symbol of symbolsToTry) {
+      try {
+        const { meta, history } = await this.fetchChart(symbol, "1mo");
+        const latest = history[history.length - 1]!;
+        const prev = history.length > 1 ? history[history.length - 2]!.close : meta.chartPreviousClose;
+        const price = meta.regularMarketPrice ?? latest.close;
+        const change = prev != null ? price - prev : 0;
 
-    const quote: Quote = {
-      symbol,
-      price,
-      currency: meta.currency || "USD",
-      change,
-      changePercent: prev ? (change / prev) * 100 : 0,
-      high52w: meta.fiftyTwoWeekHigh,
-      low52w: meta.fiftyTwoWeekLow,
-      name: meta.shortName || meta.longName,
-      lastUpdated: Date.now(),
-      exchangeName: meta.exchangeName,
-      fullExchangeName: meta.fullExchangeName,
-      marketState,
-      ...extHours,
-    };
+        const marketState = deriveMarketState(meta);
+        const extHours = await this.fetchExtendedHoursData(symbol, price, meta);
 
-    if (this.cache) this.cache.setCache(ticker, "quote", quote, QUOTE_TTL);
-    return quote;
+        const quote: Quote = {
+          symbol,
+          price,
+          currency: meta.currency || "USD",
+          change,
+          changePercent: prev ? (change / prev) * 100 : 0,
+          high52w: meta.fiftyTwoWeekHigh,
+          low52w: meta.fiftyTwoWeekLow,
+          name: meta.shortName || meta.longName,
+          lastUpdated: Date.now(),
+          exchangeName: meta.exchangeName,
+          fullExchangeName: meta.fullExchangeName,
+          marketState,
+          ...extHours,
+        };
+
+        if (this.cache) this.cache.setCache(ticker, "quote", quote, QUOTE_TTL);
+        return quote;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    throw lastError || new Error(`No quote for ${ticker}`);
   }
 
   /** Fetch exchange rate to USD */
@@ -539,13 +627,15 @@ export class YahooFinanceClient implements DataProvider {
   }
 
   /** Fetch news for a ticker */
-  async getNews(ticker: string, count = 10): Promise<NewsItem[]> {
+  async getNews(ticker: string, count = 10, exchange = ""): Promise<NewsItem[]> {
     if (this.cache) {
       const cached = this.cache.getCached<NewsItem[]>(ticker, "news");
       if (cached) return cached.map((n) => ({ ...n, publishedAt: new Date(n.publishedAt) }));
     }
 
-    const url = `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(ticker)}&quotesCount=0&newsCount=${count}`;
+    // Use the Yahoo symbol for better search results on international tickers
+    const symbol = this.getSymbol(ticker, exchange);
+    const url = `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(symbol)}&quotesCount=0&newsCount=${count}`;
     try {
       const resp = await fetch(url, {
         headers: this.defaultHeaders(),

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -39,6 +39,7 @@ export type AppAction =
   | { type: "REMOVE_TICKER"; symbol: string }
   | { type: "SET_FINANCIALS"; symbol: string; data: TickerFinancials }
   | { type: "SELECT_TICKER"; symbol: string | null }
+  | { type: "PREVIEW_TICKER"; symbol: string | null }
   | { type: "SET_ACTIVE_PANEL"; panel: "left" | "right" }
   | { type: "SET_LEFT_TAB"; tab: string }
   | { type: "SET_RIGHT_TAB"; tab: string }
@@ -88,6 +89,9 @@ function appReducer(state: AppState, action: AppAction): AppState {
 
     case "SELECT_TICKER":
       return { ...state, selectedTicker: action.symbol, activePanel: "right" };
+
+    case "PREVIEW_TICKER":
+      return { ...state, selectedTicker: action.symbol };
 
     case "SET_ACTIVE_PANEL":
       return { ...state, activePanel: action.panel };

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -17,7 +17,7 @@ export interface DataProvider {
   getQuote(ticker: string, exchange?: string): Promise<Quote>;
   getExchangeRate(fromCurrency: string): Promise<number>;
   search(query: string): Promise<Array<{ symbol: string; name: string; exchange: string; type: string }>>;
-  getNews(ticker: string, count?: number): Promise<NewsItem[]>;
+  getNews(ticker: string, count?: number, exchange?: string): Promise<NewsItem[]>;
   /** Fetch article summary/description by URL (lazy-loaded on selection) */
   getArticleSummary(url: string): Promise<string | null>;
   getPriceHistory(ticker: string, exchange: string, range: TimeRange): Promise<PricePoint[]>;


### PR DESCRIPTION
## Summary
- Fix news date year display using explicit M/D/YYYY format instead of locale-dependent `toLocaleDateString()`
- Expand Yahoo Finance exchange suffix map from ~15 to 60+ global exchanges, including common IBKR listing exchange aliases
- Add `PREVIEW_TICKER` action so browsing the ticker list doesn't steal focus to the right panel
- Add auto-scroll to portfolio list, config columns, and news tab to keep the selected item visible
- Pass exchange to `getNews()` for better search results on international tickers
- Add symbol fallback retry logic to `getQuote()` and handle tickers that already contain Yahoo suffixes

## Test plan
- [ ] Verify news dates show correct year (e.g. `3/25/2026` not `3/25`)
- [ ] Add international tickers (e.g. Tokyo, Hong Kong, Euronext) and confirm quotes resolve
- [ ] Browse ticker list with j/k and confirm right panel updates without stealing focus
- [ ] Scroll through a long ticker list and confirm the selected row stays visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)