### PR TITLE
Add help pane and IBKR trading shortcut

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -57,6 +57,7 @@ import { notesPlugin } from "./plugins/builtin/notes";
 import { askAiPlugin } from "./plugins/builtin/ask-ai";
 import { gloomberbCloudPlugin } from "./plugins/builtin/chat";
 import { chatController } from "./plugins/builtin/chat-controller";
+import { helpPlugin } from "./plugins/builtin/help";
 import {
   buildComparisonChartPaneTitle,
   COMPARISON_CHART_PANE_ID,
@@ -1550,6 +1551,7 @@ export function App({ config: initialConfig, renderer, externalPlugins = [] }: A
     pluginRegistry.register(optionsPlugin);
     pluginRegistry.register(notesPlugin);
     pluginRegistry.register(askAiPlugin);
+    pluginRegistry.register(helpPlugin);
     pluginRegistry.register(comparisonChartPlugin);
     pluginRegistry.register(debugPlugin);
 

--- a/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
+++ b/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
@@ -19,8 +19,8 @@ exports[`CommandBar renders the default layout with opencode-style chrome 1`] = 
                   Search                                                        
                   Search Ticker                                                 
                                                                                 
-                  Portfolio                                                     
-                  Add AAPL to Watchlist                                         
+                  Navigation                                                    
+                  Help                                                          
                                                                                 
                                                                                 
                                                                                 

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -77,6 +77,13 @@ function makePluginRegistry(hasPaneSettings: (paneId: string) => boolean = () =>
         defaultPosition: "right",
         defaultMode: "floating",
       }],
+      ["ibkr-trading", {
+        id: "ibkr-trading",
+        name: "IBKR Console",
+        component: () => null,
+        defaultPosition: "right",
+        defaultMode: "floating",
+      }],
     ]),
     paneTemplates: new Map([
       ["new-portfolio-pane", {
@@ -112,6 +119,18 @@ function makePluginRegistry(hasPaneSettings: (paneId: string) => boolean = () =>
         description: "Open a compact quote monitor for the selected ticker",
         shortcut: { prefix: "QQ", argPlaceholder: "ticker" },
       }],
+      ["new-ibkr-trading-pane", {
+        id: "new-ibkr-trading-pane",
+        paneId: "ibkr-trading",
+        label: "New IBKR Trading Pane",
+        description: "Open another floating IBKR trading console",
+        shortcut: { prefix: "IBKR" },
+        canCreate: (context) => context.config.brokerInstances.some((instance) => (
+          instance.brokerType === "ibkr"
+          && instance.connectionMode === "gateway"
+          && instance.enabled !== false
+        )),
+      }],
     ]),
     commands: new Map([
       ["plugin:scan", {
@@ -142,6 +161,7 @@ function makePluginRegistry(hasPaneSettings: (paneId: string) => boolean = () =>
     getPluginPaneTemplateIds: () => [],
     hasPaneSettings,
     hideWidget: () => {},
+    showWidget: () => {},
     updateLayoutFn: () => {},
     getTermSizeFn: () => ({ width: 80, height: 24 }),
     createPaneFromTemplateFn: () => {},
@@ -407,6 +427,45 @@ describe("CommandBar", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Quote Monitor");
     expect(frame).toContain("QQ");
+  });
+
+  test("matches the IBKR trading shortcut when a gateway profile exists", async () => {
+    testSetup = await testRender(<CommandBarHarness
+      query="IBKR"
+      configureConfig={(config) => ({
+        ...config,
+        brokerInstances: [{
+          id: "ibkr-paper",
+          brokerType: "ibkr",
+          label: "Paper",
+          connectionMode: "gateway",
+          config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
+          enabled: true,
+        }],
+      })}
+    />, {
+      width: 100,
+      height: 18,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("New IBKR Trading Pane");
+    expect(frame).toContain("IBKR");
+  });
+
+  test("matches the direct help command", async () => {
+    testSetup = await testRender(<CommandBarHarness query="help" />, {
+      width: 80,
+      height: 18,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Help");
+    expect(frame).toContain("Navigation");
   });
 
   test("skips pane templates whose canCreate throws", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -611,6 +611,11 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
         close();
         return;
       }
+      case "help": {
+        close();
+        pluginRegistry.showWidget("help");
+        return;
+      }
       case "cycle-chart-renderer": {
         const current = state.config.chartPreferences.renderer;
         const index = CHART_RENDERER_PREFERENCES.indexOf(current);

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -32,6 +32,14 @@ export const commands: Command[] = [
     category: "Search",
     execute: () => {}, // handled specially by command bar
   },
+  {
+    id: "help",
+    prefix: "HELP",
+    label: "Help",
+    description: "Open the help window",
+    category: "Navigation",
+    execute: () => {}, // handled specially by command bar
+  },
 
   // Watchlist/Portfolio management
   {

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -870,6 +870,7 @@ function PluginsStep({
 function ShortcutsStep() {
   const shortcuts = [
     { key: "Ctrl+P / `  ", desc: "Open the command bar" },
+    { key: "help        ", desc: "Open the help window" },
     { key: "Tab         ", desc: "Switch between panels" },
     { key: "T AAPL      ", desc: "Search and add any ticker" },
     { key: "TH          ", desc: "Switch theme" },

--- a/src/plugins/builtin/help.test.tsx
+++ b/src/plugins/builtin/help.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { HelpPane } from "./help";
+import { setSharedRegistryForTests } from "../registry";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+  setSharedRegistryForTests(undefined);
+});
+
+describe("HelpPane", () => {
+  test("renders shortcut, layout, and bug-report guidance", async () => {
+    setSharedRegistryForTests({
+      paneTemplates: new Map([
+        ["quote-monitor-pane", {
+          id: "quote-monitor-pane",
+          paneId: "quote-monitor",
+          label: "Quote Monitor",
+          description: "Open a compact quote monitor",
+          shortcut: { prefix: "QQ", argPlaceholder: "ticker" },
+        }],
+        ["notes-pane", {
+          id: "notes-pane",
+          paneId: "notes",
+          label: "Quick Notes",
+          description: "Open a notes window",
+          shortcut: { prefix: "NOTE" },
+        }],
+      ]),
+      allPlugins: new Map([
+        ["ticker-detail", { id: "ticker-detail", name: "Ticker Detail" }],
+        ["notes", { id: "notes", name: "Notes" }],
+      ]),
+      getPaneTemplatePluginId: (templateId: string) => (
+        templateId === "quote-monitor-pane" ? "ticker-detail" : "notes"
+      ),
+      getConfigFn: () => ({ disabledPlugins: [] }),
+    } as any);
+
+    testSetup = await testRender(
+      <HelpPane
+        paneId="help:main"
+        paneType="help"
+        focused
+        width={88}
+        height={36}
+        close={() => {}}
+      />,
+      { width: 88, height: 36 },
+    );
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("How To Use Gloomberb");
+    expect(frame).toContain("Window Templates");
+    expect(frame).toContain("QQ");
+    expect(frame).toContain("Quote Monitor");
+    expect(frame).toContain("Layout System");
+    expect(frame).toContain("Open Debug Log");
+  });
+
+  test("opens the debug log from the mouse action", async () => {
+    const calls: string[] = [];
+    let closed = 0;
+
+    setSharedRegistryForTests({
+      showWidget: (paneId: string) => calls.push(`widget:${paneId}`),
+      openCommandBarFn: (query?: string) => calls.push(`command:${query ?? ""}`),
+    } as any);
+
+    testSetup = await testRender(
+      <HelpPane
+        paneId="help:main"
+        paneType="help"
+        focused
+        width={88}
+        height={36}
+        close={() => {
+          closed += 1;
+        }}
+      />,
+      { width: 88, height: 36 },
+    );
+
+    await testSetup.renderOnce();
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("Open Debug Log"));
+    const col = lines[row]?.indexOf("Open Debug Log") ?? -1;
+
+    expect(row).toBeGreaterThanOrEqual(0);
+    expect(col).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(col + 1, row);
+      await testSetup!.renderOnce();
+    });
+
+    expect(closed).toBe(1);
+    expect(calls).toEqual(["widget:debug"]);
+  });
+});

--- a/src/plugins/builtin/help.tsx
+++ b/src/plugins/builtin/help.tsx
@@ -1,0 +1,276 @@
+import { TextAttributes } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
+import { useState } from "react";
+import type { ReactNode } from "react";
+import type { GloomPlugin, PaneProps } from "../../types/plugin";
+import { colors, hoverBg } from "../../theme/colors";
+import { getSharedRegistry } from "../registry";
+
+function ShortcutBadge({ label }: { label: string }) {
+  return (
+    <box backgroundColor={colors.selected}>
+      <text fg={colors.selectedText} attributes={TextAttributes.BOLD}>
+        {` ${label} `}
+      </text>
+    </box>
+  );
+}
+
+function ShortcutRow({
+  badges,
+  description,
+  compact,
+}: {
+  badges: string[];
+  description: string;
+  compact: boolean;
+}) {
+  return (
+    <box flexDirection={compact ? "column" : "row"} gap={1}>
+      <box flexDirection="row" gap={1} flexShrink={0}>
+        {badges.map((badge) => <ShortcutBadge key={badge} label={badge} />)}
+      </box>
+      <box flexGrow={1}>
+        <text fg={colors.text}>{description}</text>
+      </box>
+    </box>
+  );
+}
+
+function HelpSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <box flexDirection="column">
+      <text fg={colors.textBright} attributes={TextAttributes.BOLD}>{title}</text>
+      <box height={1} />
+      {children}
+    </box>
+  );
+}
+
+function ActionButton({
+  id,
+  label,
+  hovered,
+  onHover,
+  onPress,
+}: {
+  id: string;
+  label: string;
+  hovered: boolean;
+  onHover: (id: string | null) => void;
+  onPress: () => void;
+}) {
+  return (
+    <box
+      backgroundColor={hovered ? hoverBg() : colors.panel}
+      onMouseMove={() => onHover(id)}
+      onMouseOut={() => onHover(null)}
+      onMouseDown={(event: any) => {
+        event.stopPropagation?.();
+        event.preventDefault?.();
+        onPress();
+      }}
+    >
+      <text fg={hovered ? colors.textBright : colors.text}>{` ${label} `}</text>
+    </box>
+  );
+}
+
+function resolveWindowTemplates(registry: ReturnType<typeof getSharedRegistry>) {
+  if (!registry || !registry.paneTemplates) return [];
+
+  const disabledPlugins = new Set(registry.getConfigFn?.().disabledPlugins ?? []);
+  const allPlugins = registry.allPlugins ?? new Map<string, { name?: string }>();
+
+  return [...registry.paneTemplates.values()]
+    .filter((template) => template.shortcut)
+    .filter((template) => {
+      const pluginId = registry.getPaneTemplatePluginId?.(template.id);
+      return !pluginId || !disabledPlugins.has(pluginId);
+    })
+    .map((template) => {
+      const shortcut = template.shortcut!;
+      const pluginId = registry.getPaneTemplatePluginId?.(template.id);
+      const pluginName = pluginId ? allPlugins.get(pluginId)?.name : null;
+      return {
+        id: template.id,
+        badges: [
+          shortcut.prefix,
+          shortcut.argPlaceholder ? `<${shortcut.argPlaceholder}>` : null,
+        ].filter((value): value is string => !!value),
+        description: pluginName ? `${template.label} (${pluginName})` : template.label,
+      };
+    })
+    .sort((left, right) => (
+      left.badges.join(" ").localeCompare(right.badges.join(" "))
+      || left.description.localeCompare(right.description)
+    ));
+}
+
+export function HelpPane({ focused, width, height, close }: PaneProps) {
+  const registry = getSharedRegistry();
+  const compact = width < 78;
+  const [hoveredAction, setHoveredAction] = useState<string | null>(null);
+  const windowTemplates = resolveWindowTemplates(registry);
+
+  useKeyboard((event) => {
+    if (!focused) return;
+    if (event.name === "escape") {
+      close?.();
+    }
+  });
+
+  const openDebugLog = () => {
+    close?.();
+    registry?.showWidget("debug");
+  };
+
+  const openLayoutActions = () => {
+    close?.();
+    registry?.openCommandBarFn("LAY ");
+  };
+
+  const openPluginManager = () => {
+    close?.();
+    registry?.openCommandBarFn("PL ");
+  };
+
+  return (
+    <box flexDirection="column" width={width} height={height}>
+      <scrollbox flexGrow={1} scrollY>
+        <box flexDirection="column" padding={1}>
+          <box flexDirection="column" gap={1}>
+            <text fg={colors.textBright} attributes={TextAttributes.BOLD}>How To Use Gloomberb</text>
+            <box flexDirection="column">
+              <text fg={colors.textDim}>Gloomberb is command-bar first.</text>
+              <text fg={colors.textDim}>Use the keyboard for speed, and the mouse for windows.</text>
+            </box>
+          </box>
+
+          <box flexDirection={compact ? "column" : "row"} gap={1}>
+            <ActionButton
+              id="debug"
+              label="Open Debug Log"
+              hovered={hoveredAction === "debug"}
+              onHover={setHoveredAction}
+              onPress={openDebugLog}
+            />
+            <ActionButton
+              id="layout"
+              label="Layout Actions"
+              hovered={hoveredAction === "layout"}
+              onHover={setHoveredAction}
+              onPress={openLayoutActions}
+            />
+            <ActionButton
+              id="plugins"
+              label="Manage Plugins"
+              hovered={hoveredAction === "plugins"}
+              onHover={setHoveredAction}
+              onPress={openPluginManager}
+            />
+          </box>
+
+          <HelpSection title="Command Bar">
+            <ShortcutRow
+              badges={["Ctrl+P", "`"]}
+              description="Open the command bar from anywhere."
+              compact={compact}
+            />
+            <ShortcutRow
+              badges={["help"]}
+              description="Open this help window directly."
+              compact={compact}
+            />
+            <ShortcutRow
+              badges={["T <ticker>"]}
+              description="Search for a ticker or company and open it."
+              compact={compact}
+            />
+            <ShortcutRow
+              badges={["NP", "PS", "PL"]}
+              description="Create panes, edit pane settings, and manage plugins."
+              compact={compact}
+            />
+          </HelpSection>
+
+          <HelpSection title="Window Templates">
+            {windowTemplates.length > 0 ? windowTemplates.map((template) => (
+              <ShortcutRow
+                key={template.id}
+                badges={template.badges}
+                description={template.description}
+                compact={compact}
+              />
+            )) : (
+              <text fg={colors.textDim}>No shortcut window templates are currently registered.</text>
+            )}
+          </HelpSection>
+
+          <HelpSection title="Move Around">
+            <ShortcutRow
+              badges={["Tab", "Shift+Tab"]}
+              description="Move focus between panes and floating windows."
+              compact={compact}
+            />
+            <ShortcutRow
+              badges={["j", "k"]}
+              description="Move through lists in most panes. Arrow keys also work."
+              compact={compact}
+            />
+            <ShortcutRow
+              badges={["r", "Shift+R"]}
+              description="Refresh the focused ticker or refresh everything."
+              compact={compact}
+            />
+          </HelpSection>
+
+          <HelpSection title="Layout System">
+            <ShortcutRow
+              badges={["LAY"]}
+              description="Open layout actions."
+              compact={compact}
+            />
+            <text fg={colors.text}>Docked panes stay in the saved layout.</text>
+            <box flexDirection="column">
+              <text fg={colors.text}>Floating panes can be dragged by the title bar</text>
+              <text fg={colors.text}>and resized from the lower-right corner.</text>
+            </box>
+            <text fg={colors.text}>Run Gridlock All Windows if the layout gets messy.</text>
+          </HelpSection>
+
+          <HelpSection title="If There Is A Bug">
+            <text fg={colors.text}>Open Debug Log, then run Export Debug Log from the command bar.</text>
+            <box flexDirection="column">
+              <text fg={colors.text}>The file lands in ~/Downloads. Include steps, ticker or layout, plugin,</text>
+              <text fg={colors.text}>and a screenshot if it is visual.</text>
+            </box>
+          </HelpSection>
+        </box>
+      </scrollbox>
+
+      <box height={1} paddingX={1}>
+        <text fg={colors.textMuted}>Esc closes this window. Drag the header to move it.</text>
+      </box>
+    </box>
+  );
+}
+
+export const helpPlugin: GloomPlugin = {
+  id: "help",
+  name: "Help",
+  version: "1.0.0",
+  description: "Shortcut and layout help",
+
+  panes: [
+    {
+      id: "help",
+      name: "Help",
+      icon: "?",
+      component: HelpPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 88, height: 32 },
+    },
+  ],
+};

--- a/src/plugins/ibkr/index.test.tsx
+++ b/src/plugins/ibkr/index.test.tsx
@@ -120,6 +120,15 @@ function setupIbkrPlugin(config: AppConfig) {
 }
 
 describe("IBKR trade entry points", () => {
+  test("registers an IBKR shortcut for the trading pane template", () => {
+    const template = ibkrPlugin.paneTemplates?.find((entry) => entry.id === "new-ibkr-trading-pane");
+
+    expect(template).toBeDefined();
+    expect(template?.shortcut?.prefix).toBe("IBKR");
+    expect(template?.canCreate?.({ config: createConfig() } as any)).toBe(false);
+    expect(template?.canCreate?.({ config: createConfig([createGatewayInstance()]) } as any)).toBe(true);
+  });
+
   test("hides the Trade action when no IBKR gateway profile is configured", () => {
     const { tickerActions, ticker } = setupIbkrPlugin(createConfig());
     const tradeAction = tickerActions.find((action) => action.id === "ibkr-trade");

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -1872,6 +1872,7 @@ export const ibkrPlugin: GloomPlugin = {
       label: "New IBKR Trading Pane",
       description: "Open another floating IBKR trading console",
       keywords: ["new", "ibkr", "trading", "status", "orders", "pane"],
+      shortcut: { prefix: "IBKR" },
       canCreate: (context) => getConfiguredIbkrGatewayInstances(context.config).length > 0,
       createInstance: () => ({ placement: "floating" }),
     },


### PR DESCRIPTION
- Add a floating Help pane that opens from the command bar via `help`, explains shortcuts and layout behavior, includes bug-report guidance, and lists registered window-template shortcuts dynamically.
- Register the help pane in the app, surface the new Help command in command bar results and onboarding, and add coverage for help rendering plus direct command-bar shortcut matching.
- Add an `IBKR` shortcut for the Interactive Brokers trading pane template so it appears in Help and opens directly when a gateway profile is configured; verified with `bun test` and tmux interaction checks.