### PR TITLE
Refine command bar UI and behavior

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -454,7 +454,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
   pluginRegistry.selectTickerFn = (symbol) => dispatch({ type: "SELECT_TICKER", symbol });
   pluginRegistry.switchPanelFn = (panel) => dispatch({ type: "SET_ACTIVE_PANEL", panel });
   pluginRegistry.switchTabFn = (tabId) => dispatch({ type: "SET_RIGHT_TAB", tab: tabId });
-  pluginRegistry.openCommandBarFn = () => dispatch({ type: "SET_COMMAND_BAR", open: true });
+  pluginRegistry.openCommandBarFn = (query) => dispatch({ type: "SET_COMMAND_BAR", open: true, query });
   const persistLayout = (layout: LayoutConfig) => {
     const layouts = state.config.layouts.map((savedLayout, index) => (
       index === state.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
@@ -590,7 +590,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
     }
     // Backtick opens command bar (close is handled in command-bar.tsx)
     if (event.name === "`" && !state.commandBarOpen) {
-      dispatch({ type: "SET_COMMAND_BAR", open: true });
+      dispatch({ type: "SET_COMMAND_BAR", open: true, query: "" });
       return;
     }
     // Ctrl+1-9: switch layouts (works even when input is captured)
@@ -646,7 +646,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
       const actions = [...pluginRegistry.tickerActions.values()];
       const ticker = state.tickers.get(state.selectedTicker);
       if (actions.length > 0 && ticker) {
-        dispatch({ type: "SET_COMMAND_BAR", open: true });
+        dispatch({ type: "SET_COMMAND_BAR", open: true, query: "" });
       }
     } else if (event.name === "u" && state.updateAvailable && !state.updateProgress) {
       performUpdate(state.updateAvailable, (progress) => {
@@ -654,7 +654,10 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
       });
     } else {
       // Plugin keyboard shortcuts (built-ins take priority)
+      const disabledPlugins = new Set(state.config.disabledPlugins || []);
       for (const shortcut of pluginRegistry.shortcuts.values()) {
+        const ownerId = pluginRegistry.getShortcutPluginId(shortcut.id);
+        if (ownerId && disabledPlugins.has(ownerId)) continue;
         if (shortcut.key === event.name
             && (shortcut.ctrl ?? false) === (event.ctrl ?? false)
             && (shortcut.shift ?? false) === (event.shift ?? false)) {
@@ -671,7 +674,12 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
       <Shell pluginRegistry={pluginRegistry} />
       <StatusBar />
       {state.commandBarOpen && (
-        <CommandBar dataProvider={dataProvider} markdownStore={markdownStore} pluginRegistry={pluginRegistry} />
+        <CommandBar
+          dataProvider={dataProvider}
+          markdownStore={markdownStore}
+          pluginRegistry={pluginRegistry}
+          quitApp={() => renderer.destroy()}
+        />
       )}
       <Toaster position="bottom-right" />
     </box>

--- a/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
+++ b/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
@@ -1,0 +1,109 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`CommandBar renders the default layout with opencode-style chrome 1`] = `
+"                                                                                
+                                                                                
+                                                                                
+                  Commands                                esc                   
+                  Search                                                        
+                                                                                
+                  Tickers                                                       
+                  AAPL                                                          
+                  MSFT                                                          
+                                                                                
+                  Search                                                        
+                  Search Ticker                                                 
+                                                                                
+                  Portfolio                                                     
+                  Add AAPL to Portfolio                                         
+                                                                                
+                  Create                                                        
+                  New Portfolio                                                 
+                  New Watchlist                                                 
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+"
+`;
+
+exports[`CommandBar renders theme mode with the query line visible 1`] = `
+"                                                                                
+                                                                                
+                                                                                
+                  Commands                                esc                   
+                  TH                                                            
+                                                                                
+                  Themes                                                        
+                  Amber                                                         
+                  Green Phosphor                                                
+                  Cyan                                                          
+                  Red Phosphor                                                  
+                  Blue Phosphor                                                 
+                  Purple Phosphor                                               
+                  Hot Pink                                                      
+                  White Phosphor                                                
+                  Tokyo Night                                                   
+                  Solarized Dark                                                
+                  Dracula                                                       
+                  Nord                                                          
+                  Monokai                                                       
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+"
+`;
+
+exports[`CommandBar renders plugin toggle state 1`] = `
+"                                                                                
+                                                                                
+                                                                                
+                  Commands                                esc                   
+                  PL                                                            
+                                                                                
+                  Plugins                                                       
+                  News                                                          
+                  Notes                                                         
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+"
+`;
+
+exports[`CommandBar collapses the trailing column on narrow terminals 1`] = `
+"                                          
+                                          
+                                          
+       Commands                         es
+       Search                             
+                                          
+       Tickers                            
+       AAPL                               
+       MSFT                               
+                                          
+       Search                             
+       Search Ticker                      
+                                          
+       Portfolio                          
+       Add AAPL to Portfolio              
+                                          
+                                          
+                                          
+                                          
+                                          
+"
+`;

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useReducer } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { DialogProvider } from "@opentui-ui/dialog/react";
+import { CommandBar } from "./command-bar";
+import { AppContext, appReducer, createInitialState } from "../../state/app-context";
+import { createDefaultConfig } from "../../types/config";
+import type { DataProvider } from "../../types/data-provider";
+import type { TickerFile } from "../../types/ticker";
+import type { PluginRegistry } from "../../plugins/registry";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+});
+
+function makeTicker(symbol: string, name: string): TickerFile {
+  return {
+    frontmatter: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+    notes: "",
+    filePath: `/tmp/${symbol}.md`,
+  };
+}
+
+function makeDataProvider(): DataProvider {
+  return {
+    id: "test",
+    name: "Test Provider",
+    getTickerFinancials: async () => { throw new Error("unused"); },
+    getQuote: async () => { throw new Error("unused"); },
+    getExchangeRate: async () => 1,
+    search: async () => [],
+    getNews: async () => [],
+    getArticleSummary: async () => null,
+    getPriceHistory: async () => [],
+  };
+}
+
+function makePluginRegistry(): PluginRegistry {
+  return {
+    commands: new Map([
+      ["plugin:scan", {
+        id: "plugin:scan",
+        label: "Scan Movers",
+        description: "Run a quick movers scan",
+        category: "plugins",
+        execute: async () => {},
+      }],
+    ]),
+    tickerActions: new Map([
+      ["pin", {
+        id: "pin",
+        label: "Pin Ticker",
+        execute: async () => {},
+      }],
+    ]),
+    brokers: new Map(),
+    allPlugins: new Map([
+      ["news", { id: "news", name: "News", version: "1.0.0", description: "Latest headlines", toggleable: true }],
+      ["notes", { id: "notes", name: "Notes", version: "1.0.0", description: "Ticker notes", toggleable: true }],
+    ]),
+    getCommandPluginId: () => "news",
+    getPluginPaneIds: () => [],
+    hideWidget: () => {},
+    createBrokerInstanceFn: async () => { throw new Error("unused"); },
+    syncBrokerInstanceFn: async () => {},
+    removeBrokerInstanceFn: async () => {},
+    getConfigFn: () => createDefaultConfig("/tmp/gloomberb-test"),
+  } as unknown as PluginRegistry;
+}
+
+function CommandBarHarness({
+  query,
+  disabledPlugins = [],
+  selectedTicker,
+  live = false,
+}: {
+  query: string;
+  disabledPlugins?: string[];
+  selectedTicker?: string;
+  live?: boolean;
+}) {
+  const config = {
+    ...createDefaultConfig("/tmp/gloomberb-test"),
+    recentTickers: ["AAPL", "MSFT"],
+    disabledPlugins,
+  };
+  const tickers = [makeTicker("AAPL", "Apple Inc."), makeTicker("MSFT", "Microsoft Corp.")];
+  const dataProvider = makeDataProvider();
+  const state = {
+    ...createInitialState(config),
+    commandBarOpen: true,
+    commandBarQuery: query,
+    tickers: new Map(tickers.map((ticker) => [ticker.frontmatter.ticker, ticker])),
+    selectedTicker: selectedTicker ?? null,
+    config: { ...config, disabledPlugins },
+  };
+  const markdownStore = {
+    loadTicker: async () => null,
+    createTicker: async (frontmatter: TickerFile["frontmatter"]) => ({
+      frontmatter,
+      notes: "",
+      filePath: "/tmp/created.md",
+    }),
+    saveTicker: async () => {},
+  };
+  const pluginRegistry = makePluginRegistry();
+  const [liveState, dispatch] = useReducer(appReducer, state);
+
+  return (
+    <AppContext value={{ state: live ? liveState : state, dispatch: live ? dispatch : () => {} }}>
+      <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+        {live && <text>{`theme:${liveState.config.theme}`}</text>}
+        <CommandBar
+          dataProvider={dataProvider}
+          markdownStore={markdownStore as any}
+          pluginRegistry={pluginRegistry}
+          quitApp={() => {}}
+        />
+      </DialogProvider>
+    </AppContext>
+  );
+}
+
+describe("CommandBar", () => {
+  test("renders the default layout with opencode-style chrome", async () => {
+    testSetup = await testRender(<CommandBarHarness query="" selectedTicker="AAPL" />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    expect(testSetup.captureCharFrame()).toMatchSnapshot();
+  });
+
+  test("renders theme mode with the query line visible", async () => {
+    testSetup = await testRender(<CommandBarHarness query="TH " />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("TH");
+    expect(frame).toMatchSnapshot();
+  });
+
+  test("renders plugin toggle state", async () => {
+    testSetup = await testRender(<CommandBarHarness query="PL " disabledPlugins={["notes"]} />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    expect(testSetup.captureCharFrame()).toMatchSnapshot();
+  });
+
+  test("collapses the trailing column on narrow terminals", async () => {
+    testSetup = await testRender(<CommandBarHarness query="" selectedTicker="AAPL" />, {
+      width: 42,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+
+    expect(testSetup.captureCharFrame()).toMatchSnapshot();
+  });
+
+  test("moves the theme selector with arrow keys", async () => {
+    testSetup = await testRender(<CommandBarHarness query="TH " live />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("down");
+      await testSetup!.renderOnce();
+    });
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("theme:green");
+  });
+});

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -1,9 +1,18 @@
 import { useState, useCallback, useRef, useEffect } from "react";
-import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { TextAttributes } from "@opentui/core";
 import type { InputRenderable } from "@opentui/core";
 import { useDialog, useDialogKeyboard } from "@opentui-ui/dialog/react";
-import { colors } from "../../theme/colors";
+import {
+  colors,
+  commandBarBg,
+  commandBarHeadingText,
+  commandBarHoverBg,
+  commandBarSelectedBg,
+  commandBarSelectedText,
+  commandBarSubtleText,
+  commandBarText,
+} from "../../theme/colors";
 import { useAppState } from "../../state/app-context";
 import { fuzzyFilter } from "../../utils/fuzzy-search";
 import { commands, matchPrefix, getThemeOptions, type Command } from "./command-registry";
@@ -19,6 +28,12 @@ import type { PromptContext, AlertContext } from "@opentui-ui/dialog/react";
 import { resolveBrokerConfigFields } from "../../types/broker";
 import type { InstrumentSearchResult } from "../../types/instrument";
 import { buildIbkrConfigFromValues } from "../../plugins/ibkr/config";
+import {
+  getEmptyState,
+  getRowPresentation,
+  resolveCommandBarMode,
+  truncateText,
+} from "./view-model";
 
 /** All available columns that can be toggled */
 const ALL_COLUMNS: ColumnConfig[] = [
@@ -44,16 +59,20 @@ interface CommandBarProps {
   dataProvider: DataProvider;
   markdownStore: MarkdownStore;
   pluginRegistry: PluginRegistry;
+  quitApp: () => void;
 }
 
 interface ResultItem {
   id: string;
   label: string;
   detail: string;
-  right?: string;
   category: string;
+  kind: "command" | "ticker" | "search" | "theme" | "plugin" | "column" | "action" | "info";
+  right?: string;
   themeId?: string; // for theme items — enables live preview
   pluginToggle?: () => void; // for plugin items — toggle with space
+  checked?: boolean;
+  current?: boolean;
   action: () => void | Promise<void>;
 }
 
@@ -294,30 +313,25 @@ function ResultContent({ dismiss, dialogId, message, isError }: AlertContext & {
   );
 }
 
-export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: CommandBarProps) {
+export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitApp }: CommandBarProps) {
   const { state, dispatch } = useAppState();
   const dialog = useDialog();
+  const renderer = useRenderer();
   const { width: termWidth, height: termHeight } = useTerminalDimensions();
-  const [query, setQuery] = useState("");
   const [results, setResults] = useState<ResultItem[]>([]);
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [searching, setSearching] = useState(false);
-  const inputRef = useRef<InputRenderable>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const originalThemeRef = useRef<string>(getCurrentThemeId());
-  const spaceConsumedRef = useRef(false);
-  const scrollAnchorRef = useRef(0);
-
-  useEffect(() => {
-    if (inputRef.current) inputRef.current.focus();
-  }, []);
+  const previousSelectionContextRef = useRef<{ query: string; mode: string } | null>(null);
+  const query = state.commandBarQuery;
 
   const close = useCallback(() => {
     dispatch({ type: "SET_COMMAND_BAR", open: false });
-    setQuery("");
     setResults([]);
     setSelectedIdx(0);
-    scrollAnchorRef.current = 0;
+    setHoveredIdx(null);
   }, [dispatch]);
 
   // Revert theme on close without selection
@@ -553,14 +567,14 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           });
           if (confirmed) {
             await resetAllData(state.config.dataDir);
-            process.exit(0);
+            quitApp();
           }
         })();
         return;
       }
       case "columns": {
         // Enter columns mode by setting the prefix
-        setQuery("COL ");
+        dispatch({ type: "SET_COMMAND_BAR_QUERY", query: "COL " });
         return;
       }
       case "add-watchlist":
