### PR TITLE
Add comparison chart pane with percent axis

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,7 +32,7 @@ import {
   type PaneBinding,
   type PaneInstanceConfig,
 } from "./types/config";
-import type { PaneTemplateContext, PaneTemplateCreateOptions, PaneTemplateInstanceConfig } from "./types/plugin";
+import type { PaneTemplateContext, PaneTemplateCreateOptions, PaneTemplateInstanceConfig, WizardStep } from "./types/plugin";
 import type { PaneSettingField } from "./types/plugin";
 import type { TickerRecord, TickerMetadata, TickerPosition, Portfolio } from "./types/ticker";
 import type { DataProvider } from "./types/data-provider";
@@ -56,6 +56,11 @@ import { optionsPlugin } from "./plugins/builtin/options";
 import { notesPlugin } from "./plugins/builtin/notes";
 import { askAiPlugin } from "./plugins/builtin/ask-ai";
 import { chatPlugin } from "./plugins/builtin/chat";
+import {
+  buildComparisonChartPaneTitle,
+  COMPARISON_CHART_PANE_ID,
+  comparisonChartPlugin,
+} from "./plugins/builtin/comparison-chart";
 import { debugPlugin } from "./plugins/builtin/debug";
 import { layoutManagerPlugin, setLayoutManagerDispatch } from "./plugins/builtin/layout-manager";
 import { saveConfig } from "./data/config-store";
@@ -88,8 +93,14 @@ import {
 import { initializeAppState } from "./state/app-bootstrap";
 import { TickerRefreshQueue } from "./state/ticker-refresh-queue";
 import { PaneSettingsDialogContent } from "./components/pane-settings-dialog";
+import {
+  PaneTemplateInfoStep,
+  PaneTemplateInputStep,
+  PaneTemplateSelectStep,
+} from "./components/pane-template-wizard";
 import { setPaneSettings, updatePaneInstance } from "./pane-settings";
 import { debugLog } from "./utils/debug-log";
+import { formatTickerListInput, parseTickerListInput } from "./utils/ticker-list";
 
 /** Global-level dedup: prevents concurrent refresh calls for the same symbol. */
 const refreshInFlight: Set<string> = (globalThis as any).__refreshInFlight ??= new Set<string>();
@@ -152,6 +163,83 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     }
     return state.config.portfolios[0] ?? null;
   }, [focusedCollectionId, state.config.portfolios]);
+
+  const runPaneTemplateWizard = useCallback(async (steps: WizardStep[]): Promise<Record<string, string> | null> => {
+    const values: Record<string, string> = {};
+
+    for (const step of steps) {
+      if (step.dependsOn && values[step.dependsOn.key] !== step.dependsOn.value) {
+        continue;
+      }
+
+      if (step.type === "info") {
+        await dialog.alert({
+          content: (ctx) => <PaneTemplateInfoStep {...ctx} step={step} />,
+        });
+        continue;
+      }
+
+      const result = step.type === "select"
+        ? await dialog.prompt<string>({
+          content: (ctx) => <PaneTemplateSelectStep {...ctx} step={step} />,
+        })
+        : await dialog.prompt<string>({
+          content: (ctx) => <PaneTemplateInputStep {...ctx} step={step} />,
+        });
+
+      if (result === undefined || (step.type === "select" && !result)) {
+        return null;
+      }
+
+      values[step.key] = result;
+    }
+
+    return values;
+  }, [dialog]);
+
+  const resolveTickerListInput = useCallback(async (rawInput: string, collectionId: string | null): Promise<string[]> => {
+    const tokens = parseTickerListInput(rawInput);
+    const currentState = stateRef.current;
+    const activePortfolio = currentState.config.portfolios.find((portfolio) => portfolio.id === collectionId);
+    const symbols: string[] = [];
+    const seen = new Set<string>();
+
+    for (const token of tokens) {
+      const resolvedTicker = await resolveTickerSearch({
+        query: token,
+        activeTicker: null,
+        tickers: currentState.tickers,
+        dataProvider,
+        searchContext: {
+          preferBroker: true,
+          brokerId: activePortfolio?.brokerId,
+          brokerInstanceId: activePortfolio?.brokerInstanceId,
+        },
+      });
+
+      if (!resolvedTicker) {
+        throw new Error(`No ticker match found for "${token}".`);
+      }
+
+      const symbol = resolvedTicker.kind === "local"
+        ? resolvedTicker.ticker.metadata.ticker
+        : resolvedTicker.symbol;
+
+      if (resolvedTicker.kind === "provider") {
+        const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolvedTicker.result);
+        dispatch({ type: "UPDATE_TICKER", ticker });
+        if (created) {
+          pluginRegistry.events.emit("ticker:added", { symbol: ticker.metadata.ticker, ticker });
+        }
+      }
+
+      if (seen.has(symbol)) continue;
+      seen.add(symbol);
+      symbols.push(symbol);
+    }
+
+    return symbols;
+  }, [dataProvider, dispatch, pluginRegistry.events, tickerRepository]);
 
   const resolveCollectionSourcePaneId = useCallback((preferredPaneId?: string | null) => {
     const tryResolve = (candidate: string | null | undefined): string | null => {
@@ -925,10 +1013,20 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
       activeCollectionId: getFocusedCollectionId(state),
     };
     let resolvedOptions = options;
+    if (template.wizard && template.wizard.length > 0 && !options?.arg && !options?.values) {
+      const values = await runPaneTemplateWizard(template.wizard);
+      if (!values) return;
+      resolvedOptions = {
+        ...options,
+        values,
+        arg: template.shortcut?.argPlaceholder ? values[template.shortcut.argPlaceholder] : options?.arg,
+      };
+    }
+
     if (template.shortcut?.argPlaceholder === "ticker") {
       const activePortfolio = state.config.portfolios.find((portfolio) => portfolio.id === baseContext.activeCollectionId);
       const resolvedTicker = await resolveTickerSearch({
-        query: options?.arg,
+        query: resolvedOptions?.arg,
         activeTicker: baseContext.activeTicker,
         tickers: state.tickers,
         dataProvider,
@@ -939,13 +1037,13 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
         },
       });
       if (!resolvedTicker) {
-        pluginRegistry.showToastFn(`No ticker match found for "${options?.arg ?? ""}".`, { type: "info" });
+        pluginRegistry.showToastFn(`No ticker match found for "${resolvedOptions?.arg ?? ""}".`, { type: "info" });
         return;
       }
 
       if (resolvedTicker.kind === "local") {
         resolvedOptions = {
-          ...options,
+          ...resolvedOptions,
           symbol: resolvedTicker.ticker.metadata.ticker,
           ticker: resolvedTicker.ticker,
           searchResult: null,
@@ -957,11 +1055,24 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
           pluginRegistry.events.emit("ticker:added", { symbol: ticker.metadata.ticker, ticker });
         }
         resolvedOptions = {
-          ...options,
+          ...resolvedOptions,
           symbol: ticker.metadata.ticker,
           ticker,
           searchResult: resolvedTicker.result,
         };
+      }
+    } else if (template.shortcut?.argPlaceholder === "tickers") {
+      const rawInput = resolvedOptions?.arg ?? resolvedOptions?.values?.tickers ?? "";
+      try {
+        const symbols = await resolveTickerListInput(rawInput, baseContext.activeCollectionId);
+        resolvedOptions = {
+          ...resolvedOptions,
+          arg: rawInput,
+          symbols,
+        };
+      } catch (error) {
+        pluginRegistry.showToastFn(error instanceof Error ? error.message : "Could not resolve those tickers.", { type: "info" });
+        return;
       }
     }
 
@@ -1004,7 +1115,17 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
     }
 
     placePaneInstance(instance, paneDef, spec);
