### PR TITLE
Add Ctrl+W shortcut to close focused panes

### DIFF
--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
 import { testRender } from "@opentui/react/test-utils";
 import { DialogProvider } from "@opentui-ui/dialog/react";
 import { AppContext, createInitialState } from "../../state/app-context";
@@ -23,6 +24,13 @@ function createShellPluginRegistry(): PluginRegistry {
         name: "Portfolio List",
         component: () => <text>Portfolio Body</text>,
         defaultPosition: "left",
+      }],
+      ["ticker-detail", {
+        id: "ticker-detail",
+        name: "Ticker Detail",
+        component: () => <text>Ticker Detail Body</text>,
+        defaultPosition: "right",
+        defaultMode: "floating",
       }],
     ]),
     paneTemplates: new Map(),
@@ -73,5 +81,90 @@ describe("Shell", () => {
     await testSetup.renderOnce();
 
     expect(testSetup.captureCharFrame()).toContain("Settings");
+  });
+
+  test("closes the focused docked pane with Ctrl+W", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    if (!mainPane) throw new Error("missing default portfolio pane");
+
+    const singlePaneLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }],
+      floating: [],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(singlePaneLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(singlePaneLayout) }],
+      }),
+      focusedPaneId: "portfolio-list:main",
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </DialogProvider>
+      </AppContext>,
+      { width: 40, height: 10 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressKey("w", { ctrl: true });
+      await testSetup!.renderOnce();
+    });
+
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(actions).toContainEqual({ type: "PUSH_LAYOUT_HISTORY" });
+    expect(updateLayout?.layout.instances).toEqual([]);
+    expect(updateLayout?.layout.floating).toEqual([]);
+    expect(updateLayout?.layout.dockRoot).toBeNull();
+  });
+
+  test("closes the focused floating pane with Ctrl+W", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+    if (!mainPane || !detailPane) throw new Error("missing default panes");
+
+    const mixedLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 }],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(mixedLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(mixedLayout) }],
+      }),
+      focusedPaneId: "ticker-detail:main",
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </DialogProvider>
+      </AppContext>,
+      { width: 40, height: 12 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressKey("w", { ctrl: true });
+      await testSetup!.renderOnce();
+    });
+
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(actions).toContainEqual({ type: "PUSH_LAYOUT_HISTORY" });
+    expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId)).toEqual(["portfolio-list:main"]);
+    expect(updateLayout?.layout.floating).toEqual([]);
+    expect(updateLayout?.layout.dockRoot).toEqual({ kind: "pane", instanceId: "portfolio-list:main" });
   });
 });

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -432,9 +432,14 @@ export function Shell({ pluginRegistry }: ShellProps) {
   }, []);
 
   useKeyboard((event) => {
-    if (event.name !== "escape") return;
-    if (!dragRef.current) return;
-    cancelActiveDrag();
+    if (event.name === "escape") {
+      if (!dragRef.current) return;
+      cancelActiveDrag();
+      return;
+    }
+    if (event.name !== "w" || !event.ctrl) return;
+    if (dragRef.current || overlayOpen || state.inputCaptured) return;
+    closeFocusedPane();
   });
 
   const disabledPaneIds = useMemo(() => {
@@ -469,6 +474,11 @@ export function Shell({ pluginRegistry }: ShellProps) {
     dispatch({ type: "UPDATE_LAYOUT", layout: nextLayout });
     saveConfig({ ...state.config, layout: nextLayout, layouts }).catch(() => {});
   }, [dispatch, state.config]);
+
+  const closeFocusedPane = useCallback(() => {
+    if (!state.focusedPaneId || !isPaneInLayout(visibleLayout, state.focusedPaneId)) return;
+    persistLayout(removePane(visibleLayout, state.focusedPaneId));
+  }, [persistLayout, state.focusedPaneId, visibleLayout]);
 
   const focusPane = useCallback((paneId: string) => {
     dispatch({ type: "FOCUS_PANE", paneId });
@@ -850,6 +860,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
     }
   }, [
     bounds,
+    closeFocusedPane,
     contentHeight,
     dividerPreview,
     dockDividerLayouts,

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -16,6 +16,27 @@ afterEach(() => {
 });
 
 describe("StatusBar", () => {
+  test("shows the focused-pane close shortcut when only one layout exists", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const state = {
+      ...createInitialState(config),
+      statusBarVisible: true,
+    };
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <StatusBar />
+      </AppContext>,
+      { width: 120, height: 1 },
+    );
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Ctrl+W");
+    expect(frame).toContain("close");
+  });
+
   test("renders layout tabs without preview suffixes", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     const researchLayout = cloneLayout(config.layout);

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -87,7 +87,7 @@ export function StatusBar() {
           })
         ) : (
           <text fg={colors.textDim}>
-            <span fg={colors.text}>Ctrl+P</span> search  <span fg={colors.text}>Tab</span> switch  <span fg={colors.text}>j/k</span> navigate  <span fg={colors.text}>r</span> refresh  <span fg={colors.text}>q</span> quit
+            <span fg={colors.text}>Ctrl+P</span> search  <span fg={colors.text}>Ctrl+W</span> close  <span fg={colors.text}>Tab</span> switch  <span fg={colors.text}>r</span> refresh  <span fg={colors.text}>q</span> quit
           </text>
         )}
       </box>

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -872,6 +872,7 @@ function ShortcutsStep() {
     { key: "Ctrl+P / `  ", desc: "Open the command bar" },
     { key: "help        ", desc: "Open the help window" },
     { key: "Tab         ", desc: "Switch between panels" },
+    { key: "Ctrl+W      ", desc: "Close the focused pane" },
     { key: "T AAPL      ", desc: "Search and add any ticker" },
     { key: "TH          ", desc: "Switch theme" },
     { key: "PL          ", desc: "Toggle plugins" },

--- a/src/plugins/builtin/help.test.tsx
+++ b/src/plugins/builtin/help.test.tsx
@@ -63,6 +63,7 @@ describe("HelpPane", () => {
     expect(frame).toContain("QQ");
     expect(frame).toContain("Quote Monitor");
     expect(frame).toContain("Layout System");
+    expect(frame).toContain("Ctrl+W");
     expect(frame).toContain("Open Debug Log");
   });
 

--- a/src/plugins/builtin/help.tsx
+++ b/src/plugins/builtin/help.tsx
@@ -214,6 +214,11 @@ export function HelpPane({ focused, width, height, close }: PaneProps) {
               compact={compact}
             />
             <ShortcutRow
+              badges={["Ctrl+W"]}
+              description="Close the focused pane, docked or floating."
+              compact={compact}
+            />
+            <ShortcutRow
               badges={["j", "k"]}
               description="Move through lists in most panes. Arrow keys also work."
               compact={compact}
@@ -250,7 +255,7 @@ export function HelpPane({ focused, width, height, close }: PaneProps) {
       </scrollbox>
 
       <box height={1} paddingX={1}>
-        <text fg={colors.textMuted}>Esc closes this window. Drag the header to move it.</text>
+        <text fg={colors.textMuted}>Esc closes this window. Ctrl+W closes the focused pane.</text>
       </box>
     </box>
   );


### PR DESCRIPTION
Adds a global Ctrl+W shortcut to close the focused pane whether it is docked or floating, while leaving overlay, drag, and input-capture behavior alone. Updates the status bar, onboarding shortcuts step, and help pane copy so the shortcut is discoverable. Adds shell coverage for docked and floating close behavior plus shortcut-copy checks for help and status bar. Verified with focused Bun tests and a tmux smoke run of the app.