### PR TITLE
Refine pane creation and command bar shortcuts

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,11 +32,12 @@ import {
   type PaneBinding,
   type PaneInstanceConfig,
 } from "./types/config";
-import type { PaneTemplateContext, PaneTemplateInstanceConfig } from "./types/plugin";
+import type { PaneTemplateContext, PaneTemplateCreateOptions, PaneTemplateInstanceConfig } from "./types/plugin";
 import type { TickerRecord, TickerMetadata, TickerPosition, Portfolio } from "./types/ticker";
 import type { DataProvider } from "./types/data-provider";
 import type { BrokerContractRef } from "./types/instrument";
 import type { BrokerAccount } from "./types/trading";
+import { resolveTickerSearch, upsertTickerFromSearchResult } from "./utils/ticker-search";
 
 // Built-in plugins
 import { portfolioListPlugin } from "./plugins/builtin/portfolio-list";
@@ -882,7 +883,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     }
     placePaneInstance(instance, paneDef, { placement: "default" });
   };
-  const createPaneFromTemplate = useCallback(async (templateId: string) => {
+  const createPaneFromTemplate = useCallback(async (templateId: string, options?: PaneTemplateCreateOptions) => {
     const template = pluginRegistry.paneTemplates.get(templateId);
     if (!template) return;
 
@@ -892,19 +893,64 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
       return;
     }
 
-    const context: PaneTemplateContext = {
+    const baseContext: PaneTemplateContext = {
       config: state.config,
       layout: state.config.layout,
       focusedPaneId: state.focusedPaneId,
       activeTicker: getFocusedTickerSymbol(state),
       activeCollectionId: getFocusedCollectionId(state),
     };
-    if (template.canCreate && !template.canCreate(context)) {
+    let resolvedOptions = options;
+    if (template.shortcut?.argPlaceholder === "ticker") {
+      const activePortfolio = state.config.portfolios.find((portfolio) => portfolio.id === baseContext.activeCollectionId);
+      const resolvedTicker = await resolveTickerSearch({
+        query: options?.arg,
+        activeTicker: baseContext.activeTicker,
+        tickers: state.tickers,
+        dataProvider,
+        searchContext: {
+          preferBroker: true,
+          brokerId: activePortfolio?.brokerId,
+          brokerInstanceId: activePortfolio?.brokerInstanceId,
+        },
+      });
+      if (!resolvedTicker) {
+        pluginRegistry.showToastFn(`No ticker match found for "${options?.arg ?? ""}".`, { type: "info" });
+        return;
+      }
+
+      if (resolvedTicker.kind === "local") {
+        resolvedOptions = {
+          ...options,
+          symbol: resolvedTicker.ticker.metadata.ticker,
+          ticker: resolvedTicker.ticker,
+          searchResult: null,
+        };
+      } else {
+        const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolvedTicker.result);
+        dispatch({ type: "UPDATE_TICKER", ticker });
+        if (created) {
+          pluginRegistry.events.emit("ticker:added", { symbol: ticker.metadata.ticker, ticker });
+        }
+        resolvedOptions = {
+          ...options,
+          symbol: ticker.metadata.ticker,
+          ticker,
+          searchResult: resolvedTicker.result,
+        };
+      }
+    }
+
+    const context: PaneTemplateContext = {
+      ...baseContext,
+      activeTicker: resolvedOptions?.symbol ?? baseContext.activeTicker,
+    };
+    if (template.canCreate && !template.canCreate(context, resolvedOptions)) {
       pluginRegistry.showToastFn(`Can't create ${template.label.toLowerCase()} right now.`, { type: "info" });
       return;
     }
 
-    const spec = await template.createInstance?.(context) ?? {};
+    const spec = await template.createInstance?.(context, resolvedOptions) ?? {};
     if (spec === null) return;
 
     const paneDef = pluginRegistry.panes.get(template.paneId);
@@ -920,12 +966,12 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     }
 
     placePaneInstance(instance, paneDef, spec);
-  }, [buildPaneInstance, placePaneInstance, pluginRegistry, state]);
+  }, [buildPaneInstance, dataProvider, dispatch, placePaneInstance, pluginRegistry, state, tickerRepository]);
 
   pluginRegistry.getLayoutFn = () => state.config.layout;
   pluginRegistry.updateLayoutFn = (layout) => persistLayout(layout);
   pluginRegistry.showPaneFn = (paneId) => showPane(paneId);
