### PR TITLE
Deduplicate shared utilities and standardize types to camelCase

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,7 +32,7 @@ import {
   type PaneBinding,
   type PaneInstanceConfig,
 } from "./types/config";
-import type { TickerFile, TickerFrontmatter, Portfolio } from "./types/ticker";
+import type { TickerFile, TickerFrontmatter, TickerPosition, Portfolio } from "./types/ticker";
 import type { DataProvider } from "./types/data-provider";
 import type { BrokerContractRef } from "./types/instrument";
 
@@ -409,20 +409,20 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
         ? { ...pos.brokerContract, brokerId: instance.brokerType, brokerInstanceId: instance.id }
         : undefined;
 
-      const positionEntry = {
+      const positionEntry: TickerPosition = {
         portfolio: portfolioId,
         shares: pos.shares,
-        avg_cost: pos.avgCost,
+        avgCost: pos.avgCost,
         currency: pos.currency,
         broker: instance.brokerType,
         side: pos.side,
-        market_value: pos.marketValue,
-        unrealized_pnl: pos.unrealizedPnl,
+        marketValue: pos.marketValue,
+        unrealizedPnl: pos.unrealizedPnl,
         multiplier: pos.multiplier,
-        mark_price: pos.markPrice,
-        broker_instance_id: instance.id,
-        broker_account_id: pos.accountId,
-        broker_contract_id: brokerContract?.conId,
+        markPrice: pos.markPrice,
+        brokerInstanceId: instance.id,
+        brokerAccountId: pos.accountId,
+        brokerContractId: brokerContract?.conId,
       };
 
       let ticker = existingTickers.get(pos.ticker);
@@ -432,7 +432,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
           exchange: pos.exchange,
           currency: pos.currency,
           name: pos.name || pos.ticker,
-          asset_category: pos.assetCategory,
+          assetCategory: pos.assetCategory,
           isin: pos.isin,
           portfolios: [portfolioId],
           watchlists: [],
@@ -447,8 +447,8 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
         if (pos.name && ticker.frontmatter.name === ticker.frontmatter.ticker) {
           ticker.frontmatter.name = pos.name;
         }
-        if (pos.assetCategory && !ticker.frontmatter.asset_category) {
-          ticker.frontmatter.asset_category = pos.assetCategory;
+        if (pos.assetCategory && !ticker.frontmatter.assetCategory) {
+          ticker.frontmatter.assetCategory = pos.assetCategory;
         }
         if (pos.isin && !ticker.frontmatter.isin) {
           ticker.frontmatter.isin = pos.isin;
@@ -456,7 +456,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
 
         // Remove old positions from this broker for this account
         const otherPositions = ticker.frontmatter.positions.filter(
-          (p) => !(p.broker_instance_id === instance.id && p.portfolio === portfolioId),
+          (p) => !(p.brokerInstanceId === instance.id && p.portfolio === portfolioId),
         );
         ticker.frontmatter.positions = [...otherPositions, positionEntry];
         ticker.frontmatter.broker_contracts = mergeBrokerContracts(
@@ -471,7 +471,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
       existingTickers.set(pos.ticker, ticker);
       dispatch({ type: "UPDATE_TICKER", ticker: { ...ticker } });
       // Skip Yahoo Finance for options — IBKR symbols aren't resolvable there.
-      // Position data (mark_price, market_value, unrealized_pnl) is used directly.
+      // Position data (markPrice, marketValue, unrealizedPnl) is used directly.
       if (pos.assetCategory !== "OPT") {
         refreshTicker(pos.ticker, pos.exchange);
       }
@@ -616,7 +616,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
     const nextTickers = new Map(state.tickers);
 
     for (const ticker of state.tickers.values()) {
-      const nextPositions = ticker.frontmatter.positions.filter((position) => position.broker_instance_id !== instanceId);
+      const nextPositions = ticker.frontmatter.positions.filter((position) => position.brokerInstanceId !== instanceId);
       const nextPortfolioRefs = ticker.frontmatter.portfolios.filter((portfolioId) => !removedPortfolioIds.has(portfolioId));
       const nextBrokerContracts = (ticker.frontmatter.broker_contracts ?? []).filter((contract) => contract.brokerInstanceId !== instanceId);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -282,7 +282,7 @@ async function portfolio(name?: string) {
       } else {
         for (const pos of positions) {
           const shares = pos.shares;
-          const avgCost = pos.avg_cost;
+          const avgCost = pos.avgCost;
           const currentPrice = q?.price ?? 0;
           const pnl = (currentPrice - avgCost) * shares * (pos.multiplier ?? 1);
           totalPnl += pnl;
@@ -395,10 +395,10 @@ async function ticker(symbol: string) {
     for (const pos of tickerFile.frontmatter.positions) {
       const portfolioName = config.portfolios.find((p) => p.id === pos.portfolio)?.name ?? pos.portfolio;
       const value = q.price * pos.shares * (pos.multiplier ?? 1);
-      const pnl = (q.price - pos.avg_cost) * pos.shares * (pos.multiplier ?? 1);
+      const pnl = (q.price - pos.avgCost) * pos.shares * (pos.multiplier ?? 1);
       const pnlStr = pnl >= 0 ? `+${formatCurrency(pnl, q.currency)}` : formatCurrency(pnl, q.currency);
       console.log(`Position (${portfolioName}):`);
-      console.log(`  ${pos.shares} shares @ ${formatCurrency(pos.avg_cost, q.currency)} = ${formatCurrency(value, q.currency)} (P&L: ${pnlStr})`);
+      console.log(`  ${pos.shares} shares @ ${formatCurrency(pos.avgCost, q.currency)} = ${formatCurrency(value, q.currency)} (P&L: ${pnlStr})`);
     }
   }
 

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -830,7 +830,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
           exchange: result.exchange,
           currency: result.currency || result.brokerContract?.currency || "USD",
           name: result.name,
-          asset_category: result.brokerContract?.secType || result.type || undefined,
+          assetCategory: result.brokerContract?.secType || result.type || undefined,
           broker_contracts: result.brokerContract ? [result.brokerContract] : [],
           portfolios: [],
           watchlists: [],
@@ -843,7 +843,7 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
         existing.frontmatter.name = existing.frontmatter.name || result.name;
         existing.frontmatter.exchange = existing.frontmatter.exchange || result.exchange;
         existing.frontmatter.currency = existing.frontmatter.currency || result.currency || "USD";
-        existing.frontmatter.asset_category = existing.frontmatter.asset_category || result.brokerContract?.secType || result.type || undefined;
+        existing.frontmatter.assetCategory = existing.frontmatter.assetCategory || result.brokerContract?.secType || result.type || undefined;
         const existingContracts = existing.frontmatter.broker_contracts ?? [];
         if (result.brokerContract) {
           const nextContracts = [...existingContracts];

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -4,7 +4,7 @@ import "opentui-spinner/react";
 import { colors, priceColor } from "../../theme/colors";
 import { useAppState } from "../../state/app-context";
 import { formatPercentRaw } from "../../utils/format";
-import { marketStateLabel, marketStateColor } from "../../utils/market-status";
+import { marketStateLabel, marketStateColor, getExtendedHoursInfo } from "../../utils/market-status";
 import type { DataProvider } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
 
@@ -75,7 +75,7 @@ export function Header({ dataProvider }: { dataProvider: DataProvider }) {
     : "SPY —";
 
   // Extended hours info
-  const extText = getExtendedHoursText(spyQuote);
+  const extText = getExtendedHoursInfo(spyQuote);
 
   // Market status
   const mktState = spyQuote?.marketState;
@@ -116,17 +116,4 @@ export function Header({ dataProvider }: { dataProvider: DataProvider }) {
       </box>
     </box>
   );
-}
-
-function getExtendedHoursText(quote: Quote | null): { text: string; color: string } | null {
-  if (!quote) return null;
-  if (quote.marketState === "PRE" && quote.preMarketPrice != null) {
-    const chg = quote.preMarketChangePercent ?? 0;
-    return { text: `Pre ${quote.preMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
-  }
-  if (quote.marketState === "POST" && quote.postMarketPrice != null) {
-    const chg = quote.postMarketChangePercent ?? 0;
-    return { text: `AH ${quote.postMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
-  }
-  return null;
 }

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
 import { colors, hoverBg } from "../../theme/colors";
 import { useAppState, useFocusedTicker } from "../../state/app-context";
-import { marketStateLabel, marketStateColor, exchangeShortName } from "../../utils/market-status";
-import { formatPercentRaw } from "../../utils/format";
-import { priceColor } from "../../theme/colors";
+import { marketStateLabel, marketStateColor, exchangeShortName, getExtendedHoursInfo } from "../../utils/market-status";
 import { getSharedRegistry } from "../../plugins/registry";
 
 export function StatusBar() {
@@ -22,18 +20,9 @@ export function StatusBar() {
   const exchName = q ? exchangeShortName(q.exchangeName, q.fullExchangeName) : "";
 
   // Extended hours info for selected ticker
-  const selQ = focusedFinancials?.quote;
-  let extText = "";
-  let extColor = colors.textDim;
-  if (selQ?.marketState === "PRE" && selQ.preMarketPrice != null) {
-    const chg = selQ.preMarketChangePercent ?? 0;
-    extText = `Pre ${selQ.preMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`;
-    extColor = priceColor(chg);
-  } else if (selQ?.marketState === "POST" && selQ.postMarketPrice != null) {
-    const chg = selQ.postMarketChangePercent ?? 0;
-    extText = `AH ${selQ.postMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`;
-    extColor = priceColor(chg);
-  }
+  const extInfo = getExtendedHoursInfo(focusedFinancials?.quote);
+  const extText = extInfo?.text ?? "";
+  const extColor = extInfo?.color ?? colors.textDim;
 
   const layouts = state.config.layouts ?? [];
   const activeLayoutIdx = state.config.activeLayoutIndex ?? 0;

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -6,6 +6,7 @@ import type { GloomPlugin, GloomPluginContext, PaneProps } from "../../types/plu
 import { useAppState } from "../../state/app-context";
 import { colors, hoverBg } from "../../theme/colors";
 import { apiClient, type ChatMessage } from "../../utils/api-client";
+import { formatTimeAgo } from "../../utils/format";
 import { getSharedRegistry } from "../../plugins/registry";
 
 const CHANNEL_ID = "everyone";
@@ -46,21 +47,6 @@ function _ensureConnection() {
   );
 }
 
-// --- Relative time formatting ---
-
-function relativeTime(dateStr: string): string {
-  const now = Date.now();
-  // Server returns UTC timestamps — ensure they're parsed as UTC
-  const then = new Date(dateStr.endsWith("Z") ? dateStr : dateStr + "Z").getTime();
-  const diffS = Math.floor((now - then) / 1000);
-  if (diffS < 60) return "just now";
-  const diffM = Math.floor(diffS / 60);
-  if (diffM < 60) return `${diffM}m ago`;
-  const diffH = Math.floor(diffM / 60);
-  if (diffH < 24) return `${diffH}h ago`;
-  const diffD = Math.floor(diffH / 24);
-  return `${diffD}d ago`;
-}
 
 // --- Ticker badge rendering ---
 
@@ -315,7 +301,7 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
                 <text fg={colors.positive} attributes={TextAttributes.BOLD}>
                   {msg.user.username ?? "anon"}
                 </text>
-                <text fg={colors.textMuted}> ({relativeTime(msg.createdAt)})</text>
+                <text fg={colors.textMuted}> ({formatTimeAgo(msg.createdAt)})</text>
               </box>
               {/* Content */}
               <box paddingLeft={3}>

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -4,27 +4,16 @@ import { TextAttributes } from "@opentui/core";
 import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
 import { usePaneTicker } from "../../state/app-context";
 import { colors, hoverBg } from "../../theme/colors";
-import { padTo } from "../../utils/format";
+import { padTo, formatTimeAgo } from "../../utils/format";
 import type { NewsItem } from "../../types/data-provider";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { Spinner } from "../../components/spinner";
-
-function formatTimeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return date.toLocaleDateString("en-US", { month: "numeric", day: "numeric", year: "2-digit" });
-}
 
 function NewsTab({ width, height, focused }: DetailTabProps) {
   const { ticker } = usePaneTicker();
   const [news, setNews] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [summaryCache, setSummaryCache] = useState<Map<string, string>>(new Map());
@@ -36,11 +25,14 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
     if (!ticker || !provider) return;
     let cancelled = false;
     setLoading(true);
+    setError(null);
     setSelectedIdx(0);
     setSummaryCache(new Map());
     provider.getNews(ticker.frontmatter.ticker, 15).then((items) => {
       if (!cancelled) setNews(items);
-    }).catch(() => {}).finally(() => {
+    }).catch((err) => {
+      if (!cancelled) setError(err?.message ?? "Failed to load news");
+    }).finally(() => {
       if (!cancelled) setLoading(false);
     });
     return () => { cancelled = true; };
@@ -75,6 +67,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
 
   if (!ticker) return <text fg={colors.textDim}>Select a ticker to view news.</text>;
   if (loading && news.length === 0) return <Spinner label="Loading news..." />;
+  if (error) return <text fg={colors.textDim}>Error: {error}</text>;
   if (news.length === 0) return <text fg={colors.textDim}>No news available for {ticker.frontmatter.ticker}.</text>;
 
   const innerWidth = Math.max(width - 4, 40);

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -6,33 +6,9 @@ import type { OptionContract, OptionsChain } from "../../types/financials";
 import { usePaneTicker } from "../../state/app-context";
 import { colors, hoverBg } from "../../theme/colors";
 import { padTo, formatCompact, formatNumber } from "../../utils/format";
+import { formatExpDate, parseOptionSymbol } from "../../utils/options";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { Spinner } from "../../components/spinner";
-
-const MONTH_ABBREV = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-
-function formatExpDate(ts: number): string {
-  const d = new Date(ts * 1000);
-  const month = MONTH_ABBREV[d.getMonth()] || String(d.getMonth() + 1);
-  const yy = String(d.getFullYear()).slice(2);
-  return `${month} ${d.getDate()} '${yy}`;
-}
-
-/**
- * Parse IBKR option symbol like "UBER 260821C00090000" into components.
- * Returns null if not a recognized option symbol.
- */
-function parseOptionSymbol(symbol: string): { underlying: string; expTs: number; strike: number; side: "C" | "P" } | null {
-  const m = symbol.match(/^(\S+)\s+(\d{2})(\d{2})(\d{2})([CP])(\d{8})$/);
-  if (!m) return null;
-  const [, underlying, yy, mm, dd, side, rawStrike] = m;
-  const strike = parseInt(rawStrike!, 10) / 1000;
-  const year = 2000 + parseInt(yy!, 10);
-  const month = parseInt(mm!, 10) - 1;
-  const day = parseInt(dd!, 10);
-  const expTs = Math.floor(new Date(year, month, day).getTime() / 1000);
-  return { underlying: underlying!, expTs, strike, side: side as "C" | "P" };
-}
 
 function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const { ticker } = usePaneTicker();
@@ -46,7 +22,7 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const [hoveredExpIdx, setHoveredExpIdx] = useState<number | null>(null);
 
   // Determine if we're viewing an option position — if so, resolve the underlying
-  const isOpt = ticker?.frontmatter.asset_category === "OPT";
+  const isOpt = ticker?.frontmatter.assetCategory === "OPT";
   const parsed = isOpt ? parseOptionSymbol(ticker!.frontmatter.ticker) : null;
   const effectiveTicker = parsed?.underlying ?? ticker?.frontmatter.ticker ?? "";
   const effectiveExchange = isOpt ? "" : (ticker?.frontmatter.exchange ?? "");

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -8,41 +8,11 @@ import { getSharedRegistry } from "../../plugins/registry";
 import { useAppState, usePaneCollection, usePaneInstanceId, usePaneStateValue } from "../../state/app-context";
 import { getAllCollections, getCollectionTickers, getCollectionType } from "../../state/selectors";
 import { colors, priceColor, hoverBg } from "../../theme/colors";
-import { formatCurrency, formatPercentRaw, formatCompact, formatNumber, padTo } from "../../utils/format";
+import { formatCurrency, formatPercentRaw, formatCompact, formatNumber, padTo, convertCurrency } from "../../utils/format";
 import type { ColumnConfig } from "../../types/config";
 import type { TickerFile } from "../../types/ticker";
 import type { TickerFinancials } from "../../types/financials";
-
-const MONTH_ABBREV = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-
-/**
- * Parse IBKR option symbol like "UBER 260821C00090000" into a readable form.
- * Format: UNDERLYING YYMMDD{C|P}SSSSSSSS (strike in 1/1000 dollars, 8 digits)
- */
-function formatOptionTicker(symbol: string): string {
-  // Match: TICKER(space)YYMMDDX00SSSSSS  where X is C or P
-  const m = symbol.match(/^(\S+)\s+(\d{2})(\d{2})(\d{2})([CP])(\d{8})$/);
-  if (!m) return symbol;
-  const [, underlying, yy, mm, , side, rawStrike] = m;
-  const strike = parseInt(rawStrike!, 10) / 1000;
-  const month = MONTH_ABBREV[parseInt(mm!, 10) - 1] || mm;
-  const strikeStr = strike % 1 === 0 ? String(strike) : strike.toFixed(1);
-  return `${underlying} ${side === "C" ? "C" : "P"} $${strikeStr} ${month}'${yy}`;
-}
-
-/** Convert a value from one currency to base currency using cached exchange rates */
-function convertCurrency(
-  value: number,
-  fromCurrency: string,
-  baseCurrency: string,
-  exchangeRates: Map<string, number>,
-): number {
-  if (fromCurrency === baseCurrency) return value;
-  const fromRate = exchangeRates.get(fromCurrency);
-  const baseRate = exchangeRates.get(baseCurrency);
-  if (fromRate == null || baseRate == null || baseRate === 0) return value;
-  return (value * fromRate) / baseRate;
-}
+import { formatOptionTicker } from "../../utils/options";
 
 interface ColumnContext {
   activeTab?: string;
@@ -70,21 +40,21 @@ function getColumnValue(
     : ticker.frontmatter.positions;
   const totalShares = tabPositions.reduce((sum, p) => sum + p.shares * (p.side === "short" ? -1 : 1), 0);
   const totalCost = tabPositions.reduce(
-    (sum, p) => sum + p.shares * p.avg_cost * (p.multiplier || 1),
+    (sum, p) => sum + p.shares * p.avgCost * (p.multiplier || 1),
     0,
   );
 
   // For options without Yahoo quotes, use broker-provided position data
-  const isOption = ticker.frontmatter.asset_category === "OPT";
+  const isOption = ticker.frontmatter.assetCategory === "OPT";
   const brokerMktValue = tabPositions.reduce(
-    (sum, p) => sum + (p.market_value || 0),
+    (sum, p) => sum + (p.marketValue || 0),
     0,
   );
   const brokerPnl = tabPositions.reduce(
-    (sum, p) => sum + (p.unrealized_pnl || 0),
+    (sum, p) => sum + (p.unrealizedPnl || 0),
     0,
   );
-  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.mark_price : undefined;
+  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.markPrice : undefined;
 
   switch (col.id) {
     case "ticker": {
@@ -234,14 +204,14 @@ function getSortValue(
     : ticker.frontmatter.positions;
   const totalShares = tabPositions.reduce((sum, p) => sum + p.shares * (p.side === "short" ? -1 : 1), 0);
   const totalCost = tabPositions.reduce(
-    (sum, p) => sum + p.shares * p.avg_cost * (p.multiplier || 1),
+    (sum, p) => sum + p.shares * p.avgCost * (p.multiplier || 1),
     0,
   );
 
-  const isOption = ticker.frontmatter.asset_category === "OPT";
-  const brokerMktValue = tabPositions.reduce((sum, p) => sum + (p.market_value || 0), 0);
-  const brokerPnl = tabPositions.reduce((sum, p) => sum + (p.unrealized_pnl || 0), 0);
-  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.mark_price : undefined;
+  const isOption = ticker.frontmatter.assetCategory === "OPT";
+  const brokerMktValue = tabPositions.reduce((sum, p) => sum + (p.marketValue || 0), 0);
+  const brokerPnl = tabPositions.reduce((sum, p) => sum + (p.unrealizedPnl || 0), 0);
+  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.markPrice : undefined;
 
   switch (col.id) {
     case "ticker":
@@ -377,12 +347,12 @@ function PortfolioSummaryBar({
         : ticker.frontmatter.positions;
       const totalShares = tabPositions.reduce((sum, p) => sum + p.shares * (p.side === "short" ? -1 : 1), 0);
       const totalCost = tabPositions.reduce(
-        (sum, p) => sum + p.shares * p.avg_cost * (p.multiplier || 1),
+        (sum, p) => sum + p.shares * p.avgCost * (p.multiplier || 1),
         0,
       );
 
-      const isOption = ticker.frontmatter.asset_category === "OPT";
-      const brokerMktValue = tabPositions.reduce((sum, p) => sum + (p.market_value || 0), 0);
+      const isOption = ticker.frontmatter.assetCategory === "OPT";
+      const brokerMktValue = tabPositions.reduce((sum, p) => sum + (p.marketValue || 0), 0);
 
       if (q && totalShares !== 0) {
         hasPositions = true;

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -135,10 +135,10 @@ function OverviewTab({ width }: { width?: number }) {
         </box>
 
         {/* Sector / classification */}
-        {(ticker.frontmatter.sector || ticker.frontmatter.industry || ticker.frontmatter.asset_category || ticker.frontmatter.isin) && (
+        {(ticker.frontmatter.sector || ticker.frontmatter.industry || ticker.frontmatter.assetCategory || ticker.frontmatter.isin) && (
           <box flexDirection="column">
-            {ticker.frontmatter.asset_category && (
-              <MetricRow label="Type" value={ticker.frontmatter.asset_category} />
+            {ticker.frontmatter.assetCategory && (
+              <MetricRow label="Type" value={ticker.frontmatter.assetCategory} />
             )}
             {ticker.frontmatter.sector && (
               <MetricRow label="Sector" value={ticker.frontmatter.sector} />
@@ -159,9 +159,9 @@ function OverviewTab({ width }: { width?: number }) {
               <text attributes={TextAttributes.BOLD} fg={colors.textBright}>Positions</text>
             </box>
             {ticker.frontmatter.positions.map((pos, i) => {
-              const costBasis = pos.shares * pos.avg_cost * (pos.multiplier || 1);
-              const pnlText = pos.unrealized_pnl != null
-                ? `  P&L: ${pos.unrealized_pnl >= 0 ? "+" : ""}${formatCurrency(pos.unrealized_pnl, pos.currency)}`
+              const costBasis = pos.shares * pos.avgCost * (pos.multiplier || 1);
+              const pnlText = pos.unrealizedPnl != null
+                ? `  P&L: ${pos.unrealizedPnl >= 0 ? "+" : ""}${formatCurrency(pos.unrealizedPnl, pos.currency)}`
                 : "";
               return (
                 <box key={i} flexDirection="column">
@@ -172,18 +172,18 @@ function OverviewTab({ width }: { width?: number }) {
                   </box>
                   <box flexDirection="row" height={1}>
                     <text fg={colors.text}>
-                      {pos.shares} {pos.multiplier && pos.multiplier > 1 ? "contracts" : "shares"} @ {formatCurrency(pos.avg_cost, pos.currency)}
+                      {pos.shares} {pos.multiplier && pos.multiplier > 1 ? "contracts" : "shares"} @ {formatCurrency(pos.avgCost, pos.currency)}
                       {" = "}{formatCurrency(costBasis, pos.currency)}
                     </text>
                     {pnlText && (
-                      <text fg={priceColor(pos.unrealized_pnl!)}>{pnlText}</text>
+                      <text fg={priceColor(pos.unrealizedPnl!)}>{pnlText}</text>
                     )}
                   </box>
-                  {pos.mark_price != null && (
+                  {pos.markPrice != null && (
                     <box flexDirection="row" height={1}>
-                      <text fg={colors.textDim}>Mark: {formatCurrency(pos.mark_price, pos.currency)}</text>
-                      {pos.market_value != null && (
-                        <text fg={colors.textDim}>{" "}Mkt Value: {formatCurrency(pos.market_value, pos.currency)}</text>
+                      <text fg={colors.textDim}>Mark: {formatCurrency(pos.markPrice, pos.currency)}</text>
+                      {pos.marketValue != null && (
+                        <text fg={colors.textDim}>{" "}Mkt Value: {formatCurrency(pos.marketValue, pos.currency)}</text>
                       )}
                     </box>
                   )}

--- a/src/plugins/ibkr/trading-state.test.ts
+++ b/src/plugins/ibkr/trading-state.test.ts
@@ -16,7 +16,7 @@ function createTicker(symbol: string, brokerInstanceId?: string): TickerFile {
       exchange: "NASDAQ",
       currency: "USD",
       name: symbol,
-      asset_category: "STK",
+      assetCategory: "STK",
       portfolios: [],
       watchlists: [],
       positions: [],

--- a/src/plugins/ibkr/trading-state.ts
+++ b/src/plugins/ibkr/trading-state.ts
@@ -69,7 +69,7 @@ function normalizeContract(ticker: TickerFile): BrokerContractRef {
     brokerId: "ibkr",
     symbol: ticker.frontmatter.ticker,
     localSymbol: ticker.frontmatter.ticker,
-    secType: ticker.frontmatter.asset_category || "STK",
+    secType: ticker.frontmatter.assetCategory || "STK",
     exchange: ticker.frontmatter.exchange || "SMART",
     primaryExchange: ticker.frontmatter.exchange || undefined,
     currency: ticker.frontmatter.currency || "USD",

--- a/src/types/ticker.ts
+++ b/src/types/ticker.ts
@@ -3,20 +3,20 @@ import type { BrokerContractRef } from "./instrument";
 export interface TickerPosition {
   portfolio: string;
   shares: number;
-  avg_cost: number;
+  avgCost: number;
   currency?: string;
-  date_acquired?: string;
+  dateAcquired?: string;
   broker: string; // "manual" | future broker plugin IDs
   side?: "long" | "short";
-  market_value?: number;
-  unrealized_pnl?: number;
+  marketValue?: number;
+  unrealizedPnl?: number;
   /** Contract multiplier (e.g. 100 for options) */
   multiplier?: number;
   /** Last known mark price from broker snapshot */
-  mark_price?: number;
-  broker_instance_id?: string;
-  broker_account_id?: string;
-  broker_contract_id?: number;
+  markPrice?: number;
+  brokerInstanceId?: string;
+  brokerAccountId?: string;
+  brokerContractId?: number;
 }
 
 export interface TickerFrontmatter {
@@ -26,7 +26,7 @@ export interface TickerFrontmatter {
   name: string;
   sector?: string;
   industry?: string;
-  asset_category?: string; // STK, ETF, OPT, FUT, BOND, etc.
+  assetCategory?: string; // STK, ETF, OPT, FUT, BOND, etc.
   isin?: string;
   cusip?: string;
   portfolios: string[];

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -86,3 +86,33 @@ export function padTo(str: string, width: number, align: "left" | "right" = "lef
   if (align === "right") return str.padStart(width);
   return str.padEnd(width);
 }
+
+/** Convert a value from one currency to base currency using cached exchange rates */
+export function convertCurrency(
+  value: number,
+  fromCurrency: string,
+  baseCurrency: string,
+  exchangeRates: Map<string, number>,
+): number {
+  if (fromCurrency === baseCurrency) return value;
+  const fromRate = exchangeRates.get(fromCurrency);
+  const baseRate = exchangeRates.get(baseCurrency);
+  if (fromRate == null || baseRate == null || baseRate === 0) return value;
+  return (value * fromRate) / baseRate;
+}
+
+/** Format a date/timestamp as relative time (e.g., "5m ago", "2h ago") */
+export function formatTimeAgo(date: Date | string): string {
+  const ts = typeof date === "string"
+    ? new Date(date.endsWith("Z") ? date : date + "Z").getTime()
+    : date.getTime();
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString("en-US", { month: "numeric", day: "numeric", year: "2-digit" });
+}

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,5 +1,5 @@
 import matter from "gray-matter";
-import type { TickerFile, TickerFrontmatter } from "../types/ticker";
+import type { TickerFile, TickerFrontmatter, TickerPosition } from "../types/ticker";
 
 const DEFAULT_FRONTMATTER: Omit<TickerFrontmatter, "ticker" | "exchange" | "currency" | "name"> = {
   portfolios: [],
@@ -10,23 +10,65 @@ const DEFAULT_FRONTMATTER: Omit<TickerFrontmatter, "ticker" | "exchange" | "curr
   tags: [],
 };
 
-export function hydrateTickerFrontmatter(data: Partial<TickerFrontmatter>): TickerFrontmatter {
+/** Migrate a position from legacy snake_case YAML to camelCase */
+function hydratePosition(raw: Record<string, unknown>): TickerPosition {
+  return {
+    portfolio: (raw.portfolio as string) ?? "",
+    shares: (raw.shares as number) ?? 0,
+    avgCost: (raw.avgCost ?? raw.avg_cost) as number ?? 0,
+    currency: (raw.currency as string) ?? undefined,
+    dateAcquired: (raw.dateAcquired ?? raw.date_acquired) as string | undefined,
+    broker: (raw.broker as string) ?? "manual",
+    side: (raw.side as "long" | "short") ?? undefined,
+    marketValue: (raw.marketValue ?? raw.market_value) as number | undefined,
+    unrealizedPnl: (raw.unrealizedPnl ?? raw.unrealized_pnl) as number | undefined,
+    multiplier: (raw.multiplier as number) ?? undefined,
+    markPrice: (raw.markPrice ?? raw.mark_price) as number | undefined,
+    brokerInstanceId: (raw.brokerInstanceId ?? raw.broker_instance_id) as string | undefined,
+    brokerAccountId: (raw.brokerAccountId ?? raw.broker_account_id) as string | undefined,
+    brokerContractId: (raw.brokerContractId ?? raw.broker_contract_id) as number | undefined,
+  };
+}
+
+/** Convert a position to snake_case for YAML serialization (backward compat) */
+function serializePosition(pos: TickerPosition): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    portfolio: pos.portfolio,
+    shares: pos.shares,
+    avg_cost: pos.avgCost,
+    broker: pos.broker,
+  };
+  if (pos.currency != null) out.currency = pos.currency;
+  if (pos.dateAcquired != null) out.date_acquired = pos.dateAcquired;
+  if (pos.side != null) out.side = pos.side;
+  if (pos.marketValue != null) out.market_value = pos.marketValue;
+  if (pos.unrealizedPnl != null) out.unrealized_pnl = pos.unrealizedPnl;
+  if (pos.multiplier != null) out.multiplier = pos.multiplier;
+  if (pos.markPrice != null) out.mark_price = pos.markPrice;
+  if (pos.brokerInstanceId != null) out.broker_instance_id = pos.brokerInstanceId;
+  if (pos.brokerAccountId != null) out.broker_account_id = pos.brokerAccountId;
+  if (pos.brokerContractId != null) out.broker_contract_id = pos.brokerContractId;
+  return out;
+}
+
+export function hydrateTickerFrontmatter(data: Record<string, unknown>): TickerFrontmatter {
+  const rawPositions = Array.isArray(data.positions) ? data.positions : [];
   return {
     ...DEFAULT_FRONTMATTER,
-    ticker: data.ticker ?? "",
-    exchange: data.exchange ?? "",
-    currency: data.currency ?? "USD",
-    name: data.name ?? "",
-    sector: data.sector,
-    industry: data.industry,
-    asset_category: data.asset_category,
-    isin: data.isin,
-    cusip: data.cusip,
+    ticker: (data.ticker as string) ?? "",
+    exchange: (data.exchange as string) ?? "",
+    currency: (data.currency as string) ?? "USD",
+    name: (data.name as string) ?? "",
+    sector: data.sector as string | undefined,
+    industry: data.industry as string | undefined,
+    assetCategory: (data.assetCategory ?? data.asset_category) as string | undefined,
+    isin: data.isin as string | undefined,
+    cusip: data.cusip as string | undefined,
     portfolios: Array.isArray(data.portfolios) ? [...data.portfolios] : [],
     watchlists: Array.isArray(data.watchlists) ? [...data.watchlists] : [],
-    positions: Array.isArray(data.positions) ? [...data.positions] : [],
+    positions: rawPositions.map((p: Record<string, unknown>) => hydratePosition(p)),
     broker_contracts: Array.isArray(data.broker_contracts) ? [...data.broker_contracts] : [],
-    custom: data.custom && typeof data.custom === "object" ? { ...data.custom } : {},
+    custom: data.custom && typeof data.custom === "object" ? { ...(data.custom as Record<string, unknown>) } : {},
     tags: Array.isArray(data.tags) ? [...data.tags] : [],
   };
 }
@@ -34,17 +76,31 @@ export function hydrateTickerFrontmatter(data: Partial<TickerFrontmatter>): Tick
 export function parseTicker(filePath: string, content: string): TickerFile {
   const parsed = matter(content);
   return {
-    frontmatter: hydrateTickerFrontmatter(parsed.data as Partial<TickerFrontmatter>),
+    frontmatter: hydrateTickerFrontmatter(parsed.data as Record<string, unknown>),
     notes: parsed.content.trim(),
     filePath,
   };
 }
 
 export function serializeTicker(ticker: TickerFile): string {
-  const frontmatter = { ...ticker.frontmatter };
-  if (frontmatter.positions.length === 0) delete (frontmatter as Partial<TickerFrontmatter>).positions;
-  if ((frontmatter.broker_contracts ?? []).length === 0) delete (frontmatter as Partial<TickerFrontmatter>).broker_contracts;
-  if (frontmatter.tags.length === 0) delete (frontmatter as Partial<TickerFrontmatter>).tags;
-  if (Object.keys(frontmatter.custom).length === 0) delete (frontmatter as Partial<TickerFrontmatter>).custom;
-  return matter.stringify(ticker.notes ? `\n${ticker.notes}\n` : "\n", frontmatter);
+  const fm = ticker.frontmatter;
+  // Write snake_case keys for YAML backward compat
+  const out: Record<string, unknown> = {
+    ticker: fm.ticker,
+    exchange: fm.exchange,
+    currency: fm.currency,
+    name: fm.name,
+  };
+  if (fm.sector != null) out.sector = fm.sector;
+  if (fm.industry != null) out.industry = fm.industry;
+  if (fm.assetCategory != null) out.asset_category = fm.assetCategory;
+  if (fm.isin != null) out.isin = fm.isin;
+  if (fm.cusip != null) out.cusip = fm.cusip;
+  if (fm.portfolios.length > 0) out.portfolios = fm.portfolios;
+  if (fm.watchlists.length > 0) out.watchlists = fm.watchlists;
+  if (fm.positions.length > 0) out.positions = fm.positions.map(serializePosition);
+  if ((fm.broker_contracts ?? []).length > 0) out.broker_contracts = fm.broker_contracts;
+  if (fm.tags.length > 0) out.tags = fm.tags;
+  if (Object.keys(fm.custom).length > 0) out.custom = fm.custom;
+  return matter.stringify(ticker.notes ? `\n${ticker.notes}\n` : "\n", out);
 }

--- a/src/utils/market-status.ts
+++ b/src/utils/market-status.ts
@@ -1,5 +1,6 @@
-import type { MarketState } from "../types/financials";
-import { colors } from "../theme/colors";
+import type { MarketState, Quote } from "../types/financials";
+import { colors, priceColor } from "../theme/colors";
+import { formatPercentRaw } from "./format";
 
 export function marketStateLabel(state: MarketState): string {
   switch (state) {
@@ -48,4 +49,18 @@ export function exchangeShortName(exchangeName?: string, fullExchangeName?: stri
     JPX: "TYO",
   };
   return map[name] || name;
+}
+
+/** Get extended hours price info (pre-market or after-hours) for display */
+export function getExtendedHoursInfo(quote: Quote | null | undefined): { text: string; color: string } | null {
+  if (!quote) return null;
+  if (quote.marketState === "PRE" && quote.preMarketPrice != null) {
+    const chg = quote.preMarketChangePercent ?? 0;
+    return { text: `Pre ${quote.preMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
+  }
+  if (quote.marketState === "POST" && quote.postMarketPrice != null) {
+    const chg = quote.postMarketChangePercent ?? 0;
+    return { text: `AH ${quote.postMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
+  }
+  return null;
 }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,0 +1,39 @@
+export const MONTH_ABBREV = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** Format a unix timestamp (seconds) as "Mon DD 'YY" */
+export function formatExpDate(ts: number): string {
+  const d = new Date(ts * 1000);
+  const month = MONTH_ABBREV[d.getMonth()] || String(d.getMonth() + 1);
+  const yy = String(d.getFullYear()).slice(2);
+  return `${month} ${d.getDate()} '${yy}`;
+}
+
+/**
+ * Parse IBKR option symbol like "UBER 260821C00090000" into components.
+ * Returns null if not a recognized option symbol.
+ */
+export function parseOptionSymbol(symbol: string): { underlying: string; expTs: number; strike: number; side: "C" | "P" } | null {
+  const m = symbol.match(/^(\S+)\s+(\d{2})(\d{2})(\d{2})([CP])(\d{8})$/);
+  if (!m) return null;
+  const [, underlying, yy, mm, dd, side, rawStrike] = m;
+  const strike = parseInt(rawStrike!, 10) / 1000;
+  const year = 2000 + parseInt(yy!, 10);
+  const month = parseInt(mm!, 10) - 1;
+  const day = parseInt(dd!, 10);
+  const expTs = Math.floor(new Date(year, month, day).getTime() / 1000);
+  return { underlying: underlying!, expTs, strike, side: side as "C" | "P" };
+}
+
+/**
+ * Format IBKR option symbol like "UBER 260821C00090000" into readable form.
+ * e.g. "UBER C $90 Aug'26"
+ */
+export function formatOptionTicker(symbol: string): string {
+  const m = symbol.match(/^(\S+)\s+(\d{2})(\d{2})(\d{2})([CP])(\d{8})$/);
+  if (!m) return symbol;
+  const [, underlying, yy, mm, , side, rawStrike] = m;
+  const strike = parseInt(rawStrike!, 10) / 1000;
+  const month = MONTH_ABBREV[parseInt(mm!, 10) - 1] || mm;
+  const strikeStr = strike % 1 === 0 ? String(strike) : strike.toFixed(1);
+  return `${underlying} ${side === "C" ? "C" : "P"} $${strikeStr} ${month}'${yy}`;
+}


### PR DESCRIPTION
## Summary
- Consolidate duplicated utilities into shared modules: `formatTimeAgo` (news/chat), option symbol parsing + `MONTH_ABBREV` (options/portfolio-list), extended hours display (header/status-bar), and `convertCurrency` (portfolio-list)
- Migrate `TickerPosition` and `TickerFrontmatter` fields from snake_case to camelCase across the codebase, with backward-compatible YAML serialization so existing ticker files load without migration
- Add error state/display to the news plugin (previously silently swallowed fetch errors)
- New shared modules: `src/utils/options.ts` for option symbol utilities, additions to `format.ts` and `market-status.ts`

## Test plan
- [x] `bun test` passes (15/15, 5 pre-existing env failures unchanged)
- [ ] Verify portfolio list, ticker detail tabs, chat, news, header, and status bar render correctly
- [ ] Check extended hours info displays in header + status bar during pre/post market
- [ ] Confirm existing ticker YAML files load correctly with the new hydration layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)