### PR TITLE
Add draggable pane resize with persisted layout

### DIFF
--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -21,6 +21,7 @@ export function PaneWrapper({ title, focused, width, flexGrow, onMouseDown, chil
       title={title}
       titleAlignment="left"
       backgroundColor={colors.bg}
+      overflow="hidden"
       onMouseDown={onMouseDown}
     >
       {children}

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useCallback } from "react";
 import { useTerminalDimensions } from "@opentui/react";
 import { useDialogState } from "@opentui-ui/dialog/react";
 import { useAppState } from "../../state/app-context";
@@ -5,10 +6,14 @@ import { resolvePanes, getPanesByPosition, parseWidth } from "../../plugins/pane
 import type { PluginRegistry } from "../../plugins/registry";
 import { PaneWrapper } from "./pane";
 import { colors } from "../../theme/colors";
+import { saveConfig } from "../../data/config-store";
 
 interface ShellProps {
   pluginRegistry: PluginRegistry;
 }
+
+// How many columns around the divider count as a grab zone
+const GRAB_ZONE = 3;
 
 export function Shell({ pluginRegistry }: ShellProps) {
   const { state, dispatch } = useAppState();
@@ -17,35 +22,102 @@ export function Shell({ pluginRegistry }: ShellProps) {
   const leftPanes = getPanesByPosition(resolved, "left");
   const rightPanes = getPanesByPosition(resolved, "right");
 
-  // Calculate available height (minus header and optional status bar)
   const contentHeight = height - (state.statusBarVisible ? 2 : 1);
 
-  // Panes are unfocused when overlays or dialogs are open
   const dialogOpen = useDialogState((s) => s.isOpen);
   const overlayOpen = state.commandBarOpen || dialogOpen;
   const leftFocused = state.activePanel === "left" && !overlayOpen;
   const rightFocused = state.activePanel === "right" && !overlayOpen;
 
+  const [dragging, setDragging] = useState(false);
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const draggingRef = useRef(false);
+
+  const configuredLeftWidth = parseWidth(leftPanes[0]?.layout.width, width) ?? Math.floor(width * 0.4);
+  const leftWidth = dragWidth ?? configuredLeftWidth;
+
+  const MIN_PANE_WIDTH = 20;
+  const maxLeftWidth = width - MIN_PANE_WIDTH - 1;
+
+  const hasBothPanes = leftPanes.length > 0 && rightPanes.length > 0;
+
+  const clamp = useCallback((w: number) => {
+    return Math.max(MIN_PANE_WIDTH, Math.min(maxLeftWidth, w));
+  }, [maxLeftWidth]);
+
+  // Catch-all mouse handler on the outermost box.
+  // Events bubble up from whatever element was actually hit.
+  // e.x / e.y are absolute terminal coordinates.
+  const handleMouse = useCallback((e: { type: string; x: number; stopPropagation: () => void; preventDefault: () => void }) => {
+    if (!hasBothPanes) return;
+
+    if (e.type === "down") {
+      // Check if click is near the divider
+      const dividerX = leftWidth;
+      if (Math.abs(e.x - dividerX) <= GRAB_ZONE) {
+        draggingRef.current = true;
+        setDragging(true);
+        setDragWidth(clamp(e.x));
+        e.stopPropagation();
+        e.preventDefault();
+      }
+      return;
+    }
+
+    if (!draggingRef.current) return;
+
+    if (e.type === "drag") {
+      setDragWidth(clamp(e.x));
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
+
+    if (e.type === "up" || e.type === "drag-end") {
+      const finalWidth = dragWidth ?? leftWidth;
+      draggingRef.current = false;
+      setDragging(false);
+      setDragWidth(null);
+
+      const pct = Math.round((finalWidth / width) * 100);
+      const newLayout = state.config.layout.map((entry) => {
+        if (entry.position === "left") return { ...entry, width: `${pct}%` };
+        if (entry.position === "right") return { ...entry, width: `${100 - pct}%` };
+        return entry;
+      });
+      dispatch({ type: "UPDATE_LAYOUT", layout: newLayout });
+      saveConfig({ ...state.config, layout: newLayout }).catch(() => {});
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }, [hasBothPanes, leftWidth, dragWidth, width, state.config, dispatch, clamp]);
+
   return (
-    <box flexDirection="row" flexGrow={1} height={contentHeight}>
-      {leftPanes.map((pane) => {
-        const w = parseWidth(pane.layout.width, width);
-        return (
-          <PaneWrapper
-            key={pane.def.id}
-            title={` ${pane.def.name} `}
+    <box flexDirection="row" flexGrow={1} height={contentHeight} onMouse={handleMouse}>
+      {leftPanes.map((pane) => (
+        <PaneWrapper
+          key={pane.def.id}
+          title={` ${pane.def.name} `}
+          focused={leftFocused}
+          width={leftWidth}
+          onMouseDown={() => dispatch({ type: "SET_ACTIVE_PANEL", panel: "left" })}
+        >
+          <pane.def.component
             focused={leftFocused}
-            width={w}
-            onMouseDown={() => dispatch({ type: "SET_ACTIVE_PANEL", panel: "left" })}
-          >
-            <pane.def.component
-              focused={leftFocused}
-              width={w || Math.floor(width * 0.4)}
-              height={contentHeight - 2}
-            />
-          </PaneWrapper>
-        );
-      })}
+            width={leftWidth}
+            height={contentHeight - 2}
+          />
+        </PaneWrapper>
+      ))}
+      {hasBothPanes && (
+        <box
+          width={1}
+          height={contentHeight}
+          backgroundColor={dragging ? colors.borderFocused : undefined}
+        >
+          <text fg={dragging ? colors.bg : colors.border}>│</text>
+        </box>
+      )}
       {rightPanes.map((pane) => (
         <PaneWrapper
           key={pane.def.id}
@@ -56,7 +128,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
         >
           <pane.def.component
             focused={rightFocused}
-            width={width - (parseWidth(leftPanes[0]?.layout.width, width) || Math.floor(width * 0.4)) - 4}
+            width={width - leftWidth - 1 - 4}
             height={contentHeight - 2}
           />
         </PaneWrapper>

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -57,7 +57,8 @@ export type AppAction =
   | { type: "SET_UPDATE_PROGRESS"; progress: UpdateProgress | null }
   | { type: "TOGGLE_PLUGIN"; pluginId: string }
   | { type: "SET_INPUT_CAPTURED"; captured: boolean }
-  | { type: "SET_EXCHANGE_RATE"; currency: string; rate: number };
+  | { type: "SET_EXCHANGE_RATE"; currency: string; rate: number }
+  | { type: "UPDATE_LAYOUT"; layout: import("../types/config").PaneLayoutEntry[] };
 
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
@@ -161,6 +162,8 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, exchangeRates };
     }
 
+    case "UPDATE_LAYOUT":
+      return { ...state, config: { ...state.config, layout: action.layout } };
 
     default:
       return state;


### PR DESCRIPTION
## Summary
- Adds mouse-drag resizing of the left/right pane split via a catch-all `onMouse` handler on the shell container that detects mousedown within a 3-column grab zone around the divider
- Tracks drag events to update pane width in real-time, then persists the new width as a percentage to `config.json` via a new `UPDATE_LAYOUT` reducer action
- Adds a visible `│` divider between panes that highlights during drag
- Sets `overflow="hidden"` on PaneWrapper to prevent scrollbar overflow during resize

## Test plan
- [ ] Drag near the pane divider to resize left/right split
- [ ] Verify new width persists after restart
- [ ] Confirm scrollbar doesn't overflow pane border when resizing small
- [ ] Check that normal pane clicks still work (panel focus switching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)