### PR TITLE
Persist pane resume state and plugin UI state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -554,6 +554,50 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
   pluginRegistry.getTickerFn = (symbol) => state.tickers.get(symbol) ?? null;
   pluginRegistry.getDataFn = (symbol) => state.financials.get(symbol) ?? null;
   pluginRegistry.getConfigFn = () => state.config;
+  pluginRegistry.getPaneRuntimeStateFn = (paneId) => state.paneState[paneId] ?? null;
+  pluginRegistry.updatePaneRuntimeStateFn = (paneId, patch) => {
+    dispatch({ type: "UPDATE_PANE_STATE", paneId, patch });
+  };
+  pluginRegistry.getPluginConfigValueFn = (pluginId, key) => (
+    state.config.pluginConfig[pluginId]?.[key] ?? null
+  );
+  pluginRegistry.setPluginConfigValueFn = async (pluginId, key, value) => {
+    const nextConfig = {
+      ...state.config,
+      pluginConfig: {
+        ...state.config.pluginConfig,
+        [pluginId]: {
+          ...(state.config.pluginConfig[pluginId] ?? {}),
+          [key]: value,
+        },
+      },
+    };
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    await saveConfig(nextConfig);
+    pluginRegistry.events.emit("config:changed", { config: nextConfig });
+  };
+  pluginRegistry.deletePluginConfigValueFn = async (pluginId, key) => {
+    const currentPluginConfig = state.config.pluginConfig[pluginId];
+    if (!currentPluginConfig || !(key in currentPluginConfig)) return;
+
+    const nextPluginConfig = { ...currentPluginConfig };
+    delete nextPluginConfig[key];
+
+    const nextAllPluginConfig = { ...state.config.pluginConfig };
+    if (Object.keys(nextPluginConfig).length === 0) {
+      delete nextAllPluginConfig[pluginId];
+    } else {
+      nextAllPluginConfig[pluginId] = nextPluginConfig;
+    }
+
+    const nextConfig = {
+      ...state.config,
+      pluginConfig: nextAllPluginConfig,
+    };
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    await saveConfig(nextConfig);
+    pluginRegistry.events.emit("config:changed", { config: nextConfig });
+  };
   if (dataProvider instanceof ProviderRouter) {
     dataProvider.setConfigAccessor(() => state.config);
   }

--- a/src/data/config-store.test.ts
+++ b/src/data/config-store.test.ts
@@ -87,5 +87,42 @@ describe("loadConfig", () => {
     expect(config.chartPreferences).toEqual({
       defaultRenderMode: "area",
     });
+    expect(config.pluginConfig).toEqual({});
+  });
+
+  test("preserves plugin config state from disk", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "gloomberb-config-"));
+    tempDirs.push(dataDir);
+
+    await writeFile(join(dataDir, "config.json"), JSON.stringify({
+      configVersion: 7,
+      baseCurrency: "USD",
+      refreshIntervalMinutes: 30,
+      portfolios: [{ id: "main", name: "Main Portfolio", currency: "USD" }],
+      watchlists: [{ id: "watchlist", name: "Watchlist" }],
+      columns: [],
+      layout: DEFAULT_LAYOUT,
+      layouts: [{ name: "Default", layout: DEFAULT_LAYOUT }],
+      activeLayoutIndex: 0,
+      brokerInstances: [],
+      plugins: [],
+      disabledPlugins: [],
+      pluginConfig: {
+        news: {
+          displayMode: "expanded",
+        },
+      },
+      theme: "amber",
+      chartPreferences: { defaultRenderMode: "line" },
+      recentTickers: [],
+    }), "utf-8");
+
+    const config = await loadConfig(dataDir);
+
+    expect(config.pluginConfig).toEqual({
+      news: {
+        displayMode: "expanded",
+      },
+    });
   });
 });

