### PR TITLE
Refresh pane design: borders → background colors

### DIFF
--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { colors } from "../../theme/colors";
+import { colors, floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../../theme/colors";
 
 interface FloatingPaneWrapperProps {
   title: string;
@@ -16,8 +16,8 @@ interface FloatingPaneWrapperProps {
 export function FloatingPaneWrapper({
   title, x, y, width, height, zIndex, focused, children,
 }: FloatingPaneWrapperProps) {
-  const borderColor = focused ? colors.borderFocused : colors.border;
-  const innerWidth = width - 2; // subtract borders
+  const bg = floatingPaneBg(focused);
+  const titleBgColor = floatingPaneTitleBg(focused);
 
   return (
     <box
@@ -27,15 +27,13 @@ export function FloatingPaneWrapper({
       width={width}
       height={height}
       zIndex={zIndex}
-      backgroundColor={colors.bg}
-      borderStyle="single"
-      borderColor={borderColor}
+      backgroundColor={bg}
       flexDirection="column"
     >
-      {/* Title bar — non-selectable to prevent text highlighting during drag */}
-      <box height={1} width={innerWidth} flexDirection="row">
-        <text fg={focused ? colors.text : colors.textDim} selectable={false}>
-          {buildTitleBar(title, innerWidth)}
+      {/* Title bar */}
+      <box height={1} width={width} backgroundColor={titleBgColor} flexDirection="row">
+        <text fg={paneTitleText(focused)} selectable={false}>
+          {buildTitleBar(title, width)}
         </text>
       </box>
 
@@ -45,17 +43,18 @@ export function FloatingPaneWrapper({
       </box>
 
       {/* Resize handle at bottom-right corner */}
-      <box position="absolute" bottom={0} right={0} width={1} height={1}>
-        <text fg={colors.textDim} selectable={false}>+</text>
+      <box position="absolute" bottom={0} right={0} width={2} height={1}>
+        <text fg={colors.textDim} selectable={false}> ◢</text>
       </box>
     </box>
   );
 }
 
 function buildTitleBar(title: string, availableWidth: number): string {
-  const closeBtn = " [x]";
-  const space = availableWidth - closeBtn.length - 1; // -1 for leading space
+  const closeBtn = " × ";
+  const rightPad = " ";
+  const space = availableWidth - closeBtn.length - rightPad.length - 1; // -1 for leading space
   const truncatedTitle = title.length > space ? title.slice(0, space - 1) + ".." : title;
-  const padding = "-".repeat(Math.max(0, space - truncatedTitle.length));
-  return ` ${truncatedTitle}${padding}${closeBtn}`;
+  const padding = " ".repeat(Math.max(0, space - truncatedTitle.length));
+  return ` ${truncatedTitle}${padding}${closeBtn}${rightPad}`;
 }

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { colors } from "../../theme/colors";
+import { colors, paneBg, paneTitleBg, paneTitleText } from "../../theme/colors";
 
 interface PaneWrapperProps {
   title?: string;
@@ -12,21 +12,27 @@ interface PaneWrapperProps {
 }
 
 export function PaneWrapper({ title, focused, width, height, flexGrow, onMouseDown, children }: PaneWrapperProps) {
+  const bg = paneBg(focused);
+  const titleBgColor = paneTitleBg(focused);
+
   return (
     <box
       flexDirection="column"
       width={width}
       height={height}
       flexGrow={flexGrow}
-      borderStyle="single"
-      borderColor={focused ? colors.borderFocused : colors.border}
-      title={title}
-      titleAlignment="left"
-      backgroundColor={colors.bg}
+      backgroundColor={bg}
       overflow="hidden"
       onMouseDown={onMouseDown}
     >
-      {children}
+      {title && (
+        <box height={1} backgroundColor={titleBgColor}>
+          <text fg={paneTitleText(focused)}>{title}</text>
+        </box>
+      )}
+      <box flexGrow={1} overflow="hidden">
+        {children}
+      </box>
     </box>
   );
 }

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -113,6 +113,13 @@ export function Shell({ pluginRegistry }: ShellProps) {
       if (widths[index] === 0) widths[index] = perUnspecified;
       widths[index] = Math.max(MIN_PANE_WIDTH, widths[index] ?? MIN_PANE_WIDTH);
     }
+
+    // Distribute any leftover pixels (from rounding) to the last column
+    const totalUsed = widths.reduce((sum, w) => sum + w, 0);
+    if (widths.length > 0 && totalUsed < availableWidth) {
+      widths[widths.length - 1] += availableWidth - totalUsed;
+    }
+
     return widths;
   }, [availableWidth, columnIndices.join(","), layout.columns]);
 
@@ -159,7 +166,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
           dispatch({ type: "FOCUS_PANE", paneId: rect.id });
           dispatch({ type: "UPDATE_LAYOUT", layout: bringToFront(layout, rect.id) });
 
-          if (relativeX >= rect.w - 4 && relativeY >= rect.h - 2) {
+          if (relativeX >= rect.w - 3 && relativeY >= rect.h - 2) {
             dragRef.current = {
               type: "float-resize",
               paneId: rect.id,
@@ -175,8 +182,8 @@ export function Shell({ pluginRegistry }: ShellProps) {
             return;
           }
 
-          if (relativeY <= 1) {
-            if (relativeX >= rect.w - 5) {
+          if (relativeY === 0) {
+            if (relativeX >= rect.w - 5 && relativeX < rect.w - 1) {
               persistLayout(removePane(layout, rect.id));
               event.stopPropagation();
               event.preventDefault();
@@ -322,7 +329,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
         const columnWidth = effectiveColumnWidths[localIndex]!;
 
         return (
-          <box key={`column-${columnIndex}`} flexDirection="row">
+          <box key={`column-${columnIndex}`} flexDirection="row" height={contentHeight}>
             <box flexDirection="column" width={columnWidth}>
               {panes.map((pane) => {
                 const focused = state.focusedPaneId === pane.instance.instanceId && !overlayOpen;
@@ -341,8 +348,8 @@ export function Shell({ pluginRegistry }: ShellProps) {
                         paneId={pane.instance.instanceId}
                         paneType={pane.instance.paneId}
                         focused={focused}
-                        width={columnWidth - 2}
-                        height={paneHeight - 2}
+                        width={columnWidth}
+                        height={paneHeight - 1}
                       />
                     </PaneInstanceProvider>
                   </PaneWrapper>
@@ -354,9 +361,9 @@ export function Shell({ pluginRegistry }: ShellProps) {
               <box
                 width={1}
                 height={contentHeight}
-                backgroundColor={dragColumnIndex === columnIndex ? colors.borderFocused : undefined}
+                backgroundColor={dragColumnIndex === columnIndex ? colors.borderFocused : colors.border}
               >
-                <text fg={dragColumnIndex === columnIndex ? colors.bg : colors.border}>│</text>
+                <text fg={dragColumnIndex === columnIndex ? colors.bg : colors.border}> </text>
               </box>
             )}
           </box>
@@ -389,8 +396,8 @@ export function Shell({ pluginRegistry }: ShellProps) {
                 paneId={pane.instance.instanceId}
                 paneType={pane.instance.paneId}
                 focused={focused}
-                width={entry.width - 2}
-                height={entry.height - 4}
+                width={entry.width}
+                height={entry.height - 1}
                 close={() => handleFloatingClose(pane.instance.instanceId)}
               />
             </PaneInstanceProvider>

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -531,6 +531,7 @@ function TickerDetailPane({ focused, width, height }: PaneProps) {
 
   useKeyboard(handleKeyboard);
 
+
   if (!ticker) {
     const isEmptyFollowCollection = paneInstance?.binding?.kind === "follow" && !!collectionId && collectionTickers.length === 0;
     const message = isEmptyFollowCollection
@@ -538,7 +539,7 @@ function TickerDetailPane({ focused, width, height }: PaneProps) {
       : "No ticker selected.";
 
     return (
-      <box flexDirection="column" flexGrow={1} paddingX={1} paddingTop={1}>
+      <box flexDirection="column" flexGrow={1} paddingX={1}>
         <text fg={colors.textDim}>{message}</text>
       </box>
     );

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -114,6 +114,36 @@ export function commandBarSelectedText(): string {
   return blendForContrast(preferred, base, fallback, 4.5);
 }
 
+/** Background for docked pane bodies */
+export function paneBg(focused: boolean): string {
+  if (focused) return colors.bg;
+  return colors.panel;
+}
+
+/** Background for floating pane bodies — elevated above docked panes */
+export function floatingPaneBg(focused: boolean): string {
+  if (focused) return blendHex(colors.bg, colors.border, 0.12);
+  return blendHex(colors.panel, colors.border, 0.35);
+}
+
+/** Background for pane title bars */
+export function paneTitleBg(focused: boolean): string {
+  if (focused) return blendHex(colors.bg, colors.borderFocused, 0.15);
+  return blendHex(colors.panel, colors.border, 0.25);
+}
+
+/** Background for floating pane title bars */
+export function floatingPaneTitleBg(focused: boolean): string {
+  if (focused) return blendHex(colors.bg, colors.borderFocused, 0.18);
+  return blendHex(colors.panel, colors.border, 0.4);
+}
+
+/** Title text color for panes */
+export function paneTitleText(focused: boolean): string {
+  if (focused) return colors.textBright;
+  return colors.textDim;
+}
+
 /** Returns green for positive, red for negative, neutral for zero */
 export function priceColor(value: number): string {
   if (value > 0) return colors.positive;


### PR DESCRIPTION
## Summary
- Replace border-based pane styling with background color differentiation for both docked and floating panes
- Add themed color functions (`paneBg`, `paneTitleBg`, `floatingPaneBg`, etc.) that adapt to any theme
- Improve floating pane UI: cleaner close button (`×` with padding), more visible resize handle (`◢`), better hit areas
- Fix tab alignment bug in ticker-detail caused by `paddingTop` in the no-ticker early return
- Fix column width rounding and explicit height on column wrappers to prevent layout inconsistencies

## Test plan
- [ ] Verify focused vs unfocused docked panes are visually distinct
- [ ] Verify floating panes are distinguishable over both focused and unfocused docked panes
- [ ] Test close button and resize handle on floating panes
- [ ] Check tab alignment between left and right docked panes
- [ ] Test with different themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)