### PR TITLE
Improve cloud auth forms and saved session state

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -628,4 +628,96 @@ describe("CommandBar", () => {
     expect(frame.indexOf("AAPL")).toBeLessThan(frame.indexOf("APP"));
     expect(frame).toMatchSnapshot();
   });
+
+  test("renders form-layout wizard fields together on one screen", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="login"
+        live
+        configurePluginRegistry={(pluginRegistry) => {
+          pluginRegistry.commands.set("auth-login", {
+            id: "auth-login",
+            label: "Login",
+            description: "Log in to your account",
+            keywords: ["login", "auth"],
+            category: "config",
+            wizardLayout: "form",
+            wizard: [
+              { key: "email", label: "Email", type: "text", placeholder: "email@example.com" },
+              { key: "password", label: "Password", type: "password", placeholder: "Your password" },
+            ],
+            execute: async () => {},
+          } as any);
+        }}
+      />,
+      { width: 80, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Email");
+    expect(frame).toContain("Password");
+    expect(frame).toContain("Enter advances");
+    expect(frame).toContain("Your password");
+  });
+
+  test("submits single-field form-layout wizards", async () => {
+    const submitted: Array<Record<string, string> | undefined> = [];
+
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="workspace"
+        live
+        configurePluginRegistry={(pluginRegistry) => {
+          pluginRegistry.commands.set("new-workspace", {
+            id: "new-workspace",
+            label: "Workspace",
+            description: "Create a workspace",
+            keywords: ["workspace"],
+            category: "config",
+            wizardLayout: "form",
+            wizard: [
+              { key: "name", label: "Name", type: "text", placeholder: "Research" },
+            ],
+            execute: async (values) => {
+              submitted.push(values);
+            },
+          } as any);
+        }}
+      />,
+      { width: 80, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("Research");
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(submitted).toEqual([{ name: "Research" }]);
+  });
 });

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { createRef, useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { TextAttributes } from "@opentui/core";
 import { Spinner } from "../spinner";
@@ -150,6 +150,7 @@ function InputStepContent({ resolve, step }: PromptContext<string> & { step: Wiz
           inputRef={inputRef}
           value={value}
           placeholder={step.placeholder || ""}
+          type={step.type === "password" ? "password" : "text"}
           focused
           onChange={setValue}
           onSubmit={(submittedValue) => {
@@ -157,6 +158,99 @@ function InputStepContent({ resolve, step }: PromptContext<string> & { step: Wiz
             if (submitted) resolve(submitted);
           }}
         />
+      </box>
+    </DialogFrame>
+  );
+}
+
+function FormStepContent({
+  resolve,
+  dialogId,
+  title,
+  steps,
+  initialValues,
+}: PromptContext<Record<string, string> | null> & {
+  title: string;
+  steps: WizardStep[];
+  initialValues: Record<string, string>;
+}) {
+  const inputRefs = useMemo(() => steps.map(() => createRef<InputRenderable>()), [steps]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [values, setValues] = useState<Record<string, string>>(() => Object.fromEntries(
+    steps.map((step) => [step.key, initialValues[step.key] ?? ""]),
+  ));
+
+  useEffect(() => {
+    inputRefs[activeIndex]?.current?.focus();
+  }, [activeIndex, inputRefs]);
+
+  const focusField = useCallback((nextIndex: number) => {
+    setActiveIndex(Math.max(0, Math.min(steps.length - 1, nextIndex)));
+  }, [steps.length]);
+
+  const submitForm = useCallback((overrides?: Record<string, string>) => {
+    const nextValues = overrides ? { ...values, ...overrides } : values;
+    const submittedValues: Record<string, string> = {};
+    for (const step of steps) {
+      submittedValues[step.key] = nextValues[step.key]?.trim() || step.defaultValue || "";
+    }
+    resolve(submittedValues);
+  }, [resolve, steps, values]);
+
+  useDialogKeyboard((event) => {
+    if (event.name === "escape") {
+      event.stopPropagation();
+      resolve(null);
+      return;
+    }
+    if (event.shift && event.name === "tab") {
+      event.stopPropagation();
+      focusField(activeIndex - 1);
+      return;
+    }
+    if (event.name === "tab" || event.name === "down") {
+      event.stopPropagation();
+      focusField(activeIndex + 1);
+      return;
+    }
+    if (event.name === "up") {
+      event.stopPropagation();
+      focusField(activeIndex - 1);
+    }
+  }, dialogId);
+
+  return (
+    <DialogFrame title={title} footer="Enter advances · ↑↓ move · Esc cancels">
+      <box flexDirection="column">
+        {steps.map((step, index) => (
+          <box key={step.key} flexDirection="column">
+            {index > 0 && <box height={1} />}
+            <TextField
+              inputRef={inputRefs[index]}
+              label={step.label}
+              value={values[step.key] ?? ""}
+              placeholder={step.placeholder || ""}
+              type={step.type === "password" ? "password" : "text"}
+              focused={index === activeIndex}
+              onMouseDown={() => setActiveIndex(index)}
+              onChange={(nextValue) => setValues((current) => ({ ...current, [step.key]: nextValue }))}
+              onSubmit={(submittedValue) => {
+                const nextValues = { ...values, [step.key]: submittedValue };
+                setValues(nextValues);
+                if (index === steps.length - 1) {
+                  submitForm({ [step.key]: submittedValue });
+                  return;
+                }
+                focusField(index + 1);
+              }}
+            />
+            {step.body?.map((line, lineIndex) => (
+              <box key={`${step.key}:${lineIndex}`} height={1}>
+                <text fg={colors.textDim}>{line || " "}</text>
+              </box>
+            ))}
+          </box>
+        ))}
       </box>
     </DialogFrame>
   );
@@ -299,6 +393,10 @@ function ResultContent({ dismiss, dialogId, message, isError }: AlertContext & {
       <text fg={colors.textMuted}>Press Enter to close</text>
     </box>
   );
+}
+
+function isInputWizardStep(step: WizardStep): boolean {
+  return step.type !== "info" && step.type !== "select";
 }
 
 export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, quitApp }: CommandBarProps) {
@@ -886,12 +984,13 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
     dispatch({ type: "FOCUS_PANE", paneId: duplicate.instanceId });
   }, [dispatch, persistLayoutChange, pluginRegistry]);
 
-  // Run a wizard command through sequential dialogs
+  // Run a wizard command through dialogs, optionally grouping plain inputs into one form.
   const runWizard = useCallback(async (cmd: CommandDef) => {
     const steps = cmd.wizard!;
     const values: Record<string, string> = {};
 
-    for (const step of steps) {
+    for (let index = 0; index < steps.length; index += 1) {
+      const step = steps[index]!;
       if (step.dependsOn && values[step.dependsOn.key] !== step.dependsOn.value) {
         continue;
       }
@@ -930,6 +1029,26 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
         await dialog.alert({
           content: (ctx) => <InfoStepContent {...ctx} step={step} />,
         });
+        continue;
+      }
+
+      if (cmd.wizardLayout === "form" && isInputWizardStep(step) && !step.dependsOn) {
+        const formSteps = [step];
+        while (index + 1 < steps.length) {
+          const nextStep = steps[index + 1]!;
+          if (!isInputWizardStep(nextStep) || nextStep.dependsOn) {
+            break;
+          }
+          formSteps.push(nextStep);
+          index += 1;
+        }
+
+        const formResult = await dialog.prompt<Record<string, string> | null>({
+          content: (ctx) => <FormStepContent {...ctx} title={cmd.label} steps={formSteps} initialValues={values} />,
+        });
+
+        if (formResult === undefined || formResult === null) return;
+        Object.assign(values, formResult);
         continue;
       }
 

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -11,6 +11,7 @@ import { resolveBrokerConfigFields, type BrokerAdapter, type BrokerConfigField }
 import { buildIbkrConfigFromValues } from "../../plugins/ibkr/config";
 import { createBrokerInstanceId } from "../../utils/broker-instances";
 import { ToggleList, type ToggleListItem } from "../toggle-list";
+import { TextField } from "../ui";
 
 interface OnboardingWizardProps {
   config: AppConfig;
@@ -36,6 +37,8 @@ const LOGO = [
   "\u258C \u258C\u2590 \u258C \u258C\u258C \u258C\u258C\u2590 \u258C\u258C \u258C\u259B\u2580 \u258C  \u258C \u258C",
   "\u259D\u2580  \u2598\u259D\u2580 \u259D\u2580 \u2598\u259D \u2598\u2580\u2580 \u259D\u2580\u2598\u2598  \u2580\u2580 ",
 ];
+
+const PASSWORD_MASK_CHAR = "*";
 
 function getToggleablePlugins(pluginRegistry: PluginRegistry) {
   const result: Array<{ id: string; name: string; description: string; order: number }> = [];
@@ -660,14 +663,15 @@ function PortfolioStep({
         </box>
         <box height={1}>
           {editing ? (
-            <input
-              ref={inputRef}
+            <TextField
+              inputRef={inputRef}
+              value={portfolioName}
               placeholder="Main Portfolio"
               focused
+              backgroundColor={colors.panel}
               textColor={colors.text}
               placeholderColor={colors.textDim}
-              backgroundColor={colors.panel}
-              onChange={(val) => onNameChange(val)}
+              onChange={onNameChange}
               onSubmit={() => {}}
             />
           ) : (
@@ -714,7 +718,7 @@ function PortfolioStep({
         if (!isActive && val) {
           const selectedLabel = field.type === "select"
             ? field.options?.find((option) => option.value === val)?.label ?? val
-            : val;
+            : field.type === "password" ? PASSWORD_MASK_CHAR.repeat(val.length) : val;
           return (
             <box key={field.key} height={1}>
               <text fg={colors.positive}>{"\u2713 "}</text>
@@ -737,20 +741,22 @@ function PortfolioStep({
               </box>
               <box height={1}>
                 {field.type !== "select" && (editing ? (
-                  <input
-                    ref={inputRef}
+                  <TextField
+                    inputRef={inputRef}
+                    value={val}
+                    type={field.type === "password" ? "password" : "text"}
                     placeholder={field.placeholder || `Enter ${field.label.toLowerCase()}`}
                     focused
+                    backgroundColor={colors.panel}
                     textColor={colors.text}
                     placeholderColor={colors.textDim}
-                    backgroundColor={colors.panel}
-                    onChange={(val) => onBrokerFieldChange(selectedBrokerId, field.key, val)}
+                    onChange={(nextValue) => onBrokerFieldChange(selectedBrokerId, field.key, nextValue)}
                     onSubmit={() => {}}
                   />
                 ) : (
                   <text fg={effectiveValue ? colors.positive : colors.textMuted}>
                     {effectiveValue
-                      ? `\u2713 ${field.label}: ${effectiveValue}`
+                      ? `\u2713 ${field.label}: ${field.type === "password" ? PASSWORD_MASK_CHAR.repeat(effectiveValue.length) : effectiveValue}`
                       : "Press enter to type..."}
                   </text>
                 ))}

--- a/src/components/pane-template-wizard.tsx
+++ b/src/components/pane-template-wizard.tsx
@@ -57,6 +57,7 @@ export function PaneTemplateInputStep({
           inputRef={inputRef}
           value={value}
           placeholder={step.placeholder || ""}
+          type={step.type === "password" ? "password" : "text"}
           focused
           onChange={setValue}
           onSubmit={(submittedValue) => {

--- a/src/components/ui/fields.tsx
+++ b/src/components/ui/fields.tsx
@@ -1,4 +1,4 @@
-import { useRef, type RefObject } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import type { InputRenderable } from "@opentui/core";
 import { colors } from "../../theme/colors";
 
@@ -12,6 +12,17 @@ export interface TextFieldProps {
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
   hint?: string;
+  type?: "text" | "password";
+  backgroundColor?: string;
+  textColor?: string;
+  placeholderColor?: string;
+  onMouseDown?: () => void;
+}
+
+const PASSWORD_MASK_CHAR = "*";
+
+function maskPassword(value: string): string {
+  return PASSWORD_MASK_CHAR.repeat(value.length);
 }
 
 export function TextField({
@@ -24,36 +35,95 @@ export function TextField({
   onChange,
   onSubmit,
   hint,
+  type = "text",
+  backgroundColor = colors.bg,
+  textColor = colors.text,
+  placeholderColor = colors.textDim,
+  onMouseDown,
 }: TextFieldProps) {
+  const localInputRef = useRef<InputRenderable>(null);
+  const resolvedInputRef = inputRef ?? localInputRef;
   const currentValueRef = useRef(value ?? "");
+  const [cursorOffset, setCursorOffset] = useState((value ?? "").length);
+  const isPassword = type === "password";
+  const currentValue = value ?? "";
+  const maskedValue = maskPassword(currentValue);
+  const maskedDisplay = maskedValue.length > 0 ? maskedValue : (placeholder ?? "");
+  const maskedTextColor = maskedValue.length > 0 ? textColor : placeholderColor;
+
+  useEffect(() => {
+    currentValueRef.current = currentValue;
+    setCursorOffset(resolvedInputRef.current?.cursorOffset ?? currentValue.length);
+  }, [currentValue, resolvedInputRef]);
+
+  const syncCursorOffset = (fallbackValue = currentValueRef.current) => {
+    setCursorOffset(resolvedInputRef.current?.cursorOffset ?? fallbackValue.length);
+  };
+
+  const maskedCursorOffset = currentValue.length > 0
+    ? Math.max(0, Math.min(cursorOffset, currentValue.length))
+    : 0;
+  const maskedBefore = maskedDisplay.slice(0, maskedCursorOffset);
+  const maskedCursorChar = maskedDisplay[maskedCursorOffset] ?? " ";
+  const maskedAfter = maskedDisplay.slice(maskedCursorOffset + (maskedCursorOffset < maskedDisplay.length ? 1 : 0));
 
   return (
     <box flexDirection="column">
       {label && (
         <box height={1}>
-          <text fg={colors.textDim}>{label}</text>
+          <text fg={placeholderColor}>{label}</text>
         </box>
       )}
-      <box height={1}>
+      <box height={1} onMouseDown={() => {
+        onMouseDown?.();
+        resolvedInputRef.current?.focus?.();
+      }}>
         <input
-          ref={inputRef}
+          ref={resolvedInputRef}
           width={width}
           value={value}
-          placeholder={placeholder}
+          placeholder={isPassword ? "" : placeholder}
           focused={focused}
-          textColor={colors.text}
-          placeholderColor={colors.textDim}
-          backgroundColor={colors.bg}
+          textColor={isPassword ? backgroundColor : textColor}
+          placeholderColor={placeholderColor}
+          backgroundColor={backgroundColor}
+          selectionBg={isPassword ? backgroundColor : undefined}
+          selectionFg={isPassword ? backgroundColor : undefined}
+          showCursor={!isPassword}
+          onCursorChange={() => syncCursorOffset()}
           onInput={(nextValue) => {
             currentValueRef.current = nextValue;
+            syncCursorOffset(nextValue);
             onChange?.(nextValue);
           }}
           onChange={(nextValue) => {
             currentValueRef.current = nextValue;
+            syncCursorOffset(nextValue);
             onChange?.(nextValue);
           }}
           onSubmit={() => onSubmit?.(currentValueRef.current)}
         />
+        {isPassword && (
+          <box
+            position="absolute"
+            left={0}
+            top={0}
+            height={1}
+            width={width}
+            onMouseDown={() => {
+              onMouseDown?.();
+              resolvedInputRef.current?.focus?.();
+            }}
+          >
+            <text fg={maskedTextColor}>
+              {maskedBefore}
+              {focused && (
+                <span bg={maskedTextColor} fg={backgroundColor}>{maskedCursorChar}</span>
+              )}
+              {focused ? maskedAfter : maskedDisplay.slice(maskedBefore.length)}
+            </text>
+          </box>
+        )}
       </box>
       {hint && (
         <box height={1}>

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useState } from "react";
 import { testRender } from "@opentui/react/test-utils";
 import { Button } from "./button";
+import { TextField } from "./fields";
 import { ListView } from "./list-view";
 import { ProgressBar } from "./loading";
 import { Notice } from "./status";
@@ -109,5 +110,25 @@ describe("shared UI kit", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Row 9");
     expect(frame).not.toContain("Row 1");
+  });
+
+  test("masks password text fields", async () => {
+    testSetup = await testRender(
+      <TextField
+        type="password"
+        value="secret"
+        placeholder="Password"
+        focused
+        width={12}
+        onChange={() => {}}
+      />,
+      { width: 16, height: 3 },
+    );
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("******");
+    expect(frame).not.toContain("secret");
   });
 });

--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -120,6 +120,29 @@ describe("ChatController", () => {
     expect(snapshot.messages.map((entry) => entry.id)).toEqual(["m1"]);
   });
 
+  test("hydrates a cached verified user into the api client for offline use", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+
+    expect(apiClient.getCurrentUser()).toMatchObject({
+      id: "u1",
+      username: "vince",
+      emailVerified: true,
+    });
+    await expect(apiClient.ensureVerifiedSession()).resolves.toMatchObject({
+      id: "u1",
+      username: "vince",
+      emailVerified: true,
+    });
+  });
+
   test("reset clears persisted chat state and session token", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -1,5 +1,5 @@
 import type { PluginPersistence, PluginResumeState } from "../../types/plugin";
-import { apiClient, type ChatMessage } from "../../utils/api-client";
+import { apiClient, type ChatMessage, type PersistedAuthUser } from "../../utils/api-client";
 
 const SESSION_STATE_KEY = "session";
 const CHANNEL_STATE_KEY = "channel:everyone";
@@ -18,7 +18,7 @@ const VERIFICATION_POLL_MS = 5_000;
 interface PersistedSessionState {
   sessionToken: string | null;
   websocketToken?: string | null;
-  user: { id: string; username: string; emailVerified: boolean } | null;
+  user: PersistedAuthUser | null;
 }
 
 interface PersistedChannelState {
@@ -33,6 +33,7 @@ interface PersistedTranscript {
 
 export interface ChatControllerSnapshot {
   loading: boolean;
+  hasSavedSession: boolean;
   user: { id: string; username: string; emailVerified: boolean } | null;
   messages: ChatMessage[];
   draft: string;
@@ -72,15 +73,13 @@ export class ChatController {
     }) ?? this.persistence.getState<PersistedSessionState>(SESSION_STATE_KEY, {
       schemaVersion: SESSION_SCHEMA_VERSION,
     });
-    if (session?.sessionToken) {
-      apiClient.setSessionToken(session.sessionToken);
-    }
-    if (session?.websocketToken) {
-      apiClient.setWebSocketToken(session.websocketToken);
-    }
+    apiClient.setSessionToken(session?.sessionToken ?? null);
+    apiClient.setWebSocketToken(session?.websocketToken ?? null);
+    apiClient.restoreCachedUser(session?.user ?? null);
     this.user = session?.user
       ? {
-        ...session.user,
+        id: session.user.id,
+        username: session.user.username ?? session.user.name ?? "account",
         emailVerified: session.user.emailVerified === true,
       }
       : null;
@@ -115,6 +114,7 @@ export class ChatController {
   getSnapshot(): ChatControllerSnapshot {
     return {
       loading: !this.sessionChecked,
+      hasSavedSession: !!apiClient.getSessionToken(),
       user: this.user,
       messages: [...this.messages],
       draft: this.draft,

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -5,9 +5,9 @@ import { AppContext, createInitialState } from "../../state/app-context";
 import { createDefaultConfig } from "../../types/config";
 import type { PersistedResourceValue } from "../../types/persistence";
 import type { PluginPersistence } from "../../types/plugin";
-import type { ChatMessage } from "../../utils/api-client";
+import { apiClient, type ChatMessage } from "../../utils/api-client";
 import { setSharedDataProviderForTests, setSharedRegistryForTests } from "../registry";
-import { ChatContent } from "./chat";
+import { ChatContent, ChatStatusWidget, gloomberbCloudPlugin } from "./chat";
 import { ChatController } from "./chat-controller";
 
 const TRANSCRIPT_KIND = "channel-transcript";
@@ -97,12 +97,20 @@ function makeMessage(index: number): ChatMessage {
   };
 }
 
-function createController(messages: ChatMessage[] = []) {
+function createController(options: {
+  messages?: ChatMessage[];
+  sessionToken?: string | null;
+  user?: { id: string; username: string; emailVerified: boolean } | null;
+} = {}) {
+  const messages = options.messages ?? [];
   const persistence = new MemoryPersistence();
   const controller = new ChatController();
+  const user = Object.prototype.hasOwnProperty.call(options, "user")
+    ? options.user ?? null
+    : { id: "u0", username: "vince", emailVerified: true };
   persistence.setState("session", {
-    sessionToken: null,
-    user: { id: "u0", username: "vince", emailVerified: true },
+    sessionToken: options.sessionToken ?? null,
+    user,
   }, { schemaVersion: 1 });
   persistence.setState("channel:everyone", {
     draft: "",
@@ -156,6 +164,7 @@ async function flushFrame() {
 afterEach(async () => {
   setSharedRegistryForTests(undefined);
   setSharedDataProviderForTests(undefined);
+  apiClient.setSessionToken(null);
 
   if (testSetup) {
     await act(async () => {
@@ -203,14 +212,16 @@ describe("ChatContent", () => {
   });
 
   test("auto-scrolls to newly appended messages while following the latest transcript", async () => {
-    const controller = createController([
-      makeMessage(1),
-      makeMessage(2),
-      makeMessage(3),
-      makeMessage(4),
-      makeMessage(5),
-      makeMessage(6),
-    ]);
+    const controller = createController({
+      messages: [
+        makeMessage(1),
+        makeMessage(2),
+        makeMessage(3),
+        makeMessage(4),
+        makeMessage(5),
+        makeMessage(6),
+      ],
+    });
 
     await act(async () => {
       testSetup = await testRender(createHarness(controller, { width: 60, height: 12 }), {
@@ -238,14 +249,16 @@ describe("ChatContent", () => {
   });
 
   test("renders ticker badges and opens a floating detail pane on click", async () => {
-    const controller = createController([{
-      id: "m1",
-      channelId: "everyone",
-      content: "Watching $TSLA today",
-      replyToId: null,
-      createdAt: "2026-03-28T00:00:00.000Z",
-      user: { id: "u1", username: "vince", displayName: "Vince" },
-    }]);
+    const controller = createController({
+      messages: [{
+        id: "m1",
+        channelId: "everyone",
+        content: "Watching $TSLA today",
+        replyToId: null,
+        createdAt: "2026-03-28T00:00:00.000Z",
+        user: { id: "u1", username: "vince", displayName: "Vince" },
+      }],
+    });
     const opened: string[] = [];
 
     setSharedRegistryForTests({
@@ -308,5 +321,85 @@ describe("ChatContent", () => {
     });
 
     expect(opened).toEqual(["TSLA"]);
+  });
+
+  test("shows a saved-login message instead of logged out when a session token is cached", async () => {
+    const controller = createController({
+      sessionToken: "token-123",
+      user: null,
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller), {
+        width: 60,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Saved login found.");
+    expect(frame).toContain("Reconnect to refresh");
+    expect(frame).not.toContain("Not logged in.");
+  });
+
+  test("shows a logged-in icon in the cloud status widget for cached sessions", async () => {
+    const controller = createController({
+      sessionToken: "token-123",
+      user: null,
+    });
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+    state.config.disabledPlugins = [];
+
+    await act(async () => {
+      testSetup = await testRender(
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <ChatStatusWidget controller={controller} />
+        </AppContext>,
+        { width: 40, height: 1 },
+      );
+    });
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("@");
+    expect(frame).toContain("Shift+C");
+    expect(frame).not.toContain("vince");
+  });
+
+  test("auth commands use a single-form layout and signup no longer prompts for display name", () => {
+    const registeredCommands: Array<{ id: string; wizardLayout?: string; wizard?: Array<{ key: string }> }> = [];
+
+    gloomberbCloudPlugin.setup({
+      persistence: new MemoryPersistence(),
+      resume: {
+        getState: () => null,
+        setState: () => {},
+        deleteState: () => {},
+      },
+      registerPane: () => {},
+      registerShortcut: () => {},
+      registerCommand: (command: { id: string; wizardLayout?: string; wizard?: Array<{ key: string }> }) => {
+        registeredCommands.push(command);
+      },
+      showWidget: () => {},
+      hideWidget: () => {},
+      showToast: () => {},
+    } as any);
+
+    const loginCommand = registeredCommands.find((command) => command.id === "auth-login");
+    const signupCommand = registeredCommands.find((command) => command.id === "auth-signup");
+
+    expect(loginCommand?.wizardLayout).toBe("form");
+    expect(signupCommand?.wizardLayout).toBe("form");
+    expect(signupCommand?.wizard?.map((step) => step.key)).toEqual([
+      "email",
+      "username",
+      "password",
+      "confirmPassword",
+      "_validate",
+    ]);
   });
 });

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -23,6 +23,10 @@ interface ChatContentProps {
   >;
 }
 
+interface ChatStatusWidgetProps {
+  controller?: Pick<ChatController, "getSnapshot" | "refreshSession" | "subscribe">;
+}
+
 function estimateWrappedLineCount(text: string, width: number) {
   const safeWidth = Math.max(width, 1);
   return text.split("\n").reduce((total, line) => (
@@ -59,6 +63,7 @@ export function ChatContent({
   const { dispatch } = useAppState();
   const initialSnapshot = controller.getSnapshot();
   const [messages, setMessages] = useState<ChatMessage[]>(initialSnapshot.messages);
+  const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
   const [user, setUser] = useState<{ id: string; username: string; emailVerified: boolean } | null>(initialSnapshot.user);
   const [loading, setLoading] = useState(initialSnapshot.loading);
   const [inputFocused, setInputFocused] = useState(false);
@@ -76,6 +81,7 @@ export function ChatContent({
   useEffect(() => {
     const unsubscribe = controller.subscribe((snapshot) => {
       setMessages(snapshot.messages);
+      setHasSavedSession(snapshot.hasSavedSession);
       setUser(snapshot.user);
       setLoading(snapshot.loading);
       setInputValue(snapshot.draft);
@@ -237,13 +243,24 @@ export function ChatContent({
     );
   }
 
-  if (!user) {
+  if (!user && !hasSavedSession) {
     return (
       <box flexGrow={1} alignItems="center" justifyContent="center" flexDirection="column">
         <text fg={colors.textDim}>Not logged in.</text>
         <text fg={colors.textDim}> </text>
         <text fg={colors.text}>Press Ctrl+P and search "Login" or "Sign Up"</text>
         <text fg={colors.textDim}>to start chatting.</text>
+      </box>
+    );
+  }
+
+  if (!user && hasSavedSession) {
+    return (
+      <box flexGrow={1} alignItems="center" justifyContent="center" flexDirection="column">
+        <text fg={colors.positive}>Saved login found.</text>
+        <text fg={colors.textDim}> </text>
+        <text fg={colors.text}>Reconnect to refresh your Gloomberb Cloud session.</text>
+        <text fg={colors.textDim}>Your cached transcript is still available locally.</text>
       </box>
     );
   }
@@ -380,26 +397,35 @@ export function ChatPane({ focused, width, height, close }: PaneProps) {
   );
 }
 
-function ChatStatusWidget() {
+export function ChatStatusWidget({ controller = chatController }: ChatStatusWidgetProps) {
   const { state } = useAppState();
-  const [username, setUsername] = useState<string | null>(chatController.getSnapshot().user?.username ?? null);
+  const initialSnapshot = controller.getSnapshot();
+  const [username, setUsername] = useState<string | null>(initialSnapshot.user?.username ?? null);
+  const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
 
   useEffect(() => {
-    const unsubscribe = chatController.subscribe((snapshot) => {
+    const unsubscribe = controller.subscribe((snapshot) => {
       setUsername(snapshot.user?.username ?? null);
+      setHasSavedSession(snapshot.hasSavedSession);
     });
-    void chatController.refreshSession().catch(() => {});
+    void controller.refreshSession().catch(() => {});
     return unsubscribe;
-  }, []);
+  }, [controller]);
 
   if (state.config.disabledPlugins.includes("gloomberb-cloud")) return null;
 
   return (
     <box flexDirection="row" paddingRight={1}>
-      {username ? (
+      {username || hasSavedSession ? (
         <text fg={colors.textDim}>
-          <span fg={colors.positive}>{username}</span>
-          {"  "}
+          <span fg={colors.positive}>@</span>
+          {username ? (
+            <>
+              {" "}
+              <span fg={colors.positive}>{username}</span>
+              {"  "}
+            </>
+          ) : "  "}
           <span fg={colors.text}>Shift+C</span> cloud
         </text>
       ) : (
@@ -469,6 +495,7 @@ export const gloomberbCloudPlugin: GloomPlugin = {
       description: "Log in to your Gloomberb account",
       keywords: ["login", "sign in", "auth", "account"],
       category: "config",
+      wizardLayout: "form",
       hidden: () => !!apiClient.getSessionToken(),
       wizard: [
         { key: "email", label: "Email", type: "text", placeholder: "email@example.com" },
@@ -495,6 +522,7 @@ export const gloomberbCloudPlugin: GloomPlugin = {
       description: "Create a Gloomberb account",
       keywords: ["signup", "register", "create account"],
       category: "config",
+      wizardLayout: "form",
       hidden: () => !!apiClient.getSessionToken(),
       wizard: [
         { key: "email", label: "Email", type: "text", placeholder: "email@example.com" },
@@ -505,19 +533,18 @@ export const gloomberbCloudPlugin: GloomPlugin = {
           placeholder: "3-30 chars, starts with letter",
           body: ["Choose a username (3-30 characters, starts with a letter, alphanumeric and underscore only)"],
         },
-        { key: "name", label: "Display Name", type: "text", placeholder: "Your name" },
         { key: "password", label: "Password", type: "password", placeholder: "Min 8 characters" },
         { key: "confirmPassword", label: "Confirm Password", type: "password", placeholder: "Re-enter password" },
         { key: "_validate", label: "Creating account...", type: "info", body: ["Registering with Gloomberb...", "Account created! Welcome to Gloomberb."] },
       ],
       execute: async (values) => {
-        if (!values?.email || !values?.username || !values?.name || !values?.password) {
+        if (!values?.email || !values?.username || !values?.password) {
           throw new Error("All fields are required");
         }
         if (values.password !== values.confirmPassword) {
           throw new Error("Passwords do not match");
         }
-        await apiClient.signUp(values.email, values.username, values.name, values.password);
+        await apiClient.signUp(values.email, values.username, values.username, values.password);
         await apiClient.sendVerification();
         chatController.clearSession();
         await chatController.refreshSession();

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -177,6 +177,7 @@ export interface CommandDef {
   category: "navigation" | "data" | "portfolio" | "config";
   description?: string;
   wizard?: WizardStep[];
+  wizardLayout?: "steps" | "form";
   hidden?: () => boolean;
 }
 

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -33,6 +33,8 @@ export interface AuthUser {
   updatedAt: string;
 }
 
+export type PersistedAuthUser = Pick<AuthUser, "id" | "emailVerified"> & Partial<AuthUser>;
+
 export interface CloudQuotePayload extends Quote {
   providerId: "gloomberb-cloud";
   dataSource: "live" | "delayed";
@@ -157,6 +159,25 @@ class GloomApiClient {
 
   getCurrentUser(): AuthUser | null {
     return this.currentUser;
+  }
+
+  restoreCachedUser(user: PersistedAuthUser | null): void {
+    if (!this.sessionToken || !user?.id) {
+      this.setCurrentUser(null);
+      return;
+    }
+    this.setCurrentUser({
+      id: user.id,
+      name: typeof user.name === "string" && user.name.length > 0
+        ? user.name
+        : user.username ?? "User",
+      email: typeof user.email === "string" ? user.email : "",
+      username: typeof user.username === "string" ? user.username : null,
+      emailVerified: user.emailVerified === true,
+      image: typeof user.image === "string" ? user.image : null,
+      createdAt: typeof user.createdAt === "string" ? user.createdAt : "",
+      updatedAt: typeof user.updatedAt === "string" ? user.updatedAt : "",
+    });
   }
 
   isVerified(): boolean {


### PR DESCRIPTION
This updates the Gloomberb Cloud auth UX to treat cached sessions as saved logins instead of logged out, restoring cached users into the API client and showing a logged-in `@` status indicator even while offline.

It masks password entry in the shared text field and propagates password styling through command bar, pane-template, and onboarding flows.

It also adds a `form` wizard layout so login and signup render all fields on one screen, and signup now reuses the username instead of prompting for a separate display name.

Tests cover the cached-session behavior, status widget, password masking, and command-bar auth forms.