### PR TITLE
Refine broker onboarding and detail tab visibility

### DIFF
--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -400,16 +400,7 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
 
     const adapter = [...pluginRegistry.brokers.values()].find((broker) => broker.id === choiceId);
     if (!adapter) return null;
-    const profileLabel = await dialog.prompt<string>({
-      content: (ctx) => <InputStepContent {...ctx} step={{
-        key: "profileLabel",
-        type: "text",
-        label: "Broker Profile Label",
-        body: ["Label this broker connection, for example Work, Personal, or Paper."],
-        placeholder: "Work",
-      }} />,
-    });
-    if (!profileLabel?.trim()) return null;
+    const profileLabel = adapter.name;
 
     const values: Record<string, string> = {};
     const prompted = new Set<string>();

--- a/src/plugins/builtin/options-availability.test.tsx
+++ b/src/plugins/builtin/options-availability.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import type { DataProvider } from "../../types/data-provider";
+import type { OptionsChain } from "../../types/financials";
+import type { TickerRecord } from "../../types/ticker";
+import { setSharedDataProviderForTests } from "../registry";
+import {
+  fetchOptionsAvailability,
+  readOptionsAvailability,
+  resetOptionsAvailabilityCache,
+  useOptionsAvailability,
+} from "./options-availability";
+import { resolveOptionsTarget } from "../../utils/options";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let setHarnessTicker: ((ticker: TickerRecord | null) => void) | null = null;
+
+function makeTicker(symbol: string, assetCategory = "STK"): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: symbol,
+      assetCategory,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function createProvider(
+  getOptionsChain: NonNullable<DataProvider["getOptionsChain"]>,
+): DataProvider {
+  return {
+    id: "test-provider",
+    name: "Test Provider",
+    getTickerFinancials: async () => { throw new Error("unused"); },
+    getQuote: async () => { throw new Error("unused"); },
+    getExchangeRate: async () => 1,
+    search: async () => [],
+    getNews: async () => [],
+    getArticleSummary: async () => null,
+    getPriceHistory: async () => [],
+    getOptionsChain,
+  };
+}
+
+function createChain(underlyingSymbol: string, expirationDates: number[]): OptionsChain {
+  return {
+    underlyingSymbol,
+    expirationDates,
+    calls: [],
+    puts: [],
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function AvailabilityHarness({ initialTicker }: { initialTicker: TickerRecord | null }) {
+  const [ticker, setTicker] = useState(initialTicker);
+  setHarnessTicker = setTicker;
+  const available = useOptionsAvailability(ticker);
+  return <text>{`${ticker?.metadata.ticker ?? "none"}:${available}`}</text>;
+}
+
+async function renderFrame() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+}
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+  setHarnessTicker = null;
+  resetOptionsAvailabilityCache();
+  setSharedDataProviderForTests(undefined);
+});
+
+describe("options availability", () => {
+  test("marks a stock with expirations as available", async () => {
+    const target = resolveOptionsTarget(makeTicker("AAPL"));
+    const provider = createProvider(async () => createChain("AAPL", [1_717_113_600]));
+
+    expect(target).not.toBeNull();
+    expect(await fetchOptionsAvailability(target!, provider)).toBe(true);
+    expect(readOptionsAvailability(target!)).toBe(true);
+  });
+
+  test("marks an empty chain as unavailable", async () => {
+    const target = resolveOptionsTarget(makeTicker("AAPL"));
+    const provider = createProvider(async () => createChain("AAPL", []));
+
+    expect(target).not.toBeNull();
+    expect(await fetchOptionsAvailability(target!, provider)).toBe(false);
+    expect(readOptionsAvailability(target!)).toBe(false);
+  });
+
+  test("resolves option positions to the underlying before checking", async () => {
+    const ticker = makeTicker("SPY  260619C00500000", "OPT");
+    const calls: Array<{ symbol: string; exchange: string }> = [];
+    const provider = createProvider(async (symbol, exchange = "") => {
+      calls.push({ symbol, exchange });
+      return createChain(symbol, [1_717_113_600]);
+    });
+    const target = resolveOptionsTarget(ticker);
+
+    expect(target).not.toBeNull();
+    await fetchOptionsAvailability(target!, provider);
+
+    expect(calls).toEqual([{ symbol: "SPY", exchange: "" }]);
+  });
+
+  test("ignores stale async results when the selected ticker changes", async () => {
+    const aapl = createDeferred<OptionsChain>();
+    const tsla = createDeferred<OptionsChain>();
+    setSharedDataProviderForTests(createProvider(async (symbol) => (
+      symbol === "AAPL" ? aapl.promise : tsla.promise
+    )));
+
+    testSetup = await testRender(<AvailabilityHarness initialTicker={makeTicker("AAPL")} />, {
+      width: 40,
+      height: 4,
+    });
+
+    await renderFrame();
+
+    await act(async () => {
+      setHarnessTicker!(makeTicker("TSLA"));
+      await Promise.resolve();
+    });
+    await renderFrame();
+
+    await act(async () => {
+      tsla.resolve(createChain("TSLA", []));
+      await Promise.resolve();
+    });
+    await renderFrame();
+
+    await act(async () => {
+      aapl.resolve(createChain("AAPL", [1_717_113_600]));
+      await Promise.resolve();
+    });
+    await renderFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("TSLA:false");
+    expect(frame).not.toContain("TSLA:true");
+  });
+
+  test("suppresses duplicate preflight calls while the cache is fresh", async () => {
+    const target = resolveOptionsTarget(makeTicker("AAPL"));
+    let calls = 0;
+    const provider = createProvider(async () => {
+      calls += 1;
+      return createChain("AAPL", [1_717_113_600]);
+    });
+
+    expect(target).not.toBeNull();
+    expect(await fetchOptionsAvailability(target!, provider)).toBe(true);
+    expect(await fetchOptionsAvailability(target!, provider)).toBe(true);
+    expect(calls).toBe(1);
+  });
+});

