### PR TITLE
Add instruction to kill tmux session after testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 Stack: Bun + OpenTUI
 
 Important:
-- Use tmux to test your changes (see the testing skill)
+- Use tmux to test your changes (see the testing skill). Always kill the tmux session when done.
 - Aim for mouse/cursor interactivity for everything interactive.


### PR DESCRIPTION
Adds a reminder to AGENTS.md to always kill the tmux session when done testing, preventing leftover sessions from accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)