### PR TITLE
Stabilize IBKR trade tab connections

### DIFF
--- a/src/plugins/ibkr/gateway-service.ts
+++ b/src/plugins/ibkr/gateway-service.ts
@@ -17,6 +17,9 @@ import {
   type Order,
   type OrderState,
 } from "@stoqey/ib";
+import { mkdir, open, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
 import { firstValueFrom, filter, take, timeout } from "rxjs";
 import type { TimeRange } from "../../components/chart/chart-types";
 import type { BrokerConnectionStatus, BrokerPosition } from "../../types/broker";
@@ -30,6 +33,7 @@ import type {
   BrokerOrderPreview,
   BrokerOrderRequest,
 } from "../../types/trading";
+import { debugLog } from "../../utils/debug-log";
 import { parseReportSnapshot, parseFinStatements } from "./fundamental-parser";
 
 export interface IbkrGatewayConfig {
@@ -47,12 +51,34 @@ export interface IbkrSnapshot {
   lastError?: string;
 }
 
+interface ClientLockMetadata {
+  pid: number;
+  ownerToken: string;
+  requestedClientId: number;
+  clientId: number;
+  host: string;
+  port: number;
+  instanceId?: string;
+  cwd: string;
+  timestamp: number;
+}
+
+interface ClaimedClientLock {
+  clientId: number;
+  requestedClientId: number;
+  path: string;
+}
+
 const DEFAULT_SNAPSHOT: IbkrSnapshot = {
   status: { state: "disconnected", updatedAt: Date.now() },
   accounts: [],
   openOrders: [],
   executions: [],
 };
+
+const gatewayLog = debugLog.createLogger("ibkr-gateway");
+const IBKR_CLIENT_LOCK_DIR = join(tmpdir(), "gloomberb-ibkr-client-locks");
+const IBKR_CLIENT_ID_SEARCH_SPAN = 64;
 
 type AccountSummaryValueMap = ReadonlyMap<string, { value: string }>;
 type AccountSummaryTags = ReadonlyMap<string, AccountSummaryValueMap>;
@@ -282,6 +308,62 @@ function getIbErrorMessage(error: any): string | undefined {
   return undefined;
 }
 
+function isClientIdInUseError(code: number | undefined, message: string | undefined): boolean {
+  if (code === 326) return true;
+  const text = (message || "").toLowerCase();
+  return text.includes("client id is already in use")
+    || text.includes("clientid is already in use")
+    || text.includes("client id already in use");
+}
+
+function buildClientLockPath(config: IbkrGatewayConfig, clientId: number): string {
+  const host = (config.host || "localhost").replace(/[^a-z0-9_.-]+/gi, "_");
+  return join(IBKR_CLIENT_LOCK_DIR, `${host}-${config.port}-${clientId}.lock`);
+}
+
+function isProcessAlive(pid: number | undefined): boolean {
+  if (!pid || !Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readClientLock(path: string): Promise<ClientLockMetadata | null> {
+  try {
+    const raw = await readFile(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<ClientLockMetadata>;
+    if (
+      typeof parsed.pid !== "number"
+      || typeof parsed.ownerToken !== "string"
+      || typeof parsed.clientId !== "number"
+      || typeof parsed.requestedClientId !== "number"
+    ) {
+      return null;
+    }
+    return {
+      pid: parsed.pid,
+      ownerToken: parsed.ownerToken,
+      clientId: parsed.clientId,
+      requestedClientId: parsed.requestedClientId,
+      host: typeof parsed.host === "string" ? parsed.host : "",
+      port: typeof parsed.port === "number" ? parsed.port : 0,
+      instanceId: typeof parsed.instanceId === "string" ? parsed.instanceId : undefined,
+      cwd: typeof parsed.cwd === "string" ? parsed.cwd : "",
+      timestamp: typeof parsed.timestamp === "number" ? parsed.timestamp : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildConnectionNote(requestedClientId: number, actualClientId: number): string | undefined {
+  if (requestedClientId === actualClientId) return undefined;
+  return `Using client ID ${actualClientId} because ${requestedClientId} is already in use.`;
+}
+
 function isRetryableErrorCode(code: number): boolean {
   return ![200, 201, 202, 321, 354].includes(code);
 }
@@ -298,6 +380,9 @@ export class IbkrGatewayService {
   private autoMarketData = true;
   /** Dedup in-flight requests: reuse pending promises for the same key. */
   private pendingRequests = new Map<string, Promise<any>>();
+  private readonly clientLockOwner = `${process.pid}:${Math.random().toString(36).slice(2, 10)}`;
+  private claimedClientLock: ClaimedClientLock | null = null;
+  private connectionNote?: string;
 
   constructor(private readonly instanceId?: string) {}
 
@@ -332,7 +417,7 @@ export class IbkrGatewayService {
       return this.connecting;
     }
 
-    this.connecting = this.connectInternal(config, nextKey);
+    this.connecting = this.connectWithClientFallback(config, nextKey);
     try {
       await this.connecting;
     } finally {
@@ -346,6 +431,8 @@ export class IbkrGatewayService {
     this.configKey = null;
     this.autoMarketData = true;
     this.activeMarketDataType = MarketDataType.REALTIME;
+    this.connectionNote = undefined;
+    await this.releaseClientLock();
     this.updateSnapshot({
       ...this.snapshot,
       status: { state: "disconnected", updatedAt: Date.now() },
@@ -778,14 +865,55 @@ export class IbkrGatewayService {
     await this.listOpenOrders(config);
   }
 
-  private async connectInternal(config: IbkrGatewayConfig, configKey: string): Promise<void> {
+  private async connectWithClientFallback(config: IbkrGatewayConfig, configKey: string): Promise<void> {
+    const candidates = this.getClientIdCandidates(config.clientId);
+    let lastConflict: Error | null = null;
+
+    for (const clientId of candidates) {
+      const claimed = await this.tryClaimClientLock(config, clientId, config.clientId);
+      if (!claimed) continue;
+
+      try {
+        await this.connectInternal(
+          { ...config, clientId },
+          configKey,
+          buildConnectionNote(config.clientId, clientId),
+        );
+        return;
+      } catch (error: any) {
+        const code = getIbErrorCode(error);
+        const message = getIbErrorMessage(error) || error?.message || String(error || "");
+        await this.disconnect();
+        if (!isClientIdInUseError(code, message)) {
+          throw error;
+        }
+        lastConflict = new Error(message || `IBKR client ID ${clientId} is already in use.`);
+      }
+    }
+
+    throw lastConflict ?? new Error(
+      `No IBKR client IDs are available near ${config.clientId}. Close other sessions or choose a different client ID.`,
+    );
+  }
+
+  private async connectInternal(
+    config: IbkrGatewayConfig,
+    configKey: string,
+    connectionNote?: string,
+  ): Promise<void> {
     if (this.api && this.configKey !== configKey) {
       await this.disconnect();
     }
 
+    this.connectionNote = connectionNote;
     this.updateSnapshot({
       ...this.snapshot,
-      status: { state: "connecting", updatedAt: Date.now(), mode: "gateway" },
+      status: {
+        state: "connecting",
+        updatedAt: Date.now(),
+        mode: "gateway",
+        message: this.connectionNote,
+      },
       lastError: undefined,
     });
 
@@ -798,12 +926,39 @@ export class IbkrGatewayService {
       this.bindConnectionEvents(this.api);
     }
 
+    let unsubscribeConflict = () => {};
+    const conflictPromise = new Promise<never>((_, reject) => {
+      const subscription = this.api!.error.subscribe((err) => {
+        const code = getIbErrorCode(err);
+        const message = getIbErrorMessage(err);
+        if (!isClientIdInUseError(code, message)) return;
+        subscription.unsubscribe();
+        reject(new Error(message || `IBKR client ID ${config.clientId} is already in use.`));
+      });
+      unsubscribeConflict = () => subscription.unsubscribe();
+    });
+
     this.api.connect(config.clientId);
-    await firstValueFrom(this.api.connectionState.pipe(
-      filter((state) => state === ConnectionState.Connected),
-      take(1),
-      timeout(10_000),
-    ));
+    try {
+      await Promise.race([
+        firstValueFrom(this.api.connectionState.pipe(
+          filter((state) => state === ConnectionState.Connected),
+          take(1),
+          timeout(10_000),
+        )),
+        conflictPromise,
+      ]);
+    } finally {
+      unsubscribeConflict();
+    }
+
+    gatewayLog.info("Connected to IBKR gateway", {
+      instanceId: this.instanceId,
+      requestedClientId: this.claimedClientLock?.requestedClientId ?? config.clientId,
+      actualClientId: config.clientId,
+      host: config.host,
+      port: config.port,
+    });
     this.autoMarketData = (config.marketDataType ?? "auto") === "auto";
     this.activeMarketDataType = marketDataTypeFromConfig(config);
     this.api.setMarketDataType(this.activeMarketDataType);
@@ -815,7 +970,12 @@ export class IbkrGatewayService {
     ]);
     this.updateSnapshot({
       ...this.snapshot,
-      status: { state: "connected", updatedAt: Date.now(), mode: "gateway" },
+      status: {
+        state: "connected",
+        updatedAt: Date.now(),
+        mode: "gateway",
+        message: this.connectionNote,
+      },
     });
   }
 
@@ -824,12 +984,22 @@ export class IbkrGatewayService {
       if (state === ConnectionState.Connected) {
         this.updateSnapshot({
           ...this.snapshot,
-          status: { state: "connected", updatedAt: Date.now(), mode: "gateway" },
+          status: {
+            state: "connected",
+            updatedAt: Date.now(),
+            mode: "gateway",
+            message: this.connectionNote,
+          },
         });
       } else if (state === ConnectionState.Connecting) {
         this.updateSnapshot({
           ...this.snapshot,
-          status: { state: "connecting", updatedAt: Date.now(), mode: "gateway" },
+          status: {
+            state: "connecting",
+            updatedAt: Date.now(),
+            mode: "gateway",
+            message: this.connectionNote,
+          },
         });
       } else {
         this.updateSnapshot({
@@ -869,6 +1039,77 @@ export class IbkrGatewayService {
         lastError: message,
       });
     });
+  }
+
+  private getClientIdCandidates(requestedClientId: number): number[] {
+    const preferred = this.claimedClientLock?.clientId;
+    const candidates = new Set<number>();
+    if (preferred && Number.isFinite(preferred) && preferred > 0) {
+      candidates.add(preferred);
+    }
+    for (let offset = 0; offset < IBKR_CLIENT_ID_SEARCH_SPAN; offset += 1) {
+      candidates.add(requestedClientId + offset);
+    }
+    return [...candidates];
+  }
+
+  private async tryClaimClientLock(
+    config: IbkrGatewayConfig,
+    clientId: number,
+    requestedClientId: number,
+  ): Promise<boolean> {
+    const path = buildClientLockPath(config, clientId);
+    const existing = this.claimedClientLock;
+    if (
+      existing
+      && existing.clientId === clientId
+      && existing.requestedClientId === requestedClientId
+    ) {
+      return true;
+    }
+
+    await mkdir(IBKR_CLIENT_LOCK_DIR, { recursive: true });
+    const metadata: ClientLockMetadata = {
+      pid: process.pid,
+      ownerToken: this.clientLockOwner,
+      requestedClientId,
+      clientId,
+      host: config.host,
+      port: config.port,
+      instanceId: this.instanceId,
+      cwd: process.cwd(),
+      timestamp: Date.now(),
+    };
+
+    try {
+      const handle = await open(path, "wx");
+      await handle.writeFile(JSON.stringify(metadata), "utf-8");
+      await handle.close();
+      await this.releaseClientLock();
+      this.claimedClientLock = { clientId, requestedClientId, path };
+      return true;
+    } catch (error: any) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+
+    const lock = await readClientLock(path);
+    if (!lock || !isProcessAlive(lock.pid)) {
+      await rm(path, { force: true }).catch(() => {});
+      return this.tryClaimClientLock(config, clientId, requestedClientId);
+    }
+    if (lock.ownerToken === this.clientLockOwner) {
+      await this.releaseClientLock();
+      this.claimedClientLock = { clientId, requestedClientId, path };
+      return true;
+    }
+    return false;
+  }
+
+  private async releaseClientLock(): Promise<void> {
+    const lock = this.claimedClientLock;
+    this.claimedClientLock = null;
+    if (!lock) return;
+    await rm(lock.path, { force: true }).catch(() => {});
   }
 
   private updateSnapshot(snapshot: IbkrSnapshot): void {

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -105,6 +105,28 @@ function inferDraftAccountId(
   return undefined;
 }
 
+function getKnownIbkrAccounts(
+  brokerAccountsByInstance: Record<string, BrokerAccount[]>,
+  brokerInstanceId: string | undefined,
+  liveAccounts: BrokerAccount[],
+): BrokerAccount[] {
+  if (!brokerInstanceId) return liveAccounts;
+  const cachedAccounts = brokerAccountsByInstance[brokerInstanceId] ?? [];
+  if (liveAccounts.length === 0) return cachedAccounts;
+  if (cachedAccounts.length === 0) return liveAccounts;
+
+  const merged = new Map<string, BrokerAccount>();
+  for (const account of cachedAccounts) {
+    if (!account.accountId) continue;
+    merged.set(account.accountId, account);
+  }
+  for (const account of liveAccounts) {
+    if (!account.accountId) continue;
+    merged.set(account.accountId, { ...(merged.get(account.accountId) ?? {}), ...account });
+  }
+  return [...merged.values()];
+}
+
 function formatContractLabel(contract: BrokerContractRef): string {
   const base = contract.localSymbol || contract.symbol;
   const suffix = contract.secType ? ` ${contract.secType}` : "";
@@ -464,6 +486,8 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
   const gatewayService = selectedBrokerInstanceId ? ibkrGatewayManager.getService(selectedBrokerInstanceId) : null;
   const normalizedConfig = selectedInstance ? normalizeIbkrConfig(selectedInstance.config) : null;
   const isGatewayMode = selectedInstance != null && normalizedConfig?.connectionMode === "gateway";
+  const cachedAccounts = selectedBrokerInstanceId ? state.brokerAccounts[selectedBrokerInstanceId] ?? [] : [];
+  const availableAccounts = getKnownIbkrAccounts(state.brokerAccounts, selectedBrokerInstanceId, gatewaySnapshot.accounts);
   const gatewayRequiredMessage = gatewayInstances.length > 0
     ? "Choose a Gateway / TWS IBKR profile first."
     : "Connect a Gateway / TWS IBKR profile first.";
@@ -471,13 +495,13 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
     ? inferDraftAccountId(
       state.config,
       collectionId,
-      gatewaySnapshot.accounts,
+      availableAccounts,
       selectedInstance.id,
       tradeState.accountId,
     )
     : undefined;
   const currentAccountId = ticketState.draft.accountId || inferredAccountId;
-  const activeAccount = gatewaySnapshot.accounts.find((account) => account.accountId === currentAccountId);
+  const activeAccount = availableAccounts.find((account) => account.accountId === currentAccountId);
 
   const enterInteractive = useCallback(() => {
     setInteractive(true);
@@ -530,11 +554,11 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
   ]);
 
   useEffect(() => {
-    if (!symbol || !ticker || !isGatewayMode || gatewaySnapshot.accounts.length === 0 || ticketState.draft.accountId || !selectedInstance) return;
+    if (!symbol || !ticker || !isGatewayMode || availableAccounts.length === 0 || ticketState.draft.accountId || !selectedInstance) return;
     const inferred = inferDraftAccountId(
       state.config,
       collectionId,
-      gatewaySnapshot.accounts,
+      availableAccounts,
       selectedInstance.id,
       tradeState.accountId,
     );
@@ -546,6 +570,7 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
     ticker,
     isGatewayMode,
     gatewaySnapshot.accounts,
+    cachedAccounts,
     ticketState.draft.accountId,
     selectedInstance,
     state.config,
@@ -566,7 +591,11 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
       const inferred = inferDraftAccountId(
         state.config,
         collectionId,
-        gatewayService?.getSnapshot().accounts ?? [],
+        getKnownIbkrAccounts(
+          state.brokerAccounts,
+          selectedInstance.id,
+          gatewayService?.getSnapshot().accounts ?? [],
+        ),
         selectedInstance.id,
         tradeState.accountId,
       );
@@ -587,6 +616,7 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
     isGatewayMode,
     gatewayRequiredMessage,
     state.config,
+    state.brokerAccounts,
     collectionId,
     gatewayService,
     tradeState.accountId,
@@ -700,11 +730,15 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
 
   const chooseAccount = useCallback(async () => {
     if (!symbol || !ticker || !selectedInstance || !normalizedConfig || !gatewayService || !isGatewayMode) return;
-    const accounts = gatewaySnapshot.accounts;
+    const accounts = availableAccounts;
     if (accounts.length === 0) {
       await refresh();
     }
-    const nextAccounts = gatewayService.getSnapshot().accounts;
+    const nextAccounts = getKnownIbkrAccounts(
+      state.brokerAccounts,
+      selectedInstance.id,
+      gatewayService.getSnapshot().accounts,
+    );
     if (nextAccounts.length === 0) {
       setTradeTicketMessage(symbol, undefined, "No IBKR accounts available.", ticker);
       return;
@@ -723,7 +757,19 @@ export function TradeTab({ focused, width, height, onCapture }: DetailTabProps) 
     if (!selected) return;
     updateTradingPaneState({ accountId: selected });
     setTradeTicketDraft(symbol, { brokerInstanceId: selectedInstance.id, accountId: selected }, ticker);
-  }, [symbol, ticker, selectedInstance, normalizedConfig, gatewayService, isGatewayMode, gatewaySnapshot.accounts, refresh, dialog]);
+  }, [
+    symbol,
+    ticker,
+    selectedInstance,
+    normalizedConfig,
+    gatewayService,
+    isGatewayMode,
+    gatewaySnapshot.accounts,
+    cachedAccounts,
+    refresh,
+    dialog,
+    state.brokerAccounts,
+  ]);
 
   const editNumericField = useCallback(async (
     label: string,
@@ -1430,6 +1476,8 @@ function TradingPane({ focused, width, height }: PaneProps) {
   const gatewayService = selectedBrokerInstanceId ? ibkrGatewayManager.getService(selectedBrokerInstanceId) : null;
   const normalizedConfig = selectedInstance ? normalizeIbkrConfig(selectedInstance.config) : null;
   const isGatewayMode = selectedInstance != null && normalizedConfig?.connectionMode === "gateway";
+  const cachedAccounts = selectedBrokerInstanceId ? state.brokerAccounts[selectedBrokerInstanceId] ?? [] : [];
+  const availableAccounts = getKnownIbkrAccounts(state.brokerAccounts, selectedBrokerInstanceId, gatewaySnapshot.accounts);
   const statusMessage = gatewaySnapshot.status.message || gatewaySnapshot.lastError;
   const displayStatusState = gatewaySnapshot.status.state === "error" && isMarketDataWarning(statusMessage)
     ? "connected"
@@ -1466,18 +1514,18 @@ function TradingPane({ focused, width, height }: PaneProps) {
   }, [selectedInstance, tradeState.brokerInstanceId, tradeState.brokerLabel, tradeState.accountId, lockedBrokerInstanceId, activePortfolio?.brokerAccountId]);
 
   useEffect(() => {
-    if (!isGatewayMode || gatewaySnapshot.accounts.length === 0 || tradeState.accountId || !selectedInstance) return;
+    if (!isGatewayMode || availableAccounts.length === 0 || tradeState.accountId || !selectedInstance) return;
     const inferred = inferDraftAccountId(
       state.config,
       collectionId,
-      gatewaySnapshot.accounts,
+      availableAccounts,
       selectedInstance.id,
       tradeState.accountId,
     );
     if (inferred) {
       updateTradingPaneState({ accountId: inferred });
     }
-  }, [isGatewayMode, gatewaySnapshot.accounts, tradeState.accountId, state.config, collectionId, selectedInstance]);
+  }, [isGatewayMode, gatewaySnapshot.accounts, cachedAccounts, tradeState.accountId, state.config, collectionId, selectedInstance]);
 
   const refresh = useCallback(async () => {
     if (!selectedInstance || !normalizedConfig || !isGatewayMode || !isGatewayConfigured(selectedInstance.config)) {
@@ -1491,7 +1539,11 @@ function TradingPane({ focused, width, height }: PaneProps) {
       const inferred = inferDraftAccountId(
         state.config,
         collectionId,
-        gatewayService?.getSnapshot().accounts ?? [],
+        getKnownIbkrAccounts(
+          state.brokerAccounts,
+          selectedInstance.id,
+          gatewayService?.getSnapshot().accounts ?? [],
+        ),
         selectedInstance.id,
         tradeState.accountId,
       );
@@ -1504,7 +1556,17 @@ function TradingPane({ focused, width, height }: PaneProps) {
     } finally {
       setTradingBusy(false);
     }
-  }, [selectedInstance, normalizedConfig, isGatewayMode, state.config, collectionId, gatewayService, tradeState.accountId, gatewayRequiredMessage]);
+  }, [
+    selectedInstance,
+    normalizedConfig,
+    isGatewayMode,
+    state.config,
+    state.brokerAccounts,
+    collectionId,
+    gatewayService,
+    tradeState.accountId,
+    gatewayRequiredMessage,
+  ]);
 
   useEffect(() => {
     if (!selectedInstance || !normalizedConfig || !isGatewayMode || !isGatewayConfigured(selectedInstance.config)) return;
@@ -1546,11 +1608,15 @@ function TradingPane({ focused, width, height }: PaneProps) {
 
   const chooseAccount = useCallback(async () => {
     if (!selectedInstance || !normalizedConfig || !gatewayService || !isGatewayMode) return;
-    const accounts = gatewaySnapshot.accounts;
+    const accounts = availableAccounts;
     if (accounts.length === 0) {
       await refresh();
     }
-    const nextAccounts = gatewayService.getSnapshot().accounts;
+    const nextAccounts = getKnownIbkrAccounts(
+      state.brokerAccounts,
+      selectedInstance.id,
+      gatewayService.getSnapshot().accounts,
+    );
     if (nextAccounts.length === 0) {
       setTradingMessage(undefined, "No IBKR accounts available.");
       return;
@@ -1568,7 +1634,17 @@ function TradingPane({ focused, width, height }: PaneProps) {
     });
     if (!selected) return;
     updateTradingPaneState({ accountId: selected });
-  }, [dialog, gatewaySnapshot.accounts, selectedInstance, normalizedConfig, gatewayService, isGatewayMode, refresh]);
+  }, [
+    dialog,
+    gatewaySnapshot.accounts,
+    cachedAccounts,
+    selectedInstance,
+    normalizedConfig,
+    gatewayService,
+    isGatewayMode,
+    refresh,
+    state.brokerAccounts,
+  ]);
 
   const cancelSelectedOrder = useCallback(async () => {
     if (!selectedOrder || !selectedInstance || !normalizedConfig || !gatewayService || !isGatewayMode) return;
@@ -1641,7 +1717,7 @@ function TradingPane({ focused, width, height }: PaneProps) {
     }
   });
 
-  const activeAccount = gatewaySnapshot.accounts.find((account) => account.accountId === (tradeState.accountId || ""));
+  const activeAccount = availableAccounts.find((account) => account.accountId === (tradeState.accountId || ""));
   const orderPanelWidth = Math.max(36, Math.floor(width * 0.6));
   const listPanelWidth = Math.max(24, width - orderPanelWidth - 1);
   const listHeight = Math.max(4, height - 6);

--- a/src/plugins/ibkr/trade-tab.test.tsx
+++ b/src/plugins/ibkr/trade-tab.test.tsx
@@ -103,15 +103,18 @@ function TradeHarness({
   config,
   ticker,
   financials,
+  brokerAccounts = {},
 }: {
   config: AppConfig;
   ticker: TickerRecord;
   financials: TickerFinancials;
+  brokerAccounts?: Record<string, import("../../types/trading").BrokerAccount[]>;
 }) {
   const state = createInitialState(config);
   state.focusedPaneId = TEST_PANE_ID;
   state.tickers = new Map([[ticker.metadata.ticker, ticker]]);
   state.financials = new Map([[ticker.metadata.ticker, financials]]);
+  state.brokerAccounts = brokerAccounts;
 
   return (
     <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
@@ -178,4 +181,45 @@ test("renders the compact trade tab layout", async () => {
   expect(frame).not.toContain("1 Profile");
   expect(frame).not.toContain("Activate Ticket");
   expect(frame).toMatchSnapshot();
+});
+
+test("prefills the only cached IBKR account when the live gateway snapshot is empty", async () => {
+  const config = createTradeConfig("AMD");
+  const ticker = makeTicker("AMD", "Advanced Micro Devices, Inc.");
+  const financials = makeFinancials();
+
+  clearTradingDraft();
+  stubGatewayRefresh();
+  prefillTradeFromTicker(ticker, "BUY");
+
+  await act(async () => {
+    testSetup = await testRender(
+      <TradeHarness
+        config={config}
+        ticker={ticker}
+        financials={financials}
+        brokerAccounts={{
+          [TEST_INSTANCE_ID]: [{
+            accountId: "DU123456",
+            name: "Main",
+            currency: "USD",
+            source: "gateway",
+            updatedAt: Date.now(),
+          }],
+        }}
+      />,
+      { width: 88, height: 30 },
+    );
+  });
+
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+
+  const frame = testSetup.captureCharFrame();
+  expect(frame).toContain("Account DU123456");
+  expect(frame).toContain("Paper Gateway");
 });


### PR DESCRIPTION
This stabilizes IBKR gateway sessions when multiple Gloomberb processes share the same configured client ID by reserving and falling forward to the next available client ID. It also lets the trade tab and standalone trading pane fall back to cached broker accounts so a single connected IBKR account still prefills while the live gateway snapshot is empty. The PR adds a regression test for cached-account prefill in the trade tab. Verified with `bun test src/plugins/ibkr` after installing workspace dependencies.