-  }, [buildPaneInstance, dataProvider, dispatch, placePaneInstance, pluginRegistry, state, tickerRepository]);
+  }, [
+    buildPaneInstance,
+    dataProvider,
+    dispatch,
+    placePaneInstance,
+    pluginRegistry,
+    resolveTickerListInput,
+    runPaneTemplateWizard,
+    state,
+    tickerRepository,
+  ]);
 
   const openPaneSettings = useCallback(async (paneId?: string) => {
     const targetPaneId = paneId
@@ -1050,6 +1171,23 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, sessionSnaps
           settings: {
             ...(instance.settings ?? {}),
             symbol,
+          },
+        }));
+        persistLayout(nextLayout, { pushHistory: shouldPushHistory });
+        shouldPushHistory = false;
+        return;
+      }
+
+      if (descriptor.pane.paneId === COMPARISON_CHART_PANE_ID && field.key === "symbolsText") {
+        const rawInput = typeof value === "string" ? value : "";
+        const symbols = await resolveTickerListInput(rawInput, descriptor.context.activeCollectionId);
+        const nextLayout = updatePaneInstance(currentState.config.layout, targetId, (instance) => ({
+          ...instance,
+          title: buildComparisonChartPaneTitle(symbols),
+          settings: {
+            ...(instance.settings ?? {}),
+            symbols,
+            symbolsText: formatTickerListInput(symbols),
           },
         }));
         persistLayout(nextLayout, { pushHistory: shouldPushHistory });
@@ -1328,6 +1466,7 @@ export function App({ config: initialConfig, renderer, externalPlugins = [] }: A
     pluginRegistry.register(notesPlugin);
     pluginRegistry.register(askAiPlugin);
     pluginRegistry.register(chatPlugin);
+    pluginRegistry.register(comparisonChartPlugin);
     pluginRegistry.register(debugPlugin);
 
     for (const { plugin, error } of externalPlugins) {

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -1,5 +1,5 @@
 import { RGBA } from "@opentui/core";
-import type { ChartColors, Pixel, PixelBuffer, ChartRenderMode } from "./chart-types";
+import type { ChartAxisMode, ChartColors, Pixel, PixelBuffer, ChartRenderMode } from "./chart-types";
 import type { ProjectedChartPoint } from "./chart-data";
 
 // ---------------------------------------------------------------------------
@@ -604,6 +604,20 @@ export function formatPrice(value: number): string {
   return `$${value.toFixed(2)}`;
 }
 
+function formatPercentAxisValue(value: number): string {
+  const abs = Math.abs(value);
+  const decimals = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+  const prefix = value > 0 ? "+" : "";
+  return `${prefix}${value.toFixed(decimals)}%`;
+}
+
+function formatAxisValue(value: number, axisMode: ChartAxisMode, basePrice: number): string {
+  if (axisMode === "percent" && basePrice !== 0) {
+    return formatPercentAxisValue(((value - basePrice) / basePrice) * 100);
+  }
+  return formatPrice(value);
+}
+
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 export function formatDate(date: Date | string | number): string {
@@ -707,6 +721,7 @@ export interface RenderChartOptions {
   volumeHeight: number;
   cursorX: number | null;
   mode: ChartRenderMode;
+  axisMode?: ChartAxisMode;
   colors: ResolvedChartPalette;
 }
 
@@ -824,6 +839,7 @@ export function renderChart(
   }
 
   const { width, colors: palette, mode } = opts;
+  const axisMode = opts.axisMode ?? "price";
 
   // Braille resolution: 2 dot-columns per terminal column, 4 dot-rows per terminal row
   const dotWidth = width * 2;
@@ -880,7 +896,7 @@ export function renderChart(
     lines: bufferToBrailleLines(buf, palette.bgColor),
     axisLabels: gridLines.map((line) => ({
       row: Math.floor(line.y / 4), // 4 dot-rows per terminal row
-      label: formatPrice(line.price),
+      label: formatAxisValue(line.price, axisMode, points[0]!.close),
     })),
     timeLabels: buildTimeAxis(points.map((point) => point.date), width),
     activePoint,

--- a/src/components/chart/chart-types.ts
+++ b/src/components/chart/chart-types.ts
@@ -2,11 +2,13 @@ import type { PricePoint } from "../../types/financials";
 
 export type TimeRange = "1W" | "1M" | "3M" | "6M" | "1Y" | "5Y" | "ALL";
 export type ChartRenderMode = "area" | "line" | "candles" | "ohlc";
+export type ChartAxisMode = "price" | "percent";
 export type ChartRendererPreference = "auto" | "kitty" | "braille";
 export type ResolvedChartRenderer = "kitty" | "braille";
 
 export const TIME_RANGES: TimeRange[] = ["1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
 export const CHART_RENDER_MODES: ChartRenderMode[] = ["area", "line", "candles", "ohlc"];
+export const CHART_AXIS_MODES: ChartAxisMode[] = ["price", "percent"];
 export const CHART_RENDERER_PREFERENCES: ChartRendererPreference[] = ["auto", "kitty", "braille"];
 
 /** Number of trading days for each time range */

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -211,6 +211,27 @@ describe("renderChart", () => {
     ]);
   });
 
+  test("formats y-axis labels as percent change when requested", () => {
+    const projection = projectChartData(chartFixture, 12, "line", false);
+    const result = renderChart(projection.points, {
+      width: 12,
+      height: 5,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      mode: projection.effectiveMode,
+      axisMode: "percent",
+      colors: palette,
+    });
+
+    expect(result.axisLabels).toEqual([
+      { row: 0, label: "+9.09%" },
+      { row: 1, label: "0.00%" },
+      { row: 3, label: "-9.09%" },
+      { row: 4, label: "-18.2%" },
+    ]);
+  });
+
   test("accepts serialized string dates from cached chart data", () => {
     const serialized = chartFixture.map((point) => ({
       ...point,

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -8,7 +8,7 @@ import { formatCompact, formatCurrency } from "../../utils/format";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { filterByTimeRange, getVisibleWindow, projectChartData, resolveBarSize } from "./chart-data";
 import { buildChartScene, formatDateShort, renderChart, resolveChartPalette } from "./chart-renderer";
-import { CHART_RENDER_MODES, TIME_RANGES, type ChartRenderMode, type ChartViewState, type ResolvedChartRenderer } from "./chart-types";
+import { CHART_RENDER_MODES, TIME_RANGES, type ChartAxisMode, type ChartRenderMode, type ChartViewState, type ResolvedChartRenderer } from "./chart-types";
 import { computeBitmapSize, intersectCellRects, renderNativeChart, type CellRect } from "./native/chart-rasterizer";
 import { ensureKittySupport, getCachedKittySupport } from "./native/kitty-support";
 import { resolveChartRendererState } from "./native/renderer-selection";
@@ -35,6 +35,7 @@ interface StockChartProps {
   focused: boolean;
   interactive?: boolean;
   compact?: boolean;
+  axisMode?: ChartAxisMode;
 }
 
 interface DragState {
@@ -177,7 +178,7 @@ function buildNativeBitmapKey(
   return [pointCount, pixelWidth, pixelHeight, mode, showVolume ? "1" : "0", paletteId, fingerprint].join("::");
 }
 
-export function StockChart({ width, height, focused, interactive, compact }: StockChartProps) {
+export function StockChart({ width, height, focused, interactive, compact, axisMode = "price" }: StockChartProps) {
   const renderer = useRenderer();
   const { state, dispatch } = useAppState();
   const paneId = usePaneInstanceId();
@@ -235,7 +236,7 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
   const baseHistoryEndMs = baseHistory.length > 0
     ? new Date(baseHistory[baseHistory.length - 1]!.date).getTime()
     : null;
-  const axisWidth = compact ? 0 : 10;
+  const axisWidth = compact ? 0 : axisMode === "percent" ? 11 : 10;
   const chartWidth = Math.max(width - axisWidth - 2, 20);
   const maxCursorX = chartWidth - 1;
   const panStep = Math.max(Math.floor(chartWidth / 10), 1);
@@ -482,8 +483,9 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     volumeHeight,
     cursorX,
     mode: projection.effectiveMode,
+    axisMode,
     colors: chartColors,
-  }), [chartColors, chartHeight, chartWidth, compact, cursorX, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, cursorX, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
 
   const nativeScene = useMemo(() => buildChartScene(projection.points, {
     width: chartWidth,
@@ -492,8 +494,9 @@ export function StockChart({ width, height, focused, interactive, compact }: Sto
     volumeHeight,
     cursorX: null,
     mode: projection.effectiveMode,
+    axisMode,
     colors: chartColors,
-  }), [chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
 
   const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
   const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;

--- a/src/components/pane-template-wizard.tsx
+++ b/src/components/pane-template-wizard.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+import type { InputRenderable } from "@opentui/core";
+import { useDialogKeyboard, type AlertContext, type PromptContext } from "@opentui-ui/dialog/react";
+import type { WizardStep } from "../types/plugin";
+import { colors } from "../theme/colors";
+import { DialogFrame, ListView, TextField } from "./ui";
+
+export function PaneTemplateInfoStep({
+  dismiss,
+  dialogId,
+  step,
+}: AlertContext & { step: WizardStep }) {
+  useDialogKeyboard((event) => {
+    event.stopPropagation();
+    if (event.name === "return" || event.name === "enter" || event.name === "escape") {
+      dismiss();
+    }
+  }, dialogId);
+
+  return (
+    <DialogFrame title={step.label} footer="Press Enter to continue">
+      <box flexDirection="column">
+        {step.body?.map((line, index) => (
+          <box key={`${step.key}:${index}`} height={1}>
+            <text fg={colors.textDim}>{line || " "}</text>
+          </box>
+        ))}
+      </box>
+    </DialogFrame>
+  );
+}
+
+export function PaneTemplateInputStep({
+  resolve,
+  step,
+}: PromptContext<string> & { step: WizardStep }) {
+  const inputRef = useRef<InputRenderable>(null);
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    inputRef.current?.focus?.();
+  }, []);
+
+  return (
+    <DialogFrame
+      title={step.label}
+      footer={step.defaultValue ? `Press Enter to use ${step.defaultValue}` : "Enter to continue"}
+    >
+      <box flexDirection="column">
+        {step.body?.map((line, index) => (
+          <box key={`${step.key}:${index}`} height={1}>
+            <text fg={colors.textDim}>{line || " "}</text>
+          </box>
+        ))}
+        <box height={1} />
+        <TextField
+          inputRef={inputRef}
+          value={value}
+          placeholder={step.placeholder || ""}
+          focused
+          onChange={setValue}
+          onSubmit={(submittedValue) => {
+            const submitted = submittedValue.trim() || step.defaultValue || "";
+            if (submitted) resolve(submitted);
+          }}
+        />
+      </box>
+    </DialogFrame>
+  );
+}
+
+export function PaneTemplateSelectStep({
+  resolve,
+  step,
+  dialogId,
+}: PromptContext<string> & { step: WizardStep }) {
+  const options = step.options ?? [];
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useDialogKeyboard((event) => {
+    event.stopPropagation();
+    if (event.name === "up" || event.name === "k") {
+      setSelectedIndex((index) => Math.max(0, index - 1));
+    } else if (event.name === "down" || event.name === "j") {
+      setSelectedIndex((index) => Math.min(options.length - 1, index + 1));
+    } else if (event.name === "return" || event.name === "enter") {
+      resolve(options[selectedIndex]?.value ?? "");
+    } else if (event.name === "escape") {
+      resolve("");
+    }
+  }, dialogId);
+
+  return (
+    <DialogFrame title={step.label} footer="Use ↑↓ to choose · enter to select · esc to cancel">
+      <box flexDirection="column">
+        {step.body?.map((line, index) => (
+          <box key={`${step.key}:${index}`} height={1}>
+            <text fg={colors.textDim}>{line || " "}</text>
+          </box>
+        ))}
+        <box height={1} />
+        <ListView
+          items={options.map((option) => ({
+            id: option.value,
+            label: option.label,
+          }))}
+          selectedIndex={selectedIndex}
+          bgColor={colors.commandBg}
+          onSelect={setSelectedIndex}
+          onActivate={(item) => resolve(item.id)}
+        />
+      </box>
+    </DialogFrame>
+  );
+}

--- a/src/plugins/builtin/comparison-chart.test.tsx
+++ b/src/plugins/builtin/comparison-chart.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultConfig } from "../../types/config";
+import {
+  buildComparisonChartPaneTitle,
+  comparisonChartPlugin,
+  COMPARISON_CHART_TEMPLATE_ID,
+  getComparisonChartPaneSettings,
+} from "./comparison-chart";
+
+describe("comparisonChartPlugin", () => {
+  test("creates a configured comparison pane from resolved symbols", () => {
+    const template = comparisonChartPlugin.paneTemplates?.find((entry) => entry.id === COMPARISON_CHART_TEMPLATE_ID);
+
+    expect(template).toBeDefined();
+    expect(template?.createInstance?.({
+      config: createDefaultConfig("/tmp/gloomberb-compare"),
+      layout: createDefaultConfig("/tmp/gloomberb-compare").layout,
+      focusedPaneId: "ticker-detail:main",
+      activeTicker: null,
+      activeCollectionId: null,
+    }, {
+      symbols: ["AAPL", "MSFT", "NVDA"],
+    })).toEqual({
+      title: "AAPL · MSFT · NVDA",
+      settings: {
+        axisMode: "price",
+        symbols: ["AAPL", "MSFT", "NVDA"],
+        symbolsText: "AAPL, MSFT, NVDA",
+      },
+    });
+  });
+
+  test("parses stored pane settings and backfills the text form", () => {
+    expect(getComparisonChartPaneSettings({
+      axisMode: "percent",
+      symbols: ["AAPL", "MSFT"],
+    })).toEqual({
+      axisMode: "percent",
+      symbols: ["AAPL", "MSFT"],
+      symbolsText: "AAPL, MSFT",
+    });
+  });
+});
+
+describe("buildComparisonChartPaneTitle", () => {
+  test("summarizes longer symbol lists", () => {
+    expect(buildComparisonChartPaneTitle(["AAPL", "MSFT", "NVDA", "META"])).toBe("AAPL · MSFT +2");
+  });
+});

--- a/src/plugins/builtin/comparison-chart.tsx
+++ b/src/plugins/builtin/comparison-chart.tsx
@@ -1,0 +1,408 @@
+import { TextAttributes } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { EmptyState } from "../../components";
+import { filterByTimeRange, projectChartData } from "../../components/chart/chart-data";
+import { renderChart, resolveChartPalette } from "../../components/chart/chart-renderer";
+import type { ChartAxisMode } from "../../components/chart/chart-types";
+import { getSharedDataProvider, getSharedRegistry } from "../../plugins/registry";
+import { useAppState } from "../../state/app-context";
+import { colors, priceColor } from "../../theme/colors";
+import type { PricePoint, Quote } from "../../types/financials";
+import type { GloomPlugin, PaneProps, PaneSettingsDef } from "../../types/plugin";
+import { formatCurrency, formatPercentRaw } from "../../utils/format";
+import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } from "../../utils/ticker-list";
+
+export const COMPARISON_CHART_PANE_ID = "comparison-chart";
+export const COMPARISON_CHART_TEMPLATE_ID = "comparison-chart-pane";
+
+interface ComparisonChartPaneSettings {
+  axisMode: ChartAxisMode;
+  symbols: string[];
+  symbolsText: string;
+}
+
+function isChartAxisMode(value: unknown): value is ChartAxisMode {
+  return value === "price" || value === "percent";
+}
+
+function coerceSymbolList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const parsed = value.filter((entry): entry is string => typeof entry === "string");
+  try {
+    return parseTickerListInput(parsed.join(", "), MAX_TICKER_LIST_SIZE);
+  } catch {
+    return parsed.slice(0, MAX_TICKER_LIST_SIZE);
+  }
+}
+
+export function getComparisonChartPaneSettings(settings: Record<string, unknown> | undefined): ComparisonChartPaneSettings {
+  const storedSymbols = coerceSymbolList(settings?.symbols);
+  const storedText = typeof settings?.symbolsText === "string" ? settings.symbolsText : "";
+  let symbols = storedSymbols;
+
+  if (symbols.length === 0 && storedText.trim().length > 0) {
+    try {
+      symbols = parseTickerListInput(storedText, MAX_TICKER_LIST_SIZE);
+    } catch {
+      symbols = [];
+    }
+  }
+
+  return {
+    axisMode: isChartAxisMode(settings?.axisMode) ? settings.axisMode : "price",
+    symbols,
+    symbolsText: storedText.trim().length > 0 ? storedText : formatTickerListInput(symbols),
+  };
+}
+
+function buildComparisonChartSettingsDef(): PaneSettingsDef {
+  return {
+    title: "Comparison Chart Settings",
+    fields: [
+      {
+        key: "symbolsText",
+        label: "Tickers",
+        description: `Enter 1-${MAX_TICKER_LIST_SIZE} tickers separated by commas.`,
+        type: "text",
+        placeholder: "AAPL, MSFT, NVDA",
+      },
+      {
+        key: "axisMode",
+        label: "Chart Y-Axis",
+        description: "Show prices or percent change from the first visible point on each chart.",
+        type: "select",
+        options: [
+          { value: "price", label: "Price" },
+          { value: "percent", label: "Percent" },
+        ],
+      },
+    ],
+  };
+}
+
+export function buildComparisonChartPaneTitle(symbols: string[]): string {
+  if (symbols.length === 0) return "Compare";
+  if (symbols.length <= 3) return symbols.join(" · ");
+  return `${symbols.slice(0, 2).join(" · ")} +${symbols.length - 2}`;
+}
+
+function getDisplayQuote(quote: Quote | undefined, history: PricePoint[]): {
+  price: number;
+  change: number;
+  changePercent: number;
+  currency?: string;
+} | null {
+  if (quote) {
+    return {
+      price: quote.price,
+      change: quote.change,
+      changePercent: quote.changePercent,
+      currency: quote.currency,
+    };
+  }
+
+  if (history.length < 2) return null;
+  const first = history[0]!.close;
+  const last = history[history.length - 1]!.close;
+  const change = last - first;
+  return {
+    price: last,
+    change,
+    changePercent: first !== 0 ? (change / first) * 100 : 0,
+  };
+}
+
+function getComparisonColumnCount(width: number, count: number): number {
+  if (count <= 1) return 1;
+  if (width >= 150 && count >= 3) return 3;
+  if (width >= 90) return 2;
+  return 1;
+}
+
+function ComparisonChartCard({
+  symbol,
+  width,
+  height,
+  axisMode,
+  selected,
+  onHover,
+  onOpen,
+}: {
+  symbol: string;
+  width: number;
+  height: number;
+  axisMode: ChartAxisMode;
+  selected: boolean;
+  onHover: () => void;
+  onOpen: () => void;
+}) {
+  const { state } = useAppState();
+  const ticker = state.tickers.get(symbol) ?? null;
+  const financials = state.financials.get(symbol) ?? null;
+  const [remoteHistory, setRemoteHistory] = useState<PricePoint[] | null>(null);
+  const fetchIdRef = useRef(0);
+
+  useEffect(() => {
+    const provider = getSharedDataProvider();
+    setRemoteHistory(null);
+    if (!provider) return;
+
+    const id = ++fetchIdRef.current;
+    const instrument = ticker?.metadata.broker_contracts?.[0] ?? null;
+    provider.getPriceHistory(symbol, ticker?.metadata.exchange || "", "1Y", {
+      brokerId: instrument?.brokerId,
+      brokerInstanceId: instrument?.brokerInstanceId,
+      instrument,
+    }).then((points) => {
+      if (fetchIdRef.current === id) {
+        setRemoteHistory(points);
+      }
+    }).catch(() => {
+      if (fetchIdRef.current === id) {
+        setRemoteHistory(null);
+      }
+    });
+  }, [symbol, ticker?.metadata.broker_contracts, ticker?.metadata.exchange]);
+
+  const history = remoteHistory && remoteHistory.length > 0
+    ? remoteHistory
+    : (financials?.priceHistory ?? []);
+  const windowedHistory = useMemo(() => filterByTimeRange(history, "1Y"), [history]);
+  const displayQuote = getDisplayQuote(financials?.quote, windowedHistory);
+  const axisWidth = axisMode === "percent" ? 11 : 10;
+  const plotWidth = Math.max(width - axisWidth - 4, 18);
+  const plotHeight = Math.max(height - 4, 4);
+
+  const projection = useMemo(() => (
+    projectChartData(windowedHistory, plotWidth, "line", false)
+  ), [plotWidth, windowedHistory]);
+
+  const chartColors = useMemo(() => {
+    const rawChange = displayQuote?.change ?? 0;
+    const trend = rawChange < 0 ? "negative" : rawChange > 0 ? "positive" : "neutral";
+    return resolveChartPalette({
+      bg: colors.bg,
+      border: colors.border,
+      borderFocused: colors.borderFocused,
+      text: colors.text,
+      textDim: colors.textDim,
+      positive: colors.positive,
+      negative: colors.negative,
+    }, trend);
+  }, [displayQuote?.change]);
+
+  const result = useMemo(() => (
+    renderChart(projection.points, {
+      width: plotWidth,
+      height: plotHeight,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      mode: projection.effectiveMode,
+      axisMode,
+      colors: chartColors,
+    })
+  ), [axisMode, chartColors, plotHeight, plotWidth, projection.effectiveMode, projection.points]);
+
+  const axisLabels = new Map(result.axisLabels.map((entry) => [entry.row, entry.label]));
+  const currency = financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
+  const headerColor = priceColor(displayQuote?.change ?? 0);
+
+  return (
+    <box
+      width={width}
+      height={height}
+      flexDirection="column"
+      border
+      borderColor={selected ? colors.borderFocused : colors.border}
+      backgroundColor={colors.panel}
+      paddingX={1}
+      onMouseMove={onHover}
+      onMouseDown={onOpen}
+    >
+      <box flexDirection="row" justifyContent="space-between" height={1}>
+        <text fg={colors.textBright} attributes={TextAttributes.BOLD}>{symbol}</text>
+        <text fg={headerColor}>
+          {displayQuote ? formatCurrency(displayQuote.price, currency) : "Loading"}
+        </text>
+      </box>
+      <box height={1}>
+        <text fg={headerColor}>
+          {displayQuote
+            ? `${displayQuote.change >= 0 ? "+" : ""}${displayQuote.change.toFixed(2)} (${formatPercentRaw(displayQuote.changePercent)})`
+            : (ticker?.metadata.name ?? "Waiting for data...")}
+        </text>
+      </box>
+      {windowedHistory.length >= 2 ? (
+        <>
+          <box flexDirection="row" height={plotHeight}>
+            <box flexDirection="column" width={plotWidth}>
+              {result.lines.map((line, index) => <text key={`${symbol}:plot:${index}`} content={line as any} />)}
+            </box>
+            <box width={axisWidth} height={plotHeight} flexDirection="column">
+              {Array.from({ length: plotHeight }, (_, row) => (
+                <text key={`${symbol}:axis:${row}`} fg={colors.textDim}>
+                  {axisLabels.has(row) ? ` ${axisLabels.get(row)!.padStart(axisWidth - 1)}` : " ".repeat(axisWidth)}
+                </text>
+              ))}
+            </box>
+          </box>
+          <box height={1}>
+            <text fg={colors.textMuted}>{result.timeLabels}</text>
+          </box>
+        </>
+      ) : (
+        <box flexGrow={1} alignItems="center" justifyContent="center">
+          <text fg={colors.textDim}>No chart data yet.</text>
+        </box>
+      )}
+    </box>
+  );
+}
+
+function ComparisonChartPane({ paneId, focused, width, height }: PaneProps) {
+  const registry = getSharedRegistry();
+  const { state } = useAppState();
+  const pane = state.config.layout.instances.find((instance) => instance.instanceId === paneId);
+  const settings = getComparisonChartPaneSettings(pane?.settings);
+  const symbols = settings.symbols;
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const columns = getComparisonColumnCount(width, symbols.length);
+  const rowGap = 1;
+  const contentWidth = Math.max(width - 2, 20);
+  const cardWidth = Math.max(Math.floor((contentWidth - (columns - 1) * rowGap) / columns), 28);
+  const cardHeight = Math.max(Math.min(height - 2, width >= 150 ? 12 : 10), 8);
+
+  useEffect(() => {
+    if (selectedIndex < symbols.length) return;
+    setSelectedIndex(Math.max(0, symbols.length - 1));
+  }, [selectedIndex, symbols.length]);
+
+  const openTicker = (symbol: string) => {
+    registry?.selectTickerFn(symbol);
+    registry?.focusPaneFn("ticker-detail");
+  };
+
+  useKeyboard((event) => {
+    if (!focused || symbols.length === 0) return;
+
+    switch (event.name) {
+      case "left":
+      case "h":
+        setSelectedIndex((index) => Math.max(0, index - 1));
+        return;
+      case "right":
+      case "l":
+        setSelectedIndex((index) => Math.min(symbols.length - 1, index + 1));
+        return;
+      case "up":
+      case "k":
+        setSelectedIndex((index) => Math.max(0, index - columns));
+        return;
+      case "down":
+      case "j":
+        setSelectedIndex((index) => Math.min(symbols.length - 1, index + columns));
+        return;
+      case "return":
+      case "enter":
+        openTicker(symbols[selectedIndex]!);
+        return;
+    }
+  });
+
+  if (symbols.length === 0) {
+    return (
+      <box flexDirection="column" flexGrow={1} padding={1}>
+        <EmptyState title="No comparison tickers configured." message="Open pane settings to add up to 10 tickers." />
+      </box>
+    );
+  }
+
+  return (
+    <box flexDirection="column" flexGrow={1} paddingX={1}>
+      <scrollbox flexGrow={1} scrollY>
+        <box flexDirection="column" gap={rowGap}>
+          {Array.from({ length: Math.ceil(symbols.length / columns) }, (_, rowIndex) => (
+            <box key={`comparison-row:${rowIndex}`} flexDirection="row" gap={rowGap}>
+              {symbols.slice(rowIndex * columns, rowIndex * columns + columns).map((symbol, columnIndex) => {
+                const index = rowIndex * columns + columnIndex;
+                return (
+                  <ComparisonChartCard
+                    key={symbol}
+                    symbol={symbol}
+                    width={cardWidth}
+                    height={cardHeight}
+                    axisMode={settings.axisMode}
+                    selected={focused && index === selectedIndex}
+                    onHover={() => setSelectedIndex(index)}
+                    onOpen={() => {
+                      setSelectedIndex(index);
+                      openTicker(symbol);
+                    }}
+                  />
+                );
+              })}
+            </box>
+          ))}
+        </box>
+      </scrollbox>
+      <box height={1}>
+        <text fg={colors.textMuted}>
+          mouse click open detail  ←→↑↓ select  Enter open  PS settings
+        </text>
+      </box>
+    </box>
+  );
+}
+
+export const comparisonChartPlugin: GloomPlugin = {
+  id: "comparison-chart",
+  name: "Comparison Chart",
+  version: "1.0.0",
+  panes: [
+    {
+      id: COMPARISON_CHART_PANE_ID,
+      name: "Compare",
+      icon: "C",
+      component: ComparisonChartPane,
+      defaultPosition: "right",
+      defaultWidth: "50%",
+      settings: buildComparisonChartSettingsDef(),
+    },
+  ],
+  paneTemplates: [
+    {
+      id: COMPARISON_CHART_TEMPLATE_ID,
+      paneId: COMPARISON_CHART_PANE_ID,
+      label: "Comparison Chart",
+      description: "Compare up to 10 ticker charts side by side.",
+      keywords: ["compare", "comparison", "chart", "multi", "ticker"],
+      shortcut: { prefix: "CMP", argPlaceholder: "tickers" },
+      wizard: [
+        {
+          key: "tickers",
+          label: "Comparison Tickers",
+          placeholder: "AAPL, MSFT, NVDA",
+          body: [
+            `Enter 1-${MAX_TICKER_LIST_SIZE} ticker symbols separated by commas.`,
+          ],
+          type: "text",
+        },
+      ],
+      canCreate: (_context, options) => !options?.symbols || options.symbols.length > 0,
+      createInstance: (_context, options) => {
+        const symbols = options?.symbols ?? [];
+        if (symbols.length === 0) return null;
+        return {
+          title: buildComparisonChartPaneTitle(symbols),
+          settings: {
+            axisMode: "price",
+            symbols,
+            symbolsText: formatTickerListInput(symbols),
+          },
+        };
+      },
+    },
+  ],
+};

--- a/src/plugins/builtin/ticker-detail.tsx
+++ b/src/plugins/builtin/ticker-detail.tsx
@@ -13,6 +13,7 @@ import { formatCurrency, formatCompact, formatPercent, formatPercentRaw, formatN
 import { exchangeShortName, marketStateLabel, marketStateColor } from "../../utils/market-status";
 import { normalizeTickerInput } from "../../utils/ticker-search";
 import { StockChart } from "../../components/chart/stock-chart";
+import type { ChartAxisMode } from "../../components/chart/chart-types";
 import type { TickerFinancials } from "../../types/financials";
 import { getConfiguredIbkrGatewayInstances } from "../ibkr/instance-selection";
 import { useOptionsAvailability } from "./options-availability";
@@ -24,12 +25,14 @@ const CORE_CHART_TAB = { id: "chart", name: "Chart", order: 30 };
 interface TickerDetailPaneSettings {
   hideTabs: boolean;
   lockedTabId: string;
+  chartAxisMode: ChartAxisMode;
 }
 
 function getTickerDetailPaneSettings(settings: Record<string, unknown> | undefined): TickerDetailPaneSettings {
   return {
     hideTabs: settings?.hideTabs === true,
     lockedTabId: typeof settings?.lockedTabId === "string" ? settings.lockedTabId : "overview",
+    chartAxisMode: settings?.chartAxisMode === "percent" ? "percent" : "price",
   };
 }
 
@@ -75,6 +78,16 @@ function buildTickerDetailSettingsDef(settings: TickerDetailPaneSettings): PaneS
           label: tab.name,
         })),
       }] : []),
+      {
+        key: "chartAxisMode",
+        label: "Chart Y-Axis",
+        description: "Show chart values as raw prices or percent change from the first visible point.",
+        type: "select",
+        options: [
+          { value: "price", label: "Price" },
+          { value: "percent", label: "Percent" },
+        ],
+      },
     ],
   };
 }
@@ -662,7 +675,21 @@ export function FinancialsTab({ focused }: { focused: boolean }) {
   );
 }
 
