### PR TITLE
Fix onboarding showing empty plugin list and crash on toggle

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -256,12 +256,14 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
         setPluginIdx((i) => Math.min(toggleablePlugins.length - 1, i + 1));
       } else if (event.name === "space" || event.name === " ") {
         event.stopPropagation?.();
-        const plugin = toggleablePlugins[pluginIdx]!;
-        setDisabledPlugins((prev) =>
-          prev.includes(plugin.id)
-            ? prev.filter((id) => id !== plugin.id)
-            : [...prev, plugin.id]
-        );
+        const plugin = toggleablePlugins[pluginIdx];
+        if (plugin) {
+          setDisabledPlugins((prev) =>
+            prev.includes(plugin.id)
+              ? prev.filter((id) => id !== plugin.id)
+              : [...prev, plugin.id]
+          );
+        }
       }
     }
   });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -119,12 +119,13 @@ export class PluginRegistry {
       this.unregisterFns.set(plugin.id, unregister);
     }
 
+    // Add to plugin map before async setup so allPlugins is available synchronously
+    this.plugins.set(plugin.id, plugin);
+
     // Call setup
     if (plugin.setup) {
       await plugin.setup(this.createContext());
     }
-
-    this.plugins.set(plugin.id, plugin);
   }
 
   unregister(pluginId: string): void {


### PR DESCRIPTION
## Summary
- Move `plugins.set()` before the async `setup()` call in the plugin registry so plugins are available in `allPlugins` immediately when `register()` is called without await — fixes the onboarding wizard showing an empty plugin toggle list
- Add null guard when toggling a plugin by index to prevent `TypeError: undefined is not an object (evaluating 'plugin.id')` crash

## Test plan
- [ ] Run the app with `onboardingComplete: false` (or fresh config) and verify toggleable plugins appear in the plugins step
- [ ] Press space on the plugins step to toggle plugins without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)