### PR TITLE
Improve portfolio defaults and fix IBKR option P&L

### DIFF
--- a/src/components/markdown-text.tsx
+++ b/src/components/markdown-text.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+import { TextAttributes } from "@opentui/core";
+import { TickerBadge } from "./ticker-badge";
+import { tokenizeTickerText } from "../utils/ticker-tokenizer";
+import type { InlineTickerCatalogEntry } from "../state/use-inline-tickers";
+import { colors } from "../theme/colors";
+
+export interface MarkdownTextProps {
+  text: string;
+  lineWidth: number;
+  catalog: Record<string, InlineTickerCatalogEntry>;
+  textColor: string;
+  openTicker: (symbol: string) => void;
+}
+
+interface StyledSegment {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  dim?: boolean;
+  code?: boolean;
+  color?: string;
+}
+
+interface ParsedLine {
+  segments: StyledSegment[];
+  heading?: boolean;
+  indent?: number;
+}
+
+const INLINE_RE =
+  /(\*\*(?<bold>[^*]+)\*\*|(?<!\*)\*(?!\*)(?<italic>[^*]+)\*(?!\*)|`(?<code>[^`]+)`|~~(?<strike>[^~]+)~~)/g;
+
+function parseInlineMarkdown(text: string): StyledSegment[] {
+  const segments: StyledSegment[] = [];
+  let cursor = 0;
+
+  INLINE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = INLINE_RE.exec(text)) !== null) {
+    if (match.index > cursor) {
+      segments.push({ text: text.slice(cursor, match.index) });
+    }
+    if (match.groups?.bold != null) {
+      segments.push({ text: match.groups.bold, bold: true });
+    } else if (match.groups?.italic != null) {
+      segments.push({ text: match.groups.italic, italic: true });
+    } else if (match.groups?.code != null) {
+      segments.push({ text: match.groups.code, code: true });
+    } else if (match.groups?.strike != null) {
+      segments.push({ text: match.groups.strike, dim: true });
+    }
+    cursor = match.index + match[0].length;
+  }
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor) });
+  }
+  return segments;
+}
+
+function parseLine(line: string): ParsedLine {
+  // Headings
+  const headingMatch = line.match(/^(#{1,3})\s+(.+)$/);
+  if (headingMatch) {
+    return {
+      heading: true,
+      segments: [{ text: headingMatch[2]!, bold: true, color: colors.borderFocused }],
+    };
+  }
+
+  // List items
+  const listMatch = line.match(/^(\s*)([-*]|\d+\.)\s(.*)$/);
+  if (listMatch) {
+    const indent = listMatch[1]!.length;
+    const marker = listMatch[2]!;
+    const content = listMatch[3]!;
+    return {
+      indent,
+      segments: [
+        { text: `${marker} `, bold: true, color: colors.borderFocused },
+        ...parseInlineMarkdown(content),
+      ],
+    };
+  }
+
+  return { segments: parseInlineMarkdown(line) };
+}
+
+function SegmentSpan({ segment }: { segment: StyledSegment }) {
+  if (segment.code) {
+    return <span fg={colors.textDim}>{segment.text}</span>;
+  }
+  const attrs =
+    (segment.bold ? TextAttributes.BOLD : 0) |
+    (segment.italic ? TextAttributes.ITALIC : 0) |
+    (segment.dim ? TextAttributes.DIM : 0);
+  return (
+    <span
+      fg={segment.color ?? undefined}
+      attributes={attrs || undefined}
+    >
+      {segment.text}
+    </span>
+  );
+}
+
+function MarkdownLine({
+  parsed,
+  lineWidth,
+  catalog,
+  textColor,
+  openTicker,
+  hoveredSymbol,
+  onHover,
+}: {
+  parsed: ParsedLine;
+  lineWidth: number;
+  catalog: Record<string, InlineTickerCatalogEntry>;
+  textColor: string;
+  openTicker: (symbol: string) => void;
+  hoveredSymbol: string | null;
+  onHover: (symbol: string | null) => void;
+}) {
+  const indent = parsed.indent ?? 0;
+  const indentStr = indent > 0 ? " ".repeat(indent) : "";
+
+  // Check if any segment contains ticker symbols
+  const fullText = parsed.segments.map((s) => s.text).join("");
+  const tickerTokens = tokenizeTickerText(fullText);
+  const hasTickers = tickerTokens.some((t) => t.kind === "ticker" && catalog[t.symbol]?.status !== "missing");
+
+  if (!hasTickers) {
+    // Simple case: no tickers, render as styled text
+    return (
+      <text fg={textColor}>
+        {indentStr}
+        {parsed.segments.map((segment, i) => (
+          <SegmentSpan key={i} segment={segment} />
+        ))}
+      </text>
+    );
+  }
+
+  // Complex case: need to handle tickers within styled segments
+  // Render as a flex row to allow badge elements
+  return (
+    <box flexDirection="row" flexWrap="wrap" width={lineWidth}>
+      {indentStr ? <text fg={textColor}>{indentStr}</text> : null}
+      {parsed.segments.map((segment, segIdx) => {
+        const tokens = tokenizeTickerText(segment.text);
+        return tokens.map((token, tokIdx) => {
+          if (token.kind === "text") {
+            if (!token.value) return null;
+            return (
+              <text key={`${segIdx}:${tokIdx}`} fg={textColor}>
+                <SegmentSpan segment={{ ...segment, text: token.value }} />
+              </text>
+            );
+          }
+          const entry = catalog[token.symbol];
+          if (!entry || entry.status === "missing") {
+            return (
+              <text key={`${segIdx}:${tokIdx}`} fg={textColor}>
+                <SegmentSpan segment={{ ...segment, text: token.value }} />
+              </text>
+            );
+          }
+          return (
+            <TickerBadge
+              key={`badge:${segIdx}:${tokIdx}:${token.symbol}`}
+              symbol={token.symbol}
+              status={entry.status}
+              quote={entry.quote}
+              hovered={hoveredSymbol === token.symbol}
+              onHoverStart={() => onHover(token.symbol)}
+              onHoverEnd={() => onHover(null)}
+              onOpen={openTicker}
+            />
+          );
+        });
+      })}
+    </box>
+  );
+}
+
+export function MarkdownText({
+  text,
+  lineWidth,
+  catalog,
+  textColor,
+  openTicker,
+}: MarkdownTextProps) {
+  const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
+  const lines = text.split("\n");
+
+  return (
+    <box flexDirection="column" width={lineWidth}>
+      {lines.map((line, index) => {
+        if (line.trim() === "") {
+          return <text key={index}>{" "}</text>;
+        }
+        const parsed = parseLine(line);
+        return (
+          <MarkdownLine
+            key={index}
+            parsed={parsed}
+            lineWidth={lineWidth}
+            catalog={catalog}
+            textColor={textColor}
+            openTicker={openTicker}
+            hoveredSymbol={hoveredSymbol}
+            onHover={setHoveredSymbol}
+          />
+        );
+      })}
+    </box>
+  );
+}

--- a/src/data/config-store.test.ts
+++ b/src/data/config-store.test.ts
@@ -3,7 +3,13 @@ import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { loadConfig, sanitizeLayout, saveConfig } from "./config-store";
-import { CURRENT_CONFIG_VERSION, DEFAULT_LAYOUT, findPaneInstance } from "../types/config";
+import {
+  CURRENT_CONFIG_VERSION,
+  DEFAULT_COLUMNS,
+  DEFAULT_LAYOUT,
+  DEFAULT_PORTFOLIO_COLUMN_IDS,
+  findPaneInstance,
+} from "../types/config";
 import { getDockedPaneIds } from "../plugins/pane-manager";
 
 const tempDirs: string[] = [];
@@ -240,7 +246,7 @@ describe("loadConfig", () => {
   test("preserves IBKR gateway configs without migration rewrites", async () => {
     const dataDir = await createTempConfigDir();
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: 10,
+      configVersion: 11,
       brokerInstances: [{
         id: "ibkr-interactive-brokers",
         brokerType: "ibkr",
@@ -263,6 +269,37 @@ describe("loadConfig", () => {
       port: 4002,
       clientId: 1,
     });
+  });
+
+  test("migrates legacy main portfolio panes to the portfolio default columns", async () => {
+    const dataDir = await createTempConfigDir();
+    const legacyColumnIds = DEFAULT_COLUMNS.map((column) => column.id);
+    const legacyLayout = {
+      ...DEFAULT_LAYOUT,
+      instances: DEFAULT_LAYOUT.instances.map((instance) => (
+        instance.instanceId === "portfolio-list:main"
+          ? {
+            ...instance,
+            settings: {
+              ...(instance.settings ?? {}),
+              columnIds: legacyColumnIds,
+            },
+          }
+          : instance
+      )),
+    };
+
+    await writeConfigJson(dataDir, createSavedConfig({
+      configVersion: 10,
+      layout: legacyLayout,
+      layouts: [{ name: "Default", layout: legacyLayout }],
+    }));
+
+    const config = await loadConfig(dataDir);
+
+    expect(findPaneInstance(config.layout, "portfolio-list:main")?.settings?.columnIds).toEqual(DEFAULT_PORTFOLIO_COLUMN_IDS);
+    expect(findPaneInstance(config.layouts[0]?.layout ?? DEFAULT_LAYOUT, "portfolio-list:main")?.settings?.columnIds)
+      .toEqual(DEFAULT_PORTFOLIO_COLUMN_IDS);
   });
 
   test("falls back to the default layout when persisted layouts use the obsolete column shape", async () => {

--- a/src/data/config-store.ts
+++ b/src/data/config-store.ts
@@ -16,6 +16,8 @@ import {
   createDefaultConfig,
   createPaneInstanceId,
   CURRENT_CONFIG_VERSION,
+  DEFAULT_COLUMNS,
+  DEFAULT_PORTFOLIO_COLUMN_IDS,
   clonePaneSettings,
   normalizePaneLayout,
 } from "../types/config";
@@ -23,6 +25,7 @@ import type { Portfolio, Watchlist } from "../types/ticker";
 import { debugLog } from "../utils/debug-log";
 
 const configLog = debugLog.createLogger("config");
+const LEGACY_MAIN_PORTFOLIO_COLUMN_IDS = DEFAULT_COLUMNS.map((column) => column.id);
 
 function getGlobalConfigDir(): string {
   return join(process.env.HOME || "~", ".gloomberb");
@@ -62,8 +65,16 @@ async function loadConfigState(dataDir: string): Promise<{ config: AppConfig; ne
 
 function normalizeConfig(saved: Record<string, unknown>, dataDir: string): { config: AppConfig; needsSave: boolean } {
   const defaults = createDefaultConfig(dataDir);
-  const directLayout = sanitizeLayout(saved.layout, defaults.layout);
-  const layouts = sanitizeSavedLayouts(saved.layouts, directLayout);
+  const shouldMigratePortfolioDefaults =
+    typeof saved.configVersion !== "number" || saved.configVersion < CURRENT_CONFIG_VERSION;
+  const directLayout = migrateLegacyPortfolioDefaultColumns(
+    sanitizeLayout(saved.layout, defaults.layout),
+    shouldMigratePortfolioDefaults,
+  );
+  const layouts = sanitizeSavedLayouts(saved.layouts, directLayout).map((entry) => ({
+    ...entry,
+    layout: migrateLegacyPortfolioDefaultColumns(entry.layout, shouldMigratePortfolioDefaults),
+  }));
   const activeLayoutIndex = sanitizeActiveLayoutIndex(saved.activeLayoutIndex, layouts.length);
   const layout = cloneLayout(layouts[activeLayoutIndex]?.layout ?? directLayout);
   const syncedLayouts = layouts.map((entry, index) => (
@@ -385,6 +396,33 @@ function sanitizePaneSettings(value: unknown): Record<string, unknown> | undefin
   );
 
   return Object.keys(settings).length > 0 ? clonePaneSettings(settings) : undefined;
+}
+
+function hasExactColumnIds(value: unknown, expected: string[]): boolean {
+  return Array.isArray(value)
+    && value.length === expected.length
+    && value.every((entry, index) => entry === expected[index]);
+}
+
+function migrateLegacyPortfolioDefaultColumns(layout: LayoutConfig, enabled: boolean): LayoutConfig {
+  if (!enabled) return layout;
+
+  const instanceIndex = layout.instances.findIndex((instance) =>
+    instance.instanceId === "portfolio-list:main"
+    && instance.paneId === "portfolio-list"
+    && hasExactColumnIds(instance.settings?.columnIds, LEGACY_MAIN_PORTFOLIO_COLUMN_IDS)
+  );
+  if (instanceIndex < 0) return layout;
+
+  const nextLayout = cloneLayout(layout);
+  nextLayout.instances[instanceIndex] = {
+    ...nextLayout.instances[instanceIndex]!,
+    settings: {
+      ...(nextLayout.instances[instanceIndex]?.settings ?? {}),
+      columnIds: [...DEFAULT_PORTFOLIO_COLUMN_IDS],
+    },
+  };
+  return nextLayout;
 }
 
 function getDefaultFollowSourceInstanceId(instances: PaneInstanceConfig[]): string | null {

--- a/src/pane-settings.test.ts
+++ b/src/pane-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { cloneLayout, createDefaultConfig, createPaneInstance, type LayoutConfig } from "./types/config";
+import { cloneLayout, createDefaultConfig, createPaneInstance, DEFAULT_PORTFOLIO_COLUMN_IDS, type LayoutConfig } from "./types/config";
 import { deletePaneSetting, getPaneSettingValue, setPaneSetting } from "./pane-settings";
 
 describe("pane settings helpers", () => {
@@ -13,15 +13,7 @@ describe("pane settings helpers", () => {
       hideTabs: false,
       lockedCollectionId: "main",
     });
-    expect(portfolioPane?.settings?.columnIds).toEqual([
-      "ticker",
-      "price",
-      "change_pct",
-      "market_cap",
-      "pe",
-      "forward_pe",
-      "latency",
-    ]);
+    expect(portfolioPane?.settings?.columnIds).toEqual(DEFAULT_PORTFOLIO_COLUMN_IDS);
     expect(detailPane?.settings).toEqual({
       hideTabs: false,
       lockedTabId: "overview",
@@ -38,15 +30,7 @@ describe("pane settings helpers", () => {
     expect(clonedPortfolioSettings).not.toBe(originalPortfolioSettings);
 
     (clonedPortfolioSettings?.columnIds as string[]).push("change");
-    expect(originalPortfolioSettings?.columnIds).toEqual([
-      "ticker",
-      "price",
-      "change_pct",
-      "market_cap",
-      "pe",
-      "forward_pe",
-      "latency",
-    ]);
+    expect(originalPortfolioSettings?.columnIds).toEqual(DEFAULT_PORTFOLIO_COLUMN_IDS);
   });
 
   test("setPaneSetting and deletePaneSetting update pane-scoped settings immutably", () => {

--- a/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
+++ b/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
@@ -1,13 +1,13 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useKeyboard } from "@opentui/react";
 import { TextAttributes } from "@opentui/core";
-import type { InputRenderable } from "@opentui/core";
+import type { InputRenderable, ScrollBoxRenderable } from "@opentui/core";
 import type { DetailTabProps } from "../../../types/plugin";
 import { useAppState, usePaneTicker } from "../../../state/app-context";
 import { useFxRatesMap } from "../../../market-data/hooks";
 import { usePluginState } from "../../../plugins/plugin-runtime";
 import { useInlineTickers } from "../../../state/use-inline-tickers";
-import { TickerBadgeText } from "../../../components/ticker-badge-text";
+import { MarkdownText } from "../../../components/markdown-text";
 import { colors } from "../../../theme/colors";
 import { Spinner } from "../../../components/spinner";
 import { buildTickerAiContext } from "./ticker-context";
@@ -80,6 +80,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
   const [inputFocused, setInputFocused] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<InputRenderable>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
   const runRef = useRef<ReturnType<typeof runAiPrompt> | null>(null);
   const availableProviders = getAvailableProviders(providers);
   const currentProvider = providers.find((provider) => provider.id === providerId && provider.available)
@@ -116,13 +117,24 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
 
   useEffect(() => {
     if (!tickerSymbol || !currentProvider || messages.length === 0) return;
-    const trimmed = messages.filter((message) => !message.loading).slice(-ASK_AI_HISTORY_LIMIT);
+    const hasLoading = messages.some((message) => message.loading);
+    if (hasLoading) {
+      chatHistories.set(tickerSymbol, messages);
+      return;
+    }
+    const trimmed = messages.slice(-ASK_AI_HISTORY_LIMIT);
     chatHistories.set(tickerSymbol, trimmed);
     setPersistedConversation({
       updatedAt: Date.now(),
       messages: trimmed,
     });
   }, [currentProvider, messages, setPersistedConversation, tickerSymbol]);
+
+  useEffect(() => {
+    const sb = scrollRef.current;
+    if (!sb || messages.length === 0) return;
+    sb.scrollTo({ x: 0, y: Math.max(0, sb.scrollHeight - sb.viewport.height) });
+  }, [messages, focused]);
 
   const cycleProvider = useCallback(() => {
     if (availableProviders.length <= 1) return;
@@ -267,7 +279,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
         </box>
       </box>
 
-      <scrollbox height={chatHeight} scrollY>
+      <scrollbox ref={scrollRef} height={chatHeight} scrollY>
         <box flexDirection="column">
           {messages.length === 0 ? (
             <box paddingTop={1}>
@@ -289,7 +301,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
                 </box>
                 <box>
                   {message.content ? (
-                    <TickerBadgeText
+                    <MarkdownText
                       text={message.content}
                       lineWidth={contentWidth}
                       catalog={catalog}

--- a/src/plugins/builtin/portfolio-list/metrics.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.ts
@@ -57,6 +57,31 @@ function getPositionCurrency(
   return positions.find((position) => position.currency)?.currency || fallbackCurrency;
 }
 
+function normalizePositionMultiplier(multiplier: number | undefined): number {
+  return typeof multiplier === "number" && Number.isFinite(multiplier) && multiplier > 0
+    ? multiplier
+    : 1;
+}
+
+function resolvePositionCostMultiplier(
+  position: TickerRecord["metadata"]["positions"][number],
+): number {
+  const priceMultiplier = normalizePositionMultiplier(position.multiplier);
+  if (priceMultiplier === 1) return 1;
+
+  if (position.marketValue == null || position.unrealizedPnl == null) {
+    return priceMultiplier;
+  }
+
+  const costWithoutMultiplier = position.shares * position.avgCost;
+  const costWithMultiplier = costWithoutMultiplier * priceMultiplier;
+  const withoutMultiplierError = Math.abs((position.marketValue - costWithoutMultiplier) - position.unrealizedPnl);
+  const withMultiplierError = Math.abs((position.marketValue - costWithMultiplier) - position.unrealizedPnl);
+
+  // IBKR gateway derivatives can report avgCost already scaled to the contract.
+  return withoutMultiplierError < withMultiplierError ? 1 : priceMultiplier;
+}
+
 function getPortfolioPositionMetrics(
   ticker: TickerRecord,
   activeTab: string | undefined,
@@ -66,25 +91,24 @@ function getPortfolioPositionMetrics(
     ? ticker.metadata.positions.filter((position) => position.portfolio === activeTab)
     : ticker.metadata.positions;
   const positionCurrency = getPositionCurrency(tabPositions, fallbackCurrency);
-  const totalShares = tabPositions.reduce((sum, position) => sum + position.shares * (position.side === "short" ? -1 : 1), 0);
-  const totalCost = tabPositions.reduce(
-    (sum, position) => sum + position.shares * position.avgCost * (position.multiplier || 1),
-    0,
-  );
-  const totalCostUnits = tabPositions.reduce(
-    (sum, position) => sum + position.shares * (position.multiplier || 1),
-    0,
-  );
-  const totalPriceUnits = tabPositions.reduce(
-    (sum, position) => sum + position.shares * (position.multiplier || 1) * (position.side === "short" ? -1 : 1),
-    0,
-  );
-
+  let totalShares = 0;
+  let totalCost = 0;
+  let totalCostUnits = 0;
+  let totalPriceUnits = 0;
   let brokerMktValue = 0;
   let hasBrokerMktValue = false;
   let brokerPnl = 0;
   let hasBrokerPnl = false;
   for (const position of tabPositions) {
+    const direction = position.side === "short" ? -1 : 1;
+    const priceMultiplier = normalizePositionMultiplier(position.multiplier);
+    const costMultiplier = resolvePositionCostMultiplier(position);
+
+    totalShares += position.shares * direction;
+    totalCost += position.shares * position.avgCost * costMultiplier;
+    totalCostUnits += position.shares * costMultiplier;
+    totalPriceUnits += position.shares * priceMultiplier * direction;
+
     if (position.marketValue != null) {
       brokerMktValue += position.marketValue;
       hasBrokerMktValue = true;

--- a/src/plugins/builtin/portfolio-list/settings.ts
+++ b/src/plugins/builtin/portfolio-list/settings.ts
@@ -1,5 +1,5 @@
 import type { PaneSettingOption, PaneSettingsDef, PaneTemplateContext } from "../../../types/plugin";
-import { DEFAULT_COLUMNS, type AppConfig, type ColumnConfig } from "../../../types/config";
+import { DEFAULT_COLUMNS, DEFAULT_PORTFOLIO_COLUMN_IDS, type AppConfig, type ColumnConfig } from "../../../types/config";
 
 export type CollectionScope = "all" | "portfolios" | "watchlists" | "custom";
 
@@ -33,16 +33,6 @@ export const PORTFOLIO_COLUMN_DEFS: ColumnConfig[] = [
   { id: "mkt_value", label: "MKT VAL", width: 10, align: "right", format: "compact" },
   { id: "pnl", label: "P&L", width: 10, align: "right", format: "compact" },
   { id: "pnl_pct", label: "P&L%", width: 8, align: "right", format: "percent" },
-];
-
-export const DEFAULT_PORTFOLIO_COLUMN_IDS = [
-  ...DEFAULT_COLUMNS.map((column) => column.id),
-  "shares",
-  "avg_cost",
-  "cost_basis",
-  "mkt_value",
-  "pnl",
-  "pnl_pct",
 ];
 
 const PORTFOLIO_COLUMNS_BY_ID = new Map(PORTFOLIO_COLUMN_DEFS.map((column) => [column.id, column]));

--- a/src/plugins/builtin/portfolio-metrics.test.ts
+++ b/src/plugins/builtin/portfolio-metrics.test.ts
@@ -133,6 +133,77 @@ describe("portfolio-metrics", () => {
     });
   });
 
+  test("does not double-apply IBKR option multipliers when avgCost is already contract-scaled", () => {
+    const ticker = createTicker({
+      ticker: "AMD   270917C00230000",
+      assetCategory: "OPT",
+      positions: [{
+        portfolio: "main",
+        shares: 10,
+        avgCost: 5095.07295,
+        broker: "ibkr",
+        currency: "USD",
+        marketValue: 58803.06,
+        unrealizedPnl: 7852.33,
+        multiplier: 100,
+        markPrice: 58.8030586,
+      }],
+    });
+    const financialsMap = new Map<string, TickerFinancials>();
+
+    const totals = calculatePortfolioSummaryTotals(
+      [ticker],
+      financialsMap,
+      "USD",
+      new Map([["USD", 1]]),
+      true,
+      "main",
+    );
+
+    expect(totals.totalMktValue).toBeCloseTo(58803.06, 2);
+    expect(totals.totalCostBasis).toBeCloseTo(50950.7295, 4);
+    expect(totals.unrealizedPnl).toBeCloseTo(7852.3305, 4);
+    expect(totals.hasPositions).toBe(true);
+  });
+
+  test("keeps option avg cost display contract-scaled while using the correct cost basis", () => {
+    const ticker = createTicker({
+      ticker: "AMD   270917C00230000",
+      assetCategory: "OPT",
+      positions: [{
+        portfolio: "main",
+        shares: 10,
+        avgCost: 5095.07295,
+        broker: "ibkr",
+        currency: "USD",
+        marketValue: 58803.06,
+        unrealizedPnl: 7852.33,
+        multiplier: 100,
+        markPrice: 58.8030586,
+      }],
+    });
+    const financials = createFinancials({
+      quote: {
+        symbol: "AMD   270917C00230000",
+        price: 58.8030586,
+        currency: "USD",
+        change: 0,
+        changePercent: 0,
+        previousClose: 58.8030586,
+      },
+    });
+    const avgCostColumn: ColumnConfig = { id: "avg_cost", label: "AVG COST", width: 10, align: "right", format: "currency" };
+    const pnlColumn: ColumnConfig = { id: "pnl", label: "P&L", width: 10, align: "right", format: "compact" };
+
+    expect(getColumnValue(avgCostColumn, ticker, financials, defaultColumnContext)).toEqual({
+      text: "5,095.07",
+    });
+    expect(getColumnValue(pnlColumn, ticker, financials, defaultColumnContext)).toEqual({
+      text: "+7.9k",
+      color: expect.any(String),
+    });
+  });
+
   test("formats portfolio-only column values and sort keys consistently", () => {
     const ticker = createTicker({
       positions: [{ portfolio: "main", shares: 10, avgCost: 100, broker: "manual" }],

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,6 @@
 import type { Portfolio, Watchlist } from "./ticker";
 
-export const CURRENT_CONFIG_VERSION = 10;
+export const CURRENT_CONFIG_VERSION = 11;
 
 export type DefaultChartRenderMode = "area" | "line" | "candles" | "ohlc";
 export type ChartRendererPreference = "auto" | "kitty" | "braille";
@@ -134,6 +134,16 @@ export const DEFAULT_COLUMNS: ColumnConfig[] = [
   { id: "latency", label: "AGE", width: 6, align: "right" },
 ];
 
+export const DEFAULT_PORTFOLIO_COLUMN_IDS = [
+  ...DEFAULT_COLUMNS.map((column) => column.id),
+  "shares",
+  "avg_cost",
+  "cost_basis",
+  "mkt_value",
+  "pnl",
+  "pnl_pct",
+];
+
 export const DEFAULT_LAYOUT: LayoutConfig = {
   dockRoot: {
     kind: "split",
@@ -148,7 +158,7 @@ export const DEFAULT_LAYOUT: LayoutConfig = {
       paneId: "portfolio-list",
       params: { collectionId: "main" },
       settings: {
-        columnIds: DEFAULT_COLUMNS.map((column) => column.id),
+        columnIds: [...DEFAULT_PORTFOLIO_COLUMN_IDS],
         collectionScope: "all",
         visibleCollectionIds: [],
         hideTabs: false,


### PR DESCRIPTION
This updates the portfolio pane defaults by centralizing the default broker columns and migrating legacy main-layout configs onto the new default set. It also fixes IBKR portfolio summary math for gateway-imported derivatives by avoiding a second application of the contract multiplier when avgCost is already contract-scaled, with regression coverage for the header totals and row rendering. The Ask AI detail tab now preserves in-flight history, auto-scrolls, and renders markdown plus inline ticker badges through a new MarkdownText component. Validation: bun test src/data/config-store.test.ts src/pane-settings.test.ts src/plugins/builtin/ask-ai.test.tsx src/plugins/builtin/ai/index.test.tsx src/plugins/builtin/portfolio-metrics.test.ts src/plugins/builtin/portfolio-list.test.ts src/plugins/ibkr/gateway-service.test.ts.