### PR TITLE
Improve ticker search relevance

### DIFF
--- a/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
+++ b/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
@@ -107,3 +107,31 @@ exports[`CommandBar collapses the trailing column on narrow terminals 1`] = `
                                           
 "
 `;
+
+exports[`CommandBar groups ticker search sections and keeps exact open matches above loose provider results 1`] = `
+"                                                                                
+                                                                                
+                                                                                
+                  Commands                                esc                   
+                  T appl                                                        
+                                                                                
+                  Open                                                          
+                  AAPL                                                          
+                                                                                
+                  Search Results                                                
+                  APP                                                           
+                  AMAT                                                          
+                  AAOI                                                          
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+"
+`;

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -34,14 +34,14 @@ function makeTicker(symbol: string, name: string): TickerRecord {
   };
 }
 
-function makeDataProvider(): DataProvider {
+function makeDataProvider(searchImpl: DataProvider["search"] = async () => []): DataProvider {
   return {
     id: "test",
     name: "Test Provider",
     getTickerFinancials: async () => { throw new Error("unused"); },
     getQuote: async () => { throw new Error("unused"); },
     getExchangeRate: async () => 1,
-    search: async () => [],
+    search: searchImpl,
     getNews: async () => [],
     getArticleSummary: async () => null,
     getPriceHistory: async () => [],
@@ -86,11 +86,13 @@ function CommandBarHarness({
   disabledPlugins = [],
   selectedTicker,
   live = false,
+  dataProvider = makeDataProvider(),
 }: {
   query: string;
   disabledPlugins?: string[];
   selectedTicker?: string;
   live?: boolean;
+  dataProvider?: DataProvider;
 }) {
   const config = {
     ...createDefaultConfig("/tmp/gloomberb-test"),
@@ -98,7 +100,6 @@ function CommandBarHarness({
     disabledPlugins,
   };
   const tickers = [makeTicker("AAPL", "Apple Inc."), makeTicker("MSFT", "Microsoft Corp.")];
-  const dataProvider = makeDataProvider();
   const state = {
     ...createInitialState(config),
     commandBarOpen: true,
@@ -201,5 +202,31 @@ describe("CommandBar", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("theme:green");
+  });
+
+  test("groups ticker search sections and keeps exact open matches above loose provider results", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="T appl"
+        dataProvider={makeDataProvider(async () => [
+          { providerId: "yahoo", symbol: "IVSX", name: "Invsivx Holdings", exchange: "NYSE", type: "ETF" },
+          { providerId: "yahoo", symbol: "AAPL", name: "Apple Inc", exchange: "NASDAQ", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "AMAT", name: "Applied Materials", exchange: "NASDAQ", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "AAOI", name: "Applied Optoelectronics", exchange: "NASDAQ", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "APP", name: "AppLovin Corp", exchange: "NASDAQ", type: "EQUITY" },
+        ])}
+      />,
+      { width: 80, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+    await Bun.sleep(300);
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame.match(/Open/g)?.length).toBe(1);
+    expect(frame.match(/Search Results/g)?.length).toBe(1);
+    expect(frame.indexOf("AAPL")).toBeLessThan(frame.indexOf("APP"));
+    expect(frame).toMatchSnapshot();
   });
 });

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -32,8 +32,10 @@ import { buildIbkrConfigFromValues } from "../../plugins/ibkr/config";
 import { CHART_RENDERER_PREFERENCES } from "../chart/chart-types";
 import { DialogFrame, ListView, TextField } from "../ui";
 import {
+  buildSections,
   getEmptyState,
   getRowPresentation,
+  rankTickerSearchItems,
   resolveCommandBarMode,
   truncateText,
 } from "./view-model";
@@ -953,6 +955,7 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
   const isThemeMode = modeInfo.kind === "themes";
   const isPluginMode = modeInfo.kind === "plugins";
   const isColumnsMode = modeInfo.kind === "columns";
+  const searchModeQuery = activeMatch?.command.id === "search-ticker" ? activeMatch.arg : "";
 
   // Toggle a column on/off
   const toggleColumn = useCallback((colId: string) => {
@@ -1151,6 +1154,21 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
           kind: "info",
           action: () => {},
         });
+      } else {
+        const localMatches = rankTickerSearchItems(
+          Array.from(state.tickers.values()).map((ticker) => ({
+            id: `goto:${ticker.metadata.ticker}`,
+            label: ticker.metadata.ticker,
+            detail: ticker.metadata.name,
+            right: ticker.metadata.exchange,
+            category: "Open",
+            kind: "ticker" as const,
+            secondaryAction: () => { focusTicker(ticker.metadata.ticker, { forceNewPane: true }); close(); },
+            action: () => { focusTicker(ticker.metadata.ticker); close(); },
+          })),
+          match.arg,
+        );
+        items.push(...localMatches.slice(0, 6));
       }
     } else if (match && !match.command.hasArg) {
       if (shouldShow(match.command)) {
@@ -1240,8 +1258,20 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
             brokerInstanceId: activePortfolio?.brokerInstanceId,
           });
           if (requestId !== searchRequestIdRef.current) return; // stale response
+          const localItems = rankTickerSearchItems(
+            Array.from(state.tickers.values()).map((ticker) => ({
+              id: `goto:${ticker.metadata.ticker}`,
+              label: ticker.metadata.ticker,
+              detail: ticker.metadata.name,
+              right: ticker.metadata.exchange,
+              category: "Open",
+              kind: "ticker" as const,
+              secondaryAction: () => { focusTicker(ticker.metadata.ticker, { forceNewPane: true }); close(); },
+              action: () => { focusTicker(ticker.metadata.ticker); close(); },
+            })),
+            searchQuery,
+          ).slice(0, 6);
           const searchItems: ResultItem[] = searchResults
-            .slice(0, 8)
             .map((r) => {
               const sym = r.brokerContract?.localSymbol || r.symbol.split(".")[0]!;
               const isExisting = state.tickers.has(sym);
@@ -1249,13 +1279,15 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
                 id: `search:${r.symbol}`,
                 label: sym,
                 detail: [r.name, r.brokerLabel, r.type || r.exchange].filter(Boolean).join(" | "),
+                right: r.exchange || r.type || undefined,
                 category: isExisting ? "Open" : "Search Results",
                 kind: "search",
                 secondaryAction: () => openTickerDetail(r, { forceNewPane: true }),
                 action: () => openTickerDetail(r),
               };
             });
