### PR TITLE
Fix broker-backed portfolio values and option cost math

### DIFF
--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -311,6 +311,123 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(frame).not.toContain("$137.50");
   });
 
+  test("shows broker market value and pnl before snapshot warmup", async () => {
+    const portfolioId = "broker:ibkr-flex:DU12345";
+    const config = createPortfolioConfigWithColumns(
+      portfolioId,
+      ["ticker", "price", "mkt_value", "pnl", "pnl_pct"],
+      [createBrokerInstance("flex")],
+    );
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId={portfolioId}
+        stateMutator={(state) => {
+          state.tickers = new Map([["AAPL", makeTicker({
+            portfolios: [portfolioId],
+            positions: [{
+              portfolio: portfolioId,
+              shares: 10,
+              avgCost: 100,
+              currency: "USD",
+              broker: "ibkr",
+              brokerInstanceId: "ibkr-flex",
+              brokerAccountId: "DU12345",
+              markPrice: 125,
+              marketValue: 1250,
+              unrealizedPnl: 250,
+            }],
+          })]]);
+          state.financials = new Map();
+          state.paneState[TEST_PANE_ID] = {
+            collectionId: portfolioId,
+            cursorSymbol: "AAPL",
+            cashDrawerExpanded: false,
+          };
+        }}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Val 1.3k");
+    expect(frame).toContain("125");
+    expect(frame).toContain("+250");
+    expect(frame).toContain("25.00%");
+  });
+
+  test("keeps option avg cost on premium scale and multiplies quoted value by contract size", async () => {
+    const portfolioId = "broker:ibkr-flex:DU12345";
+    const optionTicker = "SPY  260619C00500000";
+    const config = createPortfolioConfigWithColumns(
+      portfolioId,
+      ["ticker", "price", "avg_cost", "cost_basis", "mkt_value", "pnl"],
+      [createBrokerInstance("flex")],
+    );
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId={portfolioId}
+        stateMutator={(state) => {
+          state.tickers = new Map([[
+            optionTicker,
+            makeTicker({
+              ticker: optionTicker,
+              name: "SPY Jun19'26 500 Call",
+              assetCategory: "OPT",
+              portfolios: [portfolioId],
+              positions: [{
+                portfolio: portfolioId,
+                shares: 2,
+                avgCost: 4.25,
+                currency: "USD",
+                broker: "ibkr",
+                brokerInstanceId: "ibkr-flex",
+                brokerAccountId: "DU12345",
+                multiplier: 100,
+              }],
+            }),
+          ]]);
+          state.financials = new Map([[
+            optionTicker,
+            {
+              annualStatements: [],
+              quarterlyStatements: [],
+              priceHistory: [],
+              quote: makeQuote({
+                symbol: optionTicker,
+                price: 5,
+                change: 0.5,
+                changePercent: 11.11,
+                previousClose: 4.5,
+                name: "SPY Jun19'26 500 Call",
+              }),
+            },
+          ]]);
+          state.paneState[TEST_PANE_ID] = {
+            collectionId: portfolioId,
+            cursorSymbol: optionTicker,
+            cashDrawerExpanded: false,
+          };
+        }}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("$4.25");
+    expect(frame).toContain("5");
+    expect(frame).toContain("850");
+    expect(frame).toContain("1k");
+    expect(frame).toContain("+150");
+  });
+
   test("shows flex cash summary and hides unavailable margin metrics", async () => {
     const config = createPortfolioConfig("broker:ibkr-flex:DU12345", [createBrokerInstance("flex")]);
     testSetup = await testRender(

--- a/src/plugins/builtin/portfolio-list.tsx
+++ b/src/plugins/builtin/portfolio-list.tsx
@@ -42,6 +42,91 @@ interface ColumnContext {
 function getPositionCurrency(positions: TickerRecord["metadata"]["positions"], fallbackCurrency: string): string {
   return positions.find((position) => position.currency)?.currency || fallbackCurrency;
 }
+
+interface PortfolioPositionMetrics {
+  positionCurrency: string;
+  totalShares: number;
+  totalCost: number;
+  totalCostUnits: number;
+  totalPriceUnits: number;
+  brokerMktValue: number;
+  hasBrokerMktValue: boolean;
+  brokerPnl: number;
+  hasBrokerPnl: boolean;
+  brokerMarkPrice: number | undefined;
+}
+
+function getPortfolioPositionMetrics(
+  ticker: TickerRecord,
+  activeTab: string | undefined,
+  fallbackCurrency: string,
+): PortfolioPositionMetrics {
+  const tabPositions = activeTab
+    ? ticker.metadata.positions.filter((position) => position.portfolio === activeTab)
+    : ticker.metadata.positions;
+  const positionCurrency = getPositionCurrency(tabPositions, fallbackCurrency);
+  const totalShares = tabPositions.reduce((sum, position) => sum + position.shares * (position.side === "short" ? -1 : 1), 0);
+  const totalCost = tabPositions.reduce(
+    (sum, position) => sum + position.shares * position.avgCost * (position.multiplier || 1),
+    0,
+  );
+  const totalCostUnits = tabPositions.reduce(
+    (sum, position) => sum + position.shares * (position.multiplier || 1),
+    0,
+  );
+  const totalPriceUnits = tabPositions.reduce(
+    (sum, position) => sum + position.shares * (position.multiplier || 1) * (position.side === "short" ? -1 : 1),
+    0,
+  );
+
+  let brokerMktValue = 0;
+  let hasBrokerMktValue = false;
+  let brokerPnl = 0;
+  let hasBrokerPnl = false;
+  for (const position of tabPositions) {
+    if (position.marketValue != null) {
+      brokerMktValue += position.marketValue;
+      hasBrokerMktValue = true;
+    }
+    if (position.unrealizedPnl != null) {
+      brokerPnl += position.unrealizedPnl;
+      hasBrokerPnl = true;
+    }
+  }
+
+  return {
+    positionCurrency,
+    totalShares,
+    totalCost,
+    totalCostUnits,
+    totalPriceUnits,
+    brokerMktValue,
+    hasBrokerMktValue,
+    brokerPnl,
+    hasBrokerPnl,
+    brokerMarkPrice: tabPositions.length === 1 ? tabPositions[0]?.markPrice : undefined,
+  };
+}
+
+function resolveBrokerFallbackMarketValue(metrics: PortfolioPositionMetrics): number | null {
+  if (metrics.hasBrokerMktValue) return metrics.brokerMktValue;
+  if (metrics.brokerMarkPrice != null && metrics.totalPriceUnits !== 0) {
+    return Math.abs(metrics.totalPriceUnits) * metrics.brokerMarkPrice;
+  }
+  if (metrics.hasBrokerPnl) {
+    return metrics.totalCost + metrics.brokerPnl;
+  }
+  return null;
+}
+
+function resolveBrokerFallbackPnl(metrics: PortfolioPositionMetrics, brokerMarketValue: number | null): number | null {
+  if (metrics.hasBrokerPnl) return metrics.brokerPnl;
+  if (brokerMarketValue != null && metrics.totalCost !== 0) {
+    return brokerMarketValue - metrics.totalCost;
+  }
+  return null;
+}
+
 type CollectionScope = "all" | "portfolios" | "watchlists" | "custom";
 
 interface PortfolioPaneSettings {
@@ -191,38 +276,21 @@ function getColumnValue(
   const f = financials?.fundamentals;
   const quoteCurrency = q?.currency || ticker.metadata.currency || "USD";
 
-  // Helper to get positions relevant to the active portfolio tab
-  const tabPositions = ctx.activeTab
-    ? ticker.metadata.positions.filter((p) => p.portfolio === ctx.activeTab)
-    : ticker.metadata.positions;
-  const positionCurrency = getPositionCurrency(tabPositions, quoteCurrency);
+  const positionMetrics = getPortfolioPositionMetrics(ticker, ctx.activeTab, quoteCurrency);
+  const { positionCurrency, totalShares, totalCost, totalCostUnits, totalPriceUnits, brokerMarkPrice } = positionMetrics;
+  const brokerFallbackMktValue = resolveBrokerFallbackMarketValue(positionMetrics);
+  const brokerFallbackPnl = resolveBrokerFallbackPnl(positionMetrics, brokerFallbackMktValue);
   const toBaseQuote = (value: number) =>
     convertCurrency(value, quoteCurrency, ctx.baseCurrency, ctx.exchangeRates);
   const toBasePosition = (value: number) =>
     convertCurrency(value, positionCurrency, ctx.baseCurrency, ctx.exchangeRates);
-  const totalShares = tabPositions.reduce((sum, p) => sum + p.shares * (p.side === "short" ? -1 : 1), 0);
-  const totalCost = tabPositions.reduce(
-    (sum, p) => sum + p.shares * p.avgCost * (p.multiplier || 1),
-    0,
-  );
 
   // Fall back to the imported broker mark when a live quote is unavailable.
-  const isOption = ticker.metadata.assetCategory === "OPT";
-  const brokerMktValue = tabPositions.reduce(
-    (sum, p) => sum + (p.marketValue || 0),
-    0,
-  );
-  const brokerPnl = tabPositions.reduce(
-    (sum, p) => sum + (p.unrealizedPnl || 0),
-    0,
-  );
-  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.markPrice : undefined;
-
   switch (col.id) {
     case "ticker": {
       const mkt = q?.marketState;
       const statusDot = mkt === "REGULAR" ? "\u25CF" : "\u25CB";
-      const displayName = isOption
+      const displayName = ticker.metadata.assetCategory === "OPT"
         ? formatOptionTicker(ticker.metadata.ticker)
         : ticker.metadata.ticker;
       return { text: `${statusDot} ${displayName}` };
@@ -283,8 +351,8 @@ function getColumnValue(
     case "shares":
       return { text: totalShares !== 0 ? formatCompact(totalShares) : "—" };
     case "avg_cost": {
-      if (totalShares === 0) return { text: "—" };
-      const avgCost = totalCost / Math.abs(totalShares);
+      if (totalCostUnits === 0) return { text: "—" };
+      const avgCost = totalCost / Math.abs(totalCostUnits);
       return { text: formatCurrency(avgCost, positionCurrency) };
     }
     case "cost_basis": {
@@ -292,37 +360,37 @@ function getColumnValue(
       return { text: formatCompact(toBasePosition(totalCost)) };
     }
     case "mkt_value": {
-      if (activeQuote && totalShares !== 0) {
-        const mv = Math.abs(totalShares) * activeQuote.price;
+      if (activeQuote && totalPriceUnits !== 0) {
+        const mv = Math.abs(totalPriceUnits) * activeQuote.price;
         return { text: formatCompact(toBaseQuote(mv)) };
       }
-      if (isOption && brokerMktValue !== 0) {
-        return { text: formatCompact(toBasePosition(brokerMktValue)) };
+      if (brokerFallbackMktValue != null) {
+        return { text: formatCompact(toBasePosition(brokerFallbackMktValue)) };
       }
       return { text: "—" };
     }
     case "pnl": {
-      if (activeQuote && totalShares !== 0) {
-        const mv = Math.abs(totalShares) * activeQuote.price;
+      if (activeQuote && totalPriceUnits !== 0) {
+        const mv = Math.abs(totalPriceUnits) * activeQuote.price;
         const pnl = toBaseQuote(mv) - toBasePosition(totalCost);
         return { text: (pnl >= 0 ? "+" : "") + formatCompact(pnl), color: priceColor(pnl) };
       }
-      if (isOption && brokerPnl !== 0) {
-        const pnl = toBasePosition(brokerPnl);
+      if (brokerFallbackPnl != null) {
+        const pnl = toBasePosition(brokerFallbackPnl);
         return { text: (pnl >= 0 ? "+" : "") + formatCompact(pnl), color: priceColor(pnl) };
       }
       return { text: "—" };
     }
     case "pnl_pct": {
       if (activeQuote && totalCost !== 0) {
-        const mv = toBaseQuote(Math.abs(totalShares) * activeQuote.price);
+        const mv = toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price);
         const costBasis = toBasePosition(totalCost);
         const pct = costBasis !== 0 ? ((mv - costBasis) / costBasis) * 100 : 0;
         return { text: formatPercentRaw(pct), color: priceColor(pct) };
       }
-      if (isOption && brokerPnl !== 0 && totalCost !== 0) {
+      if (brokerFallbackPnl != null && totalCost !== 0) {
         const costBasis = toBasePosition(totalCost);
-        const pnl = toBasePosition(brokerPnl);
+        const pnl = toBasePosition(brokerFallbackPnl);
         const pct = costBasis !== 0 ? (pnl / costBasis) * 100 : 0;
         return { text: formatPercentRaw(pct), color: priceColor(pct) };
       }
@@ -348,31 +416,21 @@ function getSortValue(
   const f = financials?.fundamentals;
   const quoteCurrency = q?.currency || ticker.metadata.currency || "USD";
 
-  const tabPositions = ctx.activeTab
-    ? ticker.metadata.positions.filter((p) => p.portfolio === ctx.activeTab)
-    : ticker.metadata.positions;
-  const positionCurrency = getPositionCurrency(tabPositions, quoteCurrency);
+  const positionMetrics = getPortfolioPositionMetrics(ticker, ctx.activeTab, quoteCurrency);
+  const { positionCurrency, totalShares, totalCost, totalCostUnits, totalPriceUnits, brokerMarkPrice } = positionMetrics;
+  const brokerFallbackMktValue = resolveBrokerFallbackMarketValue(positionMetrics);
+  const brokerFallbackPnl = resolveBrokerFallbackPnl(positionMetrics, brokerFallbackMktValue);
   const toBaseQuote = (value: number) =>
     convertCurrency(value, quoteCurrency, ctx.baseCurrency, ctx.exchangeRates);
   const toBasePosition = (value: number) =>
     convertCurrency(value, positionCurrency, ctx.baseCurrency, ctx.exchangeRates);
-  const totalShares = tabPositions.reduce((sum, p) => sum + p.shares * (p.side === "short" ? -1 : 1), 0);
-  const totalCost = tabPositions.reduce(
-    (sum, p) => sum + p.shares * p.avgCost * (p.multiplier || 1),
-    0,
-  );
-
-  const isOption = ticker.metadata.assetCategory === "OPT";
-  const brokerMktValue = tabPositions.reduce((sum, p) => sum + (p.marketValue || 0), 0);
-  const brokerPnl = tabPositions.reduce((sum, p) => sum + (p.unrealizedPnl || 0), 0);
-  const brokerMarkPrice = tabPositions.length === 1 ? tabPositions[0]?.markPrice : undefined;
 
   switch (col.id) {
     case "ticker":
       return ticker.metadata.ticker;
     case "price":
       if (activeQuote) return activeQuote.price;
-      if (isOption && brokerMarkPrice != null) return brokerMarkPrice;
+      if (brokerMarkPrice != null) return brokerMarkPrice;
       return null;
     case "bid":
       return q?.bid ?? null;
@@ -400,31 +458,31 @@ function getSortValue(
     case "shares":
       return totalShares !== 0 ? totalShares : null;
     case "avg_cost":
-      return totalShares !== 0 ? totalCost / Math.abs(totalShares) : null;
+      return totalCostUnits !== 0 ? totalCost / Math.abs(totalCostUnits) : null;
     case "cost_basis":
       return totalCost !== 0 ? toBasePosition(totalCost) : null;
     case "mkt_value": {
-      if (activeQuote && totalShares !== 0) return toBaseQuote(Math.abs(totalShares) * activeQuote.price);
-      if (isOption && brokerMktValue !== 0) return toBasePosition(brokerMktValue);
+      if (activeQuote && totalPriceUnits !== 0) return toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price);
+      if (brokerFallbackMktValue != null) return toBasePosition(brokerFallbackMktValue);
       return null;
     }
     case "pnl": {
-      if (activeQuote && totalShares !== 0) {
-        const mv = Math.abs(totalShares) * activeQuote.price;
+      if (activeQuote && totalPriceUnits !== 0) {
+        const mv = Math.abs(totalPriceUnits) * activeQuote.price;
         return toBaseQuote(mv) - toBasePosition(totalCost);
       }
-      if (isOption && brokerPnl !== 0) return toBasePosition(brokerPnl);
+      if (brokerFallbackPnl != null) return toBasePosition(brokerFallbackPnl);
       return null;
     }
     case "pnl_pct": {
       if (activeQuote && totalCost !== 0) {
-        const mv = toBaseQuote(Math.abs(totalShares) * activeQuote.price);
+        const mv = toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price);
         const costBasis = toBasePosition(totalCost);
         return costBasis !== 0 ? ((mv - costBasis) / costBasis) * 100 : null;
       }
-      if (isOption && brokerPnl !== 0 && totalCost !== 0) {
+      if (brokerFallbackPnl != null && totalCost !== 0) {
         const costBasis = toBasePosition(totalCost);
-        const pnl = toBasePosition(brokerPnl);
+        const pnl = toBasePosition(brokerFallbackPnl);
         return costBasis !== 0 ? (pnl / costBasis) * 100 : null;
       }
       return null;
@@ -807,33 +865,24 @@ function calculatePortfolioSummaryTotals(
       continue;
     }
 
-    const tabPositions = collectionId
-      ? ticker.metadata.positions.filter((position) => position.portfolio === collectionId)
-      : ticker.metadata.positions;
-    const positionCurrency = getPositionCurrency(tabPositions, quoteCurrency);
+    const positionMetrics = getPortfolioPositionMetrics(ticker, collectionId ?? undefined, quoteCurrency);
+    const { positionCurrency, totalPriceUnits, totalCost } = positionMetrics;
+    const brokerFallbackMktValue = resolveBrokerFallbackMarketValue(positionMetrics);
     const toBaseQuote = (value: number) => convertCurrency(value, quoteCurrency, baseCurrency, exchangeRates);
     const toBasePosition = (value: number) => convertCurrency(value, positionCurrency, baseCurrency, exchangeRates);
-    const totalShares = tabPositions.reduce((sum, position) => sum + position.shares * (position.side === "short" ? -1 : 1), 0);
-    const totalCost = tabPositions.reduce(
-      (sum, position) => sum + position.shares * position.avgCost * (position.multiplier || 1),
-      0,
-    );
 
-    const isOption = ticker.metadata.assetCategory === "OPT";
-    const brokerMktValue = tabPositions.reduce((sum, position) => sum + (position.marketValue || 0), 0);
-
-    if (q && activeQuote && totalShares !== 0) {
+    if (q && activeQuote && totalPriceUnits !== 0) {
       hasPositions = true;
-      const marketValue = Math.abs(totalShares) * activeQuote.price;
+      const marketValue = Math.abs(totalPriceUnits) * activeQuote.price;
       totalMktValue += toBaseQuote(marketValue);
       const prevClose = q.previousClose || (activeQuote.price - activeQuote.change);
-      totalPrevValue += toBaseQuote(Math.abs(totalShares) * prevClose);
+      totalPrevValue += toBaseQuote(Math.abs(totalPriceUnits) * prevClose);
       totalCostBasis += toBasePosition(totalCost);
-    } else if (isOption && brokerMktValue !== 0) {
+    } else if (brokerFallbackMktValue != null) {
       hasPositions = true;
-      totalMktValue += toBasePosition(brokerMktValue);
+      totalMktValue += toBasePosition(brokerFallbackMktValue);
       totalCostBasis += toBasePosition(totalCost);
-      totalPrevValue += toBasePosition(brokerMktValue);
+      totalPrevValue += toBasePosition(brokerFallbackMktValue);
     }
   }
 


### PR DESCRIPTION
This updates the portfolio pane to use broker-imported market value and P&L when quote snapshots have not been warmed yet, so broker-backed totals do not undercount until you scroll. It also fixes option math so AVG COST stays on the same premium scale as LAST while COST, MKT VAL, and P&L continue to apply the contract multiplier correctly for live quotes. The PR adds regression coverage for both the broker fallback path and IBKR Flex option pricing behavior. Verification: src/plugins/ibkr/flex.test.ts passes; the portfolio pane tests are still blocked in this workspace by a pre-existing @opentui/react/jsx-dev-runtime resolution error.