### PR TITLE
Refine IBKR trade tab layout

### DIFF
--- a/src/plugins/ibkr/__snapshots__/trade-tab.test.tsx.snap
+++ b/src/plugins/ibkr/__snapshots__/trade-tab.test.tsx.snap
@@ -1,0 +1,35 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`renders the compact trade tab layout 1`] = `
+" Trade AMD · Advanced Micro Devices, Inc.                                               
+ $199.80  -3.97 · Bid 199.70 · Ask 199.90 · Spd 0.20                                    
+                                                                                        
+  Broker           Account     Net Liq                                                  
+   Paper Gateway    DU123456    —                                                       
+                                                                                        
+                                                                                        
+  Next Submit order   Ticket Standby   Refresh  r                                       
+                                                                                        
+  Refreshed Paper.                                                                      
+                                                                                        
+ ╭────────────────────────────────────────────────────────────────────────────────────╮ 
+ │ Ticket                                                         Click field / Enter │ 
+ │ Click a field or press Enter to edit. Shortcuts are shown inline.                  │ 
+ │                                                                                    │ 
+ │  Profile Paper              Ticker AMD STK             Account DU123456            │ 
+ │                                                                                    │ 
+ │  Side [b/v] BUY      Type [t] MKT        Qty [q] 1           TIF DAY               │ 
+ │                                                                                    │ 
+ │ Advanced Micro Devices, Inc.                                                       │ 
+ ╰────────────────────────────────────────────────────────────────────────────────────╯ 
+                                                                                        
+ ╭────────────────────────────────────────────────────────────────────────────────────╮ 
+ │ Preview                                                              Preview ready │ 
+ │ What-if: init 12.4k → 13.2k · commission $1.25                                     │ 
+ │  Fee $1.25                              Init 12.4k → 13.2k                         │ 
+ │  Maint 10.1k → 10.7k                    Equity 58.4k → 57.1k                       │ 
+ │  Preview  p  Submit Order  Enter                                                   │ 
+ ╰────────────────────────────────────────────────────────────────────────────────────╯ 
+                                                                                        
+"
+`;

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -125,7 +125,7 @@ function formatPreviewSummary(preview: import("../../types/trading").BrokerOrder
   if (!preview) {
     return "Preview required before submit. Press p to review margin and commission.";
   }
-  return `What-if: init ${formatCompact(preview.initMarginBefore || 0)} → ${formatCompact(preview.initMarginAfter || 0)} · commission ${preview.commission != null ? formatCurrency(preview.commission, preview.commissionCurrency || "USD") : "—"}${preview.warningText ? ` · ${preview.warningText}` : ""}`;
+  return `What-if: init ${formatCompact(preview.initMarginBefore || 0)} → ${formatCompact(preview.initMarginAfter || 0)} · commission ${preview.commission != null ? formatCurrency(preview.commission, preview.commissionCurrency || "USD") : "—"}`;
 }
 
 type TradeTone = "neutral" | "accent" | "positive" | "negative";
@@ -176,37 +176,6 @@ function TradeBadge({ label, value, tone = "neutral", onPress }: TradeBadgeProps
     >
       <text fg={colors.textDim}>{label}</text>
       <text fg={palette.text} attributes={TextAttributes.BOLD}>{` ${value}`}</text>
-    </box>
-  );
-}
-
-interface TradeStepChipProps {
-  index: number;
-  label: string;
-  status: "pending" | "active" | "done";
-  onPress?: () => void;
-}
-
-function TradeStepChip({ index, label, status, onPress }: TradeStepChipProps) {
-  const palette = status === "done"
-    ? getTradeTonePalette("positive")
-    : status === "active"
-      ? getTradeTonePalette("accent")
-      : getTradeTonePalette("neutral");
-
-  return (
-    <box
-      border
-      borderStyle="rounded"
-      borderColor={palette.border}
-      paddingX={1}
-      marginRight={1}
-      marginBottom={1}
-      onMouseDown={onPress}
-    >
-      <text fg={status === "pending" ? colors.textDim : palette.text} attributes={status === "active" ? TextAttributes.BOLD : 0}>
-        {`${index} ${label}`}
-      </text>
     </box>
   );
 }
