### PR TITLE
Add multiple layout presets with Ctrl+1-9 switching

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -270,6 +270,15 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
     else toast.info(message, { duration });
   };
 
+  // Persist layout changes (switching, saving, deleting, renaming layouts)
+  const prevLayouts = useRef(state.config.layouts);
+  useEffect(() => {
+    if (state.config.layouts !== prevLayouts.current) {
+      prevLayouts.current = state.config.layouts;
+      saveConfig(state.config).catch(() => {});
+    }
+  }, [state.config.layouts, state.config]);
+
   // Emit ticker:selected events
   const prevSelectedRef = useRef(state.selectedTicker);
   useEffect(() => {
@@ -298,6 +307,15 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
     // Backtick opens command bar (close is handled in command-bar.tsx)
     if (event.name === "`" && !state.commandBarOpen) {
       dispatch({ type: "SET_COMMAND_BAR", open: true });
+      return;
+    }
+    // Ctrl+1-9: switch layouts (works even when input is captured)
+    if (/^[1-9]$/.test(event.name ?? "") && event.ctrl && (state.config.layouts ?? []).length > 1) {
+      const idx = parseInt(event.name!, 10) - 1;
+      const layouts = state.config.layouts ?? [];
+      if (idx < layouts.length && idx !== state.config.activeLayoutIndex) {
+        dispatch({ type: "SWITCH_LAYOUT", index: idx });
+      }
       return;
     }
 

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -251,6 +251,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const originalThemeRef = useRef<string>(getCurrentThemeId());
   const spaceConsumedRef = useRef(false);
+  const scrollAnchorRef = useRef(0);
 
   useEffect(() => {
     if (inputRef.current) inputRef.current.focus();
@@ -261,6 +262,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
     setQuery("");
     setResults([]);
     setSelectedIdx(0);
+    scrollAnchorRef.current = 0;
   }, [dispatch]);
 
   // Revert theme on close without selection
@@ -869,9 +871,14 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
     setResults(items);
     // In columns/plugin mode, preserve the selected index across re-renders (toggling)
     if (match?.command.id === "columns" || match?.command.id === "plugins") {
-      setSelectedIdx((prev) => Math.min(prev, items.length - 1));
+      setSelectedIdx((prev) => {
+        const next = Math.min(prev, items.length - 1);
+        scrollAnchorRef.current = next;
+        return next;
+      });
     } else {
       setSelectedIdx(initialIdx);
+      scrollAnchorRef.current = initialIdx;
     }
 
     // Yahoo search when in ticker search mode (prefix "T")
@@ -929,9 +936,17 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
         close();
       }
     } else if (event.name === "down" || (event.name === "n" && event.ctrl)) {
-      setSelectedIdx((i) => Math.min(i + 1, results.length - 1));
+      setSelectedIdx((i) => {
+        const next = Math.min(i + 1, results.length - 1);
+        scrollAnchorRef.current = next;
+        return next;
+      });
     } else if (event.name === "up" || (event.name === "p" && event.ctrl)) {
-      setSelectedIdx((i) => Math.max(i - 1, 0));
+      setSelectedIdx((i) => {
+        const next = Math.max(i - 1, 0);
+        scrollAnchorRef.current = next;
+        return next;
+      });
     } else if (event.name === "space" && isPluginMode) {
       // Space toggles plugins without closing
       spaceConsumedRef.current = true;
@@ -943,13 +958,8 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
       const selected = results[selectedIdx];
       if (selected) selected.action();
     } else if (event.name === "return" || event.name === "enter") {
-      if (isColumnsMode) {
-        const selected = results[selectedIdx];
-        if (selected) selected.action();
-      } else {
-        const selected = results[selectedIdx];
-        if (selected) selected.action();
-      }
+      // Enter is handled by the <input onSubmit> — avoid calling action twice
+      // which breaks toggle commands (e.g. Toggle Status Bar fires twice = no-op)
     }
   });
 
