### PR TITLE
Guard kitty writes during teardown

### DIFF
--- a/src/components/chart/native/kitty-adapter.ts
+++ b/src/components/chart/native/kitty-adapter.ts
@@ -1,6 +1,10 @@
 import type { CliRenderer } from "@opentui/core";
 
 export function writeRendererRaw(renderer: CliRenderer, data: string | Uint8Array): boolean {
+  if (renderer.isDestroyed) {
+    return false;
+  }
+
   const writer = (renderer as unknown as { writeOut?: (payload: string | Uint8Array) => void }).writeOut;
   if (typeof writer !== "function") return false;
   writer.call(renderer, data);


### PR DESCRIPTION
This change guards raw Kitty writes once the OpenTUI renderer has entered teardown. It fixes the Bun crash we traced to chart cleanup issuing Kitty delete-image sequences after renderer destruction had already started. The runtime behavior during normal use is unchanged; only post-destroy raw writes are skipped.