@@ -472,7 +441,7 @@ function ChoiceDialog({
   );
 }
 
-function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
+export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
   const { state } = useAppState();
   const paneId = usePaneInstanceId();
   const { collectionId } = usePaneCollection(paneId);
@@ -1004,21 +973,27 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
   const showLimit = isLimitOrder(ticketState.draft.orderType);
   const showStop = isStopOrder(ticketState.draft.orderType);
   const hasProfile = Boolean(selectedInstance);
-  const wideLayout = width >= 120;
-  const previewPanelWidth = wideLayout ? Math.min(42, Math.max(34, Math.floor(width * 0.32))) : undefined;
-  const ticketPanelWidth = wideLayout ? Math.max(56, width - (previewPanelWidth ?? 0) - 7) : Math.max(36, width - 4);
-  const cardsPerRow = ticketPanelWidth >= 96 ? 4 : ticketPanelWidth >= 58 ? 2 : 1;
-  const fieldWidth = Math.max(18, Math.floor((ticketPanelWidth - (cardsPerRow - 1)) / cardsPerRow));
-  const fieldTextWidth = Math.max(10, fieldWidth - 3);
+  const wideLayout = width >= 112;
+  const previewPanelWidth = wideLayout ? Math.min(38, Math.max(30, Math.floor(width * 0.28))) : undefined;
+  const ticketPanelWidth = wideLayout ? Math.max(52, width - (previewPanelWidth ?? 0) - 5) : Math.max(34, width - 4);
+  const fieldsPerRow = ticketPanelWidth >= 96 ? 4 : ticketPanelWidth >= 70 ? 3 : 2;
+  const fieldWidth = Math.max(16, Math.floor((ticketPanelWidth - fieldsPerRow) / fieldsPerRow));
+  const coreFieldWidth = ticketPanelWidth >= 76
+    ? Math.max(16, Math.floor((ticketPanelWidth - 4) / 3))
+    : fieldWidth;
+  const orderFieldWidth = ticketPanelWidth >= 76
+    ? Math.max(16, Math.floor((ticketPanelWidth - 5) / 4))
+    : fieldWidth;
+  const fieldTextWidth = Math.max(8, fieldWidth - 3);
   const activeContract = ticketState.draft.contract.symbol ? ticketState.draft.contract : normalizeContract(ticker);
   const hasContract = Boolean(activeContract.symbol);
   const hasAccount = Boolean(currentAccountId);
   const hasPreview = Boolean(ticketState.preview);
-  const previewTextWidth = Math.max(18, (previewPanelWidth ?? Math.max(34, width - 6)) - 6);
+  const previewTextWidth = Math.max(18, (previewPanelWidth ?? Math.max(34, width - 6)) - 4);
   const contractValue = truncateText(formatContractLabel(activeContract), fieldTextWidth);
   const contractMeta = truncateText(
     ticketState.contractName || ticker.metadata.name || "Using current ticker",
-    fieldTextWidth,
+    Math.max(fieldTextWidth * Math.max(2, fieldsPerRow), 18),
   );
   const connectionTone: TradeTone = gatewaySnapshot.status.state === "connected"
     ? "positive"
@@ -1047,8 +1022,28 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
     : ticketState.preview.warningText
       ? "Preview warning"
       : "Preview ready";
+  const previewMetricWidth = Math.max(14, Math.floor(((previewPanelWidth ?? Math.max(34, width - 6)) - 6) / 2));
+  const nextStep = !hasProfile
+    ? "Choose profile"
+    : !hasContract
+      ? "Confirm ticker"
+      : !hasAccount
+        ? "Choose account"
+        : !hasPreview
+          ? "Run preview"
+          : ticketState.editingOrderId
+            ? "Submit change"
+            : "Submit order";
+  const workflowTone: TradeTone = hasPreview
+    ? "positive"
+    : hasProfile && hasContract && hasAccount
+      ? "accent"
+      : "neutral";
+  const ticketHint = interactive
+    ? "Esc releases the ticket. Field shortcuts stay active while captured."
+    : "Click a field or press Enter to edit. Shortcuts are shown inline.";
 
