### PR TITLE
Fix IBKR price unit normalization

### DIFF
--- a/src/plugins/ibkr/gateway-service.ts
+++ b/src/plugins/ibkr/gateway-service.ts
@@ -31,6 +31,7 @@ import type {
   BrokerOrderRequest,
 } from "../../types/trading";
 import { parseReportSnapshot, parseFinStatements } from "./fundamental-parser";
+import { getIbkrPriceDivisor, normalizeIbkrPriceValue } from "./price-normalization";
 
 export interface IbkrGatewayConfig {
   host: string;
@@ -392,16 +393,17 @@ export class IbkrGatewayService {
     for (const [accountId, accountPositions] of update.all) {
       for (const position of accountPositions) {
         if (!position.contract.symbol) continue;
+        const priceDivisor = getIbkrPriceDivisor(position.contract);
         positions.push({
           ticker: position.contract.localSymbol || position.contract.symbol,
           exchange: position.contract.primaryExch || position.contract.exchange || "",
           shares: Math.abs(position.pos),
-          avgCost: position.avgCost,
+          avgCost: normalizeIbkrPriceValue(position.avgCost, priceDivisor),
           currency: position.contract.currency || "USD",
           accountId,
           name: position.contract.description || position.contract.localSymbol || position.contract.symbol,
           assetCategory: position.contract.secType,
-          markPrice: position.marketPrice,
+          markPrice: normalizeIbkrPriceValue(position.marketPrice, priceDivisor),
           marketValue: position.marketValue,
           unrealizedPnl: position.unrealizedPNL,
           side: position.pos < 0 ? "short" : "long",
@@ -492,30 +494,34 @@ export class IbkrGatewayService {
     instrument?: BrokerContractRef | null,
   ): Promise<PricePoint[]> {
     return this.dedup(`history:${ticker}:${exchange}:${range}`, async () => {
-    await this.connect(config);
-    const contract = await withTimeout(this.resolveContract(ticker, exchange, instrument ?? null), IBKR_DATA_TIMEOUT, "resolveContract");
-    const params = HISTORY_PARAMS[range];
-    const bars = await this.withMarketDataFallback(
-      config,
-      () => withTimeout(this.api!.getHistoricalData(
-        contract,
-        "",
-        params.duration,
-        params.size,
-        WhatToShow.TRADES,
-        1,
-        1,
-      ), IBKR_DATA_TIMEOUT, "getHistoricalData"),
-    );
+      await this.connect(config);
+      const contract = await withTimeout(this.resolveContract(ticker, exchange, instrument ?? null), IBKR_DATA_TIMEOUT, "resolveContract");
+      const params = HISTORY_PARAMS[range];
+      const detailsPromise = withTimeout(this.getPrimaryContractDetails(contract), IBKR_DATA_TIMEOUT, "getContractDetails")
+        .catch(() => undefined);
+      const bars = await this.withMarketDataFallback(
+        config,
+        () => withTimeout(this.api!.getHistoricalData(
+          contract,
+          "",
+          params.duration,
+          params.size,
+          WhatToShow.TRADES,
+          1,
+          1,
+        ), IBKR_DATA_TIMEOUT, "getHistoricalData"),
+      );
+      const details = await detailsPromise;
+      const priceDivisor = getIbkrPriceDivisor(contract, details);
 
-    return bars.map((bar) => ({
-      date: new Date(typeof bar.time === "number" ? bar.time * 1000 : Date.parse(String(bar.time))),
-      open: bar.open,
-      high: bar.high,
-      low: bar.low,
-      close: bar.close ?? bar.open ?? bar.high ?? bar.low ?? 0,
-      volume: bar.volume,
-    }));
+      return bars.map((bar) => ({
+        date: new Date(typeof bar.time === "number" ? bar.time * 1000 : Date.parse(String(bar.time))),
+        open: normalizeIbkrPriceValue(bar.open, priceDivisor),
+        high: normalizeIbkrPriceValue(bar.high, priceDivisor),
+        low: normalizeIbkrPriceValue(bar.low, priceDivisor),
+        close: normalizeIbkrPriceValue(bar.close ?? bar.open ?? bar.high ?? bar.low ?? 0, priceDivisor) ?? 0,
+        volume: bar.volume,
+      }));
     });
   }
 
@@ -535,6 +541,8 @@ export class IbkrGatewayService {
     return this.dedup(key, async () => {
       await this.connect(config);
       const contract = await withTimeout(this.resolveContract(ticker, exchange, instrument ?? null), IBKR_DATA_TIMEOUT, "resolveContract");
+      const detailsPromise = withTimeout(this.getPrimaryContractDetails(contract), IBKR_DATA_TIMEOUT, "getContractDetails")
+        .catch(() => undefined);
 
       // Format endDateTime as "yyyyMMdd HH:mm:ss" for IBKR
       const pad = (n: number) => String(n).padStart(2, "0");
@@ -561,13 +569,15 @@ export class IbkrGatewayService {
           1,
         ), IBKR_DATA_TIMEOUT, "getDetailedHistoricalData"),
       );
+      const details = await detailsPromise;
+      const priceDivisor = getIbkrPriceDivisor(contract, details);
 
       return bars.map((bar) => ({
         date: new Date(typeof bar.time === "number" ? bar.time * 1000 : Date.parse(String(bar.time))),
-        open: bar.open,
-        high: bar.high,
-        low: bar.low,
-        close: bar.close ?? bar.open ?? bar.high ?? bar.low ?? 0,
+        open: normalizeIbkrPriceValue(bar.open, priceDivisor),
+        high: normalizeIbkrPriceValue(bar.high, priceDivisor),
+        low: normalizeIbkrPriceValue(bar.low, priceDivisor),
+        close: normalizeIbkrPriceValue(bar.close ?? bar.open ?? bar.high ?? bar.low ?? 0, priceDivisor) ?? 0,
         volume: bar.volume,
       }));
     });
@@ -1117,15 +1127,22 @@ export class IbkrGatewayService {
   }
 
   private marketDataToQuote(contract: Contract, details: ContractDetails, marketData: ReadonlyMap<number, { value?: number; ingressTm: number }>): Quote {
-    const last = marketData.get(IBApiTickType.LAST)?.value
+    const priceDivisor = getIbkrPriceDivisor(contract, details);
+    const last = normalizeIbkrPriceValue(
+      marketData.get(IBApiTickType.LAST)?.value
       ?? marketData.get(IBApiTickType.DELAYED_LAST)?.value
-      ?? marketData.get(IBApiTickType.CLOSE)?.value;
+      ?? marketData.get(IBApiTickType.CLOSE)?.value,
+      priceDivisor,
+    );
     if (last == null || last <= 0) {
       throw new Error(`No valid market data for ${contract.symbol || contract.localSymbol || contract.conId}`);
     }
-    const close = marketData.get(IBApiTickType.CLOSE)?.value
-      ?? marketData.get(IBApiTickType.DELAYED_CLOSE)?.value
-      ?? last;
+    const close = normalizeIbkrPriceValue(
+      marketData.get(IBApiTickType.CLOSE)?.value
+        ?? marketData.get(IBApiTickType.DELAYED_CLOSE)?.value
+        ?? last,
+      priceDivisor,
+    ) ?? last;
     const change = last - close;
     const ingressTm = marketData.get(IBApiTickType.LAST)?.ingressTm
       ?? marketData.get(IBApiTickType.DELAYED_LAST)?.ingressTm
@@ -1138,22 +1155,37 @@ export class IbkrGatewayService {
       change,
       changePercent: close ? (change / close) * 100 : 0,
       previousClose: close,
-      high52w: marketData.get(IBApiTickType.HIGH_52_WEEK)?.value,
-      low52w: marketData.get(IBApiTickType.LOW_52_WEEK)?.value,
+      high52w: normalizeIbkrPriceValue(marketData.get(IBApiTickType.HIGH_52_WEEK)?.value, priceDivisor),
+      low52w: normalizeIbkrPriceValue(marketData.get(IBApiTickType.LOW_52_WEEK)?.value, priceDivisor),
       volume: marketData.get(IBApiTickType.VOLUME)?.value,
       name: details.longName || details.marketName || contract.symbol,
       lastUpdated: ingressTm,
       exchangeName: details.validExchanges?.split(",")[0],
       fullExchangeName: details.validExchanges?.split(",")[0],
       marketState: "REGULAR",
-      bid: marketData.get(IBApiTickType.BID)?.value ?? marketData.get(IBApiTickType.DELAYED_BID)?.value,
-      ask: marketData.get(IBApiTickType.ASK)?.value ?? marketData.get(IBApiTickType.DELAYED_ASK)?.value,
+      bid: normalizeIbkrPriceValue(
+        marketData.get(IBApiTickType.BID)?.value ?? marketData.get(IBApiTickType.DELAYED_BID)?.value,
+        priceDivisor,
+      ),
+      ask: normalizeIbkrPriceValue(
+        marketData.get(IBApiTickType.ASK)?.value ?? marketData.get(IBApiTickType.DELAYED_ASK)?.value,
+        priceDivisor,
+      ),
       bidSize: marketData.get(IBApiTickType.BID_SIZE)?.value ?? marketData.get(IBApiTickType.DELAYED_BID_SIZE)?.value,
       askSize: marketData.get(IBApiTickType.ASK_SIZE)?.value ?? marketData.get(IBApiTickType.DELAYED_ASK_SIZE)?.value,
-      open: marketData.get(IBApiTickType.OPEN)?.value ?? marketData.get(IBApiTickType.DELAYED_OPEN)?.value,
-      high: marketData.get(IBApiTickType.HIGH)?.value ?? marketData.get(IBApiTickType.DELAYED_HIGH)?.value,
-      low: marketData.get(IBApiTickType.LOW)?.value ?? marketData.get(IBApiTickType.DELAYED_LOW)?.value,
-      mark: marketData.get(IBApiTickType.MARK_PRICE)?.value,
+      open: normalizeIbkrPriceValue(
+        marketData.get(IBApiTickType.OPEN)?.value ?? marketData.get(IBApiTickType.DELAYED_OPEN)?.value,
+        priceDivisor,
+      ),
+      high: normalizeIbkrPriceValue(
+        marketData.get(IBApiTickType.HIGH)?.value ?? marketData.get(IBApiTickType.DELAYED_HIGH)?.value,
+        priceDivisor,
+      ),
+      low: normalizeIbkrPriceValue(
+        marketData.get(IBApiTickType.LOW)?.value ?? marketData.get(IBApiTickType.DELAYED_LOW)?.value,
+        priceDivisor,
+      ),
+      mark: normalizeIbkrPriceValue(marketData.get(IBApiTickType.MARK_PRICE)?.value, priceDivisor),
     };
   }
 

--- a/src/plugins/ibkr/price-normalization.test.ts
+++ b/src/plugins/ibkr/price-normalization.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { getIbkrPriceDivisor, normalizeIbkrPriceValue } from "./price-normalization";
+
+describe("IBKR sub-unit price normalization", () => {
+  test("detects pence-priced LSE equities", () => {
+    expect(getIbkrPriceDivisor({
+      currency: "GBP",
+      exchange: "SMART",
+      primaryExch: "LSE",
+      secType: "STK",
+    })).toBe(100);
+
+    expect(getIbkrPriceDivisor({
+      currency: "USD",
+      exchange: "NASDAQ",
+      primaryExch: "NASDAQ",
+      secType: "STK",
+    })).toBe(1);
+  });
+
+  test("prefers contract price magnifier when available", () => {
+    expect(getIbkrPriceDivisor({
+      currency: "GBP",
+      exchange: "SMART",
+      primaryExch: "LSE",
+      secType: "STK",
+    }, {
+      priceMagnifier: 1000,
+      validExchanges: "SMART,LSE",
+    })).toBe(1000);
+  });
+
+  test("normalizes individual price values", () => {
+    expect(normalizeIbkrPriceValue(24.5, 100)).toBe(0.245);
+    expect(normalizeIbkrPriceValue(24.5, 1)).toBe(24.5);
+    expect(normalizeIbkrPriceValue(undefined, 100)).toBeUndefined();
+  });
+});

--- a/src/plugins/ibkr/price-normalization.ts
+++ b/src/plugins/ibkr/price-normalization.ts
@@ -1,0 +1,59 @@
+interface IbkrPriceContractLike {
+  currency?: string;
+  exchange?: string;
+  primaryExch?: string;
+  secType?: string;
+}
+
+interface IbkrPriceDetailsLike {
+  priceMagnifier?: number;
+  validExchanges?: string;
+}
+
+const IBKR_SUB_UNIT_PRICE_RULES = [
+  { exchanges: new Set(["LSE"]), currency: "GBP", divisor: 100 },
+  { exchanges: new Set(["TASE"]), currency: "ILS", divisor: 100 },
+  { exchanges: new Set(["JSE"]), currency: "ZAR", divisor: 100 },
+] as const;
+
+function normalizeIbkrExchange(value?: string): string {
+  return (value ?? "").trim().toUpperCase();
+}
+
+function isSubUnitEligibleSecType(secType?: string): boolean {
+  const normalized = normalizeIbkrExchange(secType);
+  return normalized === "STK" || normalized === "ETF";
+}
+
+export function getIbkrPriceDivisor(
+  contract: IbkrPriceContractLike,
+  details?: IbkrPriceDetailsLike,
+): number {
+  if (!isSubUnitEligibleSecType(contract.secType)) return 1;
+
+  const magnifier = details?.priceMagnifier;
+  if (typeof magnifier === "number" && Number.isFinite(magnifier) && magnifier > 1) {
+    return magnifier;
+  }
+
+  const currency = normalizeIbkrExchange(contract.currency);
+  const exchanges = new Set([
+    normalizeIbkrExchange(contract.primaryExch),
+    normalizeIbkrExchange(contract.exchange),
+    ...(details?.validExchanges?.split(",").map((exchange) => normalizeIbkrExchange(exchange)) ?? []),
+  ]);
+
+  for (const rule of IBKR_SUB_UNIT_PRICE_RULES) {
+    if (currency !== rule.currency) continue;
+    if ([...exchanges].some((exchange) => rule.exchanges.has(exchange))) {
+      return rule.divisor;
+    }
+  }
+
+  return 1;
+}
+
+export function normalizeIbkrPriceValue(value: number | undefined, divisor: number): number | undefined {
+  if (value == null || !Number.isFinite(value) || divisor === 1) return value;
+  return value / divisor;
+}

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -378,6 +378,97 @@ describe("ProviderRouter", () => {
     persistence.close();
   });
 
+  test("prefers fallback price data when broker and provider differ by a 100x unit mismatch", async () => {
+    const router = new ProviderRouter({
+      ...fallbackProvider,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 0.245 }],
+          quote: {
+            symbol: "IQE.L",
+            price: 0.245,
+            currency: "GBP",
+            change: -0.021,
+            changePercent: -7.89,
+            lastUpdated: Date.now(),
+          },
+          fundamentals: { revenue: 1000 },
+        };
+      },
+    });
+    const broker: BrokerAdapter = {
+      id: "ibkr",
+      name: "IBKR",
+      configSchema: [],
+      async validate() {
+        return true;
+      },
+      async importPositions() {
+        return [];
+      },
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 24.5 }],
+          quote: {
+            symbol: "IQE",
+            price: 24.5,
+            currency: "GBP",
+            change: -2.1,
+            changePercent: -7.89,
+            lastUpdated: Date.now(),
+          },
+          fundamentals: { netIncome: 200 },
+        };
+      },
+    };
+
+    router.attachRegistry({
+      brokers: new Map([["ibkr", broker]]),
+      dataProviders: new Map(),
+    } as any);
+    router.setConfigAccessor(() => ({
+      dataDir: "",
+      configVersion: CURRENT_CONFIG_VERSION,
+      baseCurrency: "USD",
+      refreshIntervalMinutes: 30,
+      portfolios: [],
+      watchlists: [],
+      columns: [],
+      layout: cloneLayout(DEFAULT_LAYOUT),
+      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
+      activeLayoutIndex: 0,
+      brokerInstances: [{
+        id: "ibkr-work",
+        brokerType: "ibkr",
+        label: "Work",
+        connectionMode: "gateway",
+        config: {},
+        enabled: true,
+      }],
+      plugins: [],
+      disabledPlugins: [],
+      theme: "amber",
+      chartPreferences: {
+        defaultRenderMode: "area",
+        renderer: "auto",
+      },
+      recentTickers: [],
+    }));
+
+    const merged = await router.getTickerFinancials("IQE", "LSE", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+    });
+
+    expect(merged.quote?.price).toBe(0.245);
+    expect(merged.priceHistory[0]?.close).toBe(0.245);
+    expect(merged.fundamentals?.netIncome).toBe(200);
+  });
+
   test("preserves fallback profile data when broker already has fundamentals", async () => {
     const router = new ProviderRouter({
       ...fallbackProvider,
@@ -558,6 +649,123 @@ describe("ProviderRouter", () => {
     });
     expect(refreshed.fundamentals?.revenue).toBe(1000);
     expect(refreshed.profile?.description).toBe("Provides enterprise data storage platforms.");
+
+    persistence.close();
+  });
+
+  test("does not reuse another broker instance's financials when a specific instance is requested", async () => {
+    const dbPath = createTempDbPath("instance-scoped-financials");
+    const persistence = new AppPersistence(dbPath);
+    const router = new ProviderRouter({
+      ...fallbackProvider,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          quote: {
+            symbol: "IQE.L",
+            price: 0.245,
+            currency: "GBP",
+            change: 0,
+            changePercent: 0,
+            lastUpdated: Date.now(),
+          },
+        };
+      },
+    }, [], persistence.resources);
+    const broker: BrokerAdapter = {
+      id: "ibkr",
+      name: "IBKR",
+      configSchema: [],
+      async validate() {
+        return true;
+      },
+      async importPositions() {
+        return [];
+      },
+      async getTickerFinancials(_ticker, instance) {
+        if (instance.id === "ibkr-flex") {
+          throw new Error("Gateway mode is required for broker market data");
+        }
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          quote: {
+            symbol: "IQE",
+            price: 24.5,
+            currency: "GBP",
+            change: 0,
+            changePercent: 0,
+            lastUpdated: Date.now(),
+          },
+        };
+      },
+    };
+
+    router.attachRegistry({
+      brokers: new Map([["ibkr", broker]]),
+      dataProviders: new Map(),
+    } as any);
+    router.setConfigAccessor(() => ({
+      dataDir: "",
+      configVersion: CURRENT_CONFIG_VERSION,
+      baseCurrency: "USD",
+      refreshIntervalMinutes: 30,
+      portfolios: [],
+      watchlists: [],
+      columns: [],
+      layout: cloneLayout(DEFAULT_LAYOUT),
+      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
+      activeLayoutIndex: 0,
+      brokerInstances: [
+        {
+          id: "ibkr-flex",
+          brokerType: "ibkr",
+          label: "Flex",
+          connectionMode: "flex",
+          config: {},
+          enabled: true,
+        },
+        {
+          id: "ibkr-live",
+          brokerType: "ibkr",
+          label: "Live",
+          connectionMode: "gateway",
+          config: {},
+          enabled: true,
+        },
+      ],
+      plugins: [],
+      disabledPlugins: [],
+      theme: "amber",
+      chartPreferences: {
+        defaultRenderMode: "area",
+        renderer: "auto",
+      },
+      recentTickers: [],
+    }));
+
+    const live = await router.getTickerFinancials("IQE", "LSE", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-live",
+    });
+    expect(live.quote?.price).toBe(0.245);
+
+    const flex = await router.getTickerFinancials("IQE", "LSE", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-flex",
+    });
+    expect(flex.quote?.price).toBe(0.245);
+
+    const cached = router.getCachedFinancialsForTargets([{
+      symbol: "IQE",
+      exchange: "LSE",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-flex",
+    }], { allowExpired: true });
+    expect(cached.get("IQE")?.quote?.price).toBe(0.245);
 
     persistence.close();
   });

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -110,19 +110,44 @@ function hasMeaningfulProfile(data: TickerFinancials | null | undefined): boolea
   );
 }
 