-  pluginRegistry.createPaneFromTemplateFn = (templateId) => { void createPaneFromTemplate(templateId); };
+  pluginRegistry.createPaneFromTemplateFn = (templateId, options) => { void createPaneFromTemplate(templateId, options); };
   pluginRegistry.hidePaneFn = (paneId) => {
     const instanceId = resolvePaneTarget(paneId);
     if (!instanceId || !isPaneInLayout(state.config.layout, instanceId)) return;

--- a/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
+++ b/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
@@ -11,16 +11,16 @@ exports[`CommandBar renders the default layout with opencode-style chrome 1`] = 
                   AAPL                                                          
                   MSFT                                                          
                                                                                 
+                  Panes                                                         
+                  New Portfolio Pane                                            
+                  New Chat Pane                                                 
+                  Quote Monitor                                                 
+                                                                                
                   Search                                                        
                   Search Ticker                                                 
                                                                                 
                   Portfolio                                                     
                   Add AAPL to Watchlist                                         
-                  Add AAPL to Portfolio                                         
-                                                                                
-                  Create                                                        
-                  New Portfolio                                                 
-                  New Watchlist                                                 
                                                                                 
                                                                                 
                                                                                 
@@ -95,12 +95,12 @@ exports[`CommandBar collapses the trailing column on narrow terminals 1`] = `
        AAPL                               
        MSFT                               
                                           
-       Search                             
-       Search Ticker                      
+       Panes                              
+       New Portfolio Pane                 
+       New Chat Pane                      
+       Quote Monitor                      
                                           
-       Portfolio                          
-       Add AAPL to Watchlist              
-       Add AAPL to Portfolio              
+       Search                             
                                           
                                           
                                           

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -70,6 +70,13 @@ function makePluginRegistry(): PluginRegistry {
         defaultPosition: "right",
         defaultMode: "floating",
       }],
+      ["quote-monitor", {
+        id: "quote-monitor",
+        name: "Quote Monitor",
+        component: () => null,
+        defaultPosition: "right",
+        defaultMode: "floating",
+      }],
     ]),
     paneTemplates: new Map([
       ["new-portfolio-pane", {
@@ -77,6 +84,7 @@ function makePluginRegistry(): PluginRegistry {
         paneId: "portfolio-list",
         label: "New Portfolio Pane",
         description: "Open another portfolio list pane",
+        shortcut: { prefix: "PF" },
       }],
       ["new-watchlist-pane", {
         id: "new-watchlist-pane",
@@ -95,6 +103,14 @@ function makePluginRegistry(): PluginRegistry {
         paneId: "chat",
         label: "New Chat Pane",
         description: "Open another floating chat window",
+        shortcut: { prefix: "CHAT" },
+      }],
+      ["quote-monitor-pane", {
+        id: "quote-monitor-pane",
+        paneId: "quote-monitor",
+        label: "Quote Monitor",
+        description: "Open a compact quote monitor for the selected ticker",
+        shortcut: { prefix: "QQ", argPlaceholder: "ticker" },
       }],
     ]),
     commands: new Map([
@@ -338,6 +354,33 @@ describe("CommandBar", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("New Chat Pane");
     expect(frame).toContain("float");
+  });
+
+  test("shows pane shortcuts in the default browse results", async () => {
+    testSetup = await testRender(<CommandBarHarness query="" selectedTicker="AAPL" />, {
+      width: 100,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Panes");
+    expect(frame).toContain("Quote Monitor");
+    expect(frame).toContain("QQ");
+  });
+
+  test("matches direct pane shortcut queries", async () => {
+    testSetup = await testRender(<CommandBarHarness query="QQ MSFT" selectedTicker="AAPL" />, {
+      width: 100,
+      height: 18,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Quote Monitor");
+    expect(frame).toContain("QQ");
   });
 
   test("groups ticker search sections and keeps exact open matches above loose provider results", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { TextAttributes } from "@opentui/core";
 import { Spinner } from "../spinner";
@@ -21,9 +21,9 @@ import { getCurrentThemeId, applyTheme } from "../../theme/colors";
 import { saveConfig, resetAllData, exportConfig, importConfig } from "../../data/config-store";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRepository } from "../../data/ticker-repository";
-import type { TickerRecord, TickerMetadata } from "../../types/ticker";
+import type { TickerRecord } from "../../types/ticker";
 import type { PluginRegistry } from "../../plugins/registry";
-import type { CommandDef, WizardStep } from "../../types/plugin";
+import type { CommandDef, PaneTemplateCreateOptions, PaneTemplateDef, WizardStep } from "../../types/plugin";
 import { DEFAULT_LAYOUT, cloneLayout, createPaneInstance, findPaneInstance, type ColumnConfig, type LayoutConfig } from "../../types/config";
 import type { PromptContext, AlertContext } from "@opentui-ui/dialog/react";
 import { resolveBrokerConfigFields } from "../../types/broker";
@@ -48,10 +48,17 @@ import {
   buildSections,
   getEmptyState,
   getRowPresentation,
-  rankTickerSearchItems,
   resolveCommandBarMode,
   truncateText,
 } from "./view-model";
+import {
+  createLocalTickerSearchCandidates,
+  findExactTickerSearchMatch,
+  rankTickerSearchItems,
+  upsertTickerFromSearchResult,
+  searchTickerCandidates,
+  type TickerSearchCandidate,
+} from "../../utils/ticker-search";
 
 /** All available columns that can be toggled */
 const ALL_COLUMNS: ColumnConfig[] = [
@@ -94,6 +101,11 @@ interface ResultItem {
   checked?: boolean;
   current?: boolean;
   action: () => void | Promise<void>;
+}
+
+interface PaneShortcutMatch {
+  template: PaneTemplateDef;
+  arg: string;
 }
 
 // --- Wizard dialog content components ---
@@ -796,51 +808,57 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
 
   const openTickerDetail = useCallback((result: InstrumentSearchResult, options?: { forceNewPane?: boolean }) => {
     (async () => {
-      const symbol = result.brokerContract?.localSymbol || result.symbol.split(".")[0]!;
-      let existing = await tickerRepository.loadTicker(symbol);
-      const created = !existing;
-      if (!existing) {
-        const metadata: TickerMetadata = {
-          ticker: symbol,
-          exchange: result.exchange,
-          currency: result.currency || result.brokerContract?.currency || "USD",
-          name: result.name,
-          assetCategory: result.brokerContract?.secType || result.type || undefined,
-          broker_contracts: result.brokerContract ? [result.brokerContract] : [],
-          portfolios: [],
-          watchlists: [],
-          positions: [],
-          custom: {},
-          tags: [],
-        };
-        existing = await tickerRepository.createTicker(metadata);
-      } else {
-        existing.metadata.name = existing.metadata.name || result.name;
-        existing.metadata.exchange = existing.metadata.exchange || result.exchange;
-        existing.metadata.currency = existing.metadata.currency || result.currency || "USD";
-        existing.metadata.assetCategory = existing.metadata.assetCategory || result.brokerContract?.secType || result.type || undefined;
-        const existingContracts = existing.metadata.broker_contracts ?? [];
-        if (result.brokerContract) {
-          const nextContracts = [...existingContracts];
-          const hasContract = nextContracts.some((contract) =>
-            contract.brokerId === result.brokerContract!.brokerId
-            && contract.brokerInstanceId === result.brokerContract!.brokerInstanceId
-            && contract.conId === result.brokerContract!.conId
-            && contract.localSymbol === result.brokerContract!.localSymbol,
-          );
-          if (!hasContract) nextContracts.push(result.brokerContract);
-          existing.metadata.broker_contracts = nextContracts;
-        }
-        await tickerRepository.saveTicker(existing);
-      }
-      dispatch({ type: "UPDATE_TICKER", ticker: existing });
+      const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, result);
+      dispatch({ type: "UPDATE_TICKER", ticker });
       if (created) {
-        pluginRegistry.events.emit("ticker:added", { symbol, ticker: existing });
+        pluginRegistry.events.emit("ticker:added", { symbol: ticker.metadata.ticker, ticker });
       }
-      focusTicker(symbol, options);
+      focusTicker(ticker.metadata.ticker, options);
       close();
     })();
   }, [tickerRepository, dispatch, close, focusTicker, pluginRegistry.events]);
+
+  const mapTickerSearchCandidateToResultItem = useCallback((candidate: TickerSearchCandidate): ResultItem => {
+    if (candidate.kind === "ticker" && candidate.ticker) {
+      return {
+        id: candidate.id,
+        label: candidate.label,
+        detail: candidate.detail,
+        right: candidate.right,
+        category: candidate.category,
+        kind: "ticker",
+        secondaryAction: () => { focusTicker(candidate.ticker!.metadata.ticker, { forceNewPane: true }); close(); },
+        action: () => { focusTicker(candidate.ticker!.metadata.ticker); close(); },
+      };
+    }
+
+    const result = candidate.result!;
+    return {
+      id: candidate.id,
+      label: candidate.label,
+      detail: candidate.detail,
+      right: candidate.right,
+      category: candidate.category,
+      kind: "search",
+      secondaryAction: () => openTickerDetail(result, { forceNewPane: true }),
+      action: () => openTickerDetail(result),
+    };
+  }, [close, focusTicker, openTickerDetail]);
+
+  const localTickerSearchResultItems = useCallback((query?: string, options?: {
+    category?: string;
+    limit?: number;
+  }): ResultItem[] => {
+    const items = query
+      ? rankTickerSearchItems(createLocalTickerSearchCandidates(state.tickers.values()), query)
+      : createLocalTickerSearchCandidates(state.tickers.values());
+    return items
+      .slice(0, options?.limit)
+      .map((candidate) => ({
+        ...mapTickerSearchCandidateToResultItem(candidate),
+        category: options?.category ?? candidate.category,
+      }));
+  }, [mapTickerSearchCandidateToResultItem, state.tickers]);
 
   const persistLayoutChange = useCallback((nextLayout: LayoutConfig) => {
     pluginRegistry.updateLayoutFn(nextLayout);
@@ -988,53 +1006,119 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
         },
       }));
   }, [pluginRegistry.tickerActions, activeTickerData, activeFinancials, close]);
-  const paneTemplateItems = useCallback((filterQuery?: string): ResultItem[] => {
+
+  const getPaneTemplateContext = useCallback(() => ({
+    config: state.config,
+    layout: state.config.layout,
+    focusedPaneId: state.focusedPaneId,
+    activeTicker: activeTickerSymbol,
+    activeCollectionId,
+  }), [activeCollectionId, activeTickerSymbol, state.config, state.focusedPaneId]);
+
+  const getAvailablePaneTemplates = useCallback((options?: PaneTemplateCreateOptions): PaneTemplateDef[] => {
     const disabledPlugins = new Set(state.config.disabledPlugins || []);
-    const context = {
-      config: state.config,
-      layout: state.config.layout,
-      focusedPaneId: state.focusedPaneId,
-      activeTicker: activeTickerSymbol,
-      activeCollectionId,
-    };
-    const items = [...pluginRegistry.paneTemplates.values()]
+    const context = getPaneTemplateContext();
+    return [...pluginRegistry.paneTemplates.values()]
       .filter((template) => {
         const pluginId = pluginRegistry.getPaneTemplatePluginId(template.id);
         if (pluginId && disabledPlugins.has(pluginId)) return false;
-        return !template.canCreate || template.canCreate(context);
-      })
-      .map((template) => {
-        const pluginId = pluginRegistry.getPaneTemplatePluginId(template.id);
-        const pluginName = pluginId ? pluginRegistry.allPlugins.get(pluginId)?.name : null;
-        const paneDef = pluginRegistry.panes.get(template.paneId);
-        return {
-          id: `pane-template:${template.id}`,
-          label: template.label,
-          detail: template.description,
-          category: pluginName ? `${pluginName} Panes` : "New Panes",
-          kind: "action" as const,
-          right: paneDef?.defaultMode === "floating" ? "float" : "dock",
-          searchText: `${template.paneId} ${template.keywords?.join(" ") || ""}`,
-          action: () => {
-            close();
-            pluginRegistry.createPaneFromTemplateFn(template.id);
-          },
-        };
+        return !template.canCreate || template.canCreate(context, options);
       });
+  }, [getPaneTemplateContext, pluginRegistry, state.config.disabledPlugins]);
+
+  const createPaneTemplateItem = useCallback((
+    template: PaneTemplateDef,
+    options?: {
+      category?: string;
+      createOptions?: PaneTemplateCreateOptions;
+      showShortcut?: boolean;
+    },
+  ): ResultItem => {
+    const pluginId = pluginRegistry.getPaneTemplatePluginId(template.id);
+    const pluginName = pluginId ? pluginRegistry.allPlugins.get(pluginId)?.name : null;
+    const paneDef = pluginRegistry.panes.get(template.paneId);
+    const shortcutLabel = template.shortcut
+      ? [template.shortcut.prefix, template.shortcut.argPlaceholder && `<${template.shortcut.argPlaceholder}>`].filter(Boolean).join(" ")
+      : null;
+    const placementLabel = paneDef?.defaultMode === "floating" ? "float" : "dock";
+    return {
+      id: `pane-template:${template.id}:${options?.createOptions?.arg || ""}`,
+      label: template.label,
+      detail: shortcutLabel ? `${template.description} · ${shortcutLabel}` : template.description,
+      category: options?.category ?? (pluginName ? `${pluginName} Panes` : "New Panes"),
+      kind: "action",
+      right: options?.showShortcut ? (template.shortcut?.prefix || placementLabel) : placementLabel,
+      searchText: `${template.paneId} ${template.keywords?.join(" ") || ""} ${shortcutLabel || ""} ${pluginName || ""}`,
+      action: () => {
+        close();
+        pluginRegistry.createPaneFromTemplateFn(template.id, options?.createOptions);
+      },
+    };
+  }, [close, pluginRegistry]);
+
+  const paneTemplateItems = useCallback((filterQuery?: string): ResultItem[] => {
+    const items = getAvailablePaneTemplates()
+      .map((template) => createPaneTemplateItem(template));
 
     return filterQuery
       ? fuzzyFilter(items, filterQuery, (item) => `${item.label} ${item.detail} ${item.searchText || ""} ${item.right || ""}`)
       : items;
-  }, [
-    activeCollectionId,
-    activeTickerSymbol,
-    close,
-    pluginRegistry,
-    state.config,
-    state.focusedPaneId,
-  ]);
+  }, [createPaneTemplateItem, getAvailablePaneTemplates]);
+
+  const paneShortcutItems = useCallback((options?: {
+    filterQuery?: string;
+    createOptions?: PaneTemplateCreateOptions;
+  }): ResultItem[] => {
+    const items = getAvailablePaneTemplates(options?.createOptions)
+      .filter((template) => template.shortcut)
+      .map((template) => createPaneTemplateItem(template, {
+        category: "Panes",
+        createOptions: options?.createOptions,
+        showShortcut: true,
+      }));
+
+    return options?.filterQuery
+      ? fuzzyFilter(items, options.filterQuery, (item) => `${item.label} ${item.detail} ${item.searchText || ""} ${item.right || ""}`)
+      : items;
+  }, [createPaneTemplateItem, getAvailablePaneTemplates]);
+
+  const nonShortcutPaneTemplateItems = useCallback((filterQuery?: string): ResultItem[] => {
+    const items = getAvailablePaneTemplates()
+      .filter((template) => !template.shortcut)
+      .map((template) => createPaneTemplateItem(template, { category: "Panes" }));
+
+    return filterQuery
+      ? fuzzyFilter(items, filterQuery, (item) => `${item.label} ${item.detail} ${item.searchText || ""} ${item.right || ""}`)
+      : items;
+  }, [createPaneTemplateItem, getAvailablePaneTemplates]);
+
+  const matchPaneShortcut = useCallback((input: string): PaneShortcutMatch | null => {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+
+    const upper = trimmed.toUpperCase();
+    const templates = [...pluginRegistry.paneTemplates.values()]
+      .filter((template) => template.shortcut)
+      .sort((a, b) => (b.shortcut?.prefix.length ?? 0) - (a.shortcut?.prefix.length ?? 0));
+
+    for (const template of templates) {
+      const prefix = template.shortcut?.prefix.toUpperCase();
+      if (!prefix) continue;
+      if (!upper.startsWith(`${prefix} `) && upper !== prefix) continue;
+
+      const arg = trimmed.slice(prefix.length).trim();
+      const createOptions = arg ? { arg } : undefined;
+      if (!getAvailablePaneTemplates(createOptions).some((entry) => entry.id === template.id)) {
+        continue;
+      }
+      return { template, arg };
+    }
+
+    return null;
+  }, [getAvailablePaneTemplates, pluginRegistry.paneTemplates]);
 
   const activeMatch = matchPrefix(query);
+  const paneShortcutMatch = useMemo(() => matchPaneShortcut(query), [matchPaneShortcut, query]);
   const modeInfo = resolveCommandBarMode(query);
   const isThemeMode = modeInfo.kind === "themes";
   const isPluginMode = modeInfo.kind === "plugins";
@@ -1157,7 +1241,13 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
     const match = matchPrefix(query);
     let initialIdx = 0;
 
-    if (match && match.command.id === "plugins") {
+    if (paneShortcutMatch) {
+      items.push(createPaneTemplateItem(paneShortcutMatch.template, {
+        category: "Panes",
+        createOptions: paneShortcutMatch.arg ? { arg: paneShortcutMatch.arg } : undefined,
+        showShortcut: true,
+      }));
+    } else if (match && match.command.id === "plugins") {
       const toggleablePlugins = [...pluginRegistry.allPlugins.values()].filter((p) => p.toggleable);
       const disabledPlugins = state.config.disabledPlugins || [];
       const filtered = match.arg
@@ -1520,20 +1610,7 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
           action: () => {},
         });
       } else {
-        const localMatches = rankTickerSearchItems(
-          Array.from(state.tickers.values()).map((ticker) => ({
-            id: `goto:${ticker.metadata.ticker}`,
-            label: ticker.metadata.ticker,
-            detail: ticker.metadata.name,
-            right: ticker.metadata.exchange,
-            category: "Open",
-            kind: "ticker" as const,
-            secondaryAction: () => { focusTicker(ticker.metadata.ticker, { forceNewPane: true }); close(); },
-            action: () => { focusTicker(ticker.metadata.ticker); close(); },
-          })),
-          match.arg,
-        );
-        items.push(...localMatches.slice(0, 6));
+        items.push(...localTickerSearchResultItems(match.arg, { limit: 6 }));
       }
     } else if (match && !match.command.hasArg) {
       if (shouldShow(match.command)) {
@@ -1560,17 +1637,11 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
           if (!recentSet.has(t.metadata.ticker)) recentTickers.push(t);
         }
       }
-      for (const t of recentTickers) {
-        items.push({
-          id: `goto:${t.metadata.ticker}`,
-          label: t.metadata.ticker,
-          detail: t.metadata.name,
-          category: "Tickers",
-          kind: "ticker",
-          secondaryAction: () => { focusTicker(t.metadata.ticker, { forceNewPane: true }); close(); },
-          action: () => { focusTicker(t.metadata.ticker); close(); },
-        });
-      }
+      items.push(...recentTickers.map((ticker) => ({
+        ...mapTickerSearchCandidateToResultItem(createLocalTickerSearchCandidates([ticker])[0]!),
+        category: "Tickers",
+      })));
+      items.push(...paneShortcutItems());
       for (const cmd of commands) {
         const item = cmdToItem(cmd);
         if (item) items.push(item);
@@ -1578,17 +1649,16 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
       items.push(...tickerActionItems());
       items.push(...pluginCommandItems());
     } else {
-      const tickerItems: ResultItem[] = Array.from(state.tickers.values()).map((t) => ({
-        id: `goto:${t.metadata.ticker}`,
-        label: t.metadata.ticker,
-        detail: t.metadata.name,
-        category: "Tickers",
-        kind: "ticker",
-        secondaryAction: () => { focusTicker(t.metadata.ticker, { forceNewPane: true }); close(); },
-        action: () => { focusTicker(t.metadata.ticker); close(); },
-      }));
+      const tickerItems = localTickerSearchResultItems(undefined, { category: "Tickers" });
       const cmdItems = commands.map((cmd) => cmdToItem(cmd)).filter((item): item is ResultItem => item !== null);
-      const allItems = [...tickerItems, ...cmdItems, ...paneTemplateItems(), ...tickerActionItems(), ...pluginCommandItems()];
+      const allItems = [
+        ...tickerItems,
+        ...cmdItems,
+        ...paneShortcutItems(),
+        ...nonShortcutPaneTemplateItems(),
+        ...tickerActionItems(),
+        ...pluginCommandItems(),
+      ];
       items.push(...fuzzyFilter(allItems, query, (i) => `${i.label} ${i.detail} ${i.searchText || ""} ${i.right || ""}`));
     }
 
@@ -1617,42 +1687,19 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
       searchTimerRef.current = setTimeout(async () => {
         try {
           const activePortfolio = state.config.portfolios.find((portfolio) => portfolio.id === activeCollectionId);
-          const searchResults = await dataProvider.search(searchQuery, {
-            preferBroker: true,
-            brokerId: activePortfolio?.brokerId,
-            brokerInstanceId: activePortfolio?.brokerInstanceId,
+          const combined = await searchTickerCandidates({
+            query: searchQuery,
+            tickers: state.tickers,
+            dataProvider,
+            searchContext: {
+              preferBroker: true,
+              brokerId: activePortfolio?.brokerId,
+              brokerInstanceId: activePortfolio?.brokerInstanceId,
+            },
           });
           if (requestId !== searchRequestIdRef.current) return; // stale response
-          const localItems = rankTickerSearchItems(
-            Array.from(state.tickers.values()).map((ticker) => ({
-              id: `goto:${ticker.metadata.ticker}`,
-              label: ticker.metadata.ticker,
-              detail: ticker.metadata.name,
-              right: ticker.metadata.exchange,
-              category: "Open",
-              kind: "ticker" as const,
-              secondaryAction: () => { focusTicker(ticker.metadata.ticker, { forceNewPane: true }); close(); },
-              action: () => { focusTicker(ticker.metadata.ticker); close(); },
-            })),
-            searchQuery,
-          ).slice(0, 6);
-          const searchItems: ResultItem[] = searchResults
-            .map((r) => {
-              const sym = r.brokerContract?.localSymbol || r.symbol.split(".")[0]!;
-              const isExisting = state.tickers.has(sym);
-              return {
-                id: `search:${r.symbol}`,
-                label: sym,
-                detail: [r.name, r.brokerLabel, r.type || r.exchange].filter(Boolean).join(" | "),
-                right: r.exchange || r.type || undefined,
-                category: isExisting ? "Open" : "Search Results",
-                kind: "search",
-                secondaryAction: () => openTickerDetail(r, { forceNewPane: true }),
-                action: () => openTickerDetail(r),
-              };
-            });
-          const combined = rankTickerSearchItems([...localItems, ...searchItems], searchQuery).slice(0, 8);
-          setResults(combined.length > 0 ? combined : [{
+          const resultItems = combined.map((candidate) => mapTickerSearchCandidateToResultItem(candidate));
+          setResults(resultItems.length > 0 ? resultItems : [{
               id: "no-results",
               label: `No matches for "${searchQuery}"`,
               detail: "Try a symbol, company name, or exchange variant",
@@ -1687,10 +1734,17 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
     activeTickerData,
     activeTickerSymbol,
     close,
+    createPaneTemplateItem,
+    dataProvider,
     dialog,
     dispatch,
     duplicatePane,
     focusTicker,
+    localTickerSearchResultItems,
+    mapTickerSearchCandidateToResultItem,
+    nonShortcutPaneTemplateItems,
+    paneShortcutItems,
+    paneShortcutMatch,
     paneTemplateItems,
     persistLayoutChange,
     pluginCommandItems,
@@ -1702,12 +1756,10 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
   ]);
 
   const exactTickerResult = (() => {
-    const normalizedQuery = (searchModeQuery || query).trim().toUpperCase();
-    if (!normalizedQuery) return null;
-    return results.find((item) =>
-      (item.id.startsWith("goto:") || item.id.startsWith("search:"))
-      && item.label.toUpperCase() === normalizedQuery,
-    ) ?? null;
+    return findExactTickerSearchMatch(
+      results.filter((item) => item.id.startsWith("goto:") || item.id.startsWith("search:")),
+      searchModeQuery || query,
+    );
   })();
 
   // Live preview: apply theme as user arrows through the list

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -31,6 +31,17 @@ describe("command bar view model helpers", () => {
     expect(sections[0]?.items.map((item) => item.id)).toEqual(["a", "c"]);
   });
 
+  test("moves danger and debug sections to the end", () => {
+    const sections = buildSections([
+      { id: "a", category: "Tickers" },
+      { id: "b", category: "Danger" },
+      { id: "c", category: "Debug" },
+      { id: "d", category: "Config" },
+    ]);
+
+    expect(sections.map((section) => section.category)).toEqual(["Tickers", "Config", "Danger", "Debug"]);
+  });
+
   test("returns footer hints for plugin toggles", () => {
     expect(getFooterHints("plugins", false)).toEqual({
       left: "up/down move  enter select  space toggle",

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -1,4 +1,5 @@
 import { matchPrefix } from "./command-registry";
+export { rankTickerSearchItems } from "../../utils/ticker-search";
 
 export type CommandBarMode = "default" | "search" | "themes" | "plugins" | "columns" | "layout" | "new-pane" | "direct-command";
 
@@ -99,7 +100,13 @@ export function buildSections<T extends { category: string }>(items: T[]): Array
     }
     section.items.push(item);
   }
-  return sections;
+  return sections
+    .map((section, index) => ({ section, index }))
+    .sort((a, b) => {
+      const priorityDiff = getCategoryPriority(a.section.category) - getCategoryPriority(b.section.category);
+      return priorityDiff !== 0 ? priorityDiff : a.index - b.index;
+    })
+    .map(({ section }) => section);
 }
 
 export function getFooterHints(mode: CommandBarMode, isNarrow: boolean): CommandBarFooterHints {
@@ -171,106 +178,9 @@ export function truncateText(text: string, width: number): string {
   return `${text.slice(0, width - 3)}...`;
 }
 
-function normalizeSearchText(text: string): string {
-  return text.trim().toUpperCase().replace(/[^A-Z0-9]+/g, " ");
-}
-
-function scoreSearchField(query: string, value: string, weights: { exact: number; prefix: number; substring: number; fuzzy: number }): number {
-  if (!query || !value) return 0;
-  if (value === query) return weights.exact - value.length;
-  if (value.startsWith(query)) return weights.prefix - value.length;
-
-  const substringIndex = value.indexOf(query);
-  if (substringIndex >= 0) {
-    return weights.substring - substringIndex * 25 - value.length;
-  }
-
-  let qi = 0;
-  let score = 0;
-  for (let i = 0; i < value.length && qi < query.length; i++) {
-    if (value[i] !== query[qi]) continue;
-    score += i === 0 || value[i - 1] === " " ? 10 : 2;
-    qi += 1;
-  }
-  return qi === query.length ? weights.fuzzy + score : 0;
-}
-
-function getTickerSearchDedupKey(item: Pick<CommandBarItemView, "id" | "kind" | "label" | "detail" | "right">): string {
-  if (item.kind !== "ticker" && item.kind !== "search") return item.id;
-  const qualifier = normalizeSearchText(item.right || item.detail.split("|").at(-1) || "");
-  return `${normalizeSearchText(item.label)}|${qualifier}`;
-}
-
-export function rankTickerSearchItems<T extends Pick<CommandBarItemView, "id" | "label" | "detail" | "kind" | "category" | "right">>(
-  items: T[],
-  query: string,
-): T[] {
-  const normalizedQuery = normalizeSearchText(query);
-  if (!normalizedQuery) return items;
-
-  const openSymbols = new Set(
-    items
-      .filter((item) => item.kind === "ticker" || item.category === "Open")
-      .map((item) => normalizeSearchText(item.label)),
-  );
-
-  const ranked = items
-    .map((item, index) => {
-      const normalizedLabel = normalizeSearchText(item.label);
-      const normalizedDetail = normalizeSearchText(item.detail);
-      const normalizedRight = normalizeSearchText(item.right || "");
-      const labelScore = scoreSearchField(normalizedQuery, normalizedLabel, {
-        exact: 24_000,
-        prefix: 18_000,
-        substring: 14_000,
-        fuzzy: 7_000,
-      });
-      const detailScore = Math.max(
-        scoreSearchField(normalizedQuery, normalizedDetail, {
-          exact: 4_500,
-          prefix: 3_800,
-          substring: 2_600,
-          fuzzy: 600,
-        }),
-        scoreSearchField(normalizedQuery, normalizedRight, {
-          exact: 1_200,
-          prefix: 1_000,
-          substring: 700,
-          fuzzy: 100,
-        }),
-      );
-      const isOpenItem = item.kind === "ticker" || item.category === "Open";
-      const matchScore = labelScore + detailScore;
-
-      return {
-        item,
-        index,
-        normalizedLabel,
-        matchScore,
-        score: matchScore + (matchScore > 0 && isOpenItem ? 900 : 0),
-      };
-    })
-    .filter(({ item, normalizedLabel, matchScore }) => {
-      if (matchScore <= 0) return false;
-      if (item.kind !== "search") return true;
-      return !openSymbols.has(normalizedLabel);
-    })
-    .sort((a, b) => {
-      if (b.score !== a.score) return b.score - a.score;
-      const aOpen = a.item.kind === "ticker" || a.item.category === "Open";
-      const bOpen = b.item.kind === "ticker" || b.item.category === "Open";
-      if (aOpen !== bOpen) return aOpen ? -1 : 1;
-      if (a.item.label.length !== b.item.label.length) return a.item.label.length - b.item.label.length;
-      return a.index - b.index;
-    });
-
-  const deduped: T[] = [];
-  const seen = new Set<string>();
-  for (const entry of ranked) {
-    const key = getTickerSearchDedupKey(entry.item);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(entry.item);
-  }
-  return deduped;
+function getCategoryPriority(category: string): number {
+  const normalized = category.trim().toLowerCase();
+  if (normalized.includes("danger")) return 900;
+  if (normalized.includes("debug")) return 910;
+  return 0;
 }

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -356,6 +356,7 @@ export const chatPlugin: GloomPlugin = {
       label: "New Chat Pane",
       description: "Open another floating chat window",
       keywords: ["new", "chat", "pane", "message"],
+      shortcut: { prefix: "CHAT" },
       createInstance: () => ({ placement: "floating" }),
     },
   ],

--- a/src/plugins/builtin/notes.tsx
+++ b/src/plugins/builtin/notes.tsx
@@ -389,6 +389,7 @@ export const notesPlugin: GloomPlugin = {
       label: "Quick Notes",
       description: "Open a general-purpose notes scratchpad",
       keywords: ["notes", "quick", "scratchpad", "memo"],
+      shortcut: { prefix: "NOTE" },
       createInstance: () => ({ placement: "floating" }),
     });
   },

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -4,7 +4,7 @@ import type { ScrollBoxRenderable } from "@opentui/core";
 import { TextAttributes } from "@opentui/core";
 import { EmptyState } from "../../components";
 import { TabBar } from "../../components/tab-bar";
-import type { GloomPlugin, PaneProps } from "../../types/plugin";
+import type { GloomPlugin, PaneProps, PaneTemplateContext } from "../../types/plugin";
 import { getSharedRegistry } from "../../plugins/registry";
 import {
   useAppState,
@@ -1233,6 +1233,19 @@ export const portfolioListPlugin: GloomPlugin = {
   ],
   paneTemplates: [
     {
+      id: "new-collection-pane",
+      paneId: "portfolio-list",
+      label: "Collection Pane",
+      description: "Open another pane for the current portfolio or watchlist",
+      keywords: ["portfolio", "watchlist", "collection", "pane", "list"],
+      shortcut: { prefix: "PF" },
+      canCreate: (context) => resolveCollectionPaneId(context) !== null,
+      createInstance: (context) => {
+        const collectionId = resolveCollectionPaneId(context);
+        return collectionId ? { params: { collectionId } } : null;
+      },
+    },
+    {
       id: "new-portfolio-pane",
       paneId: "portfolio-list",
       label: "New Portfolio Pane",
@@ -1264,3 +1277,15 @@ export const portfolioListPlugin: GloomPlugin = {
     },
   ],
 };
+
+function resolveCollectionPaneId(context: PaneTemplateContext): string | null {
+  if (context.activeCollectionId) {
+    const isPortfolio = context.config.portfolios.some((portfolio) => portfolio.id === context.activeCollectionId);
+    const isWatchlist = context.config.watchlists.some((watchlist) => watchlist.id === context.activeCollectionId);
+    if (isPortfolio || isWatchlist) {
+      return context.activeCollectionId;
+    }
+  }
+
+  return context.config.portfolios[0]?.id ?? context.config.watchlists[0]?.id ?? null;
+}

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -11,6 +11,7 @@ import { EmptyState, FieldRow } from "../../components";
 import { TabBar } from "../../components/tab-bar";
 import { formatCurrency, formatCompact, formatPercent, formatPercentRaw, formatNumber, formatGrowthShort, pickUnit, formatWithDivisor, padTo } from "../../utils/format";
 import { exchangeShortName, marketStateLabel, marketStateColor } from "../../utils/market-status";
+import { normalizeTickerInput } from "../../utils/ticker-search";
 import { StockChart } from "../../components/chart/stock-chart";
 import type { TickerFinancials } from "../../types/financials";
 import { getConfiguredIbkrGatewayInstances } from "../ibkr/instance-selection";
@@ -763,16 +764,18 @@ export const tickerDetailPlugin: GloomPlugin = {
       label: "Quote Monitor",
       description: "Open a compact quote monitor for the selected ticker",
       keywords: ["quote", "monitor", "price", "ticker", "pane"],
-      canCreate: (context) => context.activeTicker !== null,
-      createInstance: (context) => (
-        context.activeTicker
+      shortcut: { prefix: "QQ", argPlaceholder: "ticker" },
+      canCreate: (context, options) => (options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg)) !== null,
+      createInstance: (context, options) => {
+        const ticker = options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg);
+        return ticker
           ? {
-            title: context.activeTicker,
-            binding: { kind: "fixed", symbol: context.activeTicker },
+            title: ticker,
+            binding: { kind: "fixed", symbol: ticker },
             placement: "floating",
           }
-          : null
-      ),
+          : null;
+      },
     },
   ],
 };

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -1825,7 +1825,7 @@ export const ibkrPlugin: GloomPlugin = {
       label: "New IBKR Trading Pane",
       description: "Open another floating IBKR trading console",
       keywords: ["new", "ibkr", "trading", "status", "orders", "pane"],
-      canCreate: (context) => getIbkrInstances(context.config).length > 0,
+      canCreate: (context) => getConfiguredIbkrGatewayInstances(context.config).length > 0,
       createInstance: () => ({ placement: "floating" }),
     },
   ],

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -16,6 +16,7 @@ import type {
   GloomSlots,
   KeyboardShortcut,
   PaneDef,
+  PaneTemplateCreateOptions,
   PaneTemplateDef,
   PluginStorage,
   PluginResumeState,
@@ -96,7 +97,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   switchTabFn: ((tabId: string, paneId?: string) => void) = () => {};
   openCommandBarFn: ((query?: string) => void) = () => {};
   showPaneFn: ((paneId: string) => void) = () => {};
-  createPaneFromTemplateFn: ((templateId: string) => void) = () => {};
+  createPaneFromTemplateFn: ((templateId: string, options?: PaneTemplateCreateOptions) => void) = () => {};
   hidePaneFn: ((paneId: string) => void) = () => {};
   focusPaneFn: ((paneId: string) => void) = () => {};
   pinTickerFn: ((symbol: string, options?: { floating?: boolean; paneType?: string }) => void) = () => {};
@@ -410,7 +411,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
       switchTab: (tabId, paneId) => this.switchTabFn(tabId, paneId),
       openCommandBar: (query) => this.openCommandBarFn(query),
       showPane: (paneId) => this.showPaneFn(paneId),
-      createPaneFromTemplate: (templateId) => this.createPaneFromTemplateFn(templateId),
+      createPaneFromTemplate: (templateId, options) => this.createPaneFromTemplateFn(templateId, options),
       hidePane: (paneId) => this.hidePaneFn(paneId),
       focusPane: (paneId) => this.focusPaneFn(paneId),
       pinTicker: (symbol, options) => this.pinTickerFn(symbol, options),

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -14,6 +14,7 @@ import type { DataProvider } from "./data-provider";
 import type { TickerFinancials } from "./financials";
 import type { CachePolicy, PersistedResourceValue } from "./persistence";
 import type { TickerRecord } from "./ticker";
+import type { InstrumentSearchResult } from "./instrument";
 
 export interface GloomSlots {
   "detail:tab": { ticker: TickerRecord; financials: TickerFinancials | null };
@@ -55,6 +56,18 @@ export interface PaneTemplateContext {
   activeCollectionId: string | null;
 }
 
+export interface PaneTemplateShortcut {
+  prefix: string;
+  argPlaceholder?: string;
+}
+
+export interface PaneTemplateCreateOptions {
+  arg?: string;
+  symbol?: string | null;
+  ticker?: TickerRecord | null;
+  searchResult?: InstrumentSearchResult | null;
+}
+
 export interface PaneTemplateInstanceConfig {
   title?: string;
   binding?: PaneBinding;
@@ -70,9 +83,11 @@ export interface PaneTemplateDef {
   label: string;
   description: string;
   keywords?: string[];
-  canCreate?: (context: PaneTemplateContext) => boolean;
+  shortcut?: PaneTemplateShortcut;
+  canCreate?: (context: PaneTemplateContext, options?: PaneTemplateCreateOptions) => boolean;
   createInstance?: (
     context: PaneTemplateContext,
+    options?: PaneTemplateCreateOptions,
   ) => PaneTemplateInstanceConfig | null | Promise<PaneTemplateInstanceConfig | null>;
 }
 
@@ -213,7 +228,7 @@ export interface GloomPluginContext {
   switchTab(tabId: string, paneId?: string): void;
   openCommandBar(query?: string): void;
   showPane(paneId: string): void;
-  createPaneFromTemplate(templateId: string): void;
+  createPaneFromTemplate(templateId: string, options?: PaneTemplateCreateOptions): void;
   hidePane(paneId: string): void;
   focusPane(paneId: string): void;
   pinTicker(symbol: string, options?: { floating?: boolean; paneType?: string }): void;

--- a/src/utils/ticker-search.test.ts
+++ b/src/utils/ticker-search.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import type { DataProvider } from "../types/data-provider";
+import type { InstrumentSearchResult } from "../types/instrument";
+import type { TickerRecord } from "../types/ticker";
+import {
+  createLocalTickerSearchCandidates,
+  findExactTickerSearchMatch,
+  normalizeTickerInput,
+  resolveTickerSearch,
+  searchTickerCandidates,
+  upsertTickerFromSearchResult,
+} from "./ticker-search";
+
+function makeTicker(symbol: string, name = symbol): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function makeSearchResult(symbol: string, name = symbol): InstrumentSearchResult {
+  return {
+    providerId: "test",
+    symbol,
+    name,
+    exchange: "NASDAQ",
+    type: "EQUITY",
+  };
+}
+
+function makeDataProvider(results: InstrumentSearchResult[]): DataProvider {
+  return {
+    id: "test",
+    name: "Test Provider",
+    getTickerFinancials: async () => { throw new Error("unused"); },
+    getQuote: async () => { throw new Error("unused"); },
+    getExchangeRate: async () => 1,
+    search: async () => results,
+    getNews: async () => [],
+    getArticleSummary: async () => null,
+    getPriceHistory: async () => [],
+  };
+}
+
+describe("ticker-search utilities", () => {
+  test("normalizes explicit and focused ticker inputs", () => {
+    expect(normalizeTickerInput("AAPL", undefined)).toBe("AAPL");
+    expect(normalizeTickerInput("AAPL", " msft ")).toBe("MSFT");
+    expect(normalizeTickerInput(null, undefined)).toBeNull();
+  });
+
+  test("finds exact provider matches for direct ticker resolution", async () => {
+    const tickers = new Map<string, TickerRecord>([["AAPL", makeTicker("AAPL", "Apple")]]);
+    const resolved = await resolveTickerSearch({
+      query: "MSFT",
+      activeTicker: null,
+      tickers,
+      dataProvider: makeDataProvider([
+        makeSearchResult("MSFT", "Microsoft"),
+        makeSearchResult("MSFTW", "Microsoft Warrants"),
+      ]),
+    });
+
+    expect(resolved).toMatchObject({
+      kind: "provider",
+      symbol: "MSFT",
+    });
+  });
+
+  test("combines local and provider candidates without duplicate open symbols", async () => {
+    const tickers = new Map<string, TickerRecord>([["AAPL", makeTicker("AAPL", "Apple")]]);
+    const results = await searchTickerCandidates({
+      query: "appl",
+      tickers,
+      dataProvider: makeDataProvider([
+        makeSearchResult("AAPL", "Apple Inc"),
+        makeSearchResult("APP", "AppLovin"),
+      ]),
+    });
+
+    expect(results.map((item) => item.id)).toEqual(["goto:AAPL", "search:APP"]);
+    expect(findExactTickerSearchMatch(results, "AAPL")?.id).toBe("goto:AAPL");
+  });
+
+  test("upserts ticker records from provider search results", async () => {
+    const saved: TickerRecord[] = [];
+    const repository = {
+      loadTicker: async () => null,
+      createTicker: async (metadata: TickerRecord["metadata"]) => ({ metadata }),
+      saveTicker: async (ticker: TickerRecord) => {
+        saved.push(ticker);
+      },
+    };
+
+    const { ticker, created } = await upsertTickerFromSearchResult(repository as any, {
+      providerId: "test",
+      symbol: "NVDA",
+      name: "NVIDIA",
+      exchange: "NASDAQ",
+      type: "EQUITY",
+      currency: "USD",
+    });
+
+    expect(created).toBe(true);
+    expect(ticker.metadata.ticker).toBe("NVDA");
+    expect(saved).toHaveLength(0);
+  });
+
+  test("exposes local ticker candidates in open category", () => {
+    expect(createLocalTickerSearchCandidates([makeTicker("TSLA", "Tesla")])).toEqual([
+      expect.objectContaining({
+        id: "goto:TSLA",
+        label: "TSLA",
+        category: "Open",
+        kind: "ticker",
+      }),
+    ]);
+  });
+});

--- a/src/utils/ticker-search.ts
+++ b/src/utils/ticker-search.ts
@@ -1,0 +1,286 @@
+import type { SearchRequestContext, DataProvider } from "../types/data-provider";
+import type { InstrumentSearchResult } from "../types/instrument";
+import type { TickerRecord } from "../types/ticker";
+import type { TickerMetadata } from "../types/ticker";
+import type { TickerRepository } from "../data/ticker-repository";
+
+export interface TickerSearchRankableItem {
+  id: string;
+  label: string;
+  detail: string;
+  kind: string;
+  category: string;
+  right?: string;
+}
+
+export interface TickerSearchCandidate {
+  id: string;
+  label: string;
+  detail: string;
+  right?: string;
+  category: "Open" | "Search Results";
+  kind: "ticker" | "search";
+  ticker?: TickerRecord;
+  result?: InstrumentSearchResult;
+}
+
+export type ResolvedTickerSearch =
+  | { kind: "local"; symbol: string; ticker: TickerRecord }
+  | { kind: "provider"; symbol: string; result: InstrumentSearchResult };
+
+export function normalizeTickerInput(activeTicker: string | null, arg?: string): string | null {
+  const explicitTicker = arg?.trim().toUpperCase();
+  if (explicitTicker) return explicitTicker;
+  return activeTicker;
+}
+
+export function createLocalTickerSearchCandidates(tickers: Iterable<TickerRecord>): TickerSearchCandidate[] {
+  return Array.from(tickers).map((ticker) => ({
+    id: `goto:${ticker.metadata.ticker}`,
+    label: ticker.metadata.ticker,
+    detail: ticker.metadata.name,
+    right: ticker.metadata.exchange,
+    category: "Open",
+    kind: "ticker",
+    ticker,
+  }));
+}
+
+export function createProviderTickerSearchCandidates(
+  searchResults: InstrumentSearchResult[],
+  localTickers: ReadonlyMap<string, TickerRecord>,
+): TickerSearchCandidate[] {
+  return searchResults.map((result) => {
+    const symbol = result.brokerContract?.localSymbol || result.symbol.split(".")[0]!;
+    const isExisting = localTickers.has(symbol);
+    return {
+      id: `search:${result.symbol}`,
+      label: symbol,
+      detail: [result.name, result.brokerLabel, result.type || result.exchange].filter(Boolean).join(" | "),
+      right: result.exchange || result.type || undefined,
+      category: isExisting ? "Open" : "Search Results",
+      kind: "search",
+      result,
+    };
+  });
+}
+
+export async function searchTickerCandidates({
+  query,
+  tickers,
+  dataProvider,
+  searchContext,
+  localLimit = 6,
+  totalLimit = 8,
+}: {
+  query: string;
+  tickers: ReadonlyMap<string, TickerRecord>;
+  dataProvider: DataProvider;
+  searchContext?: SearchRequestContext;
+  localLimit?: number;
+  totalLimit?: number;
+}): Promise<TickerSearchCandidate[]> {
+  const localItems = rankTickerSearchItems(
+    createLocalTickerSearchCandidates(tickers.values()),
+    query,
+  ).slice(0, localLimit);
+  const providerItems = createProviderTickerSearchCandidates(
+    await dataProvider.search(query, searchContext),
+    tickers,
+  );
+  return rankTickerSearchItems([...localItems, ...providerItems], query).slice(0, totalLimit);
+}
+
+export async function resolveTickerSearch({
+  query,
+  activeTicker,
+  tickers,
+  dataProvider,
+  searchContext,
+}: {
+  query?: string;
+  activeTicker: string | null;
+  tickers: ReadonlyMap<string, TickerRecord>;
+  dataProvider: DataProvider;
+  searchContext?: SearchRequestContext;
+}): Promise<ResolvedTickerSearch | null> {
+  const symbol = normalizeTickerInput(activeTicker, query);
+  if (!symbol) return null;
+
+  const local = tickers.get(symbol);
+  if (local) {
+    return { kind: "local", symbol: local.metadata.ticker, ticker: local };
+  }
+
+  const providerItems = createProviderTickerSearchCandidates(
+    await dataProvider.search(symbol, searchContext),
+    tickers,
+  );
+  const exactMatch = findExactTickerSearchMatch(providerItems, symbol);
+  if (!exactMatch?.result) return null;
+
+  return {
+    kind: "provider",
+    symbol: exactMatch.label,
+    result: exactMatch.result,
+  };
+}
+
+export async function upsertTickerFromSearchResult(
+  tickerRepository: TickerRepository,
+  result: InstrumentSearchResult,
+): Promise<{ ticker: TickerRecord; created: boolean }> {
+  const symbol = result.brokerContract?.localSymbol || result.symbol.split(".")[0]!;
+  let ticker = await tickerRepository.loadTicker(symbol);
+  const created = !ticker;
+
+  if (!ticker) {
+    const metadata: TickerMetadata = {
+      ticker: symbol,
+      exchange: result.exchange,
+      currency: result.currency || result.brokerContract?.currency || "USD",
+      name: result.name,
+      assetCategory: result.brokerContract?.secType || result.type || undefined,
+      broker_contracts: result.brokerContract ? [result.brokerContract] : [],
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    };
+    ticker = await tickerRepository.createTicker(metadata);
+  } else {
+    ticker.metadata.name = ticker.metadata.name || result.name;
+    ticker.metadata.exchange = ticker.metadata.exchange || result.exchange;
+    ticker.metadata.currency = ticker.metadata.currency || result.currency || "USD";
+    ticker.metadata.assetCategory = ticker.metadata.assetCategory || result.brokerContract?.secType || result.type || undefined;
+    const existingContracts = ticker.metadata.broker_contracts ?? [];
+    if (result.brokerContract) {
+      const nextContracts = [...existingContracts];
+      const hasContract = nextContracts.some((contract) =>
+        contract.brokerId === result.brokerContract!.brokerId
+        && contract.brokerInstanceId === result.brokerContract!.brokerInstanceId
+        && contract.conId === result.brokerContract!.conId
+        && contract.localSymbol === result.brokerContract!.localSymbol
+      );
+      if (!hasContract) nextContracts.push(result.brokerContract);
+      ticker.metadata.broker_contracts = nextContracts;
+    }
+    await tickerRepository.saveTicker(ticker);
+  }
+
+  return { ticker, created };
+}
+
+export function findExactTickerSearchMatch<T extends Pick<TickerSearchRankableItem, "label">>(
+  items: T[],
+  query: string,
+): T | null {
+  const normalizedQuery = query.trim().toUpperCase();
+  if (!normalizedQuery) return null;
+  return items.find((item) => item.label.toUpperCase() === normalizedQuery) ?? null;
+}
+
+export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "id" | "label" | "detail" | "kind" | "category" | "right">>(
+  items: T[],
+  query: string,
+): T[] {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery) return items;
+
+  const openSymbols = new Set(
+    items
+      .filter((item) => item.kind === "ticker" || item.category === "Open")
+      .map((item) => normalizeSearchText(item.label)),
+  );
+
+  const ranked = items
+    .map((item, index) => {
+      const normalizedLabel = normalizeSearchText(item.label);
+      const normalizedDetail = normalizeSearchText(item.detail);
+      const normalizedRight = normalizeSearchText(item.right || "");
+      const labelScore = scoreSearchField(normalizedQuery, normalizedLabel, {
+        exact: 24_000,
+        prefix: 18_000,
+        substring: 14_000,
+        fuzzy: 7_000,
+      });
+      const detailScore = Math.max(
+        scoreSearchField(normalizedQuery, normalizedDetail, {
+          exact: 4_500,
+          prefix: 3_800,
+          substring: 2_600,
+          fuzzy: 600,
+        }),
+        scoreSearchField(normalizedQuery, normalizedRight, {
+          exact: 1_200,
+          prefix: 1_000,
+          substring: 700,
+          fuzzy: 100,
+        }),
+      );
+      const isOpenItem = item.kind === "ticker" || item.category === "Open";
+      const matchScore = labelScore + detailScore;
+
+      return {
+        item,
+        index,
+        normalizedLabel,
+        matchScore,
+        score: matchScore + (matchScore > 0 && isOpenItem ? 900 : 0),
+      };
+    })
+    .filter(({ item, normalizedLabel, matchScore }) => {
+      if (matchScore <= 0) return false;
+      if (item.kind !== "search") return true;
+      return !openSymbols.has(normalizedLabel);
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      const aOpen = a.item.kind === "ticker" || a.item.category === "Open";
+      const bOpen = b.item.kind === "ticker" || b.item.category === "Open";
+      if (aOpen !== bOpen) return aOpen ? -1 : 1;
+      if (a.item.label.length !== b.item.label.length) return a.item.label.length - b.item.label.length;
+      return a.index - b.index;
+    });
+
+  const deduped: T[] = [];
+  const seen = new Set<string>();
+  for (const entry of ranked) {
+    const key = getTickerSearchDedupKey(entry.item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(entry.item);
+  }
+  return deduped;
+}
+
+function normalizeSearchText(text: string): string {
+  return text.trim().toUpperCase().replace(/[^A-Z0-9]+/g, " ");
+}
+
+function scoreSearchField(query: string, value: string, weights: { exact: number; prefix: number; substring: number; fuzzy: number }): number {
+  if (!query || !value) return 0;
+  if (value === query) return weights.exact - value.length;
+  if (value.startsWith(query)) return weights.prefix - value.length;
+
+  const substringIndex = value.indexOf(query);
+  if (substringIndex >= 0) {
+    return weights.substring - substringIndex * 25 - value.length;
+  }
+
+  let qi = 0;
+  let score = 0;
+  for (let i = 0; i < value.length && qi < query.length; i++) {
+    if (value[i] !== query[qi]) continue;
+    score += i === 0 || value[i - 1] === " " ? 10 : 2;
+    qi += 1;
+  }
+  return qi === query.length ? weights.fuzzy + score : 0;
+}
+
+function getTickerSearchDedupKey(item: Pick<TickerSearchRankableItem, "id" | "kind" | "label" | "detail" | "right">): string {
+  if (item.kind !== "ticker" && item.kind !== "search") return item.id;
+  const qualifier = normalizeSearchText(item.right || item.detail.split("|").at(-1) || "");
+  return `${normalizeSearchText(item.label)}|${qualifier}`;
+}


### PR DESCRIPTION
Adds a shared ticker search/resolution utility and threads pane-template creation through resolved ticker context so ticker-driven panes can accept shortcut args like "QQ MSFT" or fall back to the focused ticker.
Updates the command bar to surface pane shortcuts in browse/search results, execute direct pane shortcut queries, and push danger/debug sections to the end of the list.
Adds pane shortcuts for "PF", "QQ", "NOTE", and "CHAT", updates tests and snapshots, and fixes the IBKR pane-template gate to use configured gateway instances.