### PR TITLE
Clean up command bar: remove redundant commands, hide contextual ones

### DIFF
--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -327,6 +327,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [searching, setSearching] = useState(false);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSearchedQueryRef = useRef<string | null>(null);
   const originalThemeRef = useRef<string>(getCurrentThemeId());
   const previousSelectionContextRef = useRef<{ query: string; mode: string } | null>(null);
   const query = state.commandBarQuery;
@@ -591,26 +592,6 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
       case "add-broker-account": {
         close();
         void connectBrokerProfile();
-        return;
-      }
-      case "sync-broker-account": {
-        close();
-        (async () => {
-          const instance = await pickBrokerInstance("Sync Broker Account");
-          if (!instance) return;
-          try {
-            await pluginRegistry.syncBrokerInstanceFn(instance.id);
-            const freshConfig = pluginRegistry.getConfigFn();
-            dispatch({ type: "SET_CONFIG", config: freshConfig });
-            await dialog.alert({
-              content: (ctx) => <ResultContent {...ctx} message={`Synced ${instance.label}.`} isError={false} />,
-            });
-          } catch (err: any) {
-            await dialog.alert({
-              content: (ctx) => <ResultContent {...ctx} message={err.message || "Sync failed"} isError={true} />,
-            });
-          }
-        })();
         return;
       }
       case "disconnect-broker-account": {
@@ -1035,6 +1016,8 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
         case "remove-portfolio":
           if (!tickerData || !isPortfolioTab || isBrokerManaged) return false;
           return !!activeCollectionId && tickerData.frontmatter.portfolios.includes(activeCollectionId);
+        case "disconnect-broker-account":
+          return state.config.brokerInstances.length > 0;
         default:
           return true;
       }
@@ -1238,8 +1221,10 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
     if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
     const isTPrefix = match?.command.id === "search-ticker" && match.arg.length >= 1;
     const isImplicitSearch = !match && query.length >= 1 && /^[A-Za-z0-9.]/.test(query);
