### PR TITLE
Preserve cached cloud auth on transient refresh errors

### DIFF
--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -7,6 +7,7 @@ import { ChatController } from "./chat-controller";
 const TRANSCRIPT_KIND = "channel-transcript";
 const TRANSCRIPT_KEY = "everyone";
 const TRANSCRIPT_SOURCE = "server";
+const originalGetSession = apiClient.getSession.bind(apiClient);
 
 class MemoryPersistence implements PluginPersistence {
   private readonly state = new Map<string, { schemaVersion: number; value: unknown }>();
@@ -76,6 +77,7 @@ class MemoryPersistence implements PluginPersistence {
 
 afterEach(() => {
   apiClient.setSessionToken(null);
+  apiClient.getSession = originalGetSession;
 });
 
 describe("ChatController", () => {
@@ -161,5 +163,32 @@ describe("ChatController", () => {
     expect((controller as any).verificationPollTimer).not.toBeNull();
 
     controller.reset(true);
+  });
+
+  test("keeps the cached session when session refresh fails transiently", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => {
+      throw new Error("network down");
+    };
+
+    await expect(controller.refreshSession()).rejects.toThrow("network down");
+    expect(apiClient.getSessionToken()).toBe("token-123");
+    expect(persistence.getState("session", { schemaVersion: 1 })).toEqual({
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    });
+    expect(controller.getSnapshot().user).toEqual({
+      id: "u1",
+      username: "vince",
+      emailVerified: true,
+    });
   });
 });

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -86,6 +86,13 @@ function marketKey(symbol: string, exchange?: string): string {
 type ChannelListener = (message: ChatMessage) => void;
 type QuoteListener = (target: QuoteStreamTarget, quote: CloudQuotePayload) => void;
 
+class ApiRequestError extends Error {
+  constructor(message: string, readonly status?: number) {
+    super(message);
+    this.name = "ApiRequestError";
+  }
+}
+
 class GloomApiClient {
   private sessionToken: string | null = null;
   private websocketToken: string | null = null;
@@ -181,7 +188,7 @@ class GloomApiClient {
       } catch {
         msg = body;
       }
-      throw new Error(msg);
+      throw new ApiRequestError(msg, res.status);
     }
 
     const text = await res.text();
@@ -382,7 +389,10 @@ class GloomApiClient {
       const user = result?.user ?? null;
       this.setCurrentUser(user);
       return user;
-    } catch {
+    } catch (error) {
+      if (!(error instanceof ApiRequestError) || (error.status !== 401 && error.status !== 403)) {
+        throw error;
+      }
       this.setCurrentUser(null);
       return null;
     }


### PR DESCRIPTION
## Summary
- keep cached cloud auth state when `get-session` fails transiently instead of treating the user as logged out
- preserve explicit logout behavior by only clearing auth on 401/403 session responses
- add a regression test covering the transient refresh failure path

## Testing
- bun test src/plugins/builtin/chat-controller.test.ts