### PR TITLE
Fix chat input focus and auto-scroll

### DIFF
--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { AppContext, createInitialState } from "../../state/app-context";
+import { createDefaultConfig } from "../../types/config";
+import type { PluginPersistence } from "../../types/plugin";
+import type { PersistedResourceValue } from "../../types/persistence";
+import type { ChatMessage } from "../../utils/api-client";
+import { ChatContent } from "./chat";
+import { ChatController } from "./chat-controller";
+
+const TRANSCRIPT_KIND = "channel-transcript";
+const TRANSCRIPT_KEY = "everyone";
+const TRANSCRIPT_SOURCE = "server";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+class MemoryPersistence implements PluginPersistence {
+  private readonly state = new Map<string, { schemaVersion: number; value: unknown }>();
+  private readonly resources = new Map<string, PersistedResourceValue<unknown>>();
+
+  getState<T = unknown>(key: string, options?: { schemaVersion?: number }): T | null {
+    const record = this.state.get(key);
+    if (!record) return null;
+    if (options?.schemaVersion != null && record.schemaVersion !== options.schemaVersion) {
+      this.state.delete(key);
+      return null;
+    }
+    return record.value as T;
+  }
+
+  setState(key: string, value: unknown, options?: { schemaVersion?: number }): void {
+    this.state.set(key, { schemaVersion: options?.schemaVersion ?? 1, value });
+  }
+
+  deleteState(key: string): void {
+    this.state.delete(key);
+  }
+
+  getResource<T = unknown>(
+    kind: string,
+    key: string,
+    options?: { sourceKey?: string; schemaVersion?: number; allowExpired?: boolean },
+  ): PersistedResourceValue<T> | null {
+    const record = this.resources.get(`${kind}:${key}:${options?.sourceKey ?? ""}`);
+    if (!record) return null;
+    if (options?.schemaVersion != null && record.schemaVersion !== options.schemaVersion) {
+      this.resources.delete(`${kind}:${key}:${options.sourceKey ?? ""}`);
+      return null;
+    }
+    return record as PersistedResourceValue<T>;
+  }
+
+  setResource<T = unknown>(
+    kind: string,
+    key: string,
+    value: T,
+    options: {
+      cachePolicy: { staleMs: number; expireMs: number };
+      sourceKey?: string;
+      schemaVersion?: number;
+      provenance?: unknown;
+    },
+  ): PersistedResourceValue<T> {
+    const now = Date.now();
+    const record: PersistedResourceValue<T> = {
+      value,
+      fetchedAt: now,
+      staleAt: now + options.cachePolicy.staleMs,
+      expiresAt: now + options.cachePolicy.expireMs,
+      sourceKey: options.sourceKey ?? "",
+      schemaVersion: options.schemaVersion ?? 1,
+      provenance: options.provenance,
+    };
+    this.resources.set(`${kind}:${key}:${options.sourceKey ?? ""}`, record);
+    return record;
+  }
+
+  deleteResource(kind: string, key: string, options?: { sourceKey?: string }): void {
+    this.resources.delete(`${kind}:${key}:${options?.sourceKey ?? ""}`);
+  }
+}
+
+function makeMessage(index: number): ChatMessage {
+  return {
+    id: `m${index}`,
+    channelId: "everyone",
+    content: `message ${index}`,
+    replyToId: null,
+    createdAt: `2026-03-30T00:00:${String(index).padStart(2, "0")}.000Z`,
+    user: {
+      id: `u${index}`,
+      username: `user${index}`,
+      displayName: `User ${index}`,
+    },
+  };
+}
+
+function createController(messages: ChatMessage[] = []) {
+  const persistence = new MemoryPersistence();
+  const controller = new ChatController();
+  persistence.setState("session", {
+    sessionToken: null,
+    user: { id: "u0", username: "vince", emailVerified: true },
+  }, { schemaVersion: 1 });
+  persistence.setState("channel:everyone", {
+    draft: "",
+    replyToId: null,
+    lastCursor: messages[messages.length - 1]?.createdAt ?? null,
+  }, { schemaVersion: 1 });
+  if (messages.length > 0) {
+    persistence.setResource(TRANSCRIPT_KIND, TRANSCRIPT_KEY, { messages }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: 1,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+  }
+  controller.attachPersistence(persistence);
+  controller.refreshSession = async () => {};
+  return controller;
+}
+
+function createHarness(controller: ChatController, width = 60, height = 12) {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <ChatContent
+        controller={controller}
+        width={width}
+        height={height}
+        focused
+        selectTicker={() => {}}
+      />
+    </AppContext>
+  );
+}
+
+async function flushFrame() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+});
+
+describe("ChatContent", () => {
+  test("focuses the prompt on click and preserves typing order", async () => {
+    const controller = createController();
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller), {
+        width: 60,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    const frameBeforeClick = testSetup.captureCharFrame().split("\n");
+    const inputRow = frameBeforeClick.findIndex((line) => line.includes("Type a message..."));
+    const inputCol = frameBeforeClick[inputRow]?.indexOf("Type a message...") ?? -1;
+
+    expect(inputRow).toBeGreaterThanOrEqual(0);
+    expect(inputCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(inputCol + 1, inputRow);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("DCF");
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frameAfterType = testSetup.captureCharFrame();
+    expect(frameAfterType).toContain("> DCF");
+    expect(frameAfterType).not.toContain("> FCD");
+  });
+
+  test("auto-scrolls to newly appended messages while following the latest transcript", async () => {
+    const controller = createController([
+      makeMessage(1),
+      makeMessage(2),
+      makeMessage(3),
+      makeMessage(4),
+      makeMessage(5),
+      makeMessage(6),
+    ]);
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, 60, 12), {
+        width: 60,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    const frameBeforeUpdate = testSetup.captureCharFrame();
+    expect(frameBeforeUpdate).toContain("message 6");
+    expect(frameBeforeUpdate).not.toContain("message 1");
+
+    await act(async () => {
+      (controller as any).mergeMessages([makeMessage(7)]);
+    });
+
+    await flushFrame();
+
+    const frameAfterUpdate = testSetup.captureCharFrame();
+    expect(frameAfterUpdate).toContain("7 messages");
+    expect(frameAfterUpdate).toContain("message 7");
+    expect(frameAfterUpdate).not.toContain("message 1");
+  });
+});

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -1,14 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useKeyboard } from "@opentui/react";
-import { TextAttributes } from "@opentui/core";
-import type { InputRenderable } from "@opentui/core";
+import { TextAttributes, type InputRenderable, type ScrollBoxRenderable } from "@opentui/core";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
 import { useAppState } from "../../state/app-context";
 import { colors, hoverBg } from "../../theme/colors";
 import { apiClient, type ChatMessage } from "../../utils/api-client";
 import { formatTimeAgo } from "../../utils/format";
 import { getSharedRegistry } from "../../plugins/registry";
