### PR TITLE
Fix chart crosshair control and currency labels

### DIFF
--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -1,6 +1,7 @@
 import { RGBA } from "@opentui/core";
 import type { ChartAxisMode, ChartColors, Pixel, PixelBuffer, ChartRenderMode } from "./chart-types";
 import type { ProjectedChartPoint } from "./chart-data";
+import { formatCurrency } from "../../utils/format";
 
 // ---------------------------------------------------------------------------
 // Styled output types (unchanged public API)
@@ -649,9 +650,7 @@ export function bufferToStyledLines(buf: PixelBuffer, bgColor: string): StyledCo
 // ---------------------------------------------------------------------------
 
 export function formatPrice(value: number): string {
-  if (Math.abs(value) >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
-  if (Math.abs(value) >= 1e3 && Math.abs(value) < 1e5) return `$${(value / 1e3).toFixed(1)}K`;
-  return `$${value.toFixed(2)}`;
+  return formatPriceWithCurrency(value);
 }
 
 function formatPercentAxisValue(value: number): string {
@@ -661,11 +660,39 @@ function formatPercentAxisValue(value: number): string {
   return `${prefix}${value.toFixed(decimals)}%`;
 }
 
-export function formatAxisValue(value: number, axisMode: ChartAxisMode, basePrice: number): string {
+const currencySymbols = new Map<string, string>();
+
+function getCurrencySymbol(currency: string): string {
+  const cached = currencySymbols.get(currency);
+  if (cached) return cached;
+
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    currencyDisplay: "symbol",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const symbol = formatter.formatToParts(0).find((part) => part.type === "currency")?.value ?? currency;
+  currencySymbols.set(currency, symbol);
+  return symbol;
+}
+
+export function formatPriceWithCurrency(value: number, currency = "USD"): string {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  const symbol = getCurrencySymbol(currency);
+
+  if (abs >= 1e6) return `${sign}${symbol}${(abs / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3 && abs < 1e5) return `${sign}${symbol}${(abs / 1e3).toFixed(1)}K`;
+  return formatCurrency(value, currency);
+}
+
+export function formatAxisValue(value: number, axisMode: ChartAxisMode, basePrice: number, currency = "USD"): string {
   if (axisMode === "percent" && basePrice !== 0) {
     return formatPercentAxisValue(((value - basePrice) / basePrice) * 100);
   }
-  return formatPrice(value);
+  return formatPriceWithCurrency(value, currency);
 }
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -963,6 +990,7 @@ export interface RenderChartOptions {
   cursorY: number | null;
   mode: ChartRenderMode;
   axisMode?: ChartAxisMode;
+  currency?: string;
   colors: ResolvedChartPalette;
 }
 
@@ -1125,6 +1153,7 @@ export function renderChart(
 
   const { width, colors: palette, mode } = opts;
   const axisMode = opts.axisMode ?? "price";
+  const currency = opts.currency ?? "USD";
 
   // Braille resolution: 2 dot-columns per terminal column, 4 dot-rows per terminal row
   const dotWidth = width * 2;
@@ -1180,7 +1209,7 @@ export function renderChart(
   for (const line of gridLines) {
     axisLabelsByRow.set(
       Math.min(Math.floor(line.y / 4), Math.max(chartTermRows - 1, 0)),
-      formatAxisValue(line.price, axisMode, points[0]!.close),
+      formatAxisValue(line.price, axisMode, points[0]!.close, currency),
     );
   }
 

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bucketOhlcSeries, projectChartData, resolveRenderMode } from "./chart-data";
 import { stepCursorTowards } from "./cursor-motion";
-import { buildTimeAxis, renderChart, resolveChartPalette } from "./chart-renderer";
+import { buildTimeAxis, formatAxisValue, renderChart, resolveChartPalette } from "./chart-renderer";
 import type { PricePoint } from "../../types/financials";
 import type { ChartRenderMode } from "./chart-types";
 
@@ -89,6 +89,11 @@ describe("resolveRenderMode", () => {
 });
 
 describe("renderChart", () => {
+  test("formats price axes with the instrument currency", () => {
+    expect(formatAxisValue(21_970, "price", 0, "JPY")).toBe("¥22.0K");
+    expect(formatAxisValue(12_340, "price", 0, "HKD")).toBe("HK$12.3K");
+  });
+
   test("eases coarse cursor motion quickly and settles without overshooting", () => {
     let current: { x: number | null; y: number | null } = { x: 2, y: 1 };
     const target = { x: 6, y: 4 };
@@ -345,6 +350,25 @@ describe("renderChart", () => {
       { row: 3, label: "-9.09%" },
       { row: 4, label: "-18.2%" },
     ]);
+  });
+
+  test("uses the supplied currency for rendered price-axis labels", () => {
+    const projection = projectChartData(chartFixture, 12, "line", false);
+    const result = renderChart(projection.points, {
+      width: 12,
+      height: 5,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: projection.effectiveMode,
+      axisMode: "price",
+      currency: "JPY",
+      colors: palette,
+    });
+
+    expect(result.axisLabels.some((entry) => entry.label.includes("¥"))).toBe(true);
+    expect(result.axisLabels.every((entry) => !entry.label.includes("$"))).toBe(true);
   });
 
   test("accepts serialized string dates from cached chart data", () => {

--- a/src/components/chart/stock-chart.test.ts
+++ b/src/components/chart/stock-chart.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { BoxRenderable, CliRenderer } from "@opentui/core";
-import { getLocalPlotPointer, projectCellCursorToLocalPixels } from "./stock-chart";
+import {
+  getLocalPlotPointer,
+  projectCellCursorToLocalPixels,
+  resolveAdjacentSelectionCursorX,
+  resolveSelectionDisplayCursorState,
+} from "./stock-chart";
+import { getPointTerminalColumn } from "./chart-renderer";
 
 const renderer = {
   resolution: { width: 1200, height: 800 },
@@ -57,5 +63,45 @@ describe("stock chart pointer helpers", () => {
     expect(pixels).not.toBeNull();
     expect(pixels!.pixelX).toBeCloseTo(143.23, 2);
     expect(pixels!.pixelY).toBeCloseTo(108.64, 2);
+  });
+
+  test("keeps a visible display cursor for keyboard selection when only cursorX is explicit", () => {
+    const cursor = resolveSelectionDisplayCursorState(14, null, 14, 5, renderable, renderer);
+
+    expect(cursor).toMatchObject({
+      cellX: 14,
+      cellY: 5,
+    });
+    expect(cursor.pixelX).toBeCloseTo(143.23, 2);
+    expect(cursor.pixelY).toBeCloseTo(108.64, 2);
+  });
+
+  test("prefers the explicit selection cursorY over the derived fallback", () => {
+    const cursor = resolveSelectionDisplayCursorState(14, 3, 17, 5, renderable, renderer);
+
+    expect(cursor).toMatchObject({
+      cellX: 14,
+      cellY: 3,
+    });
+    expect(cursor.pixelY).toBeCloseTo(65.18, 2);
+  });
+
+  test("can snap keyboard display cursor x to the active chart point", () => {
+    const cursor = resolveSelectionDisplayCursorState(14, null, 17, 5, renderable, renderer);
+
+    expect(cursor).toMatchObject({
+      cellX: 17,
+      cellY: 5,
+    });
+  });
+
+  test("moves keyboard selection between snapped chart points", () => {
+    const width = 40;
+    const pointCount = 20;
+    const rightmost = getPointTerminalColumn(pointCount - 1, pointCount, width, "candles");
+    const previous = getPointTerminalColumn(pointCount - 2, pointCount, width, "candles");
+
+    expect(resolveAdjacentSelectionCursorX(width - 1, -1, pointCount, width, "candles")).toBe(previous);
+    expect(resolveAdjacentSelectionCursorX(previous, 1, pointCount, width, "candles")).toBe(rightmost);
   });
 });

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -11,6 +11,7 @@ import {
   buildChartScene,
   formatDateShort,
   formatAxisValue,
+  getActivePointIndex,
   getPointTerminalColumn,
   renderChart,
   resolveChartPalette,
@@ -239,6 +240,34 @@ function buildDisplayCursorState(
     pixelX: derivedPixels?.pixelX ?? null,
     pixelY: derivedPixels?.pixelY ?? null,
   };
+}
+
+export function resolveSelectionDisplayCursorState(
+  cursorX: number | null,
+  cursorY: number | null,
+  fallbackCursorX: number | null,
+  fallbackCursorY: number | null,
+  renderable: BoxRenderable | null,
+  renderer: Pick<CliRenderer, "resolution" | "terminalWidth" | "terminalHeight">,
+): DisplayCursorState {
+  const resolvedCursorX = cursorY === null ? (fallbackCursorX ?? cursorX) : cursorX;
+  const resolvedCursorY = cursorY ?? fallbackCursorY;
+  if (resolvedCursorX === null) return EMPTY_DISPLAY_CURSOR;
+  return buildDisplayCursorState(resolvedCursorX, resolvedCursorY, renderable, renderer);
+}
+
+export function resolveAdjacentSelectionCursorX(
+  cursorX: number | null,
+  step: -1 | 1,
+  pointCount: number,
+  width: number,
+  mode: ChartRenderMode,
+): number | null {
+  if (pointCount <= 0 || width <= 0) return null;
+  const anchorX = cursorX ?? (step < 0 ? width - 1 : 0);
+  const currentIndex = getActivePointIndex(pointCount, width, anchorX, mode);
+  const nextIndex = clamp(currentIndex + step, 0, pointCount - 1);
+  return getPointTerminalColumn(nextIndex, pointCount, width, mode);
 }
 
 export function getLocalPlotPointer(
@@ -762,6 +791,35 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
     setViewState((current) => ({ ...current, renderMode: mode }));
   };
 
+  const headerRows = compact ? 0 : 3;
+  const helpRow = compact ? 0 : 1;
+  const timeAxisRow = 1;
+  const volumeHeight = showVolume && !compact ? 3 : 0;
+  const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
+  const isDetailView = viewState.zoomLevel > 1 && detailHistory != null && detailHistory.length > 0;
+  const historyRenderKey = history.length === 0
+    ? "empty"
+    : [
+      history.length,
+      new Date(history[0]!.date).getTime(),
+      new Date(history[history.length - 1]!.date).getTime(),
+      history[history.length - 1]!.close,
+    ].join(":");
+
+  useEffect(() => {
+    queueMicrotask(() => renderer.requestRender());
+  }, [chartHeight, chartWidth, compact, historyRenderKey, renderer, ticker?.metadata.ticker, viewState.renderMode]);
+
+  const chartWindow = useMemo(() => (
+    isDetailView
+      ? { points: history, startIdx: 0, endIdx: history.length }
+      : getVisibleWindow(history, viewState, chartWidth)
+  ), [chartWidth, history, isDetailView, viewState.panOffset, viewState.timeRange, viewState.zoomLevel]);
+
+  const projection = useMemo(() => (
+    projectChartData(chartWindow.points, chartWidth, viewState.renderMode, !!compact)
+  ), [chartWindow.points, chartWidth, compact, viewState.renderMode]);
+
   useKeyboard((event) => {
     if (!focused || compact) return;
 
@@ -811,11 +869,32 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
         } else {
           cursorMotionKindRef.current = "discrete";
           setViewState((current) => {
-            const nextCursor = current.cursorX === null ? maxCursorX : current.cursorX - 1;
-            if (nextCursor < 0) {
-              return { ...current, cursorX: 0, panOffset: current.panOffset + 1 };
+            const pointCount = projection.points.length;
+            const currentIndex = pointCount <= 0
+              ? -1
+              : getActivePointIndex(
+                pointCount,
+                chartWidth,
+                current.cursorX ?? maxCursorX,
+                projection.effectiveMode,
+              );
+            const nextCursor = resolveAdjacentSelectionCursorX(
+              current.cursorX,
+              -1,
+              pointCount,
+              chartWidth,
+              projection.effectiveMode,
+            );
+            const maxPan = getMaxPanOffset(baseHistory, current.timeRange, current.zoomLevel, chartWidth);
+            if (currentIndex <= 0) {
+              return {
+                ...current,
+                cursorX: nextCursor,
+                cursorY: null,
+                panOffset: clamp(current.panOffset + 1, 0, maxPan),
+              };
             }
-            return { ...current, cursorX: nextCursor };
+            return { ...current, cursorX: nextCursor, cursorY: null };
           });
         }
         return;
@@ -825,45 +904,36 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
         } else {
           cursorMotionKindRef.current = "discrete";
           setViewState((current) => {
-            const nextCursor = current.cursorX === null ? 0 : current.cursorX + 1;
-            if (nextCursor > maxCursorX) {
-              return { ...current, cursorX: maxCursorX, panOffset: Math.max(current.panOffset - 1, 0) };
+            const pointCount = projection.points.length;
+            const currentIndex = pointCount <= 0
+              ? -1
+              : getActivePointIndex(
+                pointCount,
+                chartWidth,
+                current.cursorX ?? 0,
+                projection.effectiveMode,
+              );
+            const nextCursor = resolveAdjacentSelectionCursorX(
+              current.cursorX,
+              1,
+              pointCount,
+              chartWidth,
+              projection.effectiveMode,
+            );
+            if (currentIndex >= pointCount - 1) {
+              return {
+                ...current,
+                cursorX: nextCursor,
+                cursorY: null,
+                panOffset: Math.max(current.panOffset - 1, 0),
+              };
             }
-            return { ...current, cursorX: nextCursor };
+            return { ...current, cursorX: nextCursor, cursorY: null };
           });
         }
         return;
     }
   });
-
-  const headerRows = compact ? 0 : 3;
-  const helpRow = compact ? 0 : 1;
-  const timeAxisRow = 1;
-  const volumeHeight = showVolume && !compact ? 3 : 0;
-  const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
-  const isDetailView = viewState.zoomLevel > 1 && detailHistory != null && detailHistory.length > 0;
-  const historyRenderKey = history.length === 0
-    ? "empty"
-    : [
-      history.length,
-      new Date(history[0]!.date).getTime(),
-      new Date(history[history.length - 1]!.date).getTime(),
-      history[history.length - 1]!.close,
-    ].join(":");
-
-  useEffect(() => {
-    queueMicrotask(() => renderer.requestRender());
-  }, [chartHeight, chartWidth, compact, historyRenderKey, renderer, ticker?.metadata.ticker, viewState.renderMode]);
-
-  const chartWindow = useMemo(() => (
-    isDetailView
-      ? { points: history, startIdx: 0, endIdx: history.length }
-      : getVisibleWindow(history, viewState, chartWidth)
-  ), [chartWidth, history, isDetailView, viewState.panOffset, viewState.timeRange, viewState.zoomLevel]);
-
-  const projection = useMemo(() => (
-    projectChartData(chartWindow.points, chartWidth, viewState.renderMode, !!compact)
-  ), [chartWindow.points, chartWidth, compact, viewState.renderMode]);
 
   const chartColors = useMemo(() => {
     const rawChange = chartWindow.points.length >= 2
@@ -880,6 +950,7 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
       negative: colors.negative,
     }, trend);
   }, [chartWindow.points]);
+  const chartCurrency = financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
 
   const cursorX = viewState.cursorX !== null ? clamp(viewState.cursorX, 0, chartWidth - 1) : null;
   const cursorY = viewState.cursorY !== null ? clamp(viewState.cursorY, 0, chartHeight - 1) : null;
@@ -895,6 +966,21 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
         : { ...current, cursorX: next.cursorX, cursorY: next.cursorY }
     ));
   };
+
+  const selectionScene = useMemo(() => buildChartScene(projection.points, {
+    width: chartWidth,
+    height: chartHeight,
+    showVolume: showVolume && !compact,
+    volumeHeight,
+    cursorX: selectionCursorX,
+    cursorY: selectionCursorY,
+    mode: projection.effectiveMode,
+    axisMode,
+    colors: chartColors,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, selectionCursorX, selectionCursorY, showVolume, volumeHeight]);
+  const snappedSelectionCursorX = selectionScene
+    ? getPointTerminalColumn(selectionScene.activeIdx, projection.points.length, chartWidth, projection.effectiveMode)
+    : null;
 
   useEffect(() => {
     const remapCursor = (cursor: DisplayCursorState) => buildDisplayCursorState(
@@ -913,22 +999,17 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
   useEffect(() => {
     if (cursorMotionKindRef.current === "pixel") return;
     updateDisplayCursorTarget(
-      buildDisplayCursorState(selectionCursorX, selectionCursorY, plotRef.current, renderer),
+      resolveSelectionDisplayCursorState(
+        selectionCursorX,
+        selectionCursorY,
+        cursorMotionKindRef.current === "discrete" ? snappedSelectionCursorX : null,
+        selectionScene?.cursorY ?? null,
+        plotRef.current,
+        renderer,
+      ),
       cursorMotionKindRef.current,
     );
-  }, [renderer, selectionCursorX, selectionCursorY]);
-
-  const selectionScene = useMemo(() => buildChartScene(projection.points, {
-    width: chartWidth,
-    height: chartHeight,
-    showVolume: showVolume && !compact,
-    volumeHeight,
-    cursorX: selectionCursorX,
-    cursorY: selectionCursorY,
-    mode: projection.effectiveMode,
-    axisMode,
-    colors: chartColors,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, selectionCursorX, selectionCursorY, showVolume, volumeHeight]);
+  }, [renderer, selectionCursorX, selectionCursorY, selectionScene?.cursorY, snappedSelectionCursorX]);
 
   const nativeBaseScene = useMemo(() => buildChartScene(projection.points, {
     width: chartWidth,
@@ -954,8 +1035,9 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
     cursorY: null,
     mode: projection.effectiveMode,
     axisMode,
+    currency: chartCurrency,
     colors: chartColors,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+  }), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
 
   const interactiveResult = useMemo(() => (
     effectiveRenderer === "kitty"
@@ -969,9 +1051,10 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
         cursorY: displayCursorY,
         mode: projection.effectiveMode,
         axisMode,
+        currency: chartCurrency,
         colors: chartColors,
       })
-  ), [axisMode, chartColors, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+  ), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
 
   const result = effectiveRenderer === "kitty" ? staticResult : interactiveResult!;
 
@@ -1235,7 +1318,7 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
   const activePoint = showOhlcSummary ? (selectionScene?.activePoint ?? null) : null;
   const axisLabels = new Map(staticResult.axisLabels.map((entry) => [entry.row, entry.label]));
   const cursorAxisLabel = hasDisplayCursor && cursorRow !== null && crosshairPrice !== null
-    ? formatAxisValue(crosshairPrice, axisMode, projection.points[0]?.close ?? 0)
+    ? formatAxisValue(crosshairPrice, axisMode, projection.points[0]?.close ?? 0, chartCurrency)
     : null;
 
   const handlePlotMove = (event: ChartMouseEvent) => {
@@ -1441,7 +1524,7 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
           {ticker?.metadata.ticker ?? ""} - {viewState.timeRange}
         </text>
         <text fg={priceColor(displayChange)}>
-          {formatCurrency(displayPrice)}
+          {formatCurrency(displayPrice, chartCurrency)}
         </text>
         <text fg={priceColor(displayChange)}>
           {displayChange >= 0 ? "+" : ""}{displayChange.toFixed(2)} ({displayChangePct >= 0 ? "+" : ""}{displayChangePct.toFixed(2)}%)
@@ -1449,10 +1532,10 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
         {displayDate && <text fg={colors.textDim}>{displayDate}</text>}
         {showOhlcSummary && activePoint && (
           <>
-            <text fg={colors.textDim}>O {formatCurrency(activePoint.open)}</text>
-            <text fg={colors.textDim}>H {formatCurrency(activePoint.high)}</text>
-            <text fg={colors.textDim}>L {formatCurrency(activePoint.low)}</text>
-            <text fg={colors.textDim}>C {formatCurrency(activePoint.close)}</text>
+            <text fg={colors.textDim}>O {formatCurrency(activePoint.open, chartCurrency)}</text>
+            <text fg={colors.textDim}>H {formatCurrency(activePoint.high, chartCurrency)}</text>
+            <text fg={colors.textDim}>L {formatCurrency(activePoint.low, chartCurrency)}</text>
+            <text fg={colors.textDim}>C {formatCurrency(activePoint.close, chartCurrency)}</text>
             <text fg={colors.textDim}>V {formatCompact(activePoint.volume)}</text>
           </>
         )}

--- a/src/plugins/builtin/comparison-chart.tsx
+++ b/src/plugins/builtin/comparison-chart.tsx
@@ -170,6 +170,7 @@ function ComparisonChartCard({
     : (financials?.priceHistory ?? []);
   const windowedHistory = useMemo(() => filterByTimeRange(history, "1Y"), [history]);
   const displayQuote = getDisplayQuote(financials?.quote, windowedHistory);
+  const currency = financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
   const axisWidth = axisMode === "percent" ? 11 : 10;
   const plotWidth = Math.max(width - axisWidth - 4, 18);
   const plotHeight = Math.max(height - 4, 4);
@@ -201,12 +202,12 @@ function ComparisonChartCard({
       cursorX: null,
       mode: projection.effectiveMode,
       axisMode,
+      currency,
       colors: chartColors,
     })
-  ), [axisMode, chartColors, plotHeight, plotWidth, projection.effectiveMode, projection.points]);
+  ), [axisMode, chartColors, currency, plotHeight, plotWidth, projection.effectiveMode, projection.points]);
 
   const axisLabels = new Map(result.axisLabels.map((entry) => [entry.row, entry.label]));
-  const currency = financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
   const headerColor = priceColor(displayQuote?.change ?? 0);
 
   return (


### PR DESCRIPTION
This updates chart interaction so keyboard and mouse control can coexist cleanly. Arrow-key navigation now snaps the crosshair to chart points while mouse hover remains freeform. The chart renderer and panes now use quote or ticker currency for headers and axis labels, including non-USD symbols and comparison charts. Regression coverage was added for snapped keyboard cursor behavior and non-USD chart formatting.