### PR TITLE
Allow multiple panes of the same ticker with independent state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -789,12 +789,7 @@ function AppInner({ pluginRegistry, markdownStore, dataProvider }: AppInnerProps
     const paneType = options?.paneType ?? "ticker-detail";
     const paneDef = pluginRegistry.panes.get(paneType);
     if (!paneDef) return;
-    const existingInstance = state.config.layout.instances.find((instance) =>
-      instance.paneId === paneType
-      && instance.binding?.kind === "fixed"
-      && instance.binding.symbol === symbol,
-    );
-    const instance = existingInstance ?? buildPaneInstance(paneType, {
+    const instance = buildPaneInstance(paneType, {
       title: symbol,
       binding: { kind: "fixed", symbol },
     });

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -370,17 +370,6 @@ export function CommandBar({ dataProvider, markdownStore, pluginRegistry, quitAp
     const targetPane = findPaneInstance(currentState.config.layout, paneId);
     if (!targetPane || targetPane.paneId !== "ticker-detail") return;
 
-    const existingInstance = currentState.config.layout.instances.find((instance) =>
-      instance.instanceId !== targetPane.instanceId
-      && instance.paneId === "ticker-detail"
-      && instance.binding?.kind === "fixed"
-      && instance.binding.symbol === symbol,
-    );
-    if (existingInstance) {
-      pluginRegistry.focusPaneFn(existingInstance.instanceId);
-      return;
-    }
-
     const nextLayout = {
       ...currentState.config.layout,
       instances: currentState.config.layout.instances.map((instance) => (


### PR DESCRIPTION
## Summary
- Removes deduplication logic that prevented opening the same ticker symbol in multiple panes
- `pinTickerFn` now always creates a new pane instance instead of reusing an existing one for the same symbol
- `retargetDetailPane` no longer redirects to an existing pane with the same symbol, allowing each pane to maintain independent state (active tab, scroll position, etc.)

## Test plan
- [x] Open a ticker (e.g. AAPL) via Ctrl+P
- [x] Open the same ticker again — verify a second pane is created
- [x] Confirm each pane has independent tab/view state