+function hasLikelyPriceUnitMismatch(primary: TickerFinancials, fallback: TickerFinancials): boolean {
+  const primaryQuote = primary.quote;
+  const fallbackQuote = fallback.quote;
+  if (!primaryQuote || !fallbackQuote) return false;
+  if (!primaryQuote.currency || !fallbackQuote.currency) return false;
+  if (primaryQuote.currency !== fallbackQuote.currency) return false;
+  if (!Number.isFinite(primaryQuote.price) || !Number.isFinite(fallbackQuote.price)) return false;
+  if (primaryQuote.price <= 0 || fallbackQuote.price <= 0) return false;
+
+  const ratio = primaryQuote.price / fallbackQuote.price;
+  const normalizedRatio = ratio >= 1 ? ratio : 1 / ratio;
+  return Math.abs(normalizedRatio - 100) / 100 < 0.05;
+}
+
 function mergeFinancials(primary: TickerFinancials | null, fallback: TickerFinancials | null): TickerFinancials | null {
   if (primary && hasMeaningfulFundamentals(primary)) {
+    if (fallback && hasLikelyPriceUnitMismatch(primary, fallback)) {
+      return {
+        ...primary,
+        quote: fallback.quote ?? primary.quote,
+        priceHistory: fallback.priceHistory.length > 0 ? fallback.priceHistory : primary.priceHistory,
+        profile: primary.profile ?? fallback.profile,
+      };
+    }
     if (!primary.profile && fallback?.profile) {
       return { ...primary, profile: fallback.profile };
     }
     return primary;
   }
   if (primary && fallback) {
+    const preferFallbackPriceData = hasLikelyPriceUnitMismatch(primary, fallback);
     return {
       ...fallback,
       ...primary,
-      quote: primary.quote ?? fallback.quote,
-      priceHistory: primary.priceHistory.length > 0 ? primary.priceHistory : fallback.priceHistory,
+      quote: preferFallbackPriceData ? (fallback.quote ?? primary.quote) : (primary.quote ?? fallback.quote),
+      priceHistory: preferFallbackPriceData
+        ? (fallback.priceHistory.length > 0 ? fallback.priceHistory : primary.priceHistory)
+        : (primary.priceHistory.length > 0 ? primary.priceHistory : fallback.priceHistory),
       fundamentals: fallback.fundamentals ?? primary.fundamentals ?? {},
       annualStatements: fallback.annualStatements.length > 0 ? fallback.annualStatements : primary.annualStatements,
       quarterlyStatements: fallback.quarterlyStatements.length > 0 ? fallback.quarterlyStatements : primary.quarterlyStatements,
@@ -224,7 +249,7 @@ export class ProviderRouter implements DataProvider {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
     const sourceKeys = [
-      ...this.getBrokerCandidatesForContext(context).map((candidate) => this.brokerSourceKey(candidate)),
+      ...this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate)),
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedResource<Quote>("quote", entityKey, variantKeys, sourceKeys, false);
@@ -395,7 +420,7 @@ export class ProviderRouter implements DataProvider {
       buildVariantKey([["range", range]]),
     ];
     const sourceKeys = [
-      ...this.getBrokerCandidatesForContext(context).map((candidate) => this.brokerSourceKey(candidate)),
+      ...this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate)),
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedResource<PricePoint[]>("price-history", entityKey, variantKeys, sourceKeys, false);
@@ -430,7 +455,7 @@ export class ProviderRouter implements DataProvider {
       buildVariantKey([["start", compactDate(startDate)], ["end", compactDate(endDate)], ["bar", barSize]]),
     ];
     const sourceKeys = [
-      ...this.getBrokerCandidatesForContext(context).map((candidate) => this.brokerSourceKey(candidate)),
+      ...this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate)),
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedResource<PricePoint[]>("detailed-price-history", entityKey, variantKeys, sourceKeys, false);
@@ -456,7 +481,7 @@ export class ProviderRouter implements DataProvider {
       "",
     ];
     const sourceKeys = [
-      ...this.getBrokerCandidatesForContext(context).map((candidate) => this.brokerSourceKey(candidate)),
+      ...this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate)),
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedResource<OptionsChain>("options-chain", entityKey, variantKeys, sourceKeys, false);
@@ -590,7 +615,7 @@ export class ProviderRouter implements DataProvider {
   ): TickerFinancials | null {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
-    const brokerSourceKeys = this.getBrokerCandidatesForContext(context).map((candidate) => this.brokerSourceKey(candidate));
+    const brokerSourceKeys = this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate));
     const brokerRecord = brokerSourceKeys.length > 0
       ? this.selectCachedResource<TickerFinancials>("financials", entityKey, variantKeys, brokerSourceKeys, allowExpired)
       : null;
