### PR TITLE
Improve number formatting and merge CHG/EXT columns

### DIFF
--- a/src/data/config-store.ts
+++ b/src/data/config-store.ts
@@ -31,7 +31,12 @@ export async function loadConfig(dataDir: string): Promise<AppConfig> {
     const raw = await readFile(configPath, "utf-8");
     const saved = JSON.parse(raw);
     const defaults = createDefaultConfig(dataDir);
-    return { ...defaults, ...saved, dataDir };
+    const config = { ...defaults, ...saved, dataDir };
+    // Migration: ext_hours is now merged into change_pct
+    if (config.columns) {
+      config.columns = config.columns.filter((c: { id: string }) => c.id !== "ext_hours");
+    }
+    return config;
   } catch {
     return createDefaultConfig(dataDir);
   }

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -114,11 +114,21 @@ function getColumnValue(
         color: priceColor(q.change),
       };
     }
-    case "change_pct":
+    case "change_pct": {
+      // During pre/post market, show extended-hours change instead
+      if (q?.marketState === "PRE" && q.preMarketPrice != null) {
+        const chg = q.preMarketChangePercent ?? 0;
+        return { text: formatPercentRaw(chg), color: priceColor(chg) };
+      }
+      if (q?.marketState === "POST" && q.postMarketPrice != null) {
+        const chg = q.postMarketChangePercent ?? 0;
+        return { text: formatPercentRaw(chg), color: priceColor(chg) };
+      }
       return {
         text: q ? formatPercentRaw(q.changePercent) : "—",
         color: q ? priceColor(q.changePercent) : undefined,
       };
+    }
     case "market_cap": {
       if (!q?.marketCap) return { text: "—" };
       return { text: formatCompact(toBase(q.marketCap)) };
@@ -143,7 +153,7 @@ function getColumnValue(
       return { text: "—" };
     }
     case "shares":
-      return { text: totalShares !== 0 ? formatNumber(totalShares, 2) : "—" };
+      return { text: totalShares !== 0 ? formatCompact(totalShares) : "—" };
     case "avg_cost": {
       if (totalShares === 0) return { text: "—" };
       const avgCost = totalCost / Math.abs(totalShares);
@@ -228,8 +238,11 @@ function getSortValue(
       return null;
     case "change":
       return q ? toBase(q.change) : null;
-    case "change_pct":
+    case "change_pct": {
+      if (q?.marketState === "PRE" && q.preMarketPrice != null) return q.preMarketChangePercent ?? 0;
+      if (q?.marketState === "POST" && q.postMarketPrice != null) return q.postMarketChangePercent ?? 0;
       return q?.changePercent ?? null;
+    }
     case "market_cap":
       return q?.marketCap ? toBase(q.marketCap) : null;
     case "pe":

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -33,7 +33,6 @@ export const DEFAULT_COLUMNS: ColumnConfig[] = [
   { id: "ticker", label: "TICKER", width: 8, align: "left" },
   { id: "price", label: "PRICE", width: 10, align: "right", format: "currency" },
   { id: "change_pct", label: "CHG%", width: 8, align: "right", format: "percent" },
-  { id: "ext_hours", label: "EXT%", width: 8, align: "right", format: "percent" },
   { id: "market_cap", label: "MCAP", width: 10, align: "right", format: "compact" },
   { id: "pe", label: "P/E", width: 7, align: "right", format: "number" },
   { id: "forward_pe", label: "FWD P/E", width: 8, align: "right", format: "number" },

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -23,16 +23,22 @@ export function formatPercentRaw(value: number | undefined): string {
   return `${sign}${value.toFixed(2)}%`;
 }
 
-/** Format large numbers compactly (e.g., 1.5T, 234B, 12.3M) */
+/** Format large numbers compactly (e.g., 1.5T, 234B, 12.3M, 5k) */
 export function formatCompact(value: number | undefined): string {
   if (value === undefined || value === null) return "—";
   const abs = Math.abs(value);
   const sign = value < 0 ? "-" : "";
-  if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(2)}T`;
-  if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(2)}B`;
-  if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(2)}M`;
-  if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(1)}K`;
-  return `${sign}${abs.toFixed(2)}`;
+  const fmt = (n: number, decimals: number, suffix: string) => {
+    const fixed = n.toFixed(decimals);
+    // Strip unnecessary trailing zeros after decimal point
+    const trimmed = fixed.includes(".") ? fixed.replace(/\.?0+$/, "") : fixed;
+    return `${sign}${trimmed}${suffix}`;
+  };
+  if (abs >= 1e12) return fmt(abs / 1e12, 2, "T");
+  if (abs >= 1e9) return fmt(abs / 1e9, 2, "B");
+  if (abs >= 1e6) return fmt(abs / 1e6, 2, "M");
+  if (abs >= 1e3) return fmt(abs / 1e3, 1, "k");
+  return fmt(abs, 2, "");
 }
 
 /** Format a plain number with commas */


### PR DESCRIPTION
## Summary
- **Better compact formatting**: `formatCompact` now strips trailing zeros (e.g., `234M` instead of `234.00M`) and uses lowercase `k` for thousands
- **Shares column**: now uses compact formatting instead of raw numbers with decimals
- **Merged CHG% and EXT% into one column**: the CHG% column automatically shows extended-hours change during pre/post market, removing the separate EXT% column
- **Config migration**: existing saved configs have the `ext_hours` column stripped on load

## Test plan
- [ ] Verify compact numbers display without unnecessary decimals (market cap, shares, P&L, etc.)
- [ ] Check CHG% column shows regular change during market hours
- [ ] Check CHG% column shows ext-hours change during pre/post market
- [ ] Confirm EXT% column no longer appears for existing configs