### PR TITLE
Seed default watchlist with popular tickers on first run

### DIFF
--- a/src/state/app-bootstrap.ts
+++ b/src/state/app-bootstrap.ts
@@ -2,10 +2,25 @@ import type { Dispatch } from "react";
 import type { TickerRepository } from "../data/ticker-repository";
 import { findPaneInstance, type AppConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
-import type { TickerRecord } from "../types/ticker";
+import type { TickerMetadata, TickerRecord } from "../types/ticker";
 import { ProviderRouter } from "../sources/provider-router";
 import type { AppAction, PaneRuntimeState } from "./app-context";
 import type { AppSessionSnapshot } from "./session-persistence";
+
+const DEFAULT_WATCHLIST_TICKERS: Array<Pick<TickerMetadata, "ticker" | "exchange" | "currency" | "name">> = [
+  { ticker: "AAPL", exchange: "NASDAQ", currency: "USD", name: "Apple Inc." },
+  { ticker: "MSFT", exchange: "NASDAQ", currency: "USD", name: "Microsoft Corporation" },
+  { ticker: "GOOGL", exchange: "NASDAQ", currency: "USD", name: "Alphabet Inc." },
+  { ticker: "AMZN", exchange: "NASDAQ", currency: "USD", name: "Amazon.com Inc." },
+  { ticker: "NVDA", exchange: "NASDAQ", currency: "USD", name: "NVIDIA Corporation" },
+  { ticker: "TSLA", exchange: "NASDAQ", currency: "USD", name: "Tesla Inc." },
+  { ticker: "META", exchange: "NASDAQ", currency: "USD", name: "Meta Platforms Inc." },
+  { ticker: "BRK.B", exchange: "NYSE", currency: "USD", name: "Berkshire Hathaway Inc." },
+  { ticker: "JPM", exchange: "NYSE", currency: "USD", name: "JPMorgan Chase & Co." },
+  { ticker: "V", exchange: "NYSE", currency: "USD", name: "Visa Inc." },
+  { ticker: "BTC-USD", exchange: "CCC", currency: "USD", name: "Bitcoin USD" },
+  { ticker: "ETH-USD", exchange: "CCC", currency: "USD", name: "Ethereum USD" },
+];
 
 interface StartupPaneStateSeed {
   cursorSymbol?: string | null;
@@ -139,7 +154,25 @@ export async function initializeAppState({
   refreshTicker,
   autoImportBrokerPositions,
 }: InitializeAppStateArgs): Promise<void> {
-  const tickers = await tickerRepository.loadAllTickers();
+  let tickers = await tickerRepository.loadAllTickers();
+
+  // Seed default watchlist tickers on first run
+  if (tickers.length === 0) {
+    const defaultWatchlistId = config.watchlists[0]?.id ?? "watchlist";
+    for (const entry of DEFAULT_WATCHLIST_TICKERS) {
+      await tickerRepository.createTicker({
+        ...entry,
+        portfolios: [],
+        watchlists: [defaultWatchlistId],
+        positions: [],
+        broker_contracts: [],
+        custom: {},
+        tags: [],
+      });
+    }
+    tickers = await tickerRepository.loadAllTickers();
+  }
+
   const tickerMap = new Map<string, TickerRecord>();
   for (const ticker of tickers) {
     tickerMap.set(ticker.metadata.ticker, ticker);


### PR DESCRIPTION
When a new user opens the app for the first time and has no tickers, the default watchlist is automatically populated with 12 well-known stocks and crypto (AAPL, MSFT, GOOGL, AMZN, NVDA, TSLA, META, BRK.B, JPM, V, BTC-USD, ETH-USD). This ensures new users see data immediately instead of an empty screen. The seeding only triggers when `tickers.length === 0`, so existing users are unaffected.