### PR TITLE
Fix trade tab rendering, add price selector and mouse interactions

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,6 @@
 // Reusable components for plugins
+export { PriceSelectorDialog } from "./price-selector-dialog";
+export type { PriceSelectorDialogProps } from "./price-selector-dialog";
 export { StockChart } from "./chart/stock-chart";
 export type { ChartViewState, TimeRange, ChartRenderMode, ChartColors } from "./chart/chart-types";
 export { ToggleList } from "./toggle-list";

--- a/src/components/price-selector-dialog.tsx
+++ b/src/components/price-selector-dialog.tsx
@@ -1,0 +1,187 @@
+import { useState, useRef, useEffect } from "react";
+import { TextAttributes } from "@opentui/core";
+import type { InputRenderable } from "@opentui/core";
+import { useDialogKeyboard, type PromptContext } from "@opentui-ui/dialog/react";
+import type { Quote } from "../types/financials";
+import { colors } from "../theme/colors";
+import { padTo } from "../utils/format";
+
+interface PricePreset {
+  label: string;
+  value: number;
+  detail?: string;
+}
+
+export interface PriceSelectorDialogProps {
+  label: string;
+  currentValue?: number;
+  quote?: Quote;
+}
+
+function buildPresets(quote: Quote | undefined): PricePreset[] {
+  if (!quote) return [];
+  const presets: PricePreset[] = [];
+  if (quote.bid != null && quote.bid > 0) {
+    presets.push({ label: "Bid", value: quote.bid, detail: quote.bidSize != null ? `× ${quote.bidSize}` : undefined });
+  }
+  if (quote.ask != null && quote.ask > 0) {
+    presets.push({ label: "Ask", value: quote.ask, detail: quote.askSize != null ? `× ${quote.askSize}` : undefined });
+  }
+  if (quote.price > 0) {
+    presets.push({ label: "Last", value: quote.price });
+  }
+  if (quote.mark != null && quote.mark > 0) {
+    presets.push({ label: "Mark", value: quote.mark });
+  }
+  if (quote.high != null && quote.high > 0) {
+    presets.push({ label: "High", value: quote.high });
+  }
+  if (quote.low != null && quote.low > 0) {
+    presets.push({ label: "Low", value: quote.low });
+  }
+  if (quote.previousClose != null && quote.previousClose > 0) {
+    presets.push({ label: "Prev Close", value: quote.previousClose });
+  }
+  return presets;
+}
+
+function formatMarketContext(quote: Quote | undefined): string {
+  if (!quote) return "No quote data available";
+  const parts: string[] = [];
+  parts.push(`Last ${quote.price.toFixed(2)}`);
+  if (quote.bid != null) {
+    const bidStr = quote.bidSize != null ? `Bid ${quote.bid.toFixed(2)} × ${quote.bidSize}` : `Bid ${quote.bid.toFixed(2)}`;
+    parts.push(bidStr);
+  }
+  if (quote.ask != null) {
+    const askStr = quote.askSize != null ? `Ask ${quote.ask.toFixed(2)} × ${quote.askSize}` : `Ask ${quote.ask.toFixed(2)}`;
+    parts.push(askStr);
+  }
+  if (quote.bid != null && quote.ask != null) {
+    parts.push(`Spd ${(quote.ask - quote.bid).toFixed(2)}`);
+  }
+  return parts.join(" · ");
+}
+
+const CUSTOM_INDEX = -1;
+
+export function PriceSelectorDialog({
+  resolve,
+  dialogId,
+  label,
+  currentValue,
+  quote,
+}: PromptContext<string> & PriceSelectorDialogProps) {
+  const presets = buildPresets(quote);
+  const [index, setIndex] = useState(0);
+  const [mode, setMode] = useState<"list" | "input">(presets.length > 0 ? "list" : "input");
+  const [customValue, setCustomValue] = useState("");
+  const inputRef = useRef<InputRenderable>(null);
+
+  useEffect(() => {
+    if (mode === "input") inputRef.current?.focus();
+  }, [mode]);
+
+  useDialogKeyboard((event) => {
+    event.stopPropagation();
+
+    if (event.name === "escape") {
+      resolve("");
+      return;
+    }
+
+    if (mode === "list") {
+      if (event.name === "up" || event.name === "k") {
+        setIndex((current) => Math.max(0, current - 1));
+      } else if (event.name === "down" || event.name === "j") {
+        if (index < presets.length - 1) {
+          setIndex((current) => current + 1);
+        } else {
+          setMode("input");
+          setIndex(CUSTOM_INDEX);
+        }
+      } else if (event.name === "return") {
+        if (presets[index]) {
+          resolve(String(presets[index].value));
+        }
+      } else if (event.name === "tab") {
+        setMode("input");
+        setIndex(CUSTOM_INDEX);
+      } else if (event.sequence && /^[0-9.]$/.test(event.sequence)) {
+        setMode("input");
+        setIndex(CUSTOM_INDEX);
+        setCustomValue(event.sequence);
+      }
+    } else {
+      if (event.name === "up" || (event.name === "tab" && presets.length > 0)) {
+        setMode("list");
+        setIndex(presets.length - 1);
+      } else if (event.name === "return") {
+        resolve(customValue.trim());
+      }
+    }
+  }, dialogId);
+
+  const presetWidth = 12;
+
+  return (
+    <box flexDirection="column">
+      <text attributes={TextAttributes.BOLD} fg={colors.text}>{label}</text>
+      <box height={1} />
+      <text fg={colors.textDim}>{formatMarketContext(quote)}</text>
+      <box height={1} />
+
+      {presets.map((preset, presetIndex) => {
+        const selected = mode === "list" && presetIndex === index;
+        return (
+          <box
+            key={preset.label}
+            flexDirection="row"
+            height={1}
+            backgroundColor={selected ? colors.selected : colors.bg}
+            onMouseMove={() => { setMode("list"); setIndex(presetIndex); }}
+            onMouseDown={() => resolve(String(preset.value))}
+          >
+            <text fg={selected ? colors.selectedText : colors.textDim}>{selected ? "▸ " : "  "}</text>
+            <text fg={selected ? colors.text : colors.textDim} attributes={selected ? TextAttributes.BOLD : 0}>
+              {padTo(preset.label, presetWidth)}
+            </text>
+            <text fg={selected ? colors.text : colors.textMuted}>
+              {preset.value.toFixed(2)}
+            </text>
+            {preset.detail && (
+              <text fg={colors.textDim}>{`  ${preset.detail}`}</text>
+            )}
+          </box>
+        );
+      })}
+
+      {presets.length > 0 && <box height={1} />}
+
+      <box flexDirection="row" onMouseDown={() => { setMode("input"); setIndex(CUSTOM_INDEX); }}>
+        <text fg={mode === "input" ? colors.text : colors.textDim}>
+          {mode === "input" ? "▸ " : "  "}Custom:{" "}
+        </text>
+        <input
+          ref={inputRef}
+          focused={mode === "input"}
+          value={customValue}
+          placeholder={currentValue != null ? String(currentValue) : "type a price"}
+          textColor={colors.text}
+          placeholderColor={colors.textDim}
+          backgroundColor={colors.bg}
+          onInput={(nextValue) => setCustomValue(nextValue)}
+          onChange={(nextValue) => setCustomValue(nextValue)}
+          onSubmit={() => resolve(customValue.trim())}
+        />
+      </box>
+
+      <box height={1} />
+      <text fg={colors.textMuted}>
+        {mode === "list"
+          ? "↑↓ or hover to choose · Enter/click select · Tab or ↓ for custom · Esc cancel"
+          : "Type a price · Enter confirm · ↑ or Tab back to presets · Esc cancel"}
+      </text>
+    </box>
+  );
+}

