### PR TITLE
Add mouse support to news list and chat messages

### DIFF
--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -4,7 +4,7 @@ import { TextAttributes } from "@opentui/core";
 import type { InputRenderable } from "@opentui/core";
 import type { GloomPlugin, GloomPluginContext, PaneProps } from "../../types/plugin";
 import { useAppState } from "../../state/app-context";
-import { colors } from "../../theme/colors";
+import { colors, hoverBg } from "../../theme/colors";
 import { apiClient, type ChatMessage } from "../../utils/api-client";
 import { getSharedRegistry } from "../../plugins/registry";
 
@@ -111,6 +111,7 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
   const [inputFocused, setInputFocused] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [selectedIdx, setSelectedIdx] = useState(-1);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(null);
   const [scrollOffset, setScrollOffset] = useState(0);
   const inputRef = useRef<InputRenderable>(null);
@@ -285,7 +286,8 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
         {visibleMessages.map((msg, i) => {
           const globalIdx = visibleStart + i;
           const isSelected = globalIdx === selectedIdx;
-          const bgColor = isSelected ? colors.selected : undefined;
+          const isHovered = globalIdx === hoveredIdx && !isSelected;
+          const bgColor = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
 
           return (
             <box
@@ -293,6 +295,7 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
               flexDirection="column"
               width={contentWidth}
               backgroundColor={bgColor}
+              onMouseMove={() => setHoveredIdx(globalIdx)}
               onMouseDown={() => setSelectedIdx(globalIdx)}
             >
               {/* Reply context */}

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -3,7 +3,7 @@ import { useKeyboard } from "@opentui/react";
 import { TextAttributes } from "@opentui/core";
 import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
 import { useSelectedTicker } from "../../state/app-context";
-import { colors } from "../../theme/colors";
+import { colors, hoverBg } from "../../theme/colors";
 import { padTo } from "../../utils/format";
 import type { NewsItem } from "../../types/data-provider";
 import { getSharedDataProvider } from "../../plugins/registry";
@@ -26,6 +26,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
   const [news, setNews] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [summaryCache, setSummaryCache] = useState<Map<string, string>>(new Map());
   const [loadingSummary, setLoadingSummary] = useState(false);
   const summaryFetchRef = useRef(0);
@@ -108,6 +109,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
       <scrollbox height={listHeight} scrollY>
         {news.map((item, i) => {
           const isSelected = i === selectedIdx;
+          const isHovered = i === hoveredIdx && !isSelected;
           const title = item.title.length > titleColW
             ? item.title.slice(0, titleColW - 1) + "\u2026"
             : item.title;
@@ -119,7 +121,9 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
               key={i}
               flexDirection="row"
               height={1}
-              backgroundColor={isSelected ? colors.selected : colors.bg}
+              backgroundColor={isSelected ? colors.selected : isHovered ? hoverBg() : colors.bg}
+              onMouseMove={() => setHoveredIdx(i)}
+              onMouseDown={() => setSelectedIdx(i)}
             >
               <box width={titleColW + 1}>
                 <text fg={isSelected ? colors.selectedText : colors.text}>


### PR DESCRIPTION
## Summary
- Add `onMouseDown` (click to select) and `onMouseMove` (hover highlight) to news list rows, which previously only supported keyboard navigation
- Add `onMouseMove` hover support to chat message rows, which already had click selection but no hover feedback
- Both follow the existing pattern from portfolio-list.tsx using `hoveredIdx` state and `hoverBg()`

## Test plan
- [ ] Open the News tab and verify rows highlight on hover and select on click
- [ ] Open the Chat pane and verify messages highlight on hover
- [ ] Confirm keyboard navigation (j/k) still works in both components

🤖 Generated with [Claude Code](https://claude.com/claude-code)