--- a/src/data/config-store.ts
+++ b/src/data/config-store.ts
@@ -74,6 +74,7 @@ function normalizeConfig(saved: Record<string, unknown>, dataDir: string): { con
     brokerInstances: sanitizeBrokerInstances(saved.brokerInstances),
     plugins: sanitizeStringArray(saved.plugins, defaults.plugins),
     disabledPlugins: sanitizeStringArray(saved.disabledPlugins, defaults.disabledPlugins),
+    pluginConfig: sanitizePluginConfig(saved.pluginConfig),
     theme: typeof saved.theme === "string" ? saved.theme : defaults.theme,
     chartPreferences: sanitizeChartPreferences(saved.chartPreferences, defaults.chartPreferences),
     recentTickers: sanitizeStringArray(saved.recentTickers, defaults.recentTickers),
@@ -86,6 +87,7 @@ function normalizeConfig(saved: Record<string, unknown>, dataDir: string): { con
     || !Array.isArray((saved.layout as { instances?: unknown })?.instances)
     || !Array.isArray(saved.layouts)
     || !Array.isArray(saved.brokerInstances)
+    || !isPluginConfigMap(saved.pluginConfig)
     || !isChartPreferences(saved.chartPreferences)
     || typeof saved.activeLayoutIndex !== "number";
 
@@ -114,6 +116,7 @@ export async function saveConfig(config: AppConfig): Promise<void> {
     brokerInstances: sanitizeBrokerInstances(config.brokerInstances),
     plugins: sanitizeStringArray(config.plugins, []),
     disabledPlugins: sanitizeStringArray(config.disabledPlugins, []),
+    pluginConfig: sanitizePluginConfig(config.pluginConfig),
     chartPreferences: sanitizeChartPreferences(config.chartPreferences, createDefaultConfig(config.dataDir).chartPreferences),
     recentTickers: sanitizeStringArray(config.recentTickers, []),
   };
@@ -151,6 +154,22 @@ function sanitizeStringArray(value: unknown, fallback: string[]): string[] {
   return Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === "string")
     : fallback;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPluginConfigMap(value: unknown): value is Record<string, Record<string, unknown>> {
+  if (!isPlainRecord(value)) return false;
+  return Object.values(value).every((entry) => isPlainRecord(entry));
+}
+
+function sanitizePluginConfig(value: unknown): Record<string, Record<string, unknown>> {
+  if (!isPluginConfigMap(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).map(([pluginId, state]) => [pluginId, { ...state }]),
+  );
 }
 
 function isChartPreferences(value: unknown): value is ChartPreferences {

--- a/src/plugins/builtin/ask-ai.tsx
+++ b/src/plugins/builtin/ask-ai.tsx
@@ -6,6 +6,7 @@ import { spawn, type Subprocess } from "bun";
 import { execSync } from "child_process";
 import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
 import { usePaneTicker } from "../../state/app-context";
+import { usePluginState } from "../../plugins/plugin-runtime";
 import { colors } from "../../theme/colors";
 import { formatCurrency, formatCompact, formatPercent } from "../../utils/format";
 import type { TickerRecord } from "../../types/ticker";
@@ -136,17 +137,18 @@ interface PersistedConversation {
 function AskAiTab({ width, height, focused, onCapture }: DetailTabProps) {
   const { ticker, financials } = usePaneTicker();
   const [providers] = useState(() => detectProviders());
-  const [providerIdx, setProviderIdx] = useState(() => {
+  const defaultProviderIdx = (() => {
     const idx = providers.findIndex((p) => p.available);
     return idx >= 0 ? idx : 0;
-  });
+  })();
+  const [providerIdx, setProviderIdx] = usePluginState<number>("providerIdx", defaultProviderIdx);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputFocused, setInputFocused] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<InputRenderable>(null);
   const procRef = useRef<Subprocess | null>(null);
   const availableProviders = providers.filter((p) => p.available);
-  const currentProvider = providers[providerIdx];
+  const currentProvider = providers[providerIdx] ?? providers[defaultProviderIdx] ?? providers[0];
 
   const tickerSymbol = ticker?.metadata.ticker ?? null;
 

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -1,4 +1,4 @@
-import type { PluginPersistence } from "../../types/plugin";
+import type { PluginPersistence, PluginResumeState } from "../../types/plugin";
 import { apiClient, type ChatMessage } from "../../utils/api-client";
 
 const SESSION_STATE_KEY = "session";
@@ -41,6 +41,7 @@ type ChatConnection = { send: (content: string, replyToId?: string) => void; clo
 
 export class ChatController {
   private persistence: PluginPersistence | null = null;
+  private resume: PluginResumeState | null = null;
   private hydrated = false;
   private sessionChecked = false;
   private user: { id: string; username: string } | null = null;
@@ -52,8 +53,9 @@ export class ChatController {
   private wsConnected = false;
   private listeners = new Set<(snapshot: ChatControllerSnapshot) => void>();
 
-  attachPersistence(persistence: PluginPersistence): void {
+  attachPersistence(persistence: PluginPersistence, resume?: PluginResumeState): void {
     this.persistence = persistence;
+    this.resume = resume ?? this.resume;
     this.hydrate();
   }
 
@@ -61,7 +63,9 @@ export class ChatController {
     if (this.hydrated || !this.persistence) return;
     this.hydrated = true;
 
-    const session = this.persistence.getState<PersistedSessionState>(SESSION_STATE_KEY, {
+    const session = this.resume?.getState<PersistedSessionState>(SESSION_STATE_KEY, {
+      schemaVersion: SESSION_SCHEMA_VERSION,
+    }) ?? this.persistence.getState<PersistedSessionState>(SESSION_STATE_KEY, {
       schemaVersion: SESSION_SCHEMA_VERSION,
     });
     if (session?.sessionToken) {
@@ -70,7 +74,9 @@ export class ChatController {
     this.user = session?.user ?? null;
     this.sessionChecked = true;
 
-    const channel = this.persistence.getState<PersistedChannelState>(CHANNEL_STATE_KEY, {
+    const channel = this.resume?.getState<PersistedChannelState>(CHANNEL_STATE_KEY, {
+      schemaVersion: CHANNEL_SCHEMA_VERSION,
+    }) ?? this.persistence.getState<PersistedChannelState>(CHANNEL_STATE_KEY, {
       schemaVersion: CHANNEL_SCHEMA_VERSION,
     });
     this.draft = channel?.draft ?? "";
@@ -230,20 +236,28 @@ export class ChatController {
   }
 
   private persistSession(): void {
-    this.persistence?.setState(SESSION_STATE_KEY, {
+    const value = {
       sessionToken: apiClient.getSessionToken(),
       user: this.user,
-    } satisfies PersistedSessionState, {
+    } satisfies PersistedSessionState;
+    this.resume?.setState(SESSION_STATE_KEY, value, {
+      schemaVersion: SESSION_SCHEMA_VERSION,
+    });
+    this.persistence?.setState(SESSION_STATE_KEY, value, {
       schemaVersion: SESSION_SCHEMA_VERSION,
     });
   }
 
   private persistChannelState(): void {
-    this.persistence?.setState(CHANNEL_STATE_KEY, {
+    const value = {
       draft: this.draft,
       replyToId: this.replyToId,
       lastCursor: this.lastCursor,
-    } satisfies PersistedChannelState, {
+    } satisfies PersistedChannelState;
+    this.resume?.setState(CHANNEL_STATE_KEY, value, {
+      schemaVersion: CHANNEL_SCHEMA_VERSION,
+    });
+    this.persistence?.setState(CHANNEL_STATE_KEY, value, {
       schemaVersion: CHANNEL_SCHEMA_VERSION,
     });
   }

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -355,7 +355,7 @@ export const chatPlugin: GloomPlugin = {
   },
 
   setup(ctx) {
-    chatController.attachPersistence(ctx.persistence);
+    chatController.attachPersistence(ctx.persistence, ctx.resume);
 
     ctx.registerPane({
       id: "chat",

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -7,6 +7,7 @@ import { colors, hoverBg } from "../../theme/colors";
 import { padTo, formatTimeAgo } from "../../utils/format";
 import type { NewsItem } from "../../types/data-provider";
 import { getSharedDataProvider } from "../../plugins/registry";
+import { usePluginPaneState } from "../../plugins/plugin-runtime";
 import { Spinner } from "../../components/spinner";
 
 const ARTICLE_SUMMARY_CACHE_POLICY = {
@@ -21,7 +22,8 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
   const [news, setNews] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedIdx, setSelectedIdx] = useState(0);
+  const selectionKey = `selectedIdx:${ticker?.metadata.ticker ?? "none"}`;
+  const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>(selectionKey, 0);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [summaryCache, setSummaryCache] = useState<Map<string, string>>(new Map());
   const [loadingSummary, setLoadingSummary] = useState(false);
@@ -33,7 +35,6 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    setSelectedIdx(0);
     setSummaryCache(new Map());
     provider.getNews(ticker.metadata.ticker, 15).then((items) => {
       if (!cancelled) setNews(items);
@@ -85,6 +86,12 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
       setSelectedIdx((i) => Math.max(i - 1, 0));
     }
   });
+
+  useEffect(() => {
+    if (news.length > 0 && selectedIdx >= news.length) {
+      setSelectedIdx(Math.max(0, news.length - 1));
+    }
+  }, [news.length, selectedIdx, setSelectedIdx]);
 
   if (!ticker) return <text fg={colors.textDim}>Select a ticker to view news.</text>;
   if (loading && news.length === 0) return <Spinner label="Loading news..." />;

--- a/src/plugins/builtin/portfolio-list.test.ts
+++ b/src/plugins/builtin/portfolio-list.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import type { CollectionSortPreference } from "../../state/app-context";
+import { resolveCollectionSortPreference } from "./portfolio-list";
+
+describe("resolveCollectionSortPreference", () => {
+  test("defaults portfolio tabs to market value descending", () => {
+    expect(resolveCollectionSortPreference("main", true, {})).toEqual({
+      columnId: "mkt_value",
+      direction: "desc",
+    } satisfies CollectionSortPreference);
+  });
+
+  test("leaves watchlists unsorted by default", () => {
+    expect(resolveCollectionSortPreference("watchlist", false, {})).toEqual({
+      columnId: null,
+      direction: "asc",
+    } satisfies CollectionSortPreference);
+  });
+
+  test("prefers persisted per-collection sort settings", () => {
+    expect(resolveCollectionSortPreference("main", true, {
+      main: {
+        columnId: "pnl",
+        direction: "asc",
+      },
+    })).toEqual({
+      columnId: "pnl",
+      direction: "asc",
+    } satisfies CollectionSortPreference);
+  });
+});

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -6,7 +6,13 @@ import { EmptyState } from "../../components";
 import { TabBar } from "../../components/tab-bar";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
 import { getSharedRegistry } from "../../plugins/registry";
-import { useAppState, usePaneCollection, usePaneInstanceId, usePaneStateValue } from "../../state/app-context";
+import {
+  useAppState,
+  usePaneCollection,
+  usePaneInstanceId,
+  usePaneStateValue,
+  type CollectionSortPreference,
+} from "../../state/app-context";
 import { getAllCollections, getCollectionTickers, getCollectionType } from "../../state/selectors";
 import { colors, priceColor, hoverBg } from "../../theme/colors";
 import { formatCurrency, formatPercentRaw, formatCompact, formatNumber, padTo, convertCurrency } from "../../utils/format";
@@ -275,8 +281,6 @@ function getSortValue(
   }
 }
 
-type SortDir = "asc" | "desc";
-
 /** Position-specific columns appended when viewing a portfolio */
 const POSITION_COLUMNS: ColumnConfig[] = [
   { id: "shares", label: "SHARES", width: 9, align: "right", format: "number" },
@@ -285,6 +289,25 @@ const POSITION_COLUMNS: ColumnConfig[] = [
   { id: "pnl", label: "P&L", width: 10, align: "right", format: "compact" },
   { id: "pnl_pct", label: "P&L%", width: 8, align: "right", format: "percent" },
 ];
+
+const EMPTY_SORT_PREFERENCE: CollectionSortPreference = {
+  columnId: null,
+  direction: "asc",
+};
+
+const DEFAULT_PORTFOLIO_SORT_PREFERENCE: CollectionSortPreference = {
+  columnId: "mkt_value",
+  direction: "desc",
+};
+
+export function resolveCollectionSortPreference(
+  collectionId: string | null,
+  isPortfolio: boolean,
+  collectionSorts: Record<string, CollectionSortPreference>,
+): CollectionSortPreference {
+  if (!collectionId) return EMPTY_SORT_PREFERENCE;
+  return collectionSorts[collectionId] ?? (isPortfolio ? DEFAULT_PORTFOLIO_SORT_PREFERENCE : EMPTY_SORT_PREFERENCE);
+}
 
 function PortfolioSummaryBar({
   tickers,
@@ -436,11 +459,10 @@ function PortfolioListPane({ focused }: PaneProps) {
   const paneCollection = usePaneCollection();
   const [currentCollectionId, setCurrentCollectionId] = usePaneStateValue<string>("collectionId", paneCollection.collectionId ?? "");
   const [cursorSymbol, setCursorSymbol] = usePaneStateValue<string | null>("cursorSymbol", null);
+  const [collectionSorts, setCollectionSorts] = usePaneStateValue<Record<string, CollectionSortPreference>>("collectionSorts", {});
   const tabs = getAllCollections(state);
   const tickers = getCollectionTickers(state, currentCollectionId);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
-  const [sortCol, setSortCol] = useState<string | null>(null);
-  const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [now, setNow] = useState(Date.now());
   const [flashSymbols, setFlashSymbols] = useState<Set<string>>(new Set());
   const prevPrices = useRef<Map<string, number>>(new Map());
@@ -466,6 +488,17 @@ function PortfolioListPane({ focused }: PaneProps) {
     exchangeRates: state.exchangeRates,
     now,
   };
+  const activeSort = resolveCollectionSortPreference(currentCollectionId, isPortfolioTab, collectionSorts);
+  const sortCol = activeSort.columnId;
+  const sortDir = activeSort.direction;
+
+  const setSortPreference = useCallback((preference: CollectionSortPreference) => {
+    if (!currentCollectionId) return;
+    setCollectionSorts({
+      ...collectionSorts,
+      [currentCollectionId]: preference,
+    });
+  }, [collectionSorts, currentCollectionId, setCollectionSorts]);
 
   // Sort tickers
   const sortedTickers = useMemo(() => {
@@ -501,14 +534,12 @@ function PortfolioListPane({ focused }: PaneProps) {
     if (sortCol === colId) {
       // Toggle direction, or clear if already desc
       if (sortDir === "asc") {
-        setSortDir("desc");
+        setSortPreference({ columnId: colId, direction: "desc" });
       } else {
-        setSortCol(null);
-        setSortDir("asc");
+        setSortPreference({ columnId: null, direction: "asc" });
       }
     } else {
-      setSortCol(colId);
-      setSortDir("asc");
+      setSortPreference({ columnId: colId, direction: "asc" });
     }
   };
 

--- a/src/plugins/plugin-runtime.test.tsx
+++ b/src/plugins/plugin-runtime.test.tsx
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useEffect, useReducer } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import {
+  AppContext,
+  PaneInstanceProvider,
+  appReducer,
+  createInitialState,
+} from "../state/app-context";
+import { createDefaultConfig } from "../types/config";
+import {
+  PluginRenderProvider,
+  deletePluginPaneStateValue,
+  getPluginPaneStateValue,
+  setPluginPaneStateValue,
+  type PluginRuntimeAccess,
+  usePluginConfigState,
+  usePluginPaneState,
+  usePluginState,
+} from "./plugin-runtime";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+});
+
+describe("plugin runtime helpers", () => {
+  test("reads, writes, and deletes nested pane state under the plugin namespace", () => {
+    const initial = {
+      pluginState: {
+        news: {
+          selected: 2,
+        },
+      },
+    };
+
+    expect(getPluginPaneStateValue(initial, "news", "selected", 0)).toBe(2);
+    expect(getPluginPaneStateValue(initial, "news", "missing", 0)).toBe(0);
+    expect(setPluginPaneStateValue(initial, "news", "expanded", true)).toEqual({
+      news: {
+        selected: 2,
+        expanded: true,
+      },
+    });
+    expect(deletePluginPaneStateValue(initial, "news", "selected")).toBeUndefined();
+  });
+});
+
+describe("plugin runtime hooks", () => {
+  test("updates pane, global resume, and config state through the plugin hooks", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-plugin-runtime");
+    const stateRef: { current: ReturnType<typeof createInitialState> | null } = { current: null };
+    const dispatchRef: { current: React.Dispatch<any> | null } = { current: null };
+    const resumeState = new Map<string, unknown>();
+    const listeners = new Map<string, Set<() => void>>();
+
+    const runtime: PluginRuntimeAccess = {
+      subscribeResumeState(pluginId, key, listener) {
+        const listenerKey = `${pluginId}:${key}`;
+        if (!listeners.has(listenerKey)) listeners.set(listenerKey, new Set());
+        listeners.get(listenerKey)!.add(listener);
+        return () => {
+          const current = listeners.get(listenerKey);
+          if (!current) return;
+          current.delete(listener);
+        };
+      },
+      getResumeState(pluginId, key) {
+        return (resumeState.get(`${pluginId}:${key}`) as any) ?? null;
+      },
+      setResumeState(pluginId, key, value) {
+        const listenerKey = `${pluginId}:${key}`;
+        resumeState.set(listenerKey, value);
+        for (const listener of listeners.get(listenerKey) ?? []) listener();
+      },
+      deleteResumeState(pluginId, key) {
+        const listenerKey = `${pluginId}:${key}`;
+        resumeState.delete(listenerKey);
+        for (const listener of listeners.get(listenerKey) ?? []) listener();
+      },
+      getConfigState(pluginId, key) {
+        return (stateRef.current?.config.pluginConfig[pluginId]?.[key] as any) ?? null;
+      },
+      async setConfigState(pluginId, key, value) {
+        const currentState = stateRef.current!;
+        dispatchRef.current?.({
+          type: "SET_CONFIG",
+          config: {
+            ...currentState.config,
+            pluginConfig: {
+              ...currentState.config.pluginConfig,
+              [pluginId]: {
+                ...(currentState.config.pluginConfig[pluginId] ?? {}),
+                [key]: value,
+              },
+            },
+          },
+        });
+      },
+      async deleteConfigState(pluginId, key) {
+        const currentState = stateRef.current!;
+        const currentPluginConfig = { ...(currentState.config.pluginConfig[pluginId] ?? {}) };
+        delete currentPluginConfig[key];
+        const nextPluginConfig = { ...currentState.config.pluginConfig };
+        if (Object.keys(currentPluginConfig).length === 0) delete nextPluginConfig[pluginId];
+        else nextPluginConfig[pluginId] = currentPluginConfig;
+        dispatchRef.current?.({
+          type: "SET_CONFIG",
+          config: {
+            ...currentState.config,
+            pluginConfig: nextPluginConfig,
+          },
+        });
+      },
+      getConfigStateKeys(pluginId) {
+        return Object.keys(stateRef.current?.config.pluginConfig[pluginId] ?? {}).sort();
+      },
+    };
+
+    function HookHarness() {
+      const [state, dispatch] = useReducer(appReducer, createInitialState(config));
+      stateRef.current = state;
+      dispatchRef.current = dispatch;
+
+      return (
+        <AppContext value={{ state, dispatch }}>
+          <PaneInstanceProvider paneId="portfolio-list:main">
+            <PluginRenderProvider pluginId="news" runtime={runtime}>
+              <HookProbe />
+            </PluginRenderProvider>
+          </PaneInstanceProvider>
+        </AppContext>
+      );
+    }
+
+    function HookProbe() {
+      const [paneSelection, setPaneSelection] = usePluginPaneState<number>("selectedIdx", 0);
+      const [provider, setProvider] = usePluginState<string>("provider", "claude");
+      const [mode, setMode] = usePluginConfigState<string>("displayMode", "compact");
+
+      useEffect(() => {
+        if (paneSelection === 0) setPaneSelection(3);
+        if (provider === "claude") setProvider("codex");
+        if (mode === "compact") setMode("expanded");
+      }, [mode, paneSelection, provider, setMode, setPaneSelection, setProvider]);
+
+      return <text>{`${paneSelection}|${provider}|${mode}`}</text>;
+    }
+
+    testSetup = await testRender(<HookHarness />, { width: 40, height: 5 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("3|codex|expanded");
+    expect(stateRef.current?.paneState["portfolio-list:main"]?.pluginState).toEqual({
+      news: {
+        selectedIdx: 3,
+      },
+    });
+    expect(stateRef.current?.config.pluginConfig.news).toEqual({
+      displayMode: "expanded",
+    });
+    expect(resumeState.get("news:provider")).toBe("codex");
+  });
+});

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -1,0 +1,165 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useSyncExternalStore,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
+import { useAppState, usePaneInstanceId, type PaneRuntimeState } from "../state/app-context";
+
+export interface PluginRuntimeAccess {
+  subscribeResumeState(pluginId: string, key: string, listener: () => void): () => void;
+  getResumeState<T = unknown>(pluginId: string, key: string, schemaVersion?: number): T | null;
+  setResumeState(pluginId: string, key: string, value: unknown, schemaVersion?: number): void;
+  deleteResumeState(pluginId: string, key: string): void;
+  getConfigState<T = unknown>(pluginId: string, key: string): T | null;
+  setConfigState(pluginId: string, key: string, value: unknown): Promise<void>;
+  deleteConfigState(pluginId: string, key: string): Promise<void>;
+  getConfigStateKeys(pluginId: string): string[];
+}
+
+interface PluginRenderContextValue {
+  pluginId: string;
+  runtime: PluginRuntimeAccess;
+}
+
+const PluginRenderContext = createContext<PluginRenderContextValue | null>(null);
+
+export function PluginRenderProvider({
+  pluginId,
+  runtime,
+  children,
+}: {
+  pluginId: string;
+  runtime: PluginRuntimeAccess;
+  children: ReactNode;
+}) {
+  return (
+    <PluginRenderContext value={{ pluginId, runtime }}>
+      {children}
+    </PluginRenderContext>
+  );
+}
+
+function usePluginRenderContext(): PluginRenderContextValue {
+  const context = useContext(PluginRenderContext);
+  if (!context) {
+    throw new Error("Plugin runtime hooks must be used inside a plugin render context");
+  }
+  return context;
+}
+
+export function getPluginPaneStateValue<T>(
+  paneState: PaneRuntimeState | undefined,
+  pluginId: string,
+  key: string,
+  fallback: T,
+): T {
+  return (paneState?.pluginState?.[pluginId]?.[key] as T | undefined) ?? fallback;
+}
+
+export function setPluginPaneStateValue(
+  paneState: PaneRuntimeState | undefined,
+  pluginId: string,
+  key: string,
+  value: unknown,
+): Record<string, Record<string, unknown>> {
+  return {
+    ...(paneState?.pluginState ?? {}),
+    [pluginId]: {
+      ...(paneState?.pluginState?.[pluginId] ?? {}),
+      [key]: value,
+    },
+  };
+}
+
+export function deletePluginPaneStateValue(
+  paneState: PaneRuntimeState | undefined,
+  pluginId: string,
+  key: string,
+): Record<string, Record<string, unknown>> | undefined {
+  const pluginState = paneState?.pluginState?.[pluginId];
+  if (!pluginState || !(key in pluginState)) {
+    return paneState?.pluginState;
+  }
+
+  const nextPluginState = { ...pluginState };
+  delete nextPluginState[key];
+
+  const nextAllPluginState = { ...(paneState?.pluginState ?? {}) };
+  if (Object.keys(nextPluginState).length === 0) {
+    delete nextAllPluginState[pluginId];
+  } else {
+    nextAllPluginState[pluginId] = nextPluginState;
+  }
+
+  return Object.keys(nextAllPluginState).length > 0 ? nextAllPluginState : undefined;
+}
+
+export function usePluginPaneState<T>(key: string, fallback: T, paneId?: string): [T, (value: SetStateAction<T>) => void] {
+  const { pluginId } = usePluginRenderContext();
+  const scopedPaneId = paneId ?? usePaneInstanceId();
+  const { state, dispatch } = useAppState();
+  const paneState = state.paneState[scopedPaneId];
+  const value = getPluginPaneStateValue(paneState, pluginId, key, fallback);
+
+  const setValue = useCallback((nextValue: SetStateAction<T>) => {
+    const currentPaneState = state.paneState[scopedPaneId];
+    const currentValue = getPluginPaneStateValue(currentPaneState, pluginId, key, fallback);
+    const resolved = typeof nextValue === "function"
+      ? (nextValue as (previousValue: T) => T)(currentValue)
+      : nextValue;
+
+    dispatch({
+      type: "UPDATE_PANE_STATE",
+      paneId: scopedPaneId,
+      patch: {
+        pluginState: setPluginPaneStateValue(currentPaneState, pluginId, key, resolved),
+      },
+    });
+  }, [dispatch, fallback, key, pluginId, scopedPaneId, state.paneState]);
+
+  return [value, setValue];
+}
+
+export function usePluginState<T>(key: string, fallback: T, options?: { schemaVersion?: number }): [T, (value: SetStateAction<T>) => void] {
+  const { pluginId, runtime } = usePluginRenderContext();
+  const schemaVersion = options?.schemaVersion;
+
+  const subscribe = useCallback((listener: () => void) => (
+    runtime.subscribeResumeState(pluginId, key, listener)
+  ), [key, pluginId, runtime]);
+
+  const getSnapshot = useCallback(() => (
+    runtime.getResumeState<T>(pluginId, key, schemaVersion) ?? fallback
+  ), [fallback, key, pluginId, runtime, schemaVersion]);
+
+  const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const setValue = useCallback((nextValue: SetStateAction<T>) => {
+    const currentValue = runtime.getResumeState<T>(pluginId, key, schemaVersion) ?? fallback;
+    const resolved = typeof nextValue === "function"
+      ? (nextValue as (previousValue: T) => T)(currentValue)
+      : nextValue;
+    runtime.setResumeState(pluginId, key, resolved, schemaVersion);
+  }, [fallback, key, pluginId, runtime, schemaVersion]);
+
+  return [value, setValue];
+}
+
+export function usePluginConfigState<T>(key: string, fallback: T): [T, (value: SetStateAction<T>) => void] {
+  const { pluginId, runtime } = usePluginRenderContext();
+  const { state } = useAppState();
+  const value = (state.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? fallback;
+
+  const setValue = useCallback((nextValue: SetStateAction<T>) => {
+    const currentValue = (state.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? fallback;
+    const resolved = typeof nextValue === "function"
+      ? (nextValue as (previousValue: T) => T)(currentValue)
+      : nextValue;
+    void runtime.setConfigState(pluginId, key, resolved);
+  }, [fallback, key, pluginId, runtime, state.config.pluginConfig]);
+
+  return [value, setValue];
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,5 +1,6 @@
 import type { CliRenderer } from "@opentui/core";
 import { createReactSlotRegistry, createSlot } from "@opentui/react";
+import { createElement } from "react";
 import type { AppPersistence } from "../data/app-persistence";
 import type { TickerRepository } from "../data/ticker-repository";
 import type { BrokerAdapter } from "../types/broker";
@@ -16,6 +17,7 @@ import type {
   KeyboardShortcut,
   PaneDef,
   PluginStorage,
+  PluginResumeState,
   TickerAction,
 } from "../types/plugin";
 import type { TickerRecord } from "../types/ticker";
@@ -23,6 +25,8 @@ import { addPaneFloating, removePane } from "./pane-manager";
 import { EventBus, type PluginEvents } from "./event-bus";
 import { createPaneInstance } from "../types/config";
 import { createPluginPersistence, createPluginStorage } from "./plugin-persistence";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "./plugin-runtime";
+import type { PaneRuntimeState } from "../state/app-context";
 
 let sharedDataProvider: DataProvider | undefined;
 let sharedRegistry: PluginRegistry | undefined;
@@ -49,6 +53,7 @@ export class PluginRegistry {
   private pluginItems = new Map<string, PluginItems>();
   private commandOwners = new Map<string, string>();
   private shortcutOwners = new Map<string, string>();
+  private pluginResumeListeners = new Map<string, Set<() => void>>();
 
   private panesMap = new Map<string, PaneDef>();
   private commandsMap = new Map<string, CommandDef>();
@@ -88,6 +93,11 @@ export class PluginRegistry {
   getTermSizeFn: (() => { width: number; height: number }) = () => ({ width: 120, height: 40 });
 
   showToastFn: ((message: string, options?: { duration?: number; type?: "info" | "success" | "error" }) => void) = () => {};
+  getPaneRuntimeStateFn: ((paneId: string) => PaneRuntimeState | null) = () => null;
+  updatePaneRuntimeStateFn: ((paneId: string, patch: Partial<PaneRuntimeState>) => void) = () => {};
+  getPluginConfigValueFn: (<T = unknown>(pluginId: string, key: string) => T | null) = () => null;
+  setPluginConfigValueFn: ((pluginId: string, key: string, value: unknown) => Promise<void>) = async () => {};
+  deletePluginConfigValueFn: ((pluginId: string, key: string) => Promise<void>) = async () => {};
 
   readonly Slot;
 
@@ -122,6 +132,100 @@ export class PluginRegistry {
 
   getPluginPaneIds(pluginId: string): string[] {
     return this.pluginItems.get(pluginId)?.panes ?? [];
+  }
+
+  private getOrCreatePluginItems(pluginId: string): PluginItems {
+    const existing = this.pluginItems.get(pluginId);
+    if (existing) return existing;
+
+    const items: PluginItems = {
+      panes: [],
+      commands: [],
+      columns: [],
+      brokers: [],
+      dataProviders: [],
+      detailTabs: [],
+      shortcuts: [],
+      tickerActions: [],
+      eventDisposers: [],
+    };
+    this.pluginItems.set(pluginId, items);
+    return items;
+  }
+
+  private wrapPaneDef(pluginId: string, pane: PaneDef): PaneDef {
+    return {
+      ...pane,
+      component: (props) => createElement(
+        PluginRenderProvider,
+        { pluginId, runtime: this },
+        createElement(pane.component as any, props),
+      ),
+    };
+  }
+
+  private wrapDetailTabDef(pluginId: string, tab: DetailTabDef): DetailTabDef {
+    return {
+      ...tab,
+      component: (props) => createElement(
+        PluginRenderProvider,
+        { pluginId, runtime: this },
+        createElement(tab.component as any, props),
+      ),
+    };
+  }
+
+  private emitResumeState(pluginId: string, key: string): void {
+    const listenerKey = `${pluginId}:${key}`;
+    for (const listener of this.pluginResumeListeners.get(listenerKey) ?? []) {
+      listener();
+    }
+  }
+
+  subscribeResumeState(pluginId: string, key: string, listener: () => void): () => void {
+    const listenerKey = `${pluginId}:${key}`;
+    if (!this.pluginResumeListeners.has(listenerKey)) {
+      this.pluginResumeListeners.set(listenerKey, new Set());
+    }
+    this.pluginResumeListeners.get(listenerKey)!.add(listener);
+    return () => {
+      const listeners = this.pluginResumeListeners.get(listenerKey);
+      if (!listeners) return;
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        this.pluginResumeListeners.delete(listenerKey);
+      }
+    };
+  }
+
+  getResumeState<T = unknown>(pluginId: string, key: string, schemaVersion?: number): T | null {
+    return this.persistence.pluginState.get<T>(pluginId, `resume:${key}`, schemaVersion)?.value ?? null;
+  }
+
+  setResumeState(pluginId: string, key: string, value: unknown, schemaVersion?: number): void {
+    this.persistence.pluginState.set(pluginId, `resume:${key}`, value, schemaVersion);
+    this.emitResumeState(pluginId, key);
+  }
+
+  deleteResumeState(pluginId: string, key: string): void {
+    this.persistence.pluginState.delete(pluginId, `resume:${key}`);
+    this.emitResumeState(pluginId, key);
+  }
+
+  getConfigState<T = unknown>(pluginId: string, key: string): T | null {
+    return this.getPluginConfigValueFn<T>(pluginId, key);
+  }
+
+  setConfigState(pluginId: string, key: string, value: unknown): Promise<void> {
+    return this.setPluginConfigValueFn(pluginId, key, value);
+  }
+
+  deleteConfigState(pluginId: string, key: string): Promise<void> {
+    return this.deletePluginConfigValueFn(pluginId, key);
+  }
+
+  getConfigStateKeys(pluginId: string): string[] {
+    return Object.keys(this.getConfigFn().pluginConfig[pluginId] ?? {}).sort();
   }
 
   private resolvePrimaryPaneInstanceId(paneId: string): string | undefined {
@@ -195,26 +299,50 @@ export class PluginRegistry {
   }
 
   private createContext(pluginId: string): GloomPluginContext {
-    const items: PluginItems = {
-      panes: [],
-      commands: [],
-      columns: [],
-      brokers: [],
-      dataProviders: [],
-      detailTabs: [],
-      shortcuts: [],
-      tickerActions: [],
-      eventDisposers: [],
-    };
-    this.pluginItems.set(pluginId, items);
+    const items = this.getOrCreatePluginItems(pluginId);
 
     const pluginNamespace = `plugin:${pluginId}`;
 
     const storage: PluginStorage = createPluginStorage(this.persistence.pluginState, pluginId);
     const persistence = createPluginPersistence(this.persistence.pluginState, this.persistence.resources, pluginNamespace, pluginId);
+    const resume: PluginResumeState = {
+      getState: (key, options) => this.getResumeState(pluginId, key, options?.schemaVersion),
+      setState: (key, value, options) => this.setResumeState(pluginId, key, value, options?.schemaVersion),
+      deleteState: (key) => this.deleteResumeState(pluginId, key),
+      getPaneState: (paneId, key) => (
+        this.getPaneRuntimeStateFn(paneId)?.pluginState?.[pluginId]?.[key] ?? null
+      ),
+      setPaneState: (paneId, key, value) => {
+        const currentPaneState = this.getPaneRuntimeStateFn(paneId) ?? {};
+        const pluginState = {
+          ...(currentPaneState.pluginState ?? {}),
+          [pluginId]: {
+            ...(currentPaneState.pluginState?.[pluginId] ?? {}),
+            [key]: value,
+          },
+        };
+        this.updatePaneRuntimeStateFn(paneId, { pluginState });
+      },
+      deletePaneState: (paneId, key) => {
+        const currentPaneState = this.getPaneRuntimeStateFn(paneId) ?? {};
+        const currentPluginState = currentPaneState.pluginState?.[pluginId];
+        if (!currentPluginState || !(key in currentPluginState)) return;
+        const nextPluginState = { ...currentPluginState };
+        delete nextPluginState[key];
+        const nextAllPluginState = { ...(currentPaneState.pluginState ?? {}) };
+        if (Object.keys(nextPluginState).length === 0) {
+          delete nextAllPluginState[pluginId];
+        } else {
+          nextAllPluginState[pluginId] = nextPluginState;
+        }
+        this.updatePaneRuntimeStateFn(paneId, {
+          pluginState: Object.keys(nextAllPluginState).length > 0 ? nextAllPluginState : undefined,
+        });
+      },
+    };
 
     return {
-      registerPane: (pane) => { this.panesMap.set(pane.id, pane); items.panes.push(pane.id); },
+      registerPane: (pane) => { this.panesMap.set(pane.id, this.wrapPaneDef(pluginId, pane)); items.panes.push(pane.id); },
       registerCommand: (command) => {
         this.commandsMap.set(command.id, command);
         this.commandOwners.set(command.id, pluginId);
@@ -223,7 +351,7 @@ export class PluginRegistry {
       registerColumn: (column) => { this.columnsMap.set(column.id, column); items.columns.push(column.id); },
       registerBroker: (broker) => { this.brokersMap.set(broker.id, broker); items.brokers.push(broker.id); },
       registerDataProvider: (provider) => { this.dataProvidersMap.set(provider.id, provider); items.dataProviders.push(provider.id); },
-      registerDetailTab: (tab) => { this.detailTabsMap.set(tab.id, tab); items.detailTabs.push(tab.id); },
+      registerDetailTab: (tab) => { this.detailTabsMap.set(tab.id, this.wrapDetailTabDef(pluginId, tab)); items.detailTabs.push(tab.id); },
       registerShortcut: (shortcut) => {
         this.shortcutsMap.set(shortcut.id, shortcut);
         this.shortcutOwners.set(shortcut.id, pluginId);
@@ -239,6 +367,13 @@ export class PluginRegistry {
       tickerRepository: this.tickerRepository,
       storage,
       persistence,
+      resume,
+      configState: {
+        get: (key) => this.getConfigState(pluginId, key),
+        set: (key, value) => this.setConfigState(pluginId, key, value),
+        delete: (key) => this.deleteConfigState(pluginId, key),
+        keys: () => this.getConfigStateKeys(pluginId),
+      },
 
       createBrokerInstance: (brokerType, label, values) => this.createBrokerInstanceFn(brokerType, label, values),
       updateBrokerInstance: (instanceId, values) => this.updateBrokerInstanceFn(instanceId, values),
@@ -268,18 +403,23 @@ export class PluginRegistry {
   }
 
   async register(plugin: GloomPlugin): Promise<void> {
+    const items = this.getOrCreatePluginItems(plugin.id);
+
     if (plugin.panes) {
       for (const pane of plugin.panes) {
-        this.panesMap.set(pane.id, pane);
+        this.panesMap.set(pane.id, this.wrapPaneDef(plugin.id, pane));
+        items.panes.push(pane.id);
       }
     }
 
     if (plugin.broker) {
       this.brokersMap.set(plugin.broker.id, plugin.broker);
+      items.brokers.push(plugin.broker.id);
     }
 
     if (plugin.dataProvider) {
       this.dataProvidersMap.set(plugin.dataProvider.id, plugin.dataProvider);
+      items.dataProviders.push(plugin.dataProvider.id);
     }
 
     if (plugin.slots) {
@@ -291,7 +431,11 @@ export class PluginRegistry {
 
       for (const [slotName, renderer] of Object.entries(plugin.slots)) {
         if (renderer) {
-          corePlugin.slots[slotName] = (_ctx: unknown, props: unknown) => (renderer as any)(props);
+          corePlugin.slots[slotName] = (_ctx: unknown, props: unknown) => createElement(
+            PluginRenderProvider,
+            { pluginId: plugin.id, runtime: this },
+            (renderer as any)(props),
+          );
         }
       }
 

--- a/src/state/app-context.test.ts
+++ b/src/state/app-context.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { createInitialState, resolveTickerForPane } from "./app-context";
+import { appReducer, createInitialState, resolveCollectionForPane, resolveTickerForPane } from "./app-context";
 import { createDefaultConfig, createPaneInstance } from "../types/config";
+import type { AppSessionSnapshot } from "./session-persistence";
+import { buildBrokerPortfolioId } from "../utils/broker-instances";
 
 describe("resolveTickerForPane", () => {
   test("uses a portfolio pane cursor for inspector follow panes", () => {
@@ -33,5 +35,121 @@ describe("resolveTickerForPane", () => {
 
     const state = createInitialState(config);
     expect(resolveTickerForPane(state, instance.instanceId)).toBe("MSFT");
+  });
+
+  test("hydrates remembered pane-local tab and sort state from the previous session", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const sessionSnapshot: AppSessionSnapshot = {
+      paneState: {
+        "portfolio-list:main": {
+          collectionId: "watchlist",
+          collectionSorts: {
+            watchlist: { columnId: "change_pct", direction: "desc" },
+          },
+        },
+        "ticker-detail:main": {
+          activeTabId: "financials",
+        },
+      },
+      focusedPaneId: "ticker-detail:main",
+      activePanel: "right",
+      statusBarVisible: true,
+      openPaneIds: ["portfolio-list:main", "ticker-detail:main"],
+      hydrationTargets: [],
+      exchangeCurrencies: ["USD"],
+      savedAt: Date.now(),
+    };
+
+    const state = createInitialState(config, sessionSnapshot);
+
+    expect(state.paneState["portfolio-list:main"]).toEqual({
+      collectionId: "watchlist",
+      cursorSymbol: null,
+      collectionSorts: {
+        watchlist: { columnId: "change_pct", direction: "desc" },
+      },
+    });
+    expect(state.paneState["ticker-detail:main"]).toEqual({
+      activeTabId: "financials",
+    });
+    expect(state.focusedPaneId).toBe("ticker-detail:main");
+  });
+
+  test("preserves broker portfolio selection until broker portfolios are restored", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const brokerPortfolioId = buildBrokerPortfolioId("ibkr-live", "DU12345");
+    const sessionSnapshot: AppSessionSnapshot = {
+      paneState: {
+        "portfolio-list:main": {
+          collectionId: brokerPortfolioId,
+          cursorSymbol: "AAPL",
+        },
+      },
+      focusedPaneId: "portfolio-list:main",
+      activePanel: "left",
+      statusBarVisible: true,
+      openPaneIds: ["portfolio-list:main", "ticker-detail:main"],
+      hydrationTargets: [],
+      exchangeCurrencies: ["USD"],
+      savedAt: Date.now(),
+    };
+
+    const initial = createInitialState(config, sessionSnapshot);
+
+    expect(initial.paneState["portfolio-list:main"]).toEqual({
+      collectionId: brokerPortfolioId,
+      cursorSymbol: "AAPL",
+    });
+    expect(resolveCollectionForPane(initial, "portfolio-list:main")).toBe(brokerPortfolioId);
+    expect(resolveCollectionForPane(initial, "ticker-detail:main")).toBe(brokerPortfolioId);
+
+    const nextConfig = {
+      ...config,
+      portfolios: [
+        ...config.portfolios,
+        {
+          id: brokerPortfolioId,
+          name: "IBKR DU12345",
+          currency: "USD",
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-live",
+          brokerAccountId: "DU12345",
+        },
+      ],
+    };
+
+    const next = appReducer(initial, { type: "SET_CONFIG", config: nextConfig });
+
+    expect(next.paneState["portfolio-list:main"]).toEqual({
+      collectionId: brokerPortfolioId,
+      cursorSymbol: "AAPL",
+    });
+    expect(resolveCollectionForPane(next, "portfolio-list:main")).toBe(brokerPortfolioId);
+  });
+
+  test("falls back for unknown non-broker collection ids", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const sessionSnapshot: AppSessionSnapshot = {
+      paneState: {
+        "portfolio-list:main": {
+          collectionId: "missing-collection",
+        },
+      },
+      focusedPaneId: "portfolio-list:main",
+      activePanel: "left",
+      statusBarVisible: true,
+      openPaneIds: ["portfolio-list:main", "ticker-detail:main"],
+      hydrationTargets: [],
+      exchangeCurrencies: ["USD"],
+      savedAt: Date.now(),
+    };
+
+    const state = createInitialState(config, sessionSnapshot);
+
+    expect(state.paneState["portfolio-list:main"]).toEqual({
+      collectionId: "main",
+      cursorSymbol: null,
+    });
+    expect(resolveCollectionForPane(state, "portfolio-list:main")).toBe("main");
   });
 });

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -10,6 +10,7 @@ import {
 import type { SessionStore } from "../data/session-store";
 import { saveConfig } from "../data/config-store";
 import { applyTheme } from "../theme/colors";
+import { isBrokerPortfolioId } from "../utils/broker-instances";
 import {
   cloneLayout,
   DEFAULT_LAYOUT,
@@ -34,7 +35,16 @@ export interface PaneRuntimeState {
   cursorSymbol?: string | null;
   collectionId?: string;
   activeTabId?: string;
+  collectionSorts?: Record<string, CollectionSortPreference>;
+  pluginState?: Record<string, Record<string, unknown>>;
   [key: string]: unknown;
+}
+
+export type SortDirection = "asc" | "desc";
+
+export interface CollectionSortPreference {
+  columnId: string | null;
+  direction: SortDirection;
 }
 
 export interface AppState {
@@ -99,6 +109,10 @@ function isKnownCollection(config: AppConfig, collectionId: string | undefined):
     || config.watchlists.some((watchlist) => watchlist.id === collectionId);
 }
 
+function shouldPreserveUnknownCollectionId(collectionId: string | undefined): boolean {
+  return isBrokerPortfolioId(collectionId);
+}
+
 function defaultPaneStateForInstance(config: AppConfig, instance: PaneInstanceConfig): PaneRuntimeState {
   if (instance.paneId === "portfolio-list") {
     const candidate = instance.params?.collectionId;
@@ -118,7 +132,11 @@ function reconcilePaneState(config: AppConfig, previous: Record<string, PaneRunt
   for (const instance of config.layout.instances) {
     const defaults = defaultPaneStateForInstance(config, instance);
     const paneState = { ...defaults, ...(previous[instance.instanceId] ?? {}) };
-    if (instance.paneId === "portfolio-list" && !isKnownCollection(config, paneState.collectionId as string | undefined)) {
+    if (
+      instance.paneId === "portfolio-list"
+      && !isKnownCollection(config, paneState.collectionId as string | undefined)
+      && !shouldPreserveUnknownCollectionId(paneState.collectionId as string | undefined)
+    ) {
       paneState.collectionId = defaults.collectionId;
     }
     next[instance.instanceId] = paneState;
@@ -162,7 +180,10 @@ export function resolveCollectionForPane(state: AppState, paneId: string, seen =
     const collectionId = typeof paneState.collectionId === "string"
       ? paneState.collectionId
       : instance.params?.collectionId;
-    return isKnownCollection(state.config, collectionId) ? collectionId : getDefaultCollectionId(state.config);
+    if (isKnownCollection(state.config, collectionId) || shouldPreserveUnknownCollectionId(collectionId)) {
+      return collectionId;
+    }
+    return getDefaultCollectionId(state.config);
   }
   if (instance.binding?.kind === "follow") {
     return resolveCollectionForPane(state, instance.binding.sourceInstanceId, seen);

--- a/src/state/session-persistence.test.ts
+++ b/src/state/session-persistence.test.ts
@@ -42,7 +42,14 @@ describe("session persistence", () => {
     const snapshot = buildAppSessionSnapshot({
       config,
       paneState: {
-        "portfolio-list:main": { cursorSymbol: "AAPL", collectionId: "main" },
+        "portfolio-list:main": {
+          cursorSymbol: "AAPL",
+          collectionId: "main",
+          collectionSorts: {
+            main: { columnId: "mkt_value", direction: "desc" },
+          },
+        },
+        "ticker-detail:main": { activeTabId: "financials" },
       },
       focusedPaneId: "ticker-detail:main",
       activePanel: "right",
@@ -57,6 +64,14 @@ describe("session persistence", () => {
     expect(snapshot.hydrationTargets).toHaveLength(1);
     expect(snapshot.hydrationTargets[0]?.symbol).toBe("AAPL");
     expect(snapshot.exchangeCurrencies).toContain("JPY");
+    expect(snapshot.paneState["portfolio-list:main"]).toEqual({
+      cursorSymbol: "AAPL",
+      collectionId: "main",
+      collectionSorts: {
+        main: { columnId: "mkt_value", direction: "desc" },
+      },
+    });
+    expect(snapshot.paneState["ticker-detail:main"]).toEqual({ activeTabId: "financials" });
   });
 
   test("reconciles pane state and broker references against the current config", () => {
@@ -76,7 +91,14 @@ describe("session persistence", () => {
 
     const reconciled = reconcileAppSessionSnapshot(config, {
       paneState: {
-        "portfolio-list:main": { cursorSymbol: "AAPL" },
+        "portfolio-list:main": {
+          cursorSymbol: "AAPL",
+          collectionId: "main",
+          collectionSorts: {
+            main: { columnId: "mkt_value", direction: "desc" },
+          },
+        },
+        "ticker-detail:main": { activeTabId: "chart" },
         "missing:pane": { cursorSymbol: "MSFT" },
       },
       focusedPaneId: "missing:pane",
@@ -91,7 +113,14 @@ describe("session persistence", () => {
       savedAt: Date.now(),
     });
 
-    expect(reconciled?.paneState["portfolio-list:main"]).toEqual({ cursorSymbol: "AAPL" });
+    expect(reconciled?.paneState["portfolio-list:main"]).toEqual({
+      cursorSymbol: "AAPL",
+      collectionId: "main",
+      collectionSorts: {
+        main: { columnId: "mkt_value", direction: "desc" },
+      },
+    });
+    expect(reconciled?.paneState["ticker-detail:main"]).toEqual({ activeTabId: "chart" });
     expect(reconciled?.paneState["missing:pane"]).toBeUndefined();
     expect(reconciled?.focusedPaneId).toBe("portfolio-list:main");
     expect(reconciled?.hydrationTargets).toEqual([{ symbol: "AAPL", brokerInstanceId: "ibkr-live", brokerId: "ibkr", exchange: undefined, instrument: null }]);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,6 @@
 import type { Portfolio, Watchlist } from "./ticker";
 
-export const CURRENT_CONFIG_VERSION = 6;
+export const CURRENT_CONFIG_VERSION = 7;
 
 export type DefaultChartRenderMode = "area" | "line" | "candles" | "ohlc";
 
@@ -84,6 +84,7 @@ export interface AppConfig {
   brokerInstances: BrokerInstanceConfig[];
   plugins: string[];
   disabledPlugins: string[];
+  pluginConfig: Record<string, Record<string, unknown>>;
   theme: string;
   chartPreferences: ChartPreferences;
   recentTickers: string[];
@@ -267,6 +268,7 @@ export function createDefaultConfig(dataDir: string): AppConfig {
     brokerInstances: [],
     plugins: ["portfolio-list", "ticker-detail", "manual-entry", "ibkr"],
     disabledPlugins: [],
+    pluginConfig: {},
     theme: "amber",
     chartPreferences: {
       defaultRenderMode: "area",

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -128,6 +128,22 @@ export interface PluginPersistence {
   deleteResource(kind: string, key: string, options?: { sourceKey?: string }): void;
 }
 
+export interface PluginResumeState {
+  getState<T = unknown>(key: string, options?: { schemaVersion?: number }): T | null;
+  setState(key: string, value: unknown, options?: { schemaVersion?: number }): void;
+  deleteState(key: string): void;
+  getPaneState<T = unknown>(paneId: string, key: string): T | null;
+  setPaneState(paneId: string, key: string, value: unknown): void;
+  deletePaneState(paneId: string, key: string): void;
+}
+
+export interface PluginConfigState {
+  get<T = unknown>(key: string): T | null;
+  set(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+  keys(): string[];
+}
+
 export interface GloomPluginContext {
   registerPane(pane: PaneDef): void;
   registerCommand(command: CommandDef): void;
@@ -146,6 +162,8 @@ export interface GloomPluginContext {
   readonly tickerRepository: TickerRepository;
   readonly storage: PluginStorage;
   readonly persistence: PluginPersistence;
+  readonly resume: PluginResumeState;
+  readonly configState: PluginConfigState;
 
   createBrokerInstance(brokerType: string, label: string, values: Record<string, unknown>): Promise<BrokerInstanceConfig>;
   updateBrokerInstance(instanceId: string, values: Record<string, unknown>): Promise<void>;

--- a/src/utils/broker-instances.ts
+++ b/src/utils/broker-instances.ts
@@ -27,6 +27,10 @@ export function buildBrokerPortfolioId(brokerInstanceId: string, accountId?: str
   return `broker:${brokerInstanceId}:${accountId?.trim() || "default"}`;
 }
 
+export function isBrokerPortfolioId(collectionId: string | undefined | null): collectionId is string {
+  return typeof collectionId === "string" && collectionId.startsWith("broker:");
+}
+
 export function getBrokerInstance(
   brokerInstances: BrokerInstanceConfig[],
   instanceId: string | undefined,


### PR DESCRIPTION
This changes the app resume path so pane selections, detail tabs, and per-collection portfolio sorting are restored across relaunches, with portfolio tabs defaulting to market value sorting. It also preserves broker-generated portfolio IDs during startup so IBKR-managed portfolios can reopen before broker sync has recreated them in config. On top of that, it adds plugin-facing resume and config APIs (ctx.resume, ctx.configState, usePluginState, usePluginPaneState, and usePluginConfigState) and wires plugin render contexts through panes, detail tabs, and slots. Ask AI, News, and Chat now use the new persistence surfaces, and the change is covered by new hook/config tests plus the existing full test and build passes.