--- a/src/plugins/ibkr/gateway-service.ts
+++ b/src/plugins/ibkr/gateway-service.ts
@@ -622,8 +622,8 @@ export class IbkrGatewayService {
       symbol: ref.symbol,
       localSymbol: ref.localSymbol,
       secType: (ref.secType as SecType | undefined) ?? SecType.STK,
-      exchange: ref.exchange || "SMART",
-      primaryExch: ref.primaryExchange,
+      exchange: "SMART",
+      primaryExch: ref.primaryExchange || ref.exchange || undefined,
       currency: ref.currency || "USD",
       lastTradeDateOrContractMonth: ref.lastTradeDateOrContractMonth,
       right: ref.right === "C" ? OptionType.Call : ref.right === "P" ? OptionType.Put : undefined,
@@ -759,6 +759,14 @@ export class IbkrGatewayService {
       exchangeName: details.validExchanges?.split(",")[0],
       fullExchangeName: details.validExchanges?.split(",")[0],
       marketState: "REGULAR",
+      bid: marketData.get(IBApiTickType.BID)?.value ?? marketData.get(IBApiTickType.DELAYED_BID)?.value,
+      ask: marketData.get(IBApiTickType.ASK)?.value ?? marketData.get(IBApiTickType.DELAYED_ASK)?.value,
+      bidSize: marketData.get(IBApiTickType.BID_SIZE)?.value ?? marketData.get(IBApiTickType.DELAYED_BID_SIZE)?.value,
+      askSize: marketData.get(IBApiTickType.ASK_SIZE)?.value ?? marketData.get(IBApiTickType.DELAYED_ASK_SIZE)?.value,
+      open: marketData.get(IBApiTickType.OPEN)?.value ?? marketData.get(IBApiTickType.DELAYED_OPEN)?.value,
+      high: marketData.get(IBApiTickType.HIGH)?.value ?? marketData.get(IBApiTickType.DELAYED_HIGH)?.value,
+      low: marketData.get(IBApiTickType.LOW)?.value ?? marketData.get(IBApiTickType.DELAYED_LOW)?.value,
+      mark: marketData.get(IBApiTickType.MARK_PRICE)?.value,
     };
   }
 

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -10,7 +10,8 @@ import type { BrokerContractRef } from "../../types/instrument";
 import type { DetailTabProps, GloomPlugin, GloomPluginContext, PaneProps, WizardStep } from "../../types/plugin";
 import type { BrokerAccount, BrokerOrderRequest, BrokerOrderType } from "../../types/trading";
 import { useAppState, useSelectedTicker } from "../../state/app-context";