--- a/src/plugins/builtin/options-availability.ts
+++ b/src/plugins/builtin/options-availability.ts
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getSharedDataProvider } from "../../plugins/registry";
+import type { DataProvider } from "../../types/data-provider";
+import type { TickerRecord } from "../../types/ticker";
+import type { ResolvedOptionsTarget } from "../../utils/options";
+import { resolveOptionsTarget } from "../../utils/options";
+
+export const OPTIONS_AVAILABILITY_TTL_MS = 5 * 60_000;
+
+const EXPECTED_OPTIONS_MISS = /no data found|symbol may be delisted|not found|no options|no provider available/i;
+
+type OptionsAvailabilityRecord = {
+  available: boolean;
+  checkedAt: number;
+};
+
+const optionsAvailabilityCache = new Map<string, OptionsAvailabilityRecord>();
+const optionsAvailabilityInFlight = new Map<string, Promise<boolean>>();
+
+function getRequestContext(target: ResolvedOptionsTarget) {
+  return {
+    brokerId: target.instrument?.brokerId,
+    brokerInstanceId: target.instrument?.brokerInstanceId,
+    instrument: target.instrument,
+  };
+}
+
+function isCacheFresh(record: OptionsAvailabilityRecord | undefined, now: number): record is OptionsAvailabilityRecord {
+  return !!record && (now - record.checkedAt) < OPTIONS_AVAILABILITY_TTL_MS;
+}
+
+export function readOptionsAvailability(
+  targetOrKey: ResolvedOptionsTarget | string,
+  now = Date.now(),
+): boolean | null {
+  const key = typeof targetOrKey === "string" ? targetOrKey : targetOrKey.cacheKey;
+  const record = optionsAvailabilityCache.get(key);
+  return isCacheFresh(record, now) ? record.available : null;
+}
+
+export function setOptionsAvailability(
+  targetOrKey: ResolvedOptionsTarget | string,
+  available: boolean,
+  checkedAt = Date.now(),
+): void {
+  const key = typeof targetOrKey === "string" ? targetOrKey : targetOrKey.cacheKey;
+  optionsAvailabilityCache.set(key, { available, checkedAt });
+}
+
+export function resetOptionsAvailabilityCache(): void {
+  optionsAvailabilityCache.clear();
+  optionsAvailabilityInFlight.clear();
+}
+
+export async function fetchOptionsAvailability(
+  target: ResolvedOptionsTarget,
+  provider: DataProvider | undefined = getSharedDataProvider(),
+): Promise<boolean> {
+  const cached = readOptionsAvailability(target);
+  if (cached != null) return cached;
+
+  if (!provider?.getOptionsChain || !target.effectiveTicker) {
+    setOptionsAvailability(target, false);
+    return false;
+  }
+
+  const existing = optionsAvailabilityInFlight.get(target.cacheKey);
+  if (existing) return existing;
+
+  const request = provider.getOptionsChain(
+    target.effectiveTicker,
+    target.effectiveExchange,
+    undefined,
+    getRequestContext(target),
+  ).then((chain) => {
+    const available = chain.expirationDates.length > 0;
+    setOptionsAvailability(target, available);
+    return available;
+  }).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error ?? "");
+    if (!EXPECTED_OPTIONS_MISS.test(message)) {
+      setOptionsAvailability(target, false);
+      return false;
+    }
+    setOptionsAvailability(target, false);
+    return false;
+  }).finally(() => {
+    optionsAvailabilityInFlight.delete(target.cacheKey);
+  });
+
+  optionsAvailabilityInFlight.set(target.cacheKey, request);
+  return request;
+}
+
+export function useOptionsAvailability(ticker: TickerRecord | null | undefined): boolean {
+  const target = useMemo(() => resolveOptionsTarget(ticker), [
+    ticker?.metadata.ticker,
+    ticker?.metadata.exchange,
+    ticker?.metadata.assetCategory,
+    ticker?.metadata.broker_contracts?.[0]?.brokerInstanceId,
+    ticker?.metadata.broker_contracts?.[0]?.conId,
+  ]);
+  const [available, setAvailable] = useState(() => (target ? readOptionsAvailability(target) ?? false : false));
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    if (!target) {
+      requestRef.current += 1;
+      setAvailable(false);
+      return;
+    }
+
+    const cached = readOptionsAvailability(target);
+    if (cached != null) {
+      requestRef.current += 1;
+      setAvailable(cached);
+      return;
+    }
+
+    setAvailable(false);
+    const requestId = ++requestRef.current;
+    void fetchOptionsAvailability(target).then((result) => {
+      if (requestRef.current === requestId) {
+        setAvailable(result);
+      }
+    });
+  }, [target?.cacheKey]);
+
+  return available;
+}

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -6,9 +6,10 @@ import type { OptionContract, OptionsChain } from "../../types/financials";
 import { usePaneTicker } from "../../state/app-context";
 import { colors, hoverBg } from "../../theme/colors";
 import { padTo, formatCompact, formatNumber } from "../../utils/format";
-import { formatExpDate, parseOptionSymbol } from "../../utils/options";
+import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { Spinner } from "../../components/spinner";
+import { setOptionsAvailability } from "./options-availability";
 
 function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const { ticker } = usePaneTicker();
@@ -20,13 +21,12 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const [interactive, setInteractive] = useState(false);
   const [hoveredStrikeIdx, setHoveredStrikeIdx] = useState<number | null>(null);
   const [hoveredExpIdx, setHoveredExpIdx] = useState<number | null>(null);
