### PR TITLE
Move portfolio summary below tabs and lead with net liq

### DIFF
--- a/src/plugins/builtin/portfolio-list.test.ts
+++ b/src/plugins/builtin/portfolio-list.test.ts
@@ -3,7 +3,6 @@ import type { CollectionSortPreference } from "../../state/app-context";
 import type { BrokerAccount } from "../../types/trading";
 import {
   buildPortfolioSummarySegments,
-  calculatePortfolioSummaryWidth,
   resolvePortfolioPriceValue,
   resolveCollectionSortPreference,
   shouldToggleCashMarginDrawer,
@@ -54,6 +53,7 @@ describe("buildPortfolioSummarySegments", () => {
   const account: BrokerAccount = {
     accountId: "DU12345",
     name: "DU12345",
+    netLiquidation: 125000,
     totalCashValue: -50000,
     settledCash: -45000,
     availableFunds: 12000,
@@ -61,14 +61,14 @@ describe("buildPortfolioSummarySegments", () => {
     buyingPower: 24000,
   };
 
-  test("keeps value and cash at narrow widths for broker portfolios", () => {
+  test("prioritizes net liquidation at narrow widths for broker portfolios", () => {
     const segments = buildPortfolioSummarySegments({
       totals,
       accountState: { account, sourceLabel: "Live" },
       widthBudget: 24,
     });
 
-    expect(segments.map((segment) => segment.id)).toEqual(["val", "cash"]);
+    expect(segments.map((segment) => segment.id)).toEqual(["netliq", "val"]);
   });
 
   test("drops low-priority broker segments before required ones", () => {
@@ -79,13 +79,13 @@ describe("buildPortfolioSummarySegments", () => {
     });
 
     expect(segments.map((segment) => segment.id)).toEqual([
+      "netliq",
       "val",
       "cash",
       "day",
       "pnl",
       "settled",
       "avail",
-      "excess",
     ]);
   });
 
@@ -93,7 +93,7 @@ describe("buildPortfolioSummarySegments", () => {
     const segments = buildPortfolioSummarySegments({
       totals,
       accountState: { account, sourceLabel: "Live" },
-      widthBudget: 110,
+      widthBudget: 130,
     });
 
     expect(segments.map((segment) => segment.id)).toContain("source");
@@ -103,14 +103,6 @@ describe("buildPortfolioSummarySegments", () => {
     expect(shouldToggleCashMarginDrawer("c", true)).toBe(true);
     expect(shouldToggleCashMarginDrawer("c", false)).toBe(false);
     expect(shouldToggleCashMarginDrawer("j", true)).toBe(false);
-  });
-
-  test("hides the broker summary when tabs need the row width", () => {
-    expect(calculatePortfolioSummaryWidth(70, ["Main", "coldstart", "Interactive Brokers Paper"])).toBe(0);
-  });
-
-  test("uses leftover row width for the broker summary when tabs leave room", () => {
-    expect(calculatePortfolioSummaryWidth(100, ["Main", "coldstart"])).toBe(55);
   });
 
   test("shows broker mark price for stocks when no quote is available", () => {

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -458,7 +458,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(harnessState?.paneState[TEST_PANE_ID]?.cashDrawerExpanded).toBe(true);
   });
 
-  test("stacks the summary below tabs when the tab row is crowded", async () => {
+  test("renders the summary on its own row below the tabs", async () => {
     const config = {
       ...createPortfolioConfig("broker:ibkr-flex:DU12345", [createBrokerInstance("flex")]),
       watchlists: [
@@ -487,14 +487,18 @@ describe("PortfolioListPane cash and margin UI", () => {
           }],
         }}
       />,
-      { width: 70, height: 24 },
+      { width: 100, height: 24 },
     );
 
     await flushFrame();
 
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("Val 1.3k  Cash -50k");
-    expect(frame).toContain("▸ Cash &");
+    const lines = testSetup.captureCharFrame().split("\n");
+    const tabsRow = lines.findIndex((line) => line.includes("Main Portfolio"));
+    const summaryRow = lines.findIndex((line) => line.includes("Net Liq 125k  Val 1.3k  Cash -50k"));
+
+    expect(tabsRow).toBeGreaterThanOrEqual(0);
+    expect(summaryRow).toBeGreaterThan(tabsRow);
+    expect(lines[summaryRow + 1]).toContain("TICKER");
   });
 
   test("renders bid ask and spread when those columns are enabled", async () => {

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -867,21 +867,25 @@ export function buildPortfolioSummarySegments({
   widthBudget: number;
   refreshText?: string;
 }): PortfolioSummarySegment[] {
-  const candidates: PortfolioSummarySegment[] = [
-    createSummarySegment("val", [
-      { text: "Val", tone: "label" },
-      { text: formatCompact(totals.totalMktValue), tone: "value", bold: true },
-    ]),
-  ];
+  const candidates: PortfolioSummarySegment[] = [];
 
-  if (accountState) {
-    const { account, sourceLabel } = accountState;
-    if (account.totalCashValue != null) {
-      candidates.push(createSummarySegment("cash", [
-        { text: "Cash", tone: "label" },
-        { text: formatCompact(account.totalCashValue), tone: "value", bold: true },
-      ]));
-    }
+  if (accountState?.account.netLiquidation != null) {
+    candidates.push(createSummarySegment("netliq", [
+      { text: "Net Liq", tone: "label" },
+      { text: formatCompact(accountState.account.netLiquidation), tone: "value", bold: true },
+    ]));
+  }
+
+  candidates.push(createSummarySegment("val", [
+    { text: "Val", tone: "label" },
+    { text: formatCompact(totals.totalMktValue), tone: "value", bold: true },
+  ]));
+
+  if (accountState?.account.totalCashValue != null) {
+    candidates.push(createSummarySegment("cash", [
+      { text: "Cash", tone: "label" },
+      { text: formatCompact(accountState.account.totalCashValue), tone: "value", bold: true },
+    ]));
   }
 
   candidates.push(createSummarySegment("day", [
@@ -941,17 +945,6 @@ export function buildPortfolioSummarySegments({
 
 export function shouldToggleCashMarginDrawer(key: string | undefined, showCashDrawer: boolean): boolean {
   return key === "c" && showCashDrawer;
-}
-
-export function calculatePortfolioSummaryWidth(totalWidth: number, tabLabels: string[]): number {
-  const desiredWidth = Math.min(totalWidth, Math.min(72, Math.max(24, Math.floor(totalWidth * 0.55))));
-  if (desiredWidth <= 0) return 0;
-
-  const tabRowWidth = tabLabels.reduce((sum, label) => sum + label.length + 4, 0);
-  const availableWidth = Math.max(0, totalWidth - tabRowWidth);
-  if (availableWidth < Math.min(24, totalWidth)) return 0;
-
-  return Math.min(desiredWidth, availableWidth);
 }
 
 function renderSummarySegments(segments: PortfolioSummarySegment[], width: number) {
@@ -1263,13 +1256,9 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
       ? Math.min(6, Math.max(3, 2 + accountState.visibleCashBalances.length))
       : 1)
     : 0;
-  const summaryWidth = paneSettings.hideTabs || paneSettings.hideHeader
-    ? 0
-    : calculatePortfolioSummaryWidth(width, tabs.map((tab) => tab.name));
-  const showStackedSummary = !paneSettings.hideHeader && (paneSettings.hideTabs || summaryWidth === 0);
   const headerHeight = paneSettings.hideHeader
     ? (paneSettings.hideTabs ? 0 : 1)
-    : paneSettings.hideTabs ? 1 : (showStackedSummary ? 2 : 1);
+    : paneSettings.hideTabs ? 1 : 2;
   const drawerHeight = showCashDrawer
     ? Math.min(requestedDrawerHeight, Math.max(1, height - (headerHeight + 2)))
     : 0;
@@ -1586,22 +1575,9 @@ function PortfolioListPane({ focused, width, height }: PaneProps) {
                 compact
               />
             </box>
-            {summaryWidth > 0 && (
-              <box width={summaryWidth} flexShrink={0} alignItems="flex-start" justifyContent="center">
-                <PortfolioSummaryBar
-                  tickers={sortedTickers}
-                  financialsMap={financialsMap}
-                  state={state}
-                  isPortfolio={isPortfolioTab}
-                  collectionId={activeCollectionId}
-                  width={summaryWidth}
-                  accountState={accountState}
-                />
-              </box>
-            )}
           </box>
         )}
-        {showStackedSummary && (
+        {!paneSettings.hideHeader && (
           <box height={1}>
             <PortfolioSummaryBar
               tickers={sortedTickers}


### PR DESCRIPTION
Moves the portfolio summary bar onto its own row beneath the collection tabs instead of sharing tab-row width. Prioritizes broker net liquidation as the first summary metric, followed by value and cash. Removes the obsolete summary-width helper and updates the portfolio summary and pane tests to cover the new layout and ordering.