@@ -960,9 +970,10 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
   // Reserve rows for: top offset (3) + border (2) + input (2) + separator (1) + esc hint (1) + scroll indicators (2)
   const maxVisible = Math.min(16, Math.max(4, termHeight - 11));
 
-  // Compute a window of results centered on selectedIdx
+  // Compute a window of results centered on scroll anchor (keyboard-driven, not mouse)
+  const scrollAnchor = scrollAnchorRef.current;
   const halfWindow = Math.floor(maxVisible / 2);
-  let windowStart = Math.max(0, Math.min(selectedIdx - halfWindow, results.length - maxVisible));
+  let windowStart = Math.max(0, Math.min(scrollAnchor - halfWindow, results.length - maxVisible));
   if (windowStart < 0) windowStart = 0;
   const windowEnd = Math.min(results.length, windowStart + maxVisible);
   const windowedResults = results.slice(windowStart, windowEnd);

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -33,17 +33,35 @@ export function StatusBar() {
     extColor = priceColor(chg);
   }
 
+  const layouts = state.config.layouts ?? [];
+  const activeLayoutIdx = state.config.activeLayoutIndex ?? 0;
+  const hasMultipleLayouts = layouts.length > 1;
+
   return (
     <box
       flexDirection="row"
       height={1}
       backgroundColor={colors.panel}
     >
-      <box flexGrow={1} paddingLeft={1}>
-        <text fg={colors.textDim}>
-          <span fg={colors.text}>Ctrl+P</span> search  <span fg={colors.text}>Tab</span> switch  <span fg={colors.text}>j/k</span> navigate  <span fg={colors.text}>r</span> refresh  <span fg={colors.text}>q</span> quit
-        </text>
-      </box>
+      {hasMultipleLayouts ? (
+        <box paddingLeft={1} flexShrink={0} flexDirection="row">
+          {layouts.map((l, i) => {
+            const isActive = i === activeLayoutIdx;
+            const num = i + 1;
+            if (isActive) {
+              return <text key={i} fg={colors.headerText} bg={colors.header}>{` ^${num} ${l.name} `}</text>;
+            }
+            return <text key={i} fg={colors.textDim}>{` ^${num} `}<span fg={colors.text}>{l.name}</span>{" "}</text>;
+          })}
+        </box>
+      ) : (
+        <box paddingLeft={1}>
+          <text fg={colors.textDim}>
+            <span fg={colors.text}>Ctrl+P</span> search  <span fg={colors.text}>Tab</span> switch  <span fg={colors.text}>j/k</span> navigate  <span fg={colors.text}>r</span> refresh  <span fg={colors.text}>q</span> quit
+          </text>
+        </box>
+      )}
+      <box flexGrow={1} />
       {extText && (
         <box paddingRight={1}>
           <text fg={extColor}>{state.selectedTicker} {extText}</text>

--- a/src/data/config-store.ts
+++ b/src/data/config-store.ts
@@ -41,6 +41,11 @@ export async function loadConfig(dataDir: string): Promise<AppConfig> {
     if (saved.layout) {
       config.layout = migrateLayout(saved.layout);
     }
+    // Migration: initialize layouts array if missing
+    if (!config.layouts || !Array.isArray(config.layouts) || config.layouts.length === 0) {
+      config.layouts = [{ name: "Default", layout: config.layout }];
+      config.activeLayoutIndex = 0;
+    }
     return config;
   } catch {
     return createDefaultConfig(dataDir);

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -546,6 +546,21 @@ export const chatPlugin: GloomPlugin = {
       },
     });
 
+    // Preload: check session + fetch messages in background so chat opens instantly
+    if (savedToken) {
+      apiClient.getSession().then((session) => {
+        if (session) {
+          _cachedUser = { id: session.id, username: session.username ?? session.name };
+          _sessionChecked = true;
+          _ensureConnection();
+        } else {
+          _sessionChecked = true;
+        }
+      }).catch(() => {
+        _sessionChecked = true;
+      });
+    }
+
     // Logout command — only visible when logged in
     ctx.registerCommand({
       id: "auth-logout",

--- a/src/plugins/builtin/layout-manager.tsx
+++ b/src/plugins/builtin/layout-manager.tsx
@@ -192,6 +192,96 @@ export const layoutManagerPlugin: GloomPlugin = {
       },
     });
 
+    // New Layout — create a new layout starting from default
+    ctx.registerCommand({
+      id: "new-layout",
+      label: "New Layout",
+      description: "Create a new layout",
+      keywords: ["new", "create", "add", "layout", "workspace"],
+      category: "config",
+      wizard: [
+        { key: "name", label: "Layout name", placeholder: "e.g. Trading, Research, Overview" },
+      ],
+      execute: async (values) => {
+        if (!_dispatchFn) return;
+        const name = values?.name?.trim();
+        if (!name) {
+          ctx.showToast("Layout name is required", { type: "error" });
+          return;
+        }
+        _dispatchFn({ type: "NEW_LAYOUT", name });
+        ctx.showToast(`Layout "${name}" created`, { type: "success" });
+      },
+    });
+
+    // Delete Layout
+    ctx.registerCommand({
+      id: "delete-layout",
+      label: "Delete Layout",
+      description: "Delete the current layout preset",
+      keywords: ["delete", "remove", "layout", "preset"],
+      category: "config",
+      execute: async () => {
+        if (!_dispatchFn) return;
+        const registry = getSharedRegistry();
+        if (!registry) return;
+        const config = registry.getConfigFn();
+        const layouts = config.layouts ?? [];
+        if (layouts.length <= 1) {
+          ctx.showToast("Can't delete the only layout", { type: "error" });
+          return;
+        }
+        const idx = config.activeLayoutIndex ?? 0;
+        const name = layouts[idx]!.name;
+        _dispatchFn({ type: "DELETE_LAYOUT", index: idx });
+        ctx.showToast(`Layout "${name}" deleted`, { type: "success" });
+      },
+    });
+
+    // Rename Layout
+    ctx.registerCommand({
+      id: "rename-layout",
+      label: "Rename Layout",
+      description: "Rename the current layout preset",
+      keywords: ["rename", "layout", "preset"],
+      category: "config",
+      wizard: [
+        { key: "name", label: "New name", placeholder: "Layout name" },
+      ],
+      execute: async (values) => {
+        if (!_dispatchFn) return;
+        const name = values?.name?.trim();
+        if (!name) {
+          ctx.showToast("Name is required", { type: "error" });
+          return;
+        }
+        const registry = getSharedRegistry();
+        if (!registry) return;
+        const config = registry.getConfigFn();
+        const idx = config.activeLayoutIndex ?? 0;
+        _dispatchFn({ type: "RENAME_LAYOUT", index: idx, name });
+        ctx.showToast(`Layout renamed to "${name}"`, { type: "success" });
+      },
+    });
+
+    // Duplicate Layout
+    ctx.registerCommand({
+      id: "duplicate-layout",
+      label: "Duplicate Layout",
+      description: "Create a copy of the current layout",
+      keywords: ["duplicate", "copy", "clone", "layout"],
+      category: "config",
+      execute: async () => {
+        if (!_dispatchFn) return;
+        const registry = getSharedRegistry();
+        if (!registry) return;
+        const config = registry.getConfigFn();
+        const idx = config.activeLayoutIndex ?? 0;
+        _dispatchFn({ type: "DUPLICATE_LAYOUT", index: idx });
+        ctx.showToast("Layout duplicated", { type: "success" });
+      },
+    });
+
     // Swap Panes
     ctx.registerCommand({
       id: "swap-panes",

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -160,13 +160,11 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
               <text fg={colors.textDim}>{formatTimeAgo(selected.publishedAt)}</text>
             </box>
             <box paddingTop={1}>
-              <text fg={colors.text}>
-                {summary
-                  ? summary
-                  : loadingSummary
-                    ? <Spinner label="Loading..." />
-                    : "No preview available."}
-              </text>
+              {summary
+                ? <text fg={colors.text}>{summary}</text>
+                : loadingSummary
+                  ? <Spinner label="Loading..." />
+                  : <text fg={colors.text}>No preview available.</text>}
             </box>
           </box>
         </scrollbox>

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -658,7 +658,7 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
       >
         {sortedTickers.length === 0 ? (
           <box paddingX={1} paddingY={1}>
-            <text fg={colors.textDim}>No tickers. Press Cmd+K to add one.</text>
+            <text fg={colors.textDim}>No tickers. Press Ctrl+P to add one.</text>
           </box>
         ) : (
           sortedTickers.map((ticker, idx) => {

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useReducer, useRef, type ReactNode } from "react";
-import type { AppConfig, LayoutConfig } from "../types/config";
+import type { AppConfig, LayoutConfig, SavedLayout } from "../types/config";
+import { DEFAULT_LAYOUT } from "../types/config";
 import { saveConfig } from "../data/config-store";
 import type { TickerFile } from "../types/ticker";
 import type { TickerFinancials } from "../types/financials";
@@ -66,7 +67,12 @@ export type AppAction =
   | { type: "UPDATE_LAYOUT"; layout: LayoutConfig }
   | { type: "FOCUS_PANE"; paneId: string }
   | { type: "FOCUS_NEXT"; paneOrder: string[] }
-  | { type: "FOCUS_PREV"; paneOrder: string[] };
+  | { type: "FOCUS_PREV"; paneOrder: string[] }
+  | { type: "SWITCH_LAYOUT"; index: number }
+  | { type: "NEW_LAYOUT"; name: string }
+  | { type: "DELETE_LAYOUT"; index: number }
+  | { type: "RENAME_LAYOUT"; index: number; name: string }
+  | { type: "DUPLICATE_LAYOUT"; index: number };
 
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
@@ -191,8 +197,14 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, exchangeRates };
     }
 
-    case "UPDATE_LAYOUT":
-      return { ...state, config: { ...state.config, layout: action.layout } };
+    case "UPDATE_LAYOUT": {
+      // Also sync the layout into the active slot in layouts[]
+      const activeIdx = state.config.activeLayoutIndex ?? 0;
+      const synced = (state.config.layouts ?? []).map((l, i) =>
+        i === activeIdx ? { ...l, layout: action.layout } : l
+      );
+      return { ...state, config: { ...state.config, layout: action.layout, layouts: synced } };
+    }
 
     case "FOCUS_PANE":
       return { ...state, focusedPaneId: action.paneId };
@@ -211,6 +223,93 @@ function appReducer(state: AppState, action: AppAction): AppState {
       const idx = state.focusedPaneId ? order.indexOf(state.focusedPaneId) : 0;
       const prev = order[(idx - 1 + order.length) % order.length]!;
       return { ...state, focusedPaneId: prev };
+    }
+
+    case "SWITCH_LAYOUT": {
+      const layouts = state.config.layouts ?? [];
+      if (action.index < 0 || action.index >= layouts.length) return state;
+      const target = layouts[action.index]!;
+      // Save current layout into its slot before switching
+      const updatedLayouts = layouts.map((l, i) =>
+        i === state.config.activeLayoutIndex ? { ...l, layout: state.config.layout } : l
+      );
+      return {
+        ...state,
+        config: {
+          ...state.config,
+          layout: target.layout,
+          layouts: updatedLayouts,
+          activeLayoutIndex: action.index,
+        },
+        focusedPaneId: target.layout.docked[0]?.paneId ?? null,
+      };
+    }
+
+    case "NEW_LAYOUT": {
+      const layouts = state.config.layouts ?? [];
+      const newLayout: SavedLayout = { name: action.name, layout: structuredClone(DEFAULT_LAYOUT) };
+      const newLayouts = [...layouts, newLayout];
+      return {
+        ...state,
+        config: {
+          ...state.config,
+          layout: newLayout.layout,
+          layouts: newLayouts,
+          activeLayoutIndex: newLayouts.length - 1,
+        },
+        focusedPaneId: newLayout.layout.docked[0]?.paneId ?? null,
+      };
+    }
+
+    case "DELETE_LAYOUT": {
+      const layouts = state.config.layouts ?? [];
+      if (layouts.length <= 1) return state; // can't delete last layout
+      const newLayouts = layouts.filter((_, i) => i !== action.index);
+      const wasActive = state.config.activeLayoutIndex;
+      const newActive = action.index <= wasActive
+        ? Math.max(0, wasActive - 1)
+        : wasActive;
+      const switchTo = newLayouts[newActive]!;
+      return {
+        ...state,
+        config: {
+          ...state.config,
+          layout: switchTo.layout,
+          layouts: newLayouts,
+          activeLayoutIndex: newActive,
+        },
+        focusedPaneId: switchTo.layout.docked[0]?.paneId ?? null,
+      };
+    }
+
+    case "RENAME_LAYOUT": {
+      const layouts = state.config.layouts ?? [];
+      if (action.index < 0 || action.index >= layouts.length) return state;
+      const newLayouts = layouts.map((l, i) =>
+        i === action.index ? { ...l, name: action.name } : l
+      );
+      return { ...state, config: { ...state.config, layouts: newLayouts } };
+    }
+
+    case "DUPLICATE_LAYOUT": {
+      const layouts = state.config.layouts ?? [];
+      if (action.index < 0 || action.index >= layouts.length) return state;
+      const source = layouts[action.index]!;
+      const newLayout: SavedLayout = {
+        name: `${source.name} Copy`,
+        layout: structuredClone(source.layout),
+      };
+      const newLayouts = [...layouts, newLayout];
+      return {
+        ...state,
+        config: {
+          ...state.config,
+          layout: newLayout.layout,
+          layouts: newLayouts,
+          activeLayoutIndex: newLayouts.length - 1,
+        },
+        focusedPaneId: newLayout.layout.docked[0]?.paneId ?? null,
+      };
     }
 
     default:

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -45,6 +45,12 @@ export interface LayoutConfig {
   floating: FloatingPaneEntry[];   // panes in floating windows
 }
 
+/** A named layout preset */
+export interface SavedLayout {
+  name: string;
+  layout: LayoutConfig;
+}
+
 export interface AppConfig {
   dataDir: string;
   baseCurrency: string;
@@ -53,6 +59,8 @@ export interface AppConfig {
   watchlists: Watchlist[];
   columns: ColumnConfig[];
   layout: LayoutConfig;
+  layouts: SavedLayout[];
+  activeLayoutIndex: number;
   brokers: Record<string, Record<string, unknown>>;
   plugins: string[];
   disabledPlugins: string[];
@@ -89,6 +97,8 @@ export function createDefaultConfig(dataDir: string): AppConfig {
     watchlists: [{ id: "watchlist", name: "Watchlist" }],
     columns: DEFAULT_COLUMNS,
     layout: DEFAULT_LAYOUT,
+    layouts: [{ name: "Default", layout: DEFAULT_LAYOUT }],
+    activeLayoutIndex: 0,
     brokers: {},
     plugins: ["portfolio-list", "ticker-detail", "manual-entry", "ibkr-flex"],
     disabledPlugins: [],


### PR DESCRIPTION
## Summary

- Adds named layout presets (create, duplicate, rename, delete) managed via command bar
- Ctrl+1-9 keyboard shortcuts for instant layout switching
- Status bar shows layout tabs when multiple layouts exist
- Layouts persist automatically and existing configs are migrated
- Also fixes command bar scroll anchoring, duplicate enter handling, news plugin JSX nesting, chat session preloading, and portfolio hint text

## Test plan

- [ ] Create multiple layouts via command bar ("New Layout")
- [ ] Switch between layouts with Ctrl+1, Ctrl+2, etc.
- [ ] Verify layout tabs appear in status bar with multiple layouts
- [ ] Rename, duplicate, and delete layouts via command bar
- [ ] Confirm layouts persist across restarts
- [ ] Verify single-layout mode still shows keyboard hints in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)