### PR TITLE
Add terminal chart render modes

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -160,7 +160,7 @@ import { formatCurrency, formatCompact, padTo } from "gloomberb/components";
 ```
 
 Available components:
-- `StockChart` — interactive candlestick/area chart
+- `StockChart` — interactive area, line, candlestick, and OHLC chart
 - `TabBar` — tab navigation bar
 - `ToggleList` — checkbox list with selection
 - `colors` — theme color palette

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An open-source, extensible portfolio tracker and stock terminal for your command
 
 - **Track portfolios & watchlists** — manage multiple portfolios and watchlists with customizable, sortable columns
 - **Real-time quotes & fundamentals** — powered by Yahoo Finance with automatic caching
-- **ASCII stock charts** — 5-year price history rendered with braille characters
+- **Terminal stock charts** — interactive area, line, candlestick, and OHLC render modes
 - **Multi-currency** — automatic exchange rate conversion
 - **Keyboard-driven** — fast command bar (`Ctrl+P`) and vim-style navigation
 - **Extensible via plugins** — everything is a plugin, including core features
@@ -82,6 +82,7 @@ Plugins extend the UI through defined slots:
 | `r` | Refresh selected ticker |
 | `Shift+R` | Refresh all tickers |
 | `Ctrl+,` | Open settings |
+| `m` | Cycle chart mode in the chart tab |
 | `q` | Quit |
 
 ## License

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "bun run --watch src/index.tsx",
     "build": "bun run scripts/build.ts",
     "build:all": "bun run scripts/build.ts --all",
+    "test": "bun test",
     "postinstall": "node install.mjs"
   },
   "license": "MIT",

--- a/src/components/chart/chart-data.ts
+++ b/src/components/chart/chart-data.ts
@@ -1,6 +1,63 @@
 import type { PricePoint } from "../../types/financials";
-import type { TimeRange, ChartViewState, VisibleWindow } from "./chart-types";
+import type { TimeRange, ChartRenderMode, ChartViewState, VisibleWindow } from "./chart-types";
 import { RANGE_DAYS } from "./chart-types";
+
+export interface ProjectedChartPoint {
+  date: Date;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface ChartProjection {
+  points: ProjectedChartPoint[];
+  requestedMode: ChartRenderMode;
+  effectiveMode: ChartRenderMode;
+  fallbackMode: ChartRenderMode | null;
+}
+
+function coerceDate(value: Date | string | number): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+export function getRequestedRenderMode(mode?: ChartRenderMode, compact = false): ChartRenderMode {
+  if (compact) return "area";
+  return mode ?? "area";
+}
+
+export function resolveRenderMode(
+  mode: ChartRenderMode | undefined,
+  chartWidth: number,
+  compact = false,
+): { requestedMode: ChartRenderMode; effectiveMode: ChartRenderMode; fallbackMode: ChartRenderMode | null } {
+  const requestedMode = getRequestedRenderMode(mode, compact);
+  if (compact) {
+    return {
+      requestedMode,
+      effectiveMode: "area",
+      fallbackMode: null,
+    };
+  }
+
+  let effectiveMode = requestedMode;
+  switch (requestedMode) {
+    case "candles":
+      if (chartWidth < 28) effectiveMode = "line";
+      else if (chartWidth < 40) effectiveMode = "ohlc";
+      break;
+    case "ohlc":
+      if (chartWidth < 28) effectiveMode = "line";
+      break;
+  }
+
+  return {
+    requestedMode,
+    effectiveMode,
+    fallbackMode: effectiveMode === requestedMode ? null : effectiveMode,
+  };
+}
 
 /**
  * Filter price history to the selected time range.
@@ -45,22 +102,38 @@ export function getVisibleWindow(
   };
 }
 
+function normalizePoint(point: PricePoint): ProjectedChartPoint {
+  const open = point.open ?? point.close;
+  const high = point.high ?? point.close;
+  const low = point.low ?? point.close;
+
+  return {
+    date: coerceDate(point.date as Date | string | number),
+    open,
+    high,
+    low,
+    close: point.close,
+    volume: point.volume ?? 0,
+  };
+}
+
 /**
- * Downsample data points to fit the target width.
- * Uses LTTB-like bucketing that preserves highs and lows.
+ * Downsample close-driven chart data to fit the target width.
+ * Uses representative closes so line/area charts preserve the broad shape.
  */
-export function downsample(
+export function projectCloseSeries(
   points: PricePoint[],
   targetWidth: number,
-): PricePoint[] {
-  if (points.length <= targetWidth) return points;
+): ProjectedChartPoint[] {
+  if (points.length === 0) return [];
+  if (points.length <= targetWidth) return points.map(normalizePoint);
 
-  const result: PricePoint[] = [];
+  const result: ProjectedChartPoint[] = [];
   const bucketSize = points.length / targetWidth;
 
   for (let i = 0; i < targetWidth; i++) {
     const start = Math.floor(i * bucketSize);
-    const end = Math.floor((i + 1) * bucketSize);
+    const end = Math.min(points.length, Math.max(Math.floor((i + 1) * bucketSize), start + 1));
     const bucket = points.slice(start, end);
 
     if (bucket.length === 0) continue;
@@ -79,8 +152,76 @@ export function downsample(
         if (p.close < best.close) best = p;
       }
     }
-    result.push(best);
+    result.push(normalizePoint(best));
   }
 
   return result;
+}
+
+/**
+ * Bucket OHLC data so each rendered column preserves open, close, high, low, and volume.
+ */
+export function bucketOhlcSeries(
+  points: PricePoint[],
+  targetWidth: number,
+): ProjectedChartPoint[] {
+  if (points.length === 0) return [];
+  if (points.length <= targetWidth) return points.map(normalizePoint);
+
+  const result: ProjectedChartPoint[] = [];
+  const bucketSize = points.length / targetWidth;
+
+  for (let i = 0; i < targetWidth; i++) {
+    const start = Math.floor(i * bucketSize);
+    const end = Math.min(points.length, Math.max(Math.floor((i + 1) * bucketSize), start + 1));
+    const bucket = points.slice(start, end);
+    if (bucket.length === 0) continue;
+
+    const first = bucket[0]!;
+    const last = bucket[bucket.length - 1]!;
+
+    let high = first.high ?? first.close;
+    let low = first.low ?? first.close;
+    let volume = 0;
+
+    for (const point of bucket) {
+      high = Math.max(high, point.high ?? point.close);
+      low = Math.min(low, point.low ?? point.close);
+      volume += point.volume ?? 0;
+    }
+
+    result.push({
+      date: coerceDate(last.date as Date | string | number),
+      open: first.open ?? first.close,
+      high,
+      low,
+      close: last.close,
+      volume,
+    });
+  }
+
+  return result;
+}
+
+export function projectChartData(
+  points: PricePoint[],
+  targetWidth: number,
+  mode: ChartRenderMode | undefined,
+  compact = false,
+): ChartProjection {
+  const { requestedMode, effectiveMode, fallbackMode } = resolveRenderMode(mode, targetWidth, compact);
+  const projectionWidth = effectiveMode === "candles" || effectiveMode === "ohlc"
+    ? Math.max(Math.floor(targetWidth / 2), 1)
+    : targetWidth;
+
+  const projectedPoints = effectiveMode === "candles" || effectiveMode === "ohlc"
+    ? bucketOhlcSeries(points, projectionWidth)
+    : projectCloseSeries(points, projectionWidth);
+
+  return {
+    points: projectedPoints,
+    requestedMode,
+    effectiveMode,
+    fallbackMode,
+  };
 }

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -1,8 +1,7 @@
 import { RGBA } from "@opentui/core";
-import type { PricePoint } from "../../types/financials";
-import type { PixelBuffer, ChartColors } from "./chart-types";
+import type { ChartColors, PixelBuffer, ChartRenderMode } from "./chart-types";
+import type { ProjectedChartPoint } from "./chart-data";
 
-/** A styled chunk for OpenTUI text rendering */
 interface StyledChunk {
   __isChunk: true;
   text: string;
@@ -11,10 +10,28 @@ interface StyledChunk {
   attributes: number;
 }
 
-/** Styled content object passable to <text content={...}> */
 export interface StyledContent {
   chunks: StyledChunk[];
 }
+
+interface ChartPaletteInput {
+  bg: string;
+  border: string;
+  borderFocused: string;
+  text: string;
+  textDim: string;
+  positive: string;
+  negative: string;
+}
+
+export interface ResolvedChartPalette extends ChartColors {
+  candleUp: string;
+  candleDown: string;
+  wickUp: string;
+  wickDown: string;
+}
+
+type VolumeTrendMode = "previousClose" | "openClose";
 
 function makeChunk(text: string, fgColor: string, bgColor: string): StyledChunk {
   return {
@@ -26,7 +43,45 @@ function makeChunk(text: string, fgColor: string, bgColor: string): StyledChunk 
   };
 }
 
-// ─── Pixel Buffer ───────────────────────────────────────────────
+function blendHex(a: string, b: string, ratio: number): string {
+  const parse = (hex: string) => {
+    const h = hex.replace("#", "");
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)] as const;
+  };
+
+  const [ar, ag, ab] = parse(a);
+  const [br, bg, bb] = parse(b);
+  const mix = (x: number, y: number) => Math.round(x + (y - x) * ratio).toString(16).padStart(2, "0");
+  return `#${mix(ar, br)}${mix(ag, bg)}${mix(ab, bb)}`;
+}
+
+export function resolveChartPalette(
+  baseColors: ChartPaletteInput,
+  trend: "positive" | "negative" | "neutral" = "positive",
+): ResolvedChartPalette {
+  const lineColor = trend === "negative"
+    ? baseColors.negative
+    : trend === "neutral"
+      ? baseColors.text
+      : baseColors.positive;
+
+  return {
+    lineColor,
+    fillColor: blendHex(baseColors.bg, lineColor, 0.22),
+    volumeUp: blendHex(baseColors.bg, baseColors.positive, 0.35),
+    volumeDown: blendHex(baseColors.bg, baseColors.negative, 0.35),
+    gridColor: blendHex(baseColors.bg, baseColors.border, 0.55),
+    crosshairColor: baseColors.borderFocused,
+    bgColor: baseColors.bg,
+    axisColor: baseColors.textDim,
+    activeRangeColor: baseColors.text,
+    inactiveRangeColor: blendHex(baseColors.bg, baseColors.textDim, 0.75),
+    candleUp: baseColors.positive,
+    candleDown: baseColors.negative,
+    wickUp: blendHex(baseColors.positive, baseColors.text, 0.35),
+    wickDown: blendHex(baseColors.negative, baseColors.text, 0.35),
+  };
+}
 
 export function createPixelBuffer(width: number, heightPixels: number): PixelBuffer {
   const pixels: (string | null)[][] = [];
@@ -42,13 +97,12 @@ function setPixel(buf: PixelBuffer, x: number, y: number, color: string) {
   }
 }
 