-import { colors, priceColor } from "../../theme/colors";
+import { PriceSelectorDialog } from "../../components";
+import { colors, hoverBg, priceColor } from "../../theme/colors";
 import { formatCompact, formatCurrency, formatNumber, padTo } from "../../utils/format";
 import { getBrokerInstance, getBrokerInstancesByType } from "../../utils/broker-instances";
 import {
@@ -111,7 +112,11 @@ function formatContractLabel(contract: BrokerContractRef): string {
 function formatQuoteSummary(quote?: Quote): string {
   if (!quote) return "No broker quote loaded";
   const change = `${quote.change >= 0 ? "+" : ""}${quote.change.toFixed(2)}`;
-  return `${formatCurrency(quote.price, quote.currency)}  ${change}`;
+  const parts = [`${formatCurrency(quote.price, quote.currency)}  ${change}`];
+  if (quote.bid != null) parts.push(`Bid ${quote.bid.toFixed(2)}`);
+  if (quote.ask != null) parts.push(`Ask ${quote.ask.toFixed(2)}`);
+  if (quote.bid != null && quote.ask != null) parts.push(`Spd ${(quote.ask - quote.bid).toFixed(2)}`);
+  return parts.join(" · ");
 }
 
 function formatPreviewSummary(preview: import("../../types/trading").BrokerOrderPreview | null): string {
@@ -348,7 +353,14 @@ function ChoiceDialog({
       {choices.map((choice, choiceIndex) => {
         const selected = choiceIndex === index;
         return (
-          <box key={choice.id} backgroundColor={selected ? colors.selected : colors.bg}>
+          <box
+            key={choice.id}
+            flexDirection="row"
+            height={1}
+            backgroundColor={selected ? colors.selected : colors.bg}
+            onMouseMove={() => setIndex(choiceIndex)}
+            onMouseDown={() => resolve(choice.id)}
+          >
             <text fg={selected ? colors.selectedText : colors.textDim}>{selected ? "▸ " : "  "}</text>
             <text fg={selected ? colors.text : colors.textDim} attributes={selected ? TextAttributes.BOLD : 0}>
               {choice.label}
@@ -359,7 +371,7 @@ function ChoiceDialog({
       <box height={1} />
       <text fg={colors.textDim}>{choices[index]?.desc || ""}</text>
       <box height={1} />
-      <text fg={colors.textMuted}>Use ↑↓ to choose · Enter to select · Esc to cancel</text>
+      <text fg={colors.textMuted}>↑↓ choose · Enter/click select · Esc cancel</text>
     </box>
   );
 }
@@ -370,6 +382,8 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
   const dialog = useDialog();
   const tradeState = useTradingPaneState();
   const [interactive, setInteractive] = useState(false);
+  const [hoveredField, setHoveredField] = useState<string | null>(null);
+  const fieldHoverBg = hoverBg();
 
   const symbol = ticker?.frontmatter.ticker ?? null;
   const ticketState = getTradeTicketState(symbol, ticker);
@@ -399,18 +413,14 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
   const activeAccount = gatewaySnapshot.accounts.find((account) => account.accountId === currentAccountId);
 
   const enterInteractive = useCallback(() => {
-    if (!interactive) {
-      setInteractive(true);
-      onCapture(true);
-    }
-  }, [interactive, onCapture]);
+    setInteractive(true);
+    onCapture(true);
+  }, [onCapture]);
 
   const exitInteractive = useCallback(() => {
-    if (interactive) {
-      setInteractive(false);
-      onCapture(false);
-    }
-  }, [interactive, onCapture]);
+    setInteractive(false);
+    onCapture(false);
+  }, [onCapture]);
 
   useEffect(() => {
     if (!focused) {
@@ -420,7 +430,7 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
 
   useEffect(() => {
     exitInteractive();
-  }, [symbol, exitInteractive]);
+  }, [symbol]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!symbol || !ticker || !selectedInstance) return;
@@ -674,6 +684,32 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
     onCommit(numeric);
   }, [dialog, symbol, ticker]);
 
+  const editPriceField = useCallback(async (
+    label: string,
+    currentValue: number | undefined,
+    onCommit: (value: number | undefined) => void,
+  ) => {
+    const response = await dialog.prompt<string>({
+      content: (ctx) => <PriceSelectorDialog
+        {...ctx}
+        label={label}
+        currentValue={currentValue}
+        quote={financials?.quote}
+      />,
+    });
+    if (response === undefined) return;
+    if (!response.trim()) {
+      onCommit(undefined);
+      return;
+    }
+    const numeric = Number(response);
+    if (!Number.isFinite(numeric)) {
+      if (symbol && ticker) setTradeTicketMessage(symbol, undefined, `${label} must be numeric.`, ticker);
+      return;
+    }
+    onCommit(numeric);
+  }, [dialog, symbol, ticker, financials]);
+
   const editOrderType = useCallback(async () => {
     if (!symbol || !ticker) return;
     const choice = await dialog.prompt<string>({
@@ -829,14 +865,18 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
         editOrderType().catch(() => {});
         break;
       case "l":
-        editNumericField("Limit Price", ticketState.draft.limitPrice, (value) => {
-          setTradeTicketDraft(symbol, { limitPrice: value }, ticker);
-        }).catch(() => {});
+        if (isLimitOrder(ticketState.draft.orderType)) {
+          editPriceField("Limit Price", ticketState.draft.limitPrice, (value) => {
+            setTradeTicketDraft(symbol, { limitPrice: value }, ticker);
+          }).catch(() => {});
+        }
         break;
       case "x":
-        editNumericField("Stop Price", ticketState.draft.stopPrice, (value) => {
-          setTradeTicketDraft(symbol, { stopPrice: value }, ticker);
-        }).catch(() => {});
+        if (isStopOrder(ticketState.draft.orderType)) {
+          editPriceField("Stop Price", ticketState.draft.stopPrice, (value) => {
+            setTradeTicketDraft(symbol, { stopPrice: value }, ticker);
+          }).catch(() => {});
+        }
         break;
       case "p":
         previewOrder().catch(() => {});
@@ -857,19 +897,20 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
   }
 
   const rowWidth = Math.max(20, Math.floor((width - 4) / 4));
-  const detailHeight = Math.max(6, height - 9);
+  const showLimit = isLimitOrder(ticketState.draft.orderType);
+  const showStop = isStopOrder(ticketState.draft.orderType);
 
   return (
     <scrollbox flexGrow={1} scrollY>
       <box flexDirection="column" paddingX={1} paddingBottom={1} onMouseDown={enterInteractive}>
-        <box height={1}>
+        <box height={1} flexDirection="row">
           <text attributes={TextAttributes.BOLD} fg={colors.textBright}>{`Trade ${ticker.frontmatter.ticker}`}</text>
           {ticker.frontmatter.name && ticker.frontmatter.name !== ticker.frontmatter.ticker && (
             <text fg={colors.textDim}>{` · ${ticker.frontmatter.name}`}</text>
           )}
         </box>
 
-        <box height={1}>
+        <box height={1} flexDirection="row" onMouseDown={() => { enterInteractive(); chooseBrokerInstance().catch(() => {}); }}>
           <text fg={
             gatewaySnapshot.status.state === "connected"
               ? colors.positive
@@ -884,7 +925,7 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
           <text fg={colors.textMuted}>{` · ${interactive ? "ticket active" : "press Enter to activate ticket"}`}</text>
         </box>
 
-        <box height={1}>
+        <box height={1} flexDirection="row" onMouseDown={() => { enterInteractive(); chooseAccount().catch(() => {}); }}>
           <text fg={colors.textDim}>
             {activeAccount
               ? `${selectedInstance?.label || "IBKR"} → ${activeAccount.accountId} · ${formatCurrency(activeAccount.netLiquidation || 0, activeAccount.currency || "USD")} net liq`
@@ -900,7 +941,7 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
           <text fg={colors.textMuted}>{formatQuoteSummary(financials?.quote)}</text>
         </box>
 
-        <box height={1}>
+        <box height={1} flexDirection="row" onMouseDown={() => { enterInteractive(); chooseInstrument().catch(() => {}); }}>
           <text fg={colors.text} attributes={TextAttributes.BOLD}>
             {ticketState.draft.contract.symbol ? formatContractLabel(ticketState.draft.contract) : "No contract selected"}
           </text>
@@ -929,35 +970,75 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
           <text fg={colors.border}>{"─".repeat(Math.max(1, width - 2))}</text>
         </box>
 
-        <box flexDirection="row" height={detailHeight}>
-          <box width={rowWidth} flexDirection="column">
+        <box flexDirection="row" onMouseLeave={() => setHoveredField(null)}>
+          <box width={rowWidth} flexDirection="column"
+            backgroundColor={hoveredField === "action" ? fieldHoverBg : undefined}
+            onMouseMove={() => setHoveredField("action")}
+            onMouseDown={() => {
+              enterInteractive();
+              if (symbol && ticker) setTradeTicketDraft(symbol, { action: ticketState.draft.action === "BUY" ? "SELL" : "BUY" }, ticker);
+            }}>
             <text fg={colors.textDim}>Action</text>
             <text fg={ticketState.draft.action === "BUY" ? colors.positive : colors.negative} attributes={TextAttributes.BOLD}>
               {ticketState.draft.action}
             </text>
           </box>
-          <box width={rowWidth} flexDirection="column">
+          <box width={rowWidth} flexDirection="column"
+            backgroundColor={hoveredField === "orderType" ? fieldHoverBg : undefined}
+            onMouseMove={() => setHoveredField("orderType")}
+            onMouseDown={() => { enterInteractive(); editOrderType().catch(() => {}); }}>
             <text fg={colors.textDim}>Order Type</text>
             <text fg={colors.text}>{ticketState.draft.orderType}</text>
           </box>
-          <box width={rowWidth} flexDirection="column">
+          <box width={rowWidth} flexDirection="column"
+            backgroundColor={hoveredField === "quantity" ? fieldHoverBg : undefined}
+            onMouseMove={() => setHoveredField("quantity")}
+            onMouseDown={() => {
+              enterInteractive();
+              editNumericField("Quantity", ticketState.draft.quantity, (value) => {
+                if (value != null && symbol && ticker) setTradeTicketDraft(symbol, { quantity: value }, ticker);
+              }).catch(() => {});
+            }}>
             <text fg={colors.textDim}>Quantity</text>
             <text fg={colors.text}>{formatNumber(ticketState.draft.quantity, 0)}</text>
           </box>
-          <box width={rowWidth} flexDirection="column">
+          <box width={rowWidth} flexDirection="column"
+            backgroundColor={hoveredField === "account" ? fieldHoverBg : undefined}
+            onMouseMove={() => setHoveredField("account")}
+            onMouseDown={() => { enterInteractive(); chooseAccount().catch(() => {}); }}>
             <text fg={colors.textDim}>Account</text>
             <text fg={colors.text}>{currentAccountId || "auto"}</text>
           </box>
         </box>
 
-        <box flexDirection="row">
-          <box width={rowWidth} flexDirection="column">
-            <text fg={colors.textDim}>Limit Price</text>
-            <text fg={colors.text}>{ticketState.draft.limitPrice != null ? ticketState.draft.limitPrice.toFixed(2) : "—"}</text>
+        <box flexDirection="row" onMouseLeave={() => setHoveredField(null)}>
+          <box width={rowWidth} flexDirection="column"
+            backgroundColor={showLimit && hoveredField === "limitPrice" ? fieldHoverBg : undefined}
+            onMouseMove={() => { if (showLimit) setHoveredField("limitPrice"); }}
+            onMouseDown={showLimit ? () => {
+              enterInteractive();
+              editPriceField("Limit Price", ticketState.draft.limitPrice, (value) => {
+                if (symbol && ticker) setTradeTicketDraft(symbol, { limitPrice: value }, ticker);
+              }).catch(() => {});
+            } : undefined}>
+            <text fg={showLimit ? colors.textDim : colors.textMuted}>Limit Price</text>
+            <text fg={showLimit ? colors.text : colors.textMuted}>
+              {showLimit ? (ticketState.draft.limitPrice != null ? ticketState.draft.limitPrice.toFixed(2) : "—") : "n/a"}
+            </text>
           </box>
-          <box width={rowWidth} flexDirection="column">
-            <text fg={colors.textDim}>Stop Price</text>
-            <text fg={colors.text}>{ticketState.draft.stopPrice != null ? ticketState.draft.stopPrice.toFixed(2) : "—"}</text>
+          <box width={rowWidth} flexDirection="column"
+            backgroundColor={showStop && hoveredField === "stopPrice" ? fieldHoverBg : undefined}
+            onMouseMove={() => { if (showStop) setHoveredField("stopPrice"); }}
+            onMouseDown={showStop ? () => {
+              enterInteractive();
+              editPriceField("Stop Price", ticketState.draft.stopPrice, (value) => {
+                if (symbol && ticker) setTradeTicketDraft(symbol, { stopPrice: value }, ticker);
+              }).catch(() => {});
+            } : undefined}>
+            <text fg={showStop ? colors.textDim : colors.textMuted}>Stop Price</text>
+            <text fg={showStop ? colors.text : colors.textMuted}>
+              {showStop ? (ticketState.draft.stopPrice != null ? ticketState.draft.stopPrice.toFixed(2) : "—") : "n/a"}
+            </text>
           </box>
           <box width={rowWidth} flexDirection="column">
             <text fg={colors.textDim}>Time In Force</text>
@@ -970,11 +1051,22 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
         </box>
 
         <box height={1} />
-        <text fg={colors.textMuted}>
-          {interactive
-            ? "i profile · s contract · a account · b buy · v sell · q qty · t type · l limit · x stop · p preview · enter submit · esc release"
-            : "Enter activates the ticket. Esc returns to normal detail-tab navigation."}
-        </text>
+        {interactive ? (
+          <box flexDirection="row" flexWrap="wrap">
+            <text fg={colors.textMuted} onMouseDown={() => chooseBrokerInstance().catch(() => {})}>{" [i] Profile "}</text>
+            <text fg={colors.textMuted} onMouseDown={() => chooseInstrument().catch(() => {})}>{" [s] Contract "}</text>
+            <text fg={colors.textMuted} onMouseDown={() => chooseAccount().catch(() => {})}>{" [a] Account "}</text>
+            <text fg={colors.textMuted} onMouseDown={() => { if (symbol && ticker) setTradeTicketDraft(symbol, { action: "BUY" }, ticker); }}>{" [b] Buy "}</text>
+            <text fg={colors.textMuted} onMouseDown={() => { if (symbol && ticker) setTradeTicketDraft(symbol, { action: "SELL" }, ticker); }}>{" [v] Sell "}</text>
+            <text fg={colors.textMuted} onMouseDown={() => previewOrder().catch(() => {})}>{" [p] Preview "}</text>
+            <text fg={colors.textMuted} onMouseDown={() => submitOrder().catch(() => {})}>{" [Enter] Submit "}</text>
+            <text fg={colors.textMuted} onMouseDown={() => exitInteractive()}>{" [Esc] Release "}</text>
+          </box>
+        ) : (
+          <text fg={colors.textMuted} onMouseDown={() => enterInteractive()}>
+            {"Click here or press Enter to activate the ticket."}
+          </text>
+        )}
       </box>
     </scrollbox>
   );
@@ -1268,17 +1360,34 @@ function TradingPane({ focused, width, height }: PaneProps) {
             ) : (
               gatewaySnapshot.openOrders.map((order, index) => {
                 const selected = index === tradeState.selectedOpenOrderIndex;
+                const orderSymbol = order.contract.symbol;
+                const orderQuote = state.financials.get(orderSymbol)?.quote;
+                const bidStr = orderQuote?.bid != null ? orderQuote.bid.toFixed(2) : "---";
+                const askStr = orderQuote?.ask != null ? orderQuote.ask.toFixed(2) : "---";
+                const orderPrice = order.limitPrice != null ? order.limitPrice.toFixed(2) : order.stopPrice != null ? order.stopPrice.toFixed(2) : "MKT";
                 return (
-                  <box key={order.orderId} backgroundColor={selected ? colors.selected : colors.bg}>
+                  <box
+                    key={order.orderId}
+                    backgroundColor={selected ? colors.selected : colors.bg}
+                    onMouseDown={() => {
+                      if (selected) {
+                        openSelectedOrder();
+                      } else {
+                        updateTradingPaneState({ selectedOpenOrderIndex: index });
+                      }
+                    }}
+                  >
                     <text fg={selected ? colors.text : colors.textDim}>
                       {selected ? "▸ " : "  "}
                       {padTo(String(order.orderId), 6)}
                       {padTo(order.action, 5)}
-                      {padTo(order.contract.localSymbol || order.contract.symbol, 18)}
-                      {padTo(order.status, 12)}
-                      {padTo(String(order.remaining), 6, "right")}
+                      {padTo(order.contract.localSymbol || order.contract.symbol, 14)}
+                      {padTo(order.status, 10)}
+                      {padTo(String(order.remaining), 5, "right")}
                       {" "}
-                      {order.limitPrice != null ? order.limitPrice.toFixed(2) : order.stopPrice != null ? order.stopPrice.toFixed(2) : "MKT"}
+                      {padTo(orderPrice, 9)}
+                      {padTo(`B:${bidStr}`, 10)}
+                      {`A:${askStr}`}
                     </text>
                   </box>
                 );
@@ -1298,7 +1407,15 @@ function TradingPane({ focused, width, height }: PaneProps) {
               <text fg={colors.textDim}>No recent executions.</text>
             ) : (
               gatewaySnapshot.executions.slice(0, 20).map((execution) => (
-                <box key={execution.execId}>
+                <box
+                  key={execution.execId}
+                  onMouseDown={() => {
+                    const sym = execution.contract.symbol;
+                    if (sym && state.tickers.some((t) => t.frontmatter.ticker === sym)) {
+                      dispatch({ type: "SELECT_TICKER", symbol: sym });
+                    }
+                  }}
+                >
                   <text fg={priceColor(execution.side.toUpperCase() === "BOT" ? 1 : -1)}>
                     {padTo(execution.side, 5)}
                     {padTo(execution.contract.localSymbol || execution.contract.symbol, 18)}
@@ -1313,8 +1430,12 @@ function TradingPane({ focused, width, height }: PaneProps) {
         </box>
       </box>
 
-      <box height={1}>
-        <text fg={colors.textMuted}>i profile · a account · enter/m open selected order in trade tab · c cancel · r refresh</text>
+      <box flexDirection="row" height={1}>
+        <text fg={colors.textMuted} onMouseDown={() => chooseBrokerInstance().catch(() => {})}>{" [i] Profile "}</text>
+        <text fg={colors.textMuted} onMouseDown={() => chooseAccount().catch(() => {})}>{" [a] Account "}</text>
+        <text fg={colors.textMuted} onMouseDown={() => openSelectedOrder()}>{" [Enter] Open "}</text>
+        <text fg={colors.textMuted} onMouseDown={() => cancelSelectedOrder().catch(() => {})}>{" [c] Cancel "}</text>
+        <text fg={colors.textMuted} onMouseDown={() => refresh().catch(() => {})}>{" [r] Refresh "}</text>
       </box>
     </box>
   );

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -22,6 +22,14 @@ export interface Quote {
   postMarketPrice?: number;
   postMarketChange?: number;
   postMarketChangePercent?: number;
+  bid?: number;
+  ask?: number;
+  bidSize?: number;
+  askSize?: number;
+  open?: number;
+  high?: number;
+  low?: number;
+  mark?: number;
 }
 
 export interface Fundamentals {


### PR DESCRIPTION
## Summary
- Fix garbled text rendering in trade tab headers (missing `flexDirection="row"` on boxes with multiple text children)
- Fix enter key flicker when activating interactive mode (unstable callback dependencies in useEffect)
- Fix "destination or exchange is invalid" IBKR error by always routing through SMART exchange
- Add shared `PriceSelectorDialog` component with bid/ask/last/mark/high/low presets from live market data
- Extract bid/ask/high/low/open/mark from IBKR market data snapshots into the `Quote` type
- Add hover states and mouse click interactions to all trade tab fields, dialogs, and trading pane order rows
- Gate limit/stop price fields on order type (disabled with "n/a" for irrelevant order types)
- Show bid/ask/spread in quote summary and open orders list

## Test plan
- [ ] Open Trade tab, verify text renders correctly (no garbled/overlapping text)
- [ ] Press Enter to activate ticket — should stay active, no flicker
- [ ] Click order fields (Action, Order Type, Quantity, etc.) — should open editors with hover feedback
- [ ] Press `l`/`x` on MKT order — should be no-op; switch to LMT and verify limit price selector opens with market presets
- [ ] Hover/click dialog choices (Order Type, Contract search) — should highlight and select
- [ ] Check quote summary shows bid/ask/spread when IBKR data available
- [ ] Preview an order — verify no "destination or exchange" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)