-    if (isTPrefix || isImplicitSearch) {
-      const searchQuery = isTPrefix ? match!.arg : query;
+    const searchQuery = isTPrefix ? match!.arg : query;
+    const queryChanged = lastSearchedQueryRef.current !== searchQuery;
+    if ((isTPrefix || isImplicitSearch) && queryChanged) {
+      lastSearchedQueryRef.current = searchQuery;
       setSearching(true);
       searchTimerRef.current = setTimeout(async () => {
         try {
@@ -1296,8 +1281,9 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
           setSearching(false);
         }
       }, 200);
-    } else {
+    } else if (!isTPrefix && !isImplicitSearch) {
       setSearching(false);
+      lastSearchedQueryRef.current = null;
     }
 
     return () => {

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -109,14 +109,6 @@ export const commands: Command[] = [
     execute: () => {},
   },
   {
-    id: "sync-broker-account",
-    prefix: "",
-    label: "Sync Broker Account",
-    description: "Sync positions for a connected broker profile",
-    category: "Data",
-    execute: () => {},
-  },
-  {
     id: "disconnect-broker-account",
     prefix: "",
     label: "Disconnect Broker Account",

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -490,6 +490,7 @@ export const chatPlugin: GloomPlugin = {
       description: "Log in to your Gloomberb account",
       keywords: ["login", "sign in", "auth", "account"],
       category: "config",
+      hidden: () => !!apiClient.getSessionToken(),
       wizard: [
         { key: "email", label: "Email", type: "text", placeholder: "email@example.com" },
         { key: "password", label: "Password", type: "password", placeholder: "Your password" },
@@ -520,6 +521,7 @@ export const chatPlugin: GloomPlugin = {
       description: "Create a Gloomberb account",
       keywords: ["signup", "register", "create account"],
       category: "config",
+      hidden: () => !!apiClient.getSessionToken(),
       wizard: [
         { key: "email", label: "Email", type: "text", placeholder: "email@example.com" },
         {

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -76,16 +76,6 @@ function getIbkrInstances(appConfig: ReturnType<GloomPluginContext["getConfig"]>
   return getBrokerInstancesByType(appConfig.brokerInstances, "ibkr");
 }
 
-function firstIbkrAccount(
-  appConfig: ReturnType<GloomPluginContext["getConfig"]>,
-  brokerInstanceId?: string,
-): string | undefined {
-  return appConfig.portfolios.find((entry) =>
-    entry.brokerId === "ibkr"
-    && (!brokerInstanceId || entry.brokerInstanceId === brokerInstanceId)
-    && entry.brokerAccountId,
-  )?.brokerAccountId;
-}
 
 function inferDraftAccountId(
   appConfig: ReturnType<GloomPluginContext["getConfig"]>,
@@ -198,6 +188,7 @@ const ibkrBroker: BrokerAdapter = {
   async importPositions(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode === "gateway") {
+      await refreshGatewayData(instance);
       return ibkrGatewayManager.getService(instance.id).getPositions(normalized.gateway);
     }
     return importFlexPositions(normalized.flex);
@@ -1452,81 +1443,6 @@ function TradingPane({ focused, width, height }: PaneProps) {
   );
 }
 
-function connectWizard(): WizardStep[] {
-  return [
-    {
-      key: "_intro",
-      type: "info",
-      label: "Connect Interactive Brokers",
-      body: [
-        "Choose Flex for read-only imports or Gateway / TWS for trading and broker market data.",
-        "Gateway / TWS runs locally; Gloomberb connects to your existing paper or live session.",
-      ],
-    },
-    {
-      key: "profileLabel",
-      type: "text",
-      label: "Profile Label",
-      placeholder: "Work, Personal, Paper",
-      body: ["This labels the IBKR connection profile. Portfolio names still use the account only."],
-    },
-    {
-      key: "connectionMode",
-      type: "select",
-      label: "Connection Mode",
-      options: [
-        { label: "Flex (read-only)", value: "flex" },
-        { label: "Gateway / TWS", value: "gateway" },
-      ],
-    },
-    {
-      key: "token",
-      type: "password",
-      label: "Flex Token",
-      placeholder: "Flex Web Service token",
-      body: ["Client Portal → Performance & Reports → Flex Queries → Flex Web Service"],
-      dependsOn: { key: "connectionMode", value: "flex" },
-    },
-    {
-      key: "queryId",
-      type: "text",
-      label: "Flex Query ID",
-      placeholder: "Numeric query id",
-      body: ["Use an Activity Flex Query with Open Positions enabled."],
-      dependsOn: { key: "connectionMode", value: "flex" },
-    },
-    {
-      key: "host",
-      type: "text",
-      label: "Gateway Host",
-      placeholder: "127.0.0.1",
-      defaultValue: "127.0.0.1",
-      dependsOn: { key: "connectionMode", value: "gateway" },
-    },
-    {
-      key: "port",
-      type: "number",
-      label: "Gateway Port",
-      placeholder: "4002",
-      defaultValue: "4002",
-      dependsOn: { key: "connectionMode", value: "gateway" },
-    },
-    {
-      key: "clientId",
-      type: "number",
-      label: "Client ID",
-      placeholder: "1",
-      defaultValue: "1",
-      dependsOn: { key: "connectionMode", value: "gateway" },
-    },
-    {
-      key: "_validate",
-      type: "info",
-      label: "Connecting",
-      body: ["Saving credentials and validating the Interactive Brokers connection..."],
-    },
-  ];
-}
 
 export const ibkrPlugin: GloomPlugin = {
   id: "ibkr",
@@ -1574,82 +1490,6 @@ export const ibkrPlugin: GloomPlugin = {
       }
     });
 
-    ctx.registerCommand({
-      id: "ibkr-connect",
-      label: "Connect IBKR",
-      description: "Configure Interactive Brokers via Flex or Gateway / TWS",
-      keywords: ["ibkr", "interactive brokers", "gateway", "tws", "flex", "connect", "setup"],
-      category: "config",
-      wizard: connectWizard(),
-      execute: async (values) => {
-        const brokerConfig = buildIbkrConfigFromValues(values ?? {});
-        const profileLabel = values?.profileLabel?.trim();
-        if (!profileLabel) {
-          throw new Error("Profile label is required.");
-        }
-        const instance = await ctx.createBrokerInstance("ibkr", profileLabel, brokerConfig as unknown as Record<string, unknown>);
-        if (brokerConfig.connectionMode === "gateway") {
-          await ibkrBroker.connect?.(instance);
-          await refreshGatewayData(instance);
-          updateTradingPaneState({ brokerInstanceId: instance.id, brokerLabel: instance.label });
-          const inferredAccount = firstIbkrAccount(ctx.getConfig(), instance.id);
-          if (inferredAccount) {
-            updateTradingPaneState({ brokerInstanceId: instance.id, brokerLabel: instance.label, accountId: inferredAccount });
-          }
-        }
-        await ctx.syncBrokerInstance(instance.id);
-        ctx.showPane("ibkr-trading");
-        ctx.switchPanel("right");
-        ctx.switchTab("ibkr-trade");
-      },
-    });
-
-    ctx.registerCommand({
-      id: "ibkr-disconnect",
-      label: "Disconnect IBKR",
-      description: "Remove the IBKR integration, managed portfolios, and imported positions",
-      keywords: ["ibkr", "gateway", "disconnect", "remove", "delete"],
-      category: "config",
-      execute: async () => {
-        const config = ctx.getConfig();
-        const ibkrInstances = getIbkrInstances(config);
-        const targetInstanceId = ibkrInstances.length === 1 ? ibkrInstances[0]!.id : undefined;
-        if (!targetInstanceId) {
-          ctx.openCommandBar("Disconnect Broker Account");
-          ctx.showToast("Choose which IBKR profile to remove.", { type: "info" });
-          return;
-        }
-        await ctx.removeBrokerInstance(targetInstanceId);
-        removeBrokerInstanceFromTradingState(targetInstanceId);
-        setTradingMessage("Removed IBKR integration.", undefined);
-      },
-    });
-
-    ctx.registerCommand({
-      id: "ibkr-sync",
-      label: "Sync IBKR",
-      description: "Import positions and refresh trading state from Interactive Brokers",
-      keywords: ["ibkr", "sync", "refresh", "positions"],
-      category: "data",
-      execute: async () => {
-        const config = ctx.getConfig();
-        const ibkrInstances = getIbkrInstances(config);
-        const targetInstanceId = ibkrInstances.length === 1 ? ibkrInstances[0]!.id : undefined;
-        if (!targetInstanceId) {
-          ctx.openCommandBar("Sync Broker Account");
-          ctx.showToast("Choose which IBKR profile to sync.", { type: "info" });
-          return;
-        }
-        const instance = getBrokerInstance(config.brokerInstances, targetInstanceId);
-        if (!instance) return;
-        const normalized = normalizeIbkrConfig(instance.config);
-        if (normalized.connectionMode === "gateway") {
-          await refreshGatewayData(instance);
-        }
-        await ctx.syncBrokerInstance(targetInstanceId);
-        ctx.showPane("ibkr-trading");
-      },
-    });
 
     ctx.registerCommand({
       id: "ibkr-open-trading",
@@ -1657,6 +1497,7 @@ export const ibkrPlugin: GloomPlugin = {
       description: "Open the IBKR trade tab for the selected ticker",
       keywords: ["ibkr", "trading", "orders", "trade", "ticker"],
       category: "navigation",
+      hidden: () => getIbkrInstances(ctx.getConfig()).length === 0,
       execute: async () => {
         if (lastSelectedTickerSymbol) {
           const ticker = ctx.getTicker(lastSelectedTickerSymbol);
@@ -1676,6 +1517,7 @@ export const ibkrPlugin: GloomPlugin = {
       description: "Prefill the trading pane with a BUY ticket for the selected ticker",
       keywords: ["buy", "trade", "order", "selected", "ibkr"],
       category: "portfolio",
+      hidden: () => getIbkrInstances(ctx.getConfig()).length === 0 || !lastSelectedTickerSymbol,
       execute: async () => {
         if (!lastSelectedTickerSymbol) return;
         const ticker = ctx.getTicker(lastSelectedTickerSymbol);
@@ -1692,6 +1534,7 @@ export const ibkrPlugin: GloomPlugin = {
       description: "Prefill the trading pane with a SELL ticket for the selected ticker",
       keywords: ["sell", "trade", "order", "selected", "ibkr"],
       category: "portfolio",
+      hidden: () => getIbkrInstances(ctx.getConfig()).length === 0 || !lastSelectedTickerSymbol,
       execute: async () => {
         if (!lastSelectedTickerSymbol) return;
         const ticker = ctx.getTicker(lastSelectedTickerSymbol);


### PR DESCRIPTION
## Summary
- Hide Login/Sign Up when already logged in (Logout was already hidden when logged out)
- Remove all manual sync commands — sync runs automatically on startup; moved gateway refresh into `importPositions`
- Remove duplicate IBKR-specific connect/disconnect/sync commands since the generic broker commands already handle IBKR
- Hide "Disconnect Broker Account" when no brokers are connected
- Hide IBKR trading commands (Open Trading, Buy/Sell Selected) when no IBKR instance exists or no ticker is selected

Reduces broker-related commands from 9 to 5 (2 management + 3 trading), all contextually shown.

## Test plan
- [ ] Open command bar when logged out → Login + Sign Up visible, no Logout
- [ ] Log in → only Logout visible
- [ ] No brokers connected → only "Add Broker Account" shown
- [ ] Connect IBKR via "Add Broker Account" → Disconnect + trading commands appear
- [ ] Verify auto-sync still works on startup for both Flex and Gateway modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)