@@ -619,7 +644,11 @@ export class ProviderRouter implements DataProvider {
     );
   }
 
-  private getBrokerCandidates(preferredBrokerInstanceId?: string, preferredBrokerId?: string): BrokerCandidate[] {
+  private getBrokerCandidates(
+    preferredBrokerInstanceId?: string,
+    preferredBrokerId?: string,
+    includeFallbackInstances = true,
+  ): BrokerCandidate[] {
     if (!this.registry) return [];
     const config = this.getConfigFn();
     const candidates: BrokerCandidate[] = [];
@@ -645,6 +674,10 @@ export class ProviderRouter implements DataProvider {
       pushCandidate(preferredInstance);
     }
 
+    if (!includeFallbackInstances && preferredInstance) {
+      return candidates;
+    }
+
     for (const instance of config.brokerInstances) {
       if (instance.id === preferredBrokerInstanceId) continue;
       pushCandidate(instance);
@@ -653,10 +686,14 @@ export class ProviderRouter implements DataProvider {
     return candidates;
   }
 
-  private getBrokerCandidatesForContext(context?: MarketDataRequestContext): BrokerCandidate[] {
+  private getBrokerCandidatesForContext(
+    context?: MarketDataRequestContext,
+    includeFallbackInstances = true,
+  ): BrokerCandidate[] {
     return this.getBrokerCandidates(
       context?.instrument?.brokerInstanceId ?? context?.brokerInstanceId,
       context?.instrument?.brokerId ?? context?.brokerId,
+      includeFallbackInstances,
     );
   }
 
@@ -706,7 +743,7 @@ export class ProviderRouter implements DataProvider {
   ): Promise<SourceResult<TickerFinancials> | null> {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
-    for (const candidate of this.getBrokerCandidatesForContext(context)) {
+    for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getTickerFinancials) continue;
       try {
         const result = await candidate.broker.getTickerFinancials(
@@ -761,7 +798,7 @@ export class ProviderRouter implements DataProvider {
   ): Promise<SourceResult<Quote> | null> {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
-    for (const candidate of this.getBrokerCandidatesForContext(context)) {
+    for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getQuote) continue;
       try {
         const result = await candidate.broker.getQuote(
@@ -810,7 +847,7 @@ export class ProviderRouter implements DataProvider {
   ): Promise<SourceResult<PricePoint[]> | null> {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKey = buildVariantKey([["exchange", normalizeExchange(exchange)], ["range", range]]);
-    for (const candidate of this.getBrokerCandidatesForContext(context)) {
+    for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getPriceHistory) continue;
       try {
         const result = await candidate.broker.getPriceHistory(
@@ -870,7 +907,7 @@ export class ProviderRouter implements DataProvider {
   ): Promise<SourceResult<PricePoint[]> | null> {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKey = buildVariantKey([["exchange", normalizeExchange(exchange)], ["start", compactDate(startDate)], ["end", compactDate(endDate)], ["bar", barSize]]);
-    for (const candidate of this.getBrokerCandidatesForContext(context)) {
+    for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getDetailedPriceHistory) continue;
       try {
         const result = await candidate.broker.getDetailedPriceHistory(
@@ -935,7 +972,7 @@ export class ProviderRouter implements DataProvider {
   ): Promise<SourceResult<OptionsChain> | null> {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKey = buildVariantKey([["exchange", normalizeExchange(exchange)], ["expiration", expirationDate ?? "default"]]);
-    for (const candidate of this.getBrokerCandidatesForContext(context)) {
+    for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getOptionsChain) continue;
       try {
         const result = await candidate.broker.getOptionsChain(


### PR DESCRIPTION
Scope broker market-data routing and cache reads to the explicitly requested broker instance so flex portfolios cannot reuse a different IBKR gateway instance's financials.
Normalize IBKR stock and ETF prices for sub-unit exchanges using priceMagnifier when available and exchange/currency fallbacks otherwise, and apply that normalization to gateway quotes, history, and imported position per-share fields.
Prefer provider quote and history data when broker and provider prices share a currency but differ by roughly 100x, while still keeping broker fundamentals.
Add regression tests for broker-instance routing, the 100x mismatch fallback, and the new price-normalization helpers.