-function ChartTab({ width, height, focused, interactive, onActivate }: { width?: number; height?: number; focused: boolean; interactive: boolean; onActivate?: () => void }) {
+function ChartTab({
+  width,
+  height,
+  focused,
+  interactive,
+  axisMode,
+  onActivate,
+}: {
+  width?: number;
+  height?: number;
+  focused: boolean;
+  interactive: boolean;
+  axisMode: ChartAxisMode;
+  onActivate?: () => void;
+}) {
   const { width: termWidth, height: termHeight } = useTerminalDimensions();
 
   const chartWidth = Math.max((width || Math.floor(termWidth * 0.55)) - 2, 30);
@@ -670,7 +697,7 @@ function ChartTab({ width, height, focused, interactive, onActivate }: { width?:
 
   return (
     <box flexDirection="column" paddingX={1} flexGrow={1} onMouseDown={() => { if (!interactive && onActivate) onActivate(); }}>
-      <StockChart width={chartWidth} height={chartHeight} focused={focused} interactive={interactive} />
+      <StockChart width={chartWidth} height={chartHeight} focused={focused} interactive={interactive} axisMode={axisMode} />
     </box>
   );
 }
@@ -821,7 +848,16 @@ function TickerDetailPane({ focused, width, height }: PaneProps) {
 
       {resolvedTabId === "overview" && <OverviewTab width={width} />}
       {resolvedTabId === "financials" && <FinancialsTab focused={focused} />}
-      {resolvedTabId === "chart" && <ChartTab width={width} height={height} focused={focused} interactive={chartInteractive} onActivate={() => setChartInteractiveEager(true)} />}
+      {resolvedTabId === "chart" && (
+        <ChartTab
+          width={width}
+          height={height}
+          focused={focused}
+          interactive={chartInteractive}
+          axisMode={paneSettings.chartAxisMode}
+          onActivate={() => setChartInteractiveEager(true)}
+        />
+      )}
 
       {/* Dynamic plugin tabs */}
       {activePluginTab && (

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -125,7 +125,9 @@ export interface PaneTemplateShortcut {
 
 export interface PaneTemplateCreateOptions {
   arg?: string;
+  values?: Record<string, string>;
   symbol?: string | null;
+  symbols?: string[] | null;
   ticker?: TickerRecord | null;
   searchResult?: InstrumentSearchResult | null;
 }
@@ -147,6 +149,7 @@ export interface PaneTemplateDef {
   description: string;
   keywords?: string[];
   shortcut?: PaneTemplateShortcut;
+  wizard?: WizardStep[];
   canCreate?: (context: PaneTemplateContext, options?: PaneTemplateCreateOptions) => boolean;
   createInstance?: (
     context: PaneTemplateContext,

--- a/src/utils/ticker-list.test.ts
+++ b/src/utils/ticker-list.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { formatTickerListInput, parseTickerListInput } from "./ticker-list";
+
+describe("parseTickerListInput", () => {
+  test("normalizes, de-duplicates, and preserves order", () => {
+    expect(parseTickerListInput(" msft, aapl,\nMSFT, nvda ")).toEqual(["MSFT", "AAPL", "NVDA"]);
+  });
+
+  test("rejects empty ticker lists", () => {
+    expect(() => parseTickerListInput(" , \n ")).toThrow("Enter at least one ticker.");
+  });
+
+  test("rejects lists beyond the maximum size", () => {
+    expect(() => parseTickerListInput("A,B,C,D,E,F,G,H,I,J,K", 10)).toThrow("You can compare up to 10 tickers.");
+  });
+});
+
+describe("formatTickerListInput", () => {
+  test("joins symbols with a stable display format", () => {
+    expect(formatTickerListInput(["AAPL", "MSFT", "NVDA"])).toBe("AAPL, MSFT, NVDA");
+  });
+});

--- a/src/utils/ticker-list.ts
+++ b/src/utils/ticker-list.ts
@@ -1,0 +1,35 @@
+export const MAX_TICKER_LIST_SIZE = 10;
+
+function normalizeTickerToken(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+export function parseTickerListInput(raw: string, maxTickers = MAX_TICKER_LIST_SIZE): string[] {
+  const tokens = raw
+    .split(/[,\n]/)
+    .map(normalizeTickerToken)
+    .filter(Boolean);
+
+  const unique: string[] = [];
+  const seen = new Set<string>();
+
+  for (const token of tokens) {
+    if (seen.has(token)) continue;
+    seen.add(token);
+    unique.push(token);
+  }
+
+  if (unique.length === 0) {
+    throw new Error("Enter at least one ticker.");
+  }
+
+  if (unique.length > maxTickers) {
+    throw new Error(`You can compare up to ${maxTickers} tickers.`);
+  }
+
+  return unique;
+}
+
+export function formatTickerListInput(symbols: string[]): string {
+  return symbols.join(", ");
+}


### PR DESCRIPTION
## Summary
- add a new Comparison Chart pane and `CMP` template that resolves up to 10 tickers into pane config and renders side-by-side charts
- add reusable pane-template wizard components plus ticker-list parsing helpers for multi-symbol template input
- add shared percent y-axis support to stock charts and expose it in both ticker detail settings and the comparison pane

## Testing
- bun test src/utils/ticker-list.test.ts src/components/chart/chart.test.ts src/plugins/builtin/comparison-chart.test.tsx
- bun test src/plugins/builtin/quote-monitor.test.tsx src/plugins/builtin/ticker-detail.test.tsx
- bun run build
- tmux smoke test with an isolated HOME to confirm the comparison pane renders in the real TUI