-// ─── Drawing Primitives ─────────────────────────────────────────
-
-/** Bresenham line drawing */
 export function drawLine(
   buf: PixelBuffer,
-  x0: number, y0: number,
-  x1: number, y1: number,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
   color: string,
 ) {
   let dx = Math.abs(x1 - x0);
@@ -56,70 +110,94 @@ export function drawLine(
   const sx = x0 < x1 ? 1 : -1;
   const sy = y0 < y1 ? 1 : -1;
   let err = dx - dy;
-  let x = x0, y = y0;
+  let x = x0;
+  let y = y0;
 
   while (true) {
     setPixel(buf, x, y, color);
     if (x === x1 && y === y1) break;
     const e2 = 2 * err;
-    if (e2 > -dy) { err -= dy; x += sx; }
-    if (e2 < dx) { err += dx; y += sy; }
+    if (e2 > -dy) {
+      err -= dy;
+      x += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y += sy;
+    }
   }
 }
 
-/** Fill a vertical column from y0 down to yMax */
-function fillColumn(buf: PixelBuffer, x: number, y0: number, yMax: number, color: string) {
-  for (let y = y0; y <= yMax; y++) {
+function fillColumn(buf: PixelBuffer, x: number, y0: number, y1: number, color: string) {
+  const start = Math.min(y0, y1);
+  const end = Math.max(y0, y1);
+  for (let y = start; y <= end; y++) {
     setPixel(buf, x, y, color);
   }
 }
 
-// ─── Chart Drawing ──────────────────────────────────────────────
+function getX(index: number, pointCount: number, width: number): number {
+  if (pointCount <= 1) return Math.floor(width / 2);
+  return Math.round((index / (pointCount - 1)) * (width - 1));
+}
 
-/**
- * Draw area chart: line + filled area below.
- */
-export function drawAreaChart(
+function getScaledY(value: number, min: number, max: number, chartTop: number, chartBottom: number): number {
+  const range = max - min || 1;
+  const chartH = chartBottom - chartTop;
+  return chartTop + Math.round((1 - (value - min) / range) * chartH);
+}
+
+function drawLineSeries(
   buf: PixelBuffer,
-  points: PricePoint[],
+  points: ProjectedChartPoint[],
+  chartTop: number,
+  chartBottom: number,
+  lineColor: string,
+  min: number,
+  max: number,
+) {
+  if (points.length === 0) return;
+
+  for (let i = 0; i < points.length; i++) {
+    const x = getX(i, points.length, buf.width);
+    const y = getScaledY(points[i]!.close, min, max, chartTop, chartBottom);
+    if (i < points.length - 1) {
+      const x1 = getX(i + 1, points.length, buf.width);
+      const y1 = getScaledY(points[i + 1]!.close, min, max, chartTop, chartBottom);
+      drawLine(buf, x, y, x1, y1, lineColor);
+    } else {
+      setPixel(buf, x, y, lineColor);
+    }
+  }
+}
+
+function drawAreaChart(
+  buf: PixelBuffer,
+  points: ProjectedChartPoint[],
   chartTop: number,
   chartBottom: number,
   lineColor: string,
   fillColor: string,
+  min: number,
+  max: number,
 ) {
   if (points.length === 0) return;
 
-  const closes = points.map(p => p.close);
-  const min = Math.min(...closes);
-  const max = Math.max(...closes);
-  const range = max - min || 1;
-  const chartH = chartBottom - chartTop;
-
-  const pixelYs = closes.map(v =>
-    chartTop + Math.round((1 - (v - min) / range) * chartH)
-  );
-
-  const getX = (i: number) =>
-    points.length === 1 ? Math.floor(buf.width / 2) :
-    Math.round((i / (points.length - 1)) * (buf.width - 1));
-
   for (let i = 0; i < points.length; i++) {
-    const x = getX(i);
-    const y = pixelYs[i]!;
+    const x = getX(i, points.length, buf.width);
+    const y = getScaledY(points[i]!.close, min, max, chartTop, chartBottom);
 
-    // Fill area below line
     fillColumn(buf, x, y + 1, chartBottom, fillColor);
 
     if (i < points.length - 1) {
-      const x1 = getX(i + 1);
-      const y1 = pixelYs[i + 1]!;
+      const x1 = getX(i + 1, points.length, buf.width);
+      const y1 = getScaledY(points[i + 1]!.close, min, max, chartTop, chartBottom);
       drawLine(buf, x, y, x1, y1, lineColor);
 
-      // Fill area between line segments
       for (let cx = Math.min(x, x1); cx <= Math.max(x, x1); cx++) {
         if (cx === x || cx === x1) continue;
-        const tVal = (cx - x) / (x1 - x);
-        const iy = Math.round(y + tVal * (y1 - y));
+        const t = (cx - x) / Math.max(Math.abs(x1 - x), 1);
+        const iy = Math.round(y + t * (y1 - y));
         fillColumn(buf, cx, iy + 1, chartBottom, fillColor);
       }
     } else {
@@ -128,32 +206,89 @@ export function drawAreaChart(
   }
 }
 
-/**
- * Draw volume bars at the bottom of the chart.
- */
+function drawCandlestickChart(
+  buf: PixelBuffer,
+  points: ProjectedChartPoint[],
+  chartTop: number,
+  chartBottom: number,
+  palette: ResolvedChartPalette,
+  min: number,
+  max: number,
+) {
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i]!;
+    const x = getX(i, points.length, buf.width);
+    const highY = getScaledY(point.high, min, max, chartTop, chartBottom);
+    const lowY = getScaledY(point.low, min, max, chartTop, chartBottom);
+    const openY = getScaledY(point.open, min, max, chartTop, chartBottom);
+    const closeY = getScaledY(point.close, min, max, chartTop, chartBottom);
+    const isUp = point.close >= point.open;
+    const wickColor = isUp ? palette.wickUp : palette.wickDown;
+    const bodyColor = isUp ? palette.candleUp : palette.candleDown;
+
+    drawLine(buf, x, highY, x, lowY, wickColor);
+
+    const bodyTop = Math.min(openY, closeY);
+    const bodyBottom = Math.max(openY, closeY);
+    if (bodyTop === bodyBottom) {
+      const dojiBottom = Math.min(bodyBottom + 1, chartBottom);
+      const dojiTop = Math.max(chartTop, dojiBottom - 1);
+      fillColumn(buf, x, dojiTop, dojiBottom, bodyColor);
+    } else {
+      fillColumn(buf, x, bodyTop, bodyBottom, bodyColor);
+    }
+  }
+}
+
+function drawOhlcChart(
+  buf: PixelBuffer,
+  points: ProjectedChartPoint[],
+  chartTop: number,
+  chartBottom: number,
+  palette: ResolvedChartPalette,
+  min: number,
+  max: number,
+) {
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i]!;
+    const x = getX(i, points.length, buf.width);
+    const highY = getScaledY(point.high, min, max, chartTop, chartBottom);
+    const lowY = getScaledY(point.low, min, max, chartTop, chartBottom);
+    const openY = getScaledY(point.open, min, max, chartTop, chartBottom);
+    const closeY = getScaledY(point.close, min, max, chartTop, chartBottom);
+    const isUp = point.close >= point.open;
+    const color = isUp ? palette.candleUp : palette.candleDown;
+
+    drawLine(buf, x, highY, x, lowY, color);
+    setPixel(buf, x, openY, color);
+    setPixel(buf, Math.max(x - 1, 0), openY, color);
+    setPixel(buf, x, closeY, color);
+    setPixel(buf, Math.min(x + 1, buf.width - 1), closeY, color);
+  }
+}
+
 export function drawVolumeBars(
   buf: PixelBuffer,
-  points: PricePoint[],
+  points: ProjectedChartPoint[],
   yTop: number,
   yBottom: number,
   upColor: string,
   downColor: string,
+  trendMode: VolumeTrendMode,
 ) {
-  const volumes = points.map(p => p.volume ?? 0);
+  const volumes = points.map((point) => point.volume);
   const maxVol = Math.max(...volumes, 1);
   const volH = yBottom - yTop;
 
-  const getX = (i: number) =>
-    points.length === 1 ? Math.floor(buf.width / 2) :
-    Math.round((i / (points.length - 1)) * (buf.width - 1));
-
   for (let i = 0; i < points.length; i++) {
-    const x = getX(i);
-    const vol = volumes[i]!;
-    const barH = Math.round((vol / maxVol) * volH);
+    const point = points[i]!;
+    const x = getX(i, points.length, buf.width);
+    const barH = Math.round((point.volume / maxVol) * volH);
     if (barH === 0) continue;
 
-    const isUp = i === 0 || points[i]!.close >= points[i - 1]!.close;
+    const isUp = trendMode === "openClose"
+      ? point.close >= point.open
+      : i === 0 || point.close >= points[i - 1]!.close;
     const color = isUp ? upColor : downColor;
 
     for (let y = yBottom - barH; y <= yBottom; y++) {
@@ -162,9 +297,6 @@ export function drawVolumeBars(
   }
 }
 
-/**
- * Draw vertical crosshair line (dashed).
- */
 export function drawCrosshair(
   buf: PixelBuffer,
   x: number,
@@ -180,9 +312,6 @@ export function drawCrosshair(
   }
 }
 
-/**
- * Draw subtle horizontal grid lines (dotted).
- */
 export function drawGridLines(
   buf: PixelBuffer,
   yPositions: number[],
@@ -198,13 +327,6 @@ export function drawGridLines(
   }
 }
 
-// ─── Output Conversion ─────────────────────────────────────────
-
-/**
- * Convert pixel buffer to styled content lines using half-block characters.
- * Each terminal row = 2 virtual pixel rows.
- * Returns StyledContent objects for <text content={...}>.
- */
 export function bufferToStyledLines(buf: PixelBuffer, bgColor: string): StyledContent[] {
   const lines: StyledContent[] = [];
   const termRows = Math.ceil(buf.height / 2);
@@ -214,7 +336,6 @@ export function bufferToStyledLines(buf: PixelBuffer, bgColor: string): StyledCo
     const botY = row * 2 + 1;
     const chunks: StyledChunk[] = [];
 
-    // Track runs of identical styling for coalescing
     let runChar = "";
     let runFg = "";
     let runBg = "";
@@ -257,7 +378,6 @@ export function bufferToStyledLines(buf: PixelBuffer, bgColor: string): StyledCo
         cellBg = bot!;
       }
 
-      // Coalesce runs of identical char+fg+bg
       if (char === runChar && cellFg === runFg && cellBg === runBg) {
         runLen++;
       } else {
@@ -268,15 +388,13 @@ export function bufferToStyledLines(buf: PixelBuffer, bgColor: string): StyledCo
         runLen = 1;
       }
     }
-    flushRun();
 
+    flushRun();
     lines.push({ chunks });
   }
 
   return lines;
 }
-
-// ─── Axis Rendering ─────────────────────────────────────────────
 
 export function formatPrice(value: number): string {
   if (Math.abs(value) >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
@@ -286,25 +404,19 @@ export function formatPrice(value: number): string {
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-export function formatDate(date: Date): string {
+export function formatDate(date: Date | string | number): string {
   const d = date instanceof Date ? date : new Date(date);
   if (isNaN(d.getTime())) return "—";
   return `${MONTHS[d.getMonth()]} ${d.getFullYear()}`;
 }
 
-export function formatDateShort(date: Date): string {
+export function formatDateShort(date: Date | string | number): string {
   const d = date instanceof Date ? date : new Date(date);
   if (isNaN(d.getTime())) return "—";
   return `${MONTHS[d.getMonth()]} ${d.getDate()}`;
 }
 
-/**
- * Format a date label appropriate to the time span being displayed.
- * - < 30 days: "Mar 15"
- * - 30-365 days: "Mar 15" (but labels placed at month boundaries)
- * - > 365 days: "Mar 2025"
- */
-function formatDateForSpan(date: Date, spanDays: number): string {
+function formatDateForSpan(date: Date | string | number, spanDays: number): string {
   const d = date instanceof Date ? date : new Date(date);
   if (isNaN(d.getTime())) return "—";
   if (spanDays <= 365) {
@@ -313,46 +425,39 @@ function formatDateForSpan(date: Date, spanDays: number): string {
   return `${MONTHS[d.getMonth()]} ${d.getFullYear()}`;
 }
 
-/**
- * Build a smart time axis string with evenly-spaced labels
- * that adapt to the zoom level and time span.
- */
-export function buildTimeAxis(dates: Date[], width: number): string {
+export function buildTimeAxis(dates: Array<Date | string | number>, width: number): string {
   if (dates.length === 0) return "";
 
-  const toDate = (d: Date | string | number) => d instanceof Date ? d : new Date(d);
-  const first = toDate(dates[0]!);
-  const last = toDate(dates[dates.length - 1]!);
+  const first = dates[0] instanceof Date ? dates[0]! : new Date(dates[0]!);
+  const lastRaw = dates[dates.length - 1]!;
+  const last = lastRaw instanceof Date ? lastRaw : new Date(lastRaw);
   const spanMs = last.getTime() - first.getTime();
   const spanDays = Math.max(spanMs / (1000 * 60 * 60 * 24), 1);
-
-  // Determine label format and compute how wide each label is
   const sampleLabel = formatDateForSpan(first, spanDays);
-  const labelWidth = sampleLabel.length + 2; // padding between labels
-
-  // How many labels can fit
+  const labelWidth = sampleLabel.length + 2;
   const maxLabels = Math.max(Math.floor(width / labelWidth), 2);
   const numLabels = Math.min(maxLabels, dates.length);
 
-  // Pick evenly-spaced date indices
   const labels: { pos: number; text: string }[] = [];
   for (let i = 0; i < numLabels; i++) {
     const frac = numLabels === 1 ? 0 : i / (numLabels - 1);
     const dateIdx = Math.round(frac * (dates.length - 1));
     const xPos = Math.round(frac * (width - 1));
-    const text = formatDateForSpan(toDate(dates[dateIdx]!), spanDays);
-    labels.push({ pos: xPos, text });
+    labels.push({
+      pos: xPos,
+      text: formatDateForSpan(dates[dateIdx]!, spanDays),
+    });
   }
 
-  // Render into a fixed-width string, avoiding overlaps
   const axis = new Array(width).fill(" ");
   for (const label of labels) {
-    // Center the label around its position
     const start = Math.max(Math.min(label.pos - Math.floor(label.text.length / 2), width - label.text.length), 0);
-    // Check for overlap with existing text
     let overlaps = false;
     for (let j = start; j < start + label.text.length && j < width; j++) {
-      if (axis[j] !== " ") { overlaps = true; break; }
+      if (axis[j] !== " ") {
+        overlaps = true;
+        break;
+      }
     }
     if (overlaps) continue;
     for (let j = 0; j < label.text.length && start + j < width; j++) {
@@ -363,9 +468,6 @@ export function buildTimeAxis(dates: Date[], width: number): string {
   return axis.join("");
 }
 
-/**
- * Compute grid line Y positions and their price labels.
- */
 export function computeGridLines(
   min: number,
   max: number,
@@ -379,15 +481,14 @@ export function computeGridLines(
 
   for (let i = 0; i <= numLines; i++) {
     const frac = i / numLines;
-    const price = max - frac * range;
-    const y = chartTop + Math.round(frac * chartH);
-    result.push({ y, price });
+    result.push({
+      y: chartTop + Math.round(frac * chartH),
+      price: max - frac * range,
+    });
   }
 
   return result;
 }
-
-// ─── Full Chart Render ──────────────────────────────────────────
 
 export interface RenderChartOptions {
   width: number;
@@ -395,13 +496,15 @@ export interface RenderChartOptions {
   showVolume: boolean;
   volumeHeight: number;
   cursorX: number | null;
-  colors: ChartColors;
+  mode: ChartRenderMode;
+  colors: ResolvedChartPalette;
 }
 
 export interface RenderChartResult {
   lines: StyledContent[];
   axisLabels: { row: number; label: string }[];
   timeLabels: string;
+  activePoint: ProjectedChartPoint | null;
   priceAtCursor: number | null;
   dateAtCursor: Date | null;
   changeAtCursor: number | null;
@@ -409,7 +512,7 @@ export interface RenderChartResult {
 }
 
 export function renderChart(
-  points: PricePoint[],
+  points: ProjectedChartPoint[],
   opts: RenderChartOptions,
 ): RenderChartResult {
   if (points.length === 0) {
@@ -417,6 +520,7 @@ export function renderChart(
       lines: [],
       axisLabels: [],
       timeLabels: "",
+      activePoint: null,
       priceAtCursor: null,
       dateAtCursor: null,
       changeAtCursor: null,
@@ -424,7 +528,7 @@ export function renderChart(
     };
   }
 
-  const { width, colors: c } = opts;
+  const { width, colors: palette, mode } = opts;
   const volTermRows = opts.showVolume ? opts.volumeHeight : 0;
   const chartTermRows = opts.height - volTermRows;
   const totalPixelH = opts.height * 2;
@@ -433,56 +537,67 @@ export function renderChart(
   const volPixelBottom = totalPixelH - 1;
 
   const buf = createPixelBuffer(width, totalPixelH);
+  const min = mode === "candles" || mode === "ohlc"
+    ? Math.min(...points.map((point) => point.low))
+    : Math.min(...points.map((point) => point.close));
+  const max = mode === "candles" || mode === "ohlc"
+    ? Math.max(...points.map((point) => point.high))
+    : Math.max(...points.map((point) => point.close));
 
-  const closes = points.map(p => p.close);
-  const min = Math.min(...closes);
-  const max = Math.max(...closes);
-
-  // Grid lines
   const gridLines = computeGridLines(min, max, 0, chartPixelBottom, 3);
-  drawGridLines(buf, gridLines.map(g => g.y), c.gridColor);
+  drawGridLines(buf, gridLines.map((line) => line.y), palette.gridColor);
 
-  // Area chart
-  drawAreaChart(buf, points, 0, chartPixelBottom, c.lineColor, c.fillColor);
+  switch (mode) {
+    case "area":
+      drawAreaChart(buf, points, 0, chartPixelBottom, palette.lineColor, palette.fillColor, min, max);
+      break;
+    case "line":
+      drawLineSeries(buf, points, 0, chartPixelBottom, palette.lineColor, min, max);
+      break;
+    case "candles":
+      drawCandlestickChart(buf, points, 0, chartPixelBottom, palette, min, max);
+      break;
+    case "ohlc":
+      drawOhlcChart(buf, points, 0, chartPixelBottom, palette, min, max);
+      break;
+  }
 
-  // Volume
   if (opts.showVolume && volTermRows > 0) {
-    drawVolumeBars(buf, points, volPixelTop, volPixelBottom, c.volumeUp, c.volumeDown);
+    drawVolumeBars(
+      buf,
+      points,
+      volPixelTop,
+      volPixelBottom,
+      palette.volumeUp,
+      palette.volumeDown,
+      mode === "candles" || mode === "ohlc" ? "openClose" : "previousClose",
+    );
   }
 
-  // Cursor
-  let priceAtCursor: number | null = null;
-  let dateAtCursor: Date | null = null;
-  let changeAtCursor: number | null = null;
-  let changePctAtCursor: number | null = null;
+  const activeIdx = opts.cursorX !== null && opts.cursorX >= 0 && opts.cursorX < width
+    ? Math.min(
+      Math.max(Math.round((opts.cursorX / Math.max(width - 1, 1)) * (points.length - 1)), 0),
+      points.length - 1,
+    )
+    : points.length - 1;
+  const activePoint = points[activeIdx]!;
+  const priceAtCursor = activePoint.close;
+  const dateAtCursor = activePoint.date;
+  const changeAtCursor = activePoint.close - points[0]!.close;
+  const changePctAtCursor = points[0]!.close ? ((activePoint.close - points[0]!.close) / points[0]!.close) * 100 : 0;
 
-  if (opts.cursorX !== null && opts.cursorX >= 0 && opts.cursorX < width) {
-    const dataIdx = Math.round((opts.cursorX / Math.max(width - 1, 1)) * (points.length - 1));
-    const clamped = Math.min(Math.max(dataIdx, 0), points.length - 1);
-    const point = points[clamped]!;
-    priceAtCursor = point.close;
-    dateAtCursor = point.date;
-    changeAtCursor = point.close - points[0]!.close;
-    changePctAtCursor = points[0]!.close ? ((point.close - points[0]!.close) / points[0]!.close) * 100 : 0;
-
-    drawCrosshair(buf, opts.cursorX, 0, opts.showVolume ? volPixelBottom : chartPixelBottom, c.crosshairColor);
+  if (opts.cursorX !== null) {
+    drawCrosshair(buf, opts.cursorX, 0, opts.showVolume ? volPixelBottom : chartPixelBottom, palette.crosshairColor);
   }
-
-  const lines = bufferToStyledLines(buf, c.bgColor);
-
-  const axisLabels = gridLines.map(g => ({
-    row: Math.floor(g.y / 2),
-    label: formatPrice(g.price),
-  }));
-
-  // Time axis
-  const dates = points.map(p => p.date);
-  const timeLabels = buildTimeAxis(dates, width);
 
   return {
-    lines,
-    axisLabels,
-    timeLabels,
+    lines: bufferToStyledLines(buf, palette.bgColor),
+    axisLabels: gridLines.map((line) => ({
+      row: Math.floor(line.y / 2),
+      label: formatPrice(line.price),
+    })),
+    timeLabels: buildTimeAxis(points.map((point) => point.date), width),
+    activePoint,
     priceAtCursor,
     dateAtCursor,
     changeAtCursor,

--- a/src/components/chart/chart-types.ts
+++ b/src/components/chart/chart-types.ts
@@ -1,8 +1,10 @@
 import type { PricePoint } from "../../types/financials";
 
 export type TimeRange = "1W" | "1M" | "3M" | "6M" | "1Y" | "5Y" | "ALL";
+export type ChartRenderMode = "area" | "line" | "candles" | "ohlc";
 
 export const TIME_RANGES: TimeRange[] = ["1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
+export const CHART_RENDER_MODES: ChartRenderMode[] = ["area", "line", "candles", "ohlc"];
 
 /** Number of trading days for each time range */
 export const RANGE_DAYS: Record<TimeRange, number> = {
@@ -20,6 +22,7 @@ export interface ChartViewState {
   panOffset: number;   // data points shifted left from right edge (0 = most recent)
   zoomLevel: number;   // 1.0 = default, 2.0 = zoomed in 2x
   cursorX: number | null; // column position of crosshair (null = hidden)
+  renderMode?: ChartRenderMode;
 }
 
 export interface PixelBuffer {

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import { bucketOhlcSeries, projectChartData, resolveRenderMode } from "./chart-data";
+import { renderChart, resolveChartPalette } from "./chart-renderer";
+import type { PricePoint } from "../../types/financials";
+import type { ChartRenderMode } from "./chart-types";
+
+const aggregationFixture: PricePoint[] = [
+  { date: new Date("2024-01-02"), close: 10, volume: 100 },
+  { date: new Date("2024-01-03"), open: 11, high: 14, low: 9, close: 13, volume: 150 },
+  { date: new Date("2024-01-04"), open: 13, high: 15, low: 12, close: 14, volume: 200 },
+  { date: new Date("2024-01-05"), open: 14, high: 16, low: 10, close: 11, volume: 250 },
+];
+
+const chartFixture: PricePoint[] = [
+  { date: new Date("2024-01-02"), open: 10, high: 12, low: 9, close: 11, volume: 100 },
+  { date: new Date("2024-01-03"), open: 11, high: 13, low: 10, close: 12, volume: 120 },
+  { date: new Date("2024-01-04"), open: 12, high: 12.5, low: 8, close: 9, volume: 140 },
+  { date: new Date("2024-01-05"), open: 9, high: 11, low: 8.5, close: 10.5, volume: 160 },
+];
+
+const palette = resolveChartPalette({
+  bg: "#000000",
+  border: "#333333",
+  borderFocused: "#ffff00",
+  text: "#ffffff",
+  textDim: "#777777",
+  positive: "#00ff00",
+  negative: "#ff0000",
+}, "positive");
+
+function textLines(result: ReturnType<typeof renderChart>): string[] {
+  return result.lines.map((line) => line.chunks.map((chunk) => chunk.text).join(""));
+}
+
+describe("bucketOhlcSeries", () => {
+  test("preserves bucket open/close/high/low/volume with missing OHLC fields", () => {
+    const buckets = bucketOhlcSeries(aggregationFixture, 2);
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0]).toEqual({
+      date: new Date("2024-01-03"),
+      open: 10,
+      high: 14,
+      low: 9,
+      close: 13,
+      volume: 250,
+    });
+    expect(buckets[1]).toEqual({
+      date: new Date("2024-01-05"),
+      open: 13,
+      high: 16,
+      low: 10,
+      close: 11,
+      volume: 450,
+    });
+  });
+});
+
+describe("resolveRenderMode", () => {
+  test("applies candle fallback thresholds", () => {
+    expect(resolveRenderMode("candles", 27)).toMatchObject({ effectiveMode: "line", fallbackMode: "line" });
+    expect(resolveRenderMode("candles", 28)).toMatchObject({ effectiveMode: "ohlc", fallbackMode: "ohlc" });
+    expect(resolveRenderMode("candles", 39)).toMatchObject({ effectiveMode: "ohlc", fallbackMode: "ohlc" });
+    expect(resolveRenderMode("candles", 40)).toMatchObject({ effectiveMode: "candles", fallbackMode: null });
+  });
+
+  test("forces compact charts back to area mode", () => {
+    const projection = projectChartData(chartFixture, 80, "candles", true);
+    expect(projection.requestedMode).toBe("area");
+    expect(projection.effectiveMode).toBe("area");
+    expect(projection.fallbackMode).toBeNull();
+  });
+
+  test("uses fewer projected buckets for candles and ohlc to preserve spacing", () => {
+    const denseSeries = Array.from({ length: 100 }, (_, i) => ({
+      date: new Date(2024, 0, i + 1),
+      open: 100 + i,
+      high: 101 + i,
+      low: 99 + i,
+      close: 100.5 + i,
+      volume: 1_000 + i,
+    })) as PricePoint[];
+
+    expect(projectChartData(denseSeries, 80, "candles", false).points).toHaveLength(40);
+    expect(projectChartData(denseSeries, 80, "ohlc", false).points).toHaveLength(40);
+    expect(projectChartData(denseSeries, 80, "line", false).points).toHaveLength(80);
+  });
+});
+
+describe("renderChart", () => {
+  test("maps active bucket metadata across all render modes", () => {
+    const cases: Array<{ mode: ChartRenderMode; width: number; cursorX: number }> = [
+      { mode: "area", width: 12, cursorX: 4 },
+      { mode: "line", width: 12, cursorX: 4 },
+      { mode: "candles", width: 40, cursorX: 13 },
+      { mode: "ohlc", width: 28, cursorX: 9 },
+    ];
+
+    for (const testCase of cases) {
+      const projection = projectChartData(chartFixture, testCase.width, testCase.mode, false);
+      const result = renderChart(projection.points, {
+        width: testCase.width,
+        height: 6,
+        showVolume: false,
+        volumeHeight: 0,
+        cursorX: testCase.cursorX,
+        mode: projection.effectiveMode,
+        colors: palette,
+      });
+
+      expect(result.activePoint?.date.toISOString()).toBe("2024-01-03T00:00:00.000Z");
+      expect(result.activePoint?.close).toBe(12);
+    }
+  });
+
+  test("renders stable terminal shapes for each chart mode", () => {
+    const cases: Array<{ mode: ChartRenderMode; width: number; height: number; lines: string[]; timeLabels: string }> = [
+      {
+        mode: "area",
+        width: 12,
+        height: 5,
+        lines: [
+          "▀  ▀█ ▀  ▀  ",
+          "▄▀▀███▄  ▄  ",
+          "██████▄    ▄",
+          "██████▀  ▀▀█",
+          "████████▀███",
+        ],
+        timeLabels: "Jan 2  Jan 5",
+      },
+      {
+        mode: "line",
+        width: 12,
+        height: 5,
+        lines: [
+          "▀  ▀█ ▀  ▀  ",
+          "▄▀▀▄ █▄  ▄  ",
+          "     ▀▄    ▄",
+          "▀  ▀  █  ▀▀ ",
+          "▄  ▄  ▄█▀▄  ",
+        ],
+        timeLabels: "Jan 2  Jan 5",
+      },
+      {
+        mode: "candles",
+        width: 40,
+        height: 6,
+        lines: [
+          "▀  ▀  ▀  ▀  ▀█ ▀  ▀  ▀  ▀ ▄▀  ▀  ▀  ▀  ▀",
+          "█            █            █             ",
+          "█  ▀  ▀  ▀  ▀▀ ▀  ▀  ▀  ▀ █▀  ▀  ▀  ▀  █",
+          "█  ▄  ▄  ▄  ▄█ ▄  ▄  ▄  ▄ █▄  ▄  ▄  ▄  █",
+          "█                         █            █",
+          "▄  ▄  ▄  ▄  ▄  ▄  ▄  ▄  ▄ █▄  ▄  ▄  ▄  ▀",
+        ],
+        timeLabels: "Jan 2      Jan 3        Jan 4      Jan 5",
+      },
+      {
+        mode: "ohlc",
+        width: 28,
+        height: 6,
+        lines: [
+          "▀  ▀  ▀  █  ▀  ▀  ▀  ▀  ▀  ▀",
+          "█        █▀      ▀█         ",
+          "█▀ ▀  ▀ ▀█  ▀  ▀  █  ▀  ▀  █",
+          "█  ▄  ▄  █  ▄  ▄  █  ▄  ▄  █",
+          "█                 █▄      ▄█",
+          "▄  ▄  ▄  ▄  ▄  ▄  █  ▄  ▄  ▀",
+        ],
+        timeLabels: "Jan 2  Jan 3    Jan 4  Jan 5",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const projection = projectChartData(chartFixture, testCase.width, testCase.mode, false);
+      const result = renderChart(projection.points, {
+        width: testCase.width,
+        height: testCase.height,
+        showVolume: false,
+        volumeHeight: 0,
+        cursorX: null,
+        mode: projection.effectiveMode,
+        colors: palette,
+      });
+
+      expect(textLines(result)).toEqual(testCase.lines);
+      expect(result.timeLabels).toBe(testCase.timeLabels);
+    }
+  });
+
+  test("keeps the default area renderer stable", () => {
+    const projection = projectChartData(chartFixture, 12, undefined, false);
+    const result = renderChart(projection.points, {
+      width: 12,
+      height: 5,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      mode: projection.effectiveMode,
+      colors: palette,
+    });
+
+    expect(projection.requestedMode).toBe("area");
+    expect(projection.effectiveMode).toBe("area");
+    expect(textLines(result)).toEqual([
+      "▀  ▀█ ▀  ▀  ",
+      "▄▀▀███▄  ▄  ",
+      "██████▄    ▄",
+      "██████▀  ▀▀█",
+      "████████▀███",
+    ]);
+  });
+
+  test("accepts serialized string dates from cached chart data", () => {
+    const serialized = chartFixture.map((point) => ({
+      ...point,
+      date: point.date.toISOString(),
+    })) as unknown as PricePoint[];
+
+    const projection = projectChartData(serialized, 12, "area", false);
+    const result = renderChart(projection.points, {
+      width: 12,
+      height: 5,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      mode: projection.effectiveMode,
+      colors: palette,
+    });
+
+    expect(projection.points[0]?.date instanceof Date).toBe(true);
+    expect(result.timeLabels).toBe("Jan 2  Jan 5");
+  });
+});

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1,32 +1,28 @@
-import { useState, useMemo, useEffect, useRef } from "react";
-import { useKeyboard } from "@opentui/react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
 import { useSelectedTicker } from "../../state/app-context";
 import { colors, priceColor } from "../../theme/colors";
-import { formatCurrency, formatPercentRaw } from "../../utils/format";
-import { getVisibleWindow, downsample } from "./chart-data";
-import { renderChart, formatDateShort } from "./chart-renderer";
-import type { StyledContent } from "./chart-renderer";
-import type { ChartViewState, ChartColors } from "./chart-types";
-import type { TimeRange } from "./chart-types";
-import { TIME_RANGES } from "./chart-types";
-import type { PricePoint } from "../../types/financials";
+import { formatCompact, formatCurrency } from "../../utils/format";
 import { getSharedDataProvider } from "../../plugins/registry";
+import { getVisibleWindow, projectChartData } from "./chart-data";
+import { formatDateShort, renderChart, resolveChartPalette } from "./chart-renderer";
+import { CHART_RENDER_MODES, TIME_RANGES, type ChartRenderMode, type ChartViewState } from "./chart-types";
+import type { PricePoint } from "../../types/financials";
 
-function getChartColors(isPositive: boolean): ChartColors {
-  return {
-    lineColor: isPositive ? "#00cc66" : "#ff3333",
-    fillColor: isPositive ? "#003d1e" : "#3d0000",
-    volumeUp: "#004d2e",
-    volumeDown: "#4d0000",
-    gridColor: "#0d1a2d",
-    crosshairColor: "#ffaa00",
-    bgColor: colors.bg,
-    axisColor: colors.textDim,
-    activeRangeColor: colors.text,
-    inactiveRangeColor: "#555555",
-  };
-}
+const MODE_CHIPS: Record<ChartRenderMode, string> = {
+  area: "A",
+  line: "L",
+  candles: "C",
+  ohlc: "O",
+};
+
+const MODE_LABELS: Record<ChartRenderMode, string> = {
+  area: "AREA",
+  line: "LINE",
+  candles: "CANDLES",
+  ohlc: "OHLC",
+};
 
 interface StockChartProps {
   width: number;
@@ -43,17 +39,18 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     panOffset: 0,
     zoomLevel: 1,
     cursorX: null,
+    renderMode: "area",
   });
   const [showVolume, setShowVolume] = useState(!compact);
   const [rangeHistory, setRangeHistory] = useState<PricePoint[] | null>(null);
   const fetchIdRef = useRef(0);
 
-  // Fetch range-specific history when time range changes
   useEffect(() => {
-    if (!getSharedDataProvider() || !ticker || compact) return;
+    const dataProvider = getSharedDataProvider();
+    if (!dataProvider || !ticker || compact) return;
     const id = ++fetchIdRef.current;
-    setRangeHistory(null); // show fallback while loading
-    getSharedDataProvider()
+    setRangeHistory(null);
+    dataProvider
       .getPriceHistory(ticker.frontmatter.ticker, ticker.frontmatter.exchange || "", viewState.timeRange)
       .then((points) => {
         if (id === fetchIdRef.current) setRangeHistory(points);
@@ -63,56 +60,58 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
       });
   }, [ticker?.frontmatter.ticker, viewState.timeRange, compact]);
 
-  // Use range-specific data when available, fall back to financials.priceHistory
   const history = rangeHistory ?? financials?.priceHistory ?? [];
-
   const axisWidth = compact ? 0 : 10;
-  const chartWidth = Math.max(width - axisWidth - 2, 20); // 2 for padding
+  const chartWidth = Math.max(width - axisWidth - 2, 20);
 
-  // Show crosshair at rightmost position when entering interactive mode
   useEffect(() => {
     if (interactive) {
-      setViewState(s => s.cursorX === null ? { ...s, cursorX: chartWidth - 1 } : s);
+      setViewState((state) => (state.cursorX === null ? { ...state, cursorX: chartWidth - 1 } : state));
     } else {
-      setViewState(s => s.cursorX !== null ? { ...s, cursorX: null } : s);
+      setViewState((state) => (state.cursorX !== null ? { ...state, cursorX: null } : state));
     }
   }, [interactive, chartWidth]);
 
-  // Keyboard controls (full mode only)
   useKeyboard((event) => {
     if (!focused || compact) return;
 
     const maxCursorX = chartWidth - 1;
     const panStep = Math.max(Math.floor(chartWidth / 10), 1);
 
-    // These keys always work when focused on chart tab (no interactive mode needed)
     switch (event.name) {
       case "=":
-        setViewState(s => ({ ...s, zoomLevel: Math.min(s.zoomLevel * 1.5, 10) }));
+        setViewState((state) => ({ ...state, zoomLevel: Math.min(state.zoomLevel * 1.5, 10) }));
         return;
       case "-":
-        setViewState(s => ({ ...s, zoomLevel: Math.max(s.zoomLevel / 1.5, 0.5) }));
+        setViewState((state) => ({ ...state, zoomLevel: Math.max(state.zoomLevel / 1.5, 0.5) }));
         return;
       case "0":
-        setViewState(s => ({ ...s, panOffset: 0, zoomLevel: 1, cursorX: null }));
+        setViewState((state) => ({ ...state, panOffset: 0, zoomLevel: 1, cursorX: null }));
         return;
       case "v":
-        setShowVolume(v => !v);
+        setShowVolume((value) => !value);
         return;
       case "a":
-        setViewState(s => ({ ...s, panOffset: s.panOffset + panStep }));
+        setViewState((state) => ({ ...state, panOffset: state.panOffset + panStep }));
         return;
       case "d":
-        setViewState(s => ({ ...s, panOffset: Math.max(s.panOffset - panStep, 0) }));
+        setViewState((state) => ({ ...state, panOffset: Math.max(state.panOffset - panStep, 0) }));
+        return;
+      case "m":
+        setViewState((state) => {
+          const current = state.renderMode ?? "area";
+          const idx = CHART_RENDER_MODES.indexOf(current);
+          const next = CHART_RENDER_MODES[(idx + 1) % CHART_RENDER_MODES.length]!;
+          return { ...state, renderMode: next };
+        });
         return;
     }
 
-    // Number keys for time ranges
     if (event.name >= "1" && event.name <= "7") {
       const idx = parseInt(event.name) - 1;
       if (idx < TIME_RANGES.length) {
-        setViewState(s => ({
-          ...s,
+        setViewState((state) => ({
+          ...state,
           timeRange: TIME_RANGES[idx]!,
           panOffset: 0,
           zoomLevel: 1,
@@ -122,66 +121,72 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
       return;
     }
 
-    // Arrow keys only work in interactive mode (Enter to activate, Escape to exit)
     if (!interactive) return;
 
     switch (event.name) {
       case "left":
         if (event.shift) {
-          setViewState(s => ({ ...s, panOffset: s.panOffset + panStep }));
+          setViewState((state) => ({ ...state, panOffset: state.panOffset + panStep }));
         } else {
-          setViewState(s => {
-            const cur = s.cursorX === null ? maxCursorX : s.cursorX - 1;
-            if (cur < 0) {
-              // At left edge — pan left and keep cursor at 0
-              return { ...s, cursorX: 0, panOffset: s.panOffset + 1 };
+          setViewState((state) => {
+            const nextCursor = state.cursorX === null ? maxCursorX : state.cursorX - 1;
+            if (nextCursor < 0) {
+              return { ...state, cursorX: 0, panOffset: state.panOffset + 1 };
             }
-            return { ...s, cursorX: cur };
+            return { ...state, cursorX: nextCursor };
           });
         }
-        break;
+        return;
       case "right":
         if (event.shift) {
-          setViewState(s => ({ ...s, panOffset: Math.max(s.panOffset - panStep, 0) }));
+          setViewState((state) => ({ ...state, panOffset: Math.max(state.panOffset - panStep, 0) }));
         } else {
-          setViewState(s => {
-            const cur = s.cursorX === null ? 0 : s.cursorX + 1;
-            if (cur > maxCursorX) {
-              // At right edge — pan right and keep cursor at max
-              return { ...s, cursorX: maxCursorX, panOffset: Math.max(s.panOffset - 1, 0) };
+          setViewState((state) => {
+            const nextCursor = state.cursorX === null ? 0 : state.cursorX + 1;
+            if (nextCursor > maxCursorX) {
+              return { ...state, cursorX: maxCursorX, panOffset: Math.max(state.panOffset - 1, 0) };
             }
-            return { ...s, cursorX: cur };
+            return { ...state, cursorX: nextCursor };
           });
         }
-        break;
+        return;
     }
   });
-  const headerRows = compact ? 0 : 3; // header + range bar + spacer
+
+  const headerRows = compact ? 0 : 3;
   const helpRow = compact ? 0 : 1;
   const timeAxisRow = 1;
   const volumeHeight = showVolume && !compact ? 3 : 0;
   const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
 
-  // Compute visible data
-  const { window: visibleWindow, chartColors, result } = useMemo(() => {
-    const w = getVisibleWindow(history, viewState, chartWidth);
-    const sampled = downsample(w.points, chartWidth);
+  const { window: visibleWindow, projection, chartColors, result } = useMemo(() => {
+    const window = getVisibleWindow(history, viewState, chartWidth);
+    const projection = projectChartData(window.points, chartWidth, viewState.renderMode, !!compact);
+    const rawChange = window.points.length >= 2
+      ? window.points[window.points.length - 1]!.close - window.points[0]!.close
+      : 0;
+    const trend = rawChange < 0 ? "negative" : rawChange > 0 ? "positive" : "neutral";
+    const chartColors = resolveChartPalette({
+      bg: colors.bg,
+      border: colors.border,
+      borderFocused: colors.borderFocused,
+      text: colors.text,
+      textDim: colors.textDim,
+      positive: colors.positive,
+      negative: colors.negative,
+    }, trend);
 
-    const isPositive = sampled.length >= 2
-      ? sampled[sampled.length - 1]!.close >= sampled[0]!.close
-      : true;
-    const cc = getChartColors(isPositive);
-
-    const r = renderChart(sampled, {
+    const result = renderChart(projection.points, {
       width: chartWidth,
       height: chartHeight,
       showVolume: showVolume && !compact,
       volumeHeight,
       cursorX: viewState.cursorX !== null ? Math.min(viewState.cursorX, chartWidth - 1) : null,
-      colors: cc,
+      mode: projection.effectiveMode,
+      colors: chartColors,
     });
 
-    return { window: w, chartColors: cc, result: r };
+    return { window, projection, chartColors, result };
   }, [history, viewState, chartWidth, chartHeight, showVolume, compact, volumeHeight]);
 
   if (history.length === 0) {
@@ -192,16 +197,18 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
   const lastPrice = visibleWindow.points[visibleWindow.points.length - 1]?.close ?? 0;
   const change = lastPrice - firstPrice;
   const changePct = firstPrice ? (change / firstPrice) * 100 : 0;
-  const changeColor = priceColor(change);
-
-  // Cursor display values
-  const displayPrice = result.priceAtCursor ?? lastPrice;
-  const displayChange = result.changeAtCursor ?? change;
-  const displayChangePct = result.changePctAtCursor ?? changePct;
-  const displayDate = result.dateAtCursor ? formatDateShort(result.dateAtCursor) : null;
+  const requestedMode = projection.requestedMode;
+  const showOhlcSummary = projection.effectiveMode === "candles" || projection.effectiveMode === "ohlc";
+  const hasCursor = viewState.cursorX !== null;
+  const displayPrice = hasCursor ? (result.priceAtCursor ?? lastPrice) : lastPrice;
+  const displayChange = hasCursor ? (result.changeAtCursor ?? change) : change;
+  const displayChangePct = hasCursor ? (result.changePctAtCursor ?? changePct) : changePct;
+  const displayDate = hasCursor || showOhlcSummary
+    ? (result.dateAtCursor ? formatDateShort(result.dateAtCursor) : null)
+    : null;
+  const activePoint = showOhlcSummary ? result.activePoint : null;
 
   if (compact) {
-    // Compact mode: just the chart lines
     return (
       <box flexDirection="column">
         {result.lines.map((line, i) => (
@@ -209,7 +216,6 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
             <text content={line as any} />
           </box>
         ))}
-        {/* Time axis */}
         <box height={1}>
           <text fg={colors.textDim}>{result.timeLabels}</text>
         </box>
@@ -217,47 +223,75 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     );
   }
 
-  // Full interactive mode
   return (
     <box flexDirection="column" flexGrow={1}>
-      {/* Header: ticker + price at cursor */}
       <box flexDirection="row" gap={2} height={1}>
         <text attributes={TextAttributes.BOLD} fg={colors.textBright}>
           {ticker?.frontmatter.ticker ?? ""} - {viewState.timeRange}
         </text>
-        <text fg={changeColor}>
+        <text fg={priceColor(displayChange)}>
           {formatCurrency(displayPrice)}
         </text>
         <text fg={priceColor(displayChange)}>
           {displayChange >= 0 ? "+" : ""}{displayChange.toFixed(2)} ({displayChangePct >= 0 ? "+" : ""}{displayChangePct.toFixed(2)}%)
         </text>
-        {displayDate && (
-          <text fg={colors.textDim}>{displayDate}</text>
+        {displayDate && <text fg={colors.textDim}>{displayDate}</text>}
+        {showOhlcSummary && activePoint && (
+          <>
+            <text fg={colors.textDim}>O {formatCurrency(activePoint.open)}</text>
+            <text fg={colors.textDim}>H {formatCurrency(activePoint.high)}</text>
+            <text fg={colors.textDim}>L {formatCurrency(activePoint.low)}</text>
+            <text fg={colors.textDim}>C {formatCurrency(activePoint.close)}</text>
+            <text fg={colors.textDim}>V {formatCompact(activePoint.volume)}</text>
+          </>
         )}
       </box>
 
-      {/* Time range bar */}
-      <box flexDirection="row" gap={1} height={1}>
-        {TIME_RANGES.map((r, i) => (
-          <text
-            key={r}
-            fg={viewState.timeRange === r ? chartColors.activeRangeColor : chartColors.inactiveRangeColor}
-            attributes={viewState.timeRange === r ? TextAttributes.BOLD : 0}
-          >
-            {`${i + 1}:${r}`}
-          </text>
-        ))}
-        {viewState.zoomLevel !== 1 && (
-          <text fg={colors.textDim}> zoom:{viewState.zoomLevel.toFixed(1)}x</text>
+      <box flexDirection="row" height={1}>
+        <box flexDirection="row" gap={1}>
+          {TIME_RANGES.map((range, i) => (
+            <text
+              key={range}
+              fg={viewState.timeRange === range ? chartColors.activeRangeColor : chartColors.inactiveRangeColor}
+              attributes={viewState.timeRange === range ? TextAttributes.BOLD : 0}
+            >
+              {`${i + 1}:${range}`}
+            </text>
+          ))}
+          {viewState.zoomLevel !== 1 && (
+            <text fg={colors.textDim}> zoom:{viewState.zoomLevel.toFixed(1)}x</text>
+          )}
+        </box>
+        <box flexGrow={1} />
+        {chartWidth >= 72 ? (
+          <box flexDirection="row" gap={1}>
+            {CHART_RENDER_MODES.map((mode) => (
+              <text
+                key={mode}
+                fg={requestedMode === mode ? chartColors.activeRangeColor : chartColors.inactiveRangeColor}
+                attributes={requestedMode === mode ? TextAttributes.BOLD : 0}
+              >
+                {MODE_CHIPS[mode]}
+              </text>
+            ))}
+            {projection.fallbackMode && (
+              <text fg={colors.textDim}>auto:{MODE_LABELS[projection.fallbackMode]}</text>
+            )}
+          </box>
+        ) : (
+          <box flexDirection="row" gap={1}>
+            <text fg={colors.textDim}>mode:{MODE_LABELS[requestedMode]}</text>
+            {projection.fallbackMode && (
+              <text fg={colors.textDim}>auto:{MODE_LABELS[projection.fallbackMode]}</text>
+            )}
+          </box>
         )}
       </box>
 
-      {/* Spacer */}
       <box height={1} />
 
-      {/* Chart area with axis labels */}
       {result.lines.map((line, i) => {
-        const axisLabel = result.axisLabels.find(a => a.row === i);
+        const axisLabel = result.axisLabels.find((entry) => entry.row === i);
         return (
           <box key={i} flexDirection="row" height={1}>
             <text content={line as any} />
@@ -268,17 +302,15 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
         );
       })}
 
-      {/* Time axis */}
       <box height={1}>
         <text fg={colors.textDim}>{result.timeLabels}</text>
       </box>
 
-      {/* Help bar */}
       <box height={1}>
         <text fg={colors.textMuted}>
           {interactive
-            ? "←→ cursor  ⇧←→ pan  a/d pan  +/- zoom  1-7 range  v vol  Esc exit"
-            : "Enter crosshair  a/d pan  +/- zoom  1-7 range  v volume  0 reset"}
+            ? "←→ cursor  ⇧←→ pan  a/d pan  +/- zoom  m mode  1-7 range  v vol  Esc exit"
+            : "Enter crosshair  a/d pan  +/- zoom  m mode  1-7 range  v volume  0 reset"}
         </text>
       </box>
     </box>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,6 @@
 // Reusable components for plugins
 export { StockChart } from "./chart/stock-chart";
-export type { ChartViewState, TimeRange, ChartColors } from "./chart/chart-types";
+export type { ChartViewState, TimeRange, ChartRenderMode, ChartColors } from "./chart/chart-types";
 export { ToggleList } from "./toggle-list";
 export type { ToggleListItem, ToggleListProps } from "./toggle-list";
 export { TabBar } from "./tab-bar";


### PR DESCRIPTION
Adds area, line, candlestick, and OHLC render modes to `StockChart`, including keyboard cycling, responsive mode fallbacks, and subtle chart-mode UI in the detail pane.

Reworks chart projection and rendering to use proper OHLC bucketing, theme-derived palettes, cache-safe date normalization, and sparser candle spacing so dense candlestick views stay legible.

Adds Bun regression tests for render modes, fallback thresholds, cached string dates, and stable terminal output, and updates the README and plugin docs to match the new chart behavior.