### PR TITLE
Fix cached market resume and sub-unit cloud quotes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -36,6 +36,7 @@ import type { PaneTemplateContext, PaneTemplateCreateOptions, PaneTemplateInstan
 import type { PaneSettingField } from "./types/plugin";
 import type { TickerRecord, TickerMetadata, TickerPosition, Portfolio } from "./types/ticker";
 import type { DataProvider } from "./types/data-provider";
+import type { TickerFinancials } from "./types/financials";
 import type { BrokerContractRef } from "./types/instrument";
 import type { BrokerAccount } from "./types/trading";
 import { resolveTickerSearch, upsertTickerFromSearchResult } from "./utils/ticker-search";
@@ -512,6 +513,15 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
     });
   }, [performRefreshQuote]);
 
+  const primeCachedFinancials = useCallback((entries: Array<{ ticker: TickerRecord; financials: TickerFinancials }>) => {
+    const primeEntries = entries.flatMap(({ ticker, financials }) => {
+      const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+      return instrument ? [{ instrument, financials }] : [];
+    });
+    if (primeEntries.length === 0) return;
+    marketData.primeCachedFinancials(primeEntries);
+  }, [marketData]);
+
   // Ensure a portfolio exists in config, creating it if needed
   const ensurePortfolio = useCallback(async (
     portfolioId: string,
@@ -754,6 +764,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
           dataProvider,
           sessionSnapshot,
           dispatch,
+          primeCachedFinancials,
           refreshTicker,
           refreshQuote,
           autoImportBrokerPositions,
@@ -763,7 +774,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
         // Will show empty state
       }
     })();
-  }, [autoImportBrokerPositions, dataProvider, dispatch, tickerRepository, refreshQuote, refreshTicker, sessionSnapshot, state.config, state.initialized]);
+  }, [autoImportBrokerPositions, dataProvider, dispatch, primeCachedFinancials, tickerRepository, refreshQuote, refreshTicker, sessionSnapshot, state.config, state.initialized]);
 
   const focusedTickerSymbol = getFocusedTickerSymbol(state);
 

--- a/src/market-data/coordinator.test.ts
+++ b/src/market-data/coordinator.test.ts
@@ -290,4 +290,84 @@ describe("MarketDataCoordinator", () => {
     expect(coordinator.getQuoteEntry(instrument).data?.price).toBe(24.5);
     expect(coordinator.getLegacyFinancialsSync(instrument)?.quote?.price).toBe(0.245);
   });
+
+  it("hydrates legacy financials synchronously from primed cached data", () => {
+    const coordinator = new MarketDataCoordinator(createProvider());
+    const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+
+    coordinator.primeCachedFinancials([{
+      instrument,
+      financials: {
+        quote: {
+          symbol: "AAPL",
+          price: 246.63,
+          currency: "USD",
+          change: -2.17,
+          changePercent: -0.87,
+          marketCap: 3_640_775_908_600,
+          lastUpdated: 1_700_000_000_000,
+        },
+        fundamentals: {
+          trailingPE: 31.4,
+          forwardPE: 27.8,
+        },
+        profile: {
+          sector: "Technology",
+        },
+        annualStatements: [],
+        quarterlyStatements: [],
+        priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 248.8 }],
+      },
+    }]);
+
+    const financials = coordinator.getLegacyFinancialsSync(instrument);
+    expect(financials?.quote?.marketCap).toBe(3_640_775_908_600);
+    expect(financials?.fundamentals?.trailingPE).toBe(31.4);
+    expect(financials?.priceHistory[0]?.close).toBe(248.8);
+  });
+
+  it("merges live quote data with primed cached financials during resume", async () => {
+    const provider = createProvider({
+      getQuote: async () => ({
+        symbol: "AAPL",
+        price: 246.63,
+        currency: "USD",
+        change: -2.17,
+        changePercent: -0.87,
+        lastUpdated: 1_700_000_001_000,
+      }),
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+
+    coordinator.primeCachedFinancials([{
+      instrument,
+      financials: {
+        quote: {
+          symbol: "AAPL",
+          price: 248.8,
+          currency: "USD",
+          change: 0,
+          changePercent: 0,
+          marketCap: 3_640_775_908_600,
+          lastUpdated: 1_700_000_000_000,
+        },
+        fundamentals: {
+          trailingPE: 31.4,
+        },
+        profile: {
+          sector: "Technology",
+        },
+        annualStatements: [],
+        quarterlyStatements: [],
+        priceHistory: [],
+      },
+    }]);
+    await coordinator.loadQuote(instrument);
+
+    const financials = coordinator.getLegacyFinancialsSync(instrument);
+    expect(financials?.quote?.price).toBe(246.63);
+    expect(financials?.quote?.marketCap).toBe(3_640_775_908_600);
+    expect(financials?.fundamentals?.trailingPE).toBe(31.4);
+  });
 });

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -182,6 +182,72 @@ export class MarketDataCoordinator {
     );
   }
 
