### PR TITLE
Remove currency symbol from last/bid/ask columns

### DIFF
--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -21,7 +21,7 @@ import {
 import { getAllCollections, getCollectionTickers, getCollectionType } from "../../state/selectors";
 import { useQuoteStreaming } from "../../state/use-quote-streaming";
 import { colors, priceColor, hoverBg } from "../../theme/colors";
-import { formatCurrency, formatPercentRaw, formatCompact, formatNumber, padTo, convertCurrency } from "../../utils/format";
+import { formatCurrency, formatPercentRaw, formatCompact, formatNumber, formatPrice, padTo, convertCurrency } from "../../utils/format";
 import { getActiveQuoteDisplay } from "../../utils/market-status";
 import { clampQuoteTimestamp, formatQuoteAgeWithSource, getMostRecentQuoteUpdate } from "../../utils/quote-time";
 import { DEFAULT_COLUMNS, type AppConfig, type ColumnConfig } from "../../types/config";
@@ -170,12 +170,12 @@ export function resolvePortfolioPriceValue(
 ): { text: string; color?: string } {
   if (activeQuote) {
     return {
-      text: formatCurrency(activeQuote.price, quoteCurrency),
+      text: formatPrice(activeQuote.price),
       color: priceColor(activeQuote.change),
     };
   }
   if (brokerMarkPrice != null) {
-    return { text: formatCurrency(brokerMarkPrice, positionCurrency) };
+    return { text: formatPrice(brokerMarkPrice) };
   }
   return { text: "—" };
 }
@@ -243,9 +243,9 @@ function getColumnValue(
       };
     }
     case "bid":
-      return { text: q?.bid != null ? formatCurrency(q.bid, quoteCurrency) : "—" };
+      return { text: q?.bid != null ? formatPrice(q.bid) : "—" };
     case "ask":
-      return { text: q?.ask != null ? formatCurrency(q.ask, quoteCurrency) : "—" };
+      return { text: q?.ask != null ? formatPrice(q.ask) : "—" };
     case "spread":
       return {
         text: q?.bid != null && q?.ask != null

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -77,6 +77,13 @@ export function formatNumber(value: number | undefined, decimals = 2): string {
   return getNumberFormatter(decimals).format(value);
 }
 
+/** Format a price with commas, trimming unnecessary trailing zeros (e.g., 3,565.00 -> 3,565) */
+export function formatPrice(value: number | undefined): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  const formatted = getNumberFormatter(2).format(value);
+  return formatted.replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+}
+
 /** Format a growth rate compactly (e.g., +12%, -5%) */
 export function formatGrowthShort(value: number): string {
   const pct = value * 100;


### PR DESCRIPTION
## Summary
- Removes currency symbol ($, €, etc.) from the LAST, BID, and ASK columns in portfolio/watchlist list view
- Adds `formatPrice` utility that formats numbers with commas and trims unnecessary trailing zeros (e.g., `3,565.00` → `3,565`, `3,565.50` → `3,565.5`)
- Replaces `formatCurrency` with `formatPrice` for price, bid, and ask column rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)