-          setResults(searchItems.length > 0 ? searchItems : [{
+          const combined = rankTickerSearchItems([...localItems, ...searchItems], searchQuery).slice(0, 8);
+          setResults(combined.length > 0 ? combined : [{
               id: "no-results",
               label: `No matches for "${searchQuery}"`,
               detail: "Try a symbol, company name, or exchange variant",
@@ -1288,7 +1320,7 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
   }, [query, state.tickers, activeTickerSymbol, activeTickerData, activeCollectionId, state.config.watchlists, state.config.portfolios, state.config.brokerInstances, state.config.disabledPlugins, state.config.columns, toggleColumn, tickerActionItems, pluginCommandItems, focusTicker]);
 
   const exactTickerResult = (() => {
-    const normalizedQuery = query.trim().toUpperCase();
+    const normalizedQuery = (searchModeQuery || query).trim().toUpperCase();
     if (!normalizedQuery) return null;
     return results.find((item) =>
       (item.id.startsWith("goto:") || item.id.startsWith("search:"))
@@ -1401,7 +1433,6 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
 
   const barWidth = Math.max(42, Math.min(64, termWidth - 8, Math.floor(termWidth * 0.62)));
   const isNarrow = barWidth < 52;
-  const searchModeQuery = activeMatch?.command.id === "search-ticker" ? activeMatch.arg : "";
   const contentPadding = 3;
   const bodyHeight = Math.min(14, Math.max(8, termHeight - 10));
   const barHeight = bodyHeight + 5;
@@ -1423,25 +1454,25 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
     | { kind: "spinner"; id: string; label: string }
     | { kind: "filler"; id: string }
   > = [];
-  let previousCategory: string | null = null;
-  for (let i = 0; i < results.length; i++) {
-    const item = results[i]!;
-    if (previousCategory !== null && item.category !== previousCategory) {
+  const sections = buildSections(results);
+  let globalIdx = 0;
+  sections.forEach((section, sectionIndex) => {
+    if (sectionIndex > 0) {
       allRows.push({
         kind: "spacer",
-        id: `spacer:${i}:${item.category}`,
+        id: `spacer:${sectionIndex}:${section.category}`,
       });
     }
-    if (item.category !== previousCategory) {
-      allRows.push({
-        kind: "heading",
-        id: `heading:${i}:${item.category}`,
-        label: item.category,
-      });
+    allRows.push({
+      kind: "heading",
+      id: `heading:${sectionIndex}:${section.category}`,
+      label: section.category,
+    });
+    for (const item of section.items) {
+      allRows.push({ kind: "item", item, globalIdx });
+      globalIdx += 1;
     }
-    previousCategory = item.category;
-    allRows.push({ kind: "item", item, globalIdx: i });
-  }
+  });
   const emptyState = getEmptyState(modeInfo.kind, query, searchModeQuery);
   const resultsInnerWidth = Math.max(12, barWidth - contentPadding * 2);
   const trailingWidth = isNarrow ? 0 : Math.max(8, Math.min(12, Math.floor(resultsInnerWidth * 0.18)));
@@ -1449,7 +1480,7 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
   const queryDisplayWidth = Math.max(8, barWidth - contentPadding * 2);
 
   let visibleRows: typeof allRows;
-  if (searching) {
+  if (searching && allRows.length === 0) {
     visibleRows = [{ kind: "spinner", id: "searching", label: "Searching providers..." }];
   } else if (allRows.length === 0) {
     visibleRows = [{ kind: "message", id: "empty", label: emptyState.label }];
@@ -1459,6 +1490,12 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
     let windowStart = Math.max(0, Math.min(selectedRowIdx - halfWindow, allRows.length - bodyHeight));
     if (windowStart < 0) windowStart = 0;
     visibleRows = allRows.slice(windowStart, windowStart + bodyHeight);
+    if (searching) {
+      if (visibleRows.length >= bodyHeight) {
+        visibleRows = visibleRows.slice(0, bodyHeight - 1);
+      }
+      visibleRows.push({ kind: "spinner", id: "searching", label: "Searching providers..." });
+    }
   }
 
   while (visibleRows.length < bodyHeight) {

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -4,6 +4,7 @@ import {
   getEmptyState,
   getFooterHints,
   getRowPresentation,
+  rankTickerSearchItems,
   resolveCommandBarMode,
 } from "./view-model";
 
@@ -76,5 +77,47 @@ describe("command bar view model helpers", () => {
       glyph: " ",
       trailing: "current",
     });
+  });
+
+  test("ranks ticker search matches by symbol relevance and hides duplicate open symbols", () => {
+    const items = rankTickerSearchItems([
+      {
+        id: "search:IVSX",
+        label: "IVSX",
+        detail: "Invsivx Holdings | ETF",
+        category: "Search Results",
+        kind: "search",
+        right: "NYSE",
+      },
+      {
+        id: "goto:AAPL",
+        label: "AAPL",
+        detail: "Apple Inc.",
+        category: "Open",
+        kind: "ticker",
+        right: "NASDAQ",
+      },
+      {
+        id: "search:APP",
+        label: "APP",
+        detail: "AppLovin Corp | EQUITY",
+        category: "Search Results",
+        kind: "search",
+        right: "NASDAQ",
+      },
+      {
+        id: "search:AAPL",
+        label: "AAPL",
+        detail: "Apple Inc | EQUITY",
+        category: "Search Results",
+        kind: "search",
+        right: "NASDAQ",
+      },
+    ], "appl");
+
+    expect(items.map((item) => item.id)).toEqual([
+      "goto:AAPL",
+      "search:APP",
+    ]);
   });
 });

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -154,3 +154,107 @@ export function truncateText(text: string, width: number): string {
   if (width <= 3) return ".".repeat(width);
   return `${text.slice(0, width - 3)}...`;
 }
+
+function normalizeSearchText(text: string): string {
+  return text.trim().toUpperCase().replace(/[^A-Z0-9]+/g, " ");
+}
+
+function scoreSearchField(query: string, value: string, weights: { exact: number; prefix: number; substring: number; fuzzy: number }): number {
+  if (!query || !value) return 0;
+  if (value === query) return weights.exact - value.length;
+  if (value.startsWith(query)) return weights.prefix - value.length;
+
+  const substringIndex = value.indexOf(query);
+  if (substringIndex >= 0) {
+    return weights.substring - substringIndex * 25 - value.length;
+  }
+
+  let qi = 0;
+  let score = 0;
+  for (let i = 0; i < value.length && qi < query.length; i++) {
+    if (value[i] !== query[qi]) continue;
+    score += i === 0 || value[i - 1] === " " ? 10 : 2;
+    qi += 1;
+  }
+  return qi === query.length ? weights.fuzzy + score : 0;
+}
+
+function getTickerSearchDedupKey(item: Pick<CommandBarItemView, "id" | "kind" | "label" | "detail" | "right">): string {
+  if (item.kind !== "ticker" && item.kind !== "search") return item.id;
+  const qualifier = normalizeSearchText(item.right || item.detail.split("|").at(-1) || "");
+  return `${normalizeSearchText(item.label)}|${qualifier}`;
+}
+
+export function rankTickerSearchItems<T extends Pick<CommandBarItemView, "id" | "label" | "detail" | "kind" | "category" | "right">>(
+  items: T[],
+  query: string,
+): T[] {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery) return items;
+
+  const openSymbols = new Set(
+    items
+      .filter((item) => item.kind === "ticker" || item.category === "Open")
+      .map((item) => normalizeSearchText(item.label)),
+  );
+
+  const ranked = items
+    .map((item, index) => {
+      const normalizedLabel = normalizeSearchText(item.label);
+      const normalizedDetail = normalizeSearchText(item.detail);
+      const normalizedRight = normalizeSearchText(item.right || "");
+      const labelScore = scoreSearchField(normalizedQuery, normalizedLabel, {
+        exact: 24_000,
+        prefix: 18_000,
+        substring: 14_000,
+        fuzzy: 7_000,
+      });
+      const detailScore = Math.max(
+        scoreSearchField(normalizedQuery, normalizedDetail, {
+          exact: 4_500,
+          prefix: 3_800,
+          substring: 2_600,
+          fuzzy: 600,
+        }),
+        scoreSearchField(normalizedQuery, normalizedRight, {
+          exact: 1_200,
+          prefix: 1_000,
+          substring: 700,
+          fuzzy: 100,
+        }),
+      );
+      const isOpenItem = item.kind === "ticker" || item.category === "Open";
+      const matchScore = labelScore + detailScore;
+
+      return {
+        item,
+        index,
+        normalizedLabel,
+        matchScore,
+        score: matchScore + (matchScore > 0 && isOpenItem ? 900 : 0),
+      };
+    })
+    .filter(({ item, normalizedLabel, matchScore }) => {
+      if (matchScore <= 0) return false;
+      if (item.kind !== "search") return true;
+      return !openSymbols.has(normalizedLabel);
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      const aOpen = a.item.kind === "ticker" || a.item.category === "Open";
+      const bOpen = b.item.kind === "ticker" || b.item.category === "Open";
+      if (aOpen !== bOpen) return aOpen ? -1 : 1;
+      if (a.item.label.length !== b.item.label.length) return a.item.label.length - b.item.label.length;
+      return a.index - b.index;
+    });
+
+  const deduped: T[] = [];
+  const seen = new Set<string>();
+  for (const entry of ranked) {
+    const key = getTickerSearchDedupKey(entry.item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(entry.item);
+  }
+  return deduped;
+}

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -196,6 +196,90 @@ describe("ProviderRouter", () => {
     expect(results[0]?.brokerContract?.brokerInstanceId).toBe("ibkr-work");
   });
 
+  test("keeps the richer search result when providers return the same instrument", async () => {
+    const broker: BrokerAdapter = {
+      id: "ibkr",
+      name: "IBKR",
+      configSchema: [],
+      async validate() {
+        return true;
+      },
+      async importPositions() {
+        return [];
+      },
+      async searchInstruments() {
+        return [{
+          providerId: "ibkr",
+          symbol: "AAPL",
+          name: "Apple Inc",
+          exchange: "NASDAQ",
+          type: "STK",
+          brokerLabel: "Work",
+          brokerContract: {
+            brokerId: "ibkr",
+            brokerInstanceId: "ibkr-work",
+            symbol: "AAPL",
+            localSymbol: "AAPL",
+            exchange: "SMART",
+          },
+        }];
+      },
+    };
+    const provider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      async search() {
+        return [{
+          providerId: "yahoo",
+          symbol: "AAPL",
+          name: "Apple",
+          exchange: "NASDAQ",
+          type: "STK",
+        }];
+      },
+    };
+    const router = new ProviderRouter(fallbackProvider, [provider]);
+
+    router.attachRegistry({
+      brokers: new Map([["ibkr", broker]]),
+      dataProviders: new Map(),
+    } as any);
+    router.setConfigAccessor(() => ({
+      dataDir: "",
+      configVersion: CURRENT_CONFIG_VERSION,
+      baseCurrency: "USD",
+      refreshIntervalMinutes: 30,
+      portfolios: [],
+      watchlists: [],
+      columns: [],
+      layout: cloneLayout(DEFAULT_LAYOUT),
+      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
+      activeLayoutIndex: 0,
+      brokerInstances: [{
+        id: "ibkr-work",
+        brokerType: "ibkr",
+        label: "Work",
+        connectionMode: "gateway",
+        config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
+        enabled: true,
+      }],
+      plugins: [],
+      disabledPlugins: [],
+      theme: "amber",
+      chartPreferences: {
+        defaultRenderMode: "area",
+        renderer: "auto",
+      },
+      recentTickers: [],
+    }));
+
+    const results = await router.search("AAPL", { preferBroker: true, brokerInstanceId: "ibkr-work" });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.providerId).toBe("ibkr");
+    expect(results[0]?.brokerContract?.localSymbol).toBe("AAPL");
+  });
+
   test("merges cached broker financials with cached fallback fundamentals", async () => {
     const dbPath = createTempDbPath("cache-merge");
     const persistence = new AppPersistence(dbPath);

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -57,6 +57,31 @@ function compactDate(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+function normalizeSearchKeyPart(value?: string): string {
+  return (value ?? "").trim().toUpperCase();
+}
+
+function buildSearchResultKey(item: InstrumentSearchResult): string {
+  return [
+    normalizeSearchKeyPart(item.symbol),
+    normalizeSearchKeyPart(item.exchange),
+    normalizeSearchKeyPart(item.type),
+    normalizeSearchKeyPart(item.primaryExchange),
+    normalizeSearchKeyPart(item.currency),
+  ].join("|");
+}
+
+function getSearchResultRichness(item: InstrumentSearchResult, context?: SearchRequestContext): number {
+  let score = 0;
+  if (item.brokerContract) score += 500;
+  if (item.brokerInstanceId) score += 250;
+  if (item.brokerLabel) score += 100;
+  if (item.name) score += Math.min(80, item.name.length);
+  if (context?.brokerInstanceId && item.brokerInstanceId === context.brokerInstanceId) score += 800;
+  if (context?.brokerId && item.brokerContract?.brokerId === context.brokerId) score += 400;
+  return score;
+}
+
 function buildVariantKey(parts: Array<[string, string | number | undefined | null]>): string {
   return parts
     .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0)
@@ -215,14 +240,22 @@ export class ProviderRouter implements DataProvider {
 
   async search(query: string, context?: SearchRequestContext): Promise<InstrumentSearchResult[]> {
     const results: InstrumentSearchResult[] = [];
-    const seen = new Set<string>();
+    const resultIndexByKey = new Map<string, number>();
 
     const push = (items: InstrumentSearchResult[]) => {
       for (const item of items) {
-        const key = `${item.symbol}|${item.exchange}|${item.type}|${item.providerId}|${item.brokerInstanceId ?? ""}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        results.push(item);
+        const key = buildSearchResultKey(item);
+        const existingIndex = resultIndexByKey.get(key);
+        if (existingIndex == null) {
+          resultIndexByKey.set(key, results.length);
+          results.push(item);
+          continue;
+        }
+
+        const existing = results[existingIndex]!;
+        if (getSearchResultRichness(item, context) > getSearchResultRichness(existing, context)) {
+          results[existingIndex] = item;
+        }
       }
     };
 


### PR DESCRIPTION
This improves explicit ticker search by ranking local cached tickers ahead of weaker provider matches, deduping overlapping results, and fixing exact-match selection in T mode. It also groups the command bar search sections consistently so Open and Search Results do not alternate based on provider return order, while keeping a loading row visible during provider lookups. On the provider side, duplicate search hits now collapse to the richer result instead of whichever source responded first. The PR includes regression coverage for ranking, grouping, provider dedupe, and the updated command-bar snapshot.