### PR TITLE
Add recent tickers, AGE column, and command bar hover

### DIFF
--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -11,7 +11,7 @@ import { getCurrentThemeId, applyTheme } from "../../theme/colors";
 import { saveConfig, resetAllData, exportConfig, importConfig } from "../../data/config-store";
 import type { DataProvider } from "../../types/data-provider";
 import type { MarkdownStore } from "../../data/markdown-store";
-import type { TickerFrontmatter } from "../../types/ticker";
+import type { TickerFile, TickerFrontmatter } from "../../types/ticker";
 import type { PluginRegistry } from "../../plugins/registry";
 import type { CommandDef, WizardStep } from "../../types/plugin";
 import type { ColumnConfig } from "../../types/config";
@@ -34,6 +34,7 @@ const ALL_COLUMNS: ColumnConfig[] = [
   { id: "mkt_value", label: "MKT VAL", width: 10, align: "right", format: "compact" },
   { id: "pnl", label: "P&L", width: 10, align: "right", format: "compact" },
   { id: "pnl_pct", label: "P&L%", width: 8, align: "right", format: "percent" },
+  { id: "latency", label: "AGE", width: 6, align: "right" },
 ];
 
 interface CommandBarProps {
@@ -818,11 +819,21 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
         });
       }
     } else if (!query) {
-      // Show a limited set of tickers in the default view to avoid overwhelming the list
+      // Show recently visited tickers (or first tickers if no history)
       const maxDefaultTickers = 5;
-      let tickerCount = 0;
-      for (const t of state.tickers.values()) {
-        if (tickerCount >= maxDefaultTickers) break;
+      const recentSymbols = state.recentTickers.slice(0, maxDefaultTickers);
+      const recentTickers = recentSymbols
+        .map((s) => state.tickers.get(s))
+        .filter((t): t is TickerFile => t != null);
+      // Fill remaining slots with other tickers if not enough recent ones
+      if (recentTickers.length < maxDefaultTickers) {
+        const recentSet = new Set(recentSymbols);
+        for (const t of state.tickers.values()) {
+          if (recentTickers.length >= maxDefaultTickers) break;
+          if (!recentSet.has(t.frontmatter.ticker)) recentTickers.push(t);
+        }
+      }
+      for (const t of recentTickers) {
         items.push({
           id: `goto:${t.frontmatter.ticker}`,
           label: t.frontmatter.ticker,
@@ -830,7 +841,6 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           category: "Tickers",
           action: () => { dispatch({ type: "SELECT_TICKER", symbol: t.frontmatter.ticker }); close(); },
         });
-        tickerCount++;
       }
       for (const cmd of commands) {
         const item = cmdToItem(cmd);
@@ -1050,6 +1060,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
                     height={1}
                     paddingX={2}
                     backgroundColor={isSel ? colors.selected : colors.commandBg}
+                    onMouseMove={() => setSelectedIdx(item.globalIdx)}
                     onMouseDown={() => {
                       setSelectedIdx(item.globalIdx);
                       item.action();

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -47,6 +47,7 @@ interface ColumnContext {
   activeTab?: string;
   baseCurrency: string;
   exchangeRates: Map<string, number>;
+  now: number;
 }
 
 function getColumnValue(
@@ -197,6 +198,14 @@ function getColumnValue(
       }
       return { text: "—" };
     }
+    case "latency": {
+      if (!q?.lastUpdated) return { text: "—" };
+      const ago = (ctx.now - q.lastUpdated) / 1000;
+      if (ago < 60) return { text: `${Math.floor(ago)}s` };
+      if (ago < 3600) return { text: `${Math.floor(ago / 60)}m` };
+      if (ago < 86400) return { text: `${Math.floor(ago / 3600)}h` };
+      return { text: `${Math.floor(ago / 86400)}d` };
+    }
     default:
       return { text: "—" };
   }
@@ -283,6 +292,8 @@ function getSortValue(
       if (isOption && brokerPnl !== 0 && totalCost !== 0) return (brokerPnl / totalCost) * 100;
       return null;
     }
+    case "latency":
+      return q?.lastUpdated ?? null;
     default:
       return null;
   }
@@ -448,6 +459,9 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [sortCol, setSortCol] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [now, setNow] = useState(Date.now());
+  const [flashSymbols, setFlashSymbols] = useState<Set<string>>(new Set());
+  const prevPrices = useRef<Map<string, number>>(new Map());
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
 
@@ -468,6 +482,7 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
     activeTab: state.activeLeftTab,
     baseCurrency: state.config.baseCurrency,
     exchangeRates: state.exchangeRates,
+    now,
   };
 
   // Sort tickers
@@ -562,6 +577,31 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
     }
   }, [selectedIdx]);
 
