### PR TITLE
Move data directory to ~/.gloomberb/

### DIFF
--- a/src/data/config-store.ts
+++ b/src/data/config-store.ts
@@ -23,10 +23,6 @@ export async function getDataDir(): Promise<string | null> {
   }
 }
 
-export async function setDataDir(dataDir: string): Promise<void> {
-  await mkdir(GLOBAL_CONFIG_DIR, { recursive: true });
-  await writeFile(GLOBAL_CONFIG_FILE, JSON.stringify({ dataDir }, null, 2), "utf-8");
-}
 
 export async function loadConfig(dataDir: string): Promise<AppConfig> {
   const { config } = await loadConfigState(dataDir);
@@ -109,8 +105,7 @@ export async function saveConfig(config: AppConfig): Promise<void> {
     recentTickers: sanitizeStringArray(config.recentTickers, []),
   };
 
-  const { dataDir, ...rest } = persisted;
-  await writeFile(configPath, JSON.stringify(rest, null, 2), "utf-8");
+  await writeFile(configPath, JSON.stringify(persisted, null, 2), "utf-8");
 }
 
 export async function initDataDir(dataDir: string): Promise<AppConfig> {
@@ -119,13 +114,11 @@ export async function initDataDir(dataDir: string): Promise<AppConfig> {
   if (needsSave) {
     await saveConfig(config);
   }
-  await setDataDir(dataDir);
   return config;
 }
 
 export async function resetAllData(dataDir: string): Promise<void> {
   await rm(dataDir, { recursive: true, force: true });
-  await rm(GLOBAL_CONFIG_DIR, { recursive: true, force: true });
 }
 
 export async function exportConfig(config: AppConfig, destPath: string): Promise<void> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ async function main() {
 
   if (!dataDir) {
     // First run - use default location
-    dataDir = join(process.env.HOME || "~", "gloomberb-data");
+    dataDir = join(process.env.HOME || "~", ".gloomberb");
   }
 
   // Ensure data dir exists


### PR DESCRIPTION
## Summary
- Changes default data directory from `~/gloomberb-data` to `~/.gloomberb/`, consolidating all config, cache, and data files under one hidden directory.
- `saveConfig` now persists `dataDir` in `config.json` so `getDataDir` can read it back without a separate pointer file.
- Removes `setDataDir` (no longer needed) and the redundant second `rm` in `resetAllData`.

## Test plan
- [ ] Fresh install creates `~/.gloomberb/` with config.json and cache DB
- [ ] Existing users with a custom `dataDir` still load correctly via `getDataDir`
- [ ] `resetAllData` cleans up `~/.gloomberb/` fully

🤖 Generated with [Claude Code](https://claude.com/claude-code)