### PR TITLE
Fix command bar plugin toggle and improve chat open/close

### DIFF
--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -250,6 +250,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
   const inputRef = useRef<InputRenderable>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const originalThemeRef = useRef<string>(getCurrentThemeId());
+  const spaceConsumedRef = useRef(false);
 
   useEffect(() => {
     if (inputRef.current) inputRef.current.focus();
@@ -751,6 +752,12 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           const newDisabled = isEnabled
             ? [...disabledPlugins, p.id]
             : disabledPlugins.filter((id) => id !== p.id);
+          // When disabling, hide any floating widgets owned by this plugin
+          if (isEnabled) {
+            for (const widgetId of pluginRegistry.getPluginWidgetIds(p.id)) {
+              pluginRegistry.hideWidget(widgetId);
+            }
+          }
           saveConfig({ ...state.config, disabledPlugins: newDisabled }).catch(() => {});
         };
         items.push({
@@ -860,8 +867,8 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
     }
 
     setResults(items);
-    // In columns mode, preserve the selected index across re-renders (toggling)
-    if (match?.command.id === "columns") {
+    // In columns/plugin mode, preserve the selected index across re-renders (toggling)
+    if (match?.command.id === "columns" || match?.command.id === "plugins") {
       setSelectedIdx((prev) => Math.min(prev, items.length - 1));
     } else {
       setSelectedIdx(initialIdx);
@@ -927,10 +934,12 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
       setSelectedIdx((i) => Math.max(i - 1, 0));
     } else if (event.name === "space" && isPluginMode) {
       // Space toggles plugins without closing
+      spaceConsumedRef.current = true;
       const selected = results[selectedIdx];
       if (selected?.pluginToggle) selected.pluginToggle();
     } else if (event.name === "space" && isColumnsMode) {
       // Toggle column with space
+      spaceConsumedRef.current = true;
       const selected = results[selectedIdx];
       if (selected) selected.action();
     } else if (event.name === "return" || event.name === "enter") {
@@ -999,8 +1008,14 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           textColor={colors.text}
           placeholderColor={colors.textDim}
           backgroundColor={colors.commandBg}
-          onInput={(val) => setQuery(val)}
-          onChange={(val) => setQuery(val)}
+          onInput={(val) => {
+            if (spaceConsumedRef.current) { spaceConsumedRef.current = false; return; }
+            setQuery(val);
+          }}
+          onChange={(val) => {
+            if (spaceConsumedRef.current) { spaceConsumedRef.current = false; return; }
+            setQuery(val);
+          }}
           onSubmit={() => {
             const selected = results[selectedIdx];
             if (selected) selected.action();

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect, useReducer } from "react";
 import { useTerminalDimensions } from "@opentui/react";
 import { useDialogState } from "@opentui-ui/dialog/react";
 import { useAppState } from "../../state/app-context";
@@ -18,7 +18,21 @@ const GRAB_ZONE = 3;
 export function Shell({ pluginRegistry }: ShellProps) {
   const { state, dispatch } = useAppState();
   const { width, height } = useTerminalDimensions();
-  const resolved = resolvePanes(state.config.layout, pluginRegistry.panes);
+
+  // Force re-render when floating widget visibility changes
+  const [, forceRender] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    return pluginRegistry.onWidgetVisibilityChange(forceRender);
+  }, [pluginRegistry]);
+  const disabledPlugins = new Set(state.config.disabledPlugins || []);
+  const disabledPaneIds = new Set<string>();
+  for (const pluginId of disabledPlugins) {
+    for (const paneId of pluginRegistry.getPluginPaneIds(pluginId)) {
+      disabledPaneIds.add(paneId);
+    }
+  }
+  const resolved = resolvePanes(state.config.layout, pluginRegistry.panes)
+    .filter((p) => !disabledPaneIds.has(p.def.id));
   const leftPanes = getPanesByPosition(resolved, "left");
   const rightPanes = getPanesByPosition(resolved, "right");
 

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -10,6 +10,42 @@ import { getSharedRegistry } from "../../plugins/registry";
 
 const CHANNEL_ID = "everyone";
 
+// Module-level caches so re-opening the widget is instant
+let _cachedUser: { id: string; username: string } | null = null;
+let _sessionChecked = false;
+let _cachedMessages: ChatMessage[] = [];
+let _wsConn: { send: (content: string, replyToId?: string) => void; close: () => void } | null = null;
+let _wsConnected = false;
+let _messageListeners = new Set<(msgs: ChatMessage[]) => void>();
+
+function _notifyMessageListeners() {
+  for (const listener of _messageListeners) {
+    try { listener(_cachedMessages); } catch { /* ignore */ }
+  }
+}
+
+/** Start the persistent WebSocket connection + fetch history (called once after auth) */
+function _ensureConnection() {
+  if (_wsConnected || !_cachedUser) return;
+  _wsConnected = true;
+
+  // Fetch message history via REST
+  apiClient.getMessages(CHANNEL_ID, { limit: 50 }).then((msgs) => {
+    _cachedMessages = msgs;
+    _notifyMessageListeners();
+  }).catch(() => {});
+
+  // Connect WebSocket for live updates
+  _wsConn = apiClient.connectChannel(
+    CHANNEL_ID,
+    (msg) => {
+      if (_cachedMessages.some((m) => m.id === msg.id)) return;
+      _cachedMessages = [..._cachedMessages, msg];
+      _notifyMessageListeners();
+    },
+  );
+}
+
 // --- Relative time formatting ---
 
 function relativeTime(dateStr: string): string {
@@ -42,9 +78,8 @@ function renderMessageContent(
           return (
             <text
               key={i}
-              fg={colors.bg}
-              backgroundColor={colors.positive}
-              attributes={TextAttributes.BOLD}
+              fg={colors.positive}
+              attributes={TextAttributes.BOLD | TextAttributes.INVERSE}
               onMouseDown={() => selectTicker(symbol)}
             >
               {` ${part} `}
@@ -65,66 +100,47 @@ interface ChatContentProps {
   height: number;
   focused: boolean;
   selectTicker: (symbol: string) => void;
+  close?: () => void;
 }
 
-function ChatContent({ width, height, focused, selectTicker }: ChatContentProps) {
+function ChatContent({ width, height, focused, selectTicker, close }: ChatContentProps) {
   const { dispatch } = useAppState();
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [user, setUser] = useState<{ id: string; username: string } | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [messages, setMessages] = useState<ChatMessage[]>(_cachedMessages);
+  const [user, setUser] = useState<{ id: string; username: string } | null>(_cachedUser);
+  const [loading, setLoading] = useState(!_sessionChecked);
   const [inputFocused, setInputFocused] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(null);
   const [scrollOffset, setScrollOffset] = useState(0);
   const inputRef = useRef<InputRenderable>(null);
-  const lastMessageIdRef = useRef<string | null>(null);
 
-  // Check auth state
+  // Check auth state (uses module-level cache for instant re-opens)
   useEffect(() => {
+    if (_sessionChecked) return;
     let cancelled = false;
     const check = async () => {
       const session = await apiClient.getSession();
       if (!cancelled) {
-        setUser(session ? { id: session.id, username: session.username ?? session.name } : null);
+        const u = session ? { id: session.id, username: session.username ?? session.name } : null;
+        _cachedUser = u;
+        _sessionChecked = true;
+        setUser(u);
         setLoading(false);
+        _ensureConnection();
       }
     };
     check();
     return () => { cancelled = true; };
   }, []);
 
-  // WebSocket connection + initial history fetch
-  const wsRef = useRef<{ send: (content: string, replyToId?: string) => void; close: () => void } | null>(null);
-
+  // Subscribe to module-level message updates
   useEffect(() => {
     if (!user) return;
-
-    // Fetch message history via REST
-    apiClient.getMessages(CHANNEL_ID, { limit: 50 }).then((msgs) => {
-      setMessages(msgs);
-      if (msgs.length > 0) lastMessageIdRef.current = msgs[msgs.length - 1].id;
-    }).catch(() => {});
-
-    // Connect WebSocket for live updates
-    const conn = apiClient.connectChannel(
-      CHANNEL_ID,
-      (msg) => {
-        setMessages((prev) => {
-          // Deduplicate by ID
-          if (prev.some((m) => m.id === msg.id)) return prev;
-          const updated = [...prev, msg];
-          lastMessageIdRef.current = msg.id;
-          return updated;
-        });
-      },
-    );
-    wsRef.current = conn;
-
-    return () => {
-      conn.close();
-      wsRef.current = null;
-    };
+    _ensureConnection();
+    const listener = (msgs: ChatMessage[]) => setMessages(msgs);
+    _messageListeners.add(listener);
+    return () => { _messageListeners.delete(listener); };
   }, [user]);
 
   // Send message via WebSocket
@@ -136,7 +152,7 @@ function ChatContent({ width, height, focused, selectTicker }: ChatContentProps)
   const sendMessage = useCallback(() => {
     const content = inputValueRef.current.trim();
     if (!content) return;
-    wsRef.current?.send(content, replyToRef.current?.id);
+    _wsConn?.send(content, replyToRef.current?.id);
     setInputValue("");
     setReplyTo(null);
     setScrollOffset(0);
@@ -146,6 +162,16 @@ function ChatContent({ width, height, focused, selectTicker }: ChatContentProps)
   // Keyboard handling
   useKeyboard((event) => {
     if (!focused) return;
+
+    // Shift+C always closes the widget (even when input is captured)
+    if (event.name === "c" && event.shift) {
+      if (inputFocused) {
+        setInputFocused(false);
+        dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+      }
+      close?.();
+      return;
+    }
 
     if (inputFocused) {
       if (event.name === "escape") {
@@ -165,8 +191,9 @@ function ChatContent({ width, height, focused, selectTicker }: ChatContentProps)
       return;
     }
 
+    // Escape closes the widget
     if (event.name === "escape") {
-      setSelectedIdx(-1);
+      close?.();
       return;
     }
 
@@ -438,15 +465,20 @@ export const chatPlugin: GloomPlugin = {
       width: "90%",
       height: "90%",
       captureInput: true,
-      component: ({ width, height, focused }) => {
+      component: ({ width, height, focused, close }) => {
         const registry = getSharedRegistry();
-        const selectTicker = (symbol: string) => registry?.selectTickerFn(symbol);
+        const selectTicker = (symbol: string) => {
+          registry?.selectTickerFn(symbol);
+          registry?.switchTabFn("overview");
+          close?.();
+        };
         return (
           <ChatContent
             width={width}
             height={height}
             focused={focused}
             selectTicker={selectTicker}
+            close={close}
           />
         );
       },
@@ -485,6 +517,12 @@ export const chatPlugin: GloomPlugin = {
         await apiClient.signIn(values.email, values.password);
         const token = apiClient.getSessionToken();
         if (token) ctx.storage.set("session_token", token);
+        _sessionChecked = false;
+        _cachedUser = null;
+        _wsConn?.close();
+        _wsConn = null;
+        _wsConnected = false;
+        _cachedMessages = [];
         ctx.showWidget("chat-widget");
       },
     });
@@ -518,6 +556,12 @@ export const chatPlugin: GloomPlugin = {
         await apiClient.signUp(values.email, values.username, values.name, values.password);
         const token = apiClient.getSessionToken();
         if (token) ctx.storage.set("session_token", token);
+        _sessionChecked = false;
+        _cachedUser = null;
+        _wsConn?.close();
+        _wsConn = null;
+        _wsConnected = false;
+        _cachedMessages = [];
         ctx.showWidget("chat-widget");
       },
     });
@@ -536,6 +580,12 @@ export const chatPlugin: GloomPlugin = {
         }
         await apiClient.signOut();
         ctx.storage.delete("session_token");
+        _sessionChecked = false;
+        _cachedUser = null;
+        _wsConn?.close();
+        _wsConn = null;
+        _wsConnected = false;
+        _cachedMessages = [];
         ctx.showToast("Logged out.", { type: "info" });
       },
       // Hide when not authenticated

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -112,8 +112,47 @@ export class PluginRegistry {
     return last;
   }
 
-  showWidget(widgetId: string): void { this._visibleWidgets.add(widgetId); }
-  hideWidget(widgetId: string): void { this._visibleWidgets.delete(widgetId); }
+  private _widgetChangeListeners = new Set<() => void>();
+
+  onWidgetVisibilityChange(listener: () => void): () => void {
+    this._widgetChangeListeners.add(listener);
+    return () => { this._widgetChangeListeners.delete(listener); };
+  }
+
+  private _notifyWidgetChange(): void {
+    for (const listener of this._widgetChangeListeners) {
+      try { listener(); } catch { /* ignore */ }
+    }
+  }
+
+  /** Get floating widget IDs registered by a specific plugin */
+  getPluginWidgetIds(pluginId: string): string[] {
+    return this._pluginItems.get(pluginId)?.floatingWidgets ?? [];
+  }
+
+  /** Get pane IDs registered by a specific plugin */
+  getPluginPaneIds(pluginId: string): string[] {
+    return this._pluginItems.get(pluginId)?.panes ?? [];
+  }
+
+  showWidget(widgetId: string): void {
+    // Don't show widgets from disabled plugins
+    try {
+      const disabledPlugins = new Set(this.getConfigFn().disabledPlugins || []);
+      for (const [pluginId, items] of this._pluginItems) {
+        if (items.floatingWidgets.includes(widgetId) && disabledPlugins.has(pluginId)) {
+          return;
+        }
+      }
+    } catch { /* getConfigFn not set yet during init — allow */ }
+    this._visibleWidgets.add(widgetId);
+    this._notifyWidgetChange();
+  }
+
+  hideWidget(widgetId: string): void {
+    this._visibleWidgets.delete(widgetId);
+    this._notifyWidgetChange();
+  }
 
   private createContext(pluginId: string): GloomPluginContext {
     const items: PluginItems = {


### PR DESCRIPTION
## Summary

Fixes three bugs with plugin toggling in the command bar and improves chat widget open/close behavior:

- **Space key leaking into input**: Pressing space to toggle a plugin/column also inserted a space character into the search input. Fixed with a ref flag that suppresses the input update when space was consumed by the toggle handler.
- **Selection resetting on toggle**: Toggling a plugin re-rendered the list and reset selection to the first item. Extended the existing columns-mode index preservation to also cover plugin mode.
- **Disabled plugins still visible**: Toggling a plugin off only updated the config but didn't hide its floating widgets or panes. Now hides widgets on disable, filters panes in the shell, and prevents `showWidget()` from re-showing disabled plugin widgets via shortcuts.

Also includes chat UX improvements: persistent WebSocket connection across widget opens, module-level message caching for instant re-opens, Escape/Shift+C to close the widget, and ticker selection navigates to overview tab.

## Test plan

- [ ] Open command bar, type "PL", press space to toggle plugins — verify no space appears in input
- [ ] Toggle multiple plugins — verify selection stays on the same item
- [ ] Disable the Chat plugin — verify the chat widget and pane disappear
- [ ] Press Shift+C with chat disabled — verify it does not reappear
- [ ] Re-enable Chat plugin — verify Shift+C works again
- [ ] Open chat, close with Escape or Shift+C — verify it closes cleanly
- [ ] Close and reopen chat — verify messages load instantly from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)