### PR TITLE
Fix chart axis ordering and stale refreshes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -409,7 +409,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       const ticker = tickerOverride ?? state.tickers.get(symbol) ?? null;
       const instrument = instrumentFromTicker(ticker, symbol);
       if (!instrument) return;
-      const entry = await marketData.loadSnapshot(instrument);
+      const entry = await marketData.loadSnapshot(instrument, { forceRefresh: true });
       const data = entry.data ?? entry.lastGoodData;
       if (data) {
         pluginRegistry.events.emit("ticker:refreshed", { symbol, financials: data });
@@ -436,7 +436,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       const ticker = tickerOverride ?? state.tickers.get(symbol) ?? null;
       const instrument = instrumentFromTicker(ticker, symbol);
       if (!instrument) return;
-      const entry = await marketData.loadQuote(instrument);
+      const entry = await marketData.loadQuote(instrument, { forceRefresh: true });
       const quote = entry.data ?? entry.lastGoodData;
       if (!quote) return;
 

--- a/src/market-data/coordinator.test.ts
+++ b/src/market-data/coordinator.test.ts
@@ -96,6 +96,26 @@ describe("MarketDataCoordinator", () => {
     expect(second.lastGoodData?.length).toBe(2);
   });
 
+  it("normalizes descending chart history before storing it", async () => {
+    const provider = createProvider({
+      getPriceHistory: async () => [
+        { date: new Date("2024-01-03"), close: 103 },
+        { date: new Date("2024-01-01"), close: 101 },
+        { date: new Date("2024-01-02"), close: 102 },
+      ],
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const request = {
+      instrument: { symbol: "AAPL", exchange: "NASDAQ" },
+      range: "1Y" as const,
+      granularity: "daily" as const,
+    };
+
+    const entry = await coordinator.loadChart(request);
+
+    expect(entry.data?.map((point) => point.close)).toEqual([101, 102, 103]);
+  });
+
   it("updates the quote store from streaming events", () => {
     let streamed: ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null = null;
     const provider = createProvider({

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -22,6 +22,7 @@ import {
   toMarketDataContext,
 } from "./selectors";
 import { traceMarketData } from "./trace";
+import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../utils/price-history";
 
 const EMPTY_MESSAGE = "No data available";
 const EXPECTED_EMPTY = /no data|not found|delisted|unavailable|unsupported/i;
@@ -203,18 +204,25 @@ export class MarketDataCoordinator {
     return promise;
   }
 
-  async loadSnapshot(instrument: InstrumentRef): Promise<QueryEntry<TickerFinancials>> {
+  async loadSnapshot(
+    instrument: InstrumentRef,
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<QueryEntry<TickerFinancials>> {
     const key = buildSnapshotKey(instrument);
-    return this.runSingleFlight(key, async () => {
+    const flightKey = options.forceRefresh ? `${key}|refresh` : key;
+    return this.runSingleFlight(flightKey, async () => {
       this.snapshotStore.update(key, loadingEntry);
       const startedAt = Date.now();
       traceMarketData("snapshot:start", { key, symbol: instrument.symbol, exchange: instrument.exchange ?? "" });
       try {
-        const data = await this.dataProvider.getTickerFinancials(
+        const data = normalizeTickerFinancialsPriceHistory(await this.dataProvider.getTickerFinancials(
           instrument.symbol,
           instrument.exchange ?? "",
-          toMarketDataContext(instrument),
-        );
+          {
+            ...toMarketDataContext(instrument),
+            cacheMode: options.forceRefresh ? "refresh" : "default",
+          },
+        ));
         const source = data.quote?.providerId ?? this.dataProvider.id;
         const attempts = [createAttempt(source, startedAt, data ? "success" : "empty")];
         const entry = this.snapshotStore.update(key, (current) => readyEntry(current, data, source, attempts, { keepLastGoodOnEmpty: true }));
@@ -259,16 +267,23 @@ export class MarketDataCoordinator {
     });
   }
 
-  async loadQuote(instrument: InstrumentRef): Promise<QueryEntry<Quote>> {
+  async loadQuote(
+    instrument: InstrumentRef,
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<QueryEntry<Quote>> {
     const key = buildQuoteKey(instrument);
-    return this.runSingleFlight(key, async () => {
+    const flightKey = options.forceRefresh ? `${key}|refresh` : key;
+    return this.runSingleFlight(flightKey, async () => {
       this.quoteStore.update(key, loadingEntry);
       const startedAt = Date.now();
       try {
         const quote = await this.dataProvider.getQuote(
           instrument.symbol,
           instrument.exchange ?? "",
-          toMarketDataContext(instrument),
+          {
+            ...toMarketDataContext(instrument),
+            cacheMode: options.forceRefresh ? "refresh" : "default",
+          },
         );
         const source = quote.providerId ?? this.dataProvider.id;
         const attempts = [createAttempt(source, startedAt, "success")];
@@ -281,27 +296,39 @@ export class MarketDataCoordinator {
     });
   }
 
-  async loadChart(request: ChartRequest): Promise<QueryEntry<PricePoint[]>> {
+  async loadChart(
+    request: ChartRequest,
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<QueryEntry<PricePoint[]>> {
     const key = buildChartKey(request);
-    return this.runSingleFlight(key, async () => {
+    const flightKey = options.forceRefresh ? `${key}|refresh` : key;
+    return this.runSingleFlight(flightKey, async () => {
       this.chartStore.update(key, loadingEntry);
       const startedAt = Date.now();
       try {
-        const data = request.granularity === "detail" && request.startDate && request.endDate && request.barSize && this.dataProvider.getDetailedPriceHistory
-          ? await this.dataProvider.getDetailedPriceHistory(
-            request.instrument.symbol,
-            request.instrument.exchange ?? "",
-            request.startDate,
-            request.endDate,
-            request.barSize,
-            toMarketDataContext(request.instrument),
-          )
-          : await this.dataProvider.getPriceHistory(
-            request.instrument.symbol,
-            request.instrument.exchange ?? "",
-            request.range,
-            toMarketDataContext(request.instrument),
-          );
+        const data = normalizePriceHistory(
+          request.granularity === "detail" && request.startDate && request.endDate && request.barSize && this.dataProvider.getDetailedPriceHistory
+            ? await this.dataProvider.getDetailedPriceHistory(
+              request.instrument.symbol,
+              request.instrument.exchange ?? "",
+              request.startDate,
+              request.endDate,
+              request.barSize,
+              {
+                ...toMarketDataContext(request.instrument),
+                cacheMode: options.forceRefresh ? "refresh" : "default",
+              },
+            )
+            : await this.dataProvider.getPriceHistory(
+              request.instrument.symbol,
+              request.instrument.exchange ?? "",
+              request.range,
+              {
+                ...toMarketDataContext(request.instrument),
+                cacheMode: options.forceRefresh ? "refresh" : "default",
+              },
+            ),
+        );
         const status = data.length > 0 ? "success" : "empty";
         const attempts = [createAttempt(this.dataProvider.id, startedAt, status, data.length === 0 ? "NO_DATA" : undefined)];
         return this.chartStore.update(key, (current) => readyEntry(current, data.length > 0 ? data : null, this.dataProvider.id, attempts, { keepLastGoodOnEmpty: true }));

--- a/src/market-data/selectors.ts
+++ b/src/market-data/selectors.ts
@@ -2,6 +2,7 @@ import type { MarketDataRequestContext } from "../types/data-provider";
 import type { Quote, TickerFinancials } from "../types/financials";
 import type { InstrumentRef, NewsRequest, OptionsRequest, SecFilingsRequest, ChartRequest } from "./request-types";
 import type { QueryEntry } from "./result-types";
+import { normalizePriceHistory } from "../utils/price-history";
 
 export function buildInstrumentKey(instrument: InstrumentRef): string {
   const contractKey = instrument.instrument?.conId
@@ -166,6 +167,6 @@ export function buildLegacyFinancials(
     profile: snapshot?.profile,
     annualStatements: snapshot?.annualStatements ?? [],
     quarterlyStatements: snapshot?.quarterlyStatements ?? [],
-    priceHistory: priceHistory ?? snapshot?.priceHistory ?? [],
+    priceHistory: normalizePriceHistory(priceHistory ?? snapshot?.priceHistory ?? []),
   };
 }

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -1140,6 +1140,112 @@ describe("ProviderRouter", () => {
     persistence.close();
   });
 
+  test("sorts reversed chart history into chronological order", async () => {
+    const router = new ProviderRouter({
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      async getPriceHistory() {
+        return [
+          { date: new Date("2026-03-29T00:00:00Z"), close: 103 },
+          { date: new Date("2026-03-27T00:00:00Z"), close: 101 },
+          { date: new Date("2026-03-28T00:00:00Z"), close: 102 },
+        ];
+      },
+    });
+
+    const history = await router.getPriceHistory("AAPL", "NASDAQ", "1Y");
+
+    expect(history.map((point) => point.close)).toEqual([101, 102, 103]);
+  });
+
+  test("bypasses cached financials on explicit refresh requests", async () => {
+    const dbPath = createTempDbPath("forced-financial-refresh");
+    const persistence = new AppPersistence(dbPath);
+
+    const seedRouter = new ProviderRouter({
+      ...fallbackProvider,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [{ date: new Date("2026-03-27T00:00:00Z"), close: 101 }],
+          quote: {
+            symbol: "AAPL",
+            price: 101,
+            currency: "USD",
+            change: 1,
+            changePercent: 1,
+            lastUpdated: Date.now(),
+          },
+        };
+      },
+    }, [], persistence.resources);
+    await seedRouter.getTickerFinancials("AAPL", "NASDAQ");
+
+    let providerCalls = 0;
+    const refreshRouter = new ProviderRouter({
+      ...fallbackProvider,
+      async getTickerFinancials() {
+        providerCalls += 1;
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 202 }],
+          quote: {
+            symbol: "AAPL",
+            price: 202,
+            currency: "USD",
+            change: 2,
+            changePercent: 1,
+            lastUpdated: Date.now(),
+          },
+        };
+      },
+    }, [], persistence.resources);
+
+    const refreshed = await refreshRouter.getTickerFinancials("AAPL", "NASDAQ", { cacheMode: "refresh" });
+
+    expect(providerCalls).toBe(1);
+    expect(refreshed.quote?.price).toBe(202);
+    expect(refreshed.priceHistory[0]?.close).toBe(202);
+
+    persistence.close();
+  });
+
+  test("refreshes stale cached chart history before falling back to cache", async () => {
+    const dbPath = createTempDbPath("stale-chart-refresh");
+    const persistence = new AppPersistence(dbPath);
+
+    const seedRouter = new ProviderRouter({
+      ...fallbackProvider,
+      async getPriceHistory() {
+        return [{ date: new Date("2026-03-27T00:00:00Z"), close: 101 }];
+      },
+    }, [], persistence.resources);
+    await seedRouter.getPriceHistory("AAPL", "NASDAQ", "1Y");
+
+    persistence.database.connection
+      .query("UPDATE resource_cache SET stale_at = ? WHERE namespace = ? AND kind = ? AND entity_key = ?")
+      .run(Date.now() - 1, "market", "price-history", "AAPL");
+
+    let providerCalls = 0;
+    const refreshRouter = new ProviderRouter({
+      ...fallbackProvider,
+      async getPriceHistory() {
+        providerCalls += 1;
+        return [{ date: new Date("2026-03-28T00:00:00Z"), close: 202 }];
+      },
+    }, [], persistence.resources);
+
+    const history = await refreshRouter.getPriceHistory("AAPL", "NASDAQ", "1Y");
+
+    expect(providerCalls).toBe(1);
+    expect(history[0]?.close).toBe(202);
+
+    persistence.close();
+  });
+
   test("falls back to later providers when detailed chart history is empty", async () => {
     const cloudProvider: DataProvider = {
       ...fallbackProvider,

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -17,6 +17,7 @@ import type { CachePolicy, CachePolicyMap } from "../types/persistence";
 import type { TimeRange } from "../components/chart/chart-types";
 import type { HydrationTarget } from "../state/session-persistence";
 import { debugLog } from "../utils/debug-log";
+import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../utils/price-history";
 import { isProviderMiss } from "./provider-errors";
 
 const providerLog = debugLog.createLogger("provider-router");
@@ -151,7 +152,8 @@ function mergeDefinedObject<T extends object>(preferred: T | null | undefined, f
 
 function mergeFinancials(primary: TickerFinancials | null, fallback: TickerFinancials | null): TickerFinancials | null {
   if (!primary || !fallback) {
-    return primary ?? fallback;
+    const single = primary ?? fallback;
+    return single ? normalizeTickerFinancialsPriceHistory(single) : null;
   }
 
   const preferFallbackPriceData = hasLikelyPriceUnitMismatch(primary, fallback);
@@ -164,10 +166,17 @@ function mergeFinancials(primary: TickerFinancials | null, fallback: TickerFinan
     quote: mergeDefinedObject(dominant.quote, secondary.quote),
     profile: mergeDefinedObject(primary.profile, fallback.profile),
     fundamentals: mergeDefinedObject(primary.fundamentals, fallback.fundamentals),
-    priceHistory: dominant.priceHistory.length > 0 ? dominant.priceHistory : secondary.priceHistory,
+    priceHistory: normalizePriceHistory(dominant.priceHistory.length > 0 ? dominant.priceHistory : secondary.priceHistory),
     annualStatements: primary.annualStatements.length > 0 ? primary.annualStatements : fallback.annualStatements,
     quarterlyStatements: primary.quarterlyStatements.length > 0 ? primary.quarterlyStatements : fallback.quarterlyStatements,
   };
+}
+
+interface CachedFinancialsSelection {
+  brokerRecord: CachedResourceRecord<TickerFinancials> | null;
+  providerRecord: CachedResourceRecord<TickerFinancials> | null;
+  value: TickerFinancials | null;
+  stale: boolean;
 }
 
 interface BrokerCandidate {
@@ -244,16 +253,25 @@ export class ProviderRouter implements DataProvider {
   }
 
   async getTickerFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<TickerFinancials> {
-    const cached = this.readCachedMergedFinancials(ticker, exchange, context, false);
-    if (cached) {
-      if (!hasMeaningfulProfile(cached)) {
-        const providerResult = await this.fetchProviderFinancials(ticker, exchange, context);
-        return mergeFinancials(cached, providerResult?.value ?? null) ?? cached;
+    const cached = this.readCachedMergedFinancialsSelection(ticker, exchange, context, false);
+    const forceRefresh = context?.cacheMode === "refresh";
+    if (cached.value && !forceRefresh) {
+      if (!cached.stale && hasMeaningfulProfile(cached.value)) {
+        return cached.value;
       }
-      this.scheduleRevalidation(this.makeRevalidationKey("financials", ticker, exchange, context), async () => {
-        await this.revalidateFinancials(ticker, exchange, context);
-      });
-      return cached;
+      if (!hasMeaningfulProfile(cached.value) && !cached.stale) {
+        const providerResult = await this.fetchProviderFinancials(ticker, exchange, context);
+        return mergeFinancials(cached.value, providerResult?.value ?? null) ?? cached.value;
+      }
+    }
+
+    if (cached.value) {
+      const brokerResult = await withBrokerTimeout(this.fetchBrokerFinancials(ticker, exchange, context));
+      const providerResult = await this.fetchProviderFinancials(ticker, exchange, context);
+      return mergeFinancials(
+        brokerResult?.value ?? cached.brokerRecord?.value ?? null,
+        providerResult?.value ?? cached.providerRecord?.value ?? null,
+      ) ?? cached.value;
     }
 
     const brokerResult = await withBrokerTimeout(this.fetchBrokerFinancials(ticker, exchange, context));
@@ -273,10 +291,8 @@ export class ProviderRouter implements DataProvider {
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedResource<Quote>("quote", entityKey, variantKeys, sourceKeys, false);
-    if (cached) {
-      this.scheduleRevalidation(this.makeRevalidationKey("quote", ticker, exchange, context), async () => {
-        await this.revalidateQuote(ticker, exchange, context);
-      });
+    const forceRefresh = context?.cacheMode === "refresh";
+    if (cached && !forceRefresh && !cached.stale) {
       return cached.value;
     }
 
@@ -284,10 +300,11 @@ export class ProviderRouter implements DataProvider {
     if (brokerQuote) return brokerQuote.value;
 
     const providerQuote = await this.fetchProviderQuote(ticker, exchange, context);
-    if (!providerQuote) {
-      throw new Error(`No quote provider available for ${ticker}`);
+    if (providerQuote) {
+      return providerQuote.value;
     }
-    return providerQuote.value;
+    if (cached) return cached.value;
+    throw new Error(`No quote provider available for ${ticker}`);
   }
 
   async getExchangeRate(fromCurrency: string): Promise<number> {
@@ -457,10 +474,8 @@ export class ProviderRouter implements DataProvider {
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedArrayResource<PricePoint>("price-history", entityKey, variantKeys, sourceKeys, false);
-    if (cached) {
-      this.scheduleRevalidation(this.makeRevalidationKey("price-history", ticker, exchange, context, range), async () => {
-        await this.revalidatePriceHistory(ticker, exchange, range, context);
-      });
+    const forceRefresh = context?.cacheMode === "refresh";
+    if (cached && !forceRefresh && !cached.stale) {
       return cached.value;
     }
 
@@ -468,6 +483,10 @@ export class ProviderRouter implements DataProvider {
     if (brokerHistory && brokerHistory.value.length > 0) return brokerHistory.value;
 
     const providerHistory = await this.fetchProviderPriceHistory(ticker, exchange, range, context);
+    if (providerHistory && providerHistory.value.length > 0) {
+      return providerHistory.value;
+    }
+    if (cached) return cached.value;
     if (!providerHistory) {
       throw new Error(`No history provider available for ${ticker}`);
     }
@@ -492,10 +511,8 @@ export class ProviderRouter implements DataProvider {
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedArrayResource<PricePoint>("detailed-price-history", entityKey, variantKeys, sourceKeys, false);
-    if (cached) {
-      this.scheduleRevalidation(this.makeRevalidationKey("detailed-price-history", ticker, exchange, context, `${compactDate(startDate)}:${compactDate(endDate)}:${barSize}`), async () => {
-        await this.revalidateDetailedPriceHistory(ticker, exchange, startDate, endDate, barSize, context);
-      });
+    const forceRefresh = context?.cacheMode === "refresh";
+    if (cached && !forceRefresh && !cached.stale) {
       return cached.value;
     }
 
@@ -503,7 +520,10 @@ export class ProviderRouter implements DataProvider {
     if (brokerResult && brokerResult.value.length > 0) return brokerResult.value;
 
     const providerResult = await this.fetchProviderDetailedPriceHistory(ticker, exchange, startDate, endDate, barSize, context);
-    return providerResult?.value ?? [];
+    if (providerResult && providerResult.value.length > 0) {
+      return providerResult.value;
+    }
+    return cached?.value ?? providerResult?.value ?? [];
   }
 
   async getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, context?: MarketDataRequestContext): Promise<OptionsChain> {
@@ -671,6 +691,15 @@ export class ProviderRouter implements DataProvider {
     context?: MarketDataRequestContext,
     allowExpired = false,
   ): TickerFinancials | null {
+    return this.readCachedMergedFinancialsSelection(ticker, exchange, context, allowExpired).value;
+  }
+
+  private readCachedMergedFinancialsSelection(
+    ticker: string,
+    exchange?: string,
+    context?: MarketDataRequestContext,
+    allowExpired = false,
+  ): CachedFinancialsSelection {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
     const brokerSourceKeys = this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate));
@@ -678,7 +707,12 @@ export class ProviderRouter implements DataProvider {
       ? this.selectCachedResource<TickerFinancials>("financials", entityKey, variantKeys, brokerSourceKeys, allowExpired)
       : null;
     const providerRecord = this.selectCachedResource<TickerFinancials>("financials", entityKey, variantKeys, this.getProviderSourceKeys(), allowExpired);
-    return mergeFinancials(brokerRecord?.value ?? null, providerRecord?.value ?? null);
+    return {
+      brokerRecord,
+      providerRecord,
+      value: mergeFinancials(brokerRecord?.value ?? null, providerRecord?.value ?? null),
+      stale: (brokerRecord?.stale ?? false) || (providerRecord?.stale ?? false),
+    };
   }
 
   private readCachedExchangeRate(currency: string, allowExpired = false): number | null {
@@ -827,12 +861,12 @@ export class ProviderRouter implements DataProvider {
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getTickerFinancials) continue;
       try {
-        const result = await candidate.broker.getTickerFinancials(
+        const result = normalizeTickerFinancialsPriceHistory(await candidate.broker.getTickerFinancials(
           ticker,
           candidate.instance,
           exchange,
           context?.instrument ?? null,
-        );
+        ));
         this.cacheResource(
           "financials",
           entityKey,
@@ -861,7 +895,7 @@ export class ProviderRouter implements DataProvider {
 
     for (const provider of this.providersInPriorityOrder()) {
       try {
-        const value = await provider.getTickerFinancials(ticker, exchange, context);
+        const value = normalizeTickerFinancialsPriceHistory(await provider.getTickerFinancials(ticker, exchange, context));
         const sourceKey = this.providerSourceKey(provider);
         this.cacheResource(
           "financials",
@@ -944,13 +978,13 @@ export class ProviderRouter implements DataProvider {
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getPriceHistory) continue;
       try {
-        const result = await candidate.broker.getPriceHistory(
+        const result = normalizePriceHistory(await candidate.broker.getPriceHistory(
           ticker,
           candidate.instance,
           exchange,
           range,
           context?.instrument ?? null,
-        );
+        ));
         this.cacheResource(
           "price-history",
           entityKey,
@@ -979,7 +1013,7 @@ export class ProviderRouter implements DataProvider {
 
     for (const provider of this.providersInPriorityOrder()) {
       try {
-        const value = await provider.getPriceHistory(ticker, exchange, range, context);
+        const value = normalizePriceHistory(await provider.getPriceHistory(ticker, exchange, range, context));
         const sourceKey = this.providerSourceKey(provider);
         this.cacheResource(
           "price-history",
@@ -1016,7 +1050,7 @@ export class ProviderRouter implements DataProvider {
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getDetailedPriceHistory) continue;
       try {
-        const result = await candidate.broker.getDetailedPriceHistory(
+        const result = normalizePriceHistory(await candidate.broker.getDetailedPriceHistory(
           ticker,
           candidate.instance,
           exchange,
@@ -1024,7 +1058,7 @@ export class ProviderRouter implements DataProvider {
           endDate,
           barSize,
           context?.instrument ?? null,
-        );
+        ));
         this.cacheResource(
           "detailed-price-history",
           entityKey,
@@ -1056,7 +1090,7 @@ export class ProviderRouter implements DataProvider {
     for (const provider of this.providersInPriorityOrder()) {
       if (!provider.getDetailedPriceHistory) continue;
       try {
-        const value = await provider.getDetailedPriceHistory(ticker, exchange, startDate, endDate, barSize, context);
+        const value = normalizePriceHistory(await provider.getDetailedPriceHistory(ticker, exchange, startDate, endDate, barSize, context));
         const sourceKey = this.providerSourceKey(provider);
         this.cacheResource(
           "detailed-price-history",

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -29,6 +29,7 @@ export interface MarketDataRequestContext {
   brokerId?: string;
   brokerInstanceId?: string;
   instrument?: BrokerContractRef | null;
+  cacheMode?: "default" | "refresh";
 }
 
 export interface SearchRequestContext {

--- a/src/utils/price-history.ts
+++ b/src/utils/price-history.ts
@@ -1,0 +1,39 @@
+import type { PricePoint, TickerFinancials } from "../types/financials";
+
+function getPointTimestamp(point: PricePoint): number {
+  return point.date instanceof Date ? point.date.getTime() : new Date(point.date).getTime();
+}
+
+function comparePricePointsByDate(left: PricePoint, right: PricePoint): number {
+  const leftTime = getPointTimestamp(left);
+  const rightTime = getPointTimestamp(right);
+  const leftValid = Number.isFinite(leftTime);
+  const rightValid = Number.isFinite(rightTime);
+
+  if (leftValid && rightValid) return leftTime - rightTime;
+  if (leftValid) return -1;
+  if (rightValid) return 1;
+  return 0;
+}
+
+export function normalizePriceHistory(points: PricePoint[]): PricePoint[] {
+  if (points.length <= 1) return points;
+
+  let previousTime = Number.NEGATIVE_INFINITY;
+  for (const point of points) {
+    const time = getPointTimestamp(point);
+    if (!Number.isFinite(time) || time < previousTime) {
+      return [...points].sort(comparePricePointsByDate);
+    }
+    previousTime = time;
+  }
+
+  return points;
+}
+
+export function normalizeTickerFinancialsPriceHistory(financials: TickerFinancials): TickerFinancials {
+  const priceHistory = normalizePriceHistory(financials.priceHistory ?? []);
+  return priceHistory === financials.priceHistory
+    ? financials
+    : { ...financials, priceHistory };
+}


### PR DESCRIPTION
This normalizes chart price history into chronological order across the provider, coordinator, and legacy snapshot paths so the full chart X-axis matches the overview chart. It also changes explicit refreshes and stale cache reads to fetch fresh quote/chart data before falling back to cached values, which fixes the need to hit R multiple times. Regression tests cover reversed history ordering, explicit financial refreshes, and stale cached chart refreshes. Verified with: bun test src/market-data/coordinator.test.ts src/sources/provider-router.test.ts