+  primeCachedFinancials(entries: Array<{ instrument: InstrumentRef; financials: TickerFinancials }>): void {
+    for (const { instrument, financials } of entries) {
+      const normalized = normalizeTickerFinancialsPriceHistory(financials);
+      const source = normalized.quote?.providerId ?? this.dataProvider.id;
+      const snapshotKey = buildSnapshotKey(instrument);
+      const quoteKey = buildQuoteKey(instrument);
+      const profileKey = buildProfileKey(instrument);
+      const fundamentalsKey = buildFundamentalsKey(instrument);
+      const statementsKey = buildStatementsKey(instrument);
+
+      if (this.snapshotStore.get(snapshotKey).phase === "idle") {
+        this.snapshotStore.set(
+          snapshotKey,
+          readyEntry(this.snapshotStore.get(snapshotKey), normalized, source, [], { keepLastGoodOnEmpty: true }),
+        );
+      }
+      if (normalized.quote && this.quoteStore.get(quoteKey).phase === "idle") {
+        this.quoteStore.set(
+          quoteKey,
+          readyEntry(this.quoteStore.get(quoteKey), normalized.quote, normalized.quote.providerId ?? source, []),
+        );
+      }
+      if (this.profileStore.get(profileKey).phase === "idle") {
+        this.profileStore.set(
+          profileKey,
+          readyEntry(this.profileStore.get(profileKey), normalized.profile ?? null, source, [], { keepLastGoodOnEmpty: true }),
+        );
+      }
+      if (this.fundamentalsStore.get(fundamentalsKey).phase === "idle") {
+        this.fundamentalsStore.set(
+          fundamentalsKey,
+          readyEntry(this.fundamentalsStore.get(fundamentalsKey), normalized.fundamentals ?? null, source, [], { keepLastGoodOnEmpty: true }),
+        );
+      }
+      if (this.statementsStore.get(statementsKey).phase === "idle") {
+        this.statementsStore.set(
+          statementsKey,
+          readyEntry(
+            this.statementsStore.get(statementsKey),
+            {
+              annualStatements: normalized.annualStatements ?? [],
+              quarterlyStatements: normalized.quarterlyStatements ?? [],
+            },
+            source,
+            [],
+            { keepLastGoodOnEmpty: true },
+          ),
+        );
+      }
+      if (normalized.priceHistory.length > 0) {
+        const chartRequest: ChartRequest = {
+          instrument,
+          range: "5Y",
+          granularity: "daily",
+        };
+        const chartKey = buildChartKey(chartRequest);
+        if (this.chartStore.get(chartKey).phase === "idle") {
+          this.chartStore.set(
+            chartKey,
+            readyEntry(this.chartStore.get(chartKey), normalized.priceHistory, source, [], { keepLastGoodOnEmpty: true }),
+          );
+        }
+      }
+    }
+  }
+
   prefetchTicker(instrument: InstrumentRef | null | undefined): void {
     if (!instrument) return;
     void this.loadSnapshot(instrument);

--- a/src/market-data/selectors.ts
+++ b/src/market-data/selectors.ts
@@ -2,6 +2,7 @@ import type { MarketDataRequestContext } from "../types/data-provider";
 import type { Quote, TickerFinancials } from "../types/financials";
 import type { InstrumentRef, NewsRequest, OptionsRequest, SecFilingsRequest, ChartRequest } from "./request-types";
 import type { QueryEntry } from "./result-types";
+import { hasLikelyQuoteUnitMismatch } from "../utils/currency-units";
 import { normalizePriceHistory } from "../utils/price-history";
 
 export function buildInstrumentKey(instrument: InstrumentRef): string {
@@ -91,14 +92,7 @@ export function hasLikelyPriceUnitMismatch(
   left: Quote | null | undefined,
   right: Quote | null | undefined,
 ): boolean {
-  if (!left?.currency || !right?.currency) return false;
-  if (left.currency !== right.currency) return false;
-  if (!Number.isFinite(left.price) || !Number.isFinite(right.price)) return false;
-  if (left.price <= 0 || right.price <= 0) return false;
-
-  const ratio = left.price / right.price;
-  const normalizedRatio = ratio >= 1 ? ratio : 1 / ratio;
-  return Math.abs(normalizedRatio - 100) / 100 < 0.05;
+  return hasLikelyQuoteUnitMismatch(left, right);
 }
 
 function mergeDefinedQuoteFields(

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { act, useReducer } from "react";
 import { testRender } from "@opentui/react/test-utils";
+import { AppPersistence } from "../../data/app-persistence";
 import { AppContext, appReducer, createInitialState, PaneInstanceProvider, type AppAction } from "../../state/app-context";
+import { ProviderRouter } from "../../sources/provider-router";
 import { cloneLayout, createDefaultConfig, type AppConfig, type BrokerInstanceConfig } from "../../types/config";
 import type { DataProvider } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
@@ -17,6 +22,7 @@ let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let harnessDispatch: React.Dispatch<AppAction> | null = null;
 let sharedCoordinator: MarketDataCoordinator | null = null;
 let harnessState: ReturnType<typeof createInitialState> | null = null;
+const tempPaths: string[] = [];
 
 const PortfolioPane = portfolioListPlugin.panes![0]!.component as (props: {
   paneId: string;
@@ -37,6 +43,12 @@ function createBrokerInstance(connectionMode: "gateway" | "flex", id = `ibkr-${c
       : { connectionMode, flex: { token: "token", queryId: "query" } },
     enabled: true,
   };
+}
+
+function createTempDbPath(name: string): string {
+  const path = join(tmpdir(), `gloomberb-portfolio-list-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  tempPaths.push(path);
+  return path;
 }
 
 function makeTicker(overrides: Partial<TickerRecord["metadata"]> = {}): TickerRecord {
@@ -233,6 +245,9 @@ afterEach(async () => {
   harnessState = null;
   setSharedRegistryForTests(undefined);
   await ibkrGatewayManager.removeInstance("ibkr-live");
+  for (const path of tempPaths.splice(0)) {
+    if (existsSync(path)) rmSync(path, { force: true });
+  }
 });
 
 describe("PortfolioListPane cash and margin UI", () => {
@@ -725,6 +740,174 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(frame).toContain("2B");
     expect(frame).toContain("25.0");
     expect(frame).toContain("22.0");
+  });
+
+  test("shows cached market cap on reopen for broker-linked rows", async () => {
+    const dbPath = createTempDbPath("cached-reopen-market-cap");
+    const persistence = new AppPersistence(dbPath);
+    const instrument = {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-live",
+      symbol: "AAPL",
+      localSymbol: "AAPL",
+      exchange: "SMART",
+      primaryExchange: "NASDAQ",
+      conId: 265598,
+    };
+    const cloudProvider: DataProvider = {
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          quote: makeQuote({
+            symbol: "AAPL",
+            price: 125,
+            marketCap: undefined,
+          }),
+          fundamentals: {
+            trailingPE: 25,
+          },
+          profile: {
+            sector: "Technology",
+          },
+        };
+      },
+      async getQuote() {
+        return makeQuote({
+          symbol: "AAPL",
+          price: 125,
+        });
+      },
+      async getExchangeRate() {
+        return 1;
+      },
+      async search() {
+        return [];
+      },
+      async getNews() {
+        return [];
+      },
+      async getArticleSummary() {
+        return null;
+      },
+      async getPriceHistory() {
+        return [];
+      },
+    };
+    const yahooProvider: DataProvider = {
+      ...cloudProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 124 }],
+          quote: makeQuote({
+            symbol: "AAPL",
+            price: 124,
+            marketCap: 2_000_000_000,
+          }),
+          fundamentals: {
+            forwardPE: 22,
+          },
+          profile: {
+            sector: "Technology",
+          },
+        };
+      },
+    };
+
+    const seedRouter = new ProviderRouter(yahooProvider, [cloudProvider], persistence.resources);
+    await seedRouter.getTickerFinancials("AAPL", "NASDAQ", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-live",
+      instrument,
+    });
+
+    let liveCalls = 0;
+    const cachedRouter = new ProviderRouter({
+      ...yahooProvider,
+      async getTickerFinancials() {
+        liveCalls += 1;
+        throw new Error("expected cached yahoo snapshot");
+      },
+    }, [{
+      ...cloudProvider,
+      async getTickerFinancials() {
+        liveCalls += 1;
+        throw new Error("expected cached cloud snapshot");
+      },
+    }], persistence.resources);
+    sharedCoordinator = new MarketDataCoordinator(cachedRouter);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    const cachedFinancials = cachedRouter.getCachedFinancialsForTargets([{
+      symbol: "AAPL",
+      exchange: "NASDAQ",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-live",
+      instrument,
+    }]);
+    sharedCoordinator.primeCachedFinancials([{
+      instrument: {
+        symbol: "AAPL",
+        exchange: "NASDAQ",
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-live",
+        instrument,
+      },
+      financials: cachedFinancials.get("AAPL")!,
+    }]);
+
+    const config = createPortfolioConfigWithColumns(
+      "broker:ibkr-live:DU12345",
+      ["ticker", "market_cap", "pe", "forward_pe"],
+      [createBrokerInstance("gateway", "ibkr-live")],
+    );
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="broker:ibkr-live:DU12345"
+        stateMutator={(state) => {
+          state.tickers = new Map([["AAPL", makeTicker({
+            portfolios: ["broker:ibkr-live:DU12345"],
+            positions: [{
+              portfolio: "broker:ibkr-live:DU12345",
+              shares: 10,
+              avgCost: 100,
+              currency: "USD",
+              broker: "ibkr",
+              brokerInstanceId: "ibkr-live",
+              brokerAccountId: "DU12345",
+            }],
+            broker_contracts: [instrument],
+          })]]);
+          state.financials = new Map();
+          state.paneState[TEST_PANE_ID] = {
+            collectionId: "broker:ibkr-live:DU12345",
+            cursorSymbol: "AAPL",
+            cashDrawerExpanded: false,
+          };
+        }}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(liveCalls).toBe(0);
+    expect(frame).toContain("2B");
+    expect(frame).toContain("25.0");
+    expect(frame).toContain("22.0");
+
+    persistence.close();
   });
 
   test("updates a non-selected broker-linked row from streamed quotes", async () => {

--- a/src/sources/gloomberb-cloud.test.ts
+++ b/src/sources/gloomberb-cloud.test.ts
@@ -15,11 +15,13 @@ const verifiedUser: AuthUser = {
 
 const originalEnsureVerifiedSession = apiClient.ensureVerifiedSession.bind(apiClient);
 const originalGetCloudHistory = apiClient.getCloudHistory.bind(apiClient);
+const originalGetCloudQuote = apiClient.getCloudQuote.bind(apiClient);
 const originalSubscribeQuotes = apiClient.subscribeQuotes.bind(apiClient);
 
 afterEach(() => {
   apiClient.ensureVerifiedSession = originalEnsureVerifiedSession;
   apiClient.getCloudHistory = originalGetCloudHistory;
+  apiClient.getCloudQuote = originalGetCloudQuote;
   apiClient.subscribeQuotes = originalSubscribeQuotes;
 });
 
@@ -89,17 +91,69 @@ describe("GloomberbCloudProvider", () => {
     });
   });
 
+  test("normalizes sub-unit cloud quotes to their main currency", async () => {
+    apiClient.ensureVerifiedSession = async () => verifiedUser;
+    apiClient.getCloudQuote = async () => ({
+      status: "success",
+      data: {
+        symbol: "IQE",
+        providerId: "gloomberb-cloud",
+        price: 23.1,
+        currency: "GBp",
+        change: -1.4,
+        changePercent: -5.71,
+        previousClose: 24.5,
+        lastUpdated: Date.now(),
+        dataSource: "delayed",
+      },
+    });
+
+    const provider = new GloomberbCloudProvider();
+    const quote = await provider.getQuote("IQE", "LSE");
+
+    expect(quote.currency).toBe("GBP");
+    expect(quote.price).toBeCloseTo(0.231, 8);
+    expect(quote.change).toBeCloseTo(-0.014, 8);
+    expect(quote.previousClose).toBeCloseTo(0.245, 8);
+  });
+
+  test("normalizes sub-unit cloud history using the response currency metadata", async () => {
+    apiClient.ensureVerifiedSession = async () => verifiedUser;
+    apiClient.getCloudHistory = async () => ({
+      status: "success",
+      providerMeta: {
+        currency: "GBp",
+      },
+      data: [{
+        date: "2026-03-27 10:15:00",
+        open: 22.55,
+        high: 23.4,
+        low: 22.1,
+        close: 23.1,
+      }],
+    });
+
+    const provider = new GloomberbCloudProvider();
+    const history = await provider.getPriceHistory("IQE", "LSE", "1Y");
+
+    expect(history[0]?.open).toBeCloseTo(0.2255, 8);
+    expect(history[0]?.high).toBeCloseTo(0.234, 8);
+    expect(history[0]?.low).toBeCloseTo(0.221, 8);
+    expect(history[0]?.close).toBeCloseTo(0.231, 8);
+  });
+
   test("preserves original target context when streaming quotes", () => {
     let unsubscribeCalled = false;
+    const seenQuotes: Array<{ price: number; currency: string }> = [];
     apiClient.subscribeQuotes = (_targets, onQuote) => {
       onQuote(
         { symbol: "AAPL", exchange: "NASDAQ" },
         {
           symbol: "AAPL",
           providerId: "gloomberb-cloud",
-          price: 200,
-          currency: "USD",
-          change: 1,
+          price: 23.1,
+          currency: "GBp",
+          change: -1.4,
           changePercent: 0.5,
           lastUpdated: Date.now(),
           dataSource: "live",
@@ -119,16 +173,24 @@ describe("GloomberbCloudProvider", () => {
         brokerId: "ibkr",
         brokerInstanceId: "ibkr-live",
       },
-    }], (target) => {
+    }], (target, quote) => {
       seenTargets.push({
         brokerId: target.context?.brokerId,
         brokerInstanceId: target.context?.brokerInstanceId,
+      });
+      seenQuotes.push({
+        price: quote.price,
+        currency: quote.currency,
       });
     });
 
     expect(seenTargets).toEqual([{
       brokerId: "ibkr",
       brokerInstanceId: "ibkr-live",
+    }]);
+    expect(seenQuotes).toEqual([{
+      price: 0.231,
+      currency: "GBP",
     }]);
 
     unsubscribe();

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -10,6 +10,7 @@ import {
   type CloudPricePointPayload,
   type CloudQuotePayload,
 } from "../utils/api-client";
+import { normalizePriceValueByDivisor, resolveCurrencyUnit } from "../utils/currency-units";
 import { createProviderMiss } from "./provider-errors";
 
 const providerId = "gloomberb-cloud" as const;
@@ -37,19 +38,36 @@ async function withCloudFallback<T>(load: () => Promise<T>, message: string): Pr
 }
 
 function mapQuote(quote: CloudQuotePayload): Quote {
+  const { currency, divisor } = resolveCurrencyUnit(quote.currency);
   return {
     ...quote,
+    currency: currency || quote.currency,
+    price: normalizePriceValueByDivisor(quote.price, divisor) ?? quote.price,
+    change: normalizePriceValueByDivisor(quote.change, divisor) ?? quote.change,
+    previousClose: normalizePriceValueByDivisor(quote.previousClose, divisor),
+    high52w: normalizePriceValueByDivisor(quote.high52w, divisor),
+    low52w: normalizePriceValueByDivisor(quote.low52w, divisor),
+    bid: normalizePriceValueByDivisor(quote.bid, divisor),
+    ask: normalizePriceValueByDivisor(quote.ask, divisor),
+    open: normalizePriceValueByDivisor(quote.open, divisor),
+    high: normalizePriceValueByDivisor(quote.high, divisor),
+    low: normalizePriceValueByDivisor(quote.low, divisor),
+    mark: normalizePriceValueByDivisor(quote.mark, divisor),
+    preMarketPrice: normalizePriceValueByDivisor(quote.preMarketPrice, divisor),
+    preMarketChange: normalizePriceValueByDivisor(quote.preMarketChange, divisor),
+    postMarketPrice: normalizePriceValueByDivisor(quote.postMarketPrice, divisor),
+    postMarketChange: normalizePriceValueByDivisor(quote.postMarketChange, divisor),
     providerId,
   };
 }
 
-function mapPricePoint(point: CloudPricePointPayload): PricePoint {
+function mapPricePoint(point: CloudPricePointPayload, divisor = 1): PricePoint {
   return {
     date: new Date(point.date),
-    open: point.open,
-    high: point.high,
-    low: point.low,
-    close: point.close,
+    open: normalizePriceValueByDivisor(point.open, divisor),
+    high: normalizePriceValueByDivisor(point.high, divisor),
+    low: normalizePriceValueByDivisor(point.low, divisor),
+    close: normalizePriceValueByDivisor(point.close, divisor) ?? point.close,
     volume: point.volume,
   };
 }
@@ -237,7 +255,9 @@ export class GloomberbCloudProvider implements DataProvider {
       () => apiClient.getCloudHistory(ticker, exchange, request),
       `Cloud chart data is unavailable for ${ticker}`,
     );
-    return unwrapRequiredCloudResponse(response, `Cloud chart data is unavailable for ${ticker}`).map(mapPricePoint);
+    const { divisor } = resolveCurrencyUnit(response.providerMeta?.currency);
+    return unwrapRequiredCloudResponse(response, `Cloud chart data is unavailable for ${ticker}`)
+      .map((point) => mapPricePoint(point, divisor));
   }
 
   async getDetailedPriceHistory(
@@ -259,7 +279,9 @@ export class GloomberbCloudProvider implements DataProvider {
       }),
       `Cloud detailed chart history is unavailable for ${ticker}`,
     );
-    return unwrapRequiredCloudResponse(response, `Cloud detailed chart history is unavailable for ${ticker}`).map(mapPricePoint);
+    const { divisor } = resolveCurrencyUnit(response.providerMeta?.currency);
+    return unwrapRequiredCloudResponse(response, `Cloud detailed chart history is unavailable for ${ticker}`)
+      .map((point) => mapPricePoint(point, divisor));
   }
 
   async getOptionsChain(_ticker: string, _exchange?: string, _expirationDate?: number, _context?: MarketDataRequestContext): Promise<OptionsChain> {

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -862,6 +862,97 @@ describe("ProviderRouter", () => {
     expect(merged.priceHistory[0]?.close).toBe(124);
   });
 
+  test("merges cached financial snapshots across multiple providers", async () => {
+    const dbPath = createTempDbPath("cached-provider-financial-merge");
+    const persistence = new AppPersistence(dbPath);
+
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          quote: {
+            symbol: "AAPL",
+            price: 125,
+            currency: "USD",
+            change: 2,
+            changePercent: 1.6,
+            lastUpdated: Date.now(),
+          },
+          fundamentals: {
+            trailingPE: 25,
+          },
+          profile: {
+            sector: "Technology",
+          },
+        };
+      },
+    };
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getTickerFinancials() {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 124 }],
+          quote: {
+            symbol: "AAPL",
+            price: 124,
+            currency: "USD",
+            change: 1,
+            changePercent: 0.8,
+            marketCap: 2_000_000_000,
+            lastUpdated: Date.now(),
+          },
+          fundamentals: {
+            forwardPE: 22,
+          },
+        };
+      },
+    };
+
+    const seedRouter = new ProviderRouter(yahooProvider, [cloudProvider], persistence.resources);
+    const seeded = await seedRouter.getTickerFinancials("AAPL", "NASDAQ");
+    expect(seeded.quote?.marketCap).toBe(2_000_000_000);
+
+    let cloudCalls = 0;
+    let yahooCalls = 0;
+    const cachedRouter = new ProviderRouter({
+      ...yahooProvider,
+      async getTickerFinancials() {
+        yahooCalls += 1;
+        throw new Error("expected cached yahoo financials");
+      },
+    }, [{
+      ...cloudProvider,
+      async getTickerFinancials() {
+        cloudCalls += 1;
+        throw new Error("expected cached cloud financials");
+      },
+    }], persistence.resources);
+
+    const cached = await cachedRouter.getTickerFinancials("AAPL", "NASDAQ");
+
+    expect(cloudCalls).toBe(0);
+    expect(yahooCalls).toBe(0);
+    expect(cached.quote?.price).toBe(125);
+    expect(cached.quote?.marketCap).toBe(2_000_000_000);
+    expect(cached.fundamentals?.trailingPE).toBe(25);
+    expect(cached.fundamentals?.forwardPE).toBe(22);
+    expect(cached.profile?.sector).toBe("Technology");
+    expect(cached.priceHistory[0]?.close).toBe(124);
+
+    persistence.close();
+  });
+
   test("refreshes missing profile data even when cached financials exist", async () => {
     const dbPath = createTempDbPath("cache-profile-refresh");
     const persistence = new AppPersistence(dbPath);
@@ -1081,6 +1172,111 @@ describe("ProviderRouter", () => {
       brokerInstanceId: "ibkr-flex",
     }], { allowExpired: true });
     expect(cached.get("IQE")?.quote?.price).toBe(0.245);
+
+    persistence.close();
+  });
+
+  test("returns merged cached provider financials on cold start when sub-unit quotes exist", async () => {
+    const dbPath = createTempDbPath("cached-sub-unit-financials");
+    const persistence = new AppPersistence(dbPath);
+    const now = Date.now();
+
+    persistence.resources.set(
+      {
+        namespace: "market",
+        kind: "financials",
+        entityKey: "contract:14075064",
+        variantKey: "exchange=LSE",
+        sourceKey: "provider:gloomberb-cloud",
+      },
+      {
+        annualStatements: [],
+        quarterlyStatements: [],
+        priceHistory: [],
+        quote: {
+          symbol: "IQE",
+          price: 23.1,
+          currency: "GBp",
+          change: -1.4,
+          changePercent: -5.71,
+          previousClose: 24.5,
+          lastUpdated: now,
+          dataSource: "delayed",
+        },
+        profile: {
+          description: "Cloud profile",
+        },
+      },
+      {
+        cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
+        fetchedAt: now,
+      },
+    );
+    persistence.resources.set(
+      {
+        namespace: "market",
+        kind: "financials",
+        entityKey: "contract:14075064",
+        variantKey: "exchange=LSE",
+        sourceKey: "provider:yahoo",
+      },
+      {
+        annualStatements: [],
+        quarterlyStatements: [],
+        priceHistory: [],
+        quote: {
+          symbol: "IQE.L",
+          price: 0.231,
+          currency: "GBP",
+          change: -0.014,
+          changePercent: -5.71,
+          previousClose: 0.245,
+          lastUpdated: now,
+          dataSource: "yahoo",
+        },
+        fundamentals: {
+          revenue: 1000,
+        },
+      },
+      {
+        cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
+        fetchedAt: now,
+      },
+    );
+
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 200,
+      async getTickerFinancials() {
+        throw new Error("should not fetch yahoo financials");
+      },
+    };
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "gloomberb-cloud",
+      name: "Cloud",
+      priority: 100,
+      async getTickerFinancials() {
+        throw new Error("should not fetch cloud financials");
+      },
+    };
+    const router = new ProviderRouter(yahooProvider, [cloudProvider], persistence.resources);
+
+    const financials = await router.getTickerFinancials("IQE", "LSE", {
+      instrument: {
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-personal",
+        conId: 14075064,
+        symbol: "IQE",
+      },
+    });
+
+    expect(financials.quote?.price).toBe(0.231);
+    expect(financials.quote?.currency).toBe("GBP");
+    expect(financials.fundamentals?.revenue).toBe(1000);
+    expect(financials.profile?.description).toBe("Cloud profile");
 
     persistence.close();
   });

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -4,6 +4,7 @@ import type { BrokerAdapter } from "../types/broker";
 import type { AppConfig } from "../types/config";
 import { createDefaultConfig } from "../types/config";
 import type {
+  CachedFinancialsTarget,
   DataProvider,
   MarketDataRequestContext,
   NewsItem,
@@ -15,7 +16,7 @@ import type { OptionsChain, PricePoint, Quote, TickerFinancials } from "../types
 import type { BrokerContractRef, InstrumentSearchResult } from "../types/instrument";
 import type { CachePolicy, CachePolicyMap } from "../types/persistence";
 import type { TimeRange } from "../components/chart/chart-types";
-import type { HydrationTarget } from "../state/session-persistence";
+import { hasLikelyQuoteUnitMismatch } from "../utils/currency-units";
 import { debugLog } from "../utils/debug-log";
 import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../utils/price-history";
 import { isProviderMiss } from "./provider-errors";
@@ -121,17 +122,7 @@ function hasMeaningfulProfile(data: TickerFinancials | null | undefined): boolea
 }
 
 function hasLikelyPriceUnitMismatch(primary: TickerFinancials, fallback: TickerFinancials): boolean {
-  const primaryQuote = primary.quote;
-  const fallbackQuote = fallback.quote;
-  if (!primaryQuote || !fallbackQuote) return false;
-  if (!primaryQuote.currency || !fallbackQuote.currency) return false;
-  if (primaryQuote.currency !== fallbackQuote.currency) return false;
-  if (!Number.isFinite(primaryQuote.price) || !Number.isFinite(fallbackQuote.price)) return false;
-  if (primaryQuote.price <= 0 || fallbackQuote.price <= 0) return false;
-
-  const ratio = primaryQuote.price / fallbackQuote.price;
-  const normalizedRatio = ratio >= 1 ? ratio : 1 / ratio;
-  return Math.abs(normalizedRatio - 100) / 100 < 0.05;
+  return hasLikelyQuoteUnitMismatch(primary.quote, fallback.quote);
 }
 
 function mergeDefinedObject<T extends object>(preferred: T | null | undefined, fallback: T | null | undefined): T | undefined {
@@ -172,9 +163,27 @@ function mergeFinancials(primary: TickerFinancials | null, fallback: TickerFinan
   };
 }
 
+function mergeCachedFinancialRecords(records: CachedResourceRecord<TickerFinancials>[]): {
+  value: TickerFinancials | null;
+  stale: boolean;
+} {
+  const seenSources = new Set<string>();
+  let merged: TickerFinancials | null = null;
+  let stale = false;
+
+  for (const record of records) {
+    if (seenSources.has(record.sourceKey)) continue;
+    seenSources.add(record.sourceKey);
+    merged = mergeFinancials(merged, record.value);
+    stale = stale || record.stale;
+  }
+
+  return { value: merged, stale };
+}
+
 interface CachedFinancialsSelection {
   brokerRecord: CachedResourceRecord<TickerFinancials> | null;
-  providerRecord: CachedResourceRecord<TickerFinancials> | null;
+  providerValue: TickerFinancials | null;
   value: TickerFinancials | null;
   stale: boolean;
 }
@@ -230,7 +239,7 @@ export class ProviderRouter implements DataProvider {
     return false;
   }
 
-  getCachedFinancialsForTargets(targets: HydrationTarget[], options: { allowExpired?: boolean } = {}): Map<string, TickerFinancials> {
+  getCachedFinancialsForTargets(targets: CachedFinancialsTarget[], options: { allowExpired?: boolean } = {}): Map<string, TickerFinancials> {
     const results = new Map<string, TickerFinancials>();
     for (const target of targets) {
       const cached = this.readCachedMergedFinancials(target.symbol, target.exchange, {
@@ -270,7 +279,7 @@ export class ProviderRouter implements DataProvider {
       const providerResult = await this.fetchProviderFinancials(ticker, exchange, context);
       return mergeFinancials(
         brokerResult?.value ?? cached.brokerRecord?.value ?? null,
-        providerResult?.value ?? cached.providerRecord?.value ?? null,
+        providerResult?.value ?? cached.providerValue ?? null,
       ) ?? cached.value;
     }
 
@@ -706,12 +715,20 @@ export class ProviderRouter implements DataProvider {
     const brokerRecord = brokerSourceKeys.length > 0
       ? this.selectCachedResource<TickerFinancials>("financials", entityKey, variantKeys, brokerSourceKeys, allowExpired)
       : null;
-    const providerRecord = this.selectCachedResource<TickerFinancials>("financials", entityKey, variantKeys, this.getProviderSourceKeys(), allowExpired);
+    const providerSelection = mergeCachedFinancialRecords(
+      this.listCachedResources<TickerFinancials>(
+        "financials",
+        entityKey,
+        variantKeys,
+        this.getProviderSourceKeys(),
+        allowExpired,
+      ),
+    );
     return {
       brokerRecord,
-      providerRecord,
-      value: mergeFinancials(brokerRecord?.value ?? null, providerRecord?.value ?? null),
-      stale: (brokerRecord?.stale ?? false) || (providerRecord?.stale ?? false),
+      providerValue: providerSelection.value,
+      value: mergeFinancials(brokerRecord?.value ?? null, providerSelection.value),
+      stale: (brokerRecord?.stale ?? false) || providerSelection.stale,
     };
   }
 

--- a/src/state/app-bootstrap.test.ts
+++ b/src/state/app-bootstrap.test.ts
@@ -86,7 +86,7 @@ describe("initializeAppState", () => {
     persistence.close();
   });
 
-  test("uses quote warmup for collection panes and financial warmup for ticker panes", async () => {
+  test("uses quote warmup for quote-only collection panes and financial warmup for ticker panes", async () => {
     const dbPath = createTempDbPath("app-bootstrap-refresh-plan");
     const persistence = new AppPersistence(dbPath);
     const tickerRepository = new TickerRepository(persistence.tickers);
@@ -96,14 +96,30 @@ describe("initializeAppState", () => {
       layout: {
         ...defaultConfig.layout,
         dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
-        instances: defaultConfig.layout.instances.filter((instance) => instance.paneId === "portfolio-list"),
+        instances: defaultConfig.layout.instances
+          .filter((instance) => instance.paneId === "portfolio-list")
+          .map((instance) => ({
+            ...instance,
+            settings: {
+              ...(instance.settings ?? {}),
+              columnIds: ["ticker", "price", "change_pct", "latency"],
+            },
+          })),
       },
       layouts: defaultConfig.layouts.map((entry) => ({
         ...entry,
         layout: {
           ...entry.layout,
           dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
-          instances: entry.layout.instances.filter((instance) => instance.paneId === "portfolio-list"),
+          instances: entry.layout.instances
+            .filter((instance) => instance.paneId === "portfolio-list")
+            .map((instance) => ({
+              ...instance,
+              settings: {
+                ...(instance.settings ?? {}),
+                columnIds: ["ticker", "price", "change_pct", "latency"],
+              },
+            })),
         },
       })),
     };
@@ -154,6 +170,301 @@ describe("initializeAppState", () => {
 
     expect(financialRefreshes).toEqual(["AAPL"]);
     expect(quoteRefreshes).toEqual([]);
+
+    persistence.close();
+  });
+
+  test("uses financial warmup for collection panes that show fundamentals columns", async () => {
+    const dbPath = createTempDbPath("app-bootstrap-financial-collection");
+    const persistence = new AppPersistence(dbPath);
+    const tickerRepository = new TickerRepository(persistence.tickers);
+    const defaultConfig = createDefaultConfig(dbPath);
+    const financialCollectionConfig = {
+      ...defaultConfig,
+      layout: {
+        ...defaultConfig.layout,
+        dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        instances: defaultConfig.layout.instances
+          .filter((instance) => instance.paneId === "portfolio-list")
+          .map((instance) => ({
+            ...instance,
+            settings: {
+              ...(instance.settings ?? {}),
+              columnIds: ["ticker", "market_cap", "pe", "forward_pe"],
+            },
+          })),
+      },
+      layouts: defaultConfig.layouts.map((entry) => ({
+        ...entry,
+        layout: {
+          ...entry.layout,
+          dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+          instances: entry.layout.instances
+            .filter((instance) => instance.paneId === "portfolio-list")
+            .map((instance) => ({
+              ...instance,
+              settings: {
+                ...(instance.settings ?? {}),
+                columnIds: ["ticker", "market_cap", "pe", "forward_pe"],
+              },
+            })),
+        },
+      })),
+    };
+
+    await tickerRepository.createTicker({
+      ticker: "AAPL",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "Apple Inc.",
+      portfolios: [],
+      watchlists: ["main"],
+      positions: [],
+      broker_contracts: [],
+      custom: {},
+      tags: [],
+    });
+
+    const quoteRefreshes: string[] = [];
+    const financialRefreshes: string[] = [];
+
+    await initializeAppState({
+      config: financialCollectionConfig,
+      tickerRepository,
+      dataProvider: {} as any,
+      sessionSnapshot: null,
+      dispatch: () => {},
+      refreshTicker: (symbol) => { financialRefreshes.push(symbol); },
+      refreshQuote: (symbol) => { quoteRefreshes.push(symbol); },
+      autoImportBrokerPositions: async () => {},
+    });
+
+    expect(financialRefreshes).toEqual(["AAPL"]);
+    expect(quoteRefreshes).toEqual([]);
+
+    persistence.close();
+  });
+
+  test("restores background hydration targets even when another collection row is selected", async () => {
+    const dbPath = createTempDbPath("app-bootstrap-hydration-targets");
+    const persistence = new AppPersistence(dbPath);
+    const tickerRepository = new TickerRepository(persistence.tickers);
+    const defaultConfig = createDefaultConfig(dbPath);
+    const quoteOnlyConfig = {
+      ...defaultConfig,
+      layout: {
+        ...defaultConfig.layout,
+        dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        instances: defaultConfig.layout.instances
+          .filter((instance) => instance.paneId === "portfolio-list")
+          .map((instance) => ({
+            ...instance,
+            settings: {
+              ...(instance.settings ?? {}),
+              columnIds: ["ticker", "price", "change_pct", "latency"],
+            },
+          })),
+      },
+      layouts: defaultConfig.layouts.map((entry) => ({
+        ...entry,
+        layout: {
+          ...entry.layout,
+          dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+          instances: entry.layout.instances
+            .filter((instance) => instance.paneId === "portfolio-list")
+            .map((instance) => ({
+              ...instance,
+              settings: {
+                ...(instance.settings ?? {}),
+                columnIds: ["ticker", "price", "change_pct", "latency"],
+              },
+            })),
+        },
+      })),
+    };
+
+    await tickerRepository.createTicker({
+      ticker: "AAPL",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "Apple Inc.",
+      portfolios: [],
+      watchlists: ["main"],
+      positions: [],
+      broker_contracts: [],
+      custom: {},
+      tags: [],
+    });
+    await tickerRepository.createTicker({
+      ticker: "NVDA",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "NVIDIA Corporation",
+      portfolios: [],
+      watchlists: ["main"],
+      positions: [],
+      broker_contracts: [],
+      custom: {},
+      tags: [],
+    });
+
+    const quoteRefreshes: string[] = [];
+    const financialRefreshes: string[] = [];
+
+    await initializeAppState({
+      config: quoteOnlyConfig,
+      tickerRepository,
+      dataProvider: {} as any,
+      sessionSnapshot: {
+        paneState: {
+          "portfolio-list:main": {
+            collectionId: "main",
+            cursorSymbol: "NVDA",
+          },
+        },
+        focusedPaneId: "portfolio-list:main",
+        activePanel: "left",
+        statusBarVisible: true,
+        openPaneIds: ["portfolio-list:main"],
+        hydrationTargets: [{
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          instrument: null,
+        }],
+        exchangeCurrencies: [],
+        savedAt: Date.now(),
+      },
+      dispatch: () => {},
+      refreshTicker: (symbol) => { financialRefreshes.push(symbol); },
+      refreshQuote: (symbol) => { quoteRefreshes.push(symbol); },
+      autoImportBrokerPositions: async () => {},
+    });
+
+    expect(quoteRefreshes).toEqual(["NVDA"]);
+    expect(financialRefreshes).toEqual(["AAPL"]);
+
+    persistence.close();
+  });
+
+  test("primes cached financials for background hydration targets before initialization", async () => {
+    const dbPath = createTempDbPath("app-bootstrap-prime-cached-financials");
+    const persistence = new AppPersistence(dbPath);
+    const tickerRepository = new TickerRepository(persistence.tickers);
+    const defaultConfig = createDefaultConfig(dbPath);
+    const quoteOnlyConfig = {
+      ...defaultConfig,
+      layout: {
+        ...defaultConfig.layout,
+        dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        instances: defaultConfig.layout.instances
+          .filter((instance) => instance.paneId === "portfolio-list")
+          .map((instance) => ({
+            ...instance,
+            settings: {
+              ...(instance.settings ?? {}),
+              columnIds: ["ticker", "price", "change_pct", "latency"],
+            },
+          })),
+      },
+      layouts: defaultConfig.layouts.map((entry) => ({
+        ...entry,
+        layout: {
+          ...entry.layout,
+          dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+          instances: entry.layout.instances
+            .filter((instance) => instance.paneId === "portfolio-list")
+            .map((instance) => ({
+              ...instance,
+              settings: {
+                ...(instance.settings ?? {}),
+                columnIds: ["ticker", "price", "change_pct", "latency"],
+              },
+            })),
+        },
+      })),
+    };
+
+    await tickerRepository.createTicker({
+      ticker: "AAPL",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "Apple Inc.",
+      portfolios: [],
+      watchlists: ["main"],
+      positions: [],
+      broker_contracts: [],
+      custom: {},
+      tags: [],
+    });
+    await tickerRepository.createTicker({
+      ticker: "NVDA",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "NVIDIA Corporation",
+      portfolios: [],
+      watchlists: ["main"],
+      positions: [],
+      broker_contracts: [],
+      custom: {},
+      tags: [],
+    });
+
+    const events: string[] = [];
+
+    await initializeAppState({
+      config: quoteOnlyConfig,
+      tickerRepository,
+      dataProvider: {
+        id: "test-provider",
+        name: "Test Provider",
+        getCachedFinancialsForTargets: () => new Map([["AAPL", {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          quote: {
+            symbol: "AAPL",
+            price: 200,
+            currency: "USD",
+            change: 1,
+            changePercent: 0.5,
+            marketCap: 2_000_000_000,
+            lastUpdated: Date.now(),
+          },
+          fundamentals: {
+            trailingPE: 25,
+          },
+        }]]),
+      } as any,
+      sessionSnapshot: {
+        paneState: {
+          "portfolio-list:main": {
+            collectionId: "main",
+            cursorSymbol: "NVDA",
+          },
+        },
+        focusedPaneId: "portfolio-list:main",
+        activePanel: "left",
+        statusBarVisible: true,
+        openPaneIds: ["portfolio-list:main"],
+        hydrationTargets: [{
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          instrument: null,
+        }],
+        exchangeCurrencies: [],
+        savedAt: Date.now(),
+      },
+      dispatch: (action) => { events.push(action.type); },
+      primeCachedFinancials: (entries) => {
+        events.push(`prime:${entries.map((entry) => entry.ticker.metadata.ticker).join(",")}`);
+      },
+      refreshTicker: () => {},
+      refreshQuote: () => {},
+      autoImportBrokerPositions: async () => {},
+    });
+
+    expect(events).toContain("prime:AAPL");
+    expect(events.indexOf("prime:AAPL")).toBeLessThan(events.indexOf("SET_INITIALIZED"));
 
     persistence.close();
   });

--- a/src/state/app-bootstrap.ts
+++ b/src/state/app-bootstrap.ts
@@ -1,7 +1,8 @@
 import type { Dispatch } from "react";
 import type { TickerRepository } from "../data/ticker-repository";
 import { findPaneInstance, isTickerPaneId, type AppConfig } from "../types/config";
-import type { DataProvider } from "../types/data-provider";
+import type { CachedFinancialsTarget, DataProvider } from "../types/data-provider";
+import type { TickerFinancials } from "../types/financials";
 import type { BrokerAccount } from "../types/trading";
 import type { TickerMetadata, TickerRecord } from "../types/ticker";
 import type { AppAction, PaneRuntimeState } from "./app-context";
@@ -33,7 +34,13 @@ interface RefreshPlanEntry {
   mode: "quote" | "financials";
 }
 
-const MAX_BACKGROUND_WARMUP_TICKERS = 0;
+const MAX_BACKGROUND_WARMUP_TICKERS = 12;
+const PORTFOLIO_FINANCIAL_COLUMN_IDS = new Set([
+  "market_cap",
+  "pe",
+  "forward_pe",
+  "dividend_yield",
+]);
 
 export interface InitializeAppStateArgs {
   config: AppConfig;
@@ -41,6 +48,7 @@ export interface InitializeAppStateArgs {
   dataProvider: DataProvider;
   sessionSnapshot?: AppSessionSnapshot | null;
   dispatch: Dispatch<AppAction>;
+  primeCachedFinancials?: (entries: Array<{ ticker: TickerRecord; financials: TickerFinancials }>) => void;
   refreshTicker: (symbol: string, exchange?: string, tickerOverride?: TickerRecord | null, priority?: number) => void;
   refreshQuote: (symbol: string, exchange?: string, tickerOverride?: TickerRecord | null, priority?: number) => void;
   autoImportBrokerPositions: (tickerMap: Map<string, TickerRecord>) => Promise<void>;
@@ -136,28 +144,48 @@ function buildRefreshPlan(
     planBySymbol.set(symbol, { ticker, priority, mode });
   };
 
+  const resolveWarmupMode = (instance: AppConfig["layout"]["instances"][number] | undefined): RefreshPlanEntry["mode"] => {
+    if (!instance) return "quote";
+    if (isTickerPaneId(instance.paneId)) return "financials";
+    if (instance.paneId !== "portfolio-list") return "quote";
+
+    const columnIds = Array.isArray(instance.settings?.columnIds)
+      ? instance.settings.columnIds.filter((value): value is string => typeof value === "string")
+      : [];
+    return columnIds.some((columnId) => PORTFOLIO_FINANCIAL_COLUMN_IDS.has(columnId))
+      ? "financials"
+      : "quote";
+  };
+
   for (const instanceId of getDockedPaneIds(config.layout)) {
     const instance = findPaneInstance(config.layout, instanceId);
-    const mode = instance && isTickerPaneId(instance.paneId) ? "financials" : "quote";
-    enqueueSymbol(resolveSymbolForPane(config, instanceId, paneStateSeed, sessionSnapshot, tickerMap), 0, mode);
+    enqueueSymbol(
+      resolveSymbolForPane(config, instanceId, paneStateSeed, sessionSnapshot, tickerMap),
+      0,
+      resolveWarmupMode(instance),
+    );
   }
 
   for (const entry of config.layout.floating) {
     const instance = findPaneInstance(config.layout, entry.instanceId);
-    const mode = instance && isTickerPaneId(instance.paneId) ? "financials" : "quote";
-    enqueueSymbol(resolveSymbolForPane(config, entry.instanceId, paneStateSeed, sessionSnapshot, tickerMap), 1, mode);
-  }
-
-  const workingSetSymbols = new Set<string>();
-  for (const target of sessionSnapshot?.hydrationTargets ?? []) {
-    workingSetSymbols.add(target.symbol);
-  }
-  for (const symbol of config.recentTickers) {
-    workingSetSymbols.add(symbol);
+    enqueueSymbol(
+      resolveSymbolForPane(config, entry.instanceId, paneStateSeed, sessionSnapshot, tickerMap),
+      1,
+      resolveWarmupMode(instance),
+    );
   }
 
   let backgroundWarmups = 0;
-  for (const symbol of workingSetSymbols) {
+  for (const target of sessionSnapshot?.hydrationTargets ?? []) {
+    if (backgroundWarmups >= MAX_BACKGROUND_WARMUP_TICKERS) break;
+    const before = planBySymbol.size;
+    enqueueSymbol(target.symbol, 2, "financials");
+    if (planBySymbol.size > before) {
+      backgroundWarmups += 1;
+    }
+  }
+
+  for (const symbol of config.recentTickers) {
     if (backgroundWarmups >= MAX_BACKGROUND_WARMUP_TICKERS) break;
     const before = planBySymbol.size;
     enqueueSymbol(symbol, 2, "quote");
@@ -169,12 +197,56 @@ function buildRefreshPlan(
   return [...planBySymbol.values()].sort((left, right) => left.priority - right.priority);
 }
 
+function buildCachedFinancialTarget(ticker: TickerRecord): CachedFinancialsTarget {
+  const instrument = ticker.metadata.broker_contracts?.[0] ?? null;
+  return {
+    symbol: ticker.metadata.ticker,
+    exchange: ticker.metadata.exchange,
+    brokerId: instrument?.brokerId,
+    brokerInstanceId: instrument?.brokerInstanceId,
+    instrument,
+  };
+}
+
+function resolveCachedFinancialPrimeEntries(
+  refreshPlan: RefreshPlanEntry[],
+  sessionSnapshot: AppSessionSnapshot | null | undefined,
+  dataProvider: DataProvider,
+): Array<{ ticker: TickerRecord; financials: TickerFinancials }> {
+  if (!dataProvider.getCachedFinancialsForTargets) return [];
+
+  const sessionTargetsBySymbol = new Map<string, CachedFinancialsTarget>();
+  for (const target of sessionSnapshot?.hydrationTargets ?? []) {
+    sessionTargetsBySymbol.set(target.symbol.trim().toUpperCase(), target);
+  }
+
+  const financialEntries = refreshPlan.filter((entry) => entry.mode === "financials");
+  if (financialEntries.length === 0) return [];
+
+  const cachedFinancials = dataProvider.getCachedFinancialsForTargets(
+    financialEntries.map(({ ticker }) => (
+      sessionTargetsBySymbol.get(ticker.metadata.ticker.trim().toUpperCase()) ?? buildCachedFinancialTarget(ticker)
+    )),
+  );
+  const primedEntries: Array<{ ticker: TickerRecord; financials: TickerFinancials }> = [];
+
+  for (const entry of financialEntries) {
+    const cached = cachedFinancials.get(entry.ticker.metadata.ticker.trim().toUpperCase());
+    if (cached) {
+      primedEntries.push({ ticker: entry.ticker, financials: cached });
+    }
+  }
+
+  return primedEntries;
+}
+
 export async function initializeAppState({
   config,
   tickerRepository,
   dataProvider,
   sessionSnapshot,
   dispatch,
+  primeCachedFinancials,
   refreshTicker,
   refreshQuote,
   autoImportBrokerPositions,
@@ -214,9 +286,17 @@ export async function initializeAppState({
     dispatch({ type: "UPDATE_PANE_STATE", paneId, patch });
   }
 
+  const refreshPlan = buildRefreshPlan(config, tickerMap, paneStateSeed, sessionSnapshot);
+  if (primeCachedFinancials) {
+    const cachedPrimeEntries = resolveCachedFinancialPrimeEntries(refreshPlan, sessionSnapshot, dataProvider);
+    if (cachedPrimeEntries.length > 0) {
+      primeCachedFinancials(cachedPrimeEntries);
+    }
+  }
+
   dispatch({ type: "SET_INITIALIZED" });
 
-  for (const entry of buildRefreshPlan(config, tickerMap, paneStateSeed, sessionSnapshot)) {
+  for (const entry of refreshPlan) {
     if (entry.mode === "financials") {
       refreshTicker(entry.ticker.metadata.ticker, entry.ticker.metadata.exchange, entry.ticker, entry.priority);
     } else {

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -12,6 +12,7 @@ import type { SessionStore } from "../data/session-store";
 import { saveConfig } from "../data/config-store";
 import { applyTheme } from "../theme/colors";
 import { isBrokerPortfolioId } from "../utils/broker-instances";
+import { hasLikelyQuoteUnitMismatch } from "../utils/currency-units";
 import {
   cloneLayout,
   DEFAULT_LAYOUT,
@@ -135,14 +136,7 @@ function shouldPreserveUnknownCollectionId(collectionId: string | undefined): bo
 }
 
 function hasLikelyPriceUnitMismatch(current: Quote | undefined, next: Quote): boolean {
-  if (!current?.currency || !next.currency) return false;
-  if (current.currency !== next.currency) return false;
-  if (!Number.isFinite(current.price) || !Number.isFinite(next.price)) return false;
-  if (current.price <= 0 || next.price <= 0) return false;
-
-  const ratio = current.price / next.price;
-  const normalizedRatio = ratio >= 1 ? ratio : 1 / ratio;
-  return Math.abs(normalizedRatio - 100) / 100 < 0.05;
+  return hasLikelyQuoteUnitMismatch(current, next);
 }
 
 function getConfiguredCollectionId(config: AppConfig, instance: PaneInstanceConfig): string {

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -32,6 +32,14 @@ export interface MarketDataRequestContext {
   cacheMode?: "default" | "refresh";
 }
 
+export interface CachedFinancialsTarget {
+  symbol: string;
+  exchange?: string;
+  brokerId?: string;
+  brokerInstanceId?: string;
+  instrument?: BrokerContractRef | null;
+}
+
 export interface SearchRequestContext {
   preferBroker?: boolean;
   brokerId?: string;
@@ -52,6 +60,7 @@ export interface DataProvider {
   readonly cachePolicy?: CachePolicyMap;
 
   canProvide?(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<boolean> | boolean;
+  getCachedFinancialsForTargets?(targets: CachedFinancialsTarget[], options?: { allowExpired?: boolean }): Map<string, TickerFinancials>;
   getTickerFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<TickerFinancials>;
   getQuote(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<Quote>;
   getExchangeRate(fromCurrency: string): Promise<number>;

--- a/src/utils/currency-units.test.ts
+++ b/src/utils/currency-units.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { hasLikelyQuoteUnitMismatch, normalizePriceValueByDivisor, resolveCurrencyUnit } from "./currency-units";
+
+describe("currency unit helpers", () => {
+  test("normalizes known sub-unit currencies to their main currency", () => {
+    expect(resolveCurrencyUnit("GBp")).toEqual({ currency: "GBP", divisor: 100 });
+    expect(resolveCurrencyUnit("GBP")).toEqual({ currency: "GBP", divisor: 1 });
+  });
+
+  test("scales quote prices by the configured divisor", () => {
+    expect(normalizePriceValueByDivisor(23.1, 100)).toBeCloseTo(0.231, 8);
+    expect(normalizePriceValueByDivisor(125, 1)).toBe(125);
+  });
+
+  test("detects sub-unit quotes that match the same main-currency price", () => {
+    expect(hasLikelyQuoteUnitMismatch(
+      { price: 23.1, currency: "GBp" },
+      { price: 0.231, currency: "GBP" },
+    )).toBe(true);
+  });
+
+  test("detects classic same-currency 100x mismatches", () => {
+    expect(hasLikelyQuoteUnitMismatch(
+      { price: 24.5, currency: "GBP" },
+      { price: 0.245, currency: "GBP" },
+    )).toBe(true);
+  });
+
+  test("detects likely 1000x mismatches for three-decimal currencies", () => {
+    expect(hasLikelyQuoteUnitMismatch(
+      { price: 721, currency: "KWD" },
+      { price: 0.721, currency: "KWD" },
+    )).toBe(true);
+  });
+
+  test("does not flag similar quotes that already use the same unit", () => {
+    expect(hasLikelyQuoteUnitMismatch(
+      { price: 0.231, currency: "GBP" },
+      { price: 0.245, currency: "GBP" },
+    )).toBe(false);
+  });
+
+  test("does not assume 1000x mismatches for ordinary two-decimal currencies", () => {
+    expect(hasLikelyQuoteUnitMismatch(
+      { price: 231, currency: "USD" },
+      { price: 0.231, currency: "USD" },
+    )).toBe(false);
+  });
+});

--- a/src/utils/currency-units.ts
+++ b/src/utils/currency-units.ts
@@ -1,0 +1,82 @@
+const SUB_UNIT_CURRENCIES: Record<string, { currency: string; divisor: number }> = {
+  GBp: { currency: "GBP", divisor: 100 },
+  GBX: { currency: "GBP", divisor: 100 },
+  ILA: { currency: "ILS", divisor: 100 },
+  ZAc: { currency: "ZAR", divisor: 100 },
+};
+
+const LIKELY_UNIT_MISMATCH_RATIOS: Record<string, number[]> = {
+  BHD: [1000],
+  GBP: [100],
+  ILS: [100],
+  JOD: [1000],
+  KWD: [1000],
+  OMR: [1000],
+  TND: [1000],
+  ZAR: [100],
+};
+
+export interface CurrencyUnitInfo {
+  currency: string;
+  divisor: number;
+}
+
+export function resolveCurrencyUnit(currency?: string | null): CurrencyUnitInfo {
+  const raw = (currency ?? "").trim();
+  if (!raw) {
+    return { currency: "", divisor: 1 };
+  }
+
+  const normalized = SUB_UNIT_CURRENCIES[raw];
+  if (normalized) {
+    return normalized;
+  }
+
+  return {
+    currency: raw.toUpperCase(),
+    divisor: 1,
+  };
+}
+
+export function normalizePriceValueByDivisor(value: number | undefined, divisor: number): number | undefined {
+  if (value == null || !Number.isFinite(value) || divisor === 1) return value;
+  return value / divisor;
+}
+
+function normalizedRatio(left: number, right: number): number {
+  const ratio = left / right;
+  return ratio >= 1 ? ratio : 1 / ratio;
+}
+
+function isRatioWithin(ratio: number, target: number, tolerance = 0.05): boolean {
+  return Math.abs(ratio - target) / target < tolerance;
+}
+
+function likelyUnitMismatchRatios(currency: string): number[] {
+  return LIKELY_UNIT_MISMATCH_RATIOS[currency] ?? [100];
+}
+
+export function hasLikelyQuoteUnitMismatch(
+  left: { currency?: string; price: number } | null | undefined,
+  right: { currency?: string; price: number } | null | undefined,
+): boolean {
+  if (!left || !right) return false;
+
+  const leftUnit = resolveCurrencyUnit(left.currency);
+  const rightUnit = resolveCurrencyUnit(right.currency);
+  if (!leftUnit.currency || !rightUnit.currency) return false;
+  if (leftUnit.currency !== rightUnit.currency) return false;
+  if (!Number.isFinite(left.price) || !Number.isFinite(right.price)) return false;
+  if (left.price <= 0 || right.price <= 0) return false;
+
+  if (leftUnit.divisor !== rightUnit.divisor) {
+    const leftCanonicalPrice = left.price / leftUnit.divisor;
+    const rightCanonicalPrice = right.price / rightUnit.divisor;
+    if (isRatioWithin(normalizedRatio(leftCanonicalPrice, rightCanonicalPrice), 1)) {
+      return true;
+    }
+  }
+
+  const ratio = normalizedRatio(left.price, right.price);
+  return likelyUnitMismatchRatios(leftUnit.currency).some((target) => isRatioWithin(ratio, target));
+}


### PR DESCRIPTION
Normalize sub-unit currency quotes and history from gloomberb-cloud, and centralize quote unit mismatch detection so GBp/GBP and similar contracts stop mis-scaling. Merge cached provider financial snapshots on cold start, keep broker/provider mismatch handling, and prime cached financials for hydration targets before app initialization. Portfolio panes that show MCAP/P/E now warm financials for background resume targets so broker-linked rows restore market cap and fundamentals immediately after reopen without render-time cache reads. Adds regression coverage for currency unit helpers, cloud normalization, provider cache merging, startup warmup and priming, coordinator resume, and broker-linked portfolio reopen.