### PR TITLE
Remove refreshing indicator and hide chat widget when disabled

### DIFF
--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -9,8 +9,6 @@ export function StatusBar() {
   const { state, dispatch } = useAppState();
   const { symbol, financials: focusedFinancials } = useFocusedTicker();
   const [hoveredTab, setHoveredTab] = useState<number | null>(null);
-  const refreshCount = state.refreshing.size;
-
   if (!state.statusBarVisible) return null;
 
   // Get market state and exchange from the focused ticker context or first available.
@@ -77,13 +75,6 @@ export function StatusBar() {
       )}
       {/* Plugin status widgets */}
       {registry && <registry.Slot name="status:widget" />}
-      {refreshCount > 0 && (
-        <box paddingRight={1}>
-          <text fg={colors.textDim}>
-            refreshing {refreshCount}...
-          </text>
-        </box>
-      )}
     </box>
   );
 }

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -313,6 +313,7 @@ function ChatPane({ focused, width, height, close }: PaneProps) {
 }
 
 function ChatStatusWidget() {
+  const { state } = useAppState();
   const [username, setUsername] = useState<string | null>(chatController.getSnapshot().user?.username ?? null);
 
   useEffect(() => {
@@ -322,6 +323,8 @@ function ChatStatusWidget() {
     void chatController.refreshSession().catch(() => {});
     return unsubscribe;
   }, []);
+
+  if (state.config.disabledPlugins.includes("chat")) return null;
 
   return (
     <box flexDirection="row" paddingRight={1}>


### PR DESCRIPTION
## Summary
- Removes the "refreshing N..." indicator from the status bar, which would persist indefinitely when offline
- Hides the chat status widget (Shift+C shortcut hint) when the chat plugin is disabled

## Test plan
- [ ] Disable the chat plugin and verify the status bar no longer shows "Shift+C chat"
- [ ] Verify the "refreshing" message no longer appears in the status bar