### PR TITLE
Move update notification to header

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -9,6 +9,40 @@ import type { Quote } from "../../types/financials";
 
 const SPY_REFRESH_MS = 5 * 60_000; // 5 min
 
+function UpdateStatus() {
+  const { state } = useAppState();
+  const { updateAvailable, updateProgress } = state;
+
+  if (updateProgress) {
+    if (updateProgress.phase === "downloading") {
+      return (
+        <text fg={colors.headerText}>
+          Downloading v{updateAvailable?.version}... {updateProgress.percent ?? 0}%
+        </text>
+      );
+    }
+    if (updateProgress.phase === "replacing") {
+      return <text fg={colors.headerText}>Installing update...</text>;
+    }
+    if (updateProgress.phase === "done") {
+      return <text fg={colors.headerText}>Update installed — restart to apply</text>;
+    }
+    if (updateProgress.phase === "error") {
+      return <text fg={colors.headerText}>Update failed: {updateProgress.error}</text>;
+    }
+  }
+
+  if (updateAvailable) {
+    return (
+      <text fg={colors.headerText}>
+        v{updateAvailable.version} available — press <span fg={colors.headerText}>u</span> to update
+      </text>
+    );
+  }
+
+  return null;
+}
+
 export function Header({ dataProvider }: { dataProvider: DataProvider }) {
   const { state } = useAppState();
   const [spyQuote, setSpyQuote] = useState<Quote | null>(null);
@@ -45,10 +79,13 @@ export function Header({ dataProvider }: { dataProvider: DataProvider }) {
       height={1}
       backgroundColor={colors.header}
     >
-      <box flexGrow={1} paddingLeft={1}>
+      <box paddingLeft={1}>
         <text attributes={TextAttributes.BOLD} fg={colors.headerText}>
           GLOOMBERB TERMINAL
         </text>
+      </box>
+      <box flexGrow={1} paddingLeft={2}>
+        <UpdateStatus />
       </box>
       {mktLabel && (
         <box paddingRight={1}>

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -4,40 +4,6 @@ import { marketStateLabel, marketStateColor, exchangeShortName } from "../../uti
 import { formatPercentRaw } from "../../utils/format";
 import { priceColor } from "../../theme/colors";
 
-function UpdateStatus() {
-  const { state } = useAppState();
-  const { updateAvailable, updateProgress } = state;
-
-  if (updateProgress) {
-    if (updateProgress.phase === "downloading") {
-      return (
-        <text fg={colors.textBright}>
-          Downloading v{updateAvailable?.version}... {updateProgress.percent ?? 0}%
-        </text>
-      );
-    }
-    if (updateProgress.phase === "replacing") {
-      return <text fg={colors.textBright}>Installing update...</text>;
-    }
-    if (updateProgress.phase === "done") {
-      return <text fg={colors.positive}>Update installed — restart to apply</text>;
-    }
-    if (updateProgress.phase === "error") {
-      return <text fg={colors.negative}>Update failed: {updateProgress.error}</text>;
-    }
-  }
-
-  if (updateAvailable) {
-    return (
-      <text fg={colors.textBright}>
-        v{updateAvailable.version} available — press <span fg={colors.text}>u</span> to update
-      </text>
-    );
-  }
-
-  return null;
-}
-
 export function StatusBar() {
   const { state } = useAppState();
   const refreshCount = state.refreshing.size;
@@ -88,9 +54,6 @@ export function StatusBar() {
           </text>
         </box>
       )}
-      <box paddingRight={1}>
-        <UpdateStatus />
-      </box>
       {refreshCount > 0 && (
         <box paddingRight={1}>
           <text fg={colors.textDim}>


### PR DESCRIPTION
The status bar can be toggled off, so the update prompt should live in the always-visible header instead.