-  const renderFieldCard = ({
+  const renderFieldPill = ({
     id,
     label,
     value,
@@ -1056,6 +1051,7 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
     valueAttributes = 0,
     disabled = false,
     active = false,
+    widthOverride,
     onPress,
   }: {
     id: string;
@@ -1065,31 +1061,42 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
     valueAttributes?: number;
     disabled?: boolean;
     active?: boolean;
+    widthOverride?: number;
     onPress?: () => void;
   }) => {
+    const itemWidth = widthOverride ?? fieldWidth;
+    const valueWidth = Math.max(4, itemWidth - label.length - 3);
     const hovered = hoveredField === id;
-    const outlined = !active && !hovered;
-    const borderColor = disabled ? colors.border : active || hovered ? colors.borderFocused : colors.border;
     const backgroundColor = disabled
-      ? undefined
+      ? colors.panel
       : active
         ? colors.selected
         : hovered
           ? fieldHoverBg
-          : undefined;
+          : colors.panel;
+    const labelColor = disabled
+      ? colors.textMuted
+      : active
+        ? colors.selectedText
+        : hovered
+          ? colors.textBright
+          : colors.textDim;
+    const resolvedValueColor = active
+      ? colors.selectedText
+      : hovered
+        ? colors.textBright
+        : valueColor ?? (disabled ? colors.textMuted : colors.text);
 
     return (
       <box
         key={id}
-        width={fieldWidth}
-        minWidth={18}
-        height={4}
-        flexDirection="column"
-        border={outlined}
-        borderStyle={outlined ? "rounded" : undefined}
-        borderColor={outlined ? borderColor : undefined}
+        width={itemWidth}
+        minWidth={16}
+        height={1}
+        flexDirection="row"
         backgroundColor={backgroundColor}
         paddingX={1}
+        marginRight={1}
         onMouseMove={() => {
           if (!disabled) setHoveredField(id);
         }}
@@ -1098,17 +1105,69 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
           onPress?.();
         }}
       >
-        <text fg={disabled ? colors.textMuted : colors.textDim}>{label}</text>
-        <text fg={valueColor ?? (disabled ? colors.textMuted : colors.text)} attributes={valueAttributes}>
-          {truncateText(value, fieldTextWidth)}
+        <text fg={labelColor}>{label}</text>
+        <text fg={resolvedValueColor} attributes={valueAttributes}>
+          {` ${truncateText(value, valueWidth)}`}
         </text>
       </box>
     );
   };
 
