### PR TITLE
Use opentui-spinner for animated loading states

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@opentui/core": "^0.1.90",
         "@opentui/react": "^0.1.90",
         "gray-matter": "^4.0.3",
+        "opentui-spinner": "^0.0.6",
         "react": "^19.2.4",
         "yahoo-finance2": "^3.13.2",
       },
@@ -139,6 +140,8 @@
 
     "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-zvnUl4EAsQbKsmZVu+lEJcH8axQ7MiCfqg2OmnHd6uw1THABmHaX0GbpKiHshdgadNN2Nf+4zDyTJB5YMcAdrA=="],
 
+    "cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
+
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -200,6 +203,8 @@
     "normalize-url": ["normalize-url@4.5.1", "", {}, "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="],
 
     "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
+
+    "opentui-spinner": ["opentui-spinner@0.0.6", "", { "dependencies": { "cli-spinners": "^3.3.0" }, "peerDependencies": { "@opentui/core": "^0.1.49", "@opentui/react": "^0.1.49", "@opentui/solid": "^0.1.49", "typescript": "^5" }, "optionalPeers": ["@opentui/react", "@opentui/solid"] }, "sha512-xupLOeVQEAXEvVJCvHkfX6fChDWmJIPHe5jyUrVb8+n4XVTX8mBNhitFfB9v2ZbkC1H2UwPab/ElePHoW37NcA=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@opentui/core": "^0.1.90",
     "@opentui/react": "^0.1.90",
     "gray-matter": "^4.0.3",
+    "opentui-spinner": "^0.0.6",
     "react": "^19.2.4",
     "yahoo-finance2": "^3.13.2"
   }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { TextAttributes } from "@opentui/core";
+import "opentui-spinner/react";
 import { colors, priceColor } from "../../theme/colors";
 import { useAppState } from "../../state/app-context";
 import { formatPercentRaw } from "../../utils/format";
@@ -16,13 +17,21 @@ function UpdateStatus() {
   if (updateProgress) {
     if (updateProgress.phase === "downloading") {
       return (
-        <text fg={colors.headerText}>
-          Downloading v{updateAvailable?.version}... {updateProgress.percent ?? 0}%
-        </text>
+        <box flexDirection="row" gap={1}>
+          <spinner name="dots" color={colors.headerText} />
+          <text fg={colors.headerText}>
+            Downloading v{updateAvailable?.version}... {updateProgress.percent ?? 0}%
+          </text>
+        </box>
       );
     }
     if (updateProgress.phase === "replacing") {
-      return <text fg={colors.headerText}>Installing update...</text>;
+      return (
+        <box flexDirection="row" gap={1}>
+          <spinner name="dots" color={colors.headerText} />
+          <text fg={colors.headerText}>Installing update...</text>
+        </box>
+      );
     }
     if (updateProgress.phase === "done") {
       return <text fg={colors.headerText}>Update installed — restart to apply</text>;

--- a/src/components/spinner.tsx
+++ b/src/components/spinner.tsx
@@ -1,0 +1,15 @@
+import "opentui-spinner/react";
+import { colors } from "../theme/colors";
+
+interface SpinnerProps {
+  label?: string;
+}
+
+export function Spinner({ label }: SpinnerProps) {
+  return (
+    <box flexDirection="row" gap={1}>
+      <spinner name="dots" color={colors.textDim} />
+      {label && <text fg={colors.textDim}>{label}</text>}
+    </box>
+  );
+}

--- a/src/plugins/builtin/ask-ai.tsx
+++ b/src/plugins/builtin/ask-ai.tsx
@@ -10,6 +10,7 @@ import { colors } from "../../theme/colors";
 import { formatCurrency, formatCompact, formatPercent } from "../../utils/format";
 import type { TickerFile } from "../../types/ticker";
 import type { TickerFinancials } from "../../types/financials";
+import { Spinner } from "../../components/spinner";
 
 // --- AI Provider Detection ---
 
@@ -331,7 +332,13 @@ function AskAiTab({ width, height, focused, onCapture }: DetailTabProps) {
                   </text>
                 </box>
                 <box>
-                  <text fg={colors.text}>{msg.content || (msg.loading ? "..." : "")}</text>
+                  {msg.content ? (
+                    <text fg={colors.text}>{msg.content}</text>
+                  ) : msg.loading ? (
+                    <Spinner label="Generating..." />
+                  ) : (
+                    <text fg={colors.text}>{""}</text>
+                  )}
                 </box>
               </box>
             ))

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -5,6 +5,7 @@ import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
 import { useSelectedTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import { padTo } from "../../utils/format";
+import { Spinner } from "../../components/spinner";
 import type { DataProvider, NewsItem } from "../../types/data-provider";
 
 let _dataProvider: DataProvider | undefined;
@@ -74,7 +75,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
   });
 
   if (!ticker) return <text fg={colors.textDim}>Select a ticker to view news.</text>;
-  if (loading && news.length === 0) return <text fg={colors.textDim}>Loading news...</text>;
+  if (loading && news.length === 0) return <Spinner label="Loading news..." />;
   if (news.length === 0) return <text fg={colors.textDim}>No news available for {ticker.frontmatter.ticker}.</text>;
 
   const innerWidth = Math.max(width - 4, 40);
@@ -167,7 +168,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
                 {summary
                   ? summary
                   : loadingSummary
-                    ? "Loading..."
+                    ? <Spinner label="Loading..." />
                     : "No preview available."}
               </text>
             </box>

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -7,6 +7,7 @@ import type { OptionContract, OptionsChain } from "../../types/financials";
 import { useSelectedTicker } from "../../state/app-context";
 import { colors, hoverBg } from "../../theme/colors";
 import { padTo, formatCompact, formatNumber } from "../../utils/format";
+import { Spinner } from "../../components/spinner";
 
 let _dataProvider: DataProvider | undefined;
 export function setOptionsDataProvider(provider: DataProvider) {
@@ -169,7 +170,7 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
 
   if (!ticker) return <text fg={colors.textDim}>Select a ticker to view options.</text>;
   if (!_dataProvider?.getOptionsChain) return <text fg={colors.textDim}>Options data not available.</text>;
-  if (loading && !chain) return <text fg={colors.textDim}>Loading options chain...</text>;
+  if (loading && !chain) return <Spinner label="Loading options chain..." />;
   if (error) return <text fg={colors.textDim}>{error}</text>;
   if (!chain || chain.expirationDates.length === 0) return <text fg={colors.textDim}>No options available for {effectiveTicker}.</text>;
 
@@ -224,7 +225,7 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
             </box>
           );
         })}
-        {loading && <text fg={colors.textDim}> ...</text>}
+        {loading && <spinner name="dots" color={colors.textDim} />}
       </box>
 
       {/* Position banner */}


### PR DESCRIPTION
## Summary
- Adds `opentui-spinner` package and a reusable `<Spinner>` component wrapping it with app theme colors
- Replaces all static "Loading..." text with animated dot spinners across news, options chain, ask-ai, and header update progress
- Inline spinner used for options expiration loading indicator

## Test plan
- [ ] Verify spinners animate in news tab while loading articles and summaries
- [ ] Verify spinner in options tab during initial chain load and expiration switching
- [ ] Verify ask-ai shows spinner while waiting for AI response
- [ ] Verify header shows spinner during update download/install

🤖 Generated with [Claude Code](https://claude.com/claude-code)