### PR TITLE
Add company descriptions to ticker overview

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -334,6 +334,7 @@ async function ticker(symbol: string) {
 
   const q = financials.quote;
   const f = financials.fundamentals;
+  const profile = financials.profile;
 
   if (!q) {
     console.error(`No quote data for ${symbol}`);
@@ -350,6 +351,15 @@ async function ticker(symbol: string) {
   if (q.marketState) parts.push(`Market: ${q.marketState}`);
   console.log(parts.join("    "));
 
+  const sector = tickerFile?.metadata.sector ?? profile?.sector;
+  const industry = tickerFile?.metadata.industry ?? profile?.industry;
+  if (sector || industry) {
+    const classification = [];
+    if (sector) classification.push(`Sector: ${sector}`);
+    if (industry) classification.push(`Industry: ${industry}`);
+    console.log(classification.join("    "));
+  }
+
   // Price
   console.log(`\nPrice:     ${formatCurrency(q.price, q.currency)}  (${formatPercentRaw(q.changePercent)})`);
   if (q.high52w != null || q.low52w != null) {
@@ -362,6 +372,10 @@ async function ticker(symbol: string) {
   }
   if (q.postMarketPrice != null) {
     console.log(`Post-Mkt:  ${formatCurrency(q.postMarketPrice, q.currency)}  (${formatPercentRaw(q.postMarketChangePercent)})`);
+  }
+
+  if (profile?.description) {
+    console.log(`\nDescription:\n${profile.description}`);
   }
 
   // Fundamentals

--- a/src/plugins/builtin/ask-ai.tsx
+++ b/src/plugins/builtin/ask-ai.tsx
@@ -67,14 +67,18 @@ function buildContext(ticker: TickerRecord, financials: TickerFinancials | null)
   const f = ticker.metadata;
   const q = financials?.quote;
   const fund = financials?.fundamentals;
+  const profile = financials?.profile;
+  const sector = f.sector ?? profile?.sector;
+  const industry = f.industry ?? profile?.industry;
 
   const lines: string[] = [
     `Company: ${f.name} (${f.ticker})`,
     `Exchange: ${f.exchange}`,
   ];
 
-  if (f.sector) lines.push(`Sector: ${f.sector}`);
-  if (f.industry) lines.push(`Industry: ${f.industry}`);
+  if (sector) lines.push(`Sector: ${sector}`);
+  if (industry) lines.push(`Industry: ${industry}`);
+  if (profile?.description) lines.push(`Description: ${profile.description}`);
 
   if (q) {
     lines.push(`Current Price: ${formatCurrency(q.price, q.currency)} (${q.change >= 0 ? "+" : ""}${q.changePercent.toFixed(2)}%)`);

--- a/src/plugins/builtin/ticker-detail.test.tsx
+++ b/src/plugins/builtin/ticker-detail.test.tsx
@@ -333,6 +333,29 @@ describe("TickerDetailPane", () => {
     expect(frame).toContain("Options");
   });
 
+  test("renders the company description in Overview when profile data is available", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setSharedDataProviderForTests(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={makeFinancials({
+          profile: {
+            description: "Builds widgets for industrial customers.",
+          },
+        })}
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Description");
+    expect(frame).toContain("Builds widgets for industrial customers.");
+  });
+
   test("falls back to Overview when a hidden active tab becomes unavailable", async () => {
     const gatewayConfig = createDetailConfig("AAPL", [createGatewayInstance()]);
     const noGatewayConfig = createDetailConfig("AAPL");

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -148,6 +148,10 @@ function OverviewTab({ width }: { width?: number }) {
 
   const q = financials?.quote;
   const f = financials?.fundamentals;
+  const profile = financials?.profile;
+  const sector = ticker.metadata.sector ?? profile?.sector;
+  const industry = ticker.metadata.industry ?? profile?.industry;
+  const description = profile?.description?.trim();
 
   const chartWidth = Math.max((width || Math.floor(termWidth * 0.5)) - 4, 20);
   const hasHistory = (financials?.priceHistory?.length ?? 0) > 2;
@@ -247,17 +251,27 @@ function OverviewTab({ width }: { width?: number }) {
           />
         </box>
 
+        {/* Company description */}
+        {description && (
+          <box flexDirection="column" paddingTop={1}>
+            <box height={1}>
+              <text attributes={TextAttributes.BOLD} fg={colors.textBright}>Description</text>
+            </box>
+            <text fg={colors.text}>{description}</text>
+          </box>
+        )}
+
         {/* Sector / classification */}
-        {(ticker.metadata.sector || ticker.metadata.industry || ticker.metadata.assetCategory || ticker.metadata.isin) && (
+        {(sector || industry || ticker.metadata.assetCategory || ticker.metadata.isin) && (
           <box flexDirection="column">
             {ticker.metadata.assetCategory && (
               <FieldRow label="Type" value={ticker.metadata.assetCategory} />
             )}
-            {ticker.metadata.sector && (
-              <FieldRow label="Sector" value={ticker.metadata.sector} />
+            {sector && (
+              <FieldRow label="Sector" value={sector} />
             )}
-            {ticker.metadata.industry && (
-              <FieldRow label="Industry" value={ticker.metadata.industry} />
+            {industry && (
+              <FieldRow label="Industry" value={industry} />
             )}
             {ticker.metadata.isin && (
               <FieldRow label="ISIN" value={ticker.metadata.isin} />

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -378,6 +378,190 @@ describe("ProviderRouter", () => {
     persistence.close();
   });
 
+  test("preserves fallback profile data when broker already has fundamentals", async () => {
+    const router = new ProviderRouter({
+      ...fallbackProvider,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          profile: {
+            description: "Builds hardware and software.",
+            sector: "Technology",
+            industry: "Consumer Electronics",
+          },
+        };
+      },
+    });
+    const broker: BrokerAdapter = {
+      id: "ibkr",
+      name: "IBKR",
+      configSchema: [],
+      async validate() {
+        return true;
+      },
+      async importPositions() {
+        return [];
+      },
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          fundamentals: { revenue: 1000, netIncome: 200 },
+        };
+      },
+    };
+
+    router.attachRegistry({
+      brokers: new Map([["ibkr", broker]]),
+      dataProviders: new Map(),
+    } as any);
+    router.setConfigAccessor(() => ({
+      dataDir: "",
+      configVersion: CURRENT_CONFIG_VERSION,
+      baseCurrency: "USD",
+      refreshIntervalMinutes: 30,
+      portfolios: [],
+      watchlists: [],
+      columns: [],
+      layout: cloneLayout(DEFAULT_LAYOUT),
+      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
+      activeLayoutIndex: 0,
+      brokerInstances: [{
+        id: "ibkr-work",
+        brokerType: "ibkr",
+        label: "Work",
+        connectionMode: "gateway",
+        config: {},
+        enabled: true,
+      }],
+      plugins: [],
+      disabledPlugins: [],
+      theme: "amber",
+      chartPreferences: {
+        defaultRenderMode: "area",
+        renderer: "auto",
+      },
+      recentTickers: [],
+    }));
+
+    const merged = await router.getTickerFinancials("AAPL", "NASDAQ", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+    });
+    expect(merged.fundamentals?.revenue).toBe(1000);
+    expect(merged.profile?.description).toBe("Builds hardware and software.");
+    expect(merged.profile?.sector).toBe("Technology");
+  });
+
+  test("refreshes missing profile data even when cached financials exist", async () => {
+    const dbPath = createTempDbPath("cache-profile-refresh");
+    const persistence = new AppPersistence(dbPath);
+
+    const broker: BrokerAdapter = {
+      id: "ibkr",
+      name: "IBKR",
+      configSchema: [],
+      async validate() {
+        return true;
+      },
+      async importPositions() {
+        return [];
+      },
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          fundamentals: { revenue: 1000, netIncome: 200 },
+        };
+      },
+    };
+
+    const config = {
+      dataDir: "",
+      configVersion: CURRENT_CONFIG_VERSION,
+      baseCurrency: "USD",
+      refreshIntervalMinutes: 30,
+      portfolios: [],
+      watchlists: [],
+      columns: [],
+      layout: cloneLayout(DEFAULT_LAYOUT),
+      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
+      activeLayoutIndex: 0,
+      brokerInstances: [{
+        id: "ibkr-work",
+        brokerType: "ibkr",
+        label: "Work",
+        connectionMode: "gateway",
+        config: {},
+        enabled: true,
+      }],
+      plugins: [],
+      disabledPlugins: [],
+      theme: "amber",
+      chartPreferences: {
+        defaultRenderMode: "area",
+        renderer: "auto",
+      },
+      recentTickers: [],
+    };
+
+    const seedRouter = new ProviderRouter({
+      ...fallbackProvider,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+        };
+      },
+    }, [], persistence.resources);
+    seedRouter.attachRegistry({
+      brokers: new Map([["ibkr", broker]]),
+      dataProviders: new Map(),
+    } as any);
+    seedRouter.setConfigAccessor(() => config);
+
+    const seeded = await seedRouter.getTickerFinancials("PSTG", "NYSE", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+    });
+    expect(seeded.profile).toBeUndefined();
+
+    const refreshedRouter = new ProviderRouter({
+      ...fallbackProvider,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          profile: {
+            description: "Provides enterprise data storage platforms.",
+            sector: "Technology",
+            industry: "Computer Hardware",
+          },
+        };
+      },
+    }, [], persistence.resources);
+    refreshedRouter.attachRegistry({
+      brokers: new Map([["ibkr", broker]]),
+      dataProviders: new Map(),
+    } as any);
+    refreshedRouter.setConfigAccessor(() => config);
+
+    const refreshed = await refreshedRouter.getTickerFinancials("PSTG", "NYSE", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+    });
+    expect(refreshed.fundamentals?.revenue).toBe(1000);
+    expect(refreshed.profile?.description).toBe("Provides enterprise data storage platforms.");
+
+    persistence.close();
+  });
+
   test("does not log expected provider misses for missing chart data", async () => {
     const noisyProvider: DataProvider = {
       ...fallbackProvider,

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -100,8 +100,21 @@ function hasMeaningfulFundamentals(data: TickerFinancials | null | undefined): b
   return !!data && Object.keys(data.fundamentals ?? {}).length > 0;
 }
 
+function hasMeaningfulProfile(data: TickerFinancials | null | undefined): boolean {
+  return !!data && !!(
+    data.profile?.description
+    || data.profile?.sector
+    || data.profile?.industry
+  );
+}
+
 function mergeFinancials(primary: TickerFinancials | null, fallback: TickerFinancials | null): TickerFinancials | null {
-  if (primary && hasMeaningfulFundamentals(primary)) return primary;
+  if (primary && hasMeaningfulFundamentals(primary)) {
+    if (!primary.profile && fallback?.profile) {
+      return { ...primary, profile: fallback.profile };
+    }
+    return primary;
+  }
   if (primary && fallback) {
     return {
       ...fallback,
@@ -186,6 +199,10 @@ export class ProviderRouter implements DataProvider {
   async getTickerFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<TickerFinancials> {
     const cached = this.readCachedMergedFinancials(ticker, exchange, context, false);
     if (cached) {
+      if (!hasMeaningfulProfile(cached)) {
+        const providerResult = await this.fetchProviderFinancials(ticker, exchange, context);
+        return mergeFinancials(cached, providerResult?.value ?? null) ?? cached;
+      }
       this.scheduleRevalidation(this.makeRevalidationKey("financials", ticker, exchange, context), async () => {
         await this.revalidateFinancials(ticker, exchange, context);
       });
@@ -932,7 +949,7 @@ export class ProviderRouter implements DataProvider {
 
   private async revalidateFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<void> {
     const brokerResult = await withBrokerTimeout(this.fetchBrokerFinancials(ticker, exchange, context));
-    const needsProvider = !brokerResult || !hasMeaningfulFundamentals(brokerResult.value);
+    const needsProvider = !brokerResult || !hasMeaningfulFundamentals(brokerResult.value) || !hasMeaningfulProfile(brokerResult.value);
     if (needsProvider) {
       await this.fetchProviderFinancials(ticker, exchange, context);
     }

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -1,4 +1,4 @@
-import type { Quote, Fundamentals, FinancialStatement, PricePoint, TickerFinancials, MarketState, OptionContract, OptionsChain } from "../types/financials";
+import type { Quote, Fundamentals, FinancialStatement, PricePoint, TickerFinancials, MarketState, OptionContract, OptionsChain, CompanyProfile } from "../types/financials";
 import type { DataProvider, MarketDataRequestContext, NewsItem } from "../types/data-provider";
 import type { TimeRange } from "../components/chart/chart-types";
 import type { InstrumentSearchResult } from "../types/instrument";
@@ -136,6 +136,18 @@ type ChartResult = {
 
 type ChartResponse = { chart?: { result?: ChartResult[]; error?: { description?: string } | null } };
 type TimeseriesResponse = { timeseries?: { result?: Array<Record<string, any>>; error?: { description?: string } | null } };
+type QuoteSummaryResponse = {
+  quoteSummary?: {
+    result?: Array<{
+      assetProfile?: {
+        longBusinessSummary?: string;
+        sector?: string;
+        industry?: string;
+      };
+    }>;
+    error?: { description?: string } | null;
+  };
+};
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -463,6 +475,22 @@ export class YahooFinanceClient implements DataProvider {
     return data.timeseries?.result || [];
   }
 
+  private async fetchAssetProfile(symbol: string): Promise<CompanyProfile | undefined> {
+    const params = new URLSearchParams({ modules: "assetProfile" });
+    const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
+    const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(`asset profile ${symbol}`, url);
+    const profile = data.quoteSummary?.result?.[0]?.assetProfile;
+    if (!profile) return undefined;
+
+    const normalized: CompanyProfile = {
+      description: profile.longBusinessSummary?.trim() || undefined,
+      sector: profile.sector?.trim() || undefined,
+      industry: profile.industry?.trim() || undefined,
+    };
+
+    return normalized.description || normalized.sector || normalized.industry ? normalized : undefined;
+  }
+
   private parseTimeseries(results: Array<Record<string, any>>) {
     const parsed: Record<string, Array<{ asOfDate: string; periodType?: string; value: number }>> = {};
     for (const result of results) {
@@ -507,13 +535,14 @@ export class YahooFinanceClient implements DataProvider {
   }
 
   private async fetchFullFinancials(symbol: string): Promise<TickerFinancials> {
-    const [chart, tsRaw] = await Promise.all([
+    const [chart, tsRaw, profile] = await Promise.all([
       this.fetchChart(symbol, "5y"),
       this.fetchTimeseries(symbol, [
         ...TIMESERIES_TYPES.annual,
         ...TIMESERIES_TYPES.quarterly,
         ...TIMESERIES_TYPES.trailing,
       ]),
+      this.fetchAssetProfile(symbol).catch(() => undefined),
     ]);
 
     const { meta, history } = chart;
@@ -649,6 +678,7 @@ export class YahooFinanceClient implements DataProvider {
     return {
       quote,
       fundamentals,
+      profile,
       annualStatements: buildStatements("annual"),
       quarterlyStatements: buildStatements("quarterly"),
       priceHistory: history,

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -54,6 +54,12 @@ export interface Fundamentals {
   sharesOutstanding?: number;
 }
 
+export interface CompanyProfile {
+  description?: string;
+  sector?: string;
+  industry?: string;
+}
+
 export interface FinancialStatement {
   date: string;
   // Income Statement
@@ -104,6 +110,7 @@ export interface PricePoint {
 export interface TickerFinancials {
   quote?: Quote;
   fundamentals?: Fundamentals;
+  profile?: CompanyProfile;
   annualStatements: FinancialStatement[];
   quarterlyStatements: FinancialStatement[];
   priceHistory: PricePoint[];


### PR DESCRIPTION
Adds a company profile to ticker financials and surfaces Yahoo asset profile descriptions in the Overview tab. Updates the provider router so broker-backed tickers keep fallback profile data and refresh missing profiles immediately instead of waiting on stale cached financials. Also exposes the same sector, industry, and description data in the `ticker` CLI output and Ask AI context. Includes coverage for overview rendering, broker/fallback merge behavior, and stale-cache profile refreshes.