-import { chatController } from "./chat-controller";
+import { chatController, type ChatController } from "./chat-controller";
 import { createGloomberbCloudProvider } from "../../sources/gloomberb-cloud";
 
 function renderMessageContent(
@@ -46,26 +45,65 @@ interface ChatContentProps {
   focused: boolean;
   selectTicker: (symbol: string) => void;
   close?: () => void;
+  controller?: Pick<
+    ChatController,
+    "getSnapshot" | "refreshSession" | "send" | "setDraft" | "setReplyToId" | "subscribe"
+  >;
 }
 
-function ChatContent({ width, height, focused, selectTicker, close }: ChatContentProps) {
+function estimateWrappedLineCount(text: string, width: number) {
+  const safeWidth = Math.max(width, 1);
+  return text.split("\n").reduce((total, line) => (
+    total + Math.max(1, Math.ceil(Math.max(line.length, 1) / safeWidth))
+  ), 0);
+}
+
+function estimateMessageHeight(message: ChatMessage, width: number) {
+  const contentLineWidth = Math.max(width - 4, 1);
+  const normalizedContent = message.content.replace(/\$[A-Z]{1,5}/g, (match) => ` ${match} `);
+  return 1 + (message.replyTo ? 1 : 0) + estimateWrappedLineCount(normalizedContent, contentLineWidth);
+}
+
+function getMessageTopOffset(messages: ChatMessage[], index: number, width: number) {
+  let offset = 0;
+  for (let i = 0; i < index; i += 1) {
+    offset += estimateMessageHeight(messages[i]!, width);
+  }
+  return offset;
+}
+
+function scrollToBottom(scrollBox: ScrollBoxRenderable | null) {
+  if (!scrollBox) return;
+  scrollBox.scrollTo(Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height));
+}
+
+export function ChatContent({
+  width,
+  height,
+  focused,
+  selectTicker,
+  close,
+  controller = chatController,
+}: ChatContentProps) {
   const { dispatch } = useAppState();
-  const initialSnapshot = chatController.getSnapshot();
+  const initialSnapshot = controller.getSnapshot();
   const [messages, setMessages] = useState<ChatMessage[]>(initialSnapshot.messages);
-  const [user, setUser] = useState<{ id: string; username: string } | null>(initialSnapshot.user);
+  const [user, setUser] = useState<{ id: string; username: string; emailVerified: boolean } | null>(initialSnapshot.user);
   const [loading, setLoading] = useState(initialSnapshot.loading);
   const [inputFocused, setInputFocused] = useState(false);
   const [inputValue, setInputValue] = useState(initialSnapshot.draft);
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [followMessages, setFollowMessages] = useState(true);
+  const contentWidth = Math.max(width - 2, 1);
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(() => (
     initialSnapshot.replyToId ? initialSnapshot.messages.find((message) => message.id === initialSnapshot.replyToId) ?? null : null
   ));
-  const [scrollOffset, setScrollOffset] = useState(0);
   const inputRef = useRef<InputRenderable>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
 
   useEffect(() => {
-    const unsubscribe = chatController.subscribe((snapshot) => {
+    const unsubscribe = controller.subscribe((snapshot) => {
       setMessages(snapshot.messages);
       setUser(snapshot.user);
       setLoading(snapshot.loading);
@@ -75,38 +113,58 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
         : null);
     });
 
-    void chatController.refreshSession().catch(() => {});
+    void controller.refreshSession().catch(() => {});
     return unsubscribe;
-  }, []);
-
-  useEffect(() => {
-    if (inputRef.current && initialSnapshot.draft) {
-      (inputRef.current as any).editBuffer?.setText?.(initialSnapshot.draft) || (inputRef.current as any).setText?.(initialSnapshot.draft);
-    }
-  }, [initialSnapshot.draft]);
+  }, [controller]);
 
   const inputValueRef = useRef(inputValue);
   inputValueRef.current = inputValue;
   const replyToRef = useRef(replyTo);
   replyToRef.current = replyTo;
 
+  const focusInput = useCallback(() => {
+    setInputFocused(true);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+    inputRef.current?.focus();
+  }, [dispatch]);
+
+  const blurInput = useCallback(() => {
+    setInputFocused(false);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+  }, [dispatch]);
+
+  const updateDraft = useCallback((draft: string) => {
+    setInputValue(draft);
+    controller.setDraft(draft);
+  }, [controller]);
+
   const sendMessage = useCallback(() => {
     const content = inputValueRef.current.trim();
     if (!content) return;
-    chatController.send(content, replyToRef.current?.id);
-    setInputValue("");
+    controller.send(content, replyToRef.current?.id);
     setReplyTo(null);
-    setScrollOffset(0);
     setSelectedIdx(-1);
-  }, []);
+    setFollowMessages(true);
+  }, [controller]);
+
+  useEffect(() => {
+    if (!focused && inputFocused) {
+      blurInput();
+    }
+  }, [blurInput, focused, inputFocused]);
+
+  useEffect(() => {
+    if (focused && inputFocused) {
+      inputRef.current?.focus();
+    }
+  }, [focused, inputFocused]);
 
   useKeyboard((event) => {
     if (!focused) return;
 
     if (event.name === "c" && event.shift) {
       if (inputFocused) {
-        setInputFocused(false);
-        dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+        blurInput();
       }
       close?.();
       return;
@@ -116,18 +174,16 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
       if (event.name === "escape") {
         if (replyTo) {
           setReplyTo(null);
-          chatController.setReplyToId(null);
+          controller.setReplyToId(null);
         } else {
-          setInputFocused(false);
-          dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+          blurInput();
         }
       }
       return;
     }
 
     if (event.name === "return" || event.name === "i") {
-      setInputFocused(true);
-      dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+      focusInput();
       return;
     }
 
@@ -137,33 +193,62 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
     }
 
     if (event.name === "j" || event.name === "down") {
-      setSelectedIdx((prev) => Math.min(prev + 1, messages.length - 1));
+      if (messages.length === 0) return;
+      const next = Math.min(selectedIdx + 1, messages.length - 1);
+      setSelectedIdx(next);
+      setFollowMessages(next === messages.length - 1);
       return;
     }
     if (event.name === "k" || event.name === "up") {
-      setSelectedIdx((prev) => Math.max(prev - 1, 0));
+      if (messages.length === 0) return;
+      const start = selectedIdx < 0 ? messages.length - 1 : selectedIdx;
+      const next = Math.max(start - 1, 0);
+      setSelectedIdx(next);
+      setFollowMessages(false);
       return;
     }
 
     if (event.name === "r" && selectedIdx >= 0 && selectedIdx < messages.length) {
       const nextReplyTo = messages[selectedIdx] ?? null;
       setReplyTo(nextReplyTo);
-      chatController.setReplyToId(nextReplyTo?.id ?? null);
-      setInputFocused(true);
-      dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+      controller.setReplyToId(nextReplyTo?.id ?? null);
+      focusInput();
       return;
     }
 
     if (event.name === "g" && !event.shift) {
-      setScrollOffset(0);
       setSelectedIdx(0);
+      setFollowMessages(false);
+      scrollRef.current?.scrollTo(0);
       return;
     }
     if (event.name === "g" && event.shift) {
-      setScrollOffset(Math.max(0, messages.length - (height - 4)));
       setSelectedIdx(messages.length - 1);
+      setFollowMessages(true);
+      queueMicrotask(() => scrollToBottom(scrollRef.current));
+      return;
     }
-  });
+  }, [blurInput, close, controller, focusInput, focused, inputFocused, messages, replyTo, selectedIdx]);
+
+  useEffect(() => {
+    if (selectedIdx < messages.length) return;
+    setSelectedIdx(messages.length - 1);
+  }, [messages.length, selectedIdx]);
+
+  useEffect(() => {
+    const sb = scrollRef.current;
+    if (!sb) return;
+    if (followMessages) return;
+    if (selectedIdx < 0 || selectedIdx >= messages.length) return;
+    const top = getMessageTopOffset(messages, selectedIdx, contentWidth);
+    const rowHeight = estimateMessageHeight(messages[selectedIdx]!, contentWidth);
+    const viewportHeight = Math.max(sb.viewport.height, 1);
+    if (top < sb.scrollTop) {
+      sb.scrollTo(top);
+    } else if (top + rowHeight > sb.scrollTop + viewportHeight) {
+      sb.scrollTo(Math.max(top + rowHeight - viewportHeight, 0));
+    }
+  }, [contentWidth, followMessages, messages, selectedIdx]);
 
   if (loading) {
     return (
@@ -200,9 +285,6 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
   const headerHeight = 1;
   const separatorHeight = 1;
   const messageAreaHeight = Math.max(1, height - headerHeight - separatorHeight - inputAreaHeight - 1);
-  const visibleStart = Math.max(0, messages.length - messageAreaHeight - scrollOffset);
-  const visibleMessages = messages.slice(visibleStart, visibleStart + messageAreaHeight);
-  const contentWidth = width - 2;
 
   return (
     <box flexDirection="column" width={width} height={height}>
@@ -216,16 +298,22 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
         <text fg={colors.border}>{"-".repeat(contentWidth)}</text>
       </box>
 
-      <scrollbox height={messageAreaHeight} scrollY>
-        {visibleMessages.length === 0 && (
+      <scrollbox
+        ref={scrollRef}
+        height={messageAreaHeight}
+        scrollY
+        focusable={false}
+        stickyScroll={followMessages}
+        stickyStart="bottom"
+      >
+        {messages.length === 0 && (
           <box alignItems="center" justifyContent="center" flexGrow={1}>
             <text fg={colors.textDim}>No messages yet. Be the first to say something!</text>
           </box>
         )}
-        {visibleMessages.map((msg, i) => {
-          const globalIdx = visibleStart + i;
-          const isSelected = globalIdx === selectedIdx;
-          const isHovered = globalIdx === hoveredIdx && !isSelected;
+        {messages.map((msg, index) => {
+          const isSelected = index === selectedIdx;
+          const isHovered = index === hoveredIdx && !isSelected;
           const bgColor = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
 
           return (
@@ -234,8 +322,11 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
               flexDirection="column"
               width={contentWidth}
               backgroundColor={bgColor}
-              onMouseMove={() => setHoveredIdx(globalIdx)}
-              onMouseDown={() => setSelectedIdx(globalIdx)}
+              onMouseMove={() => setHoveredIdx(index)}
+              onMouseDown={() => {
+                setSelectedIdx(index);
+                setFollowMessages(index === messages.length - 1);
+              }}
             >
               {msg.replyTo && (
                 <box flexDirection="row" height={1} paddingLeft={2}>
@@ -275,26 +366,22 @@ function ChatContent({ width, height, focused, selectTicker, close }: ChatConten
         </box>
       )}
 
-      <box height={1} width={contentWidth} flexDirection="row">
+      <box height={1} width={contentWidth} flexDirection="row" onMouseDown={focusInput}>
         <text fg={colors.textDim}> {">"} </text>
         <input
           ref={inputRef}
+          value={inputValue}
           focused={inputFocused && focused}
           placeholder="Type a message..."
           placeholderColor={colors.textMuted}
           textColor={colors.text}
           backgroundColor={colors.bg}
           flexGrow={1}
-          onInput={(val) => {
-            setInputValue(val);
-            chatController.setDraft(val);
-          }}
+          onInput={updateDraft}
+          onChange={updateDraft}
           onSubmit={() => {
-            if (inputValue.trim()) {
+            if (inputValueRef.current.trim()) {
               sendMessage();
-              if (inputRef.current) {
-                (inputRef.current as any).editBuffer?.setText?.("") || (inputRef.current as any).setText?.("");
-              }
             }
           }}
         />


### PR DESCRIPTION
Fix the chat pane so the composer is a controlled OpenTUI input that can be focused by mouse clicks, which stops reversed typing. Replace manual transcript slicing with a sticky-bottom scrollbox and explicit selected-message scrolling so new messages auto-follow while keyboard navigation still works. Add a regression test that covers click-to-focus, typing order, and transcript auto-scroll on appended messages. Testing: bun test v1.3.11 (af24e281).