-
-  // Determine if we're viewing an option position — if so, resolve the underlying
-  const isOpt = ticker?.metadata.assetCategory === "OPT";
-  const parsed = isOpt ? parseOptionSymbol(ticker!.metadata.ticker) : null;
-  const effectiveTicker = parsed?.underlying ?? ticker?.metadata.ticker ?? "";
-  const effectiveExchange = isOpt ? "" : (ticker?.metadata.exchange ?? "");
-  const instrument = ticker?.metadata.broker_contracts?.[0] ?? null;
+  const target = resolveOptionsTarget(ticker);
+  const isOpt = target?.isOptionTicker ?? false;
+  const parsed = target?.parsedOption ?? null;
+  const effectiveTicker = target?.effectiveTicker ?? "";
+  const effectiveExchange = target?.effectiveExchange ?? "";
+  const instrument = target?.instrument ?? null;
 
   const enterInteractive = () => {
     if (!interactive) {
@@ -50,7 +50,12 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   // Fetch initial chain (all expirations list + nearest expiration data)
   useEffect(() => {
     const provider = getSharedDataProvider();
-    if (!effectiveTicker || !provider?.getOptionsChain) return;
+    if (!target || !provider?.getOptionsChain) {
+      setLoading(false);
+      setError(null);
+      setChain(null);
+      return;
+    }
     const getOptionsChain = provider.getOptionsChain.bind(provider);
     let cancelled = false;
     setLoading(true);
@@ -59,12 +64,13 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
     setExpIdx(0);
     setStrikeIdx(0);
 
-    getOptionsChain(effectiveTicker, effectiveExchange, undefined, {
+    getOptionsChain(target.effectiveTicker, target.effectiveExchange, undefined, {
       brokerId: instrument?.brokerId,
       brokerInstanceId: instrument?.brokerInstanceId,
       instrument,
     }).then((data) => {
       if (cancelled) return;
+      setOptionsAvailability(target, data.expirationDates.length > 0);
       setChain(data);
 
       // If viewing an option position, find the matching expiration
@@ -73,47 +79,56 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
           Math.abs(ts - parsed.expTs) < Math.abs(data.expirationDates[best]! - parsed.expTs) ? i : best, 0);
         if (bestExpIdx !== 0) {
           setExpIdx(bestExpIdx);
-          getOptionsChain(effectiveTicker, effectiveExchange, data.expirationDates[bestExpIdx], {
+          getOptionsChain(target.effectiveTicker, target.effectiveExchange, data.expirationDates[bestExpIdx], {
             brokerId: instrument?.brokerId,
             brokerInstanceId: instrument?.brokerInstanceId,
             instrument,
           }).then((expData) => {
-            if (!cancelled) setChain(expData);
+            if (!cancelled) {
+              setOptionsAvailability(target, expData.expirationDates.length > 0);
+              setChain(expData);
+            }
           }).catch(() => {});
         }
       }
     }).catch((err) => {
-      if (!cancelled) setError(err?.message || "Failed to load options");
+      if (!cancelled) {
+        setOptionsAvailability(target, false);
+        setError(err?.message || "Failed to load options");
+      }
     }).finally(() => {
       if (!cancelled) setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [effectiveTicker, instrument?.brokerId, instrument?.brokerInstanceId, instrument?.conId]);
+  }, [target?.cacheKey]);
 
   // Fetch chain when expiration changes (after initial load)
   useEffect(() => {
     const provider = getSharedDataProvider();
-    if (!chain || !effectiveTicker || !provider?.getOptionsChain) return;
+    if (!chain || !target || !provider?.getOptionsChain) return;
     const getOptionsChain = provider.getOptionsChain.bind(provider);
     const expDate = chain.expirationDates[expIdx];
     if (expDate == null) return;
     let cancelled = false;
     setLoading(true);
 
-    getOptionsChain(effectiveTicker, effectiveExchange, expDate, {
+    getOptionsChain(target.effectiveTicker, target.effectiveExchange, expDate, {
       brokerId: instrument?.brokerId,
       brokerInstanceId: instrument?.brokerInstanceId,
       instrument,
     }).then((data) => {
       if (!cancelled) {
+        setOptionsAvailability(target, data.expirationDates.length > 0);
         setChain(data);
         setStrikeIdx(0);
       }
-    }).catch(() => {}).finally(() => {
+    }).catch(() => {
+      setOptionsAvailability(target, false);
+    }).finally(() => {
       if (!cancelled) setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [expIdx, instrument?.brokerId, instrument?.brokerInstanceId, instrument?.conId]);
+  }, [expIdx, target?.cacheKey]);
 
   // Build sorted strike list from the union of calls and puts
   const strikes = chain ? buildStrikeList(chain) : [];

--- a/src/plugins/builtin/ticker-detail.test.tsx
+++ b/src/plugins/builtin/ticker-detail.test.tsx
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useReducer } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { AppContext, appReducer, createInitialState, PaneInstanceProvider, type AppAction } from "../../state/app-context";
+import { cloneLayout, createDefaultConfig, type AppConfig, type BrokerInstanceConfig } from "../../types/config";
+import type { DataProvider } from "../../types/data-provider";
+import type { TickerFinancials } from "../../types/financials";
+import type { DetailTabDef } from "../../types/plugin";
+import type { TickerRecord } from "../../types/ticker";
+import type { PluginRegistry } from "../registry";
+import { setSharedDataProviderForTests, setSharedRegistryForTests } from "../registry";
+import { tickerDetailPlugin } from "./ticker-detail";
+import { resetOptionsAvailabilityCache } from "./options-availability";
+
+const TEST_PANE_ID = "ticker-detail:test";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let harnessDispatch: React.Dispatch<AppAction> | null = null;
+
+const DetailPane = tickerDetailPlugin.panes![0]!.component as (props: {
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+}) => JSX.Element;
+
+function makeTicker(symbol: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function makeFinancials(overrides: Partial<TickerFinancials> = {}): TickerFinancials {
+  return {
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: [],
+    ...overrides,
+  };
+}
+
+function createProvider(hasOptions: boolean): DataProvider {
+  return {
+    id: "test-provider",
+    name: "Test Provider",
+    getTickerFinancials: async () => { throw new Error("unused"); },
+    getQuote: async () => { throw new Error("unused"); },
+    getExchangeRate: async () => 1,
+    search: async () => [],
+    getNews: async () => [],
+    getArticleSummary: async () => null,
+    getPriceHistory: async () => [],
+    getOptionsChain: async (ticker) => ({
+      underlyingSymbol: ticker,
+      expirationDates: hasOptions ? [1_717_113_600] : [],
+      calls: [],
+      puts: [],
+    }),
+  };
+}
+
+function makeRegistry(): PluginRegistry {
+  const stubTab = (_props: { width: number; height: number; focused: boolean; onCapture: (capturing: boolean) => void }) => (
+    <text>stub</text>
+  );
+  const detailTabs = new Map<string, DetailTabDef>([
+    ["ibkr-trade", { id: "ibkr-trade", name: "Trade", order: 25, component: stubTab }],
+    ["options", { id: "options", name: "Options", order: 35, component: stubTab }],
+    ["ask-ai", { id: "ask-ai", name: "Ask AI", order: 60, component: stubTab }],
+  ]);
+  return { detailTabs } as unknown as PluginRegistry;
+}
+
+function createGatewayInstance(id = "ibkr-paper"): BrokerInstanceConfig {
+  return {
+    id,
+    brokerType: "ibkr",
+    label: "Paper",
+    connectionMode: "gateway",
+    config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
+    enabled: true,
+  };
+}
+
+function createDetailConfig(symbol: string, brokerInstances: BrokerInstanceConfig[] = []): AppConfig {
+  const config = createDefaultConfig("/tmp/gloomberb-test");
+  const layout = {
+    columns: [{ width: "100%" }],
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "ticker-detail",
+      binding: { kind: "fixed" as const, symbol },
+    }],
+    docked: [{ instanceId: TEST_PANE_ID, columnIndex: 0 }],
+    floating: [],
+  };
+
+  return {
+    ...config,
+    brokerInstances,
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  };
+}
+
+function createDetailState(
+  config: AppConfig,
+  ticker: TickerRecord,
+  financials: TickerFinancials | null,
+  activeTabId = "overview",
+) {
+  const state = createInitialState(config);
+  state.focusedPaneId = TEST_PANE_ID;
+  state.tickers = new Map([[ticker.metadata.ticker, ticker]]);
+  state.financials = financials ? new Map([[ticker.metadata.ticker, financials]]) : new Map();
+  state.paneState[TEST_PANE_ID] = { activeTabId };
+  return state;
+}
+
+function DetailHarness({
+  config,
+  ticker,
+  financials,
+  activeTabId = "overview",
+}: {
+  config: AppConfig;
+  ticker: TickerRecord;
+  financials: TickerFinancials | null;
+  activeTabId?: string;
+}) {
+  const initialState = createDetailState(config, ticker, financials, activeTabId);
+  const [state, dispatch] = useReducer(appReducer, initialState);
+  harnessDispatch = dispatch;
+
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <text>{`active:${state.paneState[TEST_PANE_ID]?.activeTabId ?? ""}`}</text>
+        <DetailPane
+          paneId={TEST_PANE_ID}
+          paneType="ticker-detail"
+          focused
+          width={90}
+          height={24}
+        />
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function flushFrame() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+}
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+  harnessDispatch = null;
+  resetOptionsAvailabilityCache();
+  setSharedRegistryForTests(undefined);
+  setSharedDataProviderForTests(undefined);
+});
+
+describe("TickerDetailPane", () => {
+  test("shows only applicable tabs when no gateway, statements, or options are available", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setSharedDataProviderForTests(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={null}
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Overview");
+    expect(frame).toContain("Chart");
+    expect(frame).toContain("Ask AI");
+    expect(frame).not.toContain("Financials");
+    expect(frame).not.toContain("Trade");
+    expect(frame).not.toContain("Options");
+  });
+
+  test("shows Financials when statement data exists", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setSharedDataProviderForTests(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={makeFinancials({
+          annualStatements: [{ date: "2024-12-31", totalRevenue: 1_000 }],
+        })}
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Financials");
+  });
+
+  test("shows Trade when an IBKR gateway profile exists", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setSharedDataProviderForTests(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL", [createGatewayInstance()])}
+        ticker={makeTicker("AAPL")}
+        financials={null}
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Trade");
+  });
+
+  test("shows Options after the preflight confirms a chain exists", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setSharedDataProviderForTests(createProvider(true));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={null}
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Options");
+  });
+
+  test("falls back to Overview when a hidden active tab becomes unavailable", async () => {
+    const gatewayConfig = createDetailConfig("AAPL", [createGatewayInstance()]);
+    const noGatewayConfig = createDetailConfig("AAPL");
+    setSharedRegistryForTests(makeRegistry());
+    setSharedDataProviderForTests(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={gatewayConfig}
+        ticker={makeTicker("AAPL")}
+        financials={null}
+        activeTabId="ibkr-trade"
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    await act(async () => {
+      harnessDispatch!({ type: "SET_CONFIG", config: noGatewayConfig });
+      await Promise.resolve();
+    });
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("active:overview");
+    expect(frame).not.toContain("Trade");
+  });
+});

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -11,12 +11,40 @@ import { TabBar } from "../../components/tab-bar";
 import { formatCurrency, formatCompact, formatPercent, formatPercentRaw, formatNumber, formatGrowthShort, pickUnit, formatWithDivisor, padTo } from "../../utils/format";
 import { exchangeShortName, marketStateLabel, marketStateColor } from "../../utils/market-status";
 import { StockChart } from "../../components/chart/stock-chart";
+import type { TickerFinancials } from "../../types/financials";
+import { getConfiguredIbkrGatewayInstances } from "../ibkr/instance-selection";
+import { useOptionsAvailability } from "./options-availability";
 
-const CORE_TABS = [
-  { id: "overview", name: "Overview", order: 10 },
-  { id: "financials", name: "Financials", order: 20 },
-  { id: "chart", name: "Chart", order: 30 },
-];
+const CORE_OVERVIEW_TAB = { id: "overview", name: "Overview", order: 10 };
+const CORE_FINANCIALS_TAB = { id: "financials", name: "Financials", order: 20 };
+const CORE_CHART_TAB = { id: "chart", name: "Chart", order: 30 };
+
+function hasStatementFinancials(financials: TickerFinancials | null | undefined): boolean {
+  return (financials?.annualStatements.length ?? 0) > 0 || (financials?.quarterlyStatements.length ?? 0) > 0;
+}
+
+export function buildVisibleDetailTabs(
+  pluginTabs: DetailTabDef[],
+  financials: TickerFinancials | null | undefined,
+  options: {
+    hasIbkrGatewayTrading: boolean;
+    hasOptionsChain: boolean;
+  },
+): Array<{ id: string; name: string; order: number }> {
+  const tabs = [CORE_OVERVIEW_TAB];
+  if (hasStatementFinancials(financials)) {
+    tabs.push(CORE_FINANCIALS_TAB);
+  }
+  tabs.push(CORE_CHART_TAB);
+
+  for (const tab of pluginTabs) {
+    if (tab.id === "ibkr-trade" && !options.hasIbkrGatewayTrading) continue;
+    if (tab.id === "options" && !options.hasOptionsChain) continue;
+    tabs.push({ id: tab.id, name: tab.name, order: tab.order });
+  }
+
+  return tabs.sort((a, b) => a.order - b.order);
+}
 
 function OverviewTab({ width }: { width?: number }) {
   const { ticker, financials } = usePaneTicker();
@@ -294,22 +322,39 @@ function computeGrowth(current: number | undefined, previous: number | undefined
 
 function FinancialsTab({ focused }: { focused: boolean }) {
   const { financials } = usePaneTicker();
-  const [period, setPeriod] = useState<"annual" | "quarterly">("annual");
+  const hasAnnualStatements = (financials?.annualStatements.length ?? 0) > 0;
+  const hasQuarterlyStatements = (financials?.quarterlyStatements.length ?? 0) > 0;
+  const [period, setPeriod] = useState<"annual" | "quarterly">(
+    hasAnnualStatements ? "annual" : "quarterly",
+  );
   const [subTabIdx, setSubTabIdx] = useState(0);
 
   useKeyboard((event) => {
     if (!focused) return;
-    if (event.name === "a") setPeriod("annual");
-    else if (event.name === "q") setPeriod("quarterly");
+    if (event.name === "a" && hasAnnualStatements) setPeriod("annual");
+    else if (event.name === "q" && hasQuarterlyStatements) setPeriod("quarterly");
     else if (event.name === "1") setSubTabIdx(0);
     else if (event.name === "2") setSubTabIdx(1);
     else if (event.name === "3") setSubTabIdx(2);
   });
 
-  if (!financials) return <text fg={colors.textDim}>No financial data available.</text>;
+  useEffect(() => {
+    if (period === "annual" && !hasAnnualStatements && hasQuarterlyStatements) {
+      setPeriod("quarterly");
+    } else if (period === "quarterly" && !hasQuarterlyStatements && hasAnnualStatements) {
+      setPeriod("annual");
+    }
+  }, [hasAnnualStatements, hasQuarterlyStatements, period]);
+
+  if (!financials || (!hasAnnualStatements && !hasQuarterlyStatements)) {
+    return <text fg={colors.textDim}>No financial data available.</text>;
+  }
 
   const subTab = FINANCIAL_SUB_TABS[subTabIdx]!;
-  const isAnnual = period === "annual";
+  const resolvedPeriod = period === "annual"
+    ? (hasAnnualStatements || !hasQuarterlyStatements ? "annual" : "quarterly")
+    : (hasQuarterlyStatements || !hasAnnualStatements ? "quarterly" : "annual");
+  const isAnnual = resolvedPeriod === "annual";
   const rawStmts = isAnnual
     ? financials.annualStatements.slice(-5).reverse()
     : financials.quarterlyStatements.slice(-6).reverse();
@@ -436,11 +481,12 @@ function ChartTab({ width, height, focused, interactive, onActivate }: { width?:
 function TickerDetailPane({ focused, width, height }: PaneProps) {
   const { state, dispatch } = useAppState();
   const paneInstance = usePaneInstance();
-  const { ticker } = usePaneTicker();
+  const { ticker, financials } = usePaneTicker();
   const { collectionId } = usePaneCollection();
   const [activeTabId, setActiveTabId] = usePaneStateValue<string>("activeTabId", "overview");
   const [chartInteractive, setChartInteractive] = useState(false);
   const [pluginCaptured, setPluginCaptured] = useState(false);
+  const hasOptionsChain = useOptionsAvailability(ticker);
   const collectionTickers = getCollectionTickers(state, collectionId);
   const collectionName = getCollectionName(state, collectionId);
 
@@ -450,15 +496,17 @@ function TickerDetailPane({ focused, width, height }: PaneProps) {
   const pluginTabs: DetailTabDef[] = registry
     ? [...registry.detailTabs.values()].filter((t) => !disabledPlugins.includes(t.id))
     : [];
+  const hasIbkrGatewayTrading = getConfiguredIbkrGatewayInstances(state.config).length > 0;
 
-  const allTabs = [
-    ...CORE_TABS,
-    ...pluginTabs.map((t) => ({ id: t.id, name: t.name, order: t.order })),
-  ].sort((a, b) => a.order - b.order);
+  const allTabs = buildVisibleDetailTabs(pluginTabs, financials, {
+    hasIbkrGatewayTrading,
+    hasOptionsChain,
+  });
+  const visiblePluginTabs = pluginTabs.filter((tab) => allTabs.some((visibleTab) => visibleTab.id === tab.id));
 
-  const tabIdx = allTabs.findIndex((t) => t.id === activeTabId);
-  const isPluginTab = pluginTabs.some((t) => t.id === activeTabId);
-  const activePluginTab = isPluginTab ? pluginTabs.find((t) => t.id === activeTabId) : null;
+  const tabIdx = Math.max(0, allTabs.findIndex((t) => t.id === activeTabId));
+  const isPluginTab = visiblePluginTabs.some((t) => t.id === activeTabId);
+  const activePluginTab = isPluginTab ? visiblePluginTabs.find((t) => t.id === activeTabId) : null;
 
   // Refs to avoid stale closures in useKeyboard
   const allTabsRef = useRef(allTabs);
@@ -486,6 +534,12 @@ function TickerDetailPane({ focused, width, height }: PaneProps) {
     setPluginCaptured(false);
     dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
   }, [activeTabId, dispatch]);
+
+  useEffect(() => {
+    if (!allTabs.some((tab) => tab.id === activeTabId)) {
+      setActiveTabId("overview");
+    }
+  }, [activeTabId, allTabs, setActiveTabId]);
 
   const handleKeyboard = useCallback((event: { name?: string }) => {
     const s = stateRef.current;

--- a/src/plugins/ibkr/index.test.tsx
+++ b/src/plugins/ibkr/index.test.tsx
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultConfig, type AppConfig, type BrokerInstanceConfig } from "../../types/config";
+import type { CommandDef, GloomPluginContext, TickerAction } from "../../types/plugin";
+import type { TickerRecord } from "../../types/ticker";
+import { ibkrPlugin } from "./index";
+
+function createTicker(symbol: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function createGatewayInstance(): BrokerInstanceConfig {
+  return {
+    id: "ibkr-paper",
+    brokerType: "ibkr",
+    label: "Paper",
+    connectionMode: "gateway",
+    config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
+    enabled: true,
+  };
+}
+
+function createFlexInstance(): BrokerInstanceConfig {
+  return {
+    id: "ibkr-flex",
+    brokerType: "ibkr",
+    label: "Flex",
+    connectionMode: "flex",
+    config: { connectionMode: "flex", flex: { token: "token", queryId: "query" } },
+    enabled: true,
+  };
+}
+
+function createConfig(brokerInstances: BrokerInstanceConfig[] = []): AppConfig {
+  return {
+    ...createDefaultConfig("/tmp/gloomberb-test"),
+    brokerInstances,
+  };
+}
+
+function setupIbkrPlugin(config: AppConfig) {
+  const commands: CommandDef[] = [];
+  const tickerActions: TickerAction[] = [];
+  const toasts: string[] = [];
+  const switchedPanels: string[] = [];
+  const switchedTabs: string[] = [];
+  const tickers = new Map<string, TickerRecord>([["AAPL", createTicker("AAPL")]]);
+
+  const ctx = {
+    registerPane: () => {},
+    registerCommand: (command: CommandDef) => { commands.push(command); },
+    registerColumn: () => {},
+    registerBroker: () => {},
+    registerDataProvider: () => {},
+    registerDetailTab: () => {},
+    registerShortcut: () => {},
+    registerTickerAction: (action: TickerAction) => { tickerActions.push(action); },
+    getData: () => null,
+    getTicker: (symbol: string) => tickers.get(symbol) ?? null,
+    getConfig: () => config,
+    persistence: {} as any,
+    storage: {} as any,
+    dataProvider: {} as any,
+    tickerRepository: {} as any,
+    createBrokerInstance: async () => { throw new Error("unused"); },
+    updateBrokerInstance: async () => {},
+    syncBrokerInstance: async () => {},
+    removeBrokerInstance: async () => {},
+    selectTicker: () => {},
+    switchPanel: (panel: "left" | "right") => { switchedPanels.push(panel); },
+    switchTab: (tabId: string) => { switchedTabs.push(tabId); },
+    openCommandBar: () => {},
+    showPane: () => {},
+    hidePane: () => {},
+    focusPane: () => {},
+    pinTicker: () => {},
+    on: () => () => {},
+    emit: () => {},
+    showWidget: () => {},
+    hideWidget: () => {},
+    showToast: (message: string) => { toasts.push(message); },
+  } satisfies GloomPluginContext;
+
+  void ibkrPlugin.setup?.(ctx);
+
+  return { commands, tickerActions, toasts, switchedPanels, switchedTabs, ticker: tickers.get("AAPL")! };
+}
+
+describe("IBKR trade entry points", () => {
+  test("hides the Trade action when no IBKR gateway profile is configured", () => {
+    const { tickerActions, ticker } = setupIbkrPlugin(createConfig());
+    const tradeAction = tickerActions.find((action) => action.id === "ibkr-trade");
+
+    expect(tradeAction).toBeDefined();
+    expect(tradeAction?.filter?.(ticker)).toBe(false);
+  });
+
+  test("hides the Trade action and trading commands for flex-only setups", () => {
+    const { commands, tickerActions, ticker } = setupIbkrPlugin(createConfig([createFlexInstance()]));
+    const tradeAction = tickerActions.find((action) => action.id === "ibkr-trade");
+    const openTrading = commands.find((command) => command.id === "ibkr-open-trading");
+    const buySelected = commands.find((command) => command.id === "ibkr-buy-selected");
+    const sellSelected = commands.find((command) => command.id === "ibkr-sell-selected");
+
+    expect(tradeAction?.filter?.(ticker)).toBe(false);
+    expect(openTrading?.hidden?.()).toBe(true);
+    expect(buySelected?.hidden?.()).toBe(true);
+    expect(sellSelected?.hidden?.()).toBe(true);
+  });
+
+  test("allows the Trade action when a gateway profile exists", () => {
+    const { tickerActions, ticker } = setupIbkrPlugin(createConfig([createGatewayInstance()]));
+    const tradeAction = tickerActions.find((action) => action.id === "ibkr-trade");
+
+    expect(tradeAction?.filter?.(ticker)).toBe(true);
+  });
+
+  test("shows a clear message and does not navigate when Open Trading is executed without a gateway profile", async () => {
+    const { commands, switchedPanels, switchedTabs, toasts } = setupIbkrPlugin(createConfig());
+    const openTrading = commands.find((command) => command.id === "ibkr-open-trading");
+
+    expect(openTrading).toBeDefined();
+    await openTrading!.execute();
+
+    expect(toasts).toEqual(["Connect a Gateway / TWS IBKR profile first."]);
+    expect(switchedPanels).toHaveLength(0);
+    expect(switchedTabs).toHaveLength(0);
+  });
+
+  test("shows a clear message and does not navigate when the Trade action executes without a gateway profile", async () => {
+    const { tickerActions, ticker, switchedPanels, switchedTabs, toasts } = setupIbkrPlugin(createConfig());
+    const tradeAction = tickerActions.find((action) => action.id === "ibkr-trade");
+
+    expect(tradeAction).toBeDefined();
+    await tradeAction!.execute(ticker, null);
+
+    expect(toasts).toEqual(["Connect a Gateway / TWS IBKR profile first."]);
+    expect(switchedPanels).toHaveLength(0);
+    expect(switchedTabs).toHaveLength(0);
+  });
+});

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -18,7 +18,7 @@ import {
 import { PriceSelectorDialog } from "../../components";
 import { colors, hoverBg, priceColor } from "../../theme/colors";
 import { formatCompact, formatCurrency, formatNumber, padTo } from "../../utils/format";
-import { getBrokerInstance, getBrokerInstancesByType } from "../../utils/broker-instances";
+import { getBrokerInstance } from "../../utils/broker-instances";
 import { getSharedRegistry } from "../registry";
 import {
   buildIbkrConfigFromValues,
@@ -72,10 +72,15 @@ function isStopOrder(orderType: BrokerOrderType): boolean {
   return orderType === "STP" || orderType === "STP LMT";
 }
 
-function getIbkrInstances(appConfig: ReturnType<GloomPluginContext["getConfig"]>): BrokerInstanceConfig[] {
-  return getBrokerInstancesByType(appConfig.brokerInstances, "ibkr");
+export function hasIbkrTradingProfiles(appConfig: ReturnType<GloomPluginContext["getConfig"]>): boolean {
+  return getConfiguredIbkrGatewayInstances(appConfig).length > 0;
 }
 
+function ensureIbkrTradingProfile(ctx: GloomPluginContext): boolean {
+  if (hasIbkrTradingProfiles(ctx.getConfig())) return true;
+  ctx.showToast("Connect a Gateway / TWS IBKR profile first.", { type: "info" });
+  return false;
+}
 
 function inferDraftAccountId(
   appConfig: ReturnType<GloomPluginContext["getConfig"]>,
@@ -1488,7 +1493,9 @@ export const ibkrPlugin: GloomPlugin = {
       id: "ibkr-trade",
       label: "Trade",
       keywords: ["trade", "buy", "sell", "ibkr"],
+      filter: () => hasIbkrTradingProfiles(ctx.getConfig()),
       execute: async (ticker) => {
+        if (!ensureIbkrTradingProfile(ctx)) return;
         const current = getTradeTicketState(ticker.metadata.ticker, ticker);
         prefillTradeFromTicker(ticker, current.draft.action || "BUY");
         ctx.switchPanel("right");
@@ -1514,8 +1521,9 @@ export const ibkrPlugin: GloomPlugin = {
       description: "Open the IBKR trade tab for the selected ticker",
       keywords: ["ibkr", "trading", "orders", "trade", "ticker"],
       category: "navigation",
-      hidden: () => getIbkrInstances(ctx.getConfig()).length === 0,
+      hidden: () => !hasIbkrTradingProfiles(ctx.getConfig()),
       execute: async () => {
+        if (!ensureIbkrTradingProfile(ctx)) return;
         if (lastSelectedTickerSymbol) {
           const ticker = ctx.getTicker(lastSelectedTickerSymbol);
           if (ticker) {
@@ -1534,8 +1542,9 @@ export const ibkrPlugin: GloomPlugin = {
       description: "Prefill the trading pane with a BUY ticket for the selected ticker",
       keywords: ["buy", "trade", "order", "selected", "ibkr"],
       category: "portfolio",
-      hidden: () => getIbkrInstances(ctx.getConfig()).length === 0 || !lastSelectedTickerSymbol,
+      hidden: () => !hasIbkrTradingProfiles(ctx.getConfig()) || !lastSelectedTickerSymbol,
       execute: async () => {
+        if (!ensureIbkrTradingProfile(ctx)) return;
         if (!lastSelectedTickerSymbol) return;
         const ticker = ctx.getTicker(lastSelectedTickerSymbol);
         if (!ticker) return;
@@ -1551,8 +1560,9 @@ export const ibkrPlugin: GloomPlugin = {
       description: "Prefill the trading pane with a SELL ticket for the selected ticker",
       keywords: ["sell", "trade", "order", "selected", "ibkr"],
       category: "portfolio",
-      hidden: () => getIbkrInstances(ctx.getConfig()).length === 0 || !lastSelectedTickerSymbol,
+      hidden: () => !hasIbkrTradingProfiles(ctx.getConfig()) || !lastSelectedTickerSymbol,
       execute: async () => {
+        if (!ensureIbkrTradingProfile(ctx)) return;
         if (!lastSelectedTickerSymbol) return;
         const ticker = ctx.getTicker(lastSelectedTickerSymbol);
         if (!ticker) return;

--- a/src/plugins/ibkr/instance-selection.test.ts
+++ b/src/plugins/ibkr/instance-selection.test.ts
@@ -43,6 +43,18 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
 }
 
 describe("IBKR trading instance selection", () => {
+  test("returns no trading instance when only flex profiles exist", () => {
+    const config = createConfig({
+      brokerInstances: [
+        createIbkrInstance("ibkr-default", "IBKR", "flex", {
+          flex: { token: "token", queryId: "query" },
+        }),
+      ],
+    });
+
+    expect(resolveIbkrTradingInstanceId(config, "", "ibkr-default")).toBeUndefined();
+  });
+
   test("prefers a gateway profile over a flex profile when both exist", () => {
     const config = createConfig({
       brokerInstances: [

--- a/src/plugins/ibkr/instance-selection.ts
+++ b/src/plugins/ibkr/instance-selection.ts
@@ -32,12 +32,5 @@ export function resolveIbkrTradingInstanceId(
 
   const gatewayInstance = getConfiguredIbkrGatewayInstances(config)[0];
   if (gatewayInstance) return gatewayInstance.id;
-
-  const preferredIbkrInstance = preferredInstanceId
-    ? config.brokerInstances.find((instance) => instance.id === preferredInstanceId && instance.brokerType === "ibkr")
-    : undefined;
-
-  return preferredIbkrInstance
-    ? preferredIbkrInstance.id
-    : getBrokerInstancesByType(config.brokerInstances, "ibkr")[0]?.id;
+  return undefined;
 }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -29,6 +29,12 @@ let sharedRegistry: PluginRegistry | undefined;
 
 export function getSharedDataProvider(): DataProvider | undefined { return sharedDataProvider; }
 export function getSharedRegistry(): PluginRegistry | undefined { return sharedRegistry; }
+export function setSharedDataProviderForTests(provider: DataProvider | undefined): void {
+  sharedDataProvider = provider;
+}
+export function setSharedRegistryForTests(registry: PluginRegistry | undefined): void {
+  sharedRegistry = registry;
+}
 
 interface PluginItems {
   panes: string[];

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,3 +1,6 @@
+import type { BrokerContractRef } from "../types/instrument";
+import type { TickerRecord } from "../types/ticker";
+
 export const MONTH_ABBREV = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 /** Format a unix timestamp (seconds) as "Mon DD 'YY" */
@@ -22,6 +25,50 @@ export function parseOptionSymbol(symbol: string): { underlying: string; expTs: 
   const day = parseInt(dd!, 10);
   const expTs = Math.floor(new Date(year, month, day).getTime() / 1000);
   return { underlying: underlying!, expTs, strike, side: side as "C" | "P" };
+}
+
+export interface ResolvedOptionsTarget {
+  isOptionTicker: boolean;
+  parsedOption: ReturnType<typeof parseOptionSymbol>;
+  effectiveTicker: string;
+  effectiveExchange: string;
+  instrument: BrokerContractRef | null;
+  cacheKey: string;
+}
+
+function buildOptionsCacheKey(
+  effectiveTicker: string,
+  effectiveExchange: string,
+  instrument: BrokerContractRef | null,
+): string {
+  return [
+    effectiveTicker.trim().toUpperCase(),
+    effectiveExchange.trim().toUpperCase(),
+    instrument?.brokerInstanceId ?? "",
+    instrument?.conId != null ? String(instrument.conId) : "",
+  ].join("|");
+}
+
+export function resolveOptionsTarget(ticker: TickerRecord | null | undefined): ResolvedOptionsTarget | null {
+  if (!ticker) return null;
+
+  const isOptionTicker = ticker.metadata.assetCategory === "OPT";
+  const parsedOption = isOptionTicker ? parseOptionSymbol(ticker.metadata.ticker) : null;
+  const effectiveTicker = parsedOption?.underlying ?? ticker.metadata.ticker;
+
+  if (!effectiveTicker) return null;
+
+  const effectiveExchange = isOptionTicker ? "" : (ticker.metadata.exchange ?? "");
+  const instrument = ticker.metadata.broker_contracts?.[0] ?? null;
+
+  return {
+    isOptionTicker,
+    parsedOption,
+    effectiveTicker,
+    effectiveExchange,
+    instrument,
+    cacheKey: buildOptionsCacheKey(effectiveTicker, effectiveExchange, instrument),
+  };
 }
 
 /**


### PR DESCRIPTION
This updates broker onboarding to default new profile labels to the selected broker name instead of prompting for a separate label. It also hides inapplicable detail tabs by gating IBKR trading on configured Gateway/TWS profiles, only showing Financials when statement data exists, and only showing Options after a cached options-chain preflight succeeds. Trading entry points no longer treat flex-only IBKR setups as tradable, and the detail pane falls back to Overview if the active tab becomes unavailable. Added regression coverage for IBKR instance selection, trading entry-point visibility, options availability caching, and ticker detail tab rendering.