@@ -714,11 +728,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
         // Commands with hasArg are prefix-driven modes (theme, plugins, search)
         // — enter them by setting the query to their prefix instead of closing
         if (cmd.hasArg) {
-          setQuery(cmd.prefix + " ");
-          if (inputRef.current) {
-            (inputRef.current as any).editBuffer?.setText?.(cmd.prefix + " ") ||
-              (inputRef.current as any).setText?.(cmd.prefix + " ");
-          }
+          dispatch({ type: "SET_COMMAND_BAR_QUERY", query: cmd.prefix + " " });
           return;
         }
         cmd.execute(dispatch, ctx);
@@ -839,27 +849,38 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
 
   // Convert plugin commands to ResultItems
   const pluginCommandItems = useCallback((): ResultItem[] => {
-    return [...pluginRegistry.commands.values()].filter((cmd) => !cmd.hidden?.()).map((cmd) => ({
-      id: cmd.id,
-      label: cmd.label,
-      detail: cmd.description || "",
-      category: "Plugins",
-      action: () => {
-        close();
-        if (cmd.wizard && cmd.wizard.length > 0) {
-          runWizard(cmd);
-        } else {
-          (async () => {
-            try {
-              await cmd.execute();
-            } catch {
-              // silently fail
-            }
-          })();
-        }
-      },
-    }));
-  }, [pluginRegistry.commands, close, runWizard]);
+    const disabledPlugins = new Set(state.config.disabledPlugins || []);
+    return [...pluginRegistry.commands.values()].filter((cmd) => {
+      if (cmd.hidden?.()) return false;
+      const pluginId = pluginRegistry.getCommandPluginId(cmd.id);
+      if (pluginId && disabledPlugins.has(pluginId)) return false;
+      return true;
+    }).map((cmd) => {
+      const pluginId = pluginRegistry.getCommandPluginId(cmd.id);
+      const pluginName = pluginId ? pluginRegistry.allPlugins.get(pluginId)?.name : null;
+      return {
+        id: cmd.id,
+        label: cmd.label,
+        detail: cmd.description || "",
+        category: pluginName || "Plugin Commands",
+        kind: "command" as const,
+        action: () => {
+          close();
+          if (cmd.wizard && cmd.wizard.length > 0) {
+            runWizard(cmd);
+          } else {
+            (async () => {
+              try {
+                await cmd.execute();
+              } catch {
+                // silently fail
+              }
+            })();
+          }
+        },
+      };
+    });
+  }, [pluginRegistry, close, runWizard, state.config.disabledPlugins]);
 
   const tickerActionItems = useCallback((): ResultItem[] => {
     if (!state.selectedTicker) return [];
@@ -874,6 +895,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
         label: action.label,
         detail: ticker.frontmatter.ticker,
         category: "Actions",
+        kind: "action" as const,
         action: () => {
           close();
           void action.execute(ticker, financials);
@@ -881,10 +903,11 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
       }));
   }, [pluginRegistry.tickerActions, state.selectedTicker, state.tickers, state.financials, close]);
 