+  // Tick every 5s to keep latency column fresh
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Detect price changes and trigger flash
+  useEffect(() => {
+    const changed = new Set<string>();
+    for (const [symbol, fin] of state.financials) {
+      const price = fin.quote?.price;
+      if (price == null) continue;
+      const prev = prevPrices.current.get(symbol);
+      if (prev != null && prev !== price) {
+        changed.add(symbol);
+      }
+      prevPrices.current.set(symbol, price);
+    }
+    if (changed.size > 0) {
+      setFlashSymbols(changed);
+      const tid = setTimeout(() => setFlashSymbols(new Set()), 600);
+      return () => clearTimeout(tid);
+    }
+  }, [state.financials]);
+
   // Auto-select first ticker when list changes
   if (sortedTickers.length > 0 && selectedIdx >= sortedTickers.length) {
     setSelectedIdx(0);
@@ -626,6 +666,7 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
             const isHovered = idx === hoveredIdx && !isSelected;
             const fin = state.financials.get(ticker.frontmatter.ticker);
             const rowBg = isSelected ? colors.selected : isHovered ? hoverBg() : colors.bg;
+            const isFlashing = flashSymbols.has(ticker.frontmatter.ticker);
 
             return (
               <box
@@ -642,10 +683,12 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
               >
                 {cols.map((col) => {
                   const { text, color } = getColumnValue(col, ticker, fin, columnCtx);
+                  const shouldFlash = isFlashing && col.id !== "ticker" && col.id !== "latency";
                   return (
                     <box key={col.id} width={col.width + 1}>
                       <text
                         fg={color || (isSelected ? colors.selectedText : colors.text)}
+                        attributes={shouldFlash ? TextAttributes.DIM : 0}
                       >
                         {padTo(text, col.width, col.align)}
                       </text>

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useReducer, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useReducer, useRef, type ReactNode } from "react";
 import type { AppConfig } from "../types/config";
+import { saveConfig } from "../data/config-store";
 import type { TickerFile } from "../types/ticker";
 import type { TickerFinancials } from "../types/financials";
 import type { ReleaseInfo, UpdateProgress } from "../updater";
@@ -19,6 +20,8 @@ export interface AppState {
   activeLeftTab: string;
   activeRightTab: string;
   selectedTicker: string | null;
+  /** Most-recently-visited ticker symbols (newest first) */
+  recentTickers: string[];
   commandBarOpen: boolean;
 
   // Loading
@@ -93,8 +96,12 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, financials };
     }
 
-    case "SELECT_TICKER":
-      return { ...state, selectedTicker: action.symbol, activePanel: "right" };
+    case "SELECT_TICKER": {
+      const recentTickers = action.symbol
+        ? [action.symbol, ...state.recentTickers.filter((s) => s !== action.symbol)].slice(0, 50)
+        : state.recentTickers;
+      return { ...state, selectedTicker: action.symbol, recentTickers, activePanel: "right" };
+    }
 
     case "PREVIEW_TICKER":
       return { ...state, selectedTicker: action.symbol };
@@ -204,6 +211,7 @@ export function createInitialState(config: AppConfig): AppState {
     activeLeftTab: config.portfolios[0]?.id || "main",
     activeRightTab: "overview",
     selectedTicker: null,
+    recentTickers: config.recentTickers || [],
     commandBarOpen: false,
     refreshing: new Set(),
     initialized: false,
@@ -222,6 +230,13 @@ export function AppProvider({
   children: ReactNode;
 }) {
   const [state, dispatch] = useReducer(appReducer, config, createInitialState);
+  const prevRecent = useRef(state.recentTickers);
+  useEffect(() => {
+    if (prevRecent.current !== state.recentTickers) {
+      prevRecent.current = state.recentTickers;
+      saveConfig({ ...state.config, recentTickers: state.recentTickers }).catch(() => {});
+    }
+  }, [state.recentTickers, state.config]);
   return (
     <AppContext value={{ state, dispatch }}>
       {children}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -26,6 +26,7 @@ export interface AppConfig {
   plugins: string[];
   disabledPlugins: string[];
   theme: string;
+  recentTickers: string[];
   onboardingComplete?: boolean;
 }
 
@@ -36,6 +37,7 @@ export const DEFAULT_COLUMNS: ColumnConfig[] = [
   { id: "market_cap", label: "MCAP", width: 10, align: "right", format: "compact" },
   { id: "pe", label: "P/E", width: 7, align: "right", format: "number" },
   { id: "forward_pe", label: "FWD P/E", width: 8, align: "right", format: "number" },
+  { id: "latency", label: "AGE", width: 6, align: "right" },
 ];
 
 export const DEFAULT_LAYOUT: PaneLayoutEntry[] = [
@@ -56,5 +58,6 @@ export function createDefaultConfig(dataDir: string): AppConfig {
     plugins: ["portfolio-list", "ticker-detail", "manual-entry", "ibkr-flex"],
     disabledPlugins: [],
     theme: "amber",
+    recentTickers: [],
   };
 }


### PR DESCRIPTION
## Summary
- **Recent tickers in command bar**: Shows up to 5 most recently visited tickers first when opening the command bar with no query. Persisted to config across sessions.
- **AGE latency column**: New sortable column showing how long ago each ticker's quote was fetched (e.g. `2s`, `3m`, `1h`). Updates every 5 seconds. Available in the column editor.
- **Update flash effect**: Numeric cells briefly dim for 600ms when a ticker's price changes after a refresh, providing subtle visual feedback.
- **Command bar mouse hover**: Items in the command bar now highlight on mouse hover, matching the interaction pattern used in the portfolio list and options chain.

## Test plan
- [ ] Open command bar with no query — recently visited tickers should appear first
- [ ] Visit several tickers, reopen command bar — order should reflect recency
- [ ] Enable AGE column via COL command — verify it shows relative timestamps
- [ ] Refresh tickers (R) — verify numeric cells flash briefly
- [ ] Hover over command bar items — verify selection follows the mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)