### PR TITLE
Guard pane template crashes in command bar

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -85,10 +85,23 @@ import {
 } from "./state/session-persistence";
 import { initializeAppState } from "./state/app-bootstrap";
 import { TickerRefreshQueue } from "./state/ticker-refresh-queue";
+import { debugLog } from "./utils/debug-log";
 
 /** Global-level dedup: prevents concurrent refresh calls for the same symbol. */
 const refreshInFlight: Set<string> = (globalThis as any).__refreshInFlight ??= new Set<string>();
 const PANEL_RESOLUTION_BOUNDS = { x: 0, y: 0, width: 120, height: 40 };
+const appLog = debugLog.createLogger("app");
+
+function summarizeError(error: unknown): Record<string, string> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack || "",
+    };
+  }
+  return { message: String(error) };
+}
 
 interface AppInnerProps {
   pluginRegistry: PluginRegistry;
@@ -945,9 +958,22 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
       ...baseContext,
       activeTicker: resolvedOptions?.symbol ?? baseContext.activeTicker,
     };
-    if (template.canCreate && !template.canCreate(context, resolvedOptions)) {
-      pluginRegistry.showToastFn(`Can't create ${template.label.toLowerCase()} right now.`, { type: "info" });
-      return;
+    if (template.canCreate) {
+      try {
+        if (!template.canCreate(context, resolvedOptions)) {
+          pluginRegistry.showToastFn(`Can't create ${template.label.toLowerCase()} right now.`, { type: "info" });
+          return;
+        }
+      } catch (error) {
+        appLog.error("Pane template canCreate failed during creation", {
+          templateId: template.id,
+          pluginId: pluginRegistry.getPaneTemplatePluginId(template.id),
+          options: resolvedOptions,
+          error: summarizeError(error),
+        });
+        pluginRegistry.showToastFn(`Can't create ${template.label.toLowerCase()} right now.`, { type: "info" });
+        return;
+      }
     }
 
     const spec = await template.createInstance?.(context, resolvedOptions) ?? {};

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -158,6 +158,7 @@ function CommandBarHarness({
   live = false,
   configureConfig,
   configureState,
+  configurePluginRegistry,
   dataProvider = makeDataProvider(),
 }: {
   query: string;
@@ -166,6 +167,7 @@ function CommandBarHarness({
   live?: boolean;
   configureConfig?: (config: AppConfig) => AppConfig;
   configureState?: (state: AppState) => AppState;
+  configurePluginRegistry?: (pluginRegistry: PluginRegistry) => void;
   dataProvider?: DataProvider;
 }) {
   let config = {
@@ -203,6 +205,7 @@ function CommandBarHarness({
     saveTicker: async () => {},
   };
   const pluginRegistry = makePluginRegistry();
+  configurePluginRegistry?.(pluginRegistry);
   const [liveState, dispatch] = useReducer(appReducer, state);
 
   return (
@@ -381,6 +384,34 @@ describe("CommandBar", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Quote Monitor");
     expect(frame).toContain("QQ");
+  });
+
+  test("skips pane templates whose canCreate throws", async () => {
+    testSetup = await testRender(<CommandBarHarness
+      query=""
+      selectedTicker="AAPL"
+      configurePluginRegistry={(pluginRegistry) => {
+        pluginRegistry.paneTemplates.set("broken-pane", {
+          id: "broken-pane",
+          paneId: "chat",
+          label: "Broken Pane",
+          description: "Should not crash the command bar",
+          shortcut: { prefix: "IBKR" },
+          canCreate: () => {
+            throw new ReferenceError("getIbkrInstances is not defined");
+          },
+        });
+      }}
+    />, {
+      width: 100,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Quote Monitor");
+    expect(frame).not.toContain("Broken Pane");
   });
 
   test("groups ticker search sections and keeps exact open matches above loose provider results", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -59,6 +59,7 @@ import {
   searchTickerCandidates,
   type TickerSearchCandidate,
 } from "../../utils/ticker-search";
+import { debugLog } from "../../utils/debug-log";
 
 /** All available columns that can be toggled */
 const ALL_COLUMNS: ColumnConfig[] = [
@@ -106,6 +107,19 @@ interface ResultItem {
 interface PaneShortcutMatch {
   template: PaneTemplateDef;
   arg: string;
+}
+
+const commandBarLog = debugLog.createLogger("command-bar");
+
+function summarizeError(error: unknown): Record<string, string> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack || "",
+    };
+  }
+  return { message: String(error) };
 }
 
 // --- Wizard dialog content components ---
@@ -1022,7 +1036,18 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
       .filter((template) => {
         const pluginId = pluginRegistry.getPaneTemplatePluginId(template.id);
         if (pluginId && disabledPlugins.has(pluginId)) return false;
-        return !template.canCreate || template.canCreate(context, options);
+        if (!template.canCreate) return true;
+        try {
+          return template.canCreate(context, options);
+        } catch (error) {
+          commandBarLog.error("Pane template canCreate failed", {
+            templateId: template.id,
+            pluginId,
+            options,
+            error: summarizeError(error),
+          });
+          return false;
+        }
       });
   }, [getPaneTemplateContext, pluginRegistry, state.config.disabledPlugins]);
 


### PR DESCRIPTION
## Summary
A broken pane template `canCreate` hook now gets caught and logged instead of crashing the command bar.
The direct pane creation path in `app.tsx` now applies the same guard and falls back to the existing user-facing toast when a template cannot be created.
The command bar test suite adds a regression case that injects a throwing pane template and verifies the rest of the pane shortcuts still render.