-  // Detect special modes
-  const isThemeMode = matchPrefix(query)?.command.id === "theme";
-  const isPluginMode = matchPrefix(query)?.command.id === "plugins";
-  const isColumnsMode = matchPrefix(query)?.command.id === "columns";
+  const activeMatch = matchPrefix(query);
+  const modeInfo = resolveCommandBarMode(query);
+  const isThemeMode = modeInfo.kind === "themes";
+  const isPluginMode = modeInfo.kind === "plugins";
+  const isColumnsMode = modeInfo.kind === "columns";
 
   // Toggle a column on/off
   const toggleColumn = useCallback((colId: string) => {
@@ -905,9 +928,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
     saveConfig(newConfig).catch(() => {});
   }, [state.config, dispatch]);
 
-  // Build results based on query and prefix matching
   useEffect(() => {
-    // --- Smart command filtering (computed fresh each effect run) ---
     const isWatchlistTab = state.config.watchlists.some((w) => w.id === state.activeLeftTab);
     const isPortfolioTab = state.config.portfolios.some((p) => p.id === state.activeLeftTab);
     const activePortfolio = state.config.portfolios.find((portfolio) => portfolio.id === state.activeLeftTab);
@@ -962,18 +983,21 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
     function cmdToItem(cmd: Command): ResultItem | null {
       if (!shouldShow(cmd)) return null;
       return {
-        id: cmd.id, label: smartLabel(cmd), detail: smartDetail(cmd),
-        right: cmd.prefix, category: cmd.category,
+        id: cmd.id,
+        label: smartLabel(cmd),
+        detail: smartDetail(cmd),
+        category: cmd.category,
+        kind: "command",
+        right: cmd.prefix || undefined,
         action: () => executeCommand(cmd, ""),
       };
     }
+
     const items: ResultItem[] = [];
     const match = matchPrefix(query);
-
     let initialIdx = 0;
 
     if (match && match.command.id === "plugins") {
-      // Plugin management mode
       const toggleablePlugins = [...pluginRegistry.allPlugins.values()].filter((p) => p.toggleable);
       const disabledPlugins = state.config.disabledPlugins || [];
       const filtered = match.arg
@@ -986,7 +1010,6 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           const newDisabled = isEnabled
             ? [...disabledPlugins, p.id]
             : disabledPlugins.filter((id) => id !== p.id);
-          // When disabling, hide any floating panes owned by this plugin
           if (isEnabled) {
             for (const paneId of pluginRegistry.getPluginPaneIds(p.id)) {
               pluginRegistry.hideWidget(paneId);
@@ -996,29 +1019,31 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
         };
         items.push({
           id: `plugin:${p.id}`,
-          label: `${isEnabled ? "\u2713" : "\u2717"} ${p.name}`,
+          label: p.name,
           detail: p.description || "",
           category: "Plugins",
+          kind: "plugin",
+          checked: isEnabled,
           pluginToggle: toggleAction,
           action: toggleAction,
         });
       }
     } else if (match && match.command.id === "columns") {
-      // Column toggle mode — show all available columns as a checklist
       const activeIds = new Set(state.config.columns.map((c) => c.id));
       for (const col of ALL_COLUMNS) {
         const isOn = activeIds.has(col.id);
         items.push({
           id: `col:${col.id}`,
-          label: `${isOn ? "[\u2713]" : "[ ]"} ${col.label}`,
-          detail: `${col.id}  w:${col.width}  ${col.align}`,
+          label: col.label,
+          detail: `${col.id} | w:${col.width} | ${col.align}`,
           right: col.format || "",
           category: "Columns",
+          kind: "column",
+          checked: isOn,
           action: () => toggleColumn(col.id),
         });
       }
     } else if (match && match.command.id === "theme") {
-      // Theme selection mode
       const themeOptions = getThemeOptions();
       const savedThemeId = originalThemeRef.current;
       const filtered = match.arg
@@ -1032,9 +1057,10 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           id: `theme:${t.id}`,
           label: t.name,
           detail: t.description,
-          right: isSaved ? "current" : undefined,
-          themeId: t.id,
           category: "Themes",
+          kind: "theme",
+          current: isSaved,
+          themeId: t.id,
           action: () => {
             originalThemeRef.current = t.id;
             dispatch({ type: "SET_THEME", theme: t.id });
@@ -1045,28 +1071,33 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
       }
     } else if (match && match.command.id === "search-ticker") {
       if (!match.arg) {
-        items.push({ id: "hint", label: "Type a ticker symbol...", detail: "", category: "Search", action: () => {} });
+        items.push({
+          id: "hint",
+          label: "Type a ticker symbol",
+          detail: "Search Yahoo Finance and connected brokers",
+          category: "Search",
+          kind: "info",
+          action: () => {},
+        });
       }
     } else if (match && !match.command.hasArg) {
-      // Direct prefix match — still filter for smart commands
       if (shouldShow(match.command)) {
         items.push({
           id: match.command.id,
           label: smartLabel(match.command),
           detail: smartDetail(match.command),
-          right: match.command.prefix,
+          right: match.command.prefix || undefined,
           category: match.command.category,
+          kind: "command",
           action: () => executeCommand(match.command, match.arg),
         });
       }
     } else if (!query) {
-      // Show recently visited tickers (or first tickers if no history)
       const maxDefaultTickers = 5;
       const recentSymbols = state.recentTickers.slice(0, maxDefaultTickers);
       const recentTickers = recentSymbols
         .map((s) => state.tickers.get(s))
         .filter((t): t is TickerFile => t != null);
-      // Fill remaining slots with other tickers if not enough recent ones
       if (recentTickers.length < maxDefaultTickers) {
         const recentSet = new Set(recentSymbols);
         for (const t of state.tickers.values()) {
@@ -1080,6 +1111,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
           label: t.frontmatter.ticker,
           detail: t.frontmatter.name,
           category: "Tickers",
+          kind: "ticker",
           action: () => { dispatch({ type: "SELECT_TICKER", symbol: t.frontmatter.ticker }); close(); },
         });
       }
@@ -1091,30 +1123,31 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
       items.push(...pluginCommandItems());
     } else {
       const tickerItems: ResultItem[] = Array.from(state.tickers.values()).map((t) => ({
-        id: `goto:${t.frontmatter.ticker}`, label: t.frontmatter.ticker,
-        detail: t.frontmatter.name, category: "Tickers",
+        id: `goto:${t.frontmatter.ticker}`,
+        label: t.frontmatter.ticker,
+        detail: t.frontmatter.name,
+        category: "Tickers",
+        kind: "ticker",
         action: () => { dispatch({ type: "SELECT_TICKER", symbol: t.frontmatter.ticker }); close(); },
       }));
-      const cmdItems: ResultItem[] = commands.map((cmd) => cmdToItem(cmd)).filter((item): item is ResultItem => item !== null);
+      const cmdItems = commands.map((cmd) => cmdToItem(cmd)).filter((item): item is ResultItem => item !== null);
       const allItems = [...tickerItems, ...cmdItems, ...tickerActionItems(), ...pluginCommandItems()];
-      const filtered = fuzzyFilter(allItems, query, (i) => `${i.label} ${i.detail} ${i.right || ""}`);
-      items.push(...filtered);
+      items.push(...fuzzyFilter(allItems, query, (i) => `${i.label} ${i.detail} ${i.right || ""}`));
     }
 
     setResults(items);
-    // In columns/plugin mode, preserve the selected index across re-renders (toggling)
-    if (match?.command.id === "columns" || match?.command.id === "plugins") {
-      setSelectedIdx((prev) => {
-        const next = Math.min(prev, items.length - 1);
-        scrollAnchorRef.current = next;
-        return next;
-      });
+    setHoveredIdx((prev) => (prev != null && prev < items.length ? prev : null));
+    const selectionContextChanged =
+      previousSelectionContextRef.current?.query !== query
+      || previousSelectionContextRef.current?.mode !== modeInfo.kind;
+
+    if (match?.command.id === "columns" || match?.command.id === "plugins" || !selectionContextChanged) {
+      setSelectedIdx((prev) => Math.max(0, Math.min(prev, items.length - 1)));
     } else {
       setSelectedIdx(initialIdx);
-      scrollAnchorRef.current = initialIdx;
     }
+    previousSelectionContextRef.current = { query, mode: modeInfo.kind };
 
-    // Yahoo search when in ticker search mode (prefix "T")
     if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
     if (match?.command.id === "search-ticker" && match.arg.length >= 1) {
       const searchQuery = match.arg;
@@ -1133,17 +1166,31 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
               const sym = r.brokerContract?.localSymbol || r.symbol.split(".")[0]!;
               const isExisting = state.tickers.has(sym);
               return {
-                id: `search:${r.symbol}`, label: sym, detail: r.name,
-                right: [r.brokerLabel, r.type || r.exchange].filter(Boolean).join(" · "),
+                id: `search:${r.symbol}`,
+                label: sym,
+                detail: [r.name, r.brokerLabel, r.type || r.exchange].filter(Boolean).join(" | "),
                 category: isExisting ? "Open" : "Search Results",
+                kind: "search",
                 action: () => openTickerDetail(r),
               };
             });
           setResults(searchItems.length > 0 ? searchItems : [{
-            id: "no-results", label: "No results", detail: `for "${searchQuery}"`, category: "Search", action: () => {},
+            id: "no-results",
+            label: `No matches for "${searchQuery}"`,
+            detail: "Try a symbol, company name, or exchange variant",
+            category: "Search",
+            kind: "info",
+            action: () => {},
           }]);
         } catch {
-          setResults([{ id: "error", label: "Search failed", detail: "Check your connection", category: "Search", action: () => {} }]);
+          setResults([{
+            id: "error",
+            label: "Search failed",
+            detail: "Check your connection",
+            category: "Search",
+            kind: "info",
+            action: () => {},
+          }]);
         } finally {
           setSearching(false);
         }
