### PR TITLE
Add broker account cache and streamline IBKR trading UI

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -35,12 +35,18 @@ import {
 import type { TickerRecord, TickerMetadata, TickerPosition, Portfolio } from "./types/ticker";
 import type { DataProvider } from "./types/data-provider";
 import type { BrokerContractRef } from "./types/instrument";
+import type { BrokerAccount } from "./types/trading";
 
 // Built-in plugins
 import { portfolioListPlugin } from "./plugins/builtin/portfolio-list";
 import { tickerDetailPlugin } from "./plugins/builtin/ticker-detail";
 import { manualEntryPlugin } from "./plugins/builtin/manual-entry";
 import { ibkrPlugin } from "./plugins/ibkr";
+import {
+  clearPersistedIbkrAccounts,
+  loadPersistedIbkrAccountMap,
+  persistIbkrAccounts,
+} from "./plugins/ibkr/account-cache";
 import { newsPlugin } from "./plugins/builtin/news";
 import { optionsPlugin } from "./plugins/builtin/options";
 import { notesPlugin } from "./plugins/builtin/notes";
@@ -376,9 +382,20 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     if (!valid) return;
 
     const existingTickers = tickerMap ?? new Map(state.tickers);
-    const brokerAccounts = broker.listAccounts
-      ? await broker.listAccounts(instance).catch(() => [])
-      : [];
+    let brokerAccounts: BrokerAccount[] = [];
+    if (broker.listAccounts) {
+      try {
+        brokerAccounts = await broker.listAccounts(instance);
+        if (instance.brokerType === "ibkr") {
+          try {
+            persistIbkrAccounts(pluginRegistry.persistence.resources, instance, brokerAccounts);
+          } catch {}
+        }
+        dispatch({ type: "SET_BROKER_ACCOUNTS", instanceId: instance.id, accounts: brokerAccounts });
+      } catch {
+        brokerAccounts = [];
+      }
+    }
     const accountMetadata = new Map(
       brokerAccounts.map((account) => [
         account.accountId,
@@ -526,6 +543,13 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     (globalThis as any).__gloomInitStarted = true;
     (async () => {
       try {
+        let persistedBrokerAccounts: Record<string, BrokerAccount[]> = {};
+        try {
+          persistedBrokerAccounts = loadPersistedIbkrAccountMap(
+            pluginRegistry.persistence.resources,
+            state.config.brokerInstances,
+          );
+        } catch {}
         await initializeAppState({
           config: state.config,
           tickerRepository,
@@ -534,6 +558,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
           dispatch,
           refreshTicker,
           autoImportBrokerPositions,
+          persistedBrokerAccounts,
         });
       } catch (err) {
         // Will show empty state
@@ -559,7 +584,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     dispatch({ type: "UPDATE_PANE_STATE", paneId, patch });
   };
   pluginRegistry.getPluginConfigValueFn = (pluginId, key) => (
-    state.config.pluginConfig[pluginId]?.[key] ?? null
+    (state.config.pluginConfig[pluginId]?.[key] as any) ?? null
   );
   pluginRegistry.setPluginConfigValueFn = async (pluginId, key, value) => {
     const nextConfig = {
@@ -625,6 +650,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     return instance;
   };
   pluginRegistry.updateBrokerInstanceFn = async (instanceId, values) => {
+    clearPersistedIbkrAccounts(pluginRegistry.persistence.resources, instanceId);
     const nextConfig = {
       ...state.config,
       brokerInstances: state.config.brokerInstances.map((instance) =>
@@ -647,6 +673,8 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
   pluginRegistry.removeBrokerInstanceFn = async (instanceId) => {
     const instance = getBrokerInstance(state.config.brokerInstances, instanceId);
     if (!instance) return;
+
+    clearPersistedIbkrAccounts(pluginRegistry.persistence.resources, instanceId);
 
     const broker = pluginRegistry.brokers.get(instance.brokerType);
     await broker?.disconnect?.(instance).catch(() => {});

--- a/src/components/tab-bar.tsx
+++ b/src/components/tab-bar.tsx
@@ -9,8 +9,9 @@ export interface TabBarProps {
   tabs: Tab[];
   activeValue: string;
   onSelect: (value: string) => void;
+  compact?: boolean;
 }
 
-export function TabBar({ tabs, activeValue, onSelect }: TabBarProps) {
-  return <Tabs tabs={tabs} activeValue={activeValue} onSelect={onSelect} />;
+export function TabBar({ tabs, activeValue, onSelect, compact }: TabBarProps) {
+  return <Tabs tabs={tabs} activeValue={activeValue} onSelect={onSelect} compact={compact} />;
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -11,11 +11,12 @@ export interface TabsProps {
   tabs: TabItem[];
   activeValue: string;
   onSelect: (value: string) => void;
+  compact?: boolean;
 }
 
-export function Tabs({ tabs, activeValue, onSelect }: TabsProps) {
+export function Tabs({ tabs, activeValue, onSelect, compact = false }: TabsProps) {
   return (
-    <box flexDirection="row" height={2}>
+    <box flexDirection="row" height={compact ? 1 : 2}>
       {tabs.map((tab) => {
         const active = tab.value === activeValue;
         const tabWidth = tab.label.length + 2;
@@ -37,7 +38,7 @@ export function Tabs({ tabs, activeValue, onSelect }: TabsProps) {
             >
               {tab.label}
             </text>
-            <text fg={active ? colors.borderFocused : colors.bg}>{"▔".repeat(tabWidth)}</text>
+            {!compact && <text fg={active ? colors.borderFocused : colors.bg}>{"▔".repeat(tabWidth)}</text>}
           </box>
         );
       })}

--- a/src/plugins/builtin/portfolio-list.test.ts
+++ b/src/plugins/builtin/portfolio-list.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { CollectionSortPreference } from "../../state/app-context";
-import { resolveCollectionSortPreference } from "./portfolio-list";
+import type { BrokerAccount } from "../../types/trading";
+import {
+  buildPortfolioSummarySegments,
+  calculatePortfolioSummaryWidth,
+  resolveCollectionSortPreference,
+  shouldToggleCashMarginDrawer,
+  type PortfolioSummaryTotals,
+} from "./portfolio-list";
 
 describe("resolveCollectionSortPreference", () => {
   test("defaults portfolio tabs to market value descending", () => {
@@ -27,5 +34,81 @@ describe("resolveCollectionSortPreference", () => {
       columnId: "pnl",
       direction: "asc",
     } satisfies CollectionSortPreference);
+  });
+});
+
+describe("buildPortfolioSummarySegments", () => {
+  const totals: PortfolioSummaryTotals = {
+    totalMktValue: 125000,
+    dailyPnl: 5000,
+    dailyPnlPct: 4.17,
+    totalCostBasis: 100000,
+    hasPositions: true,
+    unrealizedPnl: 25000,
+    unrealizedPnlPct: 25,
+    avgWatchlistChange: 0,
+    watchlistCount: 0,
+  };
+
+  const account: BrokerAccount = {
+    accountId: "DU12345",
+    name: "DU12345",
+    totalCashValue: -50000,
+    settledCash: -45000,
+    availableFunds: 12000,
+    excessLiquidity: 10000,
+    buyingPower: 24000,
+  };
+
+  test("keeps value and cash at narrow widths for broker portfolios", () => {
+    const segments = buildPortfolioSummarySegments({
+      totals,
+      accountState: { account, sourceLabel: "Live" },
+      widthBudget: 24,
+    });
+
+    expect(segments.map((segment) => segment.id)).toEqual(["val", "cash"]);
+  });
+
+  test("drops low-priority broker segments before required ones", () => {
+    const segments = buildPortfolioSummarySegments({
+      totals,
+      accountState: { account, sourceLabel: "Live" },
+      widthBudget: 100,
+    });
+
+    expect(segments.map((segment) => segment.id)).toEqual([
+      "val",
+      "cash",
+      "day",
+      "pnl",
+      "settled",
+      "avail",
+      "excess",
+    ]);
+  });
+
+  test("includes the source badge only when width permits", () => {
+    const segments = buildPortfolioSummarySegments({
+      totals,
+      accountState: { account, sourceLabel: "Live" },
+      widthBudget: 110,
+    });
+
+    expect(segments.map((segment) => segment.id)).toContain("source");
+  });
+
+  test("treats c as the cash drawer shortcut only when the drawer is available", () => {
+    expect(shouldToggleCashMarginDrawer("c", true)).toBe(true);
+    expect(shouldToggleCashMarginDrawer("c", false)).toBe(false);
+    expect(shouldToggleCashMarginDrawer("j", true)).toBe(false);
+  });
+
+  test("hides the broker summary when tabs need the row width", () => {
+    expect(calculatePortfolioSummaryWidth(70, ["Main", "coldstart", "Interactive Brokers Paper"])).toBe(0);
+  });
+
+  test("uses leftover row width for the broker summary when tabs leave room", () => {
+    expect(calculatePortfolioSummaryWidth(100, ["Main", "coldstart"])).toBe(55);
   });
 });

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useReducer } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { AppContext, appReducer, createInitialState, PaneInstanceProvider, type AppAction } from "../../state/app-context";
+import { cloneLayout, createDefaultConfig, type AppConfig, type BrokerInstanceConfig } from "../../types/config";
+import type { Quote } from "../../types/financials";
+import type { TickerRecord } from "../../types/ticker";
+import { setSharedRegistryForTests } from "../registry";
+import { ibkrGatewayManager } from "../ibkr/gateway-service";
+import { portfolioListPlugin } from "./portfolio-list";
+
+const TEST_PANE_ID = "portfolio-list:test";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let harnessDispatch: React.Dispatch<AppAction> | null = null;
+
+const PortfolioPane = portfolioListPlugin.panes![0]!.component as (props: {
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+}) => JSX.Element;
+
+function createBrokerInstance(connectionMode: "gateway" | "flex", id = `ibkr-${connectionMode}`): BrokerInstanceConfig {
+  return {
+    id,
+    brokerType: "ibkr",
+    label: connectionMode === "gateway" ? "Gateway" : "Flex",
+    connectionMode,
+    config: connectionMode === "gateway"
+      ? { connectionMode, gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } }
+      : { connectionMode, flex: { token: "token", queryId: "query" } },
+    enabled: true,
+  };
+}
+
+function makeTicker(): TickerRecord {
+  return {
+    metadata: {
+      ticker: "AAPL",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "Apple",
+      portfolios: ["broker:ibkr-flex:DU12345", "broker:ibkr-live:DU12345"],
+      watchlists: [],
+      positions: [
+        {
+          portfolio: "broker:ibkr-flex:DU12345",
+          shares: 10,
+          avgCost: 100,
+          currency: "USD",
+          broker: "ibkr",
+          brokerInstanceId: "ibkr-flex",
+          brokerAccountId: "DU12345",
+        },
+        {
+          portfolio: "broker:ibkr-live:DU12345",
+          shares: 10,
+          avgCost: 100,
+          currency: "USD",
+          broker: "ibkr",
+          brokerInstanceId: "ibkr-live",
+          brokerAccountId: "DU12345",
+        },
+      ],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function makeQuote(): Quote {
+  return {
+    symbol: "AAPL",
+    price: 125,
+    currency: "USD",
+    change: 5,
+    changePercent: 4.17,
+    previousClose: 120,
+    name: "Apple",
+    lastUpdated: Date.now(),
+    marketState: "REGULAR",
+  };
+}
+
+function createPortfolioConfig(portfolioId: string, brokerInstances: BrokerInstanceConfig[] = []): AppConfig {
+  const config = createDefaultConfig("/tmp/gloomberb-portfolio-list");
+  const layout = {
+    columns: [{ width: "100%" }],
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "portfolio-list",
+      binding: { kind: "none" as const },
+      params: { collectionId: portfolioId },
+    }],
+    docked: [{ instanceId: TEST_PANE_ID, columnIndex: 0 }],
+    floating: [],
+  };
+
+  return {
+    ...config,
+    brokerInstances,
+    portfolios: [
+      ...config.portfolios,
+      {
+        id: portfolioId,
+        name: portfolioId.includes("flex") ? "Flex DU12345" : "Live DU12345",
+        currency: "USD",
+        brokerId: "ibkr",
+        brokerInstanceId: portfolioId.includes("flex") ? "ibkr-flex" : "ibkr-live",
+        brokerAccountId: "DU12345",
+      },
+    ],
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  };
+}
+
+function createPortfolioState(config: AppConfig, collectionId: string, expanded = false) {
+  const state = createInitialState(config);
+  state.focusedPaneId = TEST_PANE_ID;
+  state.paneState[TEST_PANE_ID] = {
+    collectionId,
+    cursorSymbol: "AAPL",
+    cashDrawerExpanded: expanded,
+  };
+  state.tickers = new Map([["AAPL", makeTicker()]]);
+  state.financials = new Map([["AAPL", { annualStatements: [], quarterlyStatements: [], priceHistory: [], quote: makeQuote() }]]);
+  return state;
+}
+
+function PortfolioHarness({
+  config,
+  collectionId,
+  expanded = false,
+  brokerAccounts = {},
+}: {
+  config: AppConfig;
+  collectionId: string;
+  expanded?: boolean;
+  brokerAccounts?: ReturnType<typeof createInitialState>["brokerAccounts"];
+}) {
+  const initialState = createPortfolioState(config, collectionId, expanded);
+  initialState.brokerAccounts = brokerAccounts;
+  const [state, dispatch] = useReducer(appReducer, initialState);
+  harnessDispatch = dispatch;
+
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <PortfolioPane
+          paneId={TEST_PANE_ID}
+          paneType="portfolio-list"
+          focused
+          width={100}
+          height={24}
+        />
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function flushFrame() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+  harnessDispatch = null;
+  setSharedRegistryForTests(undefined);
+  await ibkrGatewayManager.removeInstance("ibkr-live");
+});
+
+describe("PortfolioListPane cash and margin UI", () => {
+  test("keeps non-broker portfolios unchanged", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-portfolio-list");
+    const layout = {
+      columns: [{ width: "100%" }],
+      instances: [{
+        instanceId: TEST_PANE_ID,
+        paneId: "portfolio-list",
+        binding: { kind: "none" as const },
+        params: { collectionId: "main" },
+      }],
+      docked: [{ instanceId: TEST_PANE_ID, columnIndex: 0 }],
+      floating: [],
+    };
+    const nextConfig = { ...config, layout, layouts: [{ name: "Default", layout: cloneLayout(layout) }] };
+
+    testSetup = await testRender(
+      <PortfolioHarness config={nextConfig} collectionId="main" />,
+      { width: 100, height: 24 },
+    );
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).not.toContain("Cash & Margin");
+  });
+
+  test("shows flex cash summary and hides unavailable margin metrics", async () => {
+    const config = createPortfolioConfig("broker:ibkr-flex:DU12345", [createBrokerInstance("flex")]);
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="broker:ibkr-flex:DU12345"
+        expanded
+        brokerAccounts={{
+          "ibkr-flex": [{
+            accountId: "DU12345",
+            name: "DU12345",
+            currency: "USD",
+            source: "flex",
+            updatedAt: new Date(2026, 2, 27).getTime(),
+            totalCashValue: -50000,
+            settledCash: -45000,
+            netLiquidation: 125000,
+            cashBalances: [
+              { currency: "USD", quantity: -50000, baseValue: -50000, baseCurrency: "USD" },
+              { currency: "JPY", quantity: 0, baseValue: 0, baseCurrency: "USD" },
+            ],
+          }],
+        }}
+      />,
+      { width: 100, height: 24 },
+    );
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Cash");
+    expect(frame).toContain("Cash & Margin");
+    expect(frame).toContain("Net Liq");
+    expect(frame).toContain("Flex Mar 27");
+    expect(frame).not.toContain("Avail");
+    expect(frame).not.toContain("JPY");
+  });
+
+  test("shows a live gateway badge in the header and drawer preview", async () => {
+    const config = createPortfolioConfig("broker:ibkr-live:DU12345", [createBrokerInstance("gateway", "ibkr-live")]);
+    const service = ibkrGatewayManager.getService("ibkr-live") as any;
+    service.updateSnapshot({
+      status: { state: "connected", updatedAt: Date.now(), mode: "gateway" },
+      accounts: [{
+        accountId: "DU12345",
+        name: "DU12345",
+        currency: "USD",
+        source: "gateway",
+        updatedAt: Date.now(),
+        totalCashValue: -75000,
+        settledCash: -70000,
+        availableFunds: 15000,
+        excessLiquidity: 12000,
+        buyingPower: 30000,
+        netLiquidation: 200000,
+        cashBalances: [
+          { currency: "USD", quantity: -75000, baseValue: -75000, baseCurrency: "USD" },
+          { currency: "EUR", quantity: -10000, baseValue: undefined, baseCurrency: "USD" },
+        ],
+      }],
+      openOrders: [],
+      executions: [],
+    });
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="broker:ibkr-live:DU12345"
+        brokerAccounts={{
+          "ibkr-live": [{
+            accountId: "DU12345",
+            name: "DU12345",
+            currency: "USD",
+            source: "gateway",
+            updatedAt: Date.now(),
+            totalCashValue: -70000,
+          }],
+        }}
+      />,
+      { width: 100, height: 24 },
+    );
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("Live");
+    expect(testSetup.captureCharFrame()).toContain("▸ Cash & Margin");
+  });
+
+  test("stacks the summary below tabs when the tab row is crowded", async () => {
+    const config = {
+      ...createPortfolioConfig("broker:ibkr-flex:DU12345", [createBrokerInstance("flex")]),
+      watchlists: [
+        { id: "watchlist-1", name: "International Compounders" },
+        { id: "watchlist-2", name: "Interactive Brokers Paper" },
+      ],
+    };
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="broker:ibkr-flex:DU12345"
+        brokerAccounts={{
+          "ibkr-flex": [{
+            accountId: "DU12345",
+            name: "DU12345",
+            currency: "USD",
+            source: "flex",
+            updatedAt: new Date(2026, 2, 27).getTime(),
+            totalCashValue: -50000,
+            settledCash: -45000,
+            netLiquidation: 125000,
+            cashBalances: [
+              { currency: "USD", quantity: -50000, baseValue: -50000, baseCurrency: "USD" },
+            ],
+          }],
+        }}
+      />,
+      { width: 70, height: 24 },
+    );
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Val 1.3k  Cash -50k");
+    expect(frame).toContain("▸ Cash &");
+  });
+});

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback, useSyncExternalStore } from "react";
 import { useKeyboard } from "@opentui/react";
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { TextAttributes } from "@opentui/core";
@@ -17,9 +17,12 @@ import { getAllCollections, getCollectionTickers, getCollectionType } from "../.
 import { colors, priceColor, hoverBg } from "../../theme/colors";
 import { formatCurrency, formatPercentRaw, formatCompact, formatNumber, padTo, convertCurrency } from "../../utils/format";
 import type { ColumnConfig } from "../../types/config";
-import type { TickerRecord } from "../../types/ticker";
+import type { TickerRecord, Portfolio } from "../../types/ticker";
 import type { TickerFinancials } from "../../types/financials";
+import type { BrokerAccount, BrokerCashBalance } from "../../types/trading";
+import { getBrokerInstance } from "../../utils/broker-instances";
 import { formatOptionTicker } from "../../utils/options";
+import { ibkrGatewayManager } from "../ibkr/gateway-service";
 
 interface ColumnContext {
   activeTab?: string;
@@ -309,16 +312,478 @@ export function resolveCollectionSortPreference(
   return collectionSorts[collectionId] ?? (isPortfolio ? DEFAULT_PORTFOLIO_SORT_PREFERENCE : EMPTY_SORT_PREFERENCE);
 }
 
+export interface PortfolioSummaryTotals {
+  totalMktValue: number;
+  dailyPnl: number;
+  dailyPnlPct: number;
+  totalCostBasis: number;
+  hasPositions: boolean;
+  unrealizedPnl: number;
+  unrealizedPnlPct: number;
+  avgWatchlistChange: number;
+  watchlistCount: number;
+}
+
+export interface PortfolioSummarySegment {
+  id: string;
+  parts: Array<{
+    text: string;
+    tone: "label" | "value" | "muted";
+    color?: string;
+    bold?: boolean;
+  }>;
+  length: number;
+}
+
+export interface PortfolioSummaryAccountState {
+  account: BrokerAccount;
+  sourceLabel: string;
+}
+
+interface ResolvedPortfolioAccountState extends PortfolioSummaryAccountState {
+  sourceKind: "live" | "cached" | "flex";
+  visibleCashBalances: BrokerCashBalance[];
+}
+
+function createSummarySegment(
+  id: string,
+  parts: PortfolioSummarySegment["parts"],
+): PortfolioSummarySegment {
+  return {
+    id,
+    parts,
+    length: parts.reduce((sum, part) => sum + part.text.length, 0) + Math.max(0, parts.length - 1),
+  };
+}
+
+function fitSummarySegments(candidates: PortfolioSummarySegment[], widthBudget: number): PortfolioSummarySegment[] {
+  const fitted: PortfolioSummarySegment[] = [];
+  let used = 0;
+  for (const segment of candidates) {
+    const nextUsed = used + (fitted.length > 0 ? 2 : 0) + segment.length;
+    if (fitted.length > 0 && nextUsed > widthBudget) break;
+    fitted.push(segment);
+    used = nextUsed;
+  }
+  return fitted;
+}
+
+function formatSourceBadge(account: BrokerAccount, liveGateway: boolean): { label: string; kind: "live" | "cached" | "flex" } {
+  if (liveGateway) {
+    return { label: "Live", kind: "live" };
+  }
+  if (account.source === "flex") {
+    return {
+      label: account.updatedAt
+        ? `Flex ${new Date(account.updatedAt).toLocaleDateString("en-US", { month: "short", day: "numeric" })}`
+        : "Flex",
+      kind: "flex",
+    };
+  }
+  return { label: "Cached", kind: "cached" };
+}
+
+function getVisibleCashBalances(cashBalances: BrokerCashBalance[] | undefined): BrokerCashBalance[] {
+  if (!cashBalances) return [];
+  return cashBalances
+    .filter((balance) => {
+      const quantity = Math.abs(balance.quantity);
+      const baseValue = Math.abs(balance.baseValue ?? 0);
+      return quantity > 1e-9 || baseValue > 1e-9;
+    })
+    .sort((left, right) => {
+      const leftValue = Math.abs(left.baseValue ?? left.quantity);
+      const rightValue = Math.abs(right.baseValue ?? right.quantity);
+      return rightValue - leftValue;
+    });
+}
+
+function findPortfolioAccount(
+  accounts: BrokerAccount[],
+  portfolio: Portfolio,
+): BrokerAccount | undefined {
+  if (accounts.length === 0) return undefined;
+
+  const accountId = portfolio.brokerAccountId?.trim();
+  const portfolioName = portfolio.name.trim();
+  const collectionAccountId = portfolio.id.split(":").pop()?.trim();
+
+  return accounts.find((account) => account.accountId === accountId)
+    ?? accounts.find((account) => account.accountId === portfolioName || account.name === portfolioName)
+    ?? accounts.find((account) => account.accountId === collectionAccountId || account.name === collectionAccountId)
+    ?? (accounts.length === 1 ? accounts[0] : undefined);
+}
+
+function resolvePortfolioAccountState(
+  portfolio: Portfolio | null,
+  state: ReturnType<typeof useAppState>["state"],
+  liveSnapshot: ReturnType<typeof ibkrGatewayManager.getSnapshot>,
+): ResolvedPortfolioAccountState | null {
+  if (!portfolio?.brokerInstanceId) return null;
+
+  const brokerInstance = getBrokerInstance(state.config.brokerInstances, portfolio.brokerInstanceId);
+  const cachedAccounts = state.brokerAccounts[portfolio.brokerInstanceId] ?? [];
+  const cachedAccount = findPortfolioAccount(cachedAccounts, portfolio);
+
+  const liveAccount = brokerInstance?.brokerType === "ibkr"
+    && brokerInstance.connectionMode === "gateway"
+    && liveSnapshot.status.state === "connected"
+    ? findPortfolioAccount(liveSnapshot.accounts, portfolio)
+    : undefined;
+
+  const account = liveAccount ?? cachedAccount;
+  if (!account) return null;
+
+  const source = formatSourceBadge(account, !!liveAccount);
+  return {
+    account,
+    sourceLabel: source.label,
+    sourceKind: source.kind,
+    visibleCashBalances: getVisibleCashBalances(account.cashBalances),
+  };
+}
+
+function calculatePortfolioSummaryTotals(
+  tickers: TickerRecord[],
+  state: ReturnType<typeof useAppState>["state"],
+  isPortfolio: boolean,
+  collectionId: string | null,
+): PortfolioSummaryTotals {
+  const baseCurrency = state.config.baseCurrency;
+  const exchangeRates = state.exchangeRates;
+  let totalMktValue = 0;
+  let totalPrevValue = 0;
+  let totalCostBasis = 0;
+  let hasPositions = false;
+  let watchlistChangeSum = 0;
+  let watchlistCount = 0;
+
+  for (const ticker of tickers) {
+    const fin = state.financials.get(ticker.metadata.ticker);
+    const q = fin?.quote;
+    const quoteCurrency = q?.currency || ticker.metadata.currency || "USD";
+    const toBase = (value: number) => convertCurrency(value, quoteCurrency, baseCurrency, exchangeRates);
+
+    if (!isPortfolio) {
+      if (q?.changePercent != null) {
+        watchlistChangeSum += q.changePercent;
+        watchlistCount++;
+      }
+      continue;
+    }
+
+    const tabPositions = collectionId
+      ? ticker.metadata.positions.filter((position) => position.portfolio === collectionId)
+      : ticker.metadata.positions;
+    const totalShares = tabPositions.reduce((sum, position) => sum + position.shares * (position.side === "short" ? -1 : 1), 0);
+    const totalCost = tabPositions.reduce(
+      (sum, position) => sum + position.shares * position.avgCost * (position.multiplier || 1),
+      0,
+    );
+
+    const isOption = ticker.metadata.assetCategory === "OPT";
+    const brokerMktValue = tabPositions.reduce((sum, position) => sum + (position.marketValue || 0), 0);
+
+    if (q && totalShares !== 0) {
+      hasPositions = true;
+      const marketValue = Math.abs(totalShares) * q.price;
+      totalMktValue += toBase(marketValue);
+      const prevClose = q.previousClose || (q.price - q.change);
+      totalPrevValue += toBase(Math.abs(totalShares) * prevClose);
+      totalCostBasis += toBase(totalCost);
+    } else if (isOption && brokerMktValue !== 0) {
+      hasPositions = true;
+      totalMktValue += toBase(brokerMktValue);
+      totalCostBasis += toBase(totalCost);
+      totalPrevValue += toBase(brokerMktValue);
+    }
+  }
+
+  const dailyPnl = totalMktValue - totalPrevValue;
+  const dailyPnlPct = totalPrevValue !== 0 ? (dailyPnl / totalPrevValue) * 100 : 0;
+  const unrealizedPnl = totalMktValue - totalCostBasis;
+  const unrealizedPnlPct = totalCostBasis !== 0 ? (unrealizedPnl / totalCostBasis) * 100 : 0;
+  const avgWatchlistChange = watchlistCount > 0 ? watchlistChangeSum / watchlistCount : 0;
+
+  return {
+    totalMktValue,
+    dailyPnl,
+    dailyPnlPct,
+    totalCostBasis,
+    hasPositions,
+    unrealizedPnl,
+    unrealizedPnlPct,
+    avgWatchlistChange,
+    watchlistCount,
+  };
+}
+
+export function buildPortfolioSummarySegments({
+  totals,
+  accountState,
+  widthBudget,
+  refreshText,
+}: {
+  totals: PortfolioSummaryTotals;
+  accountState: PortfolioSummaryAccountState | null;
+  widthBudget: number;
+  refreshText?: string;
+}): PortfolioSummarySegment[] {
+  const candidates: PortfolioSummarySegment[] = [
+    createSummarySegment("val", [
+      { text: "Val", tone: "label" },
+      { text: formatCompact(totals.totalMktValue), tone: "value", bold: true },
+    ]),
+  ];
+
+  if (accountState) {
+    const { account, sourceLabel } = accountState;
+    if (account.totalCashValue != null) {
+      candidates.push(createSummarySegment("cash", [
+        { text: "Cash", tone: "label" },
+        { text: formatCompact(account.totalCashValue), tone: "value", bold: true },
+      ]));
+    }
+  }
+
+  candidates.push(createSummarySegment("day", [
+    { text: "Day", tone: "label" },
+    { text: `${totals.dailyPnl >= 0 ? "+" : ""}${formatCompact(totals.dailyPnl)}`, tone: "value", color: priceColor(totals.dailyPnl), bold: true },
+    { text: `(${formatPercentRaw(totals.dailyPnlPct)})`, tone: "muted", color: priceColor(totals.dailyPnlPct) },
+  ]));
+  candidates.push(createSummarySegment("pnl", [
+    { text: "P&L", tone: "label" },
+    { text: `${totals.unrealizedPnl >= 0 ? "+" : ""}${formatCompact(totals.unrealizedPnl)}`, tone: "value", color: priceColor(totals.unrealizedPnl), bold: true },
+    { text: `(${formatPercentRaw(totals.unrealizedPnlPct)})`, tone: "muted", color: priceColor(totals.unrealizedPnlPct) },
+  ]));
+
+  if (accountState) {
+    const { account, sourceLabel } = accountState;
+    const brokerSegments = [
+      account.settledCash != null
+        ? createSummarySegment("settled", [
+          { text: "Settled", tone: "label" },
+          { text: formatCompact(account.settledCash), tone: "value", bold: true },
+        ])
+        : null,
+      account.availableFunds != null
+        ? createSummarySegment("avail", [
+          { text: "Avail", tone: "label" },
+          { text: formatCompact(account.availableFunds), tone: "value", bold: true },
+        ])
+        : null,
+      account.excessLiquidity != null
+        ? createSummarySegment("excess", [
+          { text: "Excess", tone: "label" },
+          { text: formatCompact(account.excessLiquidity), tone: "value", bold: true },
+        ])
+        : null,
+      account.buyingPower != null
+        ? createSummarySegment("bp", [
+          { text: "BP", tone: "label" },
+          { text: formatCompact(account.buyingPower), tone: "value", bold: true },
+        ])
+        : null,
+      createSummarySegment("source", [
+        { text: sourceLabel, tone: "muted" },
+      ]),
+    ].filter((segment): segment is PortfolioSummarySegment => segment != null);
+
+    return fitSummarySegments([...candidates, ...brokerSegments], widthBudget);
+  }
+
+  if (refreshText) {
+    candidates.push(createSummarySegment("refresh", [
+      { text: refreshText, tone: "muted" },
+    ]));
+  }
+
+  return fitSummarySegments(candidates, widthBudget);
+}
+
+export function shouldToggleCashMarginDrawer(key: string | undefined, showCashDrawer: boolean): boolean {
+  return key === "c" && showCashDrawer;
+}
+
+export function calculatePortfolioSummaryWidth(totalWidth: number, tabLabels: string[]): number {
+  const desiredWidth = Math.min(totalWidth, Math.min(72, Math.max(24, Math.floor(totalWidth * 0.55))));
+  if (desiredWidth <= 0) return 0;
+
+  const tabRowWidth = tabLabels.reduce((sum, label) => sum + label.length + 4, 0);
+  const availableWidth = Math.max(0, totalWidth - tabRowWidth);
+  if (availableWidth < Math.min(24, totalWidth)) return 0;
+
+  return Math.min(desiredWidth, availableWidth);
+}
+
+function renderSummarySegments(segments: PortfolioSummarySegment[], width: number) {
+  if (segments.length === 0) return null;
+  return (
+    <box flexDirection="row" width={width} justifyContent="flex-start" overflow="hidden">
+      {segments.map((segment, segmentIndex) => (
+        <box key={segment.id} flexDirection="row">
+          {segmentIndex > 0 && <text fg={colors.textDim}>{"  "}</text>}
+          {segment.parts.map((part, partIndex) => (
+            <box key={`${segment.id}:${partIndex}`} flexDirection="row">
+              {partIndex > 0 && <text fg={colors.textDim}>{" "}</text>}
+              <text
+                fg={part.color ?? (part.tone === "label" || part.tone === "muted" ? colors.textDim : colors.text)}
+                attributes={part.bold ? TextAttributes.BOLD : 0}
+              >
+                {part.text}
+              </text>
+            </box>
+          ))}
+        </box>
+      ))}
+    </box>
+  );
+}
+
+function buildDrawerMetricSegments(account: BrokerAccount, widthBudget: number): PortfolioSummarySegment[] {
+  const candidates = [
+    account.totalCashValue != null
+      ? createSummarySegment("cash", [{ text: "Cash", tone: "label" }, { text: formatCompact(account.totalCashValue), tone: "value", bold: true }])
+      : null,
+    account.settledCash != null
+      ? createSummarySegment("settled", [{ text: "Settled", tone: "label" }, { text: formatCompact(account.settledCash), tone: "value", bold: true }])
+      : null,
+    account.netLiquidation != null
+      ? createSummarySegment("netliq", [{ text: "Net Liq", tone: "label" }, { text: formatCompact(account.netLiquidation), tone: "value", bold: true }])
+      : null,
+    account.availableFunds != null
+      ? createSummarySegment("avail", [{ text: "Avail", tone: "label" }, { text: formatCompact(account.availableFunds), tone: "value", bold: true }])
+      : null,
+    account.excessLiquidity != null
+      ? createSummarySegment("excess", [{ text: "Excess", tone: "label" }, { text: formatCompact(account.excessLiquidity), tone: "value", bold: true }])
+      : null,
+    account.buyingPower != null
+      ? createSummarySegment("bp", [{ text: "BP", tone: "label" }, { text: formatCompact(account.buyingPower), tone: "value", bold: true }])
+      : null,
+    account.initMarginReq != null
+      ? createSummarySegment("init", [{ text: "Init", tone: "label" }, { text: formatCompact(account.initMarginReq), tone: "value", bold: true }])
+      : null,
+    account.maintMarginReq != null
+      ? createSummarySegment("maint", [{ text: "Maint", tone: "label" }, { text: formatCompact(account.maintMarginReq), tone: "value", bold: true }])
+      : null,
+  ].filter((segment): segment is PortfolioSummarySegment => segment != null);
+
+  return fitSummarySegments(candidates, widthBudget);
+}
+
+function PortfolioCashMarginDrawer({
+  accountState,
+  expanded,
+  onToggle,
+  width,
+  height,
+}: {
+  accountState: ResolvedPortfolioAccountState;
+  expanded: boolean;
+  onToggle: () => void;
+  width: number;
+  height: number;
+}) {
+  const previewText = `${accountState.visibleCashBalances.length} ccy · Cash ${formatCompact(accountState.account.totalCashValue)} · ${accountState.sourceLabel}`;
+  const drawerHeight = Math.max(1, height);
+
+  if (!expanded) {
+    return (
+      <box
+        width={width}
+        height={drawerHeight}
+        flexDirection="row"
+        onMouseDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onMouseUp={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onToggle();
+        }}
+      >
+        <text fg={colors.textBright} attributes={TextAttributes.BOLD}>{"▸ Cash & Margin"}</text>
+        <box flexGrow={1} />
+        <text fg={colors.textDim}>{padTo(previewText, Math.max(0, width - 17), "right")}</text>
+      </box>
+    );
+  }
+
+  const metricSegments = buildDrawerMetricSegments(accountState.account, width);
+  const currencyRowsHeight = Math.max(1, drawerHeight - 2);
+
+  return (
+    <box flexDirection="column" height={drawerHeight}>
+      <box
+        width={width}
+        height={1}
+        flexDirection="row"
+        onMouseDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onMouseUp={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onToggle();
+        }}
+      >
+        <text fg={colors.textBright} attributes={TextAttributes.BOLD}>{"▾ Cash & Margin"}</text>
+        <box flexGrow={1} />
+        <text fg={colors.textDim}>{accountState.sourceLabel}</text>
+      </box>
+      <box height={1} overflow="hidden">
+        {renderSummarySegments(metricSegments, width)}
+      </box>
+      <scrollbox height={currencyRowsHeight} scrollY focusable={false}>
+        {accountState.visibleCashBalances.length === 0 ? (
+          <text fg={colors.textDim}>No non-zero cash balances.</text>
+        ) : (
+          accountState.visibleCashBalances.map((balance) => (
+            <box key={balance.currency} height={1} flexDirection="row">
+              <text fg={colors.textBright}>{padTo(balance.currency, 4)}</text>
+              <text fg={colors.textDim}>{" qty "}</text>
+              <text fg={colors.text}>{padTo(formatNumber(balance.quantity, 2), 14, "right")}</text>
+              <text fg={colors.textDim}>{"  value "}</text>
+              <text fg={colors.text}>{padTo(balance.baseValue != null ? formatCompact(balance.baseValue) : "—", 10, "right")}</text>
+            </box>
+          ))
+        )}
+      </scrollbox>
+    </box>
+  );
+}
+
+function usePortfolioAccountState(
+  portfolio: Portfolio | null,
+  state: ReturnType<typeof useAppState>["state"],
+): ResolvedPortfolioAccountState | null {
+  const instanceId = portfolio?.brokerInstanceId;
+  const snapshot = useSyncExternalStore(
+    (listener) => ibkrGatewayManager.subscribe(instanceId, listener),
+    () => ibkrGatewayManager.getSnapshot(instanceId),
+  );
+  return useMemo(
+    () => resolvePortfolioAccountState(portfolio, state, snapshot),
+    [portfolio, snapshot, state],
+  );
+}
+
 function PortfolioSummaryBar({
   tickers,
   state,
   isPortfolio,
   collectionId,
+  width,
+  accountState,
 }: {
   tickers: TickerRecord[];
   state: ReturnType<typeof useAppState>["state"];
   isPortfolio: boolean;
   collectionId: string | null;
+  width: number;
+  accountState: ResolvedPortfolioAccountState | null;
 }) {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
@@ -340,71 +805,10 @@ function PortfolioSummaryBar({
     }
   }, [state.financials.size, lastRefresh]);
 
-  const baseCurrency = state.config.baseCurrency;
-  const exchangeRates = state.exchangeRates;
-
-  const totals = useMemo(() => {
-    let totalMktValue = 0;
-    let totalPrevValue = 0;
-    let totalCostBasis = 0;
-    let hasPositions = false;
-    // For watchlists: average daily change %
-    let watchlistChangeSum = 0;
-    let watchlistCount = 0;
-
-    for (const ticker of tickers) {
-      const fin = state.financials.get(ticker.metadata.ticker);
-      const q = fin?.quote;
-      const quoteCurrency = q?.currency || ticker.metadata.currency || "USD";
-      const toBase = (v: number) => convertCurrency(v, quoteCurrency, baseCurrency, exchangeRates);
-
-      if (!isPortfolio) {
-        if (q?.changePercent != null) {
-          watchlistChangeSum += q.changePercent;
-          watchlistCount++;
-        }
-        continue;
-      }
-
-      const tabPositions = collectionId
-        ? ticker.metadata.positions.filter((p) => p.portfolio === collectionId)
-        : ticker.metadata.positions;
-      const totalShares = tabPositions.reduce((sum, p) => sum + p.shares * (p.side === "short" ? -1 : 1), 0);
-      const totalCost = tabPositions.reduce(
-        (sum, p) => sum + p.shares * p.avgCost * (p.multiplier || 1),
-        0,
-      );
-
-      const isOption = ticker.metadata.assetCategory === "OPT";
-      const brokerMktValue = tabPositions.reduce((sum, p) => sum + (p.marketValue || 0), 0);
-
-      if (q && totalShares !== 0) {
-        hasPositions = true;
-        const mv = Math.abs(totalShares) * q.price;
-        totalMktValue += toBase(mv);
-        const prevClose = q.previousClose || (q.price - q.change);
-        totalPrevValue += toBase(Math.abs(totalShares) * prevClose);
-        totalCostBasis += toBase(totalCost);
-      } else if (isOption && brokerMktValue !== 0) {
-        hasPositions = true;
-        totalMktValue += toBase(brokerMktValue);
-        totalCostBasis += toBase(totalCost);
-        totalPrevValue += toBase(brokerMktValue);
-      }
-    }
-
-    const dailyPnl = totalMktValue - totalPrevValue;
-    const dailyPnlPct = totalPrevValue !== 0 ? (dailyPnl / totalPrevValue) * 100 : 0;
-    const unrealizedPnl = totalMktValue - totalCostBasis;
-    const unrealizedPnlPct = totalCostBasis !== 0 ? (unrealizedPnl / totalCostBasis) * 100 : 0;
-    const avgWatchlistChange = watchlistCount > 0 ? watchlistChangeSum / watchlistCount : 0;
-
-    return {
-      totalMktValue, dailyPnl, dailyPnlPct, totalCostBasis, hasPositions,
-      unrealizedPnl, unrealizedPnlPct,
-      avgWatchlistChange, watchlistCount,
-    };
-  }, [tickers, state.financials, collectionId, baseCurrency, exchangeRates, isPortfolio]);
+  const totals = useMemo(
+    () => calculatePortfolioSummaryTotals(tickers, state, isPortfolio, collectionId),
+    [tickers, state, isPortfolio, collectionId],
+  );
 
   const refreshText = lastRefresh
     ? lastRefresh.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
@@ -415,7 +819,7 @@ function PortfolioSummaryBar({
   if (!isPortfolio) {
     if (totals.watchlistCount === 0) return null;
     return (
-      <box flexDirection="row" height={1} paddingRight={1}>
+      <box flexDirection="row" height={1} width={width} justifyContent="flex-start" overflow="hidden">
         <text fg={colors.textDim}>{"Avg Day "}</text>
         <text fg={priceColor(totals.avgWatchlistChange)} attributes={TextAttributes.BOLD}>
           {formatPercentRaw(totals.avgWatchlistChange)}
@@ -425,34 +829,19 @@ function PortfolioSummaryBar({
     );
   }
 
-  if (!totals.hasPositions) return null;
+  if (!totals.hasPositions && !accountState) return null;
 
-  return (
-    <box flexDirection="row" height={1} paddingRight={1}>
-      <text fg={colors.textDim}>{"Val "}</text>
-      <text fg={colors.text} attributes={TextAttributes.BOLD}>
-        {formatCompact(totals.totalMktValue)}
-      </text>
-      <text fg={colors.textDim}>{"  Day "}</text>
-      <text fg={priceColor(totals.dailyPnl)} attributes={TextAttributes.BOLD}>
-        {(totals.dailyPnl >= 0 ? "+" : "") + formatCompact(totals.dailyPnl)}
-      </text>
-      <text fg={priceColor(totals.dailyPnlPct)}>
-        {" (" + formatPercentRaw(totals.dailyPnlPct) + ")"}
-      </text>
-      <text fg={colors.textDim}>{"  P&L "}</text>
-      <text fg={priceColor(totals.unrealizedPnl)} attributes={TextAttributes.BOLD}>
-        {(totals.unrealizedPnl >= 0 ? "+" : "") + formatCompact(totals.unrealizedPnl)}
-      </text>
-      <text fg={priceColor(totals.unrealizedPnlPct)}>
-        {" (" + formatPercentRaw(totals.unrealizedPnlPct) + ")"}
-      </text>
-      <text fg={colors.textDim}>{"  " + (isRefreshing ? "Refreshing…" : refreshText)}</text>
-    </box>
-  );
+  const segments = buildPortfolioSummarySegments({
+    totals,
+    accountState: accountState ? { account: accountState.account, sourceLabel: accountState.sourceLabel } : null,
+    widthBudget: width,
+    refreshText: isRefreshing ? "Refreshing…" : refreshText,
+  });
+
+  return <box height={1}>{renderSummarySegments(segments, width)}</box>;
 }
 
-function PortfolioListPane({ focused }: PaneProps) {
+function PortfolioListPane({ focused, width, height }: PaneProps) {
   const registry = getSharedRegistry();
   const paneId = usePaneInstanceId();
   const { state } = useAppState();
@@ -460,6 +849,7 @@ function PortfolioListPane({ focused }: PaneProps) {
   const [currentCollectionId, setCurrentCollectionId] = usePaneStateValue<string>("collectionId", paneCollection.collectionId ?? "");
   const [cursorSymbol, setCursorSymbol] = usePaneStateValue<string | null>("cursorSymbol", null);
   const [collectionSorts, setCollectionSorts] = usePaneStateValue<Record<string, CollectionSortPreference>>("collectionSorts", {});
+  const [cashDrawerExpanded, setCashDrawerExpanded] = usePaneStateValue<boolean>("cashDrawerExpanded", false);
   const tabs = getAllCollections(state);
   const tickers = getCollectionTickers(state, currentCollectionId);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
@@ -471,6 +861,22 @@ function PortfolioListPane({ focused }: PaneProps) {
 
   const currentTabIdx = tabs.findIndex((t) => t.id === currentCollectionId);
   const isPortfolioTab = getCollectionType(state, currentCollectionId) === "portfolio";
+  const currentPortfolio = isPortfolioTab
+    ? state.config.portfolios.find((portfolio) => portfolio.id === currentCollectionId) ?? null
+    : null;
+  const accountState = usePortfolioAccountState(currentPortfolio, state);
+  const showCashDrawer = !!(isPortfolioTab && currentPortfolio?.brokerInstanceId && accountState);
+  const requestedDrawerHeight = showCashDrawer
+    ? (cashDrawerExpanded
+      ? Math.min(6, Math.max(3, 2 + accountState.visibleCashBalances.length))
+      : 1)
+    : 0;
+  const summaryWidth = calculatePortfolioSummaryWidth(width, tabs.map((tab) => tab.name));
+  const showStackedSummary = summaryWidth === 0;
+  const headerHeight = showStackedSummary ? 2 : 1;
+  const drawerHeight = showCashDrawer
+    ? Math.min(requestedDrawerHeight, Math.max(1, height - (headerHeight + 2)))
+    : 0;
 
   // Build columns: base config columns + position columns for portfolios
   const cols = useMemo(() => {
@@ -556,7 +962,9 @@ function PortfolioListPane({ focused }: PaneProps) {
       return;
     }
 
-    if (key === "j" || key === "down") {
+    if (shouldToggleCashMarginDrawer(key, showCashDrawer)) {
+      setCashDrawerExpanded(!cashDrawerExpanded);
+    } else if (key === "j" || key === "down") {
       const next = Math.min(safeSelectedIdx + 1, sortedTickers.length - 1);
       if (sortedTickers[next]) setCursorSymbol(sortedTickers[next]!.metadata.ticker);
     } else if (key === "k" || key === "up") {
@@ -580,7 +988,21 @@ function PortfolioListPane({ focused }: PaneProps) {
         registry?.showPaneFn("ticker-detail");
       }
     }
-  }, [focused, registry, safeSelectedIdx, sortedTickers, state.config.layout.instances, paneId, tabs, currentTabIdx, setCurrentCollectionId, setCursorSymbol]);
+  }, [
+    focused,
+    registry,
+    safeSelectedIdx,
+    sortedTickers,
+    state.config.layout.instances,
+    paneId,
+    tabs,
+    currentTabIdx,
+    setCurrentCollectionId,
+    setCursorSymbol,
+    showCashDrawer,
+    cashDrawerExpanded,
+    setCashDrawerExpanded,
+  ]);
 
   useKeyboard(handleKeyboard);
 
@@ -616,7 +1038,7 @@ function PortfolioListPane({ focused }: PaneProps) {
     const sb = scrollRef.current;
     if (!sb) return;
     sb.verticalScrollBar.visible = sortedTickers.length > sb.viewport.height;
-  }, [sortedTickers.length]);
+  }, [sortedTickers.length, drawerHeight, cashDrawerExpanded]);
 
   // Tick every 5s to keep latency column fresh
   useEffect(() => {
@@ -656,13 +1078,41 @@ function PortfolioListPane({ focused }: PaneProps) {
 
   return (
     <box flexDirection="column" flexGrow={1}>
-      <box flexDirection="row" height={2} justifyContent="space-between">
-        <TabBar
-          tabs={tabs.map((t) => ({ label: t.name, value: t.id }))}
-          activeValue={currentCollectionId}
-          onSelect={setCurrentCollectionId}
-        />
-        <PortfolioSummaryBar tickers={sortedTickers} state={state} isPortfolio={isPortfolioTab} collectionId={currentCollectionId} />
+      <box flexDirection="column" height={headerHeight}>
+        <box flexDirection="row" height={1}>
+          <box flexShrink={1} overflow="hidden">
+            <TabBar
+              tabs={tabs.map((t) => ({ label: t.name, value: t.id }))}
+              activeValue={currentCollectionId}
+              onSelect={setCurrentCollectionId}
+              compact
+            />
+          </box>
+          {summaryWidth > 0 && (
+            <box width={summaryWidth} flexShrink={0} alignItems="flex-start" justifyContent="center">
+              <PortfolioSummaryBar
+                tickers={sortedTickers}
+                state={state}
+                isPortfolio={isPortfolioTab}
+                collectionId={currentCollectionId}
+                width={summaryWidth}
+                accountState={accountState}
+              />
+            </box>
+          )}
+        </box>
+        {showStackedSummary && (
+          <box height={1}>
+            <PortfolioSummaryBar
+              tickers={sortedTickers}
+              state={state}
+              isPortfolio={isPortfolioTab}
+              collectionId={currentCollectionId}
+              width={Math.max(0, width)}
+              accountState={accountState}
+            />
+          </box>
+        )}
       </box>
 
       {/* Fixed column headers — synced horizontally with rows */}
@@ -681,7 +1131,10 @@ function PortfolioListPane({ focused }: PaneProps) {
               <box
                 key={col.id}
                 width={col.width + 1}
-                onMouseDown={() => handleHeaderClick(col.id)}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  handleHeaderClick(col.id);
+                }}
               >
                 <text
                   attributes={TextAttributes.BOLD}
@@ -723,7 +1176,8 @@ function PortfolioListPane({ focused }: PaneProps) {
                 paddingX={1}
                 backgroundColor={rowBg}
                 onMouseMove={() => setHoveredIdx(idx)}
-                onMouseDown={() => {
+                onMouseDown={(event) => {
+                  event.preventDefault();
                   setCursorSymbol(ticker.metadata.ticker);
                 }}
               >
@@ -746,6 +1200,18 @@ function PortfolioListPane({ focused }: PaneProps) {
           })
         )}
       </scrollbox>
+
+      {showCashDrawer && accountState && (
+        <box height={drawerHeight} paddingX={1}>
+          <PortfolioCashMarginDrawer
+            accountState={accountState}
+            expanded={cashDrawerExpanded}
+            onToggle={() => setCashDrawerExpanded(!cashDrawerExpanded)}
+            width={Math.max(0, width - 2)}
+            height={drawerHeight}
+          />
+        </box>
+      )}
     </box>
   );
 }

--- a/src/plugins/ibkr/account-cache.test.ts
+++ b/src/plugins/ibkr/account-cache.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { AppPersistence } from "../../data/app-persistence";
+import type { BrokerInstanceConfig } from "../../types/config";
+import type { BrokerAccount } from "../../types/trading";
+import {
+  clearPersistedIbkrAccounts,
+  loadPersistedIbkrAccountMap,
+  loadPersistedIbkrAccounts,
+  persistIbkrAccounts,
+} from "./account-cache";
+
+const tempPaths: string[] = [];
+
+function createTempDbPath(name: string): string {
+  const path = join(tmpdir(), `gloomberb-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  tempPaths.push(path);
+  return path;
+}
+
+function createIbkrInstance(connectionMode: "flex" | "gateway", overrides: Partial<BrokerInstanceConfig> = {}): BrokerInstanceConfig {
+  return {
+    id: overrides.id ?? `ibkr-${connectionMode}`,
+    brokerType: "ibkr",
+    label: overrides.label ?? `IBKR ${connectionMode}`,
+    connectionMode,
+    config: connectionMode === "gateway"
+      ? { connectionMode, gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } }
+      : { connectionMode, flex: { token: "token", queryId: "query" } },
+    enabled: true,
+    ...overrides,
+  };
+}
+
+const TEST_ACCOUNTS: BrokerAccount[] = [{
+  accountId: "DU12345",
+  name: "DU12345",
+  currency: "USD",
+  source: "gateway",
+  updatedAt: 1_717_000_000_000,
+  totalCashValue: 125000,
+  cashBalances: [{ currency: "USD", quantity: 125000, baseValue: 125000, baseCurrency: "USD" }],
+}];
+
+afterEach(() => {
+  for (const path of tempPaths.splice(0)) {
+    if (existsSync(path)) rmSync(path, { force: true });
+  }
+});
+
+describe("IBKR account cache", () => {
+  test("persists and reloads account snapshots by broker instance", () => {
+    const persistence = new AppPersistence(createTempDbPath("ibkr-account-cache"));
+    const instance = createIbkrInstance("flex", { id: "ibkr-personal" });
+
+    persistIbkrAccounts(persistence.resources, instance, TEST_ACCOUNTS);
+
+    expect(loadPersistedIbkrAccounts(persistence.resources, instance)).toEqual(TEST_ACCOUNTS);
+    expect(loadPersistedIbkrAccountMap(persistence.resources, [instance])).toEqual({
+      "ibkr-personal": TEST_ACCOUNTS,
+    });
+
+    persistence.close();
+  });
+
+  test("drops snapshots whose config fingerprint no longer matches", () => {
+    const persistence = new AppPersistence(createTempDbPath("ibkr-account-cache-mismatch"));
+    const original = createIbkrInstance("gateway", { id: "ibkr-live" });
+    const updated = createIbkrInstance("gateway", {
+      id: "ibkr-live",
+      config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4003, clientId: 1 } },
+    });
+
+    persistIbkrAccounts(persistence.resources, original, TEST_ACCOUNTS);
+
+    expect(loadPersistedIbkrAccounts(persistence.resources, updated)).toBeNull();
+    expect(persistence.resources.list({
+      namespace: "plugin:ibkr",
+      kind: "account-snapshot",
+      entityKey: "ibkr-live",
+    }, {
+      allowExpired: true,
+      schemaVersion: 1,
+    })).toHaveLength(0);
+
+    persistence.close();
+  });
+
+  test("clears all persisted snapshots for an IBKR instance", () => {
+    const persistence = new AppPersistence(createTempDbPath("ibkr-account-cache-clear"));
+    const instance = createIbkrInstance("gateway", { id: "ibkr-live" });
+
+    persistIbkrAccounts(persistence.resources, instance, TEST_ACCOUNTS);
+    clearPersistedIbkrAccounts(persistence.resources, instance.id);
+
+    expect(loadPersistedIbkrAccounts(persistence.resources, instance)).toBeNull();
+    persistence.close();
+  });
+});

--- a/src/plugins/ibkr/account-cache.ts
+++ b/src/plugins/ibkr/account-cache.ts
@@ -1,0 +1,137 @@
+import { createHash } from "crypto";
+import type { ResourceStore } from "../../data/resource-store";
+import type { BrokerInstanceConfig } from "../../types/config";
+import type { BrokerAccount } from "../../types/trading";
+import { normalizeIbkrConfig, type IbkrConnectionMode } from "./config";
+
+const IBKR_PLUGIN_NAMESPACE = "plugin:ibkr";
+const IBKR_ACCOUNT_SNAPSHOT_KIND = "account-snapshot";
+const IBKR_ACCOUNT_SNAPSHOT_SCHEMA_VERSION = 1;
+
+const FLEX_ACCOUNT_CACHE_POLICY = {
+  staleMs: 6 * 60 * 60 * 1000,
+  expireMs: 30 * 24 * 60 * 60 * 1000,
+} as const;
+
+const GATEWAY_ACCOUNT_CACHE_POLICY = {
+  staleMs: 30 * 1000,
+  expireMs: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+interface PersistedIbkrAccountSnapshot {
+  connectionMode: IbkrConnectionMode;
+  accounts: BrokerAccount[];
+}
+
+function getIbkrAccountSnapshotSourceKey(instance: BrokerInstanceConfig): string {
+  const normalized = normalizeIbkrConfig(instance.config);
+  return createHash("sha256")
+    .update(JSON.stringify(normalized))
+    .digest("hex");
+}
+
+function getAccountCachePolicy(instance: BrokerInstanceConfig) {
+  const normalized = normalizeIbkrConfig(instance.config);
+  return normalized.connectionMode === "gateway"
+    ? GATEWAY_ACCOUNT_CACHE_POLICY
+    : FLEX_ACCOUNT_CACHE_POLICY;
+}
+
+function pruneMismatchedSnapshots(resources: ResourceStore, instance: BrokerInstanceConfig, sourceKey: string): void {
+  const records = resources.list<PersistedIbkrAccountSnapshot>({
+    namespace: IBKR_PLUGIN_NAMESPACE,
+    kind: IBKR_ACCOUNT_SNAPSHOT_KIND,
+    entityKey: instance.id,
+  }, {
+    schemaVersion: IBKR_ACCOUNT_SNAPSHOT_SCHEMA_VERSION,
+    allowExpired: true,
+  });
+
+  for (const record of records) {
+    if (record.sourceKey === sourceKey) continue;
+    resources.delete({
+      namespace: IBKR_PLUGIN_NAMESPACE,
+      kind: IBKR_ACCOUNT_SNAPSHOT_KIND,
+      entityKey: instance.id,
+      sourceKey: record.sourceKey,
+    });
+  }
+}
+
+export function loadPersistedIbkrAccounts(
+  resources: ResourceStore,
+  instance: BrokerInstanceConfig,
+): BrokerAccount[] | null {
+  const sourceKey = getIbkrAccountSnapshotSourceKey(instance);
+  pruneMismatchedSnapshots(resources, instance, sourceKey);
+
+  return resources.get<PersistedIbkrAccountSnapshot>({
+    namespace: IBKR_PLUGIN_NAMESPACE,
+    kind: IBKR_ACCOUNT_SNAPSHOT_KIND,
+    entityKey: instance.id,
+    sourceKey,
+  }, {
+    schemaVersion: IBKR_ACCOUNT_SNAPSHOT_SCHEMA_VERSION,
+  })?.value.accounts ?? null;
+}
+
+export function persistIbkrAccounts(
+  resources: ResourceStore,
+  instance: BrokerInstanceConfig,
+  accounts: BrokerAccount[],
+): void {
+  const sourceKey = getIbkrAccountSnapshotSourceKey(instance);
+  pruneMismatchedSnapshots(resources, instance, sourceKey);
+
+  resources.set<PersistedIbkrAccountSnapshot>({
+    namespace: IBKR_PLUGIN_NAMESPACE,
+    kind: IBKR_ACCOUNT_SNAPSHOT_KIND,
+    entityKey: instance.id,
+    sourceKey,
+  }, {
+    connectionMode: normalizeIbkrConfig(instance.config).connectionMode,
+    accounts,
+  }, {
+    schemaVersion: IBKR_ACCOUNT_SNAPSHOT_SCHEMA_VERSION,
+    cachePolicy: getAccountCachePolicy(instance),
+  });
+}
+
+export function loadPersistedIbkrAccountMap(
+  resources: ResourceStore,
+  brokerInstances: BrokerInstanceConfig[],
+): Record<string, BrokerAccount[]> {
+  const accountMap: Record<string, BrokerAccount[]> = {};
+
+  for (const instance of brokerInstances) {
+    if (instance.brokerType !== "ibkr") continue;
+    const accounts = loadPersistedIbkrAccounts(resources, instance);
+    if (!accounts || accounts.length === 0) continue;
+    accountMap[instance.id] = accounts;
+  }
+
+  return accountMap;
+}
+
+export function clearPersistedIbkrAccounts(
+  resources: ResourceStore,
+  instanceId: string,
+): void {
+  const records = resources.list<PersistedIbkrAccountSnapshot>({
+    namespace: IBKR_PLUGIN_NAMESPACE,
+    kind: IBKR_ACCOUNT_SNAPSHOT_KIND,
+    entityKey: instanceId,
+  }, {
+    schemaVersion: IBKR_ACCOUNT_SNAPSHOT_SCHEMA_VERSION,
+    allowExpired: true,
+  });
+
+  for (const record of records) {
+    resources.delete({
+      namespace: IBKR_PLUGIN_NAMESPACE,
+      kind: IBKR_ACCOUNT_SNAPSHOT_KIND,
+      entityKey: instanceId,
+      sourceKey: record.sourceKey,
+    });
+  }
+}

--- a/src/plugins/ibkr/flex.test.ts
+++ b/src/plugins/ibkr/flex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseFlexPositions } from "./flex";
+import { parseFlexAccounts, parseFlexPositions } from "./flex";
 
 describe("parseFlexPositions", () => {
   test("parses option positions with broker contract metadata", () => {
@@ -29,5 +29,79 @@ describe("parseFlexPositions", () => {
       multiplier: "100",
       tradingClass: "SPY",
     });
+  });
+});
+
+describe("parseFlexAccounts", () => {
+  test("parses cash balances and summary values from a flex statement", () => {
+    const xml = `
+      <FlexQueryResponse>
+        <FlexStatements count="1">
+          <FlexStatement accountId="DU12345" fromDate="20260327" toDate="20260327" whenGenerated="20260328;102707">
+            <ChangeInNAV accountId="DU12345" acctAlias="Main" currency="USD" endingValue="764713.626876249" />
+            <CashReport>
+              <CashReportCurrency accountId="DU12345" currency="BASE_SUMMARY" endingCash="-1050953.720462251" endingSettledCash="-917604.448220862" />
+            </CashReport>
+            <FxPositions>
+              <FxPosition accountId="DU12345" assetCategory="CASH" functionalCurrency="USD" fxCurrency="USD" quantity="-303029.144938754" value="-303029.144938754" />
+              <FxPosition accountId="DU12345" assetCategory="CASH" functionalCurrency="USD" fxCurrency="EUR" quantity="-351957.025" value="-405102.535775" />
+            </FxPositions>
+          </FlexStatement>
+        </FlexStatements>
+      </FlexQueryResponse>
+    `;
+
+    const accounts = parseFlexAccounts(xml);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]).toMatchObject({
+      accountId: "DU12345",
+      name: "Main",
+      currency: "USD",
+      source: "flex",
+      netLiquidation: 764713.626876249,
+      totalCashValue: -1050953.720462251,
+      settledCash: -917604.448220862,
+      cashBalances: [
+        {
+          currency: "USD",
+          quantity: -303029.144938754,
+          baseValue: -303029.144938754,
+          baseCurrency: "USD",
+        },
+        {
+          currency: "EUR",
+          quantity: -351957.025,
+          baseValue: -405102.535775,
+          baseCurrency: "USD",
+        },
+      ],
+    });
+    expect(accounts[0]?.updatedAt).toBe(new Date(2026, 2, 28, 10, 27, 7).getTime());
+  });
+
+  test("handles missing cash sections gracefully", () => {
+    const xml = `
+      <FlexQueryResponse>
+        <FlexStatements count="1">
+          <FlexStatement accountId="DU12345" fromDate="20260327" toDate="20260327">
+            <ChangeInNAV accountId="DU12345" currency="USD" endingValue="12345.67" />
+          </FlexStatement>
+        </FlexStatements>
+      </FlexQueryResponse>
+    `;
+
+    expect(parseFlexAccounts(xml)).toEqual([
+      {
+        accountId: "DU12345",
+        name: "DU12345",
+        currency: "USD",
+        source: "flex",
+        updatedAt: new Date(2026, 2, 27).getTime(),
+        netLiquidation: 12345.67,
+        totalCashValue: undefined,
+        settledCash: undefined,
+        cashBalances: undefined,
+      },
+    ]);
   });
 });

--- a/src/plugins/ibkr/flex.ts
+++ b/src/plugins/ibkr/flex.ts
@@ -1,9 +1,50 @@
 import type { BrokerPosition } from "../../types/broker";
 import type { BrokerContractRef } from "../../types/instrument";
+import type { BrokerAccount, BrokerCashBalance } from "../../types/trading";
 import type { FlexQueryConfig } from "./config";
 import { IBKR_STATEMENT_URL } from "./config";
 
 const IBKR_STATEMENT_GET_URL = "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.GetStatement";
+const FLEX_STATEMENT_CACHE_MS = 15_000;
+const flexStatementCache = new Map<string, { createdAt: number; promise: Promise<string> }>();
+
+function parseAttributes(raw: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  for (const [, key, value] of raw.matchAll(/([a-zA-Z0-9]+)="([^"]*)"/g)) {
+    if (!key) continue;
+    attributes[key] = value ?? "";
+  }
+  return attributes;
+}
+
+function parseNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseFlexTimestamp(raw: string | undefined, fallbackDate: string | undefined): number | undefined {
+  if (raw) {
+    const match = raw.match(/^(\d{4})(\d{2})(\d{2});(\d{2})(\d{2})(\d{2})$/);
+    if (match) {
+      const [, year, month, day, hour, minute, second] = match;
+      return new Date(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second),
+      ).getTime();
+    }
+  }
+
+  if (!fallbackDate) return undefined;
+  const match = fallbackDate.match(/^(\d{4})(\d{2})(\d{2})$/);
+  if (!match) return undefined;
+  const [, year, month, day] = match;
+  return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+}
 
 export async function requestFlexStatement(config: FlexQueryConfig): Promise<string> {
   const endpoint = config.endpoint || IBKR_STATEMENT_URL;
@@ -46,6 +87,27 @@ export async function getFlexStatement(token: string, referenceCode: string): Pr
   throw new Error("Flex statement generation timed out");
 }
 
+export async function loadFlexStatement(config: FlexQueryConfig): Promise<string> {
+  const cacheKey = `${config.endpoint || IBKR_STATEMENT_URL}|${config.token}|${config.queryId}`;
+  const existing = flexStatementCache.get(cacheKey);
+  if (existing && Date.now() - existing.createdAt < FLEX_STATEMENT_CACHE_MS) {
+    return existing.promise;
+  }
+
+  const promise = (async () => {
+    const referenceCode = await requestFlexStatement(config);
+    return getFlexStatement(config.token, referenceCode);
+  })();
+  flexStatementCache.set(cacheKey, { createdAt: Date.now(), promise });
+  setTimeout(() => {
+    const cached = flexStatementCache.get(cacheKey);
+    if (cached?.promise === promise) {
+      flexStatementCache.delete(cacheKey);
+    }
+  }, FLEX_STATEMENT_CACHE_MS);
+  return promise;
+}
+
 function buildContractRef(attributes: Record<string, string>, symbol: string, assetCategory: string): BrokerContractRef | undefined {
   const conIdRaw = attributes.conid || attributes.conId;
   const strikeRaw = attributes.strike;
@@ -86,19 +148,11 @@ export function parseFlexPositions(xml: string): BrokerPosition[] {
   let match: RegExpExecArray | null;
 
   while ((match = posRegex.exec(xml)) !== null) {
-    const tag = match[0];
-    const attributes: Record<string, string> = {};
-    for (const [, key, value] of tag.matchAll(/([a-zA-Z0-9]+)="([^"]*)"/g)) {
-      if (!key) continue;
-      attributes[key] = value ?? "";
-    }
+    const attributes = parseAttributes(match[0]);
 
     const attr = (name: string) => attributes[name] || "";
     const numAttr = (name: string) => {
-      const raw = attr(name);
-      if (!raw) return undefined;
-      const parsed = Number(raw);
-      return Number.isFinite(parsed) ? parsed : undefined;
+      return parseNumber(attr(name));
     };
 
     const symbol = attr("symbol");
@@ -137,4 +191,77 @@ export function parseFlexPositions(xml: string): BrokerPosition[] {
   }
 
   return positions;
+}
+
+export function parseFlexAccounts(xml: string): BrokerAccount[] {
+  const accounts: BrokerAccount[] = [];
+  const statementRegex = /<FlexStatement\b([^>]*)>([\s\S]*?)<\/FlexStatement>/g;
+
+  for (const match of xml.matchAll(statementRegex)) {
+    const statementAttrs = parseAttributes(match[1] ?? "");
+    const body = match[2] ?? "";
+    const statementAccountId = statementAttrs.accountId || "";
+
+    const changeInNavAttrs = [...body.matchAll(/<ChangeInNAV\b([^>]*)\/>/g)]
+      .map((entry) => parseAttributes(entry[1] ?? ""))
+      .find((attributes) => !statementAccountId || !attributes.accountId || attributes.accountId === statementAccountId);
+    const baseCashAttrs = [...body.matchAll(/<CashReportCurrency\b([^>]*)\/>/g)]
+      .map((entry) => parseAttributes(entry[1] ?? ""))
+      .find((attributes) =>
+        attributes.currency === "BASE_SUMMARY"
+        && (!statementAccountId || !attributes.accountId || attributes.accountId === statementAccountId),
+      );
+    const fallbackCurrencyAttrs = [...body.matchAll(/<CashReportCurrency\b([^>]*)\/>/g)]
+      .map((entry) => parseAttributes(entry[1] ?? ""))
+      .find((attributes) =>
+        attributes.currency !== "BASE_SUMMARY"
+        && (!statementAccountId || !attributes.accountId || attributes.accountId === statementAccountId),
+      );
+
+    const balancesByCurrency = new Map<string, BrokerCashBalance>();
+    for (const entry of body.matchAll(/<FxPosition\b([^>]*)\/>/g)) {
+      const attributes = parseAttributes(entry[1] ?? "");
+      const accountId = attributes.accountId || statementAccountId;
+      if (!accountId || (statementAccountId && accountId !== statementAccountId)) continue;
+      if (attributes.assetCategory !== "CASH") continue;
+
+      const currency = attributes.fxCurrency || "";
+      if (!currency) continue;
+
+      const existing = balancesByCurrency.get(currency);
+      const quantity = parseNumber(attributes.quantity) ?? 0;
+      const baseValue = parseNumber(attributes.value);
+      balancesByCurrency.set(currency, {
+        currency,
+        quantity: (existing?.quantity ?? 0) + quantity,
+        baseValue: existing?.baseValue != null || baseValue != null
+          ? (existing?.baseValue ?? 0) + (baseValue ?? 0)
+          : undefined,
+        baseCurrency: attributes.functionalCurrency || existing?.baseCurrency,
+      });
+    }
+
+    const accountId = statementAccountId || changeInNavAttrs?.accountId;
+    if (!accountId) continue;
+
+    const cashBalances = [...balancesByCurrency.values()];
+    const accountCurrency = changeInNavAttrs?.currency
+      || cashBalances[0]?.baseCurrency
+      || fallbackCurrencyAttrs?.currency
+      || undefined;
+
+    accounts.push({
+      accountId,
+      name: changeInNavAttrs?.acctAlias || statementAttrs.acctAlias || accountId,
+      currency: accountCurrency,
+      source: "flex",
+      updatedAt: parseFlexTimestamp(statementAttrs.whenGenerated, statementAttrs.toDate || statementAttrs.fromDate),
+      netLiquidation: parseNumber(changeInNavAttrs?.endingValue),
+      totalCashValue: parseNumber(baseCashAttrs?.endingCash),
+      settledCash: parseNumber(baseCashAttrs?.endingSettledCash),
+      cashBalances: cashBalances.length > 0 ? cashBalances : undefined,
+    });
+  }
+
+  return accounts;
 }

--- a/src/plugins/ibkr/gateway-service.test.ts
+++ b/src/plugins/ibkr/gateway-service.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeBrokerAccount } from "./gateway-service";
+
+function makeTags(input: Record<string, Record<string, string>>) {
+  return new Map(
+    Object.entries(input).map(([tag, values]) => [
+      tag,
+      new Map(Object.entries(values).map(([currency, value]) => [currency, { value }])),
+    ]),
+  );
+}
+
+describe("summarizeBrokerAccount", () => {
+  test("maps gateway account summary fields and ledger balances", () => {
+    const tags = makeTags({
+      NetLiquidation: { USD: "764713.62" },
+      TotalCashValue: { USD: "-1050953.72" },
+      SettledCash: { USD: "-917604.44" },
+      AvailableFunds: { USD: "112345.67" },
+      BuyingPower: { USD: "224691.34" },
+      ExcessLiquidity: { USD: "98321.12" },
+      InitMarginReq: { USD: "45678.9" },
+      MaintMarginReq: { USD: "34567.8" },
+      "$LEDGER:ALL": { USD: "-303029.14", EUR: "-351957.02" },
+    });
+
+    expect(summarizeBrokerAccount("DU12345", tags, 1_717_000_000_000)).toEqual({
+      accountId: "DU12345",
+      name: "DU12345",
+      currency: "USD",
+      source: "gateway",
+      updatedAt: 1_717_000_000_000,
+      netLiquidation: 764713.62,
+      totalCashValue: -1050953.72,
+      settledCash: -917604.44,
+      availableFunds: 112345.67,
+      buyingPower: 224691.34,
+      excessLiquidity: 98321.12,
+      initMarginReq: 45678.9,
+      maintMarginReq: 34567.8,
+      cashBalances: [
+        { currency: "USD", quantity: -303029.14, baseValue: -303029.14, baseCurrency: "USD" },
+        { currency: "EUR", quantity: -351957.02, baseValue: undefined, baseCurrency: "USD" },
+      ],
+    });
+  });
+
+  test("falls back to the aggregate cash summary for single-account gateways", () => {
+    const accountTags = makeTags({
+      NetLiquidation: { USD: "129360.15" },
+      TotalCashValue: { USD: "128293.79" },
+      AvailableFunds: { USD: "129031.52" },
+      BuyingPower: { USD: "860210.13" },
+      ExcessLiquidity: { USD: "129061.51" },
+      InitMarginReq: { USD: "328.63" },
+      MaintMarginReq: { USD: "298.64" },
+    });
+    const aggregateTags = makeTags({
+      CashBalance: {
+        HKD: "1012836.31",
+        USD: "-1020.86",
+        BASE: "128293.7944",
+      },
+      ExchangeRate: {
+        HKD: "0.1276758",
+        USD: "1.00",
+        BASE: "1.00",
+      },
+    });
+
+    expect(summarizeBrokerAccount("DU12345", accountTags, 1_717_000_000_000, aggregateTags, true)).toEqual({
+      accountId: "DU12345",
+      name: "DU12345",
+      currency: "USD",
+      source: "gateway",
+      updatedAt: 1_717_000_000_000,
+      netLiquidation: 129360.15,
+      totalCashValue: 128293.79,
+      settledCash: undefined,
+      availableFunds: 129031.52,
+      buyingPower: 860210.13,
+      excessLiquidity: 129061.51,
+      initMarginReq: 328.63,
+      maintMarginReq: 298.64,
+      cashBalances: [
+        { currency: "HKD", quantity: 1012836.31, baseValue: 129314.68614829802, baseCurrency: "USD" },
+        { currency: "USD", quantity: -1020.86, baseValue: -1020.86, baseCurrency: "USD" },
+      ],
+    });
+  });
+
+  test("returns a minimal account when summary tags are missing", () => {
+    expect(summarizeBrokerAccount("DU12345", undefined, 123)).toEqual({
+      accountId: "DU12345",
+      name: "DU12345",
+      currency: undefined,
+      source: "gateway",
+      updatedAt: 123,
+      netLiquidation: undefined,
+      totalCashValue: undefined,
+      settledCash: undefined,
+      availableFunds: undefined,
+      buyingPower: undefined,
+      excessLiquidity: undefined,
+      initMarginReq: undefined,
+      maintMarginReq: undefined,
+      cashBalances: undefined,
+    });
+  });
+});

--- a/src/plugins/ibkr/gateway-service.ts
+++ b/src/plugins/ibkr/gateway-service.ts
@@ -22,7 +22,14 @@ import type { TimeRange } from "../../components/chart/chart-types";
 import type { BrokerConnectionStatus, BrokerPosition } from "../../types/broker";
 import type { Fundamentals, FinancialStatement, Quote, PricePoint, TickerFinancials } from "../../types/financials";
 import type { BrokerContractRef, InstrumentSearchResult } from "../../types/instrument";
-import type { BrokerAccount, BrokerExecution, BrokerOrder, BrokerOrderPreview, BrokerOrderRequest } from "../../types/trading";
+import type {
+  BrokerAccount,
+  BrokerCashBalance,
+  BrokerExecution,
+  BrokerOrder,
+  BrokerOrderPreview,
+  BrokerOrderRequest,
+} from "../../types/trading";
 import { parseReportSnapshot, parseFinStatements } from "./fundamental-parser";
 
 export interface IbkrGatewayConfig {
@@ -46,6 +53,141 @@ const DEFAULT_SNAPSHOT: IbkrSnapshot = {
   openOrders: [],
   executions: [],
 };
+
+type AccountSummaryValueMap = ReadonlyMap<string, { value: string }>;
+type AccountSummaryTags = ReadonlyMap<string, AccountSummaryValueMap>;
+
+function getAccountSummaryEntry(
+  values: AccountSummaryValueMap | undefined,
+  preferredCurrency?: string,
+): { currency: string; value: number } | null {
+  if (!values) return null;
+
+  if (preferredCurrency) {
+    const preferred = values.get(preferredCurrency);
+    if (preferred?.value) {
+      const numeric = parseFloat(preferred.value);
+      if (Number.isFinite(numeric)) {
+        return { currency: preferredCurrency, value: numeric };
+      }
+    }
+  }
+
+  for (const [currency, entry] of values.entries()) {
+    const numeric = parseFloat(entry?.value ?? "");
+    if (Number.isFinite(numeric)) {
+      return { currency, value: numeric };
+    }
+  }
+  return null;
+}
+
+function getAccountSummaryNumber(
+  tags: AccountSummaryTags | undefined,
+  tagName: string,
+  preferredCurrency?: string,
+): number | undefined {
+  return getAccountSummaryEntry(tags?.get(tagName), preferredCurrency)?.value;
+}
+
+function inferAccountCurrency(tags: AccountSummaryTags | undefined): string | undefined {
+  if (!tags) return undefined;
+  for (const tagName of ["NetLiquidation", "TotalCashValue", "SettledCash", "AvailableFunds"]) {
+    const entry = getAccountSummaryEntry(tags.get(tagName));
+    if (entry?.currency) return entry.currency;
+  }
+  return undefined;
+}
+
+function getSummaryMap(
+  tags: AccountSummaryTags | undefined,
+  tagName: string,
+): AccountSummaryValueMap | undefined {
+  const values = tags?.get(tagName);
+  return values && values.size > 0 ? values : undefined;
+}
+
+function buildCashBalancesFromSummary(
+  cashBalanceMap: AccountSummaryValueMap | undefined,
+  exchangeRateMap: AccountSummaryValueMap | undefined,
+  baseCurrency?: string,
+): BrokerCashBalance[] | undefined {
+  const balances: BrokerCashBalance[] = [];
+  for (const [currency, entry] of cashBalanceMap?.entries() ?? []) {
+    if (!currency || currency === "BASE") continue;
+    const numeric = parseFloat(entry?.value ?? "");
+    if (!Number.isFinite(numeric)) continue;
+
+    const exchangeRate = currency === baseCurrency
+      ? 1
+      : parseFloat(exchangeRateMap?.get(currency)?.value ?? "");
+    const baseValue = Number.isFinite(exchangeRate) ? numeric * exchangeRate : undefined;
+
+    balances.push({
+      currency,
+      quantity: numeric,
+      baseValue,
+      baseCurrency,
+    });
+  }
+
+  return balances.length > 0 ? balances : undefined;
+}
+
+function buildCashBalances(
+  tags: AccountSummaryTags | undefined,
+  aggregateTags: AccountSummaryTags | undefined,
+  baseCurrency: string | undefined,
+  allowAggregateFallback: boolean,
+): BrokerCashBalance[] | undefined {
+  const directLedger = buildCashBalancesFromSummary(
+    getSummaryMap(tags, "$LEDGER:ALL"),
+    undefined,
+    baseCurrency,
+  );
+  if (directLedger) return directLedger;
+
+  const directSummary = buildCashBalancesFromSummary(
+    getSummaryMap(tags, "CashBalance") ?? getSummaryMap(tags, "TotalCashBalance"),
+    getSummaryMap(tags, "ExchangeRate"),
+    baseCurrency,
+  );
+  if (directSummary) return directSummary;
+
+  if (!allowAggregateFallback) return undefined;
+
+  return buildCashBalancesFromSummary(
+    getSummaryMap(aggregateTags, "CashBalance") ?? getSummaryMap(aggregateTags, "TotalCashBalance"),
+    getSummaryMap(aggregateTags, "ExchangeRate"),
+    baseCurrency,
+  );
+}
+
+export function summarizeBrokerAccount(
+  accountId: string,
+  tags: AccountSummaryTags | undefined,
+  updatedAt: number,
+  aggregateTags?: AccountSummaryTags,
+  allowAggregateCashBalances = false,
+): BrokerAccount {
+  const currency = inferAccountCurrency(tags);
+  return {
+    accountId,
+    name: accountId,
+    currency,
+    source: "gateway",
+    updatedAt,
+    netLiquidation: getAccountSummaryNumber(tags, "NetLiquidation", currency),
+    totalCashValue: getAccountSummaryNumber(tags, "TotalCashValue", currency),
+    settledCash: getAccountSummaryNumber(tags, "SettledCash", currency),
+    availableFunds: getAccountSummaryNumber(tags, "AvailableFunds", currency),
+    buyingPower: getAccountSummaryNumber(tags, "BuyingPower", currency),
+    excessLiquidity: getAccountSummaryNumber(tags, "ExcessLiquidity", currency),
+    initMarginReq: getAccountSummaryNumber(tags, "InitMarginReq", currency),
+    maintMarginReq: getAccountSummaryNumber(tags, "MaintMarginReq", currency),
+    cashBalances: buildCashBalances(tags, aggregateTags, currency, allowAggregateCashBalances),
+  };
+}
 
 /** Wrap a promise with a timeout so that IBKR calls don't hang indefinitely. */
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
@@ -799,7 +941,10 @@ export class IbkrGatewayService {
     let summary: ReadonlyMap<string, ReadonlyMap<string, ReadonlyMap<string, { value: string }>>> | undefined;
     try {
       const result = await firstValueFrom(
-        this.api!.getAccountSummary("All", "NetLiquidation,AvailableFunds,BuyingPower,ExcessLiquidity,$LEDGER:ALL")
+        this.api!.getAccountSummary(
+          "All",
+          "NetLiquidation,TotalCashValue,SettledCash,AvailableFunds,BuyingPower,ExcessLiquidity,InitMarginReq,MaintMarginReq,$LEDGER:ALL",
+        )
           .pipe(take(1), timeout(10_000)),
       );
       summary = result.all;
@@ -807,31 +952,16 @@ export class IbkrGatewayService {
       // Account summary may fail; return accounts with basic info only.
     }
 
-    return managedAccounts.map((accountId) => {
-      const tags = summary?.get(accountId);
-      return {
-        accountId,
-        name: accountId,
-        currency: this.getAccountValue(tags, "$LEDGER:ALL", "USD") ? "USD" : undefined,
-        netLiquidation: this.getAccountValue(tags, "NetLiquidation"),
-        availableFunds: this.getAccountValue(tags, "AvailableFunds"),
-        buyingPower: this.getAccountValue(tags, "BuyingPower"),
-        excessLiquidity: this.getAccountValue(tags, "ExcessLiquidity"),
-      };
-    });
-  }
-
-  private getAccountValue(
-    tags: ReadonlyMap<string, ReadonlyMap<string, { value: string }>> | undefined,
-    tagName: string,
-    preferredCurrency?: string,
-  ): number | undefined {
-    const values = tags?.get(tagName);
-    if (!values) return undefined;
-    const entry = preferredCurrency ? values.get(preferredCurrency) : values.values().next().value;
-    if (!entry?.value) return undefined;
-    const numeric = parseFloat(entry.value);
-    return Number.isFinite(numeric) ? numeric : undefined;
+    const updatedAt = Date.now();
+    const aggregateTags = summary?.get("All");
+    const allowAggregateCashBalances = managedAccounts.length === 1;
+    return managedAccounts.map((accountId) => summarizeBrokerAccount(
+      accountId,
+      summary?.get(accountId),
+      updatedAt,
+      aggregateTags,
+      allowAggregateCashBalances,
+    ));
   }
 
   private contractDescriptionToSearchResult(description: ContractDescription): InstrumentSearchResult | null {

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -16,6 +16,7 @@ import {
   usePaneTicker,
 } from "../../state/app-context";
 import { PriceSelectorDialog } from "../../components";
+import { Button } from "../../components/ui/button";
 import { colors, hoverBg, priceColor } from "../../theme/colors";
 import { formatCompact, formatCurrency, formatNumber, padTo } from "../../utils/format";
 import { getBrokerInstance } from "../../utils/broker-instances";
@@ -29,7 +30,7 @@ import {
   normalizeIbkrConfig,
   type FlexQueryConfig,
 } from "./config";
-import { getFlexStatement, parseFlexPositions, requestFlexStatement } from "./flex";
+import { loadFlexStatement, parseFlexAccounts, parseFlexPositions } from "./flex";
 import { ibkrGatewayManager } from "./gateway-service";
 import {
   getConfiguredIbkrGatewayInstances,
@@ -127,6 +128,89 @@ function formatPreviewSummary(preview: import("../../types/trading").BrokerOrder
   return `What-if: init ${formatCompact(preview.initMarginBefore || 0)} → ${formatCompact(preview.initMarginAfter || 0)} · commission ${preview.commission != null ? formatCurrency(preview.commission, preview.commissionCurrency || "USD") : "—"}${preview.warningText ? ` · ${preview.warningText}` : ""}`;
 }
 
+type TradeTone = "neutral" | "accent" | "positive" | "negative";
+
+function getTradeTonePalette(tone: TradeTone) {
+  switch (tone) {
+    case "accent":
+      return { border: colors.borderFocused, text: colors.textBright, background: colors.selected };
+    case "positive":
+      return { border: colors.positive, text: colors.positive, background: colors.panel };
+    case "negative":
+      return { border: colors.negative, text: colors.negative, background: colors.panel };
+    case "neutral":
+    default:
+      return { border: colors.border, text: colors.text, background: colors.panel };
+  }
+}
+
+function formatPreviewMetric(before?: number, after?: number): string {
+  if (before == null && after == null) return "—";
+  return `${formatCompact(before || 0)} → ${formatCompact(after || 0)}`;
+}
+
+function truncateText(value: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (value.length <= maxWidth) return value;
+  if (maxWidth <= 3) return value.slice(0, maxWidth);
+  return `${value.slice(0, maxWidth - 3)}...`;
+}
+
+interface TradeBadgeProps {
+  label: string;
+  value: string;
+  tone?: TradeTone;
+  onPress?: () => void;
+}
+
+function TradeBadge({ label, value, tone = "neutral", onPress }: TradeBadgeProps) {
+  const palette = getTradeTonePalette(tone);
+
+  return (
+    <box
+      backgroundColor={palette.background}
+      paddingX={1}
+      marginRight={1}
+      marginBottom={1}
+      onMouseDown={onPress}
+    >
+      <text fg={colors.textDim}>{label}</text>
+      <text fg={palette.text} attributes={TextAttributes.BOLD}>{` ${value}`}</text>
+    </box>
+  );
+}
+
+interface TradeStepChipProps {
+  index: number;
+  label: string;
+  status: "pending" | "active" | "done";
+  onPress?: () => void;
+}
+
+function TradeStepChip({ index, label, status, onPress }: TradeStepChipProps) {
+  const palette = status === "done"
+    ? getTradeTonePalette("positive")
+    : status === "active"
+      ? getTradeTonePalette("accent")
+      : getTradeTonePalette("neutral");
+
+  return (
+    <box
+      border
+      borderStyle="rounded"
+      borderColor={palette.border}
+      paddingX={1}
+      marginRight={1}
+      marginBottom={1}
+      onMouseDown={onPress}
+    >
+      <text fg={status === "pending" ? colors.textDim : palette.text} attributes={status === "active" ? TextAttributes.BOLD : 0}>
+        {`${index} ${label}`}
+      </text>
+    </box>
+  );
+}
+
 function findTickerForOrder(
   order: { contract: BrokerContractRef },
   tickers: Map<string, import("../../types/ticker").TickerRecord>,
@@ -162,8 +246,7 @@ function isMarketDataWarning(message?: string): boolean {
 }
 
 async function importFlexPositions(config: FlexQueryConfig): Promise<BrokerPosition[]> {
-  const referenceCode = await requestFlexStatement(config);
-  const xml = await getFlexStatement(config.token, referenceCode);
+  const xml = await loadFlexStatement(config);
   return parseFlexPositions(xml);
 }
 
@@ -215,8 +298,11 @@ const ibkrBroker: BrokerAdapter = {
 
   async listAccounts(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
-    if (normalized.connectionMode !== "gateway") return [];
-    return ibkrGatewayManager.getService(instance.id).getAccounts(normalized.gateway);
+    if (normalized.connectionMode === "gateway") {
+      return ibkrGatewayManager.getService(instance.id).getAccounts(normalized.gateway);
+    }
+    const xml = await loadFlexStatement(normalized.flex);
+    return parseFlexAccounts(xml);
   },
 
   async searchInstruments(query, instance) {
@@ -601,9 +687,9 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
       content: (ctx) => <InputDialog {...ctx} step={{
         key: "query",
         type: "text",
-        label: "Search IBKR Contract",
+        label: "Override Ticker Contract",
         placeholder: "AAPL, ES, SPY 260619C00500000",
-        body: ["Search Interactive Brokers contracts by symbol, future, or local symbol."],
+        body: ["The current ticker is preloaded. Search only if you need a different listing, future, or options contract."],
       }} />,
     });
     if (!search) return;
@@ -915,179 +1001,440 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
     );
   }
 
-  const rowWidth = Math.max(20, Math.floor((width - 4) / 4));
   const showLimit = isLimitOrder(ticketState.draft.orderType);
   const showStop = isStopOrder(ticketState.draft.orderType);
+  const hasProfile = Boolean(selectedInstance);
+  const wideLayout = width >= 120;
+  const previewPanelWidth = wideLayout ? Math.min(42, Math.max(34, Math.floor(width * 0.32))) : undefined;
+  const ticketPanelWidth = wideLayout ? Math.max(56, width - (previewPanelWidth ?? 0) - 7) : Math.max(36, width - 4);
+  const cardsPerRow = ticketPanelWidth >= 96 ? 4 : ticketPanelWidth >= 58 ? 2 : 1;
+  const fieldWidth = Math.max(18, Math.floor((ticketPanelWidth - (cardsPerRow - 1)) / cardsPerRow));
+  const fieldTextWidth = Math.max(10, fieldWidth - 3);
+  const activeContract = ticketState.draft.contract.symbol ? ticketState.draft.contract : normalizeContract(ticker);
+  const hasContract = Boolean(activeContract.symbol);
+  const hasAccount = Boolean(currentAccountId);
+  const hasPreview = Boolean(ticketState.preview);
+  const previewTextWidth = Math.max(18, (previewPanelWidth ?? Math.max(34, width - 6)) - 6);
+  const contractValue = truncateText(formatContractLabel(activeContract), fieldTextWidth);
+  const contractMeta = truncateText(
+    ticketState.contractName || ticker.metadata.name || "Using current ticker",
+    fieldTextWidth,
+  );
+  const connectionTone: TradeTone = gatewaySnapshot.status.state === "connected"
+    ? "positive"
+    : gatewaySnapshot.status.state === "error"
+      ? "negative"
+      : "neutral";
+  const statusTone: TradeTone = ticketState.lastError
+    ? "negative"
+    : ticketState.isSuccess
+      ? "positive"
+      : "accent";
+  const statusText = ticketState.busy
+    ? "Working…"
+    : ticketState.lastError
+      || ticketState.lastInfo
+      || gatewaySnapshot.status.message
+      || gatewaySnapshot.lastError
+      || "Click a workflow step or field to activate the ticket, then preview before submit.";
+  const previewTone: TradeTone = !ticketState.preview
+    ? "neutral"
+    : ticketState.preview.warningText
+      ? "negative"
+      : "positive";
+  const previewHeading = !ticketState.preview
+    ? "Preview required"
+    : ticketState.preview.warningText
+      ? "Preview warning"
+      : "Preview ready";
+
+  const renderFieldCard = ({
+    id,
+    label,
+    value,
+    valueColor,
+    valueAttributes = 0,
+    disabled = false,
+    active = false,
+    onPress,
+  }: {
+    id: string;
+    label: string;
+    value: string;
+    valueColor?: string;
+    valueAttributes?: number;
+    disabled?: boolean;
+    active?: boolean;
+    onPress?: () => void;
+  }) => {
+    const hovered = hoveredField === id;
+    const outlined = !active && !hovered;
+    const borderColor = disabled ? colors.border : active || hovered ? colors.borderFocused : colors.border;
+    const backgroundColor = disabled
+      ? undefined
+      : active
+        ? colors.selected
+        : hovered
+          ? fieldHoverBg
+          : undefined;
+
+    return (
+      <box
+        key={id}
+        width={fieldWidth}
+        minWidth={18}
+        height={4}
+        flexDirection="column"
+        border={outlined}
+        borderStyle={outlined ? "rounded" : undefined}
+        borderColor={outlined ? borderColor : undefined}
+        backgroundColor={backgroundColor}
+        paddingX={1}
+        onMouseMove={() => {
+          if (!disabled) setHoveredField(id);
+        }}
+        onMouseDown={disabled ? undefined : () => {
+          enterInteractive();
+          onPress?.();
+        }}
+      >
+        <text fg={disabled ? colors.textMuted : colors.textDim}>{label}</text>
+        <text fg={valueColor ?? (disabled ? colors.textMuted : colors.text)} attributes={valueAttributes}>
+          {truncateText(value, fieldTextWidth)}
+        </text>
+      </box>
+    );
+  };
 
   return (
     <scrollbox flexGrow={1} scrollY>
-      <box flexDirection="column" paddingX={1} paddingBottom={1} onMouseDown={enterInteractive}>
-        <box height={1} flexDirection="row">
-          <text attributes={TextAttributes.BOLD} fg={colors.textBright}>{`Trade ${ticker.metadata.ticker}`}</text>
-          {ticker.metadata.name && ticker.metadata.name !== ticker.metadata.ticker && (
-            <text fg={colors.textDim}>{` · ${ticker.metadata.name}`}</text>
-          )}
+      <box flexDirection="column" paddingX={1} paddingBottom={1} gap={1} onMouseDown={enterInteractive}>
+        <box flexDirection="row" flexWrap="wrap" justifyContent="space-between">
+          <box flexDirection="column" marginBottom={1}>
+            <box height={1} flexDirection="row">
+              <text attributes={TextAttributes.BOLD} fg={colors.textBright}>{`Trade ${ticker.metadata.ticker}`}</text>
+              {ticker.metadata.name && ticker.metadata.name !== ticker.metadata.ticker && (
+                <text fg={colors.textDim}>{` · ${ticker.metadata.name}`}</text>
+              )}
+            </box>
+            <box height={1}>
+              <text fg={colors.textMuted}>{formatQuoteSummary(financials?.quote)}</text>
+            </box>
+          </box>
+
+          <box flexDirection="row" flexWrap="wrap" justifyContent="flex-end">
+            <TradeBadge
+              label="Broker"
+              value={selectedInstance ? `${selectedInstance.label} ${isGatewayMode ? "Gateway" : "Flex"}` : "Select profile"}
+              tone={connectionTone}
+              onPress={() => {
+                enterInteractive();
+                chooseBrokerInstance().catch(() => {});
+              }}
+            />
+            <TradeBadge
+              label="Account"
+              value={currentAccountId || (lockedBrokerInstanceId ? "Locked" : "Select")}
+              tone={hasAccount ? "accent" : "neutral"}
+              onPress={() => {
+                enterInteractive();
+                chooseAccount().catch(() => {});
+              }}
+            />
+            <TradeBadge
+              label="Net Liq"
+              value={activeAccount ? formatCurrency(activeAccount.netLiquidation || 0, activeAccount.currency || "USD") : "—"}
+              tone="neutral"
+              onPress={activeAccount ? undefined : () => {
+                enterInteractive();
+                chooseAccount().catch(() => {});
+              }}
+            />
+          </box>
         </box>
 
-        <box height={1} flexDirection="row" onMouseDown={() => { enterInteractive(); chooseBrokerInstance().catch(() => {}); }}>
-          <text fg={
-            gatewaySnapshot.status.state === "connected"
-              ? colors.positive
-              : gatewaySnapshot.status.state === "error"
-                ? colors.negative
-                : colors.textDim
-          }>
-            {selectedInstance
-              ? `${selectedInstance.label} · ${isGatewayMode ? "Gateway" : "Flex"}`
-              : "IBKR · no profile selected"}
-          </text>
-          <text fg={colors.textMuted}>{` · ${interactive ? "ticket active" : "press Enter to activate ticket"}`}</text>
-        </box>
-
-        <box height={1} flexDirection="row" onMouseDown={() => { enterInteractive(); chooseAccount().catch(() => {}); }}>
-          <text fg={colors.textDim}>
-            {activeAccount
-              ? `${selectedInstance?.label || "IBKR"} → ${activeAccount.accountId} · ${formatCurrency(activeAccount.netLiquidation || 0, activeAccount.currency || "USD")} net liq`
-              : isGatewayMode
-                ? lockedBrokerInstanceId
-                  ? `Locked to ${selectedInstance?.label || "IBKR"}`
-                  : "No account selected"
-                : gatewayInstances.length > 0
-                  ? "Choose a Gateway / TWS profile"
-                  : "Connect an IBKR profile"}
-          </text>
-          <box flexGrow={1} />
-          <text fg={colors.textMuted}>{formatQuoteSummary(financials?.quote)}</text>
-        </box>
-
-        <box height={1} flexDirection="row" onMouseDown={() => { enterInteractive(); chooseInstrument().catch(() => {}); }}>
-          <text fg={colors.text} attributes={TextAttributes.BOLD}>
-            {ticketState.draft.contract.symbol ? formatContractLabel(ticketState.draft.contract) : "No contract selected"}
-          </text>
-          {ticketState.contractName && (
-            <text fg={colors.textDim}>{` · ${ticketState.contractName}`}</text>
-          )}
-        </box>
-
-        <box height={1}>
-          <text fg={ticketState.lastError ? colors.negative : ticketState.isSuccess ? colors.positive : colors.textDim}>
-            {ticketState.busy
-              ? "Working…"
-              : ticketState.lastError
-              || ticketState.lastInfo
-              || gatewaySnapshot.status.message
-              || gatewaySnapshot.lastError
-              || "Enter to activate, then use i profile · s contract · a account · p preview."}
-          </text>
-        </box>
-
-        <box height={1}>
-          <text fg={ticketState.preview?.warningText ? colors.negative : colors.textDim}>
-            {formatPreviewSummary(ticketState.preview)}
-          </text>
-        </box>
-
-        <box height={1}>
-          <text fg={colors.border}>{"─".repeat(Math.max(1, width - 2))}</text>
-        </box>
-
-        <box flexDirection="row">
-          <box width={rowWidth} flexDirection="column"
-            backgroundColor={hoveredField === "action" ? fieldHoverBg : undefined}
-            onMouseMove={() => setHoveredField("action")}
-            onMouseDown={() => {
+        <box flexDirection="row" flexWrap="wrap">
+          <TradeStepChip
+            index={1}
+            label="Profile"
+            status={hasProfile ? "done" : "active"}
+            onPress={() => {
               enterInteractive();
-              if (symbol && ticker) setTradeTicketDraft(symbol, { action: ticketState.draft.action === "BUY" ? "SELL" : "BUY" }, ticker);
-            }}>
-            <text fg={colors.textDim}>Action</text>
-            <text fg={ticketState.draft.action === "BUY" ? colors.positive : colors.negative} attributes={TextAttributes.BOLD}>
-              {ticketState.draft.action}
-            </text>
-          </box>
-          <box width={rowWidth} flexDirection="column"
-            backgroundColor={hoveredField === "orderType" ? fieldHoverBg : undefined}
-            onMouseMove={() => setHoveredField("orderType")}
-            onMouseDown={() => { enterInteractive(); editOrderType().catch(() => {}); }}>
-            <text fg={colors.textDim}>Order Type</text>
-            <text fg={colors.text}>{ticketState.draft.orderType}</text>
-          </box>
-          <box width={rowWidth} flexDirection="column"
-            backgroundColor={hoveredField === "quantity" ? fieldHoverBg : undefined}
-            onMouseMove={() => setHoveredField("quantity")}
-            onMouseDown={() => {
+              chooseBrokerInstance().catch(() => {});
+            }}
+          />
+            <TradeStepChip
+              index={2}
+            label="Ticker"
+            status={hasContract ? "done" : hasProfile ? "active" : "pending"}
+            onPress={() => {
               enterInteractive();
-              editNumericField("Quantity", ticketState.draft.quantity, (value) => {
-                if (value != null && symbol && ticker) setTradeTicketDraft(symbol, { quantity: value }, ticker);
-              }).catch(() => {});
-            }}>
-            <text fg={colors.textDim}>Quantity</text>
-            <text fg={colors.text}>{formatNumber(ticketState.draft.quantity, 0)}</text>
-          </box>
-          <box width={rowWidth} flexDirection="column"
-            backgroundColor={hoveredField === "account" ? fieldHoverBg : undefined}
-            onMouseMove={() => setHoveredField("account")}
-            onMouseDown={() => { enterInteractive(); chooseAccount().catch(() => {}); }}>
-            <text fg={colors.textDim}>Account</text>
-            <text fg={colors.text}>{currentAccountId || "auto"}</text>
-          </box>
+              chooseInstrument().catch(() => {});
+            }}
+          />
+          <TradeStepChip
+            index={3}
+            label="Account"
+            status={hasAccount ? "done" : hasContract ? "active" : "pending"}
+            onPress={() => {
+              enterInteractive();
+              chooseAccount().catch(() => {});
+            }}
+          />
+          <TradeStepChip
+            index={4}
+            label="Ticket"
+            status={hasProfile && hasContract && hasAccount ? "done" : "pending"}
+            onPress={enterInteractive}
+          />
+          <TradeStepChip
+            index={5}
+            label="Preview"
+            status={hasPreview ? "done" : hasProfile && hasContract && hasAccount ? "active" : "pending"}
+            onPress={() => previewOrder().catch(() => {})}
+          />
+          <TradeStepChip
+            index={6}
+            label="Submit"
+            status={hasPreview ? "active" : "pending"}
+            onPress={() => submitOrder().catch(() => {})}
+          />
         </box>
 
-        <box flexDirection="row">
-          <box width={rowWidth} flexDirection="column"
-            backgroundColor={showLimit && hoveredField === "limitPrice" ? fieldHoverBg : undefined}
-            onMouseMove={() => { if (showLimit) setHoveredField("limitPrice"); }}
-            onMouseDown={showLimit ? () => {
-              enterInteractive();
-              editPriceField("Limit Price", ticketState.draft.limitPrice, (value) => {
-                if (symbol && ticker) setTradeTicketDraft(symbol, { limitPrice: value }, ticker);
-              }).catch(() => {});
-            } : undefined}>
-            <text fg={showLimit ? colors.textDim : colors.textMuted}>Limit Price</text>
-            <text fg={showLimit ? colors.text : colors.textMuted}>
-              {showLimit ? (ticketState.draft.limitPrice != null ? ticketState.draft.limitPrice.toFixed(2) : "—") : "n/a"}
-            </text>
-          </box>
-          <box width={rowWidth} flexDirection="column"
-            backgroundColor={showStop && hoveredField === "stopPrice" ? fieldHoverBg : undefined}
-            onMouseMove={() => { if (showStop) setHoveredField("stopPrice"); }}
-            onMouseDown={showStop ? () => {
-              enterInteractive();
-              editPriceField("Stop Price", ticketState.draft.stopPrice, (value) => {
-                if (symbol && ticker) setTradeTicketDraft(symbol, { stopPrice: value }, ticker);
-              }).catch(() => {});
-            } : undefined}>
-            <text fg={showStop ? colors.textDim : colors.textMuted}>Stop Price</text>
-            <text fg={showStop ? colors.text : colors.textMuted}>
-              {showStop ? (ticketState.draft.stopPrice != null ? ticketState.draft.stopPrice.toFixed(2) : "—") : "n/a"}
-            </text>
-          </box>
-          <box width={rowWidth} flexDirection="column">
-            <text fg={colors.textDim}>Time In Force</text>
-            <text fg={colors.text}>{ticketState.draft.tif || "DAY"}</text>
-          </box>
-          <box width={rowWidth} flexDirection="column">
-            <text fg={colors.textDim}>Editing</text>
-            <text fg={colors.text}>{ticketState.editingOrderId ? `#${ticketState.editingOrderId}` : "New order"}</text>
-          </box>
-        </box>
-
-        <box height={1} />
-        {interactive ? (
-          <box flexDirection="row" flexWrap="wrap">
-            <text fg={colors.textMuted} onMouseDown={() => chooseBrokerInstance().catch(() => {})}>{" [i] Profile "}</text>
-            <text fg={colors.textMuted} onMouseDown={() => chooseInstrument().catch(() => {})}>{" [s] Contract "}</text>
-            <text fg={colors.textMuted} onMouseDown={() => chooseAccount().catch(() => {})}>{" [a] Account "}</text>
-            <text fg={colors.textMuted} onMouseDown={() => { if (symbol && ticker) setTradeTicketDraft(symbol, { action: "BUY" }, ticker); }}>{" [b] Buy "}</text>
-            <text fg={colors.textMuted} onMouseDown={() => { if (symbol && ticker) setTradeTicketDraft(symbol, { action: "SELL" }, ticker); }}>{" [v] Sell "}</text>
-            <text fg={colors.textMuted} onMouseDown={() => previewOrder().catch(() => {})}>{" [p] Preview "}</text>
-            <text fg={colors.textMuted} onMouseDown={() => submitOrder().catch(() => {})}>{" [Enter] Submit "}</text>
-            <text fg={colors.textMuted} onMouseDown={() => exitInteractive()}>{" [Esc] Release "}</text>
-          </box>
-        ) : (
-          <text fg={colors.textMuted} onMouseDown={() => enterInteractive()}>
-            {"Click here or press Enter to activate the ticket."}
+        <box
+          border
+          borderStyle="rounded"
+          borderColor={getTradeTonePalette(statusTone).border}
+          paddingX={1}
+        >
+          <text fg={ticketState.lastError ? colors.negative : ticketState.isSuccess ? colors.positive : colors.text}>
+            {statusText}
           </text>
-        )}
+        </box>
+
+        <box flexDirection={wideLayout ? "row" : "column"} alignItems="stretch" gap={1}>
+          <box
+            flexDirection="column"
+            flexGrow={1}
+            width={wideLayout ? ticketPanelWidth : undefined}
+            border
+            borderStyle="rounded"
+            borderColor={interactive ? colors.borderFocused : colors.border}
+            paddingX={1}
+            paddingY={1}
+          >
+            <box height={1} flexDirection="row">
+              <text fg={colors.textBright} attributes={TextAttributes.BOLD}>Ticket</text>
+              <box flexGrow={1} />
+              <text fg={interactive ? colors.positive : colors.textMuted}>
+                {interactive ? "Active" : "Click field to activate"}
+              </text>
+            </box>
+            <box height={1}>
+              <text fg={colors.textMuted}>
+                {interactive
+                  ? "Mouse and keyboard are captured here. Esc releases the ticket."
+                  : "Current ticker is loaded by default. Click a field to adjust, then preview."}
+              </text>
+            </box>
+            <box height={1} />
+
+            <box flexDirection="row" flexWrap="wrap" gap={1}>
+              {renderFieldCard({
+                id: "profile",
+                label: "Profile",
+                value: selectedInstance ? selectedInstance.label : "Choose profile",
+                active: hasProfile,
+                onPress: () => chooseBrokerInstance().catch(() => {}),
+              })}
+              {renderFieldCard({
+                id: "contract",
+                label: "Ticker",
+                value: contractValue,
+                active: hasContract,
+                onPress: () => chooseInstrument().catch(() => {}),
+              })}
+              {renderFieldCard({
+                id: "account",
+                label: "Account",
+                value: currentAccountId || "Select account",
+                active: hasAccount,
+                onPress: () => chooseAccount().catch(() => {}),
+              })}
+              <box
+                width={fieldWidth}
+                minWidth={18}
+                height={4}
+                flexDirection="column"
+                backgroundColor={hoveredField === "action" ? fieldHoverBg : undefined}
+                paddingX={1}
+                onMouseMove={() => setHoveredField("action")}
+              >
+                <text fg={colors.textDim}>Action</text>
+                <box flexDirection="row" gap={1}>
+                  <text
+                    fg={ticketState.draft.action === "BUY" ? colors.textBright : colors.textDim}
+                    attributes={ticketState.draft.action === "BUY" ? TextAttributes.BOLD : 0}
+                    onMouseDown={() => {
+                      enterInteractive();
+                      setTradeTicketDraft(symbol, { action: "BUY" }, ticker);
+                    }}
+                  >
+                    BUY [b]
+                  </text>
+                  <text
+                    fg={ticketState.draft.action === "SELL" ? colors.textBright : colors.textDim}
+                    attributes={ticketState.draft.action === "SELL" ? TextAttributes.BOLD : 0}
+                    onMouseDown={() => {
+                      enterInteractive();
+                      setTradeTicketDraft(symbol, { action: "SELL" }, ticker);
+                    }}
+                  >
+                    SELL [v]
+                  </text>
+                </box>
+              </box>
+
+              {renderFieldCard({
+                id: "orderType",
+                label: "Type [t]",
+                value: ticketState.draft.orderType,
+                onPress: () => editOrderType().catch(() => {}),
+              })}
+              {renderFieldCard({
+                id: "quantity",
+                label: "Qty [q]",
+                value: formatNumber(ticketState.draft.quantity, 0),
+                onPress: () => {
+                  editNumericField("Quantity", ticketState.draft.quantity, (value) => {
+                    if (value != null && symbol && ticker) setTradeTicketDraft(symbol, { quantity: value }, ticker);
+                  }).catch(() => {});
+                },
+              })}
+              {renderFieldCard({
+                id: "limitPrice",
+                label: "Limit [l]",
+                value: showLimit ? (ticketState.draft.limitPrice != null ? ticketState.draft.limitPrice.toFixed(2) : "—") : "n/a",
+                disabled: !showLimit,
+                onPress: showLimit ? () => {
+                  editPriceField("Limit Price", ticketState.draft.limitPrice, (value) => {
+                    if (symbol && ticker) setTradeTicketDraft(symbol, { limitPrice: value }, ticker);
+                  }).catch(() => {});
+                } : undefined,
+              })}
+              {renderFieldCard({
+                id: "stopPrice",
+                label: "Stop [x]",
+                value: showStop ? (ticketState.draft.stopPrice != null ? ticketState.draft.stopPrice.toFixed(2) : "—") : "n/a",
+                disabled: !showStop,
+                onPress: showStop ? () => {
+                  editPriceField("Stop Price", ticketState.draft.stopPrice, (value) => {
+                    if (symbol && ticker) setTradeTicketDraft(symbol, { stopPrice: value }, ticker);
+                  }).catch(() => {});
+                } : undefined,
+              })}
+              {renderFieldCard({
+                id: "tif",
+                label: "TIF",
+                value: ticketState.draft.tif || "DAY",
+                active: Boolean(ticketState.draft.tif),
+              })}
+              {renderFieldCard({
+                id: "editing",
+                label: "Mode",
+                value: ticketState.editingOrderId ? `Editing #${ticketState.editingOrderId}` : "New order",
+                valueColor: ticketState.editingOrderId ? colors.textBright : colors.text,
+              })}
+            </box>
+            <box height={1} />
+            <text fg={colors.textMuted}>{contractMeta}</text>
+          </box>
+
+          <box
+            flexDirection="column"
+            width={previewPanelWidth}
+            minWidth={34}
+            border
+            borderStyle="rounded"
+            borderColor={getTradeTonePalette(previewTone).border}
+            paddingX={1}
+            paddingY={1}
+          >
+            <box height={1} flexDirection="row">
+              <text fg={colors.textBright} attributes={TextAttributes.BOLD}>Preview</text>
+              <box flexGrow={1} />
+              <text fg={getTradeTonePalette(previewTone).text}>{previewHeading}</text>
+            </box>
+            <box height={1}>
+              <text fg={ticketState.preview?.warningText ? colors.negative : colors.textMuted}>
+                {truncateText(formatPreviewSummary(ticketState.preview), previewTextWidth)}
+              </text>
+            </box>
+            <box height={1} />
+
+            <box flexDirection="column">
+              <box height={1} flexDirection="row">
+                <box width={12}><text fg={colors.textDim}>Fee</text></box>
+                <text fg={colors.text}>{ticketState.preview?.commission != null ? formatCurrency(ticketState.preview.commission, ticketState.preview.commissionCurrency || "USD") : "—"}</text>
+              </box>
+              <box height={1} flexDirection="row">
+                <box width={12}><text fg={colors.textDim}>Init</text></box>
+                <text fg={colors.text}>{formatPreviewMetric(ticketState.preview?.initMarginBefore, ticketState.preview?.initMarginAfter)}</text>
+              </box>
+              <box height={1} flexDirection="row">
+                <box width={12}><text fg={colors.textDim}>Maint</text></box>
+                <text fg={colors.text}>{formatPreviewMetric(ticketState.preview?.maintMarginBefore, ticketState.preview?.maintMarginAfter)}</text>
+              </box>
+              <box height={1} flexDirection="row">
+                <box width={12}><text fg={colors.textDim}>Equity</text></box>
+                <text fg={colors.text}>{formatPreviewMetric(ticketState.preview?.equityWithLoanBefore, ticketState.preview?.equityWithLoanAfter)}</text>
+              </box>
+              <box height={1} flexDirection="row">
+                <box width={12}><text fg={colors.textDim}>Warning</text></box>
+                <text fg={ticketState.preview?.warningText ? colors.negative : colors.textMuted}>
+                  {truncateText(ticketState.preview?.warningText || "None", 20)}
+                </text>
+              </box>
+            </box>
+
+            <box height={1} />
+            <box flexDirection="column">
+              <Button
+                label="Preview"
+                shortcut="p"
+                variant="secondary"
+                disabled={ticketState.busy}
+                onPress={() => previewOrder().catch(() => {})}
+              />
+              <box height={1} />
+              <Button
+                label={ticketState.editingOrderId ? "Submit Change" : "Submit Order"}
+                shortcut="Enter"
+                variant="primary"
+                disabled={!ticketState.preview || ticketState.busy}
+                onPress={() => submitOrder().catch(() => {})}
+              />
+            </box>
+          </box>
+        </box>
+
+        <box
+          border
+          borderStyle="rounded"
+          borderColor={interactive ? colors.borderFocused : colors.border}
+          paddingX={1}
+          paddingY={1}
+          flexDirection="row"
+          flexWrap="wrap"
+          gap={1}
+        >
+          <Button label="Profile" shortcut="i" variant="ghost" disabled={ticketState.busy} onPress={() => chooseBrokerInstance().catch(() => {})} />
+          <Button label="Override" shortcut="s" variant="ghost" disabled={ticketState.busy} onPress={() => chooseInstrument().catch(() => {})} />
+          <Button label="Account" shortcut="a" variant="ghost" disabled={ticketState.busy} onPress={() => chooseAccount().catch(() => {})} />
+          <Button label="Preview" shortcut="p" variant="secondary" disabled={ticketState.busy} onPress={() => previewOrder().catch(() => {})} />
+          <Button label={ticketState.editingOrderId ? "Submit Change" : "Submit"} shortcut="Enter" variant="primary" disabled={!ticketState.preview || ticketState.busy} onPress={() => submitOrder().catch(() => {})} />
+          <Button label={interactive ? "Release Ticket" : "Activate Ticket"} shortcut={interactive ? "Esc" : "Enter"} variant="ghost" onPress={() => (interactive ? exitInteractive() : enterInteractive())} />
+        </box>
       </box>
     </scrollbox>
   );

--- a/src/state/app-bootstrap.test.ts
+++ b/src/state/app-bootstrap.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { AppPersistence } from "../data/app-persistence";
+import { TickerRepository } from "../data/ticker-repository";
+import { createDefaultConfig, type BrokerInstanceConfig } from "../types/config";
+import type { AppAction } from "./app-context";
+import { initializeAppState } from "./app-bootstrap";
+
+const tempPaths: string[] = [];
+
+function createTempDbPath(name: string): string {
+  const path = join(tmpdir(), `gloomberb-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  tempPaths.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of tempPaths.splice(0)) {
+    if (existsSync(path)) rmSync(path, { force: true });
+  }
+});
+
+describe("initializeAppState", () => {
+  test("hydrates persisted broker account snapshots into app state before broker sync", async () => {
+    const dbPath = createTempDbPath("app-bootstrap");
+    const persistence = new AppPersistence(dbPath);
+    const tickerRepository = new TickerRepository(persistence.tickers);
+    const brokerInstance: BrokerInstanceConfig = {
+      id: "ibkr-live",
+      brokerType: "ibkr",
+      label: "Interactive Brokers",
+      connectionMode: "gateway",
+      config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
+      enabled: true,
+    };
+    const config = {
+      ...createDefaultConfig(dbPath),
+      brokerInstances: [brokerInstance],
+    };
+
+    const actions: AppAction[] = [];
+
+    await initializeAppState({
+      config,
+      tickerRepository,
+      dataProvider: {} as any,
+      sessionSnapshot: null,
+      dispatch: (action) => { actions.push(action); },
+      refreshTicker: () => {},
+      autoImportBrokerPositions: async () => {},
+      persistedBrokerAccounts: {
+        "ibkr-live": [{
+          accountId: "DU12345",
+          name: "DU12345",
+          currency: "USD",
+          source: "gateway",
+          updatedAt: 1_717_000_000_000,
+          totalCashValue: 125000,
+        }],
+      },
+    });
+
+    expect(actions).toContainEqual({
+      type: "SET_BROKER_ACCOUNTS",
+      instanceId: "ibkr-live",
+      accounts: [{
+        accountId: "DU12345",
+        name: "DU12345",
+        currency: "USD",
+        source: "gateway",
+        updatedAt: 1_717_000_000_000,
+        totalCashValue: 125000,
+      }],
+    });
+
+    const initializedIndex = actions.findIndex((action) => action.type === "SET_INITIALIZED");
+    const brokerAccountsIndex = actions.findIndex((action) =>
+      action.type === "SET_BROKER_ACCOUNTS" && action.instanceId === "ibkr-live"
+    );
+    expect(brokerAccountsIndex).toBeGreaterThan(-1);
+    expect(initializedIndex).toBeGreaterThan(brokerAccountsIndex);
+
+    persistence.close();
+  });
+});

--- a/src/state/app-bootstrap.ts
+++ b/src/state/app-bootstrap.ts
@@ -2,6 +2,7 @@ import type { Dispatch } from "react";
 import type { TickerRepository } from "../data/ticker-repository";
 import { findPaneInstance, type AppConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
+import type { BrokerAccount } from "../types/trading";
 import type { TickerMetadata, TickerRecord } from "../types/ticker";
 import { ProviderRouter } from "../sources/provider-router";
 import type { AppAction, PaneRuntimeState } from "./app-context";
@@ -39,6 +40,7 @@ export interface InitializeAppStateArgs {
   dispatch: Dispatch<AppAction>;
   refreshTicker: (symbol: string, exchange?: string, tickerOverride?: TickerRecord | null, priority?: number) => void;
   autoImportBrokerPositions: (tickerMap: Map<string, TickerRecord>) => Promise<void>;
+  persistedBrokerAccounts?: Record<string, BrokerAccount[]>;
 }
 
 function buildPaneStateSeed(
@@ -153,6 +155,7 @@ export async function initializeAppState({
   dispatch,
   refreshTicker,
   autoImportBrokerPositions,
+  persistedBrokerAccounts = {},
 }: InitializeAppStateArgs): Promise<void> {
   let tickers = await tickerRepository.loadAllTickers();
 
@@ -178,6 +181,10 @@ export async function initializeAppState({
     tickerMap.set(ticker.metadata.ticker, ticker);
   }
   dispatch({ type: "SET_TICKERS", tickers: tickerMap });
+
+  for (const [instanceId, accounts] of Object.entries(persistedBrokerAccounts)) {
+    dispatch({ type: "SET_BROKER_ACCOUNTS", instanceId, accounts });
+  }
 
   if (dataProvider instanceof ProviderRouter) {
     const cachedFinancials = dataProvider.getCachedFinancialsForTargets(sessionSnapshot?.hydrationTargets ?? [], {

--- a/src/state/app-context.test.ts
+++ b/src/state/app-context.test.ts
@@ -153,3 +153,63 @@ describe("resolveTickerForPane", () => {
     expect(resolveCollectionForPane(state, "portfolio-list:main")).toBe("main");
   });
 });
+
+describe("broker account cache", () => {
+  test("stores broker accounts by instance id", () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    const next = appReducer(state, {
+      type: "SET_BROKER_ACCOUNTS",
+      instanceId: "ibkr-flex",
+      accounts: [{ accountId: "DU12345", name: "DU12345", totalCashValue: 10 }],
+    });
+
+    expect(next.brokerAccounts).toEqual({
+      "ibkr-flex": [{ accountId: "DU12345", name: "DU12345", totalCashValue: 10 }],
+    });
+  });
+
+  test("preserves cached broker accounts across unrelated config updates", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    config.brokerInstances.push({
+      id: "ibkr-flex",
+      brokerType: "ibkr",
+      label: "Flex",
+      connectionMode: "flex",
+      config: { connectionMode: "flex", flex: { token: "t", queryId: "q" } },
+      enabled: true,
+    });
+    const state = appReducer(createInitialState(config), {
+      type: "SET_BROKER_ACCOUNTS",
+      instanceId: "ibkr-flex",
+      accounts: [{ accountId: "DU12345", name: "DU12345", totalCashValue: 10 }],
+    });
+
+    const next = appReducer(state, { type: "SET_CONFIG", config: { ...config, theme: "amber" } });
+
+    expect(next.brokerAccounts).toEqual(state.brokerAccounts);
+  });
+
+  test("clears cached broker accounts when the broker instance is removed", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    config.brokerInstances.push({
+      id: "ibkr-flex",
+      brokerType: "ibkr",
+      label: "Flex",
+      connectionMode: "flex",
+      config: { connectionMode: "flex", flex: { token: "t", queryId: "q" } },
+      enabled: true,
+    });
+    const state = appReducer(createInitialState(config), {
+      type: "SET_BROKER_ACCOUNTS",
+      instanceId: "ibkr-flex",
+      accounts: [{ accountId: "DU12345", name: "DU12345", totalCashValue: 10 }],
+    });
+
+    const next = appReducer(state, {
+      type: "SET_CONFIG",
+      config: { ...config, brokerInstances: [] },
+    });
+
+    expect(next.brokerAccounts).toEqual({});
+  });
+});

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -23,6 +23,7 @@ import {
 import type { AppConfig, PaneBinding, PaneInstanceConfig, SavedLayout } from "../types/config";
 import type { TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
+import type { BrokerAccount } from "../types/trading";
 import type { ReleaseInfo, UpdateProgress } from "../updater";
 import {
   APP_SESSION_ID,
@@ -52,6 +53,7 @@ export interface AppState {
   tickers: Map<string, TickerRecord>;
   financials: Map<string, TickerFinancials>;
   exchangeRates: Map<string, number>;
+  brokerAccounts: Record<string, BrokerAccount[]>;
   activePanel: "left" | "right";
   focusedPaneId: string | null;
   paneState: Record<string, PaneRuntimeState>;
@@ -79,6 +81,7 @@ export type AppAction =
   | { type: "SET_COMMAND_BAR"; open: boolean; query?: string }
   | { type: "SET_COMMAND_BAR_QUERY"; query: string }
   | { type: "SET_REFRESHING"; symbol: string; refreshing: boolean }
+  | { type: "SET_BROKER_ACCOUNTS"; instanceId: string; accounts: BrokerAccount[] }
   | { type: "SET_INITIALIZED" }
   | { type: "TOGGLE_STATUS_BAR" }
   | { type: "SET_THEME"; theme: string }
@@ -144,6 +147,16 @@ function reconcilePaneState(config: AppConfig, previous: Record<string, PaneRunt
   return next;
 }
 
+function reconcileBrokerAccounts(
+  config: AppConfig,
+  brokerAccounts: Record<string, BrokerAccount[]>,
+): Record<string, BrokerAccount[]> {
+  const validInstanceIds = new Set(config.brokerInstances.map((instance) => instance.id));
+  return Object.fromEntries(
+    Object.entries(brokerAccounts).filter(([instanceId]) => validInstanceIds.has(instanceId)),
+  );
+}
+
 function resolveTickerFromBinding(
   state: Pick<AppState, "config" | "paneState">,
   binding: PaneBinding | undefined,
@@ -181,7 +194,7 @@ export function resolveCollectionForPane(state: AppState, paneId: string, seen =
       ? paneState.collectionId
       : instance.params?.collectionId;
     if (isKnownCollection(state.config, collectionId) || shouldPreserveUnknownCollectionId(collectionId)) {
-      return collectionId;
+      return collectionId ?? null;
     }
     return getDefaultCollectionId(state.config);
   }
@@ -246,7 +259,13 @@ function withFocusedPane(state: AppState, config: AppConfig): AppState {
   const focusedPaneId = state.focusedPaneId && paneIds.includes(state.focusedPaneId)
     ? state.focusedPaneId
     : paneIds[0] ?? null;
-  return { ...state, config: nextConfig, paneState: nextPaneState, focusedPaneId };
+  return {
+    ...state,
+    config: nextConfig,
+    paneState: nextPaneState,
+    brokerAccounts: reconcileBrokerAccounts(nextConfig, state.brokerAccounts),
+    focusedPaneId,
+  };
 }
 
 export function appReducer(state: AppState, action: AppAction): AppState {
@@ -335,6 +354,15 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       else refreshing.delete(action.symbol);
       return { ...state, refreshing };
     }
+
+    case "SET_BROKER_ACCOUNTS":
+      return {
+        ...state,
+        brokerAccounts: {
+          ...state.brokerAccounts,
+          [action.instanceId]: action.accounts,
+        },
+      };
 
     case "SET_INITIALIZED":
       return { ...state, initialized: true };
@@ -598,6 +626,7 @@ export function createInitialState(config: AppConfig, sessionSnapshot: AppSessio
     tickers: new Map(),
     financials: new Map(),
     exchangeRates: new Map([["USD", 1]]),
+    brokerAccounts: {},
     activePanel: sessionSnapshot?.activePanel === "right" ? "right" : "left",
     focusedPaneId,
     paneState,

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -3,14 +3,28 @@ import type { BrokerContractRef } from "./instrument";
 export type BrokerOrderAction = "BUY" | "SELL";
 export type BrokerOrderType = "MKT" | "LMT" | "STP" | "STP LMT";
 
+export interface BrokerCashBalance {
+  currency: string;
+  quantity: number;
+  baseValue?: number;
+  baseCurrency?: string;
+}
+
 export interface BrokerAccount {
   accountId: string;
   name: string;
   currency?: string;
+  source?: "gateway" | "flex";
+  updatedAt?: number;
   netLiquidation?: number;
+  totalCashValue?: number;
+  settledCash?: number;
   buyingPower?: number;
   availableFunds?: number;
   excessLiquidity?: number;
+  initMarginReq?: number;
+  maintMarginReq?: number;
+  cashBalances?: BrokerCashBalance[];
 }
 
 export interface BrokerOrderRequest {


### PR DESCRIPTION
## Summary
- persist and hydrate cached IBKR accounts, and extend broker account metadata plus related tests
- add portfolio cash and margin summary/drawer UI with compact collection tabs
- tighten the IBKR trade pane layout, default the current ticker contract, and clean up preview and account flows

## Testing
- bun test
- bun run build