### PR TITLE
Show snap hint for half-window snaps

### DIFF
--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -9,7 +9,7 @@ import { setSharedRegistryForTests } from "../../plugins/registry";
 import { portfolioListPlugin } from "../../plugins/builtin/portfolio-list";
 import { StatusBar } from "./status-bar";
 import { Header } from "./header";
-import { buildNativeWindowState, resolveNativeDockDividers, Shell } from "./shell";
+import { buildNativeWindowState, finalizePaneDragRelease, resolveNativeDockDividers, Shell } from "./shell";
 import type { DataProvider } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
@@ -456,6 +456,29 @@ describe("Shell", () => {
     expect(harnessState?.paneState["portfolio-list:main"]?.cashDrawerExpanded).toBe(false);
     expect(layoutUpdates.length).toBe(1);
     expect(toasts).toEqual(["Retiled all panes"]);
+  });
+
+  test("shows the gridlock tip after snapping a pane to a half screen", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-snap-test");
+    const snapLayout = cloneLayout(config.layout);
+    snapLayout.dockRoot = { kind: "pane", instanceId: "portfolio-list:main" };
+    snapLayout.floating = [{ instanceId: "ticker-detail:main", x: 8, y: 2, width: 36, height: 12, zIndex: 75 }];
+
+    const result = finalizePaneDragRelease(
+      snapLayout,
+      "ticker-detail:main",
+      { x: 8, y: 2, width: 36, height: 12 },
+      { kind: "snap", position: "left", rect: { x: 0, y: 0, width: 50, height: 22 } },
+    );
+
+    expect(result.shouldShowGridlockTip).toBe(true);
+    expect(result.nextLayout.floating[0]).toEqual(expect.objectContaining({
+      instanceId: "ticker-detail:main",
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 22,
+    }));
   });
 
   test("closes the focused docked pane with Ctrl+W", async () => {

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -62,13 +62,6 @@ type SnapGuidePosition =
   | "bottom-left"
   | "bottom-right";
 
-function isCornerSnapPosition(position: SnapGuidePosition): boolean {
-  return position === "top-left"
-    || position === "top-right"
-    || position === "bottom-left"
-    || position === "bottom-right";
-}
-
 interface SnapGuide {
   position: SnapGuidePosition;
   triggerRect: LayoutBounds;
@@ -115,6 +108,11 @@ interface NativeTransientOccluder {
   id: string;
   rect: LayoutBounds;
   zIndex: number;
+}
+
+interface PaneDragReleaseResult {
+  nextLayout: LayoutConfig;
+  shouldShowGridlockTip: boolean;
 }
 
 type DragMode =
@@ -331,6 +329,32 @@ export function resolveNativeDockDividers(
       ? { ...divider, rect: dividerPreview.rect, ratio: dividerPreview.ratio }
       : divider
   ));
+}
+
+export function finalizePaneDragRelease(
+  layout: LayoutConfig,
+  paneId: string,
+  previewRect: FloatingRect,
+  dockPreview: DragPreview | null,
+): PaneDragReleaseResult {
+  if (dockPreview?.kind === "dock") {
+    return {
+      nextLayout: applyDrop(layout, paneId, dockPreview.target),
+      shouldShowGridlockTip: false,
+    };
+  }
+
+  if (dockPreview?.kind === "snap") {
+    return {
+      nextLayout: floatAtRect(layout, paneId, dockPreview.rect),
+      shouldShowGridlockTip: true,
+    };
+  }
+
+  return {
+    nextLayout: floatAtRect(layout, paneId, previewRect),
+    shouldShowGridlockTip: false,
+  };
 }
 
 function makeSnapGuides(width: number, height: number): SnapGuide[] {
@@ -949,24 +973,13 @@ export function Shell({ pluginRegistry }: ShellProps) {
           setDockPreview(null);
           setDragCursor(null);
           setDragFloatingRect(null);
-        } else if (dockPreview?.kind === "dock") {
-          persistLayout(applyDrop(visibleLayout, drag.paneId, dockPreview.target));
+        } else {
+          const releaseResult = finalizePaneDragRelease(visibleLayout, drag.paneId, previewRect, dockPreview);
+          persistLayout(releaseResult.nextLayout);
           focusPane(drag.paneId);
-          setDockPreview(null);
-          setDragCursor(null);
-          setDragFloatingRect(null);
-        } else if (dockPreview?.kind === "snap") {
-          persistLayout(floatAtRect(visibleLayout, drag.paneId, dockPreview.rect));
-          focusPane(drag.paneId);
-          if (isCornerSnapPosition(dockPreview.position)) {
+          if (releaseResult.shouldShowGridlockTip) {
             dispatch({ type: "SHOW_GRIDLOCK_TIP" });
           }
-          setDockPreview(null);
-          setDragCursor(null);
-          setDragFloatingRect(null);
-        } else {
-          persistLayout(floatAtRect(visibleLayout, drag.paneId, previewRect));
-          focusPane(drag.paneId);
           setDockPreview(null);
           setDragCursor(null);
           setDragFloatingRect(null);


### PR DESCRIPTION
## Summary
- show the gridlock tip for any snap target, including half-window snaps
- factor pane-drag release handling into a shared helper and cover the half-snap case with a regression test

## Testing
- bun test src/components/layout/shell.test.tsx src/components/layout/status-bar.test.tsx
- repeated the same test run in tmux