### PR TITLE
Show a gridlock tip after corner snaps

### DIFF
--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -63,6 +63,13 @@ type SnapGuidePosition =
   | "bottom-left"
   | "bottom-right";
 
+function isCornerSnapPosition(position: SnapGuidePosition): boolean {
+  return position === "top-left"
+    || position === "top-right"
+    || position === "bottom-left"
+    || position === "bottom-right";
+}
+
 interface SnapGuide {
   position: SnapGuidePosition;
   triggerRect: LayoutBounds;
@@ -817,6 +824,9 @@ export function Shell({ pluginRegistry }: ShellProps) {
         } else if (dockPreview?.kind === "snap") {
           persistLayout(floatAtRect(visibleLayout, drag.paneId, dockPreview.rect));
           focusPane(drag.paneId);
+          if (isCornerSnapPosition(dockPreview.position)) {
+            dispatch({ type: "SHOW_GRIDLOCK_TIP" });
+          }
           setDockPreview(null);
           setDragCursor(null);
           setDragFloatingRect(null);

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -3,6 +3,7 @@ import { testRender } from "@opentui/react/test-utils";
 import { AppContext, createInitialState } from "../../state/app-context";
 import { cloneLayout, createDefaultConfig } from "../../types/config";
 import { StatusBar } from "./status-bar";
+import { setSharedRegistryForTests } from "../../plugins/registry";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -11,6 +12,7 @@ afterEach(() => {
     testSetup.renderer.destroy();
     testSetup = undefined;
   }
+  setSharedRegistryForTests(undefined);
 });
 
 describe("StatusBar", () => {
@@ -43,5 +45,108 @@ describe("StatusBar", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Default");
     expect(frame).toContain("Research");
+  });
+
+  test("shows a gridlock tip after a corner snap and runs gridlock on click", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const floatingLayout = cloneLayout(config.layout);
+    floatingLayout.dockRoot = { kind: "pane", instanceId: "portfolio-list:main" };
+    floatingLayout.floating = [{ instanceId: "ticker-detail:main", x: 8, y: 2, width: 36, height: 12 }];
+
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: floatingLayout,
+        layouts: [
+          { name: "Default", layout: cloneLayout(floatingLayout) },
+          { name: "Research", layout: cloneLayout(floatingLayout) },
+        ],
+      }),
+      statusBarVisible: true,
+      gridlockTipVisible: true,
+    };
+
+    const actions: Array<{ type: string }> = [];
+    let updatedLayout = null as ReturnType<typeof cloneLayout> | null;
+    const toasts: string[] = [];
+
+    setSharedRegistryForTests({
+      getLayoutFn: () => state.config.layout,
+      getTermSizeFn: () => ({ width: 120, height: 40 }),
+      updateLayoutFn: (layout) => { updatedLayout = layout; },
+      showToastFn: (message: string) => { toasts.push(message); },
+      Slot: () => null,
+    } as any);
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action as { type: string }) }}>
+        <StatusBar />
+      </AppContext>,
+      { width: 120, height: 1 },
+    );
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Snapped a window?");
+    expect(frame).toContain("Gridlock All");
+
+    const buttonX = frame.split("\n")[0]?.indexOf("Gridlock All") ?? -1;
+    expect(buttonX).toBeGreaterThanOrEqual(0);
+
+    await testSetup.mockMouse.click(buttonX + 1, 0);
+    await testSetup.renderOnce();
+
+    expect(updatedLayout?.floating).toHaveLength(0);
+    expect(toasts).toEqual(["Retiled all panes"]);
+    expect(actions).toContainEqual({ type: "DISMISS_GRIDLOCK_TIP" });
+  });
+
+  test("auto-dismisses the gridlock tip after its timeout", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const state = {
+      ...createInitialState(config),
+      statusBarVisible: true,
+      gridlockTipVisible: true,
+      gridlockTipSequence: 1,
+    };
+    const actions: Array<{ type: string }> = [];
+    const timers: Array<{ callback: (() => void) | null; delay: number | undefined }> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    globalThis.setTimeout = ((callback: TimerHandler, delay?: number) => {
+      timers.push({ callback: typeof callback === "function" ? callback : null, delay });
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+
+    setSharedRegistryForTests({
+      getLayoutFn: () => state.config.layout,
+      getTermSizeFn: () => ({ width: 120, height: 40 }),
+      updateLayoutFn: () => {},
+      showToastFn: () => {},
+      Slot: () => null,
+    } as any);
+
+    try {
+      testSetup = await testRender(
+        <AppContext value={{ state, dispatch: (action) => actions.push(action as { type: string }) }}>
+          <StatusBar />
+        </AppContext>,
+        { width: 120, height: 1 },
+      );
+
+      await testSetup.renderOnce();
+
+      const gridlockTimer = timers.find((entry) => entry.delay === 60_000);
+      expect(gridlockTimer?.callback).toBeDefined();
+      gridlockTimer?.callback?.();
+
+      expect(actions).toContainEqual({ type: "DISMISS_GRIDLOCK_TIP" });
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
   });
 });

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,8 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { colors, hoverBg } from "../../theme/colors";
 import { useAppState, useFocusedTicker } from "../../state/app-context";
 import { marketStateLabel, marketStateColor, exchangeShortName, getExtendedHoursInfo } from "../../utils/market-status";
 import { getSharedRegistry } from "../../plugins/registry";