+  const renderSummaryPill = ({
+    id,
+    label,
+    value,
+    tone = "neutral",
+    onPress,
+  }: {
+    id: string;
+    label: string;
+    value: string;
+    tone?: TradeTone;
+    onPress?: () => void;
+  }) => {
+    const palette = getTradeTonePalette(tone);
+
+    return (
+      <box
+        key={id}
+        height={1}
+        flexDirection="row"
+        backgroundColor={palette.background}
+        paddingX={1}
+        marginRight={1}
+        onMouseDown={onPress}
+      >
+        <text fg={tone === "neutral" ? colors.textDim : palette.text}>{label}</text>
+        <text fg={palette.text} attributes={TextAttributes.BOLD}>{` ${value}`}</text>
+      </box>
+    );
+  };
+
+  const renderPreviewMetric = (label: string, value: string, tone: TradeTone = "neutral") => (
+    <box
+      key={label}
+      width={previewMetricWidth}
+      height={1}
+      backgroundColor={colors.panel}
+      paddingX={1}
+      marginRight={1}
+    >
+      <text fg={tone === "negative" ? colors.negative : tone === "positive" ? colors.positive : colors.text}>
+        {truncateText(`${label} ${value}`, Math.max(6, previewMetricWidth - 2))}
+      </text>
+    </box>
+  );
+
   return (
     <scrollbox flexGrow={1} scrollY>
-      <box flexDirection="column" paddingX={1} paddingBottom={1} gap={1} onMouseDown={enterInteractive}>
+      <box
+        flexDirection="column"
+        paddingX={1}
+        paddingBottom={1}
+        gap={1}
+        onMouseDown={!interactive ? enterInteractive : undefined}
+      >
         <box flexDirection="row" flexWrap="wrap" justifyContent="space-between">
           <box flexDirection="column" marginBottom={1}>
             <box height={1} flexDirection="row">
@@ -1154,57 +1213,25 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
         </box>
 
         <box flexDirection="row" flexWrap="wrap">
-          <TradeStepChip
-            index={1}
-            label="Profile"
-            status={hasProfile ? "done" : "active"}
-            onPress={() => {
-              enterInteractive();
-              chooseBrokerInstance().catch(() => {});
-            }}
-          />
-            <TradeStepChip
-              index={2}
-            label="Ticker"
-            status={hasContract ? "done" : hasProfile ? "active" : "pending"}
-            onPress={() => {
-              enterInteractive();
-              chooseInstrument().catch(() => {});
-            }}
-          />
-          <TradeStepChip
-            index={3}
-            label="Account"
-            status={hasAccount ? "done" : hasContract ? "active" : "pending"}
-            onPress={() => {
-              enterInteractive();
-              chooseAccount().catch(() => {});
-            }}
-          />
-          <TradeStepChip
-            index={4}
-            label="Ticket"
-            status={hasProfile && hasContract && hasAccount ? "done" : "pending"}
-            onPress={enterInteractive}
-          />
-          <TradeStepChip
-            index={5}
-            label="Preview"
-            status={hasPreview ? "done" : hasProfile && hasContract && hasAccount ? "active" : "pending"}
-            onPress={() => previewOrder().catch(() => {})}
-          />
-          <TradeStepChip
-            index={6}
-            label="Submit"
-            status={hasPreview ? "active" : "pending"}
-            onPress={() => submitOrder().catch(() => {})}
+          {renderSummaryPill({ id: "next", label: "Next", value: nextStep, tone: workflowTone })}
+          {renderSummaryPill({
+            id: "ticket",
+            label: "Ticket",
+            value: interactive ? "Captured" : "Standby",
+            tone: interactive ? "accent" : "neutral",
+            onPress: () => (interactive ? exitInteractive() : enterInteractive()),
+          })}
+          <Button
+            label="Refresh"
+            shortcut="r"
+            variant="ghost"
+            disabled={ticketState.busy}
+            onPress={() => refresh().catch(() => {})}
           />
         </box>
 
         <box
-          border
-          borderStyle="rounded"
-          borderColor={getTradeTonePalette(statusTone).border}
+          backgroundColor={getTradeTonePalette(statusTone).background}
           paddingX={1}
         >
           <text fg={ticketState.lastError ? colors.negative : ticketState.isSuccess ? colors.positive : colors.text}>
@@ -1221,129 +1248,108 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
             borderStyle="rounded"
             borderColor={interactive ? colors.borderFocused : colors.border}
             paddingX={1}
-            paddingY={1}
           >
             <box height={1} flexDirection="row">
               <text fg={colors.textBright} attributes={TextAttributes.BOLD}>Ticket</text>
               <box flexGrow={1} />
               <text fg={interactive ? colors.positive : colors.textMuted}>
-                {interactive ? "Active" : "Click field to activate"}
+                {interactive ? "Captured" : "Click field / Enter"}
               </text>
             </box>
-            <box height={1}>
-              <text fg={colors.textMuted}>
-                {interactive
-                  ? "Mouse and keyboard are captured here. Esc releases the ticket."
-                  : "Current ticker is loaded by default. Click a field to adjust, then preview."}
-              </text>
-            </box>
+            <text fg={colors.textMuted}>{truncateText(ticketHint, Math.max(ticketPanelWidth - 4, 24))}</text>
             <box height={1} />
 
-            <box flexDirection="row" flexWrap="wrap" gap={1}>
-              {renderFieldCard({
+            <box flexDirection="row" flexWrap="wrap">
+              {renderFieldPill({
                 id: "profile",
                 label: "Profile",
                 value: selectedInstance ? selectedInstance.label : "Choose profile",
                 active: hasProfile,
+                widthOverride: coreFieldWidth,
                 onPress: () => chooseBrokerInstance().catch(() => {}),
               })}
-              {renderFieldCard({
+              {renderFieldPill({
                 id: "contract",
                 label: "Ticker",
                 value: contractValue,
                 active: hasContract,
+                widthOverride: coreFieldWidth,
                 onPress: () => chooseInstrument().catch(() => {}),
               })}
-              {renderFieldCard({
+              {renderFieldPill({
                 id: "account",
                 label: "Account",
                 value: currentAccountId || "Select account",
                 active: hasAccount,
+                widthOverride: coreFieldWidth,
                 onPress: () => chooseAccount().catch(() => {}),
               })}
-              <box
-                width={fieldWidth}
-                minWidth={18}
-                height={4}
-                flexDirection="column"
-                backgroundColor={hoveredField === "action" ? fieldHoverBg : undefined}
-                paddingX={1}
-                onMouseMove={() => setHoveredField("action")}
-              >
-                <text fg={colors.textDim}>Action</text>
-                <box flexDirection="row" gap={1}>
-                  <text
-                    fg={ticketState.draft.action === "BUY" ? colors.textBright : colors.textDim}
-                    attributes={ticketState.draft.action === "BUY" ? TextAttributes.BOLD : 0}
-                    onMouseDown={() => {
-                      enterInteractive();
-                      setTradeTicketDraft(symbol, { action: "BUY" }, ticker);
-                    }}
-                  >
-                    BUY [b]
-                  </text>
-                  <text
-                    fg={ticketState.draft.action === "SELL" ? colors.textBright : colors.textDim}
-                    attributes={ticketState.draft.action === "SELL" ? TextAttributes.BOLD : 0}
-                    onMouseDown={() => {
-                      enterInteractive();
-                      setTradeTicketDraft(symbol, { action: "SELL" }, ticker);
-                    }}
-                  >
-                    SELL [v]
-                  </text>
-                </box>
-              </box>
-
-              {renderFieldCard({
+            </box>
+            <box height={1} />
+            <box flexDirection="row" flexWrap="wrap">
+              {renderFieldPill({
+                id: "action",
+                label: "Side [b/v]",
+                value: ticketState.draft.action,
+                valueColor: ticketState.draft.action === "BUY" ? colors.positive : colors.negative,
+                valueAttributes: TextAttributes.BOLD,
+                widthOverride: orderFieldWidth,
+                onPress: () => {
+                  setTradeTicketDraft(symbol, { action: ticketState.draft.action === "BUY" ? "SELL" : "BUY" }, ticker);
+                },
+              })}
+              {renderFieldPill({
                 id: "orderType",
                 label: "Type [t]",
                 value: ticketState.draft.orderType,
+                widthOverride: orderFieldWidth,
                 onPress: () => editOrderType().catch(() => {}),
               })}
-              {renderFieldCard({
+              {renderFieldPill({
                 id: "quantity",
                 label: "Qty [q]",
                 value: formatNumber(ticketState.draft.quantity, 0),
+                widthOverride: orderFieldWidth,
                 onPress: () => {
                   editNumericField("Quantity", ticketState.draft.quantity, (value) => {
                     if (value != null && symbol && ticker) setTradeTicketDraft(symbol, { quantity: value }, ticker);
                   }).catch(() => {});
                 },
               })}
-              {renderFieldCard({
+              {showLimit && renderFieldPill({
                 id: "limitPrice",
                 label: "Limit [l]",
-                value: showLimit ? (ticketState.draft.limitPrice != null ? ticketState.draft.limitPrice.toFixed(2) : "—") : "n/a",
-                disabled: !showLimit,
-                onPress: showLimit ? () => {
+                value: ticketState.draft.limitPrice != null ? ticketState.draft.limitPrice.toFixed(2) : "—",
+                widthOverride: orderFieldWidth,
+                onPress: () => {
                   editPriceField("Limit Price", ticketState.draft.limitPrice, (value) => {
                     if (symbol && ticker) setTradeTicketDraft(symbol, { limitPrice: value }, ticker);
                   }).catch(() => {});
-                } : undefined,
+                },
               })}
-              {renderFieldCard({
+              {showStop && renderFieldPill({
                 id: "stopPrice",
                 label: "Stop [x]",
-                value: showStop ? (ticketState.draft.stopPrice != null ? ticketState.draft.stopPrice.toFixed(2) : "—") : "n/a",
-                disabled: !showStop,
-                onPress: showStop ? () => {
+                value: ticketState.draft.stopPrice != null ? ticketState.draft.stopPrice.toFixed(2) : "—",
+                widthOverride: orderFieldWidth,
+                onPress: () => {
                   editPriceField("Stop Price", ticketState.draft.stopPrice, (value) => {
                     if (symbol && ticker) setTradeTicketDraft(symbol, { stopPrice: value }, ticker);
                   }).catch(() => {});
-                } : undefined,
+                },
               })}
-              {renderFieldCard({
+              {renderFieldPill({
                 id: "tif",
                 label: "TIF",
                 value: ticketState.draft.tif || "DAY",
-                active: Boolean(ticketState.draft.tif),
+                widthOverride: orderFieldWidth,
               })}
-              {renderFieldCard({
+              {ticketState.editingOrderId && renderFieldPill({
                 id: "editing",
                 label: "Mode",
-                value: ticketState.editingOrderId ? `Editing #${ticketState.editingOrderId}` : "New order",
-                valueColor: ticketState.editingOrderId ? colors.textBright : colors.text,
+                value: `Edit #${ticketState.editingOrderId}`,
+                valueColor: colors.textBright,
+                widthOverride: orderFieldWidth,
               })}
             </box>
             <box height={1} />
@@ -1358,47 +1364,30 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
             borderStyle="rounded"
             borderColor={getTradeTonePalette(previewTone).border}
             paddingX={1}
-            paddingY={1}
           >
             <box height={1} flexDirection="row">
               <text fg={colors.textBright} attributes={TextAttributes.BOLD}>Preview</text>
               <box flexGrow={1} />
               <text fg={getTradeTonePalette(previewTone).text}>{previewHeading}</text>
             </box>
-            <box height={1}>
-              <text fg={ticketState.preview?.warningText ? colors.negative : colors.textMuted}>
-                {truncateText(formatPreviewSummary(ticketState.preview), previewTextWidth)}
-              </text>
-            </box>
-            <box height={1} />
+            <text fg={ticketState.preview?.warningText ? colors.negative : colors.textMuted}>
+              {truncateText(formatPreviewSummary(ticketState.preview), previewTextWidth)}
+            </text>
 
-            <box flexDirection="column">
-              <box height={1} flexDirection="row">
-                <box width={12}><text fg={colors.textDim}>Fee</text></box>
-                <text fg={colors.text}>{ticketState.preview?.commission != null ? formatCurrency(ticketState.preview.commission, ticketState.preview.commissionCurrency || "USD") : "—"}</text>
-              </box>
-              <box height={1} flexDirection="row">
-                <box width={12}><text fg={colors.textDim}>Init</text></box>
-                <text fg={colors.text}>{formatPreviewMetric(ticketState.preview?.initMarginBefore, ticketState.preview?.initMarginAfter)}</text>
-              </box>
-              <box height={1} flexDirection="row">
-                <box width={12}><text fg={colors.textDim}>Maint</text></box>
-                <text fg={colors.text}>{formatPreviewMetric(ticketState.preview?.maintMarginBefore, ticketState.preview?.maintMarginAfter)}</text>
-              </box>
-              <box height={1} flexDirection="row">
-                <box width={12}><text fg={colors.textDim}>Equity</text></box>
-                <text fg={colors.text}>{formatPreviewMetric(ticketState.preview?.equityWithLoanBefore, ticketState.preview?.equityWithLoanAfter)}</text>
-              </box>
-              <box height={1} flexDirection="row">
-                <box width={12}><text fg={colors.textDim}>Warning</text></box>
-                <text fg={ticketState.preview?.warningText ? colors.negative : colors.textMuted}>
-                  {truncateText(ticketState.preview?.warningText || "None", 20)}
-                </text>
-              </box>
+            <box flexDirection="row" flexWrap="wrap">
+              {renderPreviewMetric(
+                "Fee",
+                ticketState.preview?.commission != null
+                  ? formatCurrency(ticketState.preview.commission, ticketState.preview.commissionCurrency || "USD")
+                  : "—",
+              )}
+              {renderPreviewMetric("Init", formatPreviewMetric(ticketState.preview?.initMarginBefore, ticketState.preview?.initMarginAfter))}
+              {renderPreviewMetric("Maint", formatPreviewMetric(ticketState.preview?.maintMarginBefore, ticketState.preview?.maintMarginAfter))}
+              {renderPreviewMetric("Equity", formatPreviewMetric(ticketState.preview?.equityWithLoanBefore, ticketState.preview?.equityWithLoanAfter))}
+              {ticketState.preview?.warningText && renderPreviewMetric("Warn", ticketState.preview.warningText, "negative")}
             </box>
 
-            <box height={1} />
-            <box flexDirection="column">
+            <box flexDirection="row" flexWrap="wrap">
               <Button
                 label="Preview"
                 shortcut="p"
@@ -1406,7 +1395,7 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
                 disabled={ticketState.busy}
                 onPress={() => previewOrder().catch(() => {})}
               />
-              <box height={1} />
+              <box width={1} />
               <Button
                 label={ticketState.editingOrderId ? "Submit Change" : "Submit Order"}
                 shortcut="Enter"
@@ -1416,24 +1405,6 @@ function TradeTab({ focused, width, height, onCapture }: DetailTabProps) {
               />
             </box>
           </box>
-        </box>
-
-        <box
-          border
-          borderStyle="rounded"
-          borderColor={interactive ? colors.borderFocused : colors.border}
-          paddingX={1}
-          paddingY={1}
-          flexDirection="row"
-          flexWrap="wrap"
-          gap={1}
-        >
-          <Button label="Profile" shortcut="i" variant="ghost" disabled={ticketState.busy} onPress={() => chooseBrokerInstance().catch(() => {})} />
-          <Button label="Override" shortcut="s" variant="ghost" disabled={ticketState.busy} onPress={() => chooseInstrument().catch(() => {})} />
-          <Button label="Account" shortcut="a" variant="ghost" disabled={ticketState.busy} onPress={() => chooseAccount().catch(() => {})} />
-          <Button label="Preview" shortcut="p" variant="secondary" disabled={ticketState.busy} onPress={() => previewOrder().catch(() => {})} />
-          <Button label={ticketState.editingOrderId ? "Submit Change" : "Submit"} shortcut="Enter" variant="primary" disabled={!ticketState.preview || ticketState.busy} onPress={() => submitOrder().catch(() => {})} />
-          <Button label={interactive ? "Release Ticket" : "Activate Ticket"} shortcut={interactive ? "Esc" : "Enter"} variant="ghost" onPress={() => (interactive ? exitInteractive() : enterInteractive())} />
         </box>
       </box>
     </scrollbox>

--- a/src/plugins/ibkr/trade-tab.test.tsx
+++ b/src/plugins/ibkr/trade-tab.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, expect, test } from "bun:test";
+import { DialogProvider } from "@opentui-ui/dialog/react";
+import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
+import {
+  AppContext,
+  PaneInstanceProvider,
+  createInitialState,
+} from "../../state/app-context";
+import { cloneLayout, createDefaultConfig, type AppConfig, type BrokerInstanceConfig } from "../../types/config";
+import type { TickerFinancials } from "../../types/financials";
+import type { TickerRecord } from "../../types/ticker";
+import { ibkrGatewayManager } from "./gateway-service";
+import { TradeTab } from "./index";
+import {
+  clearTradingDraft,
+  prefillTradeFromTicker,
+  setTradeTicketDraft,
+  setTradeTicketPreview,
+  updateTradingPaneState,
+} from "./trading-state";
+
+const TEST_PANE_ID = "ticker-detail:trade-test";
+const TEST_INSTANCE_ID = "ibkr-paper";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function createGatewayInstance(): BrokerInstanceConfig {
+  return {
+    id: TEST_INSTANCE_ID,
+    brokerType: "ibkr",
+    label: "Paper",
+    connectionMode: "gateway",
+    config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
+    enabled: true,
+  };
+}
+
+function createTradeConfig(symbol: string): AppConfig {
+  const config = createDefaultConfig("/tmp/gloomberb-trade-tab");
+  const layout = {
+    dockRoot: { kind: "pane" as const, instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "ticker-detail",
+      binding: { kind: "fixed" as const, symbol },
+    }],
+    floating: [],
+  };
+
+  return {
+    ...config,
+    brokerInstances: [createGatewayInstance()],
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  };
+}
+
+function makeTicker(symbol: string, name = symbol): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name,
+      assetCategory: "STK",
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function makeFinancials(): TickerFinancials {
+  return {
+    quote: {
+      symbol: "AMD",
+      price: 199.8,
+      currency: "USD",
+      change: -3.97,
+      changePercent: -1.95,
+      bid: 199.7,
+      ask: 199.9,
+      lastUpdated: Date.now(),
+    },
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: [],
+  };
+}
+
+function stubGatewayRefresh(): void {
+  const service = ibkrGatewayManager.getService(TEST_INSTANCE_ID) as any;
+  service.connect = async () => {};
+  service.getAccounts = async () => [];
+  service.listOpenOrders = async () => [];
+  service.listExecutions = async () => [];
+}
+
+function TradeHarness({
+  config,
+  ticker,
+  financials,
+}: {
+  config: AppConfig;
+  ticker: TickerRecord;
+  financials: TickerFinancials;
+}) {
+  const state = createInitialState(config);
+  state.focusedPaneId = TEST_PANE_ID;
+  state.tickers = new Map([[ticker.metadata.ticker, ticker]]);
+  state.financials = new Map([[ticker.metadata.ticker, financials]]);
+
+  return (
+    <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId={TEST_PANE_ID}>
+          <TradeTab focused width={88} height={30} onCapture={() => {}} />
+        </PaneInstanceProvider>
+      </AppContext>
+    </DialogProvider>
+  );
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+  clearTradingDraft();
+  await ibkrGatewayManager.removeInstance(TEST_INSTANCE_ID);
+});
+
+test("renders the compact trade tab layout", async () => {
+  const config = createTradeConfig("AMD");
+  const ticker = makeTicker("AMD", "Advanced Micro Devices, Inc.");
+  const financials = makeFinancials();
+
+  clearTradingDraft();
+  stubGatewayRefresh();
+  prefillTradeFromTicker(ticker, "BUY");
+  setTradeTicketDraft("AMD", { accountId: "DU123456" }, ticker);
+  setTradeTicketPreview("AMD", {
+    commission: 1.25,
+    commissionCurrency: "USD",
+    initMarginBefore: 12_400,
+    initMarginAfter: 13_150,
+    maintMarginBefore: 10_050,
+    maintMarginAfter: 10_700,
+    equityWithLoanBefore: 58_400,
+    equityWithLoanAfter: 57_150,
+  }, ticker);
+  updateTradingPaneState({ accountId: "DU123456" });
+
+  await act(async () => {
+    testSetup = await testRender(
+      <TradeHarness config={config} ticker={ticker} financials={financials} />,
+      { width: 88, height: 30 },
+    );
+  });
+
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+
+  const frame = testSetup.captureCharFrame();
+  expect(frame).toContain("Next Submit order");
+  expect(frame).toContain("Ticket Standby");
+  expect(frame).toContain("Side [b/v]");
+  expect(frame).toContain("What-if: init");
+  expect(frame).not.toContain("1 Profile");
+  expect(frame).not.toContain("Activate Ticket");
+  expect(frame).toMatchSnapshot();
+});


### PR DESCRIPTION
Refine the IBKR Trade tab so the workflow/status controls are compact summary pills, the ticket fields are grouped into clearer rows, and the preview block stays dense without feeling cramped.
Keep mouse-first interaction intact while removing the old stepper/footer duplication and tuning widths for narrower panes.
Add a focused OpenTUI snapshot test for the Trade tab layout.

Testing:
- bun test src/plugins/ibkr/trade-tab.test.tsx src/plugins/ibkr/index.test.tsx
- tmux smoke: bun run src/index.tsx