### PR TITLE
Add modular pane system with dynamic columns and floating windows

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -72,7 +72,6 @@ The `setup()` function receives a context object with these capabilities:
 | `ctx.registerDataProvider(provider)` | Add a data source |
 | `ctx.registerShortcut(shortcut)` | Add a global keyboard shortcut |
 | `ctx.registerTickerAction(action)` | Add a per-ticker action (shown via `a` key) |
-| `ctx.registerFloatingWidget(widget)` | Add a floating overlay widget |
 
 ### Data access
 
@@ -128,25 +127,27 @@ ctx.showToast("Something went wrong", { type: "error", duration: 5000 });
 ctx.showToast("FYI...");  // defaults to "info"
 ```
 
-### Floating widgets
+### Floating panes
+
+Panes with `defaultMode: "floating"` open as draggable/resizable floating windows:
 
 ```typescript
-ctx.registerFloatingWidget({
-  id: "my-widget",
-  name: "My Widget",
-  position: "top-right",  // top-left, top-right, bottom-left, bottom-right, center
-  width: 40,
-  height: 10,
+ctx.registerPane({
+  id: "my-pane",
+  name: "My Pane",
   component: ({ width, height, focused, close }) => (
     <Box flexDirection="column" width={width} height={height}>
-      <Text>Hello from widget!</Text>
+      <Text>Hello from pane!</Text>
     </Box>
   ),
+  defaultPosition: "right",
+  defaultMode: "floating",
+  defaultFloatingSize: { width: 40, height: 10 },
 });
 
-// Show/hide programmatically
-ctx.showWidget("my-widget");
-ctx.hideWidget("my-widget");
+// Show/hide as floating window programmatically
+ctx.showWidget("my-pane");
+ctx.hideWidget("my-pane");
 ```
 
 ## Reusable components

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -27,6 +27,7 @@ import { optionsPlugin } from "./plugins/builtin/options";
 import { notesPlugin } from "./plugins/builtin/notes";
 import { askAiPlugin } from "./plugins/builtin/ask-ai";
 import { chatPlugin } from "./plugins/builtin/chat";
+import { layoutManagerPlugin, setLayoutManagerDispatch } from "./plugins/builtin/layout-manager";
 import { saveConfig } from "./data/config-store";
 import { Toaster, toast } from "@opentui-ui/toast/react";
 import { checkForUpdate, performUpdate } from "./updater";
@@ -246,6 +247,19 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
   pluginRegistry.switchPanelFn = (panel) => dispatch({ type: "SET_ACTIVE_PANEL", panel });
   pluginRegistry.switchTabFn = (tabId) => dispatch({ type: "SET_RIGHT_TAB", tab: tabId });
   pluginRegistry.openCommandBarFn = () => dispatch({ type: "SET_COMMAND_BAR", open: true });
+  pluginRegistry.focusPaneFn = (paneId) => dispatch({ type: "FOCUS_PANE", paneId });
+  pluginRegistry.getLayoutFn = () => state.config.layout;
+  pluginRegistry.updateLayoutFn = (layout) => {
+    dispatch({ type: "UPDATE_LAYOUT", layout });
+    saveConfig({ ...state.config, layout }).catch(() => {});
+  };
+
+  // Wire up layout manager
+  setLayoutManagerDispatch(dispatch, () => ({
+    layout: state.config.layout,
+    termWidth: 120, // approximate — will be exact when Shell renders
+    termHeight: 40,
+  }));
 
   // Wire up toast
   pluginRegistry.showToastFn = (message, options) => {
@@ -292,10 +306,26 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
     if (state.commandBarOpen || state.inputCaptured) return;
 
     if (event.name === "tab") {
-      dispatch({
-        type: "SET_ACTIVE_PANEL",
-        panel: state.activePanel === "left" ? "right" : "left",
-      });
+      // Build pane order from current layout for cycling
+      const layout = state.config.layout;
+      const paneOrder: string[] = [];
+      // Docked panes by column, then floating
+      const byCol = new Map<number, string[]>();
+      for (const d of layout.docked) {
+        const list = byCol.get(d.columnIndex) ?? [];
+        list.push(d.paneId);
+        byCol.set(d.columnIndex, list);
+      }
+      for (const colIdx of [...byCol.keys()].sort((a, b) => a - b)) {
+        paneOrder.push(...byCol.get(colIdx)!);
+      }
+      for (const f of layout.floating) paneOrder.push(f.paneId);
+
+      if (event.shift) {
+        dispatch({ type: "FOCUS_PREV", paneOrder });
+      } else {
+        dispatch({ type: "FOCUS_NEXT", paneOrder });
+      }
     } else if (event.name === "q" && !(state.activePanel === "right" && state.activeRightTab === "financials")) {
       renderer.destroy();
     } else if (event.name === "r") {
@@ -373,6 +403,9 @@ export function App({ config: initialConfig, renderer, externalPlugins = [] }: A
   pluginRegistry.register(tickerDetailPlugin);
   pluginRegistry.register(manualEntryPlugin);
   pluginRegistry.register(ibkrFlexPlugin);
+
+  // Core utility plugins
+  pluginRegistry.register(layoutManagerPlugin);
 
   // Feature plugins (toggleable by user)
   pluginRegistry.register(newsPlugin);

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -752,10 +752,10 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           const newDisabled = isEnabled
             ? [...disabledPlugins, p.id]
             : disabledPlugins.filter((id) => id !== p.id);
-          // When disabling, hide any floating widgets owned by this plugin
+          // When disabling, hide any floating panes owned by this plugin
           if (isEnabled) {
-            for (const widgetId of pluginRegistry.getPluginWidgetIds(p.id)) {
-              pluginRegistry.hideWidget(widgetId);
+            for (const paneId of pluginRegistry.getPluginPaneIds(p.id)) {
+              pluginRegistry.hideWidget(paneId);
             }
           }
           saveConfig({ ...state.config, disabledPlugins: newDisabled }).catch(() => {});

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { colors } from "../../theme/colors";
+
+interface FloatingPaneWrapperProps {
+  title: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zIndex: number;
+  focused: boolean;
+  children: ReactNode;
+}
+
+/** Pure visual wrapper — all mouse handling done by Shell at root level */
+export function FloatingPaneWrapper({
+  title, x, y, width, height, zIndex, focused, children,
+}: FloatingPaneWrapperProps) {
+  const borderColor = focused ? colors.borderFocused : colors.border;
+  const innerWidth = width - 2; // subtract borders
+
+  return (
+    <box
+      position="absolute"
+      top={y}
+      left={x}
+      width={width}
+      height={height}
+      zIndex={zIndex}
+      backgroundColor={colors.bg}
+      borderStyle="single"
+      borderColor={borderColor}
+      flexDirection="column"
+    >
+      {/* Title bar — non-selectable to prevent text highlighting during drag */}
+      <box height={1} width={innerWidth} flexDirection="row">
+        <text fg={focused ? colors.text : colors.textDim} selectable={false}>
+          {buildTitleBar(title, innerWidth)}
+        </text>
+      </box>
+
+      {/* Content */}
+      <box flexGrow={1} overflow="hidden">
+        {children}
+      </box>
+
+      {/* Resize handle at bottom-right corner */}
+      <box position="absolute" bottom={0} right={0} width={1} height={1}>
+        <text fg={colors.textDim} selectable={false}>+</text>
+      </box>
+    </box>
+  );
+}
+
+function buildTitleBar(title: string, availableWidth: number): string {
+  const closeBtn = " [x]";
+  const space = availableWidth - closeBtn.length - 1; // -1 for leading space
+  const truncatedTitle = title.length > space ? title.slice(0, space - 1) + ".." : title;
+  const padding = "-".repeat(Math.max(0, space - truncatedTitle.length));
+  return ` ${truncatedTitle}${padding}${closeBtn}`;
+}

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,10 +1,16 @@
-import { useState, useRef, useCallback, useEffect, useReducer } from "react";
+import { useState, useRef, useCallback, useMemo } from "react";
 import { useTerminalDimensions } from "@opentui/react";
 import { useDialogState } from "@opentui-ui/dialog/react";
 import { useAppState } from "../../state/app-context";
-import { resolvePanes, getPanesByPosition, parseWidth } from "../../plugins/pane-manager";
+import {
+  resolveDockedByColumn, resolveFloating, parseWidth,
+  updateFloatingPane, bringToFront, updateColumnWidth, removePane,
+  type ResolvedPane,
+} from "../../plugins/pane-manager";
 import type { PluginRegistry } from "../../plugins/registry";
+import type { LayoutConfig } from "../../types/config";
 import { PaneWrapper } from "./pane";
+import { FloatingPaneWrapper } from "./floating-pane";
 import { colors } from "../../theme/colors";
 import { saveConfig } from "../../data/config-store";
 
@@ -12,18 +18,28 @@ interface ShellProps {
   pluginRegistry: PluginRegistry;
 }
 
-// How many columns around the divider count as a grab zone
 const GRAB_ZONE = 3;
+const MIN_PANE_WIDTH = 20;
+const MIN_FLOAT_WIDTH = 15;
+const MIN_FLOAT_HEIGHT = 6;
+// The Shell sits below a 1-row Header. onMouse e.x/e.y are absolute terminal
+// coords, so we subtract this offset to get Shell-relative y values that match
+// the `top` prop of position:absolute children.
+const HEADER_HEIGHT = 1;
+
+type DragMode =
+  | { type: "column-divider"; colIdx: number; startX: number; origWidth: number }
+  | { type: "float-move"; paneId: string; startX: number; startY: number; origX: number; origY: number; paneW: number; paneH: number }
+  | { type: "float-resize"; paneId: string; startX: number; startY: number; origW: number; origH: number; paneX: number; paneY: number };
 
 export function Shell({ pluginRegistry }: ShellProps) {
   const { state, dispatch } = useAppState();
   const { width, height } = useTerminalDimensions();
 
-  // Force re-render when floating widget visibility changes
-  const [, forceRender] = useReducer((x: number) => x + 1, 0);
-  useEffect(() => {
-    return pluginRegistry.onWidgetVisibilityChange(forceRender);
-  }, [pluginRegistry]);
+  const layout = state.config.layout;
+  const contentHeight = height - (state.statusBarVisible ? 2 : 1);
+
+  // Filter out panes from disabled plugins
   const disabledPlugins = new Set(state.config.disabledPlugins || []);
   const disabledPaneIds = new Set<string>();
   for (const pluginId of disabledPlugins) {
@@ -31,173 +47,337 @@ export function Shell({ pluginRegistry }: ShellProps) {
       disabledPaneIds.add(paneId);
     }
   }
-  const resolved = resolvePanes(state.config.layout, pluginRegistry.panes)
-    .filter((p) => !disabledPaneIds.has(p.def.id));
-  const leftPanes = getPanesByPosition(resolved, "left");
-  const rightPanes = getPanesByPosition(resolved, "right");
 
-  const contentHeight = height - (state.statusBarVisible ? 2 : 1);
+  // Resolve docked and floating panes
+  const dockedByColumn = resolveDockedByColumn(layout, pluginRegistry.panes);
+  const floatingPanes = resolveFloating(layout, pluginRegistry.panes);
+
+  const filteredColumns = new Map<number, ResolvedPane[]>();
+  for (const [colIdx, panes] of dockedByColumn) {
+    const filtered = panes.filter((p) => !disabledPaneIds.has(p.def.id));
+    if (filtered.length > 0) filteredColumns.set(colIdx, filtered);
+  }
+  const filteredFloating = floatingPanes.filter((p) => !disabledPaneIds.has(p.def.id));
+
+  const columnIndices = [...filteredColumns.keys()].sort((a, b) => a - b);
+  const numColumns = columnIndices.length;
+
+  // Pane focus order: docked left→right, top→bottom, then floating by z
+  const paneOrder = useMemo(() => {
+    const order: string[] = [];
+    for (const colIdx of columnIndices) {
+      for (const p of filteredColumns.get(colIdx)!) order.push(p.def.id);
+    }
+    for (const p of filteredFloating) order.push(p.def.id);
+    return order;
+  }, [columnIndices.join(","), filteredColumns, filteredFloating]);
 
   const dialogOpen = useDialogState((s) => s.isOpen);
   const overlayOpen = state.commandBarOpen || dialogOpen;
-  const leftFocused = state.activePanel === "left" && !overlayOpen;
-  const rightFocused = state.activePanel === "right" && !overlayOpen;
 
-  const [dragging, setDragging] = useState(false);
-  const [dragWidth, setDragWidth] = useState<number | null>(null);
-  const draggingRef = useRef(false);
+  // --- Drag state ---
+  const dragRef = useRef<DragMode | null>(null);
+  const [dragColIdx, setDragColIdx] = useState<number | null>(null);
+  const [dragColWidth, setDragColWidth] = useState<number | null>(null);
 
-  const configuredLeftWidth = parseWidth(leftPanes[0]?.layout.width, width) ?? Math.floor(width * 0.4);
-  const leftWidth = dragWidth ?? configuredLeftWidth;
+  // --- Column widths ---
+  const dividerCount = Math.max(0, numColumns - 1);
+  const availableWidth = width - dividerCount;
 
-  const MIN_PANE_WIDTH = 20;
-  const maxLeftWidth = width - MIN_PANE_WIDTH - 1;
+  const columnWidths = useMemo(() => {
+    const widths: number[] = [];
+    let totalSpecified = 0;
+    let unspecifiedCount = 0;
 
-  const hasBothPanes = leftPanes.length > 0 && rightPanes.length > 0;
+    for (const colIdx of columnIndices) {
+      const colConfig = layout.columns[colIdx];
+      const parsed = parseWidth(colConfig?.width, availableWidth);
+      if (parsed !== undefined) {
+        widths.push(parsed);
+        totalSpecified += parsed;
+      } else {
+        widths.push(0);
+        unspecifiedCount++;
+      }
+    }
 
-  const clamp = useCallback((w: number) => {
-    return Math.max(MIN_PANE_WIDTH, Math.min(maxLeftWidth, w));
-  }, [maxLeftWidth]);
+    const remaining = Math.max(0, availableWidth - totalSpecified);
+    const perUnspecified = unspecifiedCount > 0 ? Math.floor(remaining / unspecifiedCount) : 0;
+    for (let i = 0; i < widths.length; i++) {
+      if (widths[i] === 0) widths[i] = perUnspecified;
+    }
+    for (let i = 0; i < widths.length; i++) {
+      widths[i] = Math.max(MIN_PANE_WIDTH, widths[i]!);
+    }
+    return widths;
+  }, [columnIndices.join(","), layout.columns, availableWidth]);
 
-  // Catch-all mouse handler on the outermost box.
-  // Events bubble up from whatever element was actually hit.
-  // e.x / e.y are absolute terminal coordinates.
-  const handleMouse = useCallback((e: { type: string; x: number; stopPropagation: () => void; preventDefault: () => void }) => {
-    if (!hasBothPanes) return;
+  const effectiveColumnWidths = [...columnWidths];
+  if (dragColIdx !== null && dragColWidth !== null) {
+    const localIdx = columnIndices.indexOf(dragColIdx);
+    if (localIdx >= 0 && localIdx < effectiveColumnWidths.length - 1) {
+      const nextOldWidth = columnWidths[localIdx + 1]!;
+      const delta = dragColWidth - columnWidths[localIdx]!;
+      effectiveColumnWidths[localIdx] = Math.max(MIN_PANE_WIDTH, dragColWidth);
+      effectiveColumnWidths[localIdx + 1] = Math.max(MIN_PANE_WIDTH, nextOldWidth - delta);
+    }
+  }
+
+  const persistLayout = useCallback((newLayout: LayoutConfig) => {
+    dispatch({ type: "UPDATE_LAYOUT", layout: newLayout });
+    saveConfig({ ...state.config, layout: newLayout }).catch(() => {});
+  }, [state.config, dispatch]);
+
+  // --- Build list of all floating rects for hit-testing ---
+  // Sorted by zIndex descending so highest z is tested first.
+  const allFloatingRects = useMemo(() => {
+    const rects: Array<{
+      id: string;
+      x: number; y: number; w: number; h: number;
+    }> = [];
+
+    for (const pane of filteredFloating) {
+      const e = pane.floating!;
+      rects.push({ id: pane.def.id, x: e.x, y: e.y, w: e.width, h: e.height });
+    }
+
+    // Higher zIndex first for hit-testing
+    rects.sort((a, b) => {
+      const zA = filteredFloating.find((p) => p.def.id === a.id)?.floating?.zIndex ?? 50;
+      const zB = filteredFloating.find((p) => p.def.id === b.id)?.floating?.zIndex ?? 50;
+      return zB - zA;
+    });
+
+    return rects;
+  }, [filteredFloating]);
+
+  // --- Root mouse handler: ALL mouse interactions go through here ---
+  const handleMouse = useCallback((e: { type: string; x: number; y: number; stopPropagation: () => void; preventDefault: () => void }) => {
+    // Convert absolute terminal coords to Shell-relative
+    const sy = e.y - HEADER_HEIGHT;
 
     if (e.type === "down") {
-      // Check if click is near the divider
-      const dividerX = leftWidth;
-      if (Math.abs(e.x - dividerX) <= GRAB_ZONE) {
-        draggingRef.current = true;
-        setDragging(true);
-        setDragWidth(clamp(e.x));
-        e.stopPropagation();
-        e.preventDefault();
+      // 1. Check floating panes (highest z first)
+      for (const rect of allFloatingRects) {
+        if (e.x >= rect.x && e.x < rect.x + rect.w && sy >= rect.y && sy < rect.y + rect.h) {
+          const relX = e.x - rect.x;
+          const relY = sy - rect.y;
+
+          // Focus and bring to front
+          dispatch({ type: "FOCUS_PANE", paneId: rect.id });
+          const newLayout = bringToFront(layout, rect.id);
+          dispatch({ type: "UPDATE_LAYOUT", layout: newLayout });
+
+          // Resize handle: bottom-right 4x2 area (generous grab zone)
+          if (relX >= rect.w - 4 && relY >= rect.h - 2) {
+            dragRef.current = {
+              type: "float-resize",
+              paneId: rect.id,
+              startX: e.x,
+              startY: e.y,
+              origW: rect.w,
+              origH: rect.h,
+              paneX: rect.x,
+              paneY: rect.y,
+            };
+            e.stopPropagation();
+            e.preventDefault();
+            return;
+          }
+
+          // Title bar: border row (relY===0) or content row (relY===1)
+          if (relY <= 1) {
+            // Close button: last 5 chars
+            if (relX >= rect.w - 5) {
+              const closeLayout = removePane(layout, rect.id);
+              persistLayout(closeLayout);
+              e.stopPropagation();
+              e.preventDefault();
+              return;
+            }
+
+            // Start move drag
+            dragRef.current = {
+              type: "float-move",
+              paneId: rect.id,
+              startX: e.x,
+              startY: e.y,
+              origX: rect.x,
+              origY: rect.y,
+              paneW: rect.w,
+              paneH: rect.h,
+            };
+            e.stopPropagation();
+            e.preventDefault();
+            return;
+          }
+
+          // Click inside pane body — just consume so column divider doesn't trigger
+          e.stopPropagation();
+          e.preventDefault();
+          return;
+        }
       }
+
+      // 2. Check column dividers
+      if (numColumns >= 2) {
+        let xOffset = 0;
+        for (let i = 0; i < numColumns - 1; i++) {
+          xOffset += effectiveColumnWidths[i]!;
+          if (Math.abs(e.x - xOffset) <= GRAB_ZONE) {
+            dragRef.current = { type: "column-divider", colIdx: columnIndices[i]!, startX: e.x, origWidth: effectiveColumnWidths[i]! };
+            setDragColIdx(columnIndices[i]!);
+            setDragColWidth(effectiveColumnWidths[i]!);
+            e.stopPropagation();
+            e.preventDefault();
+            return;
+          }
+          xOffset += 1;
+        }
+      }
+
       return;
     }
 
-    if (!draggingRef.current) return;
+    // --- Drag ---
+    const drag = dragRef.current;
+    if (!drag) return;
 
     if (e.type === "drag") {
-      setDragWidth(clamp(e.x));
+      if (drag.type === "column-divider") {
+        const delta = e.x - drag.startX;
+        setDragColWidth(Math.max(MIN_PANE_WIDTH, drag.origWidth + delta));
+      } else if (drag.type === "float-move") {
+        const dx = e.x - drag.startX;
+        const dy = e.y - drag.startY;
+        const newX = Math.max(0, Math.min(width - drag.paneW, drag.origX + dx));
+        const newY = Math.max(0, Math.min(contentHeight - drag.paneH, drag.origY + dy));
+        const moveLayout = updateFloatingPane(layout, drag.paneId, { x: newX, y: newY });
+        dispatch({ type: "UPDATE_LAYOUT", layout: moveLayout });
+      } else if (drag.type === "float-resize") {
+        const dx = e.x - drag.startX;
+        const dy = e.y - drag.startY;
+        const newW = Math.max(MIN_FLOAT_WIDTH, Math.min(width - drag.paneX, drag.origW + dx));
+        const newH = Math.max(MIN_FLOAT_HEIGHT, Math.min(contentHeight - drag.paneY, drag.origH + dy));
+        const resizeLayout = updateFloatingPane(layout, drag.paneId, { width: newW, height: newH });
+        dispatch({ type: "UPDATE_LAYOUT", layout: resizeLayout });
+      }
       e.stopPropagation();
       e.preventDefault();
       return;
     }
 
+    // --- Up / drag-end ---
     if (e.type === "up" || e.type === "drag-end") {
-      const finalWidth = dragWidth ?? leftWidth;
-      draggingRef.current = false;
-      setDragging(false);
-      setDragWidth(null);
-
-      const pct = Math.round((finalWidth / width) * 100);
-      const newLayout = state.config.layout.map((entry) => {
-        if (entry.position === "left") return { ...entry, width: `${pct}%` };
-        if (entry.position === "right") return { ...entry, width: `${100 - pct}%` };
-        return entry;
-      });
-      dispatch({ type: "UPDATE_LAYOUT", layout: newLayout });
-      saveConfig({ ...state.config, layout: newLayout }).catch(() => {});
+      if (drag.type === "column-divider") {
+        if (dragColWidth !== null) {
+          const colIdx = drag.colIdx;
+          const pct = Math.round((dragColWidth / availableWidth) * 100);
+          let newLayout = updateColumnWidth(layout, colIdx, `${pct}%`);
+          const localIdx = columnIndices.indexOf(colIdx);
+          if (localIdx >= 0 && localIdx < numColumns - 1) {
+            const nextColIdx = columnIndices[localIdx + 1]!;
+            const nextPct = Math.round((effectiveColumnWidths[localIdx + 1]! / availableWidth) * 100);
+            newLayout = updateColumnWidth(newLayout, nextColIdx, `${nextPct}%`);
+          }
+          persistLayout(newLayout);
+        }
+        setDragColIdx(null);
+        setDragColWidth(null);
+      } else if (drag.type === "float-move" || drag.type === "float-resize") {
+        // Persist layout on release
+        saveConfig({ ...state.config, layout }).catch(() => {});
+      }
+      dragRef.current = null;
       e.stopPropagation();
       e.preventDefault();
     }
-  }, [hasBothPanes, leftWidth, dragWidth, width, state.config, dispatch, clamp]);
+  }, [allFloatingRects, numColumns, effectiveColumnWidths, columnIndices, availableWidth, layout, dragColWidth, width, contentHeight, state.config, dispatch, persistLayout]);
 
+  const handleFloatingClose = useCallback((paneId: string) => {
+    const newLayout = removePane(layout, paneId);
+    persistLayout(newLayout);
+  }, [layout, persistLayout]);
+
+  // --- Render ---
   return (
     <box flexDirection="row" flexGrow={1} height={contentHeight} onMouse={handleMouse}>
-      {leftPanes.map((pane) => (
-        <PaneWrapper
-          key={pane.def.id}
-          title={` ${pane.def.name} `}
-          focused={leftFocused}
-          width={leftWidth}
-          onMouseDown={() => dispatch({ type: "SET_ACTIVE_PANEL", panel: "left" })}
-        >
-          <pane.def.component
-            focused={leftFocused}
-            width={leftWidth}
-            height={contentHeight - 2}
-          />
-        </PaneWrapper>
-      ))}
-      {hasBothPanes && (
-        <box
-          width={1}
-          height={contentHeight}
-          backgroundColor={dragging ? colors.borderFocused : undefined}
-        >
-          <text fg={dragging ? colors.bg : colors.border}>│</text>
-        </box>
-      )}
-      {rightPanes.map((pane) => (
-        <PaneWrapper
-          key={pane.def.id}
-          title={` ${pane.def.name} `}
-          focused={rightFocused}
-          flexGrow={1}
-          onMouseDown={() => dispatch({ type: "SET_ACTIVE_PANEL", panel: "right" })}
-        >
-          <pane.def.component
-            focused={rightFocused}
-            width={width - leftWidth - 1 - 4}
-            height={contentHeight - 2}
-          />
-        </PaneWrapper>
-      ))}
-      {leftPanes.length === 0 && rightPanes.length === 0 && (
+      {/* Docked columns */}
+      {columnIndices.map((colIdx, localIdx) => {
+        const panes = filteredColumns.get(colIdx)!;
+        const colWidth = effectiveColumnWidths[localIdx]!;
+
+        return (
+          <box key={`col-${colIdx}`} flexDirection="row">
+            <box flexDirection="column" width={colWidth}>
+              {panes.map((pane) => {
+                const isFocused = state.focusedPaneId === pane.def.id && !overlayOpen;
+                const paneHeight = Math.floor(contentHeight / panes.length);
+                const innerHeight = paneHeight - 2;
+
+                return (
+                  <PaneWrapper
+                    key={pane.def.id}
+                    title={` ${pane.def.name} `}
+                    focused={isFocused}
+                    flexGrow={1}
+                    onMouseDown={() => dispatch({ type: "FOCUS_PANE", paneId: pane.def.id })}
+                  >
+                    <pane.def.component
+                      focused={isFocused}
+                      width={colWidth - 2}
+                      height={innerHeight}
+                    />
+                  </PaneWrapper>
+                );
+              })}
+            </box>
+
+            {localIdx < numColumns - 1 && (
+              <box
+                width={1}
+                height={contentHeight}
+                backgroundColor={dragColIdx === colIdx ? colors.borderFocused : undefined}
+              >
+                <text fg={dragColIdx === colIdx ? colors.bg : colors.border}>│</text>
+              </box>
+            )}
+          </box>
+        );
+      })}
+
+      {/* Empty state */}
+      {numColumns === 0 && filteredFloating.length === 0 && (
         <box flexGrow={1} alignItems="center" justifyContent="center">
           <text fg={colors.textDim}>No panes configured. Press Ctrl+P to get started.</text>
         </box>
       )}
 
-      {/* Floating widgets from plugins */}
-      {[...pluginRegistry.floatingWidgets.values()]
-        .filter((w) => pluginRegistry.visibleWidgets.has(w.id))
-        .map((widget) => {
-          const ww = typeof widget.width === "number" ? widget.width : Math.floor(width * parseInt(widget.width) / 100);
-          const wh = typeof widget.height === "number" ? widget.height : Math.floor(contentHeight * parseInt(widget.height) / 100);
-          const pos = computeWidgetPosition(widget.position, width, contentHeight, ww, wh);
-          return (
-            <box
-              key={widget.id}
-              position="absolute"
-              top={pos.top}
-              left={pos.left}
-              width={ww}
-              height={wh}
-              zIndex={widget.zIndex ?? 50}
-              backgroundColor={colors.bg}
-              borderStyle="single"
-              borderColor={colors.borderFocused}
-            >
-              <widget.component
-                width={ww - 2}
-                height={wh - 2}
-                focused={!overlayOpen}
-                close={() => pluginRegistry.hideWidget(widget.id)}
-              />
-            </box>
-          );
-        })}
+      {/* Floating panes */}
+      {filteredFloating.map((pane) => {
+        const entry = pane.floating!;
+        const isFocused = state.focusedPaneId === pane.def.id && !overlayOpen;
+
+        return (
+          <FloatingPaneWrapper
+            key={pane.def.id}
+            title={pane.def.name}
+            x={entry.x}
+            y={entry.y}
+            width={entry.width}
+            height={entry.height}
+            zIndex={entry.zIndex ?? 50}
+            focused={isFocused}
+          >
+            <pane.def.component
+              focused={isFocused}
+              width={entry.width - 2}
+              height={entry.height - 4}
+              close={() => handleFloatingClose(pane.def.id)}
+            />
+          </FloatingPaneWrapper>
+        );
+      })}
     </box>
   );
-}
-
-function computeWidgetPosition(
-  anchor: "top-right" | "top-left" | "bottom-right" | "bottom-left" | "center",
-  termWidth: number, termHeight: number, widgetWidth: number, widgetHeight: number,
-): { top: number; left: number } {
-  switch (anchor) {
-    case "top-left": return { top: 1, left: 1 };
-    case "top-right": return { top: 1, left: termWidth - widgetWidth - 1 };
-    case "bottom-left": return { top: termHeight - widgetHeight - 1, left: 1 };
-    case "bottom-right": return { top: termHeight - widgetHeight - 1, left: termWidth - widgetWidth - 1 };
-    case "center": return {
-      top: Math.floor((termHeight - widgetHeight) / 2),
-      left: Math.floor((termWidth - widgetWidth) / 2),
-    };
-  }
 }

--- a/src/data/config-store.ts
+++ b/src/data/config-store.ts
@@ -3,6 +3,7 @@ import { join, dirname } from "path";
 import { existsSync } from "fs";
 import type { AppConfig } from "../types/config";
 import { createDefaultConfig } from "../types/config";
+import { migrateLayout } from "../plugins/pane-manager";
 
 const GLOBAL_CONFIG_DIR = join(process.env.HOME || "~", ".gloomberb");
 const GLOBAL_CONFIG_FILE = join(GLOBAL_CONFIG_DIR, "config.json");
@@ -35,6 +36,10 @@ export async function loadConfig(dataDir: string): Promise<AppConfig> {
     // Migration: ext_hours is now merged into change_pct
     if (config.columns) {
       config.columns = config.columns.filter((c: { id: string }) => c.id !== "ext_hours");
+    }
+    // Migration: old PaneLayoutEntry[] to new LayoutConfig
+    if (saved.layout) {
+      config.layout = migrateLayout(saved.layout);
     }
     return config;
   } catch {

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -366,11 +366,15 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
 
 // --- Pane wrapper (for when used as a right-side pane) ---
 
-function ChatPane({ focused, width, height }: PaneProps) {
+function ChatPane({ focused, width, height, close }: PaneProps) {
   const registry = getSharedRegistry();
   const selectTicker = useCallback((symbol: string) => {
     registry?.selectTickerFn(symbol);
-  }, [registry]);
+    if (close) {
+      registry?.switchTabFn("overview");
+      close();
+    }
+  }, [registry, close]);
 
   return (
     <ChatContent
@@ -378,6 +382,7 @@ function ChatPane({ focused, width, height }: PaneProps) {
       height={height}
       focused={focused}
       selectTicker={selectTicker}
+      close={close}
     />
   );
 }
@@ -448,40 +453,15 @@ export const chatPlugin: GloomPlugin = {
     const savedToken = ctx.storage.get<string>("session_token");
     if (savedToken) apiClient.setSessionToken(savedToken);
 
-    // Register as a right-side pane
+    // Register as a pane (opens floating by default, can be docked)
     ctx.registerPane({
       id: "chat",
       name: "Chat",
       icon: "C",
       component: ChatPane,
       defaultPosition: "right",
-    });
-
-    // Register as a floating widget
-    ctx.registerFloatingWidget({
-      id: "chat-widget",
-      name: "Chat",
-      position: "center",
-      width: "90%",
-      height: "90%",
-      captureInput: true,
-      component: ({ width, height, focused, close }) => {
-        const registry = getSharedRegistry();
-        const selectTicker = (symbol: string) => {
-          registry?.selectTickerFn(symbol);
-          registry?.switchTabFn("overview");
-          close?.();
-        };
-        return (
-          <ChatContent
-            width={width}
-            height={height}
-            focused={focused}
-            selectTicker={selectTicker}
-            close={close}
-          />
-        );
-      },
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 80, height: 30 },
     });
 
     // Toggle chat widget shortcut
@@ -492,10 +472,10 @@ export const chatPlugin: GloomPlugin = {
       description: "Toggle chat",
       execute: () => {
         const registry = getSharedRegistry();
-        if (registry?.visibleWidgets.has("chat-widget")) {
-          ctx.hideWidget("chat-widget");
+        if (registry?.isPaneFloating("chat")) {
+          ctx.hideWidget("chat");
         } else {
-          ctx.showWidget("chat-widget");
+          ctx.showWidget("chat");
         }
       },
     });
@@ -523,7 +503,7 @@ export const chatPlugin: GloomPlugin = {
         _wsConn = null;
         _wsConnected = false;
         _cachedMessages = [];
-        ctx.showWidget("chat-widget");
+        ctx.showWidget("chat");
       },
     });
 
@@ -562,7 +542,7 @@ export const chatPlugin: GloomPlugin = {
         _wsConn = null;
         _wsConnected = false;
         _cachedMessages = [];
-        ctx.showWidget("chat-widget");
+        ctx.showWidget("chat");
       },
     });
 

--- a/src/plugins/builtin/layout-manager.tsx
+++ b/src/plugins/builtin/layout-manager.tsx
@@ -1,0 +1,223 @@
+import type { GloomPlugin, GloomPluginContext } from "../../types/plugin";
+import { getSharedRegistry } from "../registry";
+import {
+  floatPane, dockPane, addPaneFloating,
+  removePane, isPaneInLayout,
+} from "../pane-manager";
+import type { LayoutConfig } from "../../types/config";
+import { saveConfig } from "../../data/config-store";
+
+const MAX_COLUMNS = 4;
+
+let _ctx: GloomPluginContext | null = null;
+let _dispatchFn: ((action: any) => void) | null = null;
+let _getStateFn: (() => { layout: LayoutConfig; termWidth: number; termHeight: number }) | null = null;
+
+/** Set the dispatch/state functions from the app (called after mount) */
+export function setLayoutManagerDispatch(
+  dispatch: (action: any) => void,
+  getState: () => { layout: LayoutConfig; termWidth: number; termHeight: number },
+) {
+  _dispatchFn = dispatch;
+  _getStateFn = getState;
+}
+
+function persistLayout(layout: LayoutConfig) {
+  if (!_dispatchFn) return;
+  _dispatchFn({ type: "UPDATE_LAYOUT", layout });
+  const registry = getSharedRegistry();
+  if (registry) {
+    const config = registry.getConfigFn();
+    saveConfig({ ...config, layout }).catch(() => {});
+  }
+}
+
+export const layoutManagerPlugin: GloomPlugin = {
+  id: "layout-manager",
+  name: "Layout Manager",
+  version: "1.0.0",
+  description: "Pane layout management commands",
+
+  setup(ctx) {
+    _ctx = ctx;
+
+    // Float Pane — detach a docked pane to a floating window
+    ctx.registerCommand({
+      id: "float-pane",
+      label: "Float Pane",
+      description: "Detach a docked pane into a floating window",
+      keywords: ["float", "detach", "undock", "window", "pane"],
+      category: "config",
+      execute: async () => {
+        if (!_getStateFn) return;
+        const registry = getSharedRegistry();
+        if (!registry) return;
+
+        const { layout, termWidth, termHeight } = _getStateFn();
+        const dockedPanes = layout.docked.map((d) => {
+          const def = registry.panes.get(d.paneId);
+          return def ? { id: d.paneId, name: def.name } : null;
+        }).filter(Boolean) as { id: string; name: string }[];
+
+        if (dockedPanes.length === 0) {
+          ctx.showToast("No docked panes to float", { type: "info" });
+          return;
+        }
+
+        // Use command bar to pick — for now, float the first non-focused one
+        // TODO: integrate with wizard for selection
+        const paneId = dockedPanes[0]!.id;
+        const def = registry.panes.get(paneId);
+        const newLayout = floatPane(layout, paneId, termWidth, termHeight, def);
+        persistLayout(newLayout);
+        if (_dispatchFn) _dispatchFn({ type: "FOCUS_PANE", paneId });
+      },
+    });
+
+    // Dock Pane — dock a floating pane back
+    ctx.registerCommand({
+      id: "dock-pane",
+      label: "Dock Pane",
+      description: "Dock a floating pane back into the layout",
+      keywords: ["dock", "attach", "pin", "pane"],
+      category: "config",
+      execute: async () => {
+        if (!_getStateFn) return;
+        const registry = getSharedRegistry();
+        if (!registry) return;
+
+        const { layout } = _getStateFn();
+        const floatingPanes = layout.floating.map((f) => {
+          const def = registry.panes.get(f.paneId);
+          return def ? { id: f.paneId, name: def.name } : null;
+        }).filter(Boolean) as { id: string; name: string }[];
+
+        if (floatingPanes.length === 0) {
+          ctx.showToast("No floating panes to dock", { type: "info" });
+          return;
+        }
+
+        const paneId = floatingPanes[0]!.id;
+
+        // Dock to the right of the last column's first pane
+        const lastDockedPane = layout.docked[layout.docked.length - 1];
+        if (lastDockedPane) {
+          const colCount = layout.columns.length + 1;
+          if (colCount > MAX_COLUMNS) {
+            // Stack below instead of creating a new column
+            const newLayout = dockPane(layout, paneId, {
+              relativeTo: lastDockedPane.paneId,
+              position: "below",
+            });
+            persistLayout(newLayout);
+          } else {
+            const newLayout = dockPane(layout, paneId, {
+              relativeTo: lastDockedPane.paneId,
+              position: "right",
+            });
+            persistLayout(newLayout);
+          }
+        } else {
+          // No docked panes — create first column
+          const newLayout: LayoutConfig = {
+            columns: [{}],
+            docked: [{ paneId, columnIndex: 0 }],
+            floating: layout.floating.filter((f) => f.paneId !== paneId),
+          };
+          persistLayout(newLayout);
+        }
+
+        if (_dispatchFn) _dispatchFn({ type: "FOCUS_PANE", paneId });
+      },
+    });
+
+    // Add Pane — add a registered pane that's not in the layout
+    ctx.registerCommand({
+      id: "add-pane",
+      label: "Add Pane",
+      description: "Add a pane to the layout",
+      keywords: ["add", "pane", "panel", "show"],
+      category: "config",
+      execute: async () => {
+        if (!_getStateFn) return;
+        const registry = getSharedRegistry();
+        if (!registry) return;
+
+        const { layout, termWidth, termHeight } = _getStateFn();
+        const availablePanes = [...registry.panes.values()].filter(
+          (def) => !isPaneInLayout(layout, def.id)
+        );
+
+        if (availablePanes.length === 0) {
+          ctx.showToast("All panes are already in the layout", { type: "info" });
+          return;
+        }
+
+        // Add first available as floating
+        const def = availablePanes[0]!;
+        const newLayout = addPaneFloating(layout, def.id, termWidth, termHeight, def);
+        persistLayout(newLayout);
+        if (_dispatchFn) _dispatchFn({ type: "FOCUS_PANE", paneId: def.id });
+      },
+    });
+
+    // Remove Pane — remove a pane from the layout
+    ctx.registerCommand({
+      id: "remove-pane",
+      label: "Remove Pane",
+      description: "Remove a pane from the layout",
+      keywords: ["remove", "pane", "close", "hide", "panel"],
+      category: "config",
+      execute: async () => {
+        if (!_getStateFn) return;
+        const registry = getSharedRegistry();
+        if (!registry) return;
+
+        const { layout } = _getStateFn();
+        // Get all visible panes
+        const allPanes = [
+          ...layout.docked.map((d) => d.paneId),
+          ...layout.floating.map((f) => f.paneId),
+        ];
+
+        if (allPanes.length === 0) {
+          ctx.showToast("No panes to remove", { type: "info" });
+          return;
+        }
+
+        // Remove the last one (TODO: wizard selection)
+        const paneId = allPanes[allPanes.length - 1]!;
+        const newLayout = removePane(layout, paneId);
+        persistLayout(newLayout);
+      },
+    });
+
+    // Swap Panes
+    ctx.registerCommand({
+      id: "swap-panes",
+      label: "Swap Panes",
+      description: "Swap two pane positions",
+      keywords: ["swap", "switch", "pane", "panel"],
+      category: "config",
+      execute: async () => {
+        if (!_getStateFn) return;
+        const { layout } = _getStateFn();
+
+        if (layout.docked.length < 2) {
+          ctx.showToast("Need at least 2 docked panes to swap", { type: "info" });
+          return;
+        }
+
+        // Swap first two docked panes
+        const [a, b] = layout.docked;
+        const newDocked = layout.docked.map((d) => {
+          if (d.paneId === a!.paneId) return { ...d, columnIndex: b!.columnIndex, order: b!.order };
+          if (d.paneId === b!.paneId) return { ...d, columnIndex: a!.columnIndex, order: a!.order };
+          return d;
+        });
+
+        persistLayout({ ...layout, docked: newDocked });
+      },
+    });
+  },
+};

--- a/src/plugins/pane-manager.ts
+++ b/src/plugins/pane-manager.ts
@@ -1,37 +1,233 @@
-import type { PaneLayoutEntry } from "../types/config";
+import type { LayoutConfig, DockedPaneEntry, FloatingPaneEntry, PaneLayoutEntry, LayoutColumnConfig } from "../types/config";
 import type { PaneDef } from "../types/plugin";
 
 export interface ResolvedPane {
   def: PaneDef;
-  layout: PaneLayoutEntry;
+  docked?: DockedPaneEntry;
+  floating?: FloatingPaneEntry;
 }
 
-/** Resolve layout entries against registered panes */
-export function resolvePanes(
-  layout: PaneLayoutEntry[],
+/** Resolve docked panes grouped by column index */
+export function resolveDockedByColumn(
+  layout: LayoutConfig,
   registeredPanes: ReadonlyMap<string, PaneDef>,
-): ResolvedPane[] {
-  const resolved: ResolvedPane[] = [];
+): Map<number, ResolvedPane[]> {
+  const result = new Map<number, ResolvedPane[]>();
 
-  for (const entry of layout) {
+  for (const entry of layout.docked) {
     const def = registeredPanes.get(entry.paneId);
-    if (def) {
-      resolved.push({ def, layout: entry });
-    }
+    if (!def) continue;
+    const list = result.get(entry.columnIndex) ?? [];
+    list.push({ def, docked: entry });
+    result.set(entry.columnIndex, list);
   }
 
-  return resolved;
+  // Sort each column by order
+  for (const [, panes] of result) {
+    panes.sort((a, b) => (a.docked!.order ?? 0) - (b.docked!.order ?? 0));
+  }
+
+  return result;
 }
 
-/** Get panes by position */
-export function getPanesByPosition(
-  panes: ResolvedPane[],
-  position: "left" | "right" | "bottom",
+/** Resolve floating panes */
+export function resolveFloating(
+  layout: LayoutConfig,
+  registeredPanes: ReadonlyMap<string, PaneDef>,
 ): ResolvedPane[] {
-  return panes.filter((p) => p.layout.position === position);
+  const result: ResolvedPane[] = [];
+  for (const entry of layout.floating) {
+    const def = registeredPanes.get(entry.paneId);
+    if (!def) continue;
+    result.push({ def, floating: entry });
+  }
+  // Sort by zIndex ascending (higher z on top)
+  result.sort((a, b) => (a.floating!.zIndex ?? 50) - (b.floating!.zIndex ?? 50));
+  return result;
 }
 
-/** Parse a width string (e.g., "40%") into a flex value or character count */
+/** Move a docked pane to floating (centered on screen) */
+export function floatPane(
+  layout: LayoutConfig,
+  paneId: string,
+  termWidth: number,
+  termHeight: number,
+  def?: PaneDef,
+): LayoutConfig {
+  const docked = layout.docked.find((d) => d.paneId === paneId);
+  if (!docked) return layout;
+
+  const fw = def?.defaultFloatingSize?.width ?? Math.floor(termWidth * 0.6);
+  const fh = def?.defaultFloatingSize?.height ?? Math.floor(termHeight * 0.6);
+  const x = Math.floor((termWidth - fw) / 2);
+  const y = Math.floor((termHeight - fh) / 2);
+
+  const maxZ = layout.floating.reduce((max, f) => Math.max(max, f.zIndex ?? 50), 50);
+
+  const newLayout: LayoutConfig = {
+    ...layout,
+    docked: layout.docked.filter((d) => d.paneId !== paneId),
+    floating: [...layout.floating, { paneId, x, y, width: fw, height: fh, zIndex: maxZ + 1 }],
+  };
+
+  return normalizeColumns(newLayout);
+}
+
+export interface DockTarget {
+  relativeTo: string;
+  position: "left" | "right" | "above" | "below";
+}
+
+/** Move a floating pane to docked, relative to an existing pane */
+export function dockPane(
+  layout: LayoutConfig,
+  paneId: string,
+  target: DockTarget,
+): LayoutConfig {
+  // Remove from floating
+  const newFloating = layout.floating.filter((f) => f.paneId !== paneId);
+
+  // Find the target docked pane
+  const targetEntry = layout.docked.find((d) => d.paneId === target.relativeTo);
+  if (!targetEntry) return layout;
+
+  let newDocked = [...layout.docked];
+  let newColumns = [...layout.columns];
+
+  if (target.position === "above" || target.position === "below") {
+    // Stack in same column
+    const order = targetEntry.order ?? 0;
+    const newOrder = target.position === "above" ? order - 1 : order + 1;
+    newDocked.push({ paneId, columnIndex: targetEntry.columnIndex, order: newOrder });
+  } else {
+    // Create new column
+    const insertIdx = target.position === "left" ? targetEntry.columnIndex : targetEntry.columnIndex + 1;
+
+    // Shift existing column indices
+    newDocked = newDocked.map((d) => ({
+      ...d,
+      columnIndex: d.columnIndex >= insertIdx ? d.columnIndex + 1 : d.columnIndex,
+    }));
+
+    // Insert new column
+    newColumns.splice(insertIdx, 0, {});
+
+    // Add the pane
+    newDocked.push({ paneId, columnIndex: insertIdx });
+  }
+
+  return normalizeColumns({
+    columns: newColumns,
+    docked: newDocked,
+    floating: newFloating,
+  });
+}
+
+/** Add a pane that's not currently in the layout */
+export function addPaneToLayout(
+  layout: LayoutConfig,
+  paneId: string,
+  target: DockTarget,
+): LayoutConfig {
+  return dockPane(
+    { ...layout, floating: [...layout.floating, { paneId, x: 0, y: 0, width: 0, height: 0 }] },
+    paneId,
+    target,
+  );
+}
+
+/** Add a pane as floating */
+export function addPaneFloating(
+  layout: LayoutConfig,
+  paneId: string,
+  termWidth: number,
+  termHeight: number,
+  def?: PaneDef,
+): LayoutConfig {
+  const fw = def?.defaultFloatingSize?.width ?? Math.floor(termWidth * 0.6);
+  const fh = def?.defaultFloatingSize?.height ?? Math.floor(termHeight * 0.6);
+  const x = Math.floor((termWidth - fw) / 2);
+  const y = Math.floor((termHeight - fh) / 2);
+  const maxZ = layout.floating.reduce((max, f) => Math.max(max, f.zIndex ?? 50), 50);
+
+  return {
+    ...layout,
+    floating: [...layout.floating, { paneId, x, y, width: fw, height: fh, zIndex: maxZ + 1 }],
+  };
+}
+
+/** Remove a pane from the layout entirely */
+export function removePane(layout: LayoutConfig, paneId: string): LayoutConfig {
+  return normalizeColumns({
+    ...layout,
+    docked: layout.docked.filter((d) => d.paneId !== paneId),
+    floating: layout.floating.filter((f) => f.paneId !== paneId),
+  });
+}
+
+/** Remove empty columns and re-index */
+export function normalizeColumns(layout: LayoutConfig): LayoutConfig {
+  // Find which column indices are actually used
+  const usedIndices = new Set(layout.docked.map((d) => d.columnIndex));
+
+  if (usedIndices.size === layout.columns.length) return layout;
+  if (usedIndices.size === 0 && layout.columns.length === 0) return layout;
+
+  // Build mapping from old index to new index
+  const sortedUsed = [...usedIndices].sort((a, b) => a - b);
+  const indexMap = new Map<number, number>();
+  sortedUsed.forEach((oldIdx, newIdx) => indexMap.set(oldIdx, newIdx));
+
+  // Keep only used columns
+  const newColumns: LayoutColumnConfig[] = sortedUsed.map((idx) => layout.columns[idx] ?? {});
+
+  const newDocked = layout.docked.map((d) => ({
+    ...d,
+    columnIndex: indexMap.get(d.columnIndex) ?? d.columnIndex,
+  }));
+
+  return { columns: newColumns, docked: newDocked, floating: layout.floating };
+}
+
+/** Check if a pane is in the layout (docked or floating) */
+export function isPaneInLayout(layout: LayoutConfig, paneId: string): boolean {
+  return layout.docked.some((d) => d.paneId === paneId)
+    || layout.floating.some((f) => f.paneId === paneId);
+}
+
+/** Update a floating pane's position/size */
+export function updateFloatingPane(
+  layout: LayoutConfig,
+  paneId: string,
+  updates: Partial<Pick<FloatingPaneEntry, "x" | "y" | "width" | "height" | "zIndex">>,
+): LayoutConfig {
+  return {
+    ...layout,
+    floating: layout.floating.map((f) =>
+      f.paneId === paneId ? { ...f, ...updates } : f
+    ),
+  };
+}
+
+/** Bring a floating pane to front (highest zIndex) */
+export function bringToFront(layout: LayoutConfig, paneId: string): LayoutConfig {
+  const maxZ = layout.floating.reduce((max, f) => Math.max(max, f.zIndex ?? 50), 50);
+  return updateFloatingPane(layout, paneId, { zIndex: maxZ + 1 });
+}
+
+/** Update a column's width */
+export function updateColumnWidth(
+  layout: LayoutConfig,
+  columnIndex: number,
+  width: string,
+): LayoutConfig {
+  const newColumns = layout.columns.map((c, i) =>
+    i === columnIndex ? { ...c, width } : c
+  );
+  return { ...layout, columns: newColumns };
+}
+
+/** Parse a width string (e.g., "40%") into pixel count */
 export function parseWidth(width: string | undefined, totalWidth: number): number | undefined {
   if (!width) return undefined;
   if (width.endsWith("%")) {
@@ -39,4 +235,26 @@ export function parseWidth(width: string | undefined, totalWidth: number): numbe
     return Math.floor((pct / 100) * totalWidth);
   }
   return parseInt(width, 10);
+}
+
+/** Migrate old PaneLayoutEntry[] to new LayoutConfig */
+export function migrateLayout(raw: unknown): LayoutConfig {
+  // Already new format
+  if (raw && typeof raw === "object" && "columns" in raw) return raw as LayoutConfig;
+
+  // Old format: PaneLayoutEntry[]
+  if (Array.isArray(raw)) {
+    const old = raw as PaneLayoutEntry[];
+    const leftWidth = old.find((e) => e.position === "left")?.width ?? "40%";
+    const rightWidth = old.find((e) => e.position === "right")?.width ?? "60%";
+    const columns: LayoutColumnConfig[] = [{ width: leftWidth }, { width: rightWidth }];
+    const docked: DockedPaneEntry[] = old.map((e) => ({
+      paneId: e.paneId,
+      columnIndex: e.position === "left" ? 0 : 1,
+    }));
+    return { columns, docked, floating: [] };
+  }
+
+  // Fallback
+  return { columns: [], docked: [], floating: [] };
 }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -3,7 +3,7 @@ import type { CliRenderer } from "@opentui/core";
 import type {
   GloomSlots, GloomPlugin, GloomPluginContext, PaneDef, CommandDef,
   CustomColumnDef, DetailTabDef, KeyboardShortcut, TickerAction,
-  FloatingWidgetDef, PluginStorage,
+  PluginStorage,
 } from "../types/plugin";
 import type { BrokerAdapter } from "../types/broker";
 import type { TickerFile } from "../types/ticker";
@@ -11,6 +11,8 @@ import type { TickerFinancials } from "../types/financials";
 import type { DataProvider } from "../types/data-provider";
 import type { MarkdownStore } from "../data/markdown-store";
 import type { SqliteCache } from "../data/sqlite-cache";
+import type { LayoutConfig } from "../types/config";
+import { addPaneFloating, removePane } from "./pane-manager";
 import { EventBus, type PluginEvents } from "./event-bus";
 
 // Shared references for React components (which can't access setup context)
@@ -32,7 +34,6 @@ interface PluginItems {
   detailTabs: string[];
   shortcuts: string[];
   tickerActions: string[];
-  floatingWidgets: string[];
   eventDisposers: Array<() => void>;
 }
 
@@ -50,8 +51,6 @@ export class PluginRegistry {
   private _detailTabs = new Map<string, DetailTabDef>();
   private _shortcuts = new Map<string, KeyboardShortcut>();
   private _tickerActions = new Map<string, TickerAction>();
-  private _floatingWidgets = new Map<string, FloatingWidgetDef>();
-  private _visibleWidgets = new Set<string>();
 
   readonly events: EventBus;
   readonly dataProvider: DataProvider;
@@ -70,6 +69,12 @@ export class PluginRegistry {
   switchPanelFn: ((panel: "left" | "right") => void) = () => {};
   switchTabFn: ((tabId: string) => void) = () => {};
   openCommandBarFn: ((query?: string) => void) = () => {};
+  focusPaneFn: ((paneId: string) => void) = () => {};
+
+  // Layout functions (set by app after render)
+  getLayoutFn: (() => LayoutConfig) = () => ({ columns: [], docked: [], floating: [] });
+  updateLayoutFn: ((layout: LayoutConfig) => void) = () => {};
+  getTermSizeFn: (() => { width: number; height: number }) = () => ({ width: 120, height: 40 });
 
   // Toast function (set by app after ToastProvider mounts)
   showToastFn: ((message: string, options?: { duration?: number; type?: "info" | "success" | "error" }) => void) = () => {};
@@ -101,8 +106,6 @@ export class PluginRegistry {
   get detailTabs(): ReadonlyMap<string, DetailTabDef> { return this._detailTabs; }
   get shortcuts(): ReadonlyMap<string, KeyboardShortcut> { return this._shortcuts; }
   get tickerActions(): ReadonlyMap<string, TickerAction> { return this._tickerActions; }
-  get floatingWidgets(): ReadonlyMap<string, FloatingWidgetDef> { return this._floatingWidgets; }
-  get visibleWidgets(): ReadonlySet<string> { return this._visibleWidgets; }
   get allPlugins(): ReadonlyMap<string, GloomPlugin> { return this.plugins; }
 
   /** Returns the last registered provider (paid providers override the default Yahoo) */
@@ -112,53 +115,60 @@ export class PluginRegistry {
     return last;
   }
 
-  private _widgetChangeListeners = new Set<() => void>();
-
-  onWidgetVisibilityChange(listener: () => void): () => void {
-    this._widgetChangeListeners.add(listener);
-    return () => { this._widgetChangeListeners.delete(listener); };
-  }
-
-  private _notifyWidgetChange(): void {
-    for (const listener of this._widgetChangeListeners) {
-      try { listener(); } catch { /* ignore */ }
-    }
-  }
-
-  /** Get floating widget IDs registered by a specific plugin */
-  getPluginWidgetIds(pluginId: string): string[] {
-    return this._pluginItems.get(pluginId)?.floatingWidgets ?? [];
-  }
-
   /** Get pane IDs registered by a specific plugin */
   getPluginPaneIds(pluginId: string): string[] {
     return this._pluginItems.get(pluginId)?.panes ?? [];
   }
 
-  showWidget(widgetId: string): void {
-    // Don't show widgets from disabled plugins
+  /** Check if a pane is currently visible as a floating pane in the layout */
+  isPaneFloating(paneId: string): boolean {
+    try {
+      return this.getLayoutFn().floating.some((f) => f.paneId === paneId);
+    } catch { return false; }
+  }
+
+  /** Show a pane as a floating window (adds to layout.floating if not already present) */
+  showWidget(paneId: string): void {
+    // Don't show panes from disabled plugins
     try {
       const disabledPlugins = new Set(this.getConfigFn().disabledPlugins || []);
       for (const [pluginId, items] of this._pluginItems) {
-        if (items.floatingWidgets.includes(widgetId) && disabledPlugins.has(pluginId)) {
+        if (items.panes.includes(paneId) && disabledPlugins.has(pluginId)) {
           return;
         }
       }
     } catch { /* getConfigFn not set yet during init — allow */ }
-    this._visibleWidgets.add(widgetId);
-    this._notifyWidgetChange();
+
+    const layout = this.getLayoutFn();
+    // Already floating — just focus
+    if (layout.floating.some((f) => f.paneId === paneId)) {
+      this.focusPaneFn(paneId);
+      return;
+    }
+
+    // Remove from docked if present, then add as floating
+    const def = this._panes.get(paneId);
+    const { width, height } = this.getTermSizeFn();
+    const newLayout = addPaneFloating(
+      { ...layout, docked: layout.docked.filter((d) => d.paneId !== paneId) },
+      paneId, width, height, def,
+    );
+    this.updateLayoutFn(newLayout);
+    this.focusPaneFn(paneId);
   }
 
-  hideWidget(widgetId: string): void {
-    this._visibleWidgets.delete(widgetId);
-    this._notifyWidgetChange();
+  /** Hide a floating pane (removes from layout) */
+  hideWidget(paneId: string): void {
+    const layout = this.getLayoutFn();
+    const newLayout = removePane(layout, paneId);
+    this.updateLayoutFn(newLayout);
   }
 
   private createContext(pluginId: string): GloomPluginContext {
     const items: PluginItems = {
       panes: [], commands: [], columns: [], brokers: [],
       dataProviders: [], detailTabs: [], shortcuts: [],
-      tickerActions: [], floatingWidgets: [], eventDisposers: [],
+      tickerActions: [], eventDisposers: [],
     };
     this._pluginItems.set(pluginId, items);
 
@@ -186,7 +196,6 @@ export class PluginRegistry {
       registerDetailTab: (tab) => { this._detailTabs.set(tab.id, tab); items.detailTabs.push(tab.id); },
       registerShortcut: (shortcut) => { this._shortcuts.set(shortcut.id, shortcut); items.shortcuts.push(shortcut.id); },
       registerTickerAction: (action) => { this._tickerActions.set(action.id, action); items.tickerActions.push(action.id); },
-      registerFloatingWidget: (widget) => { this._floatingWidgets.set(widget.id, widget); items.floatingWidgets.push(widget.id); },
 
       // Data access
       getData: (ticker) => this.getDataFn(ticker),
@@ -217,8 +226,8 @@ export class PluginRegistry {
       emit: (event, payload) => this.events.emit(event, payload),
 
       // UI
-      showWidget: (widgetId) => this.showWidget(widgetId),
-      hideWidget: (widgetId) => this.hideWidget(widgetId),
+      showWidget: (paneId) => this.showWidget(paneId),
+      hideWidget: (paneId) => this.hideWidget(paneId),
       showToast: (message, options) => this.showToastFn(message, options),
     };
   }
@@ -287,10 +296,6 @@ export class PluginRegistry {
       for (const id of items.detailTabs) this._detailTabs.delete(id);
       for (const id of items.shortcuts) this._shortcuts.delete(id);
       for (const id of items.tickerActions) this._tickerActions.delete(id);
-      for (const id of items.floatingWidgets) {
-        this._floatingWidgets.delete(id);
-        this._visibleWidgets.delete(id);
-      }
       for (const dispose of items.eventDisposers) dispose();
       this._pluginItems.delete(pluginId);
     }

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useReducer, useRef, type ReactNode } from "react";
-import type { AppConfig } from "../types/config";
+import type { AppConfig, LayoutConfig } from "../types/config";
 import { saveConfig } from "../data/config-store";
 import type { TickerFile } from "../types/ticker";
 import type { TickerFinancials } from "../types/financials";
@@ -16,7 +16,9 @@ export interface AppState {
   exchangeRates: Map<string, number>;
 
   // UI state
+  /** @deprecated Use focusedPaneId instead */
   activePanel: "left" | "right";
+  focusedPaneId: string | null;
   activeLeftTab: string;
   activeRightTab: string;
   selectedTicker: string | null;
@@ -61,7 +63,10 @@ export type AppAction =
   | { type: "TOGGLE_PLUGIN"; pluginId: string }
   | { type: "SET_INPUT_CAPTURED"; captured: boolean }
   | { type: "SET_EXCHANGE_RATE"; currency: string; rate: number }
-  | { type: "UPDATE_LAYOUT"; layout: import("../types/config").PaneLayoutEntry[] };
+  | { type: "UPDATE_LAYOUT"; layout: LayoutConfig }
+  | { type: "FOCUS_PANE"; paneId: string }
+  | { type: "FOCUS_NEXT"; paneOrder: string[] }
+  | { type: "FOCUS_PREV"; paneOrder: string[] };
 
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
@@ -100,14 +105,31 @@ function appReducer(state: AppState, action: AppAction): AppState {
       const recentTickers = action.symbol
         ? [action.symbol, ...state.recentTickers.filter((s) => s !== action.symbol)].slice(0, 50)
         : state.recentTickers;
-      return { ...state, selectedTicker: action.symbol, recentTickers, activePanel: "right" };
+      // Focus the ticker-detail pane (or keep current focus if not found)
+      const tickerPaneId = state.config.layout.docked.find((d) => d.paneId === "ticker-detail")?.paneId
+        ?? state.config.layout.floating.find((f) => f.paneId === "ticker-detail")?.paneId;
+      return {
+        ...state,
+        selectedTicker: action.symbol,
+        recentTickers,
+        activePanel: "right",
+        focusedPaneId: tickerPaneId ?? state.focusedPaneId,
+      };
     }
 
     case "PREVIEW_TICKER":
       return { ...state, selectedTicker: action.symbol };
 
-    case "SET_ACTIVE_PANEL":
-      return { ...state, activePanel: action.panel };
+    case "SET_ACTIVE_PANEL": {
+      // Backward compat: map "left"/"right" to first pane in that column
+      const colIdx = action.panel === "left" ? 0 : (state.config.layout.columns.length - 1);
+      const firstInCol = state.config.layout.docked.find((d) => d.columnIndex === colIdx);
+      return {
+        ...state,
+        activePanel: action.panel,
+        focusedPaneId: firstInCol?.paneId ?? state.focusedPaneId,
+      };
+    }
 
     case "SET_LEFT_TAB":
       return { ...state, activeLeftTab: action.tab };
@@ -172,6 +194,25 @@ function appReducer(state: AppState, action: AppAction): AppState {
     case "UPDATE_LAYOUT":
       return { ...state, config: { ...state.config, layout: action.layout } };
 
+    case "FOCUS_PANE":
+      return { ...state, focusedPaneId: action.paneId };
+
+    case "FOCUS_NEXT": {
+      const order = action.paneOrder;
+      if (order.length === 0) return state;
+      const idx = state.focusedPaneId ? order.indexOf(state.focusedPaneId) : -1;
+      const next = order[(idx + 1) % order.length]!;
+      return { ...state, focusedPaneId: next };
+    }
+
+    case "FOCUS_PREV": {
+      const order = action.paneOrder;
+      if (order.length === 0) return state;
+      const idx = state.focusedPaneId ? order.indexOf(state.focusedPaneId) : 0;
+      const prev = order[(idx - 1 + order.length) % order.length]!;
+      return { ...state, focusedPaneId: prev };
+    }
+
     default:
       return state;
   }
@@ -208,6 +249,7 @@ export function createInitialState(config: AppConfig): AppState {
     financials: new Map(),
     exchangeRates: new Map([["USD", 1]]),
     activePanel: "left",
+    focusedPaneId: config.layout.docked[0]?.paneId ?? null,
     activeLeftTab: config.portfolios[0]?.id || "main",
     activeRightTab: "overview",
     selectedTicker: null,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -8,10 +8,41 @@ export interface ColumnConfig {
   format?: "currency" | "percent" | "number" | "compact";
 }
 
+/** @deprecated Use LayoutConfig instead. Kept for migration from old configs. */
 export interface PaneLayoutEntry {
   paneId: string;
   position: "left" | "right" | "bottom";
-  width?: string; // e.g., "40%", "60"
+  width?: string;
+}
+
+/** A pane docked into the tiled layout */
+export interface DockedPaneEntry {
+  paneId: string;
+  columnIndex: number;       // 0-based column index
+  order?: number;            // vertical order within column (lower = higher)
+  height?: string;           // e.g. "50%", "200" — omit = equal split
+}
+
+/** Configuration for a single layout column */
+export interface LayoutColumnConfig {
+  width?: string;            // e.g. "40%", "300" — omit = equal split
+}
+
+/** A pane floating as a draggable overlay */
+export interface FloatingPaneEntry {
+  paneId: string;
+  x: number;                 // absolute terminal column
+  y: number;                 // absolute terminal row
+  width: number;             // character columns
+  height: number;            // character rows
+  zIndex?: number;
+}
+
+/** The unified layout config */
+export interface LayoutConfig {
+  columns: LayoutColumnConfig[];    // ordered list of columns
+  docked: DockedPaneEntry[];       // panes placed in columns
+  floating: FloatingPaneEntry[];   // panes in floating windows
 }
 
 export interface AppConfig {
@@ -21,7 +52,7 @@ export interface AppConfig {
   portfolios: Portfolio[];
   watchlists: Watchlist[];
   columns: ColumnConfig[];
-  layout: PaneLayoutEntry[];
+  layout: LayoutConfig;
   brokers: Record<string, Record<string, unknown>>;
   plugins: string[];
   disabledPlugins: string[];
@@ -40,10 +71,14 @@ export const DEFAULT_COLUMNS: ColumnConfig[] = [
   { id: "latency", label: "AGE", width: 6, align: "right" },
 ];
 
-export const DEFAULT_LAYOUT: PaneLayoutEntry[] = [
-  { paneId: "portfolio-list", position: "left", width: "40%" },
-  { paneId: "ticker-detail", position: "right", width: "60%" },
-];
+export const DEFAULT_LAYOUT: LayoutConfig = {
+  columns: [{ width: "40%" }, { width: "60%" }],
+  docked: [
+    { paneId: "portfolio-list", columnIndex: 0 },
+    { paneId: "ticker-detail", columnIndex: 1 },
+  ],
+  floating: [],
+};
 
 export function createDefaultConfig(dataDir: string): AppConfig {
   return {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -33,6 +33,8 @@ export interface PaneProps {
   focused: boolean;
   width: number;
   height: number;
+  /** Present when pane is floating — call to dock back or hide */
+  close?: () => void;
 }
 
 export interface PaneDef {
@@ -42,6 +44,10 @@ export interface PaneDef {
   component: (props: PaneProps) => ReactNode;
   defaultPosition: "left" | "right" | "bottom";
   defaultWidth?: string;
+  /** Hint for initial floating size (character columns/rows) */
+  defaultFloatingSize?: { width: number; height: number };
+  /** Whether this pane starts docked or floating. Default: "docked" */
+  defaultMode?: "docked" | "floating";
 }
 
 export interface WizardStep {
@@ -111,18 +117,6 @@ export interface TickerAction {
   execute: (ticker: TickerFile, financials: TickerFinancials | null) => void | Promise<void>;
 }
 
-/** Floating widget overlay registered by a plugin */
-export interface FloatingWidgetDef {
-  id: string;
-  name: string;
-  position: "top-right" | "top-left" | "bottom-right" | "bottom-left" | "center";
-  width: number | string;
-  height: number | string;
-  captureInput?: boolean;
-  zIndex?: number;
-  component: (props: { width: number; height: number; focused: boolean; close: () => void }) => ReactNode;
-}
-
 /** Scoped key-value storage for a plugin */
 export interface PluginStorage {
   get<T = unknown>(key: string): T | null;
@@ -141,7 +135,6 @@ export interface GloomPluginContext {
   registerDetailTab(tab: DetailTabDef): void;
   registerShortcut(shortcut: KeyboardShortcut): void;
   registerTickerAction(action: TickerAction): void;
-  registerFloatingWidget(widget: FloatingWidgetDef): void;
 
   // --- Data access ---
   getData(ticker: string): TickerFinancials | null;


### PR DESCRIPTION
## Summary

- Replaces the fixed left/right split layout with a fully modular pane system where any pane can be docked in dynamic columns (up to 4) or detached as a draggable/resizable floating window
- New `LayoutConfig` schema (`columns`/`docked`/`floating` arrays) with automatic migration from the old `PaneLayoutEntry[]` format
- Floating panes support drag-to-move via title bar, drag-to-resize via corner handle, close button, and bring-to-front on click — all mouse handling done at the Shell root level
- Eliminates the legacy `FloatingWidgetDef`/`registerFloatingWidget` API — all panes (including chat) now use the unified `PaneDef` system with `defaultMode: "floating"` support
- Adds layout manager plugin with Float/Dock/Add/Remove/Swap commands, and replaces `activePanel` with `focusedPaneId` for Tab-cycling through all visible panes

## Test plan

- [ ] Start app with existing config — verify it migrates and renders same 2-column layout
- [ ] Use command bar to Float/Dock/Add/Remove panes
- [ ] Drag floating pane title bars to move, corner handles to resize
- [ ] Click floating panes to bring to front
- [ ] Shift+C toggles chat as a floating pane
- [ ] Tab/Shift+Tab cycles focus through all docked and floating panes
- [ ] Drag column dividers to resize docked columns
- [ ] Disable a plugin with floating panes — verify they're removed from layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)