@@ -1152,233 +1199,276 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry }: Comm
       setSearching(false);
     }
 
-    return () => { if (searchTimerRef.current) clearTimeout(searchTimerRef.current); };
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    };
   }, [query, state.tickers, state.selectedTicker, state.activeLeftTab, state.config.watchlists, state.config.portfolios, state.config.brokerInstances, state.config.disabledPlugins, state.config.columns, toggleColumn, tickerActionItems, pluginCommandItems]);
 
   // Live preview: apply theme as user arrows through the list
   useEffect(() => {
     if (!isThemeMode) return;
     const selected = results[selectedIdx];
-    if (selected?.themeId) {
+    if (selected?.themeId && state.config.theme !== selected.themeId) {
       applyTheme(selected.themeId);
-      // Force a re-render by dispatching a no-op-like action
       dispatch({ type: "SET_THEME", theme: selected.themeId });
     }
-  }, [selectedIdx, isThemeMode, results]);
+  }, [selectedIdx, isThemeMode, results, state.config.theme, dispatch]);
 
-  useKeyboard((event) => {
-    if (event.name === "escape" || event.name === "`") {
-      if (isThemeMode) {
-        closeAndRevert();
-      } else {
-        close();
+  const setCommandBarQuery = useCallback((nextQuery: string) => {
+    dispatch({ type: "SET_COMMAND_BAR_QUERY", query: nextQuery });
+  }, [dispatch]);
+
+  useEffect(() => {
+    const handleKeyPress = (event: {
+      name: string;
+      ctrl?: boolean;
+      meta?: boolean;
+      stopPropagation: () => void;
+      preventDefault: () => void;
+    }) => {
+      setHoveredIdx(null);
+
+      if (event.name === "escape" || event.name === "`") {
+        event.stopPropagation();
+        event.preventDefault();
+        if (isThemeMode) {
+          closeAndRevert();
+        } else {
+          close();
+        }
+        return;
       }
-    } else if (event.name === "down" || (event.name === "n" && event.ctrl)) {
-      setSelectedIdx((i) => {
-        const next = Math.min(i + 1, results.length - 1);
-        scrollAnchorRef.current = next;
-        return next;
+
+      if (event.name === "down" || (event.name === "n" && event.ctrl)) {
+        event.stopPropagation();
+        event.preventDefault();
+        setSelectedIdx((i) => Math.min(i + 1, results.length - 1));
+        return;
+      }
+
+      if (event.name === "up" || (event.name === "p" && event.ctrl)) {
+        event.stopPropagation();
+        event.preventDefault();
+        setSelectedIdx((i) => Math.max(i - 1, 0));
+        return;
+      }
+
+      if ((event.meta && (event.name === "backspace" || event.name === "delete")) || (event.ctrl && event.name === "u")) {
+        event.stopPropagation();
+        event.preventDefault();
+        setCommandBarQuery("");
+        return;
+      }
+
+      if ((event.ctrl && event.name === "w") || (event.meta && (event.name === "h" || event.name === "u"))) {
+        event.stopPropagation();
+        event.preventDefault();
+        const trimmed = query.replace(/\s+$/, "");
+        const nextQuery = trimmed.replace(/[^\s]+$/, "").replace(/\s+$/, "");
+        setCommandBarQuery(nextQuery);
+        return;
+      }
+
+      if (event.name === "space" && isPluginMode) {
+        event.stopPropagation();
+        event.preventDefault();
+        const selected = results[selectedIdx];
+        if (selected?.pluginToggle) selected.pluginToggle();
+        return;
+      }
+
+      if (event.name === "space" && isColumnsMode) {
+        event.stopPropagation();
+        event.preventDefault();
+        const selected = results[selectedIdx];
+        if (selected) selected.action();
+        return;
+      }
+
+      if (event.name === "return" || event.name === "enter") {
+        event.stopPropagation();
+        event.preventDefault();
+        const selected = results[selectedIdx];
+        if (selected) selected.action();
+      }
+    };
+
+    renderer.keyInput.on("keypress", handleKeyPress);
+    return () => {
+      renderer.keyInput.off("keypress", handleKeyPress);
+    };
+  }, [close, closeAndRevert, isColumnsMode, isPluginMode, isThemeMode, query, renderer, results, selectedIdx, setCommandBarQuery]);
+
+  const barWidth = Math.max(42, Math.min(64, termWidth - 8, Math.floor(termWidth * 0.62)));
+  const isNarrow = barWidth < 52;
+  const searchModeQuery = activeMatch?.command.id === "search-ticker" ? activeMatch.arg : "";
+  const contentPadding = 3;
+  const bodyHeight = Math.min(14, Math.max(8, termHeight - 10));
+  const barHeight = bodyHeight + 5;
+  const barLeft = Math.max(4, Math.floor((termWidth - barWidth) / 2));
+  const barTop = Math.max(1, Math.floor((termHeight - barHeight) / 2));
+  const paletteBg = commandBarBg();
+  const paletteHeadingText = commandBarHeadingText();
+  const paletteHoverBg = commandBarHoverBg();
+  const paletteSelectedBg = commandBarSelectedBg();
+  const paletteText = commandBarText();
+  const paletteSubtleText = commandBarSubtleText();
+  const paletteSelectedText = commandBarSelectedText();
+
+  const allRows: Array<
+    | { kind: "spacer"; id: string }
+    | { kind: "heading"; id: string; label: string }
+    | { kind: "item"; item: ResultItem; globalIdx: number }
+    | { kind: "message"; id: string; label: string; dim?: boolean }
+    | { kind: "filler"; id: string }
+  > = [];
+  let previousCategory: string | null = null;
+  for (let i = 0; i < results.length; i++) {
+    const item = results[i]!;
+    if (previousCategory !== null && item.category !== previousCategory) {
+      allRows.push({
+        kind: "spacer",
+        id: `spacer:${i}:${item.category}`,
       });
-    } else if (event.name === "up" || (event.name === "p" && event.ctrl)) {
-      setSelectedIdx((i) => {
-        const next = Math.max(i - 1, 0);
-        scrollAnchorRef.current = next;
-        return next;
-      });
-    } else if (event.name === "space" && isPluginMode) {
-      // Space toggles plugins without closing
-      spaceConsumedRef.current = true;
-      const selected = results[selectedIdx];
-      if (selected?.pluginToggle) selected.pluginToggle();
-    } else if (event.name === "space" && isColumnsMode) {
-      // Toggle column with space
-      spaceConsumedRef.current = true;
-      const selected = results[selectedIdx];
-      if (selected) selected.action();
-    } else if (event.name === "return" || event.name === "enter") {
-      // Enter is handled by the <input onSubmit> — avoid calling action twice
-      // which breaks toggle commands (e.g. Toggle Status Bar fires twice = no-op)
     }
-  });
+    if (item.category !== previousCategory) {
+      allRows.push({
+        kind: "heading",
+        id: `heading:${i}:${item.category}`,
+        label: item.category,
+      });
+    }
+    previousCategory = item.category;
+    allRows.push({ kind: "item", item, globalIdx: i });
+  }
+  const emptyState = getEmptyState(modeInfo.kind, query, searchModeQuery);
+  const resultsInnerWidth = Math.max(12, barWidth - contentPadding * 2);
+  const trailingWidth = isNarrow ? 0 : Math.max(8, Math.min(12, Math.floor(resultsInnerWidth * 0.18)));
+  const labelWidth = Math.max(10, resultsInnerWidth - trailingWidth);
+  const queryDisplayWidth = Math.max(8, barWidth - contentPadding * 2);
 
-  // Layout
-  const barWidth = Math.min(Math.floor(termWidth * 0.6), 72);
-  const barLeft = Math.floor((termWidth - barWidth) / 2);
-  // Cap visible results based on terminal height
-  // Reserve rows for: top offset (3) + border (2) + input (2) + separator (1) + esc hint (1) + scroll indicators (2)
-  const maxVisible = Math.min(16, Math.max(4, termHeight - 11));
-
-  // Compute a window of results centered on scroll anchor (keyboard-driven, not mouse)
-  const scrollAnchor = scrollAnchorRef.current;
-  const halfWindow = Math.floor(maxVisible / 2);
-  let windowStart = Math.max(0, Math.min(scrollAnchor - halfWindow, results.length - maxVisible));
-  if (windowStart < 0) windowStart = 0;
-  const windowEnd = Math.min(results.length, windowStart + maxVisible);
-  const windowedResults = results.slice(windowStart, windowEnd);
-  const hasMoreAbove = windowStart > 0;
-  const hasMoreBelow = windowEnd < results.length;
-
-  // Group by category (preserving global indices for selection highlight)
-  const grouped: Array<{ category: string; items: Array<ResultItem & { globalIdx: number }> }> = [];
-  for (let i = 0; i < windowedResults.length; i++) {
-    const result = windowedResults[i]!;
-    let group = grouped.find((g) => g.category === result.category);
-    if (!group) { group = { category: result.category, items: [] }; grouped.push(group); }
-    group.items.push({ ...result, globalIdx: windowStart + i });
+  let visibleRows: typeof allRows;
+  if (searching) {
+    visibleRows = [{ kind: "message", id: "searching", label: "Searching providers...", dim: true }];
+  } else if (allRows.length === 0) {
+    visibleRows = [{ kind: "message", id: "empty", label: emptyState.label }];
+  } else {
+    const selectedRowIdx = allRows.findIndex((row) => row.kind === "item" && row.globalIdx === selectedIdx);
+    const halfWindow = Math.floor(bodyHeight / 2);
+    let windowStart = Math.max(0, Math.min(selectedRowIdx - halfWindow, allRows.length - bodyHeight));
+    if (windowStart < 0) windowStart = 0;
+    visibleRows = allRows.slice(windowStart, windowStart + bodyHeight);
   }
 
-  // Detect active prefix for hint display
-  const activeMatch = matchPrefix(query);
-  const prefixHint = activeMatch
-    ? `${activeMatch.command.prefix}: ${activeMatch.command.label}${activeMatch.command.hasArg ? ` \u2014 ${activeMatch.command.argPlaceholder}` : ""}`
-    : null;
+  while (visibleRows.length < bodyHeight) {
+    visibleRows.push({ kind: "filler", id: `filler:${visibleRows.length}` });
+  }
 
   return (
     <box
       position="absolute"
-      top={3}
+      top={barTop}
       left={barLeft}
       width={barWidth}
+      height={barHeight}
       flexDirection="column"
-      backgroundColor={colors.commandBg}
-      borderStyle="rounded"
-      borderColor={colors.border}
+      backgroundColor={paletteBg}
       zIndex={100}
     >
-      {/* Spacer above input */}
       <box height={1} />
 
-      {/* Search input */}
-      <box height={1} paddingX={2}>
+      <box height={1} paddingX={contentPadding} flexDirection="row">
+        <box flexGrow={1}>
+          <text fg={paletteText}>Commands</text>
+        </box>
+        <text fg={paletteSubtleText}>esc</text>
+      </box>
+
+      <box height={1} paddingX={contentPadding}>
         <input
-          ref={inputRef}
-          placeholder="> Type a command or search..."
+          value={query}
+          onInput={setCommandBarQuery}
+          onChange={setCommandBarQuery}
+          placeholder="Search"
           focused
-          textColor={colors.text}
-          placeholderColor={colors.textDim}
-          backgroundColor={colors.commandBg}
-          onInput={(val) => {
-            if (spaceConsumedRef.current) { spaceConsumedRef.current = false; return; }
-            setQuery(val);
-          }}
-          onChange={(val) => {
-            if (spaceConsumedRef.current) { spaceConsumedRef.current = false; return; }
-            setQuery(val);
-          }}
-          onSubmit={() => {
-            const selected = results[selectedIdx];
-            if (selected) selected.action();
-          }}
+          width={queryDisplayWidth}
+          backgroundColor={paletteBg}
+          focusedBackgroundColor={paletteBg}
+          textColor={paletteText}
+          focusedTextColor={paletteText}
+          placeholderColor={paletteSubtleText}
+          cursorColor={colors.textBright}
         />
       </box>
 
-      {/* Prefix hint */}
-      {prefixHint && (
-        <box height={1} paddingX={2}>
-          <text fg={colors.textBright}>{prefixHint}</text>
-        </box>
-      )}
+      <box height={1} />
 
-      {/* Separator between input and results */}
-      <box height={1} paddingX={1}>
-        <text fg={colors.border}>{"\u2500".repeat(barWidth - 2)}</text>
-      </box>
+      <box flexDirection="column" height={bodyHeight}>
+        {visibleRows.map((row) => {
+          if (row.kind === "filler") {
+            return <box key={row.id} height={1} />;
+          }
 
-      {/* Scroll-up indicator */}
-      {hasMoreAbove && (
-        <box height={1} paddingX={2}>
-          <text fg={colors.textMuted}>{"  \u2191 more"}</text>
-        </box>
-      )}
+          if (row.kind === "spacer") {
+            return <box key={row.id} height={1} />;
+          }
 
-      {/* Results */}
-      <box flexDirection="column" flexGrow={1}>
-        {searching ? (
-          <box paddingX={2} height={1}>
-            <text fg={colors.textDim}>Searching providers...</text>
-          </box>
-        ) : grouped.length === 0 ? (
-          <box paddingX={2} height={1}>
-            <text fg={colors.textDim}>No results</text>
-          </box>
-        ) : (
-          grouped.map((group, gi) => (
-            <box key={group.category} flexDirection="column">
-              {gi > 0 && <box height={1} />}
-              <box height={1} paddingX={2}>
-                <text attributes={TextAttributes.BOLD} fg={colors.textBright}>
-                  {group.category}
+          if (row.kind === "message") {
+            return (
+              <box key={row.id} height={1} paddingX={contentPadding}>
+                <text fg={row.dim ? paletteSubtleText : paletteText}>{truncateText(row.label, barWidth - contentPadding * 2)}</text>
+              </box>
+            );
+          }
+
+          if (row.kind === "heading") {
+            return (
+              <box key={row.id} height={1} paddingX={contentPadding}>
+                <text attributes={TextAttributes.BOLD} fg={paletteHeadingText}>
+                  {truncateText(row.label, barWidth - contentPadding * 2)}
                 </text>
               </box>
-              {group.items.map((item) => {
-                const isSel = item.globalIdx === selectedIdx;
-                const isThemeItem = !!item.themeId;
-                const isPluginItem = item.id.startsWith("plugin:");
-                const isColumnItem = item.id.startsWith("col:");
-                const isSearchResult = item.id.startsWith("search:") || item.id.startsWith("goto:");
-                const isChecked = isColumnItem && item.label.includes("\u2713");
-                return (
-                  <box
-                    key={item.id}
-                    flexDirection="row"
-                    height={1}
-                    paddingX={2}
-                    backgroundColor={isSel ? colors.selected : colors.commandBg}
-                    onMouseMove={() => setSelectedIdx(item.globalIdx)}
-                    onMouseDown={() => {
-                      setSelectedIdx(item.globalIdx);
-                      item.action();
-                    }}
-                  >
-                    {/* Prefix shortcut column — shown only for commands (not tickers/themes/plugins/columns) */}
-                    {!isThemeItem && !isPluginItem && !isSearchResult && !isColumnItem && (
-                      <box width={5}>
-                        <text fg={colors.textMuted}>{item.right || ""}</text>
-                      </box>
-                    )}
-                    {/* Label */}
-                    <box width={isColumnItem ? Math.floor(barWidth * 0.4) : (isThemeItem || isPluginItem) ? Math.floor(barWidth * 0.35) : isSearchResult ? 10 : Math.floor(barWidth * 0.3)}>
-                      <text fg={isColumnItem ? (isChecked ? colors.text : colors.textDim) : (isSel ? colors.text : colors.textDim)}>
-                        {item.label}
-                      </text>
-                    </box>
-                    <box flexGrow={1}>
-                      <text fg={colors.textMuted}>{item.detail}</text>
-                    </box>
-                    {/* Right-side tag */}
-                    {(isThemeItem || isSearchResult) && item.right && (
-                      <box>
-                        <text fg={colors.textMuted}>{item.right}</text>
-                      </box>
-                    )}
-                    {isColumnItem && item.right && (
-                      <box>
-                        <text fg={colors.textMuted}>{item.right}</text>
-                      </box>
-                    )}
-                  </box>
-                );
-              })}
+            );
+          }
+
+          const isSel = row.globalIdx === selectedIdx;
+          const isHovered = row.globalIdx === hoveredIdx && !isSel;
+          const presentation = getRowPresentation(row.item, isSel, trailingWidth > 0);
+          const label = truncateText(presentation.label, labelWidth);
+          const trailing = truncateText(presentation.trailing, trailingWidth);
+
+          return (
+            <box
+              key={row.item.id}
+              flexDirection="row"
+              height={1}
+              paddingX={contentPadding}
+              backgroundColor={isSel ? paletteSelectedBg : isHovered ? paletteHoverBg : paletteBg}
+              onMouseMove={() => {
+                setHoveredIdx((current) => (current === row.globalIdx ? current : row.globalIdx));
+              }}
+              onMouseDown={() => {
+                setHoveredIdx(row.globalIdx);
+                setSelectedIdx(row.globalIdx);
+                row.item.action();
+              }}
+            >
+              <box width={labelWidth}>
+                <text fg={isSel ? paletteSelectedText : presentation.primaryMuted ? paletteSubtleText : paletteText}>
+                  {label}
+                </text>
+              </box>
+              {trailingWidth > 0 && (
+                <box width={trailingWidth}>
+                  <text fg={isSel ? paletteSelectedText : paletteSubtleText}>{trailing}</text>
+                </box>
+              )}
             </box>
-          ))
-        )}
+          );
+        })}
       </box>
 
-      {/* Scroll-down indicator */}
-      {hasMoreBelow && (
-        <box height={1} paddingX={2}>
-          <text fg={colors.textMuted}>{"  \u2193 more"}</text>
-        </box>
-      )}
-
-      {/* Bottom padding + hint */}
-      <box flexDirection="row" height={1} paddingX={2}>
-        <box flexGrow={1}>
-          {isPluginMode && <text fg={colors.textMuted}>space toggle</text>}
-          {isColumnsMode && <text fg={colors.textMuted}>space/enter toggle</text>}
-        </box>
-        <text fg={colors.textMuted}>esc to close</text>
-      </box>
+      <box height={1} />
     </box>
   );
 }

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildSections,
+  getEmptyState,
+  getFooterHints,
+  getRowPresentation,
+  resolveCommandBarMode,
+} from "./view-model";
+
+describe("command bar view model helpers", () => {
+  test("resolves prefix-driven modes", () => {
+    expect(resolveCommandBarMode("")).toMatchObject({ kind: "default", badge: "BROWSE" });
+    expect(resolveCommandBarMode("T NVDA")).toMatchObject({ kind: "search", badge: "SEARCH" });
+    expect(resolveCommandBarMode("TH ")).toMatchObject({ kind: "themes", badge: "THEMES" });
+    expect(resolveCommandBarMode("PL notes")).toMatchObject({ kind: "plugins", badge: "PLUGINS" });
+    expect(resolveCommandBarMode("COL price")).toMatchObject({ kind: "columns", badge: "COLUMNS" });
+    expect(resolveCommandBarMode("AW")).toMatchObject({ kind: "direct-command", badge: "COMMAND" });
+  });
+
+  test("builds sections while preserving order", () => {
+    const sections = buildSections([
+      { id: "a", category: "Tickers" },
+      { id: "b", category: "Commands" },
+      { id: "c", category: "Tickers" },
+    ]);
+
+    expect(sections.map((section) => section.category)).toEqual(["Tickers", "Commands"]);
+    expect(sections[0]?.items.map((item) => item.id)).toEqual(["a", "c"]);
+  });
+
+  test("returns footer hints for plugin toggles", () => {
+    expect(getFooterHints("plugins", false)).toEqual({
+      left: "up/down move  enter select  space toggle",
+      right: "esc close",
+    });
+  });
+
+  test("returns specific empty states", () => {
+    expect(getEmptyState("search", "T ", "")).toEqual({
+      label: "Type a ticker symbol",
+      detail: "Search Yahoo Finance and connected brokers",
+    });
+    expect(getEmptyState("search", "T zom", "zom")).toEqual({
+      label: 'No matches for "zom"',
+      detail: "Try a symbol, company name, or exchange variant",
+    });
+    expect(getEmptyState("default", "abc")).toEqual({
+      label: 'No matches for "abc"',
+      detail: "Try a ticker, command name, or prefix",
+    });
+  });
+
+  test("derives row presentation for toggles and current theme rows", () => {
+    expect(getRowPresentation({
+      id: "plugin:news",
+      label: "News",
+      detail: "Latest headlines",
+      category: "Plugins",
+      kind: "plugin",
+      checked: true,
+    }, false, true)).toMatchObject({
+      glyph: " ",
+      trailing: "on",
+      primaryMuted: false,
+    });
+
+    expect(getRowPresentation({
+      id: "theme:amber",
+      label: "Amber",
+      detail: "Warm terminal palette",
+      category: "Themes",
+      kind: "theme",
+      right: "amber",
+      current: true,
+    }, false, true)).toMatchObject({
+      glyph: " ",
+      trailing: "current",
+    });
+  });
+});

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -1,0 +1,156 @@
+import { matchPrefix } from "./command-registry";
+
+export type CommandBarMode = "default" | "search" | "themes" | "plugins" | "columns" | "direct-command";
+
+export interface CommandBarModeInfo {
+  kind: CommandBarMode;
+  badge: string;
+  hint: string;
+}
+
+export interface CommandBarModeStripEntry {
+  prefix: string;
+  label: string;
+  active: boolean;
+}
+
+export interface CommandBarFooterHints {
+  left: string;
+  right: string;
+}
+
+export interface CommandBarSection<T> {
+  category: string;
+  items: T[];
+}
+
+export interface CommandBarItemView {
+  id: string;
+  label: string;
+  detail: string;
+  category: string;
+  kind: "command" | "ticker" | "search" | "theme" | "plugin" | "column" | "action" | "info";
+  right?: string;
+  checked?: boolean;
+  current?: boolean;
+}
+
+export interface CommandBarRowPresentation {
+  glyph: string;
+  label: string;
+  trailing: string;
+  selected: boolean;
+  primaryMuted: boolean;
+}
+
+const MODE_STRIP_ENTRIES = [
+  { prefix: "T", label: "Search ticker", kind: "search" },
+  { prefix: "TH", label: "Change theme", kind: "themes" },
+  { prefix: "PL", label: "Toggle plugins", kind: "plugins" },
+  { prefix: "COL", label: "Edit columns", kind: "columns" },
+] as const;
+
+export function resolveCommandBarMode(query: string): CommandBarModeInfo {
+  const match = matchPrefix(query);
+
+  if (!query.trim()) {
+    return { kind: "default", badge: "BROWSE", hint: "Type a command, ticker, or prefix" };
+  }
+
+  if (!match) {
+    return { kind: "default", badge: "FILTER", hint: `Filtering for "${query.trim()}"` };
+  }
+
+  switch (match.command.id) {
+    case "search-ticker":
+      return { kind: "search", badge: "SEARCH", hint: "Search Yahoo Finance and broker-backed symbols" };
+    case "theme":
+      return { kind: "themes", badge: "THEMES", hint: "Preview with arrows, Enter to save, Esc to revert" };
+    case "plugins":
+      return { kind: "plugins", badge: "PLUGINS", hint: "Toggle plugins without leaving the list" };
+    case "columns":
+      return { kind: "columns", badge: "COLUMNS", hint: "Choose visible table columns" };
+    default:
+      return { kind: "direct-command", badge: "COMMAND", hint: `Run ${match.command.label}` };
+  }
+}
+
+export function getModeStrip(mode: CommandBarMode): CommandBarModeStripEntry[] {
+  return MODE_STRIP_ENTRIES.map((entry) => ({
+    prefix: entry.prefix,
+    label: entry.label,
+    active: entry.kind === mode,
+  }));
+}
+
+export function buildSections<T extends { category: string }>(items: T[]): Array<CommandBarSection<T>> {
+  const sections: Array<CommandBarSection<T>> = [];
+  for (const item of items) {
+    let section = sections.find((candidate) => candidate.category === item.category);
+    if (!section) {
+      section = { category: item.category, items: [] };
+      sections.push(section);
+    }
+    section.items.push(item);
+  }
+  return sections;
+}
+
+export function getFooterHints(mode: CommandBarMode, isNarrow: boolean): CommandBarFooterHints {
+  const moveAndSelect = isNarrow ? "up/down move  enter select" : "up/down move  enter select";
+  if (mode === "plugins" || mode === "columns") {
+    return {
+      left: isNarrow ? "space toggle" : `${moveAndSelect}  space toggle`,
+      right: "esc close",
+    };
+  }
+  return { left: moveAndSelect, right: "esc close" };
+}
+
+export function getEmptyState(mode: CommandBarMode, query: string, searchQuery?: string): { label: string; detail: string } {
+  switch (mode) {
+    case "search":
+      if (!searchQuery) {
+        return { label: "Type a ticker symbol", detail: "Search Yahoo Finance and connected brokers" };
+      }
+      return { label: `No matches for "${searchQuery}"`, detail: "Try a symbol, company name, or exchange variant" };
+    case "plugins":
+      return { label: "No plugins match", detail: query.trim() || "Toggleable plugins will appear here" };
+    case "columns":
+      return { label: "No columns available", detail: "Column toggles will appear here" };
+    case "themes":
+      return { label: "No themes match", detail: query.trim() || "Installed themes will appear here" };
+    default:
+      if (query.trim()) {
+        return { label: `No matches for "${query.trim()}"`, detail: "Try a ticker, command name, or prefix" };
+      }
+      return { label: "No results yet", detail: "Recent tickers and suggested commands will appear here" };
+  }
+}
+
+export function getRowPresentation(item: CommandBarItemView, selected: boolean, showTrailing: boolean): CommandBarRowPresentation {
+  const glyph = selected ? "\u203a" : " ";
+  const primaryMuted = (item.kind === "plugin" || item.kind === "column") && !item.checked;
+  let trailing = "";
+
+  if (showTrailing) {
+    if (item.current) trailing = "current";
+    else if (item.kind === "plugin" || item.kind === "column") trailing = item.checked ? "on" : "off";
+    else trailing = item.right || "";
+  }
+
+  return {
+    glyph,
+    label: item.label,
+    trailing,
+    selected,
+    primaryMuted,
+  };
+}
+
+export function truncateText(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (text.length <= width) return text;
+  if (width <= 3) return ".".repeat(width);
+  return `${text.slice(0, width - 3)}...`;
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -47,6 +47,8 @@ export class PluginRegistry {
   private plugins = new Map<string, GloomPlugin>();
   private unregisterFns = new Map<string, () => void>();
   private pluginItems = new Map<string, PluginItems>();
+  private commandOwners = new Map<string, string>();
+  private shortcutOwners = new Map<string, string>();
 
   private panesMap = new Map<string, PaneDef>();
   private commandsMap = new Map<string, CommandDef>();
@@ -122,6 +124,14 @@ export class PluginRegistry {
     return this.pluginItems.get(pluginId)?.panes ?? [];
   }
 
+  getCommandPluginId(commandId: string): string | undefined {
+    return this.commandOwners.get(commandId);
+  }
+
+  getShortcutPluginId(shortcutId: string): string | undefined {
+    return this.shortcutOwners.get(shortcutId);
+  }
+
   isPaneFloating(paneId: string): boolean {
     try {
       return this.getLayoutFn().floating.some((entry) => entry.paneId === paneId);
@@ -195,12 +205,20 @@ export class PluginRegistry {
 
     return {
       registerPane: (pane) => { this.panesMap.set(pane.id, pane); items.panes.push(pane.id); },
-      registerCommand: (command) => { this.commandsMap.set(command.id, command); items.commands.push(command.id); },
+      registerCommand: (command) => {
+        this.commandsMap.set(command.id, command);
+        this.commandOwners.set(command.id, pluginId);
+        items.commands.push(command.id);
+      },
       registerColumn: (column) => { this.columnsMap.set(column.id, column); items.columns.push(column.id); },
       registerBroker: (broker) => { this.brokersMap.set(broker.id, broker); items.brokers.push(broker.id); },
       registerDataProvider: (provider) => { this.dataProvidersMap.set(provider.id, provider); items.dataProviders.push(provider.id); },
       registerDetailTab: (tab) => { this.detailTabsMap.set(tab.id, tab); items.detailTabs.push(tab.id); },
-      registerShortcut: (shortcut) => { this.shortcutsMap.set(shortcut.id, shortcut); items.shortcuts.push(shortcut.id); },
+      registerShortcut: (shortcut) => {
+        this.shortcutsMap.set(shortcut.id, shortcut);
+        this.shortcutOwners.set(shortcut.id, pluginId);
+        items.shortcuts.push(shortcut.id);
+      },
       registerTickerAction: (action) => { this.tickerActionsMap.set(action.id, action); items.tickerActions.push(action.id); },
 
       getData: (ticker) => this.getDataFn(ticker),
@@ -289,12 +307,18 @@ export class PluginRegistry {
     const items = this.pluginItems.get(pluginId);
     if (items) {
       for (const paneId of items.panes) this.panesMap.delete(paneId);
-      for (const commandId of items.commands) this.commandsMap.delete(commandId);
+      for (const commandId of items.commands) {
+        this.commandsMap.delete(commandId);
+        this.commandOwners.delete(commandId);
+      }
       for (const columnId of items.columns) this.columnsMap.delete(columnId);
       for (const brokerId of items.brokers) this.brokersMap.delete(brokerId);
       for (const providerId of items.dataProviders) this.dataProvidersMap.delete(providerId);
       for (const tabId of items.detailTabs) this.detailTabsMap.delete(tabId);
-      for (const shortcutId of items.shortcuts) this.shortcutsMap.delete(shortcutId);
+      for (const shortcutId of items.shortcuts) {
+        this.shortcutsMap.delete(shortcutId);
+        this.shortcutOwners.delete(shortcutId);
+      }
       for (const actionId of items.tickerActions) this.tickerActionsMap.delete(actionId);
       for (const dispose of items.eventDisposers) dispose();
       this.pluginItems.delete(pluginId);

--- a/src/state/app-context.test.tsx
+++ b/src/state/app-context.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultConfig } from "../types/config";
+import { appReducer, createInitialState } from "./app-context";
+
+describe("appReducer command bar state", () => {
+  test("opens the command bar with an explicit query", () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    const next = appReducer(state, { type: "SET_COMMAND_BAR", open: true, query: "Sync Broker Account" });
+
+    expect(next.commandBarOpen).toBe(true);
+    expect(next.commandBarQuery).toBe("Sync Broker Account");
+  });
+
+  test("clears the command bar query when closing", () => {
+    const state = appReducer(
+      createInitialState(createDefaultConfig("/tmp/gloomberb-test")),
+      { type: "SET_COMMAND_BAR", open: true, query: "Disconnect Broker Account" },
+    );
+    const next = appReducer(state, { type: "SET_COMMAND_BAR", open: false });
+
+    expect(next.commandBarOpen).toBe(false);
+    expect(next.commandBarQuery).toBe("");
+  });
+
+  test("toggle opens blank and clears on close", () => {
+    const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    const opened = appReducer(initial, { type: "TOGGLE_COMMAND_BAR" });
+    const closed = appReducer({ ...opened, commandBarQuery: "stale" }, { type: "TOGGLE_COMMAND_BAR" });
+
+    expect(opened.commandBarOpen).toBe(true);
+    expect(opened.commandBarQuery).toBe("");
+    expect(closed.commandBarOpen).toBe(false);
+    expect(closed.commandBarQuery).toBe("");
+  });
+
+  test("updates the live command bar query without closing the overlay", () => {
+    const state = appReducer(
+      createInitialState(createDefaultConfig("/tmp/gloomberb-test")),
+      { type: "SET_COMMAND_BAR", open: true, query: "PL " },
+    );
+    const next = appReducer(state, { type: "SET_COMMAND_BAR_QUERY", query: "PL notes" });
+
+    expect(next.commandBarOpen).toBe(true);
+    expect(next.commandBarQuery).toBe("PL notes");
+  });
+});

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -19,6 +19,7 @@ export interface AppState {
   selectedTicker: string | null;
   recentTickers: string[];
   commandBarOpen: boolean;
+  commandBarQuery: string;
   refreshing: Set<string>;
   initialized: boolean;
   statusBarVisible: boolean;
@@ -39,7 +40,8 @@ export type AppAction =
   | { type: "SET_LEFT_TAB"; tab: string }
   | { type: "SET_RIGHT_TAB"; tab: string }
   | { type: "TOGGLE_COMMAND_BAR" }
-  | { type: "SET_COMMAND_BAR"; open: boolean }
+  | { type: "SET_COMMAND_BAR"; open: boolean; query?: string }
+  | { type: "SET_COMMAND_BAR_QUERY"; query: string }
   | { type: "SET_REFRESHING"; symbol: string; refreshing: boolean }
   | { type: "SET_INITIALIZED" }
   | { type: "TOGGLE_STATUS_BAR" }
@@ -65,7 +67,7 @@ function syncLayouts(layouts: SavedLayout[], activeLayoutIndex: number, layout: 
   ));
 }
 
-function appReducer(state: AppState, action: AppAction): AppState {
+export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case "SET_CONFIG":
       return { ...state, config: action.config };
@@ -133,10 +135,19 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, activeRightTab: action.tab };
 
     case "TOGGLE_COMMAND_BAR":
-      return { ...state, commandBarOpen: !state.commandBarOpen };
+      return state.commandBarOpen
+        ? { ...state, commandBarOpen: false, commandBarQuery: "" }
+        : { ...state, commandBarOpen: true, commandBarQuery: "" };
 
     case "SET_COMMAND_BAR":
-      return { ...state, commandBarOpen: action.open };
+      return {
+        ...state,
+        commandBarOpen: action.open,
+        commandBarQuery: action.open ? (action.query ?? "") : "",
+      };
+
+    case "SET_COMMAND_BAR_QUERY":
+      return { ...state, commandBarQuery: action.query };
 
     case "SET_REFRESHING": {
       const refreshing = new Set(state.refreshing);
@@ -290,7 +301,7 @@ interface AppContextValue {
   dispatch: React.Dispatch<AppAction>;
 }
 
-const AppContext = createContext<AppContextValue | null>(null);
+export const AppContext = createContext<AppContextValue | null>(null);
 
 export function useAppState(): AppContextValue {
   const context = useContext(AppContext);
@@ -320,6 +331,7 @@ export function createInitialState(config: AppConfig): AppState {
     selectedTicker: null,
     recentTickers: config.recentTickers,
     commandBarOpen: false,
+    commandBarQuery: "",
     refreshing: new Set(),
     initialized: false,
     statusBarVisible: true,

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -31,9 +31,87 @@ function blendHex(a: string, b: string, ratio: number): string {
   return `#${mix(ar, br)}${mix(ag, bg)}${mix(ab, bb)}`;
 }
 
+function relativeLuminance(hex: string): number {
+  const h = hex.replace("#", "");
+  const toLinear = (value: string) => {
+    const normalized = parseInt(value, 16) / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : Math.pow((normalized + 0.055) / 1.055, 2.4);
+  };
+  const r = toLinear(h.slice(0, 2));
+  const g = toLinear(h.slice(2, 4));
+  const b = toLinear(h.slice(4, 6));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(a: string, b: string): number {
+  const lighter = Math.max(relativeLuminance(a), relativeLuminance(b));
+  const darker = Math.min(relativeLuminance(a), relativeLuminance(b));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function blendForContrast(base: string, against: string, fallback: string, minContrast: number): string {
+  const steps = [0, 0.08, 0.14, 0.2, 0.28, 0.36, 0.48, 0.62, 0.78, 1] as const;
+  let candidate = base;
+
+  for (const ratio of steps) {
+    candidate = ratio === 0 ? base : blendHex(base, fallback, ratio);
+    if (contrastRatio(candidate, against) >= minContrast) {
+      return candidate;
+    }
+  }
+
+  return candidate;
+}
+
+function higherContrast(a: string, b: string, against: string): string {
+  return contrastRatio(a, against) >= contrastRatio(b, against) ? a : b;
+}
+
 /** Returns a hover background color derived from bg and selected */
 export function hoverBg(): string {
   return blendHex(colors.bg, colors.selected, 0.5);
+}
+
+export function commandBarBg(): string {
+  const base = higherContrast(colors.commandBg, colors.panel, colors.bg);
+  const accent = higherContrast(colors.textBright, colors.borderFocused, base);
+  return blendForContrast(base, colors.bg, accent, 1.45);
+}
+
+export function commandBarSelectedBg(): string {
+  const base = commandBarBg();
+  const accent = higherContrast(colors.selectedText, colors.textBright, colors.selected);
+  return blendForContrast(colors.selected, base, accent, 1.6);
+}
+
+export function commandBarHoverBg(): string {
+  return blendHex(commandBarBg(), commandBarSelectedBg(), 0.45);
+}
+
+export function commandBarText(): string {
+  const base = commandBarBg();
+  const fallback = higherContrast(colors.textBright, "#f2f2f2", base);
+  return blendForContrast(colors.text, base, fallback, 5.4);
+}
+
+export function commandBarHeadingText(): string {
+  const base = commandBarBg();
+  return blendForContrast("#8f959e", base, "#b7bec8", 3.6);
+}
+
+export function commandBarSubtleText(): string {
+  const base = commandBarBg();
+  const fallback = higherContrast(commandBarText(), "#d8d8d8", base);
+  return blendForContrast(colors.textDim, base, fallback, 4.1);
+}
+
+export function commandBarSelectedText(): string {
+  const base = commandBarSelectedBg();
+  const preferred = higherContrast(colors.selectedText, colors.text, base);
+  const fallback = higherContrast(colors.textBright, "#f2f2f2", base);
+  return blendForContrast(preferred, base, fallback, 4.5);
 }
 
 /** Returns green for positive, red for negative, neutral for zero */


### PR DESCRIPTION
This PR refines the command bar into a more minimal centered palette with improved spacing, grouping, and contrast across themes. It moves the command bar query into app state so plugins can open it prefilled, keeps disabled plugin commands and shortcuts out of the palette, and groups plugin-owned commands by plugin. It also fixes theme preview/navigation, mouse interaction, and renderer-driven keyboard handling while preserving the current terminal aesthetic. Tests cover app-context command bar state, command-bar view models, render snapshots, and theme arrow navigation via `bun test`.