### PR TITLE
Fix position data: normalize currencies, symbol resolution, and options support

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -121,6 +121,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
         market_value: pos.marketValue,
         unrealized_pnl: pos.unrealizedPnl,
         multiplier: pos.multiplier,
+        mark_price: pos.markPrice,
       };
 
       let ticker = existingTickers.get(pos.ticker);
@@ -163,7 +164,11 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
       }
       existingTickers.set(pos.ticker, ticker);
       dispatch({ type: "UPDATE_TICKER", ticker: { ...ticker } });
-      refreshTicker(pos.ticker, pos.exchange);
+      // Skip Yahoo Finance for options — IBKR symbols aren't resolvable there.
+      // Position data (mark_price, market_value, unrealized_pnl) is used directly.
+      if (pos.assetCategory !== "OPT") {
+        refreshTicker(pos.ticker, pos.exchange);
+      }
     }
   }, [pluginRegistry.brokers, state.config, state.tickers, markdownStore, dispatch, refreshTicker, ensurePortfolio]);
 

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -21,7 +21,7 @@ function formatTimeAgo(date: Date): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return date.toLocaleDateString();
+  return date.toLocaleDateString("en-US", { month: "numeric", day: "numeric", year: "2-digit" });
 }
 
 function NewsTab({ width, height, focused }: DetailTabProps) {
@@ -78,7 +78,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
   if (news.length === 0) return <text fg={colors.textDim}>No news available for {ticker.frontmatter.ticker}.</text>;
 
   const innerWidth = Math.max(width - 4, 40);
-  const timeColW = 7;
+  const timeColW = 8;
   const sourceColW = 16;
   const titleColW = Math.max(innerWidth - timeColW - sourceColW - 2, 10);
   const summary = selected ? summaryCache.get(selected.url) : undefined;

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -12,6 +12,23 @@ import type { ColumnConfig } from "../../types/config";
 import type { TickerFile } from "../../types/ticker";
 import type { TickerFinancials } from "../../types/financials";
 
+const MONTH_ABBREV = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/**
+ * Parse IBKR option symbol like "UBER 260821C00090000" into a readable form.
+ * Format: UNDERLYING YYMMDD{C|P}SSSSSSSS (strike in 1/1000 dollars, 8 digits)
+ */
+function formatOptionTicker(symbol: string): string {
+  // Match: TICKER(space)YYMMDDX00SSSSSS  where X is C or P
+  const m = symbol.match(/^(\S+)\s+(\d{2})(\d{2})(\d{2})([CP])(\d{8})$/);
+  if (!m) return symbol;
+  const [, underlying, yy, mm, , side, rawStrike] = m;
+  const strike = parseInt(rawStrike!, 10) / 1000;
+  const month = MONTH_ABBREV[parseInt(mm!, 10) - 1] || mm;
+  const strikeStr = strike % 1 === 0 ? String(strike) : strike.toFixed(1);
+  return `${underlying} ${side === "C" ? "C" : "P"} $${strikeStr} ${month}'${yy}`;
+}
+
 /** Convert a value from one currency to base currency using cached exchange rates */
 function convertCurrency(
   value: number,
@@ -55,19 +72,39 @@ function getColumnValue(
     0,
   );
 
+  // For options without Yahoo quotes, use broker-provided position data
+  const isOption = ticker.frontmatter.asset_category === "OPT";
+  const brokerMktValue = tabPositions.reduce(
+    (sum, p) => sum + (p.market_value || 0),
+    0,
+  );
+  const brokerPnl = tabPositions.reduce(
+    (sum, p) => sum + (p.unrealized_pnl || 0),
+    0,
+  );
+  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.mark_price : undefined;
+
   switch (col.id) {
     case "ticker": {
       const mkt = q?.marketState;
       const statusDot = mkt === "REGULAR" ? "\u25CF" : "\u25CB";
-      return { text: `${statusDot} ${ticker.frontmatter.ticker}` };
+      const displayName = isOption
+        ? formatOptionTicker(ticker.frontmatter.ticker)
+        : ticker.frontmatter.ticker;
+      return { text: `${statusDot} ${displayName}` };
     }
     case "price": {
-      if (!q) return { text: "—" };
-      const converted = toBase(q.price);
-      return {
-        text: formatCurrency(converted, ctx.baseCurrency),
-        color: priceColor(q.change),
-      };
+      if (q) {
+        const converted = toBase(q.price);
+        return {
+          text: formatCurrency(converted, ctx.baseCurrency),
+          color: priceColor(q.change),
+        };
+      }
+      if (isOption && brokerMarkPrice != null) {
+        return { text: formatCurrency(toBase(brokerMarkPrice), ctx.baseCurrency) };
+      }
+      return { text: "—" };
     }
     case "change": {
       if (!q) return { text: "—" };
@@ -117,21 +154,38 @@ function getColumnValue(
       return { text: formatCompact(toBase(totalCost)) };
     }
     case "mkt_value": {
-      if (!q || totalShares === 0) return { text: "—" };
-      const mv = Math.abs(totalShares) * q.price;
-      return { text: formatCompact(toBase(mv)) };
+      if (q && totalShares !== 0) {
+        const mv = Math.abs(totalShares) * q.price;
+        return { text: formatCompact(toBase(mv)) };
+      }
+      if (isOption && brokerMktValue !== 0) {
+        return { text: formatCompact(toBase(brokerMktValue)) };
+      }
+      return { text: "—" };
     }
     case "pnl": {
-      if (!q || totalShares === 0) return { text: "—" };
-      const mv = Math.abs(totalShares) * q.price;
-      const pnl = toBase(mv - totalCost);
-      return { text: (pnl >= 0 ? "+" : "") + formatCompact(pnl), color: priceColor(pnl) };
+      if (q && totalShares !== 0) {
+        const mv = Math.abs(totalShares) * q.price;
+        const pnl = toBase(mv - totalCost);
+        return { text: (pnl >= 0 ? "+" : "") + formatCompact(pnl), color: priceColor(pnl) };
+      }
+      if (isOption && brokerPnl !== 0) {
+        const pnl = toBase(brokerPnl);
+        return { text: (pnl >= 0 ? "+" : "") + formatCompact(pnl), color: priceColor(pnl) };
+      }
+      return { text: "—" };
     }
     case "pnl_pct": {
-      if (!q || totalCost === 0) return { text: "—" };
-      const mv = Math.abs(totalShares) * q.price;
-      const pct = ((mv - totalCost) / totalCost) * 100;
-      return { text: formatPercentRaw(pct), color: priceColor(pct) };
+      if (q && totalCost !== 0) {
+        const mv = Math.abs(totalShares) * q.price;
+        const pct = ((mv - totalCost) / totalCost) * 100;
+        return { text: formatPercentRaw(pct), color: priceColor(pct) };
+      }
+      if (isOption && brokerPnl !== 0 && totalCost !== 0) {
+        const pct = (brokerPnl / totalCost) * 100;
+        return { text: formatPercentRaw(pct), color: priceColor(pct) };
+      }
+      return { text: "—" };
     }
     default:
       return { text: "—" };
@@ -160,11 +214,18 @@ function getSortValue(
     0,
   );
 
+  const isOption = ticker.frontmatter.asset_category === "OPT";
+  const brokerMktValue = tabPositions.reduce((sum, p) => sum + (p.market_value || 0), 0);
+  const brokerPnl = tabPositions.reduce((sum, p) => sum + (p.unrealized_pnl || 0), 0);
+  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.mark_price : undefined;
+
   switch (col.id) {
     case "ticker":
       return ticker.frontmatter.ticker;
     case "price":
-      return q ? toBase(q.price) : null;
+      if (q) return toBase(q.price);
+      if (isOption && brokerMarkPrice != null) return toBase(brokerMarkPrice);
+      return null;
     case "change":
       return q ? toBase(q.change) : null;
     case "change_pct":
@@ -189,18 +250,25 @@ function getSortValue(
     case "cost_basis":
       return totalCost !== 0 ? toBase(totalCost) : null;
     case "mkt_value": {
-      if (!q || totalShares === 0) return null;
-      return toBase(Math.abs(totalShares) * q.price);
+      if (q && totalShares !== 0) return toBase(Math.abs(totalShares) * q.price);
+      if (isOption && brokerMktValue !== 0) return toBase(brokerMktValue);
+      return null;
     }
     case "pnl": {
-      if (!q || totalShares === 0) return null;
-      const mv = Math.abs(totalShares) * q.price;
-      return toBase(mv - totalCost);
+      if (q && totalShares !== 0) {
+        const mv = Math.abs(totalShares) * q.price;
+        return toBase(mv - totalCost);
+      }
+      if (isOption && brokerPnl !== 0) return toBase(brokerPnl);
+      return null;
     }
     case "pnl_pct": {
-      if (!q || totalCost === 0) return null;
-      const mv = Math.abs(totalShares) * q.price;
-      return ((mv - totalCost) / totalCost) * 100;
+      if (q && totalCost !== 0) {
+        const mv = Math.abs(totalShares) * q.price;
+        return ((mv - totalCost) / totalCost) * 100;
+      }
+      if (isOption && brokerPnl !== 0 && totalCost !== 0) return (brokerPnl / totalCost) * 100;
+      return null;
     }
     default:
       return null;

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -47,9 +47,11 @@ function OverviewTab({ width }: { width?: number }) {
           <text attributes={TextAttributes.BOLD} fg={colors.textBright}>
             {ticker.frontmatter.ticker}
           </text>
+          {ticker.frontmatter.name && ticker.frontmatter.name !== ticker.frontmatter.ticker && (
           <text fg={colors.textDim}>
             {" "}- {ticker.frontmatter.name || q?.name || ""}
           </text>
+          )}
           {q?.exchangeName && (
             <text fg={colors.textDim}>
               {" "}({exchangeShortName(q.exchangeName, q.fullExchangeName)})
@@ -170,13 +172,21 @@ function OverviewTab({ width }: { width?: number }) {
                   </box>
                   <box flexDirection="row" height={1}>
                     <text fg={colors.text}>
-                      {pos.shares} shares @ {formatCurrency(pos.avg_cost, pos.currency)}
+                      {pos.shares} {pos.multiplier && pos.multiplier > 1 ? "contracts" : "shares"} @ {formatCurrency(pos.avg_cost, pos.currency)}
                       {" = "}{formatCurrency(costBasis, pos.currency)}
                     </text>
                     {pnlText && (
                       <text fg={priceColor(pos.unrealized_pnl!)}>{pnlText}</text>
                     )}
                   </box>
+                  {pos.mark_price != null && (
+                    <box flexDirection="row" height={1}>
+                      <text fg={colors.textDim}>Mark: {formatCurrency(pos.mark_price, pos.currency)}</text>
+                      {pos.market_value != null && (
+                        <text fg={colors.textDim}>{" "}Mkt Value: {formatCurrency(pos.market_value, pos.currency)}</text>
+                      )}
+                    </box>
+                  )}
                 </box>
               );
             })}

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -139,6 +139,24 @@ type TimeseriesResponse = { timeseries?: { result?: Array<Record<string, any>>; 
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * Sub-unit currency normalization.
+ * Yahoo Finance returns prices for some exchanges in sub-units (e.g. pence instead of pounds).
+ * IBKR and most brokers report in the main currency unit, so we normalize here to avoid mismatches.
+ */
+const SUB_UNIT_CURRENCIES: Record<string, { main: string; divisor: number }> = {
+  GBp: { main: "GBP", divisor: 100 },
+  GBX: { main: "GBP", divisor: 100 },
+  ILA: { main: "ILS", divisor: 100 },
+  ZAc: { main: "ZAR", divisor: 100 },
+};
+
+function normalizeSubUnitCurrency(currency: string): { currency: string; divisor: number } {
+  const sub = SUB_UNIT_CURRENCIES[currency];
+  if (sub) return { currency: sub.main, divisor: sub.divisor };
+  return { currency, divisor: 1 };
+}
+
 function deriveMarketState(meta: NonNullable<ChartResult["meta"]>): MarketState {
   const ctp = meta.currentTradingPeriod;
   if (!ctp) return "CLOSED";
@@ -282,7 +300,8 @@ export class YahooFinanceClient implements DataProvider {
     if (this.isHKExchange(exchange) && /^\d+$/.test(ticker)) {
       return ticker.padStart(4, "0");
     }
-    return ticker;
+    // Yahoo Finance uses hyphens where IBKR uses spaces (e.g. "HEXA B" → "HEXA-B")
+    return ticker.replace(/ /g, "-");
   }
 
   private getSymbol(ticker: string, exchange: string): string {
@@ -297,11 +316,17 @@ export class YahooFinanceClient implements DataProvider {
     if (this.tickerHasSuffix(ticker)) return [ticker];
 
     const normalized = this.normalizeTicker(ticker, exchange);
+
+    // For tickers with dots that aren't Yahoo suffixes (e.g. "BTC.USD"),
+    // also try replacing the dot with a hyphen (Yahoo uses "BTC-USD" for crypto pairs)
+    const dotVariant = normalized.includes(".") ? normalized.replace(/\./g, "-") : null;
+
     const ex = (exchange || "").toUpperCase();
     if (!ex) {
       const symbols = new Set<string>();
       // For numeric tickers with no exchange, also try HK-padded variant
       const candidates = [normalized];
+      if (dotVariant) candidates.unshift(dotVariant); // Try hyphen variant first
       if (/^\d+$/.test(normalized) && normalized.length < 4) {
         candidates.push(normalized.padStart(4, "0"));
       }
@@ -311,8 +336,17 @@ export class YahooFinanceClient implements DataProvider {
       return Array.from(symbols);
     }
     const fallbacks = EXCHANGE_FALLBACKS[exchange];
-    if (fallbacks) return fallbacks.map((s) => `${normalized}${s}`);
-    return [this.getSymbol(ticker, exchange)];
+    if (fallbacks) {
+      const results = fallbacks.map((s) => `${normalized}${s}`);
+      if (dotVariant) results.unshift(...fallbacks.map((s) => `${dotVariant}${s}`));
+      return results;
+    }
+    const primary = this.getSymbol(ticker, exchange);
+    if (dotVariant) {
+      const suffix = EXCHANGE_SUFFIX_MAP[exchange] ?? "";
+      return [`${dotVariant}${suffix}`, primary];
+    }
+    return [primary];
   }
 
   private async fetchChart(symbol: string, range: string, interval = "1d", includePrePost = false) {
@@ -438,6 +472,25 @@ export class YahooFinanceClient implements DataProvider {
       return pts?.length ? pts[pts.length - 1]!.value : undefined;
     };
 
+    // Normalize sub-unit currencies (e.g. GBp → GBP, dividing prices by 100)
+    const rawCurrency = meta.currency || "USD";
+    const { currency: normalizedCurrency, divisor: currencyDivisor } = normalizeSubUnitCurrency(rawCurrency);
+
+    if (currencyDivisor !== 1) {
+      // Normalize price history points
+      for (const point of history) {
+        point.close /= currencyDivisor;
+        if (point.open != null) point.open /= currencyDivisor;
+        if (point.high != null) point.high /= currencyDivisor;
+        if (point.low != null) point.low /= currencyDivisor;
+      }
+      // Normalize meta prices
+      if (meta.regularMarketPrice != null) meta.regularMarketPrice /= currencyDivisor;
+      if (meta.chartPreviousClose != null) meta.chartPreviousClose /= currencyDivisor;
+      if (meta.fiftyTwoWeekHigh != null) meta.fiftyTwoWeekHigh /= currencyDivisor;
+      if (meta.fiftyTwoWeekLow != null) meta.fiftyTwoWeekLow /= currencyDivisor;
+    }
+
     const currentPrice = meta.regularMarketPrice ?? history[history.length - 1]!.close;
     const prev = history.length > 1 ? history[history.length - 2]!.close : meta.chartPreviousClose;
     const change = prev != null ? currentPrice - prev : 0;
@@ -446,10 +499,18 @@ export class YahooFinanceClient implements DataProvider {
     const marketState = deriveMarketState(meta);
     const extHours = await this.fetchExtendedHoursData(symbol, currentPrice, meta);
 
+    // Normalize extended hours prices too
+    if (currencyDivisor !== 1) {
+      if (extHours.preMarketPrice != null) extHours.preMarketPrice /= currencyDivisor;
+      if (extHours.preMarketChange != null) extHours.preMarketChange /= currencyDivisor;
+      if (extHours.postMarketPrice != null) extHours.postMarketPrice /= currencyDivisor;
+      if (extHours.postMarketChange != null) extHours.postMarketChange /= currencyDivisor;
+    }
+
     const quote: Quote = {
       symbol,
       price: currentPrice,
-      currency: meta.currency || "USD",
+      currency: normalizedCurrency,
       change,
       changePercent: changePct,
       high52w: meta.fiftyTwoWeekHigh,
@@ -553,6 +614,24 @@ export class YahooFinanceClient implements DataProvider {
     for (const symbol of symbolsToTry) {
       try {
         const { meta, history } = await this.fetchChart(symbol, "1mo");
+
+        // Normalize sub-unit currencies
+        const rawCurrency = meta.currency || "USD";
+        const { currency: normalizedCurrency, divisor: currencyDivisor } = normalizeSubUnitCurrency(rawCurrency);
+
+        if (currencyDivisor !== 1) {
+          for (const point of history) {
+            point.close /= currencyDivisor;
+            if (point.open != null) point.open /= currencyDivisor;
+            if (point.high != null) point.high /= currencyDivisor;
+            if (point.low != null) point.low /= currencyDivisor;
+          }
+          if (meta.regularMarketPrice != null) meta.regularMarketPrice /= currencyDivisor;
+          if (meta.chartPreviousClose != null) meta.chartPreviousClose /= currencyDivisor;
+          if (meta.fiftyTwoWeekHigh != null) meta.fiftyTwoWeekHigh /= currencyDivisor;
+          if (meta.fiftyTwoWeekLow != null) meta.fiftyTwoWeekLow /= currencyDivisor;
+        }
+
         const latest = history[history.length - 1]!;
         const prev = history.length > 1 ? history[history.length - 2]!.close : meta.chartPreviousClose;
         const price = meta.regularMarketPrice ?? latest.close;
@@ -561,10 +640,17 @@ export class YahooFinanceClient implements DataProvider {
         const marketState = deriveMarketState(meta);
         const extHours = await this.fetchExtendedHoursData(symbol, price, meta);
 
+        if (currencyDivisor !== 1) {
+          if (extHours.preMarketPrice != null) extHours.preMarketPrice /= currencyDivisor;
+          if (extHours.preMarketChange != null) extHours.preMarketChange /= currencyDivisor;
+          if (extHours.postMarketPrice != null) extHours.postMarketPrice /= currencyDivisor;
+          if (extHours.postMarketChange != null) extHours.postMarketChange /= currencyDivisor;
+        }
+
         const quote: Quote = {
           symbol,
           price,
-          currency: meta.currency || "USD",
+          currency: normalizedCurrency,
           change,
           changePercent: prev ? (change / prev) * 100 : 0,
           high52w: meta.fiftyTwoWeekHigh,
@@ -588,6 +674,9 @@ export class YahooFinanceClient implements DataProvider {
 
   /** Fetch exchange rate to USD */
   async getExchangeRate(fromCurrency: string): Promise<number> {
+    // Normalize sub-unit currencies to their main unit
+    const { currency: normalized } = normalizeSubUnitCurrency(fromCurrency);
+    fromCurrency = normalized;
     if (fromCurrency === "USD") return 1;
 
     if (this.cache) {
@@ -701,7 +790,19 @@ export class YahooFinanceClient implements DataProvider {
 
     for (const symbol of symbolsToTry) {
       try {
-        const { history } = await this.fetchChart(symbol, params.range, params.interval);
+        const { meta, history } = await this.fetchChart(symbol, params.range, params.interval);
+
+        // Normalize sub-unit currencies in price history
+        const { divisor } = normalizeSubUnitCurrency(meta.currency || "USD");
+        if (divisor !== 1) {
+          for (const point of history) {
+            point.close /= divisor;
+            if (point.open != null) point.open /= divisor;
+            if (point.high != null) point.high /= divisor;
+            if (point.low != null) point.low /= divisor;
+          }
+        }
+
         if (this.cache) this.cache.setCache(ticker, cacheKey, history, params.ttl);
         return history;
       } catch (err) {

--- a/src/types/ticker.ts
+++ b/src/types/ticker.ts
@@ -10,6 +10,8 @@ export interface TickerPosition {
   unrealized_pnl?: number;
   /** Contract multiplier (e.g. 100 for options) */
   multiplier?: number;
+  /** Last known mark price from broker snapshot */
+  mark_price?: number;
 }
 
 export interface TickerFrontmatter {


### PR DESCRIPTION
## Summary
- **Fix sub-unit currency mismatch**: Yahoo Finance returns LSE prices in GBp (pence) while IBKR uses GBP (pounds), causing 100x errors in market value and P&L. Normalizes GBp→GBP, ZAc→ZAR, ILA→ILS across all quote, history, and exchange rate paths.
- **Fix symbol resolution for IBKR tickers**: Spaces are now replaced with hyphens (e.g. `HEXA B` → `HEXA-B.ST`), and dot-separated pairs try hyphen variants (e.g. `BTC.USD` → `BTC-USD`).
- **Options support**: Skip Yahoo lookups for options (symbols aren't resolvable) and use IBKR-provided mark price, market value, and P&L directly. Options display in human-readable format (e.g. `UBER C $90 Aug'26`).
- Store and display broker mark price in the detail view.

## Test plan
- [ ] Verify LSE stocks (e.g. IQE) show correct prices in GBP, not inflated pence values
- [ ] Verify HEXA B resolves to Yahoo data via `HEXA-B.ST`
- [ ] Verify BTC.USD resolves to Yahoo data via `BTC-USD`
- [ ] Verify options positions display mark price and P&L from IBKR data
- [ ] Verify P&L and market value calculations are correct after currency normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)