### PR TITLE
Remove currency units from avg cost column

### DIFF
--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -319,9 +319,10 @@ describe("PortfolioListPane cash and margin UI", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toMatch(/AAPL\s+125\s+\+4\.17%/);
-    expect(frame).toContain("€100.00");
+    expect(frame).toContain("100");
     expect(frame).toContain("1.4k");
     expect(frame).toContain("+275");
+    expect(frame).not.toContain("€100.00");
     expect(frame).not.toContain("$137.50");
   });
 
@@ -435,11 +436,12 @@ describe("PortfolioListPane cash and margin UI", () => {
     await flushFrame();
 
     const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("$4.25");
+    expect(frame).toContain("4.25");
     expect(frame).toContain("5");
     expect(frame).toContain("850");
     expect(frame).toContain("1k");
     expect(frame).toContain("+150");
+    expect(frame).not.toContain("$4.25");
   });
 
   test("shows flex cash summary and hides unavailable margin metrics", async () => {

--- a/src/plugins/builtin/portfolio-list/metrics.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.ts
@@ -220,7 +220,7 @@ export function getColumnValue(
       return { text: totalShares !== 0 ? formatCompact(totalShares) : "—" };
     case "avg_cost":
       if (totalCostUnits === 0) return { text: "—" };
-      return { text: formatCurrency(totalCost / Math.abs(totalCostUnits), positionCurrency) };
+      return { text: formatPrice(totalCost / Math.abs(totalCostUnits)) };
     case "cost_basis":
       if (totalCost === 0) return { text: "—" };
       return { text: formatCompact(toBasePosition(totalCost)) };


### PR DESCRIPTION
## Summary
- render portfolio avg cost values with plain price formatting instead of currency formatting
- update portfolio list coverage for equity and option rows to assert avg cost no longer shows currency symbols

## Testing
- bun test src/plugins/builtin/portfolio-list.test.tsx