### PR TITLE
Fix left pane scrollbox hijacking arrow key navigation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -312,7 +312,6 @@ export function App({ config: initialConfig, renderer }: AppProps) {
 
   const dbPath = join(config.dataDir, ".gloomberb-cache.db");
   const cache = new SqliteCache(dbPath);
-  cache.clearByType("full"); // Clear stale financials cache on startup
   const markdownStore = new MarkdownStore(config.dataDir, cache);
   // Migrate old YAML-frontmatter .md files to SQLite on first run
   markdownStore.migrate();

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -406,7 +406,7 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
       />
 
       {/* Scrollable table with headers + rows */}
-      <scrollbox ref={scrollRef} flexGrow={1} scrollX scrollY>
+      <scrollbox ref={scrollRef} flexGrow={1} scrollX scrollY focusable={false}>
         {/* Column headers — clickable for sorting */}
         <box flexDirection="row" height={1} paddingX={1}>
           {cols.map((col) => {


### PR DESCRIPTION
## Summary
- Set `focusable={false}` on the portfolio list scrollbox to prevent it from receiving focus on click and intercepting arrow key events that should be handled by the custom keyboard navigation handler
- Remove unnecessary `cache.clearByType("full")` call that cleared the financials cache on every startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)