+import { gridlockAllPanes } from "../../plugins/pane-manager";
+
+const GRIDLOCK_TIP_DURATION_MS = 60_000;
 
 function truncate(text: string, width: number): string {
   if (width <= 0) return "";
@@ -16,6 +19,7 @@ export function StatusBar() {
   const { state, dispatch } = useAppState();
   const { symbol, financials: focusedFinancials } = useFocusedTicker();
   const [hoveredTab, setHoveredTab] = useState<number | null>(null);
+  const [hoveredControl, setHoveredControl] = useState<string | null>(null);
   if (!state.statusBarVisible) return null;
 
   // Get market state and exchange from the focused ticker context or first available.
@@ -32,6 +36,27 @@ export function StatusBar() {
   const layouts = state.config.layouts ?? [];
   const activeLayoutIdx = state.config.activeLayoutIndex ?? 0;
   const hasMultipleLayouts = layouts.length > 1;
+  const showGridlockTip = state.gridlockTipVisible && !!registry;
+
+  useEffect(() => {
+    if (!state.gridlockTipVisible) return;
+    const timer = setTimeout(() => {
+      dispatch({ type: "DISMISS_GRIDLOCK_TIP" });
+    }, GRIDLOCK_TIP_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [dispatch, state.gridlockTipSequence, state.gridlockTipVisible]);
+
+  const handleGridlockTip = () => {
+    if (!registry) return;
+    const { width, height } = registry.getTermSizeFn();
+    registry.updateLayoutFn(gridlockAllPanes(registry.getLayoutFn(), { x: 0, y: 0, width, height }));
+    registry.showToastFn("Retiled all panes", { type: "success" });
+    dispatch({ type: "DISMISS_GRIDLOCK_TIP" });
+  };
+
+  const dismissGridlockTip = () => {
+    dispatch({ type: "DISMISS_GRIDLOCK_TIP" });
+  };
 
   return (
     <box
@@ -66,6 +91,26 @@ export function StatusBar() {
           </text>
         )}
       </box>
+      {showGridlockTip && (
+        <box paddingLeft={1} flexShrink={0} flexDirection="row">
+          <text fg={colors.textDim}>Snapped a window?</text>
+          <box width={1} />
+          <box
+            backgroundColor={hoveredControl === "gridlock-tip" ? hoverBg() : colors.header}
+            onMouseMove={() => setHoveredControl("gridlock-tip")}
+            onMouseDown={handleGridlockTip}
+          >
+            <text fg={colors.headerText}> Gridlock All </text>
+          </box>
+          <text
+            fg={hoveredControl === "gridlock-tip-dismiss" ? colors.text : colors.textDim}
+            onMouseMove={() => setHoveredControl("gridlock-tip-dismiss")}
+            onMouseDown={dismissGridlockTip}
+          >
+            {" x"}
+          </text>
+        </box>
+      )}
       <box flexGrow={1} />
       {extText && (
         <box paddingRight={1}>

--- a/src/state/app-context.test.tsx
+++ b/src/state/app-context.test.tsx
@@ -44,6 +44,22 @@ describe("appReducer command bar state", () => {
     expect(next.commandBarQuery).toBe("PL notes");
   });
 
+  test("re-shows the gridlock tip and refreshes its sequence on every trigger", () => {
+    const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+
+    const shown = appReducer(initial, { type: "SHOW_GRIDLOCK_TIP" });
+    expect(shown.gridlockTipVisible).toBe(true);
+    expect(shown.gridlockTipSequence).toBe(1);
+
+    const dismissed = appReducer(shown, { type: "DISMISS_GRIDLOCK_TIP" });
+    expect(dismissed.gridlockTipVisible).toBe(false);
+    expect(dismissed.gridlockTipSequence).toBe(1);
+
+    const repeated = appReducer(dismissed, { type: "SHOW_GRIDLOCK_TIP" });
+    expect(repeated.gridlockTipVisible).toBe(true);
+    expect(repeated.gridlockTipSequence).toBe(2);
+  });
+
   test("tracks layout undo and redo history", () => {
     const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
     const changedLayout = cloneLayout(initial.config.layout);

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -71,6 +71,8 @@ export interface AppState {
   refreshing: Set<string>;
   initialized: boolean;
   statusBarVisible: boolean;
+  gridlockTipVisible: boolean;
+  gridlockTipSequence: number;
   inputCaptured: boolean;
   updateAvailable: ReleaseInfo | null;
   updateProgress: UpdateProgress | null;
@@ -93,6 +95,8 @@ export type AppAction =
   | { type: "SET_BROKER_ACCOUNTS"; instanceId: string; accounts: BrokerAccount[] }
   | { type: "SET_INITIALIZED" }
   | { type: "TOGGLE_STATUS_BAR" }
+  | { type: "SHOW_GRIDLOCK_TIP" }
+  | { type: "DISMISS_GRIDLOCK_TIP" }
   | { type: "SET_THEME"; theme: string }
   | { type: "SET_UPDATE_AVAILABLE"; release: ReleaseInfo }
   | { type: "SET_UPDATE_PROGRESS"; progress: UpdateProgress | null }
@@ -452,6 +456,17 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     case "TOGGLE_STATUS_BAR":
       return { ...state, statusBarVisible: !state.statusBarVisible };
 
+    case "SHOW_GRIDLOCK_TIP":
+      return {
+        ...state,
+        gridlockTipVisible: true,
+        gridlockTipSequence: state.gridlockTipSequence + 1,
+      };
+
+    case "DISMISS_GRIDLOCK_TIP":
+      if (!state.gridlockTipVisible) return state;
+      return { ...state, gridlockTipVisible: false };
+
     case "SET_THEME":
       applyTheme(action.theme);
       return { ...state, config: { ...state.config, theme: action.theme } };
@@ -806,6 +821,8 @@ export function createInitialState(config: AppConfig, sessionSnapshot: AppSessio
     refreshing: new Set(),
     initialized: false,
     statusBarVisible: sessionSnapshot?.statusBarVisible !== false,
+    gridlockTipVisible: false,
+    gridlockTipSequence: 0,
     inputCaptured: false,
     updateAvailable: null,
     updateProgress: null,


### PR DESCRIPTION
Shows a status bar tip after snapping a floating window into a corner so users can discover Gridlock.

The tip can retile windows, be dismissed manually, and auto-hide after 60 seconds, with repeated corner snaps refreshing the timer.

Tests: `bun test src/state/app-context.test.tsx src/components/layout/status-bar.test.tsx src/components/layout/shell.test.tsx`