### PR TITLE
Render charts with Kitty graphics and fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "bun run --watch src/index.tsx",
     "build": "bun run scripts/build.ts",
     "build:all": "bun run scripts/build.ts --all",
+    "poc:framebuffer-chart": "bun run src/poc/framebuffer-chart.tsx",
     "test": "bun test",
     "postinstall": "node install.mjs"
   },

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -710,6 +710,28 @@ export interface RenderChartOptions {
   colors: ResolvedChartPalette;
 }
 
+export interface ChartScene {
+  points: ProjectedChartPoint[];
+  width: number;
+  height: number;
+  showVolume: boolean;
+  volumeHeight: number;
+  chartRows: number;
+  mode: ChartRenderMode;
+  colors: ResolvedChartPalette;
+  min: number;
+  max: number;
+  activeIdx: number;
+  activePoint: ProjectedChartPoint;
+  priceAtCursor: number;
+  dateAtCursor: Date;
+  changeAtCursor: number;
+  changePctAtCursor: number;
+  timeLabels: string;
+  cursorX: number | null;
+  cursorRow: number | null;
+}
+
 export interface RenderChartResult {
   lines: StyledContent[];
   axisLabels: { row: number; label: string }[];
@@ -719,15 +741,74 @@ export interface RenderChartResult {
   dateAtCursor: Date | null;
   changeAtCursor: number | null;
   changePctAtCursor: number | null;
+  cursorRow: number | null;
   /** Raw pixel buffer for GPU/Kitty rendering path */
   pixelBuffer: PixelBuffer | null;
+}
+
+export function getActivePointIndex(pointCount: number, width: number, cursorX: number | null): number {
+  if (pointCount <= 0) return 0;
+  if (cursorX === null || cursorX < 0 || cursorX >= width) {
+    return pointCount - 1;
+  }
+  return Math.min(
+    Math.max(Math.round((cursorX / Math.max(width - 1, 1)) * (pointCount - 1)), 0),
+    pointCount - 1,
+  );
+}
+
+export function buildChartScene(
+  points: ProjectedChartPoint[],
+  opts: RenderChartOptions,
+): ChartScene | null {
+  if (points.length === 0) return null;
+
+  const min = opts.mode === "candles" || opts.mode === "ohlc"
+    ? Math.min(...points.map((point) => point.low))
+    : Math.min(...points.map((point) => point.close));
+  const max = opts.mode === "candles" || opts.mode === "ohlc"
+    ? Math.max(...points.map((point) => point.high))
+    : Math.max(...points.map((point) => point.close));
+  const activeIdx = getActivePointIndex(points.length, opts.width, opts.cursorX);
+  const activePoint = points[activeIdx]!;
+  const range = max - min || 1;
+  const chartRows = opts.height - (opts.showVolume ? opts.volumeHeight : 0);
+  const cursorRow = opts.cursorX === null
+    ? null
+    : Math.min(
+      Math.max(Math.round((1 - (activePoint.close - min) / range) * Math.max(chartRows - 1, 0)), 0),
+      Math.max(chartRows - 1, 0),
+    );
+
+  return {
+    points,
+    width: opts.width,
+    height: opts.height,
+    showVolume: opts.showVolume,
+    volumeHeight: opts.volumeHeight,
+    chartRows,
+    mode: opts.mode,
+    colors: opts.colors,
+    min,
+    max,
+    activeIdx,
+    activePoint,
+    priceAtCursor: activePoint.close,
+    dateAtCursor: activePoint.date,
+    changeAtCursor: activePoint.close - points[0]!.close,
+    changePctAtCursor: points[0]!.close ? ((activePoint.close - points[0]!.close) / points[0]!.close) * 100 : 0,
+    timeLabels: buildTimeAxis(points.map((point) => point.date), opts.width),
+    cursorX: opts.cursorX,
+    cursorRow,
+  };
 }
 
 export function renderChart(
   points: ProjectedChartPoint[],
   opts: RenderChartOptions,
 ): RenderChartResult {
-  if (points.length === 0) {
+  const scene = buildChartScene(points, opts);
+  if (!scene) {
     return {
       lines: [],
       axisLabels: [],
@@ -737,6 +818,7 @@ export function renderChart(
       dateAtCursor: null,
       changeAtCursor: null,
       changePctAtCursor: null,
+      cursorRow: null,
       pixelBuffer: null,
     };
   }
@@ -753,12 +835,7 @@ export function renderChart(
   const volDotBottom = totalDotH - 1;
 
   const buf = createPixelBuffer(dotWidth, totalDotH);
-  const min = mode === "candles" || mode === "ohlc"
-    ? Math.min(...points.map((point) => point.low))
-    : Math.min(...points.map((point) => point.close));
-  const max = mode === "candles" || mode === "ohlc"
-    ? Math.max(...points.map((point) => point.high))
-    : Math.max(...points.map((point) => point.close));
+  const { min, max } = scene;
 
   const gridLines = computeGridLines(min, max, 0, chartDotBottom, 3);
   drawGridLines(buf, gridLines.map((line) => line.y), palette.gridColor);
@@ -791,17 +868,7 @@ export function renderChart(
   }
 
   // Cursor mapping stays in terminal-column space
-  const activeIdx = opts.cursorX !== null && opts.cursorX >= 0 && opts.cursorX < width
-    ? Math.min(
-      Math.max(Math.round((opts.cursorX / Math.max(width - 1, 1)) * (points.length - 1)), 0),
-      points.length - 1,
-    )
-    : points.length - 1;
-  const activePoint = points[activeIdx]!;
-  const priceAtCursor = activePoint.close;
-  const dateAtCursor = activePoint.date;
-  const changeAtCursor = activePoint.close - points[0]!.close;
-  const changePctAtCursor = points[0]!.close ? ((activePoint.close - points[0]!.close) / points[0]!.close) * 100 : 0;
+  const { activePoint, priceAtCursor, dateAtCursor, changeAtCursor, changePctAtCursor } = scene;
 
   if (opts.cursorX !== null) {
     // Map terminal column to dot column (center of the cell)
@@ -821,6 +888,7 @@ export function renderChart(
     dateAtCursor,
     changeAtCursor,
     changePctAtCursor,
+    cursorRow: scene.cursorRow,
     pixelBuffer: buf,
   };
 }

--- a/src/components/chart/chart-types.ts
+++ b/src/components/chart/chart-types.ts
@@ -2,9 +2,12 @@ import type { PricePoint } from "../../types/financials";
 
 export type TimeRange = "1W" | "1M" | "3M" | "6M" | "1Y" | "5Y" | "ALL";
 export type ChartRenderMode = "area" | "line" | "candles" | "ohlc";
+export type ChartRendererPreference = "auto" | "kitty" | "braille";
+export type ResolvedChartRenderer = "kitty" | "braille";
 
 export const TIME_RANGES: TimeRange[] = ["1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
 export const CHART_RENDER_MODES: ChartRenderMode[] = ["area", "line", "candles", "ohlc"];
+export const CHART_RENDERER_PREFERENCES: ChartRendererPreference[] = ["auto", "kitty", "braille"];
 
 /** Number of trading days for each time range */
 export const RANGE_DAYS: Record<TimeRange, number> = {

--- a/src/components/chart/native/chart-rasterizer.ts
+++ b/src/components/chart/native/chart-rasterizer.ts
@@ -1,0 +1,500 @@
+import type { PixelResolution } from "@opentui/core";
+import { computeGridLines, type ChartScene } from "../chart-renderer";
+import type { ChartRenderMode } from "../chart-types";
+
+interface RgbaColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export interface CellRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PixelRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface NativeChartBitmap {
+  width: number;
+  height: number;
+  pixels: Uint8Array;
+}
+
+export interface NativePlacement {
+  column: number;
+  row: number;
+  cols: number;
+  rows: number;
+  cropX: number;
+  cropY: number;
+  cropWidth: number;
+  cropHeight: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+function smoothstep(edge0: number, edge1: number, value: number): number {
+  const range = edge1 - edge0;
+  if (range === 0) return value < edge0 ? 0 : 1;
+  const t = clamp((value - edge0) / range, 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+function parseHex(hex: string, alpha = 1): RgbaColor {
+  const normalized = hex.replace("#", "");
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+    a: Math.round(clamp(alpha, 0, 1) * 255),
+  };
+}
+
+function blendPixel(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+  color: RgbaColor,
+  opacity = 1,
+) {
+  if (x < 0 || y < 0 || x >= width || y >= height) return;
+
+  const alpha = clamp((color.a / 255) * opacity, 0, 1);
+  if (alpha <= 0) return;
+
+  const index = (y * width + x) * 4;
+  const dstAlpha = data[index + 3]! / 255;
+  const outAlpha = alpha + dstAlpha * (1 - alpha);
+
+  if (outAlpha <= 0) return;
+
+  const dstFactor = dstAlpha * (1 - alpha);
+  data[index] = Math.round((color.r * alpha + data[index]! * dstFactor) / outAlpha);
+  data[index + 1] = Math.round((color.g * alpha + data[index + 1]! * dstFactor) / outAlpha);
+  data[index + 2] = Math.round((color.b * alpha + data[index + 2]! * dstFactor) / outAlpha);
+  data[index + 3] = Math.round(outAlpha * 255);
+}
+
+function drawLine(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  color: RgbaColor,
+  thickness: number,
+) {
+  const half = thickness / 2;
+  const minX = Math.floor(Math.min(x0, x1) - half - 1);
+  const maxX = Math.ceil(Math.max(x0, x1) + half + 1);
+  const minY = Math.floor(Math.min(y0, y1) - half - 1);
+  const maxY = Math.ceil(Math.max(y0, y1) + half + 1);
+  const dx = x1 - x0;
+  const dy = y1 - y0;
+  const segmentLengthSq = dx * dx + dy * dy || 1;
+
+  for (let py = minY; py <= maxY; py++) {
+    for (let px = minX; px <= maxX; px++) {
+      const cx = px + 0.5;
+      const cy = py + 0.5;
+      const projection = clamp(((cx - x0) * dx + (cy - y0) * dy) / segmentLengthSq, 0, 1);
+      const nearestX = x0 + dx * projection;
+      const nearestY = y0 + dy * projection;
+      const distance = Math.hypot(cx - nearestX, cy - nearestY);
+      const coverage = 1 - smoothstep(half, half + 1.1, distance);
+      if (coverage > 0) {
+        blendPixel(data, width, height, px, py, color, coverage);
+      }
+    }
+  }
+}
+
+function fillRect(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  left: number,
+  top: number,
+  right: number,
+  bottom: number,
+  color: RgbaColor,
+  opacity = 1,
+) {
+  for (let y = Math.max(Math.floor(top), 0); y <= Math.min(Math.ceil(bottom), height - 1); y++) {
+    for (let x = Math.max(Math.floor(left), 0); x <= Math.min(Math.ceil(right), width - 1); x++) {
+      blendPixel(data, width, height, x, y, color, opacity);
+    }
+  }
+}
+
+function drawCircle(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  centerX: number,
+  centerY: number,
+  radius: number,
+  color: RgbaColor,
+) {
+  const minX = Math.floor(centerX - radius - 1);
+  const maxX = Math.ceil(centerX + radius + 1);
+  const minY = Math.floor(centerY - radius - 1);
+  const maxY = Math.ceil(centerY + radius + 1);
+
+  for (let py = minY; py <= maxY; py++) {
+    for (let px = minX; px <= maxX; px++) {
+      const distance = Math.hypot(px + 0.5 - centerX, py + 0.5 - centerY);
+      const coverage = 1 - smoothstep(radius - 0.65, radius + 0.65, distance);
+      if (coverage > 0) {
+        blendPixel(data, width, height, px, py, color, coverage);
+      }
+    }
+  }
+}
+
+function drawAreaFill(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  yByColumn: Float32Array,
+  bottom: number,
+  color: RgbaColor,
+) {
+  for (let x = 0; x < yByColumn.length; x++) {
+    const yTop = yByColumn[x]!;
+    if (!Number.isFinite(yTop)) continue;
+    const distance = Math.max(bottom - yTop, 1);
+    for (let y = Math.max(Math.floor(yTop), 0); y <= Math.min(Math.ceil(bottom), height - 1); y++) {
+      const fade = 1 - (y - yTop) / distance;
+      blendPixel(data, width, height, x, y, color, 0.08 + fade * 0.32);
+    }
+  }
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function getChartPixelLayout(scene: ChartScene, pixelWidth: number, pixelHeight: number) {
+  const volumeHeight = scene.showVolume ? Math.max(Math.round((scene.volumeHeight / Math.max(scene.height, 1)) * pixelHeight), 1) : 0;
+  const plotHeight = Math.max(pixelHeight - volumeHeight, 1);
+  return {
+    plotLeft: 0,
+    plotTop: 0,
+    plotRight: Math.max(pixelWidth - 1, 0),
+    plotBottom: Math.max(plotHeight - 1, 0),
+    volumeTop: plotHeight,
+    volumeBottom: Math.max(pixelHeight - 1, plotHeight),
+  };
+}
+
+function projectX(index: number, count: number, left: number, right: number): number {
+  if (count <= 1) return (left + right) / 2;
+  return lerp(left, right, index / (count - 1));
+}
+
+function projectY(value: number, min: number, max: number, top: number, bottom: number): number {
+  const range = max - min || 1;
+  return lerp(bottom, top, (value - min) / range);
+}
+
+function drawPriceGrid(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  scene: ChartScene,
+  top: number,
+  bottom: number,
+) {
+  const gridLines = computeGridLines(scene.min, scene.max, top, bottom, 3);
+  const color = parseHex(scene.colors.gridColor, 0.28);
+
+  for (const line of gridLines) {
+    drawLine(data, width, height, 0, line.y, width - 1, line.y, color, 1);
+  }
+}
+
+function drawLineSeries(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  scene: ChartScene,
+  top: number,
+  bottom: number,
+) {
+  const glow = parseHex(scene.colors.lineColor, 0.2);
+  const line = parseHex(scene.colors.lineColor, 0.95);
+  const fill = parseHex(scene.colors.fillColor, 0.7);
+  const yByColumn = new Float32Array(width).fill(Number.POSITIVE_INFINITY);
+
+  for (let index = 0; index < scene.points.length - 1; index++) {
+    const current = scene.points[index]!;
+    const next = scene.points[index + 1]!;
+    const x0 = projectX(index, scene.points.length, 0, width - 1);
+    const x1 = projectX(index + 1, scene.points.length, 0, width - 1);
+    const y0 = projectY(current.close, scene.min, scene.max, top, bottom);
+    const y1 = projectY(next.close, scene.min, scene.max, top, bottom);
+
+    const start = Math.max(Math.floor(Math.min(x0, x1)), 0);
+    const end = Math.min(Math.ceil(Math.max(x0, x1)), width - 1);
+    for (let x = start; x <= end; x++) {
+      const t = x1 === x0 ? 0 : (x - x0) / (x1 - x0);
+      const y = lerp(y0, y1, clamp(t, 0, 1));
+      yByColumn[x] = Math.min(yByColumn[x]!, y);
+    }
+
+    if (scene.mode === "area") {
+      drawLine(data, width, height, x0, y0, x1, y1, glow, 4);
+      drawLine(data, width, height, x0, y0, x1, y1, line, 1.75);
+    } else {
+      drawLine(data, width, height, x0, y0, x1, y1, glow, 3.2);
+      drawLine(data, width, height, x0, y0, x1, y1, line, 1.4);
+    }
+  }
+
+  if (scene.mode === "area") {
+    drawAreaFill(data, width, height, yByColumn, bottom, fill);
+  }
+}
+
+function drawCandles(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  scene: ChartScene,
+  top: number,
+  bottom: number,
+  mode: Extract<ChartRenderMode, "candles" | "ohlc">,
+) {
+  const spacing = width / Math.max(scene.points.length, 1);
+  const bodyWidth = clamp(spacing * 0.58, 2, Math.max(spacing - 1, 2));
+  const tickLength = clamp(spacing * 0.34, 2, Math.max(spacing * 0.48, 2));
+
+  for (let index = 0; index < scene.points.length; index++) {
+    const point = scene.points[index]!;
+    const x = projectX(index, scene.points.length, 0, width - 1);
+    const highY = projectY(point.high, scene.min, scene.max, top, bottom);
+    const lowY = projectY(point.low, scene.min, scene.max, top, bottom);
+    const openY = projectY(point.open, scene.min, scene.max, top, bottom);
+    const closeY = projectY(point.close, scene.min, scene.max, top, bottom);
+    const isUp = point.close >= point.open;
+
+    const wickColor = parseHex(isUp ? scene.colors.wickUp : scene.colors.wickDown, 0.92);
+    const bodyColor = parseHex(isUp ? scene.colors.candleUp : scene.colors.candleDown, 0.95);
+
+    drawLine(data, width, height, x, highY, x, lowY, wickColor, 1.2);
+
+    if (mode === "ohlc") {
+      drawLine(data, width, height, x - tickLength, openY, x, openY, bodyColor, 1.4);
+      drawLine(data, width, height, x, closeY, x + tickLength, closeY, bodyColor, 1.4);
+      continue;
+    }
+
+    const bodyTop = Math.min(openY, closeY);
+    const bodyBottom = Math.max(openY, closeY);
+    if (Math.abs(bodyBottom - bodyTop) < 1.25) {
+      drawLine(data, width, height, x - bodyWidth / 2, bodyTop, x + bodyWidth / 2, bodyTop, bodyColor, 1.5);
+    } else {
+      fillRect(data, width, height, x - bodyWidth / 2, bodyTop, x + bodyWidth / 2, bodyBottom, bodyColor, 0.92);
+    }
+  }
+}
+
+function drawVolume(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  scene: ChartScene,
+  top: number,
+  bottom: number,
+) {
+  if (!scene.showVolume || bottom < top) return;
+
+  const volumes = scene.points.map((point) => point.volume);
+  const maxVolume = Math.max(...volumes, 1);
+  const spacing = width / Math.max(scene.points.length, 1);
+  const barWidth = clamp(spacing * 0.72, 1, Math.max(spacing, 1));
+
+  for (let index = 0; index < scene.points.length; index++) {
+    const point = scene.points[index]!;
+    const heightRatio = point.volume / maxVolume;
+    if (heightRatio <= 0) continue;
+    const x = projectX(index, scene.points.length, 0, width - 1);
+    const barTop = lerp(bottom, top, heightRatio);
+    const isUp = scene.mode === "candles" || scene.mode === "ohlc"
+      ? point.close >= point.open
+      : index === 0 || point.close >= scene.points[index - 1]!.close;
+    const color = parseHex(isUp ? scene.colors.volumeUp : scene.colors.volumeDown, 0.6);
+    fillRect(data, width, height, x - barWidth / 2, barTop, x + barWidth / 2, bottom, color, 0.8);
+  }
+}
+
+export function renderNativeChart(scene: ChartScene, pixelWidth: number, pixelHeight: number): NativeChartBitmap {
+  const pixels = new Uint8Array(pixelWidth * pixelHeight * 4);
+  if (scene.points.length === 0 || pixelWidth <= 0 || pixelHeight <= 0) {
+    return { width: Math.max(pixelWidth, 1), height: Math.max(pixelHeight, 1), pixels };
+  }
+
+  const layout = getChartPixelLayout(scene, pixelWidth, pixelHeight);
+  drawPriceGrid(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
+
+  switch (scene.mode) {
+    case "area":
+    case "line":
+      drawLineSeries(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
+      break;
+    case "candles":
+      drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "candles");
+      break;
+    case "ohlc":
+      drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "ohlc");
+      break;
+  }
+
+  drawVolume(pixels, pixelWidth, pixelHeight, scene, layout.volumeTop, layout.volumeBottom);
+
+  return { width: pixelWidth, height: pixelHeight, pixels };
+}
+
+export function intersectCellRects(a: CellRect, b: CellRect): CellRect | null {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.width, b.x + b.width);
+  const bottom = Math.min(a.y + a.height, b.y + b.height);
+  if (right <= x || bottom <= y) return null;
+  return {
+    x,
+    y,
+    width: right - x,
+    height: bottom - y,
+  };
+}
+
+export function subtractCellRect(rect: CellRect, cut: CellRect): CellRect[] {
+  const intersection = intersectCellRects(rect, cut);
+  if (!intersection) return [rect];
+
+  const fragments: CellRect[] = [];
+  const rectRight = rect.x + rect.width;
+  const rectBottom = rect.y + rect.height;
+  const cutRight = intersection.x + intersection.width;
+  const cutBottom = intersection.y + intersection.height;
+
+  if (intersection.y > rect.y) {
+    fragments.push({
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: intersection.y - rect.y,
+    });
+  }
+
+  if (cutBottom < rectBottom) {
+    fragments.push({
+      x: rect.x,
+      y: cutBottom,
+      width: rect.width,
+      height: rectBottom - cutBottom,
+    });
+  }
+
+  if (intersection.x > rect.x) {
+    fragments.push({
+      x: rect.x,
+      y: intersection.y,
+      width: intersection.x - rect.x,
+      height: intersection.height,
+    });
+  }
+
+  if (cutRight < rectRight) {
+    fragments.push({
+      x: cutRight,
+      y: intersection.y,
+      width: rectRight - cutRight,
+      height: intersection.height,
+    });
+  }
+
+  return fragments.filter((fragment) => fragment.width > 0 && fragment.height > 0);
+}
+
+export function subtractCellRects(rects: CellRect[], cut: CellRect): CellRect[] {
+  return rects.flatMap((rect) => subtractCellRect(rect, cut));
+}
+
+export function excludeCellRects(rect: CellRect, cuts: CellRect[]): CellRect[] {
+  let fragments = [rect];
+  for (const cut of cuts) {
+    fragments = subtractCellRects(fragments, cut);
+    if (fragments.length === 0) break;
+  }
+  return fragments;
+}
+
+export function computeBitmapSize(rect: CellRect, resolution: PixelResolution, terminalWidth: number, terminalHeight: number) {
+  const cellWidth = resolution.width / Math.max(terminalWidth, 1);
+  const cellHeight = resolution.height / Math.max(terminalHeight, 1);
+  return {
+    cellWidth,
+    cellHeight,
+    pixelWidth: Math.max(1, Math.round(rect.width * cellWidth)),
+    pixelHeight: Math.max(1, Math.round(rect.height * cellHeight)),
+  };
+}
+
+export function computeNativePlacement(
+  rect: CellRect,
+  visibleRect: CellRect,
+  bitmap: NativeChartBitmap,
+  resolution: PixelResolution,
+  terminalWidth: number,
+  terminalHeight: number,
+): NativePlacement | null {
+  const cellWidth = resolution.width / Math.max(terminalWidth, 1);
+  const cellHeight = resolution.height / Math.max(terminalHeight, 1);
+  const clipped = intersectCellRects(rect, visibleRect);
+  if (!clipped) return null;
+
+  const cropX = Math.max(0, Math.round((clipped.x - rect.x) * cellWidth));
+  const cropY = Math.max(0, Math.round((clipped.y - rect.y) * cellHeight));
+  const cropWidth = Math.max(1, Math.min(bitmap.width - cropX, Math.round(clipped.width * cellWidth)));
+  const cropHeight = Math.max(1, Math.min(bitmap.height - cropY, Math.round(clipped.height * cellHeight)));
+
+  return {
+    column: clipped.x + 1,
+    row: clipped.y + 1,
+    cols: clipped.width,
+    rows: clipped.height,
+    cropX,
+    cropY,
+    cropWidth,
+    cropHeight,
+  };
+}
+
+export function computeNativePlacements(
+  rect: CellRect,
+  visibleRects: CellRect[],
+  bitmap: NativeChartBitmap,
+  resolution: PixelResolution,
+  terminalWidth: number,
+  terminalHeight: number,
+): NativePlacement[] {
+  return visibleRects
+    .map((visibleRect) => computeNativePlacement(rect, visibleRect, bitmap, resolution, terminalWidth, terminalHeight))
+    .filter((placement): placement is NativePlacement => placement !== null);
+}

--- a/src/components/chart/native/kitty-adapter.ts
+++ b/src/components/chart/native/kitty-adapter.ts
@@ -1,0 +1,8 @@
+import type { CliRenderer } from "@opentui/core";
+
+export function writeRendererRaw(renderer: CliRenderer, data: string | Uint8Array): boolean {
+  const writer = (renderer as unknown as { writeOut?: (payload: string | Uint8Array) => void }).writeOut;
+  if (typeof writer !== "function") return false;
+  writer.call(renderer, data);
+  return true;
+}

--- a/src/components/chart/native/kitty-manager.ts
+++ b/src/components/chart/native/kitty-manager.ts
@@ -1,0 +1,142 @@
+import type { CliRenderer } from "@opentui/core";
+import type { NativeChartBitmap, NativePlacement } from "./chart-rasterizer";
+import { writeRendererRaw } from "./kitty-adapter";
+import { encodeKittyDeleteImage, encodeKittyPlacement, encodeKittyTransmitRgba } from "./kitty-protocol";
+
+let nextImageId = 2000;
+let nextPlacementId = 1;
+
+function allocateImageId(): number {
+  const id = nextImageId;
+  nextImageId += 1;
+  return id;
+}
+
+function allocatePlacementId(): number {
+  const id = nextPlacementId;
+  nextPlacementId += 1;
+  return id;
+}
+
+function serializePlacement(placement: NativePlacement): string {
+  return [
+    placement.column,
+    placement.row,
+    placement.cols,
+    placement.rows,
+    placement.cropX,
+    placement.cropY,
+    placement.cropWidth,
+    placement.cropHeight,
+  ].join(":");
+}
+
+function asPlacementArray(placement: NativePlacement | NativePlacement[]): NativePlacement[] {
+  return Array.isArray(placement) ? placement : [placement];
+}
+
+export class KittyImageManager {
+  private readonly imageIds = [allocateImageId(), allocateImageId()] as const;
+  private readonly placementIds: number[] = [];
+  private activeSlot: 0 | 1 | null = null;
+  private lastBitmapKey: string | null = null;
+  private lastPlacementKeys: string[] = [];
+
+  constructor(private readonly renderer: CliRenderer) {}
+
+  render(bitmap: NativeChartBitmap, placement: NativePlacement | NativePlacement[], bitmapKey: string) {
+    const placements = asPlacementArray(placement);
+    if (this.activeSlot !== null && this.lastBitmapKey === bitmapKey) {
+      this.placeActive(placements);
+      return;
+    }
+
+    const nextSlot: 0 | 1 = this.activeSlot === 0 ? 1 : 0;
+    const imageId = this.imageIds[nextSlot];
+    const placementIds = this.ensurePlacementIds(placements.length);
+    const sequences = [
+      ...encodeKittyTransmitRgba({
+        imageId,
+        width: bitmap.width,
+        height: bitmap.height,
+        rgba: bitmap.pixels,
+      }),
+      ...placements.map((entry, index) => encodeKittyPlacement({
+        imageId,
+        placementId: placementIds[index]!,
+        column: entry.column,
+        row: entry.row,
+        cols: entry.cols,
+        rows: entry.rows,
+        cropX: entry.cropX,
+        cropY: entry.cropY,
+        cropWidth: entry.cropWidth,
+        cropHeight: entry.cropHeight,
+      })),
+    ];
+
+    if (this.activeSlot !== null) {
+      sequences.push(encodeKittyDeleteImage(this.imageIds[this.activeSlot]));
+    }
+
+    writeRendererRaw(this.renderer, sequences.join(""));
+    this.activeSlot = nextSlot;
+    this.lastBitmapKey = bitmapKey;
+    this.lastPlacementKeys = placements.map(serializePlacement);
+  }
+
+  placeActive(placement: NativePlacement | NativePlacement[]) {
+    if (this.activeSlot === null) return;
+    const placements = asPlacementArray(placement);
+    const imageId = this.imageIds[this.activeSlot];
+    const placementIds = this.ensurePlacementIds(placements.length);
+    const sequences: string[] = [];
+
+    placements.forEach((entry, index) => {
+      const placementKey = serializePlacement(entry);
+      if (placementKey === this.lastPlacementKeys[index]) return;
+      sequences.push(encodeKittyPlacement({
+        imageId,
+        placementId: placementIds[index]!,
+        column: entry.column,
+        row: entry.row,
+        cols: entry.cols,
+        rows: entry.rows,
+        cropX: entry.cropX,
+        cropY: entry.cropY,
+        cropWidth: entry.cropWidth,
+        cropHeight: entry.cropHeight,
+      }));
+    });
+
+    for (let index = placements.length; index < this.lastPlacementKeys.length; index += 1) {
+      sequences.push(encodeKittyDeleteImage(imageId, placementIds[index]!));
+    }
+
+    if (sequences.length === 0) return;
+
+    writeRendererRaw(this.renderer, sequences.join(""));
+    this.lastPlacementKeys = placements.map(serializePlacement);
+  }
+
+  clear() {
+    writeRendererRaw(
+      this.renderer,
+      `${encodeKittyDeleteImage(this.imageIds[0])}${encodeKittyDeleteImage(this.imageIds[1])}`,
+    );
+    this.activeSlot = null;
+    this.lastBitmapKey = null;
+    this.lastPlacementKeys = [];
+  }
+
+  destroy() {
+    this.clear();
+  }
+
+  private ensurePlacementIds(count: number): number[] {
+    while (this.placementIds.length < count) {
+      this.placementIds.push(allocatePlacementId());
+    }
+    return this.placementIds;
+  }
+}

--- a/src/components/chart/native/kitty-protocol.ts
+++ b/src/components/chart/native/kitty-protocol.ts
@@ -1,0 +1,110 @@
+import { deflateSync } from "node:zlib";
+
+export interface KittyPlacement {
+  imageId: number;
+  placementId: number;
+  column: number;
+  row: number;
+  cols: number;
+  rows: number;
+  cropX?: number;
+  cropY?: number;
+  cropWidth?: number;
+  cropHeight?: number;
+  xOffset?: number;
+  yOffset?: number;
+  zIndex?: number;
+}
+
+export interface KittyTransmitOptions {
+  imageId: number;
+  width: number;
+  height: number;
+  rgba: Uint8Array;
+  chunkSize?: number;
+}
+
+const APC_START = "\x1b_G";
+const APC_END = "\x1b\\";
+const DEFAULT_CHUNK_SIZE = 4096;
+
+function buildControlData(entries: Array<[string, string | number | null | undefined]>): string {
+  return entries
+    .filter(([, value]) => value !== null && value !== undefined)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(",");
+}
+
+function wrapKittySequence(control: string, payload = ""): string {
+  return `${APC_START}${control};${payload}${APC_END}`;
+}
+
+export function chunkBase64Payload(base64: string, chunkSize = DEFAULT_CHUNK_SIZE): string[] {
+  const chunks: string[] = [];
+  for (let index = 0; index < base64.length; index += chunkSize) {
+    chunks.push(base64.slice(index, index + chunkSize));
+  }
+  return chunks.length > 0 ? chunks : [""];
+}
+
+export function buildKittyGraphicsQuery(imageId = 31): string {
+  return wrapKittySequence(`i=${imageId},s=1,v=1,a=q,t=d,f=24`, "AAAA");
+}
+
+export function encodeKittyTransmitRgba(options: KittyTransmitOptions): string[] {
+  const compressed = deflateSync(Buffer.from(options.rgba));
+  const chunks = chunkBase64Payload(compressed.toString("base64"), options.chunkSize);
+
+  return chunks.map((chunk, index) => {
+    const isLast = index === chunks.length - 1;
+    const control = index === 0
+      ? buildControlData([
+        ["a", "t"],
+        ["f", 32],
+        ["t", "d"],
+        ["o", "z"],
+        ["s", options.width],
+        ["v", options.height],
+        ["i", options.imageId],
+        ["q", 2],
+        ["m", isLast ? 0 : 1],
+      ])
+      : buildControlData([
+        ["m", isLast ? 0 : 1],
+      ]);
+
+    return wrapKittySequence(control, chunk);
+  });
+}
+
+export function encodeKittyPlacement(placement: KittyPlacement): string {
+  const control = buildControlData([
+    ["a", "p"],
+    ["i", placement.imageId],
+    ["p", placement.placementId],
+    ["q", 2],
+    ["x", placement.cropX ?? 0],
+    ["y", placement.cropY ?? 0],
+    ["w", placement.cropWidth ?? 0],
+    ["h", placement.cropHeight ?? 0],
+    ["X", placement.xOffset ?? 0],
+    ["Y", placement.yOffset ?? 0],
+    ["c", placement.cols],
+    ["r", placement.rows],
+    ["z", placement.zIndex ?? -1],
+    ["C", 1],
+  ]);
+
+  return `\x1b[s\x1b[${placement.row};${placement.column}H${wrapKittySequence(control)}\x1b[u`;
+}
+
+export function encodeKittyDeleteImage(imageId: number, placementId?: number): string {
+  return wrapKittySequence(buildControlData([
+    ["a", "d"],
+    ["d", "I"],
+    ["i", imageId],
+    ["p", placementId ?? null],
+    ["q", 2],
+  ]));
+}
+

--- a/src/components/chart/native/kitty-support.ts
+++ b/src/components/chart/native/kitty-support.ts
@@ -1,0 +1,71 @@
+import type { CliRenderer } from "@opentui/core";
+import { writeRendererRaw } from "./kitty-adapter";
+import { buildKittyGraphicsQuery } from "./kitty-protocol";
+
+interface RendererCapabilities {
+  kitty_graphics?: boolean;
+}
+
+interface SupportCacheEntry {
+  value: boolean | null;
+  promise?: Promise<boolean>;
+}
+
+const supportCache = new WeakMap<CliRenderer, SupportCacheEntry>();
+const QUERY_TIMEOUT_MS = 250;
+
+function readKnownSupport(renderer: CliRenderer): boolean | null {
+  const capabilities = renderer.capabilities as RendererCapabilities | null;
+  return typeof capabilities?.kitty_graphics === "boolean" ? capabilities.kitty_graphics : null;
+}
+
+export function getCachedKittySupport(renderer: CliRenderer): boolean | null {
+  const cached = supportCache.get(renderer)?.value ?? null;
+  if (cached !== null) return cached;
+  return readKnownSupport(renderer);
+}
+
+export function ensureKittySupport(renderer: CliRenderer): Promise<boolean> {
+  const known = readKnownSupport(renderer);
+  if (known !== null) {
+    supportCache.set(renderer, { value: known });
+    return Promise.resolve(known);
+  }
+
+  const cached = supportCache.get(renderer);
+  if (cached?.promise) return cached.promise;
+
+  const nextEntry: SupportCacheEntry = { value: null };
+  const promise = new Promise<boolean>((resolve) => {
+    let settled = false;
+
+    const finish = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      renderer.off("capabilities", onCapabilities);
+      nextEntry.value = value;
+      nextEntry.promise = undefined;
+      resolve(value);
+    };
+
+    const onCapabilities = () => {
+      const supported = readKnownSupport(renderer);
+      if (supported !== null) finish(supported);
+    };
+
+    const timer = setTimeout(() => finish(false), QUERY_TIMEOUT_MS);
+    renderer.on("capabilities", onCapabilities);
+    if (!writeRendererRaw(renderer, `${buildKittyGraphicsQuery()}\x1b[c`)) {
+      finish(false);
+      return;
+    }
+    const supported = readKnownSupport(renderer);
+    if (supported !== null) finish(supported);
+  });
+
+  nextEntry.promise = promise;
+  supportCache.set(renderer, nextEntry);
+  return promise;
+}
+

--- a/src/components/chart/native/kitty.test.ts
+++ b/src/components/chart/native/kitty.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import type { CliRenderer } from "@opentui/core";
+import { computeBitmapSize, computeNativePlacement, excludeCellRects, type CellRect } from "./chart-rasterizer";
+import { KittyImageManager } from "./kitty-manager";
+import { chunkBase64Payload, encodeKittyTransmitRgba } from "./kitty-protocol";
+import { resolveChartRendererState } from "./renderer-selection";
+import { computeSurfaceVisibleFragments } from "./surface-manager";
+
+describe("resolveChartRendererState", () => {
+  test("resolves auto and forced kitty correctly", () => {
+    expect(resolveChartRendererState("auto", true, { width: 1200, height: 800 })).toMatchObject({
+      renderer: "kitty",
+      nativeReady: true,
+      nativeUnavailable: false,
+    });
+    expect(resolveChartRendererState("auto", false, { width: 1200, height: 800 })).toMatchObject({
+      renderer: "braille",
+      nativeReady: false,
+      nativeUnavailable: false,
+    });
+    expect(resolveChartRendererState("kitty", false, null)).toMatchObject({
+      renderer: "braille",
+      nativeReady: false,
+      nativeUnavailable: true,
+    });
+    expect(resolveChartRendererState("braille", true, { width: 1200, height: 800 })).toMatchObject({
+      renderer: "braille",
+      nativeReady: true,
+      nativeUnavailable: false,
+    });
+  });
+});
+
+describe("encodeKittyTransmitRgba", () => {
+  test("chunks compressed rgba uploads and keeps metadata on the first chunk", () => {
+    const rgba = new Uint8Array(64).fill(255);
+    const sequences = encodeKittyTransmitRgba({
+      imageId: 41,
+      width: 4,
+      height: 4,
+      rgba,
+      chunkSize: 8,
+    });
+
+    expect(sequences.length).toBeGreaterThan(1);
+    expect(sequences[0]).toContain("a=t");
+    expect(sequences[0]).toContain("f=32");
+    expect(sequences[0]).toContain("o=z");
+    expect(sequences[0]).toContain("i=41");
+    expect(sequences[0]).toContain("s=4");
+    expect(sequences[0]).toContain("v=4");
+    expect(sequences[0]).toContain("m=1");
+    expect(sequences[1]).not.toContain("a=t");
+    expect(sequences[sequences.length - 1]).toContain("m=0");
+  });
+
+  test("splits base64 payloads deterministically", () => {
+    expect(chunkBase64Payload("abcdefghijkl", 5)).toEqual(["abcde", "fghij", "kl"]);
+  });
+});
+
+describe("computeNativePlacement", () => {
+  test("maps clipped cell rectangles back into source pixel crops", () => {
+    const fullRect: CellRect = { x: 5, y: 4, width: 10, height: 6 };
+    const visibleRect: CellRect = { x: 8, y: 6, width: 4, height: 3 };
+    const bitmapSize = computeBitmapSize(fullRect, { width: 1000, height: 600 }, 100, 30);
+    const placement = computeNativePlacement(
+      fullRect,
+      visibleRect,
+      { width: bitmapSize.pixelWidth, height: bitmapSize.pixelHeight, pixels: new Uint8Array(0) },
+      { width: 1000, height: 600 },
+      100,
+      30,
+    );
+
+    expect(placement).toEqual({
+      column: 9,
+      row: 7,
+      cols: 4,
+      rows: 3,
+      cropX: 30,
+      cropY: 40,
+      cropWidth: 40,
+      cropHeight: 60,
+    });
+  });
+});
+
+describe("excludeCellRects", () => {
+  test("splits a surface into remaining visible fragments", () => {
+    expect(excludeCellRects(
+      { x: 10, y: 6, width: 12, height: 8 },
+      [{ x: 14, y: 8, width: 3, height: 2 }],
+    )).toEqual([
+      { x: 10, y: 6, width: 12, height: 2 },
+      { x: 10, y: 10, width: 12, height: 4 },
+      { x: 10, y: 8, width: 4, height: 2 },
+      { x: 17, y: 8, width: 5, height: 2 },
+    ]);
+  });
+});
+
+describe("computeSurfaceVisibleFragments", () => {
+  test("subtracts overlapping higher-layer occluders", () => {
+    expect(computeSurfaceVisibleFragments(
+      { x: 10, y: 6, width: 12, height: 8 },
+      { x: 10, y: 6, width: 12, height: 8 },
+      0,
+      "ticker-detail:main",
+      [{
+        id: "console:main",
+        paneId: "console:main",
+        rect: { x: 14, y: 8, width: 3, height: 2 },
+        zIndex: 90,
+      }],
+    )).toEqual([
+      { x: 10, y: 6, width: 12, height: 2 },
+      { x: 10, y: 8, width: 4, height: 2 },
+      { x: 17, y: 8, width: 5, height: 2 },
+      { x: 10, y: 10, width: 12, height: 4 },
+    ]);
+  });
+
+  test("ignores occluders from lower layers or the same pane", () => {
+    expect(computeSurfaceVisibleFragments(
+      { x: 10, y: 6, width: 12, height: 8 },
+      { x: 10, y: 6, width: 12, height: 8 },
+      120,
+      "chart:float",
+      [
+        {
+          id: "chart:float",
+          paneId: "chart:float",
+          rect: { x: 12, y: 8, width: 4, height: 2 },
+          zIndex: 120,
+        },
+        {
+          id: "console:main",
+          paneId: "console:main",
+          rect: { x: 14, y: 8, width: 3, height: 2 },
+          zIndex: 80,
+        },
+      ],
+    )).toEqual([
+      { x: 10, y: 6, width: 12, height: 8 },
+    ]);
+  });
+});
+
+describe("KittyImageManager", () => {
+  test("reuses placement ids across multiple fragments and deletes the previous image on swap", () => {
+    const writes: string[] = [];
+    const renderer = {
+      writeOut(payload: string | Uint8Array) {
+        writes.push(typeof payload === "string" ? payload : Buffer.from(payload).toString("utf8"));
+      },
+    } as unknown as CliRenderer;
+
+    const manager = new KittyImageManager(renderer);
+    const placements = [
+      {
+        column: 2,
+        row: 3,
+        cols: 4,
+        rows: 2,
+        cropX: 0,
+        cropY: 0,
+        cropWidth: 40,
+        cropHeight: 20,
+      },
+      {
+        column: 8,
+        row: 3,
+        cols: 2,
+        rows: 2,
+        cropX: 60,
+        cropY: 0,
+        cropWidth: 20,
+        cropHeight: 20,
+      },
+    ];
+
+    manager.render({ width: 40, height: 20, pixels: new Uint8Array(40 * 20 * 4) }, placements, "first");
+    manager.render({ width: 40, height: 20, pixels: new Uint8Array(40 * 20 * 4).fill(1) }, placements, "second");
+
+    const firstWrite = writes[0]!;
+    const secondWrite = writes[1]!;
+    const firstImageId = firstWrite.match(/i=(\d+)/)?.[1];
+    const secondImageId = secondWrite.match(/i=(\d+)/)?.[1];
+    const firstPlacementIds = [...firstWrite.matchAll(/p=(\d+)/g)].map((match) => match[1]);
+    const secondPlacementIds = [...secondWrite.matchAll(/p=(\d+)/g)].map((match) => match[1]);
+
+    expect(firstImageId).toBeTruthy();
+    expect(secondImageId).toBeTruthy();
+    expect(secondImageId).not.toBe(firstImageId);
+    expect(firstPlacementIds.length).toBeGreaterThanOrEqual(2);
+    expect(secondPlacementIds.slice(0, 2)).toEqual(firstPlacementIds.slice(0, 2));
+    expect(secondWrite).toContain(`a=d,d=I,i=${firstImageId!}`);
+  });
+});

--- a/src/components/chart/native/renderer-selection.ts
+++ b/src/components/chart/native/renderer-selection.ts
@@ -1,0 +1,24 @@
+import type { PixelResolution } from "@opentui/core";
+import type { ChartRendererPreference, ResolvedChartRenderer } from "../chart-types";
+
+export interface ResolvedChartRendererState {
+  renderer: ResolvedChartRenderer;
+  nativeUnavailable: boolean;
+  nativeReady: boolean;
+}
+
+export function resolveChartRendererState(
+  preference: ChartRendererPreference,
+  kittySupport: boolean | null,
+  resolution: PixelResolution | null,
+): ResolvedChartRendererState {
+  const nativeReady = kittySupport === true && resolution !== null;
+  if (preference === "braille") {
+    return { renderer: "braille", nativeUnavailable: false, nativeReady };
+  }
+  if (preference === "kitty") {
+    return { renderer: nativeReady ? "kitty" : "braille", nativeUnavailable: !nativeReady && kittySupport !== null, nativeReady };
+  }
+  return { renderer: nativeReady ? "kitty" : "braille", nativeUnavailable: false, nativeReady };
+}
+

--- a/src/components/chart/native/surface-manager.ts
+++ b/src/components/chart/native/surface-manager.ts
@@ -1,0 +1,169 @@
+import type { CliRenderer } from "@opentui/core";
+import {
+  computeNativePlacements,
+  excludeCellRects,
+  intersectCellRects,
+  type CellRect,
+  type NativeChartBitmap,
+} from "./chart-rasterizer";
+import { KittyImageManager } from "./kitty-manager";
+
+export interface NativePaneLayer {
+  paneId: string;
+  zIndex: number;
+}
+
+export interface NativeOccluder {
+  id: string;
+  paneId?: string | null;
+  rect: CellRect;
+  zIndex: number;
+}
+
+export interface NativeSurfaceSnapshot {
+  id: string;
+  paneId: string;
+  rect: CellRect;
+  visibleRect: CellRect | null;
+  bitmap: NativeChartBitmap;
+  bitmapKey: string;
+}
+
+interface SurfaceEntry {
+  imageManager: KittyImageManager;
+  snapshot: NativeSurfaceSnapshot;
+}
+
+interface NativeWindowState {
+  paneLayers: NativePaneLayer[];
+  occluders: NativeOccluder[];
+}
+
+function compareRects(a: CellRect, b: CellRect): number {
+  if (a.y !== b.y) return a.y - b.y;
+  if (a.x !== b.x) return a.x - b.x;
+  if (a.height !== b.height) return a.height - b.height;
+  return a.width - b.width;
+}
+
+export function computeSurfaceVisibleFragments(
+  rect: CellRect,
+  visibleRect: CellRect | null,
+  surfaceZIndex: number,
+  paneId: string,
+  occluders: NativeOccluder[],
+): CellRect[] {
+  if (!visibleRect) return [];
+  const clipped = intersectCellRects(rect, visibleRect);
+  if (!clipped) return [];
+
+  const relevantCuts = occluders
+    .filter((occluder) => occluder.paneId !== paneId && occluder.zIndex >= surfaceZIndex)
+    .sort((left, right) => right.zIndex - left.zIndex)
+    .map((occluder) => occluder.rect);
+
+  return excludeCellRects(clipped, relevantCuts).sort(compareRects);
+}
+
+export class NativeSurfaceManager {
+  private windowState: NativeWindowState = { paneLayers: [], occluders: [] };
+  private readonly surfaces = new Map<string, SurfaceEntry>();
+
+  constructor(private readonly renderer: CliRenderer) {}
+
+  setWindowState(windowState: NativeWindowState) {
+    this.windowState = {
+      paneLayers: [...windowState.paneLayers],
+      occluders: [...windowState.occluders],
+    };
+    this.syncAll();
+  }
+
+  upsertSurface(snapshot: NativeSurfaceSnapshot) {
+    const existing = this.surfaces.get(snapshot.id);
+    if (existing) {
+      existing.snapshot = snapshot;
+      this.syncSurface(existing);
+      return;
+    }
+
+    const entry: SurfaceEntry = {
+      imageManager: new KittyImageManager(this.renderer),
+      snapshot,
+    };
+    this.surfaces.set(snapshot.id, entry);
+    this.syncSurface(entry);
+  }
+
+  updateSurfaceGeometry(id: string, geometry: Pick<NativeSurfaceSnapshot, "paneId" | "rect" | "visibleRect">) {
+    const entry = this.surfaces.get(id);
+    if (!entry) return;
+    entry.snapshot = {
+      ...entry.snapshot,
+      ...geometry,
+    };
+    this.syncSurface(entry);
+  }
+
+  removeSurface(id: string) {
+    const entry = this.surfaces.get(id);
+    if (!entry) return;
+    entry.imageManager.destroy();
+    this.surfaces.delete(id);
+  }
+
+  destroy() {
+    for (const id of [...this.surfaces.keys()]) {
+      this.removeSurface(id);
+    }
+  }
+
+  private syncAll() {
+    for (const entry of this.surfaces.values()) {
+      this.syncSurface(entry);
+    }
+  }
+
+  private syncSurface(entry: SurfaceEntry) {
+    const resolution = this.renderer.resolution;
+    if (!resolution) {
+      entry.imageManager.clear();
+      return;
+    }
+
+    const surfaceZIndex = this.windowState.paneLayers.find((layer) => layer.paneId === entry.snapshot.paneId)?.zIndex ?? 0;
+    const fragments = computeSurfaceVisibleFragments(
+      entry.snapshot.rect,
+      entry.snapshot.visibleRect,
+      surfaceZIndex,
+      entry.snapshot.paneId,
+      this.windowState.occluders,
+    );
+
+    const placements = computeNativePlacements(
+      entry.snapshot.rect,
+      fragments,
+      entry.snapshot.bitmap,
+      resolution,
+      this.renderer.terminalWidth,
+      this.renderer.terminalHeight,
+    );
+
+    if (placements.length === 0) {
+      entry.imageManager.clear();
+      return;
+    }
+
+    entry.imageManager.render(entry.snapshot.bitmap, placements, entry.snapshot.bitmapKey);
+  }
+}
+
+const nativeSurfaceManagers = new WeakMap<CliRenderer, NativeSurfaceManager>();
+
+export function getNativeSurfaceManager(renderer: CliRenderer): NativeSurfaceManager {
+  const existing = nativeSurfaceManagers.get(renderer);
+  if (existing) return existing;
+  const manager = new NativeSurfaceManager(renderer);
+  nativeSurfaceManagers.set(renderer, manager);
+  return manager;
+}

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { TextAttributes } from "@opentui/core";
-import { useKeyboard } from "@opentui/react";
-import { useAppState, usePaneTicker } from "../../state/app-context";
+import { TextAttributes, type BoxRenderable } from "@opentui/core";
+import { useKeyboard, useRenderer } from "@opentui/react";
+import { useAppState, usePaneInstanceId, usePaneTicker } from "../../state/app-context";
 import { saveConfig } from "../../data/config-store";
 import { colors, priceColor } from "../../theme/colors";
 import { formatCompact, formatCurrency } from "../../utils/format";
 import { getSharedDataProvider } from "../../plugins/registry";
-import { getVisibleWindow, projectChartData, resolveBarSize } from "./chart-data";
-import { formatDateShort, renderChart, resolveChartPalette } from "./chart-renderer";
-import { CHART_RENDER_MODES, TIME_RANGES, type ChartRenderMode, type ChartViewState } from "./chart-types";
+import { filterByTimeRange, getVisibleWindow, projectChartData, resolveBarSize } from "./chart-data";
+import { buildChartScene, formatDateShort, renderChart, resolveChartPalette } from "./chart-renderer";
+import { CHART_RENDER_MODES, TIME_RANGES, type ChartRenderMode, type ChartViewState, type ResolvedChartRenderer } from "./chart-types";
+import { computeBitmapSize, intersectCellRects, renderNativeChart, type CellRect } from "./native/chart-rasterizer";
+import { ensureKittySupport, getCachedKittySupport } from "./native/kitty-support";
+import { resolveChartRendererState } from "./native/renderer-selection";
+import { getNativeSurfaceManager } from "./native/surface-manager";
 import type { PricePoint } from "../../types/financials";
 
 const MODE_CHIPS: Record<ChartRenderMode, string> = {
@@ -33,10 +37,154 @@ interface StockChartProps {
   compact?: boolean;
 }
 
+interface DragState {
+  startGlobalX: number;
+  startPanOffset: number;
+}
+
+interface ChartMouseEvent {
+  x: number;
+  y: number;
+  modifiers: {
+    shift: boolean;
+    alt: boolean;
+    ctrl: boolean;
+  };
+  scroll?: {
+    direction: "up" | "down" | "left" | "right";
+    delta: number;
+  };
+}
+
+interface RenderableNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  parent: RenderableNode | null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function getLocalPlotX(event: ChartMouseEvent, renderable: BoxRenderable | null): number | null {
+  if (!renderable) return null;
+  const localX = event.x - renderable.x;
+  if (localX < 0 || localX >= renderable.width) return null;
+  return localX;
+}
+
+function extractCellRect(renderable: RenderableNode): CellRect {
+  return {
+    x: renderable.x,
+    y: renderable.y,
+    width: renderable.width,
+    height: renderable.height,
+  };
+}
+
+function resolveVisibleRect(
+  renderable: RenderableNode | null,
+  terminalWidth: number,
+  terminalHeight: number,
+): CellRect | null {
+  if (!renderable) return null;
+
+  let visible: CellRect = {
+    x: 0,
+    y: 0,
+    width: terminalWidth,
+    height: terminalHeight,
+  };
+  let current: RenderableNode | null = renderable;
+
+  while (current) {
+    const currentRect = extractCellRect(current);
+    const nextVisible = intersectCellRects(visible, currentRect);
+    if (!nextVisible) return null;
+    visible = nextVisible;
+    current = current.parent;
+  }
+
+  return visible;
+}
+
+function buildNativeOverlayLines(width: number, height: number, cursorX: number | null, cursorRow: number | null): string[] {
+  return Array.from({ length: height }, (_, row) => {
+    if (cursorX === null) return " ".repeat(width);
+    const chars = new Array(width).fill(" ");
+    if (cursorX >= 0 && cursorX < width) {
+      chars[cursorX] = row === cursorRow ? "┼" : "│";
+    }
+    if (cursorRow !== null && row === cursorRow) {
+      for (let index = 0; index < width; index++) {
+        chars[index] = index === cursorX ? "┼" : "─";
+      }
+    }
+    return chars.join("");
+  });
+}
+
+function getMaxPanOffset(history: PricePoint[], timeRange: ChartViewState["timeRange"], zoomLevel: number, chartWidth: number): number {
+  const filtered = filterByTimeRange(history, timeRange);
+  const visibleCount = Math.max(Math.floor(chartWidth / zoomLevel), 10);
+  return Math.max(filtered.length - visibleCount, 0);
+}
+
+function applyZoomAroundAnchor(
+  view: ChartViewState,
+  nextZoomLevel: number,
+  anchorRatio: number,
+  history: PricePoint[],
+  chartWidth: number,
+): ChartViewState {
+  const filtered = filterByTimeRange(history, view.timeRange);
+  if (filtered.length === 0) return view;
+
+  const clampedZoom = clamp(nextZoomLevel, 0.5, 10);
+  const currentVisibleCount = Math.max(Math.floor(chartWidth / view.zoomLevel), 10);
+  const nextVisibleCount = Math.max(Math.floor(chartWidth / clampedZoom), 10);
+  const currentPanOffset = clamp(view.panOffset, 0, Math.max(filtered.length - currentVisibleCount, 0));
+  const ratio = clamp(anchorRatio, 0, 1);
+  const anchorIndex = filtered.length - currentPanOffset - currentVisibleCount + ratio * Math.max(currentVisibleCount - 1, 0);
+  const nextStart = Math.round(anchorIndex - ratio * Math.max(nextVisibleCount - 1, 0));
+  const clampedStart = clamp(nextStart, 0, Math.max(filtered.length - nextVisibleCount, 0));
+  const nextPanOffset = filtered.length - nextVisibleCount - clampedStart;
+
+  return {
+    ...view,
+    zoomLevel: clampedZoom,
+    panOffset: clamp(nextPanOffset, 0, Math.max(filtered.length - nextVisibleCount, 0)),
+  };
+}
+
+function buildNativeBitmapKey(
+  pointCount: number,
+  points: PricePoint[],
+  pixelWidth: number,
+  pixelHeight: number,
+  mode: ChartRenderMode,
+  showVolume: boolean,
+  paletteId: string,
+): string {
+  const fingerprint = points
+    .map((point) => {
+      const date = point.date instanceof Date ? point.date.getTime() : new Date(point.date).getTime();
+      return `${date}:${point.open}:${point.high}:${point.low}:${point.close}:${point.volume ?? 0}`;
+    })
+    .join("|");
+  return [pointCount, pixelWidth, pixelHeight, mode, showVolume ? "1" : "0", paletteId, fingerprint].join("::");
+}
+
 export function StockChart({ width, height, focused, interactive, compact }: StockChartProps) {
+  const renderer = useRenderer();
   const { state, dispatch } = useAppState();
+  const paneId = usePaneInstanceId();
   const { ticker, financials } = usePaneTicker();
+  const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);
   const defaultRenderMode = state.config.chartPreferences.defaultRenderMode;
+  const preferredRenderer = state.config.chartPreferences.renderer;
   const [viewState, setViewState] = useState<ChartViewState>({
     timeRange: compact ? "1Y" : "5Y",
     panOffset: 0,
@@ -47,9 +195,19 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
   const [showVolume, setShowVolume] = useState(!compact);
   const [rangeHistory, setRangeHistory] = useState<PricePoint[] | null>(null);
   const [detailHistory, setDetailHistory] = useState<PricePoint[] | null>(null);
+  const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
   const fetchIdRef = useRef(0);
   const detailFetchIdRef = useRef(0);
   const detailDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const plotRef = useRef<BoxRenderable | null>(null);
+  const nativeSurfaceIdRef = useRef(`chart-surface:${paneId}:${compact ? "compact" : "full"}`);
+  const dragRef = useRef<DragState | null>(null);
+
+  useEffect(() => (
+    () => {
+      nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
+    }
+  ), [nativeSurfaceManager]);
 
   useEffect(() => {
     const provider = getSharedDataProvider();
@@ -79,8 +237,9 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     : null;
   const axisWidth = compact ? 0 : 10;
   const chartWidth = Math.max(width - axisWidth - 2, 20);
+  const maxCursorX = chartWidth - 1;
+  const panStep = Math.max(Math.floor(chartWidth / 10), 1);
 
-  // Fetch higher-resolution data when zoomed in
   useEffect(() => {
     if (compact || !ticker || baseHistory.length < 2 || viewState.zoomLevel <= 1) {
       setDetailHistory(null);
@@ -149,74 +308,104 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     viewState.zoomLevel,
   ]);
 
-  // Use detail data when available and zoomed in, otherwise fall back to base
   const history = (viewState.zoomLevel > 1 && detailHistory) ? detailHistory : baseHistory;
 
   useEffect(() => {
     if (interactive) {
-      setViewState((state) => (state.cursorX === null ? { ...state, cursorX: chartWidth - 1 } : state));
+      setViewState((current) => (current.cursorX === null ? { ...current, cursorX: chartWidth - 1 } : current));
     } else {
-      setViewState((state) => (state.cursorX !== null ? { ...state, cursorX: null } : state));
+      setViewState((current) => (current.cursorX !== null ? { ...current, cursorX: null } : current));
     }
   }, [interactive, chartWidth]);
+
+  useEffect(() => {
+    const refreshSupport = () => setKittySupport(getCachedKittySupport(renderer));
+    refreshSupport();
+    renderer.on("capabilities", refreshSupport);
+    return () => {
+      renderer.off("capabilities", refreshSupport);
+    };
+  }, [renderer]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const known = getCachedKittySupport(renderer);
+    setKittySupport(known);
+    if (preferredRenderer === "braille" || known !== null) return;
+    ensureKittySupport(renderer).then((supported) => {
+      if (!cancelled) setKittySupport(supported);
+    }).catch(() => {
+      if (!cancelled) setKittySupport(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [preferredRenderer, renderer]);
+
+  const persistDefaultRenderMode = (nextMode: ChartRenderMode) => {
+    if (nextMode === defaultRenderMode) return;
+    const nextConfig = {
+      ...state.config,
+      chartPreferences: {
+        ...state.config.chartPreferences,
+        defaultRenderMode: nextMode,
+      },
+    };
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    saveConfig(nextConfig).catch(() => {});
+  };
+
+  const setRange = (range: ChartViewState["timeRange"]) => {
+    setViewState((current) => ({
+      ...current,
+      timeRange: range,
+      panOffset: 0,
+      zoomLevel: 1,
+      cursorX: null,
+    }));
+  };
+
+  const setRenderMode = (mode: ChartRenderMode) => {
+    persistDefaultRenderMode(mode);
+    setViewState((current) => ({ ...current, renderMode: mode }));
+  };
 
   useKeyboard((event) => {
     if (!focused || compact) return;
 
-    const maxCursorX = chartWidth - 1;
-    const panStep = Math.max(Math.floor(chartWidth / 10), 1);
-
     switch (event.name) {
       case "=":
-        setViewState((state) => ({ ...state, zoomLevel: Math.min(state.zoomLevel * 1.5, 10) }));
+        setViewState((current) => ({ ...current, zoomLevel: Math.min(current.zoomLevel * 1.5, 10) }));
         return;
       case "-":
-        setViewState((state) => ({ ...state, zoomLevel: Math.max(state.zoomLevel / 1.5, 0.5) }));
+        setViewState((current) => ({ ...current, zoomLevel: Math.max(current.zoomLevel / 1.5, 0.5) }));
         return;
       case "0":
-        setViewState((state) => ({ ...state, panOffset: 0, zoomLevel: 1, cursorX: null }));
+        setViewState((current) => ({ ...current, panOffset: 0, zoomLevel: 1, cursorX: null }));
         return;
       case "v":
         setShowVolume((value) => !value);
         return;
       case "a":
-        setViewState((state) => ({ ...state, panOffset: state.panOffset + panStep }));
+        setViewState((current) => ({ ...current, panOffset: current.panOffset + panStep }));
         return;
       case "d":
-        setViewState((state) => ({ ...state, panOffset: Math.max(state.panOffset - panStep, 0) }));
+        setViewState((current) => ({ ...current, panOffset: Math.max(current.panOffset - panStep, 0) }));
         return;
       case "m":
-        setViewState((view) => {
-          const current = view.renderMode ?? "area";
-          const idx = CHART_RENDER_MODES.indexOf(current);
-          const next = CHART_RENDER_MODES[(idx + 1) % CHART_RENDER_MODES.length]!;
-          if (next !== defaultRenderMode) {
-            const nextConfig = {
-              ...state.config,
-              chartPreferences: {
-                ...state.config.chartPreferences,
-                defaultRenderMode: next,
-              },
-            };
-            dispatch({ type: "SET_CONFIG", config: nextConfig });
-            saveConfig(nextConfig).catch(() => {});
-          }
-          return { ...view, renderMode: next };
+        setViewState((current) => {
+          const activeMode = current.renderMode ?? "area";
+          const index = CHART_RENDER_MODES.indexOf(activeMode);
+          const nextMode = CHART_RENDER_MODES[(index + 1) % CHART_RENDER_MODES.length]!;
+          persistDefaultRenderMode(nextMode);
+          return { ...current, renderMode: nextMode };
         });
         return;
     }
 
     if (event.name >= "1" && event.name <= "7") {
-      const idx = parseInt(event.name) - 1;
-      if (idx < TIME_RANGES.length) {
-        setViewState((state) => ({
-          ...state,
-          timeRange: TIME_RANGES[idx]!,
-          panOffset: 0,
-          zoomLevel: 1,
-          cursorX: null,
-        }));
-      }
+      const index = parseInt(event.name) - 1;
+      if (index < TIME_RANGES.length) setRange(TIME_RANGES[index]!);
       return;
     }
 
@@ -225,27 +414,27 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     switch (event.name) {
       case "left":
         if (event.shift) {
-          setViewState((state) => ({ ...state, panOffset: state.panOffset + panStep }));
+          setViewState((current) => ({ ...current, panOffset: current.panOffset + panStep }));
         } else {
-          setViewState((state) => {
-            const nextCursor = state.cursorX === null ? maxCursorX : state.cursorX - 1;
+          setViewState((current) => {
+            const nextCursor = current.cursorX === null ? maxCursorX : current.cursorX - 1;
             if (nextCursor < 0) {
-              return { ...state, cursorX: 0, panOffset: state.panOffset + 1 };
+              return { ...current, cursorX: 0, panOffset: current.panOffset + 1 };
             }
-            return { ...state, cursorX: nextCursor };
+            return { ...current, cursorX: nextCursor };
           });
         }
         return;
       case "right":
         if (event.shift) {
-          setViewState((state) => ({ ...state, panOffset: Math.max(state.panOffset - panStep, 0) }));
+          setViewState((current) => ({ ...current, panOffset: Math.max(current.panOffset - panStep, 0) }));
         } else {
-          setViewState((state) => {
-            const nextCursor = state.cursorX === null ? 0 : state.cursorX + 1;
+          setViewState((current) => {
+            const nextCursor = current.cursorX === null ? 0 : current.cursorX + 1;
             if (nextCursor > maxCursorX) {
-              return { ...state, cursorX: maxCursorX, panOffset: Math.max(state.panOffset - 1, 0) };
+              return { ...current, cursorX: maxCursorX, panOffset: Math.max(current.panOffset - 1, 0) };
             }
-            return { ...state, cursorX: nextCursor };
+            return { ...current, cursorX: nextCursor };
           });
         }
         return;
@@ -257,20 +446,24 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
   const timeAxisRow = 1;
   const volumeHeight = showVolume && !compact ? 3 : 0;
   const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
-
   const isDetailView = viewState.zoomLevel > 1 && detailHistory != null && detailHistory.length > 0;
 
-  const { window: visibleWindow, projection, chartColors, result } = useMemo(() => {
-    // When using detail data, it's already scoped to the visible window — skip zoom/pan windowing
-    const window = isDetailView
+  const chartWindow = useMemo(() => (
+    isDetailView
       ? { points: history, startIdx: 0, endIdx: history.length }
-      : getVisibleWindow(history, viewState, chartWidth);
-    const projection = projectChartData(window.points, chartWidth, viewState.renderMode, !!compact);
-    const rawChange = window.points.length >= 2
-      ? window.points[window.points.length - 1]!.close - window.points[0]!.close
+      : getVisibleWindow(history, viewState, chartWidth)
+  ), [chartWidth, history, isDetailView, viewState.panOffset, viewState.timeRange, viewState.zoomLevel]);
+
+  const projection = useMemo(() => (
+    projectChartData(chartWindow.points, chartWidth, viewState.renderMode, !!compact)
+  ), [chartWindow.points, chartWidth, compact, viewState.renderMode]);
+
+  const chartColors = useMemo(() => {
+    const rawChange = chartWindow.points.length >= 2
+      ? chartWindow.points[chartWindow.points.length - 1]!.close - chartWindow.points[0]!.close
       : 0;
     const trend = rawChange < 0 ? "negative" : rawChange > 0 ? "positive" : "neutral";
-    const chartColors = resolveChartPalette({
+    return resolveChartPalette({
       bg: colors.bg,
       border: colors.border,
       borderFocused: colors.borderFocused,
@@ -279,31 +472,132 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
       positive: colors.positive,
       negative: colors.negative,
     }, trend);
+  }, [chartWindow.points]);
 
-    const result = renderChart(projection.points, {
-      width: chartWidth,
-      height: chartHeight,
-      showVolume: showVolume && !compact,
-      volumeHeight,
-      cursorX: viewState.cursorX !== null ? Math.min(viewState.cursorX, chartWidth - 1) : null,
-      mode: projection.effectiveMode,
-      colors: chartColors,
+  const cursorX = viewState.cursorX !== null ? Math.min(viewState.cursorX, chartWidth - 1) : null;
+  const result = useMemo(() => renderChart(projection.points, {
+    width: chartWidth,
+    height: chartHeight,
+    showVolume: showVolume && !compact,
+    volumeHeight,
+    cursorX,
+    mode: projection.effectiveMode,
+    colors: chartColors,
+  }), [chartColors, chartHeight, chartWidth, compact, cursorX, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+
+  const nativeScene = useMemo(() => buildChartScene(projection.points, {
+    width: chartWidth,
+    height: chartHeight,
+    showVolume: showVolume && !compact,
+    volumeHeight,
+    cursorX: null,
+    mode: projection.effectiveMode,
+    colors: chartColors,
+  }), [chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+
+  const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
+  const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;
+  const overlayLines = useMemo(() => (
+    buildNativeOverlayLines(chartWidth, chartHeight, interactive ? cursorX : null, interactive ? result.cursorRow : null)
+  ), [chartHeight, chartWidth, cursorX, interactive, result.cursorRow]);
+
+  useEffect(() => {
+    if (effectiveRenderer === "kitty") return;
+    nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
+  }, [effectiveRenderer, nativeSurfaceManager]);
+
+  useEffect(() => {
+    if (!plotRef.current) return;
+    const plot = plotRef.current;
+
+    const syncPlacement = () => {
+      if (effectiveRenderer !== "kitty" || !rendererState.nativeReady || !plotRef.current) return;
+      const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+      nativeSurfaceManager.updateSurfaceGeometry(nativeSurfaceIdRef.current, {
+        paneId,
+        rect: extractCellRect(plotRef.current),
+        visibleRect,
+      });
+    };
+
+    plot.onLifecyclePass = syncPlacement;
+    renderer.registerLifecyclePass(plot);
+    return () => {
+      plot.onLifecyclePass = null;
+      renderer.unregisterLifecyclePass(plot);
+    };
+  }, [effectiveRenderer, nativeSurfaceManager, paneId, renderer, rendererState.nativeReady]);
+
+  useEffect(() => {
+    if (effectiveRenderer !== "kitty" || !rendererState.nativeReady || !renderer.resolution || !plotRef.current || !nativeScene) {
+      nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
+      return;
+    }
+
+    const plotRect = extractCellRect(plotRef.current);
+    const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+    if (!visibleRect) {
+      nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
+      return;
+    }
+
+    const bitmapSize = computeBitmapSize(plotRect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
+    const bitmap = renderNativeChart(nativeScene, bitmapSize.pixelWidth, bitmapSize.pixelHeight);
+    nativeSurfaceManager.upsertSurface({
+      id: nativeSurfaceIdRef.current,
+      paneId,
+      rect: plotRect,
+      visibleRect,
+      bitmap,
+      bitmapKey: buildNativeBitmapKey(
+        projection.points.length,
+        projection.points,
+        bitmap.width,
+        bitmap.height,
+        projection.effectiveMode,
+        showVolume && !compact,
+        [
+          chartColors.lineColor,
+          chartColors.fillColor,
+          chartColors.gridColor,
+          chartColors.volumeUp,
+          chartColors.volumeDown,
+          chartColors.candleUp,
+          chartColors.candleDown,
+        ].join(","),
+      ),
     });
-
-    return { window, projection, chartColors, result };
-  }, [history, viewState, chartWidth, chartHeight, showVolume, compact, volumeHeight, isDetailView]);
+  }, [
+    chartColors.candleDown,
+    chartColors.candleUp,
+    chartColors.fillColor,
+    chartColors.gridColor,
+    chartColors.lineColor,
+    chartColors.volumeDown,
+    chartColors.volumeUp,
+    compact,
+    effectiveRenderer,
+    nativeScene,
+    nativeSurfaceManager,
+    paneId,
+    projection.effectiveMode,
+    projection.points,
+    renderer,
+    rendererState.nativeReady,
+    showVolume,
+  ]);
 
   if (history.length === 0) {
     return <text fg={colors.textDim}>No price history available.</text>;
   }
 
-  const firstPrice = visibleWindow.points[0]?.close ?? 0;
-  const lastPrice = visibleWindow.points[visibleWindow.points.length - 1]?.close ?? 0;
+  const firstPrice = chartWindow.points[0]?.close ?? 0;
+  const lastPrice = chartWindow.points[chartWindow.points.length - 1]?.close ?? 0;
   const change = lastPrice - firstPrice;
   const changePct = firstPrice ? (change / firstPrice) * 100 : 0;
   const requestedMode = projection.requestedMode;
   const showOhlcSummary = projection.effectiveMode === "candles" || projection.effectiveMode === "ohlc";
-  const hasCursor = viewState.cursorX !== null;
+  const hasCursor = cursorX !== null;
   const displayPrice = hasCursor ? (result.priceAtCursor ?? lastPrice) : lastPrice;
   const displayChange = hasCursor ? (result.changeAtCursor ?? change) : change;
   const displayChangePct = hasCursor ? (result.changePctAtCursor ?? changePct) : changePct;
@@ -311,24 +605,124 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     ? (result.dateAtCursor ? formatDateShort(result.dateAtCursor) : null)
     : null;
   const activePoint = showOhlcSummary ? result.activePoint : null;
+  const axisLabels = new Map(result.axisLabels.map((entry) => [entry.row, entry.label]));
 
-  // Shared chart lines rendering for both compact and full modes
-  const chartLines = result.lines.map((line, i) => {
-    const axisLabel = !compact ? result.axisLabels.find((entry) => entry.row === i) : null;
-    return (
-      <box key={i} flexDirection="row" height={1}>
-        <text content={line as any} />
-        {axisLabel && (
-          <text fg={colors.textDim}> {axisLabel.label.padStart(axisWidth - 1)}</text>
-        )}
-      </box>
+  const handlePlotMove = (event: ChartMouseEvent) => {
+    if (!interactive || compact) return;
+    const localX = getLocalPlotX(event, plotRef.current);
+    if (localX === null) return;
+    setViewState((current) => (current.cursorX === localX ? current : { ...current, cursorX: localX }));
+  };
+
+  const handlePlotDown = (event: ChartMouseEvent) => {
+    if (!interactive || compact) return;
+    const localX = getLocalPlotX(event, plotRef.current);
+    if (localX === null) return;
+    dragRef.current = {
+      startGlobalX: event.x,
+      startPanOffset: viewState.panOffset,
+    };
+    setViewState((current) => ({ ...current, cursorX: localX }));
+  };
+
+  const handlePlotDrag = (event: ChartMouseEvent) => {
+    if (!interactive || compact) return;
+    const localX = getLocalPlotX(event, plotRef.current);
+    if (localX !== null) {
+      setViewState((current) => ({ ...current, cursorX: localX }));
+    }
+    if (!dragRef.current) return;
+
+    const filtered = filterByTimeRange(baseHistory, viewState.timeRange);
+    const visibleCount = Math.max(Math.floor(chartWidth / viewState.zoomLevel), 10);
+    const deltaCells = event.x - dragRef.current.startGlobalX;
+    const pointDelta = Math.round((deltaCells / Math.max(chartWidth, 1)) * visibleCount);
+    const nextPan = clamp(
+      dragRef.current.startPanOffset - pointDelta,
+      0,
+      Math.max(filtered.length - visibleCount, 0),
     );
-  });
+    setViewState((current) => ({ ...current, panOffset: nextPan }));
+  };
+
+  const handlePlotScroll = (event: ChartMouseEvent) => {
+    if (!interactive || compact) return;
+    const direction = event.scroll?.direction;
+    if (!direction) return;
+
+    const localX = getLocalPlotX(event, plotRef.current);
+    const anchorRatio = localX === null ? 0.5 : localX / Math.max(chartWidth - 1, 1);
+
+    if (event.modifiers.shift && (direction === "up" || direction === "down")) {
+      const shiftDirection = direction === "up" ? 1 : -1;
+      const nextPan = clamp(
+        viewState.panOffset + shiftDirection * Math.max(Math.round(chartWidth * 0.08), 1),
+        0,
+        getMaxPanOffset(baseHistory, viewState.timeRange, viewState.zoomLevel, chartWidth),
+      );
+      setViewState((current) => ({ ...current, panOffset: nextPan }));
+      return;
+    }
+
+    switch (direction) {
+      case "up":
+        setViewState((current) => applyZoomAroundAnchor(current, current.zoomLevel * 1.18, anchorRatio, baseHistory, chartWidth));
+        return;
+      case "down":
+        setViewState((current) => applyZoomAroundAnchor(current, current.zoomLevel / 1.18, anchorRatio, baseHistory, chartWidth));
+        return;
+      case "left":
+        setViewState((current) => ({
+          ...current,
+          panOffset: clamp(
+            current.panOffset + Math.max(Math.round(chartWidth * 0.08), 1),
+            0,
+            getMaxPanOffset(baseHistory, current.timeRange, current.zoomLevel, chartWidth),
+          ),
+        }));
+        return;
+      case "right":
+        setViewState((current) => ({
+          ...current,
+          panOffset: clamp(
+            current.panOffset - Math.max(Math.round(chartWidth * 0.08), 1),
+            0,
+            getMaxPanOffset(baseHistory, current.timeRange, current.zoomLevel, chartWidth),
+          ),
+        }));
+        return;
+    }
+  };
+
+  const plotContent = effectiveRenderer === "kitty"
+    ? overlayLines.map((line, index) => (
+      <text key={index} fg={chartColors.crosshairColor}>{line}</text>
+    ))
+    : result.lines.map((line, index) => (
+      <text key={index} content={line as any} />
+    ));
+
+  const plotBox = (
+    <box
+      ref={plotRef}
+      width={chartWidth}
+      height={chartHeight}
+      flexDirection="column"
+      onMouseMove={compact ? undefined : handlePlotMove}
+      onMouseDown={compact ? undefined : handlePlotDown}
+      onMouseDrag={compact ? undefined : handlePlotDrag}
+      onMouseDragEnd={compact ? undefined : () => { dragRef.current = null; }}
+      onMouseOut={compact ? undefined : () => { dragRef.current = null; }}
+      onMouseScroll={compact ? undefined : handlePlotScroll}
+    >
+      {plotContent}
+    </box>
+  );
 
   if (compact) {
     return (
       <box flexDirection="column">
-        {chartLines}
+        {plotBox}
         <box height={1}>
           <text fg={colors.textDim}>{result.timeLabels}</text>
         </box>
@@ -362,13 +756,14 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
 
       <box flexDirection="row" height={1}>
         <box flexDirection="row" gap={1}>
-          {TIME_RANGES.map((range, i) => (
+          {TIME_RANGES.map((range, index) => (
             <text
               key={range}
               fg={viewState.timeRange === range ? chartColors.activeRangeColor : chartColors.inactiveRangeColor}
               attributes={viewState.timeRange === range ? TextAttributes.BOLD : 0}
+              onMouseDown={() => setRange(range)}
             >
-              {`${i + 1}:${range}`}
+              {`${index + 1}:${range}`}
             </text>
           ))}
           {viewState.zoomLevel !== 1 && (
@@ -383,12 +778,16 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
                 key={mode}
                 fg={requestedMode === mode ? chartColors.activeRangeColor : chartColors.inactiveRangeColor}
                 attributes={requestedMode === mode ? TextAttributes.BOLD : 0}
+                onMouseDown={() => setRenderMode(mode)}
               >
                 {MODE_CHIPS[mode]}
               </text>
             ))}
             {projection.fallbackMode && (
               <text fg={colors.textDim}>auto:{MODE_LABELS[projection.fallbackMode]}</text>
+            )}
+            {rendererState.nativeUnavailable && (
+              <text fg={colors.textDim}>native unavailable</text>
             )}
           </box>
         ) : (
@@ -397,13 +796,25 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
             {projection.fallbackMode && (
               <text fg={colors.textDim}>auto:{MODE_LABELS[projection.fallbackMode]}</text>
             )}
+            {rendererState.nativeUnavailable && (
+              <text fg={colors.textDim}>native unavailable</text>
+            )}
           </box>
         )}
       </box>
 
       <box height={1} />
 
-      {chartLines}
+      <box flexDirection="row" height={chartHeight}>
+        {plotBox}
+        <box width={axisWidth} height={chartHeight} flexDirection="column">
+          {Array.from({ length: chartHeight }, (_, row) => (
+            <text key={row} fg={colors.textDim}>
+              {axisLabels.has(row) ? ` ${axisLabels.get(row)!.padStart(axisWidth - 1)}` : " ".repeat(axisWidth)}
+            </text>
+          ))}
+        </box>
+      </box>
 
       <box height={1}>
         <text fg={colors.textDim}>{result.timeLabels}</text>
@@ -412,8 +823,8 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
       <box height={1}>
         <text fg={colors.textMuted}>
           {interactive
-            ? "←→ cursor  ⇧←→ pan  a/d pan  +/- zoom  m mode  1-7 range  v vol  Esc exit"
-            : "Enter crosshair  a/d pan  +/- zoom  m mode  1-7 range  v volume  0 reset"}
+            ? "mouse hover inspect  drag pan  wheel zoom  ⇧wheel pan  ←→ cursor  ⇧←→ pan  m mode  1-7 range  v vol  Esc exit"
+            : "Enter crosshair  click chart to focus  a/d pan  +/- zoom  m mode  1-7 range  v volume  0 reset"}
         </text>
       </box>
     </box>

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -29,6 +29,7 @@ import type { PromptContext, AlertContext } from "@opentui-ui/dialog/react";
 import { resolveBrokerConfigFields } from "../../types/broker";
 import type { InstrumentSearchResult } from "../../types/instrument";
 import { buildIbkrConfigFromValues } from "../../plugins/ibkr/config";
+import { CHART_RENDERER_PREFERENCES } from "../chart/chart-types";
 import { DialogFrame, ListView, TextField } from "../ui";
 import {
   getEmptyState,
@@ -593,6 +594,22 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
       case "columns": {
         // Enter columns mode by setting the prefix
         dispatch({ type: "SET_COMMAND_BAR_QUERY", query: "COL " });
+        return;
+      }
+      case "cycle-chart-renderer": {
+        const current = state.config.chartPreferences.renderer;
+        const index = CHART_RENDERER_PREFERENCES.indexOf(current);
+        const next = CHART_RENDERER_PREFERENCES[(index + 1) % CHART_RENDERER_PREFERENCES.length] ?? "auto";
+        const nextConfig = {
+          ...state.config,
+          chartPreferences: {
+            ...state.config.chartPreferences,
+            renderer: next,
+          },
+        };
+        dispatch({ type: "SET_CONFIG", config: nextConfig });
+        saveConfig(nextConfig).catch(() => {});
+        close();
         return;
       }
       case "add-watchlist":

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -148,6 +148,14 @@ export const commands: Command[] = [
     category: "Config",
     execute: () => {}, // handled by command bar
   },
+  {
+    id: "cycle-chart-renderer",
+    prefix: "CR",
+    label: "Cycle Chart Renderer",
+    description: "Cycle chart rendering between Auto, Kitty, and Braille",
+    category: "Config",
+    execute: () => {}, // handled specially by command bar
+  },
 
   // Plugins
   {

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from "react";
-import { useTerminalDimensions } from "@opentui/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { useDialogState } from "@opentui-ui/dialog/react";
 import { saveConfig } from "../../data/config-store";
 import {
@@ -21,6 +21,7 @@ import {
 } from "../../state/app-context";
 import type { LayoutConfig } from "../../types/config";
 import { colors } from "../../theme/colors";
+import { getNativeSurfaceManager, type NativeOccluder, type NativePaneLayer } from "../chart/native/surface-manager";
 import { FloatingPaneWrapper } from "./floating-pane";
 import { PaneWrapper } from "./pane";
 
@@ -41,7 +42,9 @@ type DragMode =
 
 export function Shell({ pluginRegistry }: ShellProps) {
   const { state, dispatch } = useAppState();
+  const renderer = useRenderer();
   const { width, height } = useTerminalDimensions();
+  const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);
 
   const layout = state.config.layout;
   const contentHeight = height - (state.statusBarVisible ? 2 : 1);
@@ -154,6 +157,59 @@ export function Shell({ pluginRegistry }: ShellProps) {
     rects.sort((a, b) => b.z - a.z);
     return rects;
   }, [filteredFloating]);
+
+  const nativePaneLayers = useMemo<NativePaneLayer[]>(() => {
+    const layers: NativePaneLayer[] = [];
+    for (const panes of filteredColumns.values()) {
+      for (const pane of panes) {
+        layers.push({ paneId: pane.instance.instanceId, zIndex: 0 });
+      }
+    }
+    for (const pane of filteredFloating) {
+      layers.push({
+        paneId: pane.instance.instanceId,
+        zIndex: pane.floating?.zIndex ?? 50,
+      });
+    }
+    return layers;
+  }, [filteredColumns, filteredFloating]);
+
+  const nativeOccluders = useMemo<NativeOccluder[]>(() => {
+    const occluders: NativeOccluder[] = filteredFloating.map((pane) => ({
+      id: pane.instance.instanceId,
+      paneId: pane.instance.instanceId,
+      rect: {
+        x: pane.floating!.x,
+        y: pane.floating!.y + HEADER_HEIGHT,
+        width: pane.floating!.width,
+        height: pane.floating!.height,
+      },
+      zIndex: pane.floating?.zIndex ?? 50,
+    }));
+
+    if (overlayOpen) {
+      occluders.push({
+        id: "overlay:global",
+        paneId: null,
+        rect: {
+          x: 0,
+          y: HEADER_HEIGHT,
+          width,
+          height: contentHeight,
+        },
+        zIndex: Number.MAX_SAFE_INTEGER,
+      });
+    }
+
+    return occluders;
+  }, [contentHeight, filteredFloating, overlayOpen, width]);
+
+  useEffect(() => {
+    nativeSurfaceManager.setWindowState({
+      paneLayers: nativePaneLayers,
+      occluders: nativeOccluders,
+    });
+  }, [nativeOccluders, nativePaneLayers, nativeSurfaceManager]);
 
   const handleMouse = useCallback((event: { type: string; x: number; y: number; stopPropagation: () => void; preventDefault: () => void }) => {
     const shellY = event.y - HEADER_HEIGHT;

--- a/src/data/config-store.test.ts
+++ b/src/data/config-store.test.ts
@@ -86,6 +86,40 @@ describe("loadConfig", () => {
 
     expect(config.chartPreferences).toEqual({
       defaultRenderMode: "area",
+      renderer: "auto",
+    });
+  });
+
+  test("sanitizes invalid chart renderer values back to auto", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "gloomberb-config-"));
+    tempDirs.push(dataDir);
+
+    await writeFile(join(dataDir, "config.json"), JSON.stringify({
+      configVersion: 7,
+      baseCurrency: "USD",
+      refreshIntervalMinutes: 30,
+      portfolios: [{ id: "main", name: "Main Portfolio", currency: "USD" }],
+      watchlists: [{ id: "watchlist", name: "Watchlist" }],
+      columns: [],
+      layout: DEFAULT_LAYOUT,
+      layouts: [{ name: "Default", layout: DEFAULT_LAYOUT }],
+      activeLayoutIndex: 0,
+      brokerInstances: [],
+      plugins: [],
+      disabledPlugins: [],
+      theme: "amber",
+      chartPreferences: {
+        defaultRenderMode: "line",
+        renderer: "nope",
+      },
+      recentTickers: [],
+    }), "utf-8");
+
+    const config = await loadConfig(dataDir);
+
+    expect(config.chartPreferences).toEqual({
+      defaultRenderMode: "line",
+      renderer: "auto",
     });
   });
 });

--- a/src/data/config-store.ts
+++ b/src/data/config-store.ts
@@ -156,16 +156,34 @@ function sanitizeStringArray(value: unknown, fallback: string[]): string[] {
 function isChartPreferences(value: unknown): value is ChartPreferences {
   if (!value || typeof value !== "object") return false;
   const defaultRenderMode = (value as ChartPreferences).defaultRenderMode;
-  return defaultRenderMode === "area"
+  const renderer = (value as ChartPreferences).renderer;
+  return (defaultRenderMode === "area"
     || defaultRenderMode === "line"
     || defaultRenderMode === "candles"
-    || defaultRenderMode === "ohlc";
+    || defaultRenderMode === "ohlc")
+    && (renderer === "auto" || renderer === "kitty" || renderer === "braille");
 }
 
 function sanitizeChartPreferences(value: unknown, fallback: ChartPreferences): ChartPreferences {
-  return isChartPreferences(value)
-    ? { defaultRenderMode: value.defaultRenderMode }
-    : { ...fallback };
+  if (!value || typeof value !== "object") return { ...fallback };
+
+  const candidate = value as Partial<ChartPreferences>;
+  const defaultRenderMode = candidate.defaultRenderMode === "area"
+    || candidate.defaultRenderMode === "line"
+    || candidate.defaultRenderMode === "candles"
+    || candidate.defaultRenderMode === "ohlc"
+    ? candidate.defaultRenderMode
+    : fallback.defaultRenderMode;
+  const renderer = candidate.renderer === "auto"
+    || candidate.renderer === "kitty"
+    || candidate.renderer === "braille"
+    ? candidate.renderer
+    : fallback.renderer;
+
+  return {
+    defaultRenderMode,
+    renderer,
+  };
 }
 
 function sanitizeColumns(value: unknown, fallback: ColumnConfig[]): ColumnConfig[] {

--- a/src/plugins/ibkr/instance-selection.test.ts
+++ b/src/plugins/ibkr/instance-selection.test.ts
@@ -36,6 +36,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     theme: "amber",
     chartPreferences: {
       defaultRenderMode: "area",
+      renderer: "auto",
     },
     recentTickers: [],
     ...overrides,

--- a/src/poc/framebuffer-chart.tsx
+++ b/src/poc/framebuffer-chart.tsx
@@ -1,0 +1,627 @@
+import { ptr } from "bun:ffi";
+import {
+  createCliRenderer,
+  RGBA,
+  type BoxRenderable,
+  type CliRenderer,
+  type MouseEvent,
+  type OptimizedBuffer,
+} from "@opentui/core";
+import { createRoot, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { projectCloseSeries } from "../components/chart/chart-data";
+import { resolveChartPalette } from "../components/chart/chart-renderer";
+import { colors } from "../theme/colors";
+import type { PricePoint } from "../types/financials";
+import { formatCurrency } from "../utils/format";
+
+interface RgbaColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+interface DragState {
+  startGlobalX: number;
+  startPanOffset: number;
+}
+
+interface TerminalSnapshot {
+  kittyGraphics: boolean | null;
+  resolutionLabel: string;
+  terminalLabel: string;
+}
+
+const SERIES_POINT_COUNT = 240;
+const MIN_VISIBLE_POINTS = 24;
+const MIN_PLOT_CELLS = 12;
+const DEFAULT_ZOOM = 1.4;
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 7;
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const demoSeries = createDemoSeries(SERIES_POINT_COUNT);
+const seriesTrend = demoSeries[demoSeries.length - 1]!.close - demoSeries[0]!.close;
+const chartPalette = resolveChartPalette({
+  bg: colors.bg,
+  border: colors.border,
+  borderFocused: colors.borderFocused,
+  text: colors.text,
+  textDim: colors.textDim,
+  positive: colors.positive,
+  negative: colors.negative,
+}, seriesTrend < 0 ? "negative" : seriesTrend > 0 ? "positive" : "neutral");
+
+const backgroundColor = toRgbaColor(colors.panel);
+const gridColor = withOpacity(toRgbaColor(chartPalette.gridColor), 0.24);
+const axisGlowColor = withOpacity(toRgbaColor(colors.borderFocused), 0.42);
+const areaFillColor = withOpacity(toRgbaColor(chartPalette.fillColor), 0.32);
+const lineGlowColor = withOpacity(toRgbaColor(chartPalette.lineColor), 0.14);
+const lineColor = withOpacity(toRgbaColor(chartPalette.lineColor), 0.9);
+const markerColor = toRgbaColor(colors.textBright);
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function smoothstep(edge0: number, edge1: number, value: number): number {
+  const range = edge1 - edge0;
+  if (range === 0) return value < edge0 ? 0 : 1;
+  const t = clamp((value - edge0) / range, 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+function toRgbaColor(hex: string, alpha = 1): RgbaColor {
+  const normalized = hex.replace("#", "");
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+    a: Math.round(clamp(alpha, 0, 1) * 255),
+  };
+}
+
+function withOpacity(color: RgbaColor, opacity: number): RgbaColor {
+  return { ...color, a: Math.round(clamp(opacity, 0, 1) * 255) };
+}
+
+function fillPixels(data: Uint8Array, color: RgbaColor) {
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = color.r;
+    data[i + 1] = color.g;
+    data[i + 2] = color.b;
+    data[i + 3] = color.a;
+  }
+}
+
+function blendPixel(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+  color: RgbaColor,
+  opacity = 1,
+) {
+  if (x < 0 || y < 0 || x >= width || y >= height) return;
+
+  const alpha = clamp((color.a / 255) * opacity, 0, 1);
+  if (alpha <= 0) return;
+
+  const index = (y * width + x) * 4;
+  const dstAlpha = data[index + 3]! / 255;
+  const outAlpha = alpha + dstAlpha * (1 - alpha);
+
+  if (outAlpha <= 0) {
+    data[index] = 0;
+    data[index + 1] = 0;
+    data[index + 2] = 0;
+    data[index + 3] = 0;
+    return;
+  }
+
+  const dstFactor = dstAlpha * (1 - alpha);
+  data[index] = Math.round((color.r * alpha + data[index]! * dstFactor) / outAlpha);
+  data[index + 1] = Math.round((color.g * alpha + data[index + 1]! * dstFactor) / outAlpha);
+  data[index + 2] = Math.round((color.b * alpha + data[index + 2]! * dstFactor) / outAlpha);
+  data[index + 3] = Math.round(outAlpha * 255);
+}
+
+function drawLine(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  color: RgbaColor,
+  thickness: number,
+) {
+  const half = thickness / 2;
+  const minX = Math.floor(Math.min(x0, x1) - half - 1);
+  const maxX = Math.ceil(Math.max(x0, x1) + half + 1);
+  const minY = Math.floor(Math.min(y0, y1) - half - 1);
+  const maxY = Math.ceil(Math.max(y0, y1) + half + 1);
+
+  const dx = x1 - x0;
+  const dy = y1 - y0;
+  const segmentLengthSq = dx * dx + dy * dy || 1;
+
+  for (let py = minY; py <= maxY; py++) {
+    for (let px = minX; px <= maxX; px++) {
+      const cx = px + 0.5;
+      const cy = py + 0.5;
+      const projection = clamp(((cx - x0) * dx + (cy - y0) * dy) / segmentLengthSq, 0, 1);
+      const nearestX = x0 + dx * projection;
+      const nearestY = y0 + dy * projection;
+      const distance = Math.hypot(cx - nearestX, cy - nearestY);
+      const coverage = 1 - smoothstep(half, half + 1.1, distance);
+      if (coverage > 0) {
+        blendPixel(data, width, height, px, py, color, coverage);
+      }
+    }
+  }
+}
+
+function drawCircle(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  centerX: number,
+  centerY: number,
+  radius: number,
+  color: RgbaColor,
+) {
+  const minX = Math.floor(centerX - radius - 1);
+  const maxX = Math.ceil(centerX + radius + 1);
+  const minY = Math.floor(centerY - radius - 1);
+  const maxY = Math.ceil(centerY + radius + 1);
+
+  for (let py = minY; py <= maxY; py++) {
+    for (let px = minX; px <= maxX; px++) {
+      const distance = Math.hypot(px + 0.5 - centerX, py + 0.5 - centerY);
+      const coverage = 1 - smoothstep(radius - 0.6, radius + 0.6, distance);
+      if (coverage > 0) {
+        blendPixel(data, width, height, px, py, color, coverage);
+      }
+    }
+  }
+}
+
+function drawFill(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  yByColumn: Float32Array,
+  plotTop: number,
+  plotBottom: number,
+  color: RgbaColor,
+) {
+  const startX = 0;
+  const endX = Math.min(width - 1, yByColumn.length - 1);
+
+  for (let x = startX; x <= endX; x++) {
+    const yTop = yByColumn[x]!;
+    if (!Number.isFinite(yTop)) continue;
+
+    for (let y = Math.max(Math.floor(yTop), plotTop); y <= plotBottom; y++) {
+      const distance = plotBottom - yTop || 1;
+      const fade = 1 - (y - yTop) / distance;
+      const opacity = 0.04 + fade * 0.16;
+      blendPixel(data, width, height, x, y, color, opacity);
+    }
+  }
+}
+
+function drawGrid(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  plotLeft: number,
+  plotTop: number,
+  plotRight: number,
+  plotBottom: number,
+) {
+  const horizontalSteps = 4;
+  const verticalSteps = 5;
+
+  for (let i = 0; i <= horizontalSteps; i++) {
+    const y = Math.round(lerp(plotTop, plotBottom, i / horizontalSteps));
+    drawLine(data, width, height, plotLeft, y, plotRight, y, gridColor, 1);
+  }
+
+  for (let i = 0; i <= verticalSteps; i++) {
+    const x = Math.round(lerp(plotLeft, plotRight, i / verticalSteps));
+    drawLine(data, width, height, x, plotTop, x, plotBottom, gridColor, 1);
+  }
+}
+
+function formatDate(date: Date): string {
+  return DATE_FORMATTER.format(date);
+}
+
+function calculateVisibleCount(plotWidthCells: number, zoom: number, total: number): number {
+  const baseCount = Math.min(total, Math.max(plotWidthCells * 2, MIN_VISIBLE_POINTS));
+  return clamp(Math.round(baseCount / zoom), MIN_VISIBLE_POINTS, total);
+}
+
+function resolveLocalPlotX(event: MouseEvent, renderable: BoxRenderable | null): number | null {
+  if (!renderable) return null;
+
+  const localX = event.x - renderable.x - 1;
+  const plotWidth = Math.max(renderable.width - 2, 0);
+  if (plotWidth <= 0 || localX < 0 || localX >= plotWidth) {
+    return null;
+  }
+
+  return localX;
+}
+
+function getActiveIndex(hoverCellX: number | null, plotWidthCells: number, pointCount: number): number {
+  if (pointCount <= 1) return 0;
+  if (hoverCellX === null || plotWidthCells <= 1) return pointCount - 1;
+  const ratio = clamp(hoverCellX / (plotWidthCells - 1), 0, 1);
+  return clamp(Math.round(ratio * (pointCount - 1)), 0, pointCount - 1);
+}
+
+function readTerminalSnapshot(renderer: CliRenderer): TerminalSnapshot {
+  const caps = renderer.capabilities as {
+    kitty_graphics?: boolean;
+    terminal?: { name?: string; version?: string };
+  } | null;
+  const resolution = renderer.resolution;
+  const terminalName = caps?.terminal?.name || "unknown";
+  const terminalVersion = caps?.terminal?.version ? ` ${caps.terminal.version}` : "";
+
+  return {
+    kittyGraphics: caps?.kitty_graphics ?? null,
+    resolutionLabel: resolution ? `${resolution.width}x${resolution.height}px` : "probing",
+    terminalLabel: `${terminalName}${terminalVersion}`.trim(),
+  };
+}
+
+function createDemoSeries(count: number): PricePoint[] {
+  const series: PricePoint[] = [];
+  let seed = 0x6d2b79f5;
+  let close = 102;
+
+  const random = () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  for (let index = 0; index < count; index++) {
+    const drift = Math.sin(index / 15) * 0.45 + Math.cos(index / 27) * 0.35;
+    const shock = (random() - 0.5) * 2.8;
+    const nextClose = Math.max(18, close + drift + shock + (index > count * 0.6 ? 0.16 : 0.05));
+    const open = close + (random() - 0.5) * 1.5;
+    const high = Math.max(open, nextClose) + random() * 1.8;
+    const low = Math.min(open, nextClose) - random() * 1.8;
+    const date = new Date(Date.UTC(2025, 0, 2 + index));
+
+    series.push({
+      date,
+      open,
+      high,
+      low,
+      close: nextClose,
+      volume: Math.round(700_000 + random() * 1_900_000),
+    });
+
+    close = nextClose;
+  }
+
+  return series;
+}
+
+function renderChartToPixels(
+  pixels: Uint8Array,
+  pixelWidth: number,
+  pixelHeight: number,
+  points: PricePoint[],
+  activeIndex: number,
+) {
+  fillPixels(pixels, backgroundColor);
+
+  if (points.length === 0) return;
+
+  const insetX = 2;
+  const insetTop = 2;
+  const insetBottom = 3;
+  const plotLeft = insetX;
+  const plotRight = Math.max(plotLeft, pixelWidth - insetX - 1);
+  const plotTop = insetTop;
+  const plotBottom = Math.max(plotTop, pixelHeight - insetBottom - 1);
+
+  drawGrid(pixels, pixelWidth, pixelHeight, plotLeft, plotTop, plotRight, plotBottom);
+
+  let minValue = Number.POSITIVE_INFINITY;
+  let maxValue = Number.NEGATIVE_INFINITY;
+  for (const point of points) {
+    minValue = Math.min(minValue, point.close);
+    maxValue = Math.max(maxValue, point.close);
+  }
+
+  const valueSpan = maxValue - minValue || 1;
+  const paddedMin = minValue - valueSpan * 0.12;
+  const paddedMax = maxValue + valueSpan * 0.12;
+  const paddedSpan = paddedMax - paddedMin || 1;
+
+  const xByIndex = points.map((_, index) =>
+    points.length === 1
+      ? (plotLeft + plotRight) / 2
+      : lerp(plotLeft, plotRight, index / (points.length - 1)));
+  const yByIndex = points.map((point) =>
+    lerp(plotBottom, plotTop, (point.close - paddedMin) / paddedSpan));
+
+  const yByColumn = new Float32Array(pixelWidth).fill(Number.POSITIVE_INFINITY);
+  for (let index = 0; index < points.length - 1; index++) {
+    const x0 = xByIndex[index]!;
+    const y0 = yByIndex[index]!;
+    const x1 = xByIndex[index + 1]!;
+    const y1 = yByIndex[index + 1]!;
+    const startX = Math.max(plotLeft, Math.floor(Math.min(x0, x1)));
+    const endX = Math.min(plotRight, Math.ceil(Math.max(x0, x1)));
+
+    for (let x = startX; x <= endX; x++) {
+      const t = x1 === x0 ? 0 : (x - x0) / (x1 - x0);
+      const y = lerp(y0, y1, clamp(t, 0, 1));
+      yByColumn[x] = Math.min(yByColumn[x]!, y);
+    }
+  }
+
+  drawFill(pixels, pixelWidth, pixelHeight, yByColumn, plotTop, plotBottom, areaFillColor);
+
+  for (let index = 0; index < points.length - 1; index++) {
+    const x0 = xByIndex[index]!;
+    const y0 = yByIndex[index]!;
+    const x1 = xByIndex[index + 1]!;
+    const y1 = yByIndex[index + 1]!;
+    drawLine(pixels, pixelWidth, pixelHeight, x0, y0, x1, y1, lineGlowColor, 3.6);
+    drawLine(pixels, pixelWidth, pixelHeight, x0, y0, x1, y1, lineColor, 1.6);
+  }
+
+  const activeX = xByIndex[activeIndex]!;
+  const activeY = yByIndex[activeIndex]!;
+  drawLine(pixels, pixelWidth, pixelHeight, activeX, plotTop, activeX, plotBottom, axisGlowColor, 1.4);
+  drawLine(pixels, pixelWidth, pixelHeight, plotLeft, activeY, plotRight, activeY, axisGlowColor, 1.4);
+  drawCircle(pixels, pixelWidth, pixelHeight, activeX, activeY, 3.8, lineGlowColor);
+  drawCircle(pixels, pixelWidth, pixelHeight, activeX, activeY, 2.1, lineColor);
+  drawCircle(pixels, pixelWidth, pixelHeight, activeX, activeY, 1.35, markerColor);
+}
+
+function FramebufferChartDemo() {
+  const renderer = useRenderer();
+  const { width, height } = useTerminalDimensions();
+  const chartRef = useRef<BoxRenderable | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+  const [panOffset, setPanOffset] = useState(0);
+  const [hoverCellX, setHoverCellX] = useState<number | null>(null);
+  const [terminalSnapshot, setTerminalSnapshot] = useState(() => readTerminalSnapshot(renderer));
+  const [chartSize, setChartSize] = useState({
+    width: Math.max(width - 4, MIN_PLOT_CELLS + 2),
+    height: Math.max(height - 9, 10),
+  });
+
+  useEffect(() => {
+    const refresh = () => setTerminalSnapshot(readTerminalSnapshot(renderer));
+    refresh();
+
+    const timer = setInterval(refresh, 250);
+    const onCapabilities = () => refresh();
+    renderer.on("capabilities", onCapabilities);
+
+    return () => {
+      clearInterval(timer);
+      renderer.off("capabilities", onCapabilities);
+    };
+  }, [renderer]);
+
+  const plotWidthCells = Math.max(chartSize.width - 2, MIN_PLOT_CELLS);
+  const visibleCount = calculateVisibleCount(plotWidthCells, zoom, demoSeries.length);
+  const maxPanOffset = Math.max(demoSeries.length - visibleCount, 0);
+
+  useEffect(() => {
+    if (panOffset > maxPanOffset) {
+      setPanOffset(maxPanOffset);
+    }
+  }, [maxPanOffset, panOffset]);
+
+  const visibleSeries = useMemo(() => {
+    const endIndex = demoSeries.length - panOffset;
+    const startIndex = Math.max(endIndex - visibleCount, 0);
+    return demoSeries.slice(startIndex, endIndex);
+  }, [panOffset, visibleCount]);
+
+  const projectedSeries = useMemo(() => {
+    return projectCloseSeries(visibleSeries, Math.max(plotWidthCells * 2, MIN_VISIBLE_POINTS));
+  }, [plotWidthCells, visibleSeries]);
+
+  const activeIndex = getActiveIndex(hoverCellX, plotWidthCells, projectedSeries.length);
+  const activePoint = projectedSeries[activeIndex] ?? projectedSeries[projectedSeries.length - 1] ?? null;
+  const windowStart = projectedSeries[0] ?? null;
+  const windowEnd = projectedSeries[projectedSeries.length - 1] ?? null;
+  const windowChange = windowStart && activePoint ? activePoint.close - windowStart.close : 0;
+  const windowChangePct = windowStart && windowStart.close !== 0
+    ? (windowChange / windowStart.close) * 100
+    : 0;
+
+  const syncChartSize = () => {
+    if (!chartRef.current) return;
+    setChartSize({ width: chartRef.current.width, height: chartRef.current.height });
+  };
+
+  const applyZoom = (nextZoom: number, anchorRatio: number) => {
+    const clampedZoom = clamp(nextZoom, MIN_ZOOM, MAX_ZOOM);
+    const nextVisibleCount = calculateVisibleCount(plotWidthCells, clampedZoom, demoSeries.length);
+    const ratio = clamp(anchorRatio, 0, 1);
+    const anchorGlobalIndex = demoSeries.length - panOffset - visibleCount + ratio * Math.max(visibleCount - 1, 0);
+    const nextStart = Math.round(anchorGlobalIndex - ratio * Math.max(nextVisibleCount - 1, 0));
+    const clampedStart = clamp(nextStart, 0, Math.max(demoSeries.length - nextVisibleCount, 0));
+    const nextPanOffset = demoSeries.length - nextVisibleCount - clampedStart;
+
+    setZoom(clampedZoom);
+    setPanOffset(nextPanOffset);
+  };
+
+  const updateHover = (event: MouseEvent): number | null => {
+    const localX = resolveLocalPlotX(event, chartRef.current);
+    setHoverCellX(localX);
+    return localX;
+  };
+
+  useKeyboard((event) => {
+    if (event.name === "q" || event.name === "escape") {
+      renderer.destroy();
+    }
+  });
+
+  return (
+    <box flexDirection="column" width="100%" height="100%" padding={1} backgroundColor={colors.bg}>
+      <box height={1} flexDirection="row">
+        <text fg={colors.textBright}>
+          OpenTUI framebuffer chart POC
+        </text>
+        <text fg={colors.textDim}>
+          {"  drawSuperSampleBuffer + alpha + mouse scrub"}
+        </text>
+      </box>
+
+      <box height={1} flexDirection="row">
+        <text fg={windowChange >= 0 ? colors.positive : colors.negative}>
+          {activePoint ? formatCurrency(activePoint.close) : "--"}
+        </text>
+        <text fg={windowChange >= 0 ? colors.positive : colors.negative}>
+          {"  "}
+          {windowChange >= 0 ? "+" : ""}{windowChange.toFixed(2)} ({windowChangePct >= 0 ? "+" : ""}{windowChangePct.toFixed(2)}%)
+        </text>
+        <text fg={colors.textDim}>
+          {"  "}
+          {activePoint ? formatDate(activePoint.date) : "No point selected"}
+        </text>
+      </box>
+
+      <box height={1}>
+        <text fg={colors.textMuted}>
+          terminal:{terminalSnapshot.terminalLabel}
+          {"  "}kitty_graphics:{terminalSnapshot.kittyGraphics === null ? "probing" : terminalSnapshot.kittyGraphics ? "yes" : "no"}
+          {"  "}resolution:{terminalSnapshot.resolutionLabel}
+          {"  "}visible:{visibleSeries.length}
+          {"  "}projected:{projectedSeries.length}
+          {"  "}zoom:{zoom.toFixed(2)}x
+        </text>
+      </box>
+
+      <box height={1} />
+
+      <box flexGrow={1}>
+        <box
+          ref={chartRef}
+          flexGrow={1}
+          border
+          borderStyle="rounded"
+          borderColor={colors.borderFocused}
+          backgroundColor={colors.panel}
+          buffered
+          onSizeChange={syncChartSize}
+          onMouseMove={(event) => {
+            updateHover(event);
+          }}
+          onMouseOut={() => {
+            dragRef.current = null;
+            setHoverCellX(null);
+          }}
+          onMouseDown={(event) => {
+            const localX = updateHover(event);
+            if (localX === null) return;
+            dragRef.current = {
+              startGlobalX: event.x,
+              startPanOffset: panOffset,
+            };
+          }}
+          onMouseDrag={(event) => {
+            updateHover(event);
+            if (!dragRef.current) return;
+
+            const deltaCells = event.x - dragRef.current.startGlobalX;
+            const pointDelta = Math.round((deltaCells / Math.max(plotWidthCells, 1)) * visibleCount);
+            setPanOffset(clamp(dragRef.current.startPanOffset - pointDelta, 0, maxPanOffset));
+          }}
+          onMouseDragEnd={() => {
+            dragRef.current = null;
+          }}
+          onMouseScroll={(event) => {
+            const localX = resolveLocalPlotX(event, chartRef.current);
+            const anchorRatio = localX === null ? 0.5 : localX / Math.max(plotWidthCells - 1, 1);
+            if (event.scroll?.direction === "up") {
+              applyZoom(zoom * 1.18, anchorRatio);
+            } else if (event.scroll?.direction === "down") {
+              applyZoom(zoom / 1.18, anchorRatio);
+            } else if (event.scroll?.direction === "left") {
+              setPanOffset((current) => clamp(current + Math.max(Math.round(visibleCount * 0.08), 1), 0, maxPanOffset));
+            } else if (event.scroll?.direction === "right") {
+              setPanOffset((current) => clamp(current - Math.max(Math.round(visibleCount * 0.08), 1), 0, maxPanOffset));
+            }
+          }}
+          renderAfter={(buffer: OptimizedBuffer) => {
+            const plotWidth = Math.max(buffer.width - 2, 1);
+            const plotHeight = Math.max(buffer.height - 2, 1);
+            const pixelWidth = plotWidth * 2;
+            const pixelHeight = plotHeight * 2;
+            const pixels = new Uint8Array(pixelWidth * pixelHeight * 4);
+
+            renderChartToPixels(pixels, pixelWidth, pixelHeight, projectedSeries, activeIndex);
+            buffer.pushScissorRect(1, 1, plotWidth, plotHeight);
+            buffer.drawSuperSampleBuffer(1, 1, ptr(pixels), pixels.byteLength, "rgba8unorm", pixelWidth * 4);
+            buffer.popScissorRect();
+          }}
+        />
+      </box>
+
+      <box height={1} />
+
+      <box height={1}>
+        <text fg={colors.textDim}>
+          {windowStart && windowEnd ? `${formatDate(windowStart.date)} -> ${formatDate(windowEnd.date)}` : "No visible window"}
+        </text>
+      </box>
+
+      <box height={1}>
+        <text fg={colors.textMuted}>
+          mouse move inspect  drag pan  wheel zoom  shift-wheel pan  q or Esc quit
+        </text>
+      </box>
+    </box>
+  );
+}
+
+async function main() {
+  const renderer = await createCliRenderer({
+    exitOnCtrlC: true,
+    backgroundColor: colors.bg,
+    useMouse: true,
+    enableMouseMovement: true,
+    useAlternateScreen: true,
+  });
+
+  createRoot(renderer).render(<FramebufferChartDemo />);
+}
+
+main().catch((error) => {
+  console.error("Framebuffer chart POC failed:", error);
+  process.exitCode = 1;
+});

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -110,6 +110,7 @@ describe("ProviderRouter", () => {
       theme: "amber",
       chartPreferences: {
         defaultRenderMode: "area",
+        renderer: "auto",
       },
       recentTickers: [],
     }));
@@ -184,6 +185,7 @@ describe("ProviderRouter", () => {
       theme: "amber",
       chartPreferences: {
         defaultRenderMode: "area",
+        renderer: "auto",
       },
       recentTickers: [],
     }));
@@ -267,6 +269,7 @@ describe("ProviderRouter", () => {
       theme: "amber",
       chartPreferences: {
         defaultRenderMode: "area",
+        renderer: "auto",
       },
       recentTickers: [],
     }));

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,11 +1,13 @@
 import type { Portfolio, Watchlist } from "./ticker";
 
-export const CURRENT_CONFIG_VERSION = 6;
+export const CURRENT_CONFIG_VERSION = 7;
 
 export type DefaultChartRenderMode = "area" | "line" | "candles" | "ohlc";
+export type ChartRendererPreference = "auto" | "kitty" | "braille";
 
 export interface ChartPreferences {
   defaultRenderMode: DefaultChartRenderMode;
+  renderer: ChartRendererPreference;
 }
 
 export interface BrokerInstanceConfig {
@@ -270,6 +272,7 @@ export function createDefaultConfig(dataDir: string): AppConfig {
     theme: "amber",
     chartPreferences: {
       defaultRenderMode: "area",
+      renderer: "auto",
     },
     recentTickers: [],
   };


### PR DESCRIPTION
This adds a Kitty-native chart pipeline with RGBA rasterization, protocol/detection helpers, and a shell-driven native surface manager that clips chart fragments under floating panes and overlays while preserving braille fallback. It keeps the existing financial chart semantics for area, line, candles, and OHLC, adds mouse hover/drag/wheel interaction, and leaves the cursor/crosshair as a cheap text overlay. The change also persists a chart renderer preference, adds a command-bar action to cycle Auto/Kitty/Braille, and updates config/test fixtures for the new setting. Included tests cover renderer selection, Kitty protocol encoding, placement reuse, fragment clipping, and config migration, and the framebuffer POC remains available via `bun run poc:framebuffer-chart` for manual Ghostty validation.