### PR TITLE
Keep dock resize separator above chart panes

### DIFF
--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act } from "react";
 import { testRender } from "@opentui/react/test-utils";
 import { DialogProvider } from "@opentui-ui/dialog/react";
 import { act, useReducer } from "react";
@@ -10,7 +9,7 @@ import { setSharedRegistryForTests } from "../../plugins/registry";
 import { portfolioListPlugin } from "../../plugins/builtin/portfolio-list";
 import { StatusBar } from "./status-bar";
 import { Header } from "./header";
-import { buildNativeWindowState, Shell } from "./shell";
+import { buildNativeWindowState, resolveNativeDockDividers, Shell } from "./shell";
 import type { DataProvider } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
@@ -316,6 +315,65 @@ describe("Shell", () => {
         paneId: null,
         rect: { x: 0, y: 1, width: 60, height: 20 },
         zIndex: 96,
+      },
+    ]);
+  });
+
+  test("adds dock dividers as global native occluders", () => {
+    const state = buildNativeWindowState(
+      ["left:main", "right:main"],
+      [],
+      null,
+      { open: false, width: 120, contentHeight: 40 },
+      [],
+      [{
+        path: [],
+        axis: "horizontal",
+        bounds: { x: 0, y: 0, width: 120, height: 40 },
+        ratio: 0.5,
+        rect: { x: 59, y: 0, width: 1, height: 40 },
+      }],
+    );
+
+    expect(state.occluders).toEqual([
+      {
+        id: "dock-divider:root",
+        paneId: null,
+        rect: { x: 59, y: 1, width: 1, height: 40 },
+        zIndex: 1,
+      },
+    ]);
+  });
+
+  test("uses the live divider preview rect for dock divider occluders", () => {
+    const state = buildNativeWindowState(
+      ["left:main", "right:main"],
+      [],
+      null,
+      { open: false, width: 120, contentHeight: 40 },
+      [],
+      resolveNativeDockDividers(
+        [{
+          path: [],
+          axis: "horizontal",
+          bounds: { x: 0, y: 0, width: 120, height: 40 },
+          ratio: 0.5,
+          rect: { x: 59, y: 0, width: 1, height: 40 },
+        }],
+        {
+          pathKey: "",
+          rect: { x: 71, y: 0, width: 1, height: 40 },
+          ratio: 0.6,
+        },
+      ),
+    );
+
+    expect(state.occluders).toEqual([
+      {
+        id: "dock-divider:root",
+        paneId: null,
+        rect: { x: 71, y: 1, width: 1, height: 40 },
+        zIndex: 1,
       },
     ]);
   });

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -100,6 +100,12 @@ interface FloatingPreviewRect {
   rect: FloatingRect;
 }
 
+interface DividerPreviewState {
+  pathKey: string;
+  rect: LayoutBounds;
+  ratio: number;
+}
+
 interface NativeFloatingPaneState {
   paneId: string;
   rect: FloatingRect;
@@ -245,6 +251,7 @@ export function buildNativeWindowState(
   dragFloatingRect: FloatingPreviewRect | null,
   overlay: { open: boolean; width: number; contentHeight: number },
   transientOccluders: readonly NativeTransientOccluder[] = [],
+  dockDividers: readonly DockDividerLayout[] = [],
 ): { paneLayers: NativePaneLayer[]; occluders: NativeOccluder[] } {
   const previewedFloatingPanes = floatingPanes.map((pane) => (
     dragFloatingRect?.paneId === pane.paneId
@@ -268,6 +275,21 @@ export function buildNativeWindowState(
     },
     zIndex: pane.zIndex,
   }));
+
+  for (const divider of dockDividers) {
+    occluders.push({
+      id: `dock-divider:${divider.path.length > 0 ? divider.path.join(".") : "root"}`,
+      paneId: null,
+      rect: {
+        x: divider.rect.x,
+        y: divider.rect.y + HEADER_HEIGHT,
+        width: divider.rect.width,
+        height: divider.rect.height,
+      },
+      // Dividers sit above docked native panes but below floating windows.
+      zIndex: 1,
+    });
+  }
 
   for (const occluder of transientOccluders) {
     occluders.push({
@@ -298,6 +320,18 @@ export function buildNativeWindowState(
   }
 
   return { paneLayers, occluders };
+}
+
+export function resolveNativeDockDividers(
+  dockDividers: readonly DockDividerLayout[],
+  dividerPreview: DividerPreviewState | null,
+): DockDividerLayout[] {
+  if (!dividerPreview) return [...dockDividers];
+  return dockDividers.map((divider) => (
+    divider.path.join(".") === dividerPreview.pathKey
+      ? { ...divider, rect: dividerPreview.rect, ratio: dividerPreview.ratio }
+      : divider
+  ));
 }
 
 function makeSnapGuides(width: number, height: number): SnapGuide[] {
@@ -498,7 +532,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
   const dragRef = useRef<DragMode | null>(null);
   const [dragFloatingRect, setDragFloatingRect] = useState<{ paneId: string; rect: FloatingRect } | null>(null);
   const [dragCursor, setDragCursor] = useState<{ x: number; y: number } | null>(null);
-  const [dividerPreview, setDividerPreview] = useState<{ pathKey: string; rect: LayoutBounds; ratio: number } | null>(null);
+  const [dividerPreview, setDividerPreview] = useState<DividerPreviewState | null>(null);
   const [dockPreview, setDockPreview] = useState<DragPreview | null>(null);
 
   const cancelActiveDrag = useCallback(() => {
@@ -622,6 +656,10 @@ export function Shell({ pluginRegistry }: ShellProps) {
 
     return occluders;
   }, [activeHoverOverlay, activePaneDrag, dockPreview, dragFloatingRect]);
+  const nativeDockDividers = useMemo(
+    () => resolveNativeDockDividers(dockDividerLayouts, dividerPreview),
+    [dividerPreview, dockDividerLayouts],
+  );
   const nativeWindowState = useMemo(
     () => buildNativeWindowState(
       dockedPanes.map((pane) => pane.instance.instanceId),
@@ -633,8 +671,9 @@ export function Shell({ pluginRegistry }: ShellProps) {
       dragFloatingRect,
       { open: overlayOpen, width, contentHeight },
       nativeTransientOccluders,
+      nativeDockDividers,
     ),
-    [contentHeight, dockedPanes, dragFloatingRect, floatingPanes, nativeTransientOccluders, overlayOpen, width],
+    [contentHeight, dockedPanes, dragFloatingRect, floatingPanes, nativeDockDividers, nativeTransientOccluders, overlayOpen, width],
   );
 
   useEffect(() => {
@@ -1055,6 +1094,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
             top={rect.y}
             width={rect.width}
             height={rect.height}
+            zIndex={active ? 2 : 1}
             backgroundColor={active ? colors.borderFocused : colors.border}
           />
         );


### PR DESCRIPTION
This keeps the dock resize separator above native pane content after docking, moving, and gridlock transitions. It reserves dock divider cells in the native occlusion map, tracks live divider preview rects during drag, and raises the divider overlay above docked panes. It also adds shell regressions for settled and live divider occlusion behavior. Verified with the targeted pane-manager and shell tests plus a tmux app smoke run.