### PR TITLE
Hide watchlist scrollbar when content fits

### DIFF
--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -577,6 +577,13 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
     }
   }, [selectedIdx]);
 
+  // Hide vertical scrollbar when content fits in viewport
+  useEffect(() => {
+    const sb = scrollRef.current;
+    if (!sb) return;
+    sb.verticalScrollBar.visible = sortedTickers.length > sb.viewport.height;
+  }, [sortedTickers.length]);
+
   // Tick every 5s to keep latency column fresh
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 5000);


### PR DESCRIPTION
## Summary
- Hides the vertical scrollbar in the watchlist/portfolio list when the number of ticker rows fits within the viewport height
- Uses the same `verticalScrollBar.visible` pattern already used for hiding the header's horizontal scrollbar

## Test plan
- [ ] Open the watchlist with fewer tickers than viewport height — scrollbar should not appear
- [ ] Add enough tickers to exceed viewport height — scrollbar should appear