### PR TITLE
Improve theme contrast defaults

### DIFF
--- a/src/components/layout/pane-header.tsx
+++ b/src/components/layout/pane-header.tsx
@@ -36,7 +36,7 @@ export function PaneHeader({
 
   return (
     <box height={PANE_HEADER_HEIGHT} width={width} backgroundColor={backgroundColor} flexDirection="row">
-      <text fg={paneTitleText(focused)} selectable={false}>
+      <text fg={paneTitleText(focused, floating)} selectable={false}>
         {`${PANE_HEADER_GRIP}${clippedTitle}${padding}${actionText}${closeText}`}
       </text>
     </box>

--- a/src/theme/color-utils.ts
+++ b/src/theme/color-utils.ts
@@ -1,0 +1,67 @@
+export function blendHex(a: string, b: string, ratio: number): string {
+  const parse = (hex: string) => {
+    const h = hex.replace("#", "");
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)] as const;
+  };
+  const [ar, ag, ab] = parse(a);
+  const [br, bg, bb] = parse(b);
+  const mix = (x: number, y: number) => Math.round(x + (y - x) * ratio).toString(16).padStart(2, "0");
+  return `#${mix(ar, br)}${mix(ag, bg)}${mix(ab, bb)}`;
+}
+
+function relativeLuminance(hex: string): number {
+  const h = hex.replace("#", "");
+  const toLinear = (value: string) => {
+    const normalized = parseInt(value, 16) / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : Math.pow((normalized + 0.055) / 1.055, 2.4);
+  };
+  const r = toLinear(h.slice(0, 2));
+  const g = toLinear(h.slice(2, 4));
+  const b = toLinear(h.slice(4, 6));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function contrastRatio(a: string, b: string): number {
+  const lighter = Math.max(relativeLuminance(a), relativeLuminance(b));
+  const darker = Math.min(relativeLuminance(a), relativeLuminance(b));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+const CONTRAST_BLEND_STEPS = [0, 0.08, 0.14, 0.2, 0.28, 0.36, 0.48, 0.62, 0.78, 1] as const;
+
+export function blendForContrast(base: string, against: string, fallback: string, minContrast: number): string {
+  let candidate = base;
+
+  for (const ratio of CONTRAST_BLEND_STEPS) {
+    candidate = ratio === 0 ? base : blendHex(base, fallback, ratio);
+    if (contrastRatio(candidate, against) >= minContrast) {
+      return candidate;
+    }
+  }
+
+  return candidate;
+}
+
+export function blendForContrastOnSurfaces(
+  base: string,
+  surfaces: readonly string[],
+  fallback: string,
+  minContrast: number,
+): string {
+  let candidate = base;
+
+  for (const ratio of CONTRAST_BLEND_STEPS) {
+    candidate = ratio === 0 ? base : blendHex(base, fallback, ratio);
+    if (surfaces.every((surface) => contrastRatio(candidate, surface) >= minContrast)) {
+      return candidate;
+    }
+  }
+
+  return candidate;
+}
+
+export function higherContrast(a: string, b: string, against: string): string {
+  return contrastRatio(a, against) >= contrastRatio(b, against) ? a : b;
+}

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,3 +1,4 @@
+import { blendForContrast, blendHex, higherContrast } from "./color-utils";
 import { getTheme, DEFAULT_THEME, type Theme } from "./themes";
 
 // Mutable colors object — properties are updated in-place when the theme changes.
@@ -19,17 +20,7 @@ export function applyTheme(id: string): void {
 
 export type ColorKey = keyof typeof colors;
 
-/** Blend two hex colors by a ratio (0 = color a, 1 = color b) */
-export function blendHex(a: string, b: string, ratio: number): string {
-  const parse = (hex: string) => {
-    const h = hex.replace("#", "");
-    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)] as const;
-  };
-  const [ar, ag, ab] = parse(a);
-  const [br, bg, bb] = parse(b);
-  const mix = (x: number, y: number) => Math.round(x + (y - x) * ratio).toString(16).padStart(2, "0");
-  return `#${mix(ar, br)}${mix(ag, bg)}${mix(ab, bb)}`;
-}
+export { blendHex } from "./color-utils";
 
 const COMPARISON_SERIES_COLORS = [
   "#5bc0eb",
@@ -46,44 +37,6 @@ const COMPARISON_SERIES_COLORS = [
 
 export function getComparisonSeriesColor(index: number): string {
   return COMPARISON_SERIES_COLORS[((index % COMPARISON_SERIES_COLORS.length) + COMPARISON_SERIES_COLORS.length) % COMPARISON_SERIES_COLORS.length]!;
-}
-
-function relativeLuminance(hex: string): number {
-  const h = hex.replace("#", "");
-  const toLinear = (value: string) => {
-    const normalized = parseInt(value, 16) / 255;
-    return normalized <= 0.03928
-      ? normalized / 12.92
-      : Math.pow((normalized + 0.055) / 1.055, 2.4);
-  };
-  const r = toLinear(h.slice(0, 2));
-  const g = toLinear(h.slice(2, 4));
-  const b = toLinear(h.slice(4, 6));
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-}
-
-function contrastRatio(a: string, b: string): number {
-  const lighter = Math.max(relativeLuminance(a), relativeLuminance(b));
-  const darker = Math.min(relativeLuminance(a), relativeLuminance(b));
-  return (lighter + 0.05) / (darker + 0.05);
-}
-
-function blendForContrast(base: string, against: string, fallback: string, minContrast: number): string {
-  const steps = [0, 0.08, 0.14, 0.2, 0.28, 0.36, 0.48, 0.62, 0.78, 1] as const;
-  let candidate = base;
-
-  for (const ratio of steps) {
-    candidate = ratio === 0 ? base : blendHex(base, fallback, ratio);
-    if (contrastRatio(candidate, against) >= minContrast) {
-      return candidate;
-    }
-  }
-
-  return candidate;
-}
-
-function higherContrast(a: string, b: string, against: string): string {
-  return contrastRatio(a, against) >= contrastRatio(b, against) ? a : b;
 }
 
 /** Returns a hover background color derived from bg and selected */
@@ -156,9 +109,15 @@ export function floatingPaneTitleBg(focused: boolean): string {
 }
 
 /** Title text color for panes */
-export function paneTitleText(focused: boolean): string {
-  if (focused) return colors.textBright;
-  return colors.textDim;
+export function paneTitleText(focused: boolean, floating = false): string {
+  const background = floating ? floatingPaneTitleBg(focused) : paneTitleBg(focused);
+  const preferred = focused
+    ? higherContrast(colors.textBright, colors.headerText, background)
+    : colors.textDim;
+  const fallback = focused
+    ? higherContrast(colors.text, "#f2f2f2", background)
+    : higherContrast(colors.text, colors.textBright, background);
+  return blendForContrast(preferred, background, fallback, focused ? 5.2 : 4.5);
 }
 
 /** Returns green for positive, red for negative, neutral for zero */

--- a/src/theme/themes.test.ts
+++ b/src/theme/themes.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, test } from "bun:test";
+import { applyTheme, floatingPaneTitleBg, paneTitleBg, paneTitleText } from "./colors";
+import { contrastRatio } from "./color-utils";
+import { DEFAULT_THEME, themes } from "./themes";
+
+const BODY_TEXT_MIN = 4.5;
+const SUBTLE_TEXT_MIN = 3.6;
+const CHROME_TEXT_MIN = 4.5;
+
+function assertMinContrast(themeId: string, label: string, fg: string, bg: string, min: number): void {
+  const ratio = contrastRatio(fg, bg);
+  if (ratio < min) {
+    throw new Error(`${themeId} ${label} contrast ${ratio.toFixed(2)} is below ${min}`);
+  }
+}
+
+afterEach(() => {
+  applyTheme(DEFAULT_THEME);
+});
+
+describe("theme contrast", () => {
+  test("keeps shared text roles readable on body surfaces", () => {
+    for (const [id, theme] of Object.entries(themes)) {
+      for (const [surfaceLabel, surface] of [["bg", theme.bg], ["panel", theme.panel]] as const) {
+        assertMinContrast(id, `text/${surfaceLabel}`, theme.text, surface, BODY_TEXT_MIN);
+        assertMinContrast(id, `textDim/${surfaceLabel}`, theme.textDim, surface, BODY_TEXT_MIN);
+        assertMinContrast(id, `textMuted/${surfaceLabel}`, theme.textMuted, surface, SUBTLE_TEXT_MIN);
+        assertMinContrast(id, `positive/${surfaceLabel}`, theme.positive, surface, SUBTLE_TEXT_MIN);
+        assertMinContrast(id, `negative/${surfaceLabel}`, theme.negative, surface, SUBTLE_TEXT_MIN);
+        assertMinContrast(id, `neutral/${surfaceLabel}`, theme.neutral, surface, SUBTLE_TEXT_MIN);
+      }
+
+      assertMinContrast(id, "headerText/header", theme.headerText, theme.header, BODY_TEXT_MIN);
+      assertMinContrast(id, "selectedText/selected", theme.selectedText, theme.selected, BODY_TEXT_MIN);
+    }
+  });
+
+  test("keeps unfocused pane chrome readable", () => {
+    for (const id of Object.keys(themes)) {
+      applyTheme(id);
+      assertMinContrast(id, "paneTitleText/unfocused", paneTitleText(false), paneTitleBg(false), CHROME_TEXT_MIN);
+      assertMinContrast(id, "floatingPaneTitleText/unfocused", paneTitleText(false, true), floatingPaneTitleBg(false), CHROME_TEXT_MIN);
+    }
+  });
+});

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -1,3 +1,5 @@
+import { blendForContrast, blendForContrastOnSurfaces, blendHex, contrastRatio, higherContrast } from "./color-utils";
+
 export interface Theme {
   name: string;
   description: string;
@@ -26,7 +28,79 @@ export interface Theme {
   commandBorder: string;
 }
 
-export const themes: Record<string, Theme> = {
+function highestMinimumContrast(surfaces: readonly string[], candidates: readonly string[]): string {
+  return candidates.reduce((best, candidate) => {
+    const bestScore = Math.min(...surfaces.map((surface) => contrastRatio(best, surface)));
+    const candidateScore = Math.min(...surfaces.map((surface) => contrastRatio(candidate, surface)));
+    return candidateScore > bestScore ? candidate : best;
+  });
+}
+
+function normalizeTheme(theme: Theme): Theme {
+  const bodySurfaces = [theme.bg, theme.panel] as const;
+  const text = blendForContrastOnSurfaces(
+    theme.text,
+    bodySurfaces,
+    highestMinimumContrast(bodySurfaces, [theme.textBright, theme.headerText, "#f2f2f2"]),
+    4.5,
+  );
+  const textDim = blendForContrastOnSurfaces(
+    theme.textDim,
+    bodySurfaces,
+    highestMinimumContrast(bodySurfaces, [text, theme.textBright, "#d0d7de"]),
+    4.5,
+  );
+  const textMuted = blendForContrastOnSurfaces(
+    theme.textMuted,
+    bodySurfaces,
+    highestMinimumContrast(bodySurfaces, [textDim, text, "#c0c7d1"]),
+    3.6,
+  );
+  const positive = blendForContrastOnSurfaces(
+    theme.positive,
+    bodySurfaces,
+    blendHex(theme.positive, theme.textBright, 0.5),
+    3.6,
+  );
+  const negative = blendForContrastOnSurfaces(
+    theme.negative,
+    bodySurfaces,
+    blendHex(theme.negative, theme.textBright, 0.45),
+    3.6,
+  );
+  const neutral = blendForContrastOnSurfaces(
+    theme.neutral,
+    bodySurfaces,
+    highestMinimumContrast(bodySurfaces, [textDim, text, "#c0c7d1"]),
+    3.6,
+  );
+  const headerText = blendForContrast(
+    theme.headerText,
+    theme.header,
+    higherContrast(text, theme.textBright, theme.header),
+    4.5,
+  );
+  const selectedText = blendForContrast(
+    theme.selectedText,
+    theme.selected,
+    higherContrast(text, theme.textBright, theme.selected),
+    4.5,
+  );
+
+  return {
+    ...theme,
+    text,
+    textDim,
+    textMuted,
+    positive,
+    negative,
+    neutral,
+    headerText,
+    selectedText,
+  };
+}
+
+const rawThemes: Record<string, Theme> = {
   amber: {
     name: "Amber",
     description: "Classic amber-on-black terminal",
@@ -401,6 +475,10 @@ export const themes: Record<string, Theme> = {
     commandBorder: "#ff6600",
   },
 };
+
+export const themes: Record<string, Theme> = Object.fromEntries(
+  Object.entries(rawThemes).map(([id, theme]) => [id, normalizeTheme(theme)]),
+) as Record<string, Theme>;
 
 export const DEFAULT_THEME = "amber";
 


### PR DESCRIPTION
## Summary
- normalize theme palettes so core text, muted text, status colors, and selected/header text keep stronger contrast on dark surfaces
- derive pane title text against the actual docked or floating title-bar background so unfocused windows stay readable
- add regression tests for theme contrast floors across body surfaces and pane chrome

## Testing
- bun test src/theme/themes.test.ts