### PR TITLE
Fix options browser keyboard scrolling

### DIFF
--- a/src/components/ui/list-view.tsx
+++ b/src/components/ui/list-view.tsx
@@ -1,5 +1,5 @@
-import { useState, type ReactNode } from "react";
-import { TextAttributes } from "@opentui/core";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
 import { colors, hoverBg } from "../../theme/colors";
 
 export interface ListViewItem {
@@ -19,14 +19,20 @@ export interface ListRowState {
 export interface ListViewProps {
   items: ListViewItem[];
   selectedIndex: number;
+  scrollIndex?: number;
   onSelect?: (index: number) => void;
   onActivate?: (item: ListViewItem, index: number) => void;
-  renderRow?: (item: ListViewItem, state: ListRowState) => ReactNode;
+  renderRow?: (item: ListViewItem, state: ListRowState, index: number) => ReactNode;
+  getRowBackgroundColor?: (item: ListViewItem, state: ListRowState, index: number) => string | undefined;
   showSelectedDescription?: boolean;
   emptyMessage?: string;
   bgColor?: string;
   selectedBgColor?: string;
   hoverBgColor?: string;
+  height?: number;
+  flexGrow?: number;
+  scrollable?: boolean;
+  autoScrollToIndex?: boolean;
 }
 
 function DefaultRow({
@@ -59,20 +65,48 @@ function DefaultRow({
 export function ListView({
   items,
   selectedIndex,
+  scrollIndex,
   onSelect,
   onActivate,
   renderRow,
+  getRowBackgroundColor,
   showSelectedDescription = false,
   emptyMessage = "Nothing to show.",
   bgColor,
   selectedBgColor,
   hoverBgColor,
+  height,
+  flexGrow,
+  scrollable = false,
+  autoScrollToIndex = true,
 }: ListViewProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
   const baseBg = bgColor ?? colors.bg;
   const activeBg = selectedBgColor ?? colors.selected;
   const rowHoverBg = hoverBgColor ?? hoverBg();
-  const selectedItem = items[selectedIndex];
+  const selectedItem = selectedIndex >= 0 ? items[selectedIndex] : undefined;
+  const activeScrollIndex = scrollIndex ?? selectedIndex;
+
+  useEffect(() => {
+    if (!scrollable || !autoScrollToIndex || activeScrollIndex < 0) return;
+    const sb = scrollRef.current;
+    if (!sb) return;
+    const safeIndex = Math.min(activeScrollIndex, items.length - 1);
+    const viewportH = Math.max(sb.viewport.height, 1);
+    if (safeIndex < sb.scrollTop) {
+      sb.scrollTo(safeIndex);
+    } else if (safeIndex >= sb.scrollTop + viewportH) {
+      sb.scrollTo(safeIndex - viewportH + 1);
+    }
+  }, [activeScrollIndex, autoScrollToIndex, items.length, scrollable]);
+
+  useEffect(() => {
+    if (!scrollable) return;
+    const sb = scrollRef.current;
+    if (!sb) return;
+    sb.verticalScrollBar.visible = items.length > sb.viewport.height;
+  }, [items.length, height, flexGrow, scrollable]);
 
   if (items.length === 0) {
     return (
@@ -82,33 +116,42 @@ export function ListView({
     );
   }
 
-  return (
-    <box flexDirection="column">
-      {items.map((item, index) => {
-        const selected = index === selectedIndex;
-        const hovered = index === hoveredIndex && !selected;
-        const disabled = item.disabled === true;
+  const rows = items.map((item, index) => {
+    const selected = index === selectedIndex;
+    const hovered = index === hoveredIndex && !selected;
+    const disabled = item.disabled === true;
+    const state = { selected, hovered, disabled };
+    const rowBg = getRowBackgroundColor?.(item, state, index)
+      ?? (selected ? activeBg : hovered ? rowHoverBg : baseBg);
 
-        return (
-          <box
-            key={item.id}
-            height={1}
-            backgroundColor={selected ? activeBg : hovered ? rowHoverBg : baseBg}
-            onMouseMove={() => {
-              if (!disabled) setHoveredIndex(index);
-            }}
-            onMouseDown={() => {
-              if (disabled) return;
-              onSelect?.(index);
-              onActivate?.(item, index);
-            }}
-          >
-            {renderRow
-              ? renderRow(item, { selected, hovered, disabled })
-              : <DefaultRow item={item} selected={selected} />}
-          </box>
-        );
-      })}
+    return (
+      <box
+        key={item.id}
+        height={1}
+        backgroundColor={rowBg}
+        onMouseMove={() => {
+          if (!disabled) setHoveredIndex(index);
+        }}
+        onMouseDown={() => {
+          if (disabled) return;
+          onSelect?.(index);
+          onActivate?.(item, index);
+        }}
+      >
+        {renderRow
+          ? renderRow(item, state, index)
+          : <DefaultRow item={item} selected={selected} />}
+      </box>
+    );
+  });
+
+  return (
+    <box flexDirection="column" height={height} flexGrow={flexGrow}>
+      {scrollable ? (
+        <scrollbox ref={scrollRef} height={height} flexGrow={flexGrow} scrollY focusable={false}>
+          {rows}
+        </scrollbox>
+      ) : rows}
 
       {showSelectedDescription && selectedItem?.description && (
         <>

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -1,18 +1,39 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { act, useState } from "react";
 import { testRender } from "@opentui/react/test-utils";
 import { Button } from "./button";
+import { ListView } from "./list-view";
 import { ProgressBar } from "./loading";
 import { Notice } from "./status";
 import { Tabs } from "./tabs";
 import { ToggleList } from "../toggle-list";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let setListSelection: ((index: number) => void) | null = null;
+
+function ScrollableListHarness() {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  setListSelection = setSelectedIndex;
+
+  return (
+    <ListView
+      items={Array.from({ length: 12 }, (_, index) => ({
+        id: `row-${index}`,
+        label: `Row ${index + 1}`,
+      }))}
+      selectedIndex={selectedIndex}
+      height={4}
+      scrollable
+    />
+  );
+}
 
 afterEach(() => {
   if (testSetup) {
     testSetup.renderer.destroy();
     testSetup = undefined;
   }
+  setListSelection = null;
 });
 
 describe("shared UI kit", () => {
@@ -66,5 +87,27 @@ describe("shared UI kit", () => {
     expect(frame).toContain("[✓] News");
     expect(frame).toContain("Notes");
     expect(frame).toContain("Headlines and previews");
+  });
+
+  test("auto-scrolls a scrollable list to keep the selected row visible", async () => {
+    testSetup = await testRender(
+      <ScrollableListHarness />,
+      { width: 20, height: 6 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      setListSelection!(8);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Row 9");
+    expect(frame).not.toContain("Row 1");
   });
 });

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -4,6 +4,7 @@ import { TextAttributes } from "@opentui/core";
 import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
 import type { OptionContract, OptionsChain } from "../../types/financials";
 import { usePaneTicker } from "../../state/app-context";
+import { ListView, type ListViewItem } from "../../components/ui";
 import { colors, hoverBg } from "../../theme/colors";
 import { padTo, formatCompact, formatNumber } from "../../utils/format";
 import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
@@ -19,7 +20,6 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const [expIdx, setExpIdx] = useState(0);
   const [strikeIdx, setStrikeIdx] = useState(0);
   const [interactive, setInteractive] = useState(false);
-  const [hoveredStrikeIdx, setHoveredStrikeIdx] = useState<number | null>(null);
   const [hoveredExpIdx, setHoveredExpIdx] = useState<number | null>(null);
   const target = resolveOptionsTarget(ticker);
   const isOpt = target?.isOptionTicker ?? false;
@@ -46,6 +46,10 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   useEffect(() => {
     exitInteractive();
   }, [effectiveTicker]);
+
+  useEffect(() => {
+    setHoveredExpIdx(null);
+  }, [expIdx]);
 
   // Fetch initial chain (all expirations list + nearest expiration data)
   useEffect(() => {
@@ -201,6 +205,10 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const selectedStrike = strikes[strikeIdx];
   const selectedCall = selectedStrike != null ? callsByStrike.get(selectedStrike) : undefined;
   const selectedPut = selectedStrike != null ? putsByStrike.get(selectedStrike) : undefined;
+  const strikeItems: ListViewItem[] = strikes.map((strike) => ({
+    id: String(strike),
+    label: formatStrikeLabel(strike),
+  }));
 
   const hoverColor = hoverBg();
 
@@ -217,6 +225,7 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
             <box
               key={ts}
               onMouseMove={() => setHoveredExpIdx(realIdx)}
+              onMouseOut={() => setHoveredExpIdx(null)}
               onMouseDown={() => { enterInteractive(); setExpIdx(realIdx); }}
             >
               <text
@@ -258,7 +267,7 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
         </box>
         <box width={divW}><text fg={colors.textDim}>{"\u2502"}</text></box>
         <box width={strikeW}>
-          <text attributes={TextAttributes.BOLD} fg={colors.textDim}>{padTo("Strike", strikeW, "right")}</text>
+          <text attributes={TextAttributes.BOLD} fg={colors.textDim}>{padTo("Strike", strikeW, "center")}</text>
         </box>
         <box width={divW}><text fg={colors.textDim}>{"\u2502"}</text></box>
         <box width={sideW}>
@@ -269,32 +278,25 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
       </box>
 
       {/* Chain rows */}
-      <scrollbox flexGrow={1} scrollY>
-        {strikes.map((strike, i) => {
+      <ListView
+        items={strikeItems}
+        selectedIndex={interactive ? strikeIdx : -1}
+        scrollIndex={strikeIdx}
+        onSelect={(index) => {
+          enterInteractive();
+          setStrikeIdx(index);
+        }}
+        renderRow={(_, state, i) => {
+          const strike = strikes[i]!;
           const call = callsByStrike.get(strike);
           const put = putsByStrike.get(strike);
-          const isSelected = interactive && i === strikeIdx;
-          const isHovered = i === hoveredStrikeIdx && !isSelected;
+          const isSelected = state.selected;
           const isPositionStrike = parsed && Math.abs(strike - parsed.strike) < 0.01;
-          const bg = isSelected
-            ? colors.selected
-            : isHovered
-              ? hoverColor
-              : isPositionStrike
-                ? colors.selected
-                : colors.bg;
           const callItm = call?.inTheMoney;
           const putItm = put?.inTheMoney;
 
           return (
-            <box
-              key={strike}
-              flexDirection="row"
-              height={1}
-              backgroundColor={bg}
-              onMouseMove={() => setHoveredStrikeIdx(i)}
-              onMouseDown={() => { enterInteractive(); setStrikeIdx(i); }}
-            >
+            <box flexDirection="row">
               <box width={sideW}>
                 <text fg={callItm ? colors.textBright : colors.text}>
                   {formatContractRow(call, colW)}
@@ -303,7 +305,7 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
               <box width={divW}><text fg={colors.textDim}>{"\u2502"}</text></box>
               <box width={strikeW}>
                 <text fg={isSelected ? colors.textBright : colors.neutral} attributes={isSelected ? TextAttributes.BOLD : 0}>
-                  {padTo(formatNumber(strike, strike % 1 === 0 ? 0 : 2), strikeW, "right")}
+                  {padTo(formatStrikeLabel(strike), strikeW, "center")}
                 </text>
               </box>
               <box width={divW}><text fg={colors.textDim}>{"\u2502"}</text></box>
@@ -314,8 +316,18 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
               </box>
             </box>
           );
-        })}
-      </scrollbox>
+        }}
+        getRowBackgroundColor={(_, state, i) => {
+          const strike = strikes[i]!;
+          const isPositionStrike = parsed && Math.abs(strike - parsed.strike) < 0.01;
+          if (state.selected) return colors.selected;
+          if (state.hovered) return hoverColor;
+          return isPositionStrike ? colors.selected : colors.bg;
+        }}
+        hoverBgColor={hoverColor}
+        flexGrow={1}
+        scrollable
+      />
 
       {/* Detail for selected row */}
       {interactive && (selectedCall || selectedPut) && (
@@ -345,6 +357,11 @@ function buildStrikeList(chain: OptionsChain): number[] {
   for (const c of chain.calls) set.add(c.strike);
   for (const p of chain.puts) set.add(p.strike);
   return Array.from(set).sort((a, b) => a - b);
+}
+
+function formatStrikeLabel(strike: number): string {
+  const decimals = strike % 1 === 0 ? 0 : 2;
+  return formatNumber(strike, decimals).replace(/(\.\d*?[1-9])0+$/, "$1").replace(/\.0+$/, "");
 }
 
 interface ColWidths {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -102,9 +102,15 @@ export function formatWithDivisor(value: number | undefined, divisor: number): s
 }
 
 /** Pad/truncate a string to a fixed width */
-export function padTo(str: string, width: number, align: "left" | "right" = "left"): string {
+export function padTo(str: string, width: number, align: "left" | "right" | "center" = "left"): string {
   if (str.length > width) return str.slice(0, width);
   if (align === "right") return str.padStart(width);
+  if (align === "center") {
+    const totalPadding = width - str.length;
+    const leftPadding = Math.floor(totalPadding / 2);
+    const rightPadding = totalPadding - leftPadding;
+    return " ".repeat(leftPadding) + str + " ".repeat(rightPadding);
+  }
   return str.padEnd(width);
 }
 


### PR DESCRIPTION
## Summary
- switch the options browser strike table to the shared list view so keyboard navigation controls selection without the scrollbox stealing arrow keys
- auto-scroll the selected strike into view, center the strike column, and trim redundant trailing zeroes in strike labels
- clear stale expiration hover state when moving by keyboard and add a shared list autoscroll regression test

## Testing
- bun test src/components/ui/ui.test.tsx