### PR TITLE
Fix release update checks and add command bar action

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -70,7 +70,7 @@ import {
 } from "./plugins/prediction-markets/launch";
 import { saveConfig } from "./data/config-store";
 import { Toaster, toast } from "@opentui-ui/toast/react";
-import { canSelfUpdate, checkForUpdate, performUpdate } from "./updater";
+import { canSelfUpdate, checkForUpdateDetailed, performUpdate } from "./updater";
 import { VERSION } from "./version";
 import { join } from "path";
 import {
@@ -543,12 +543,46 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
     }
   }, [state.config.brokerInstances, importBrokerPositions]);
 
+  const runUpdateCheck = useCallback(async (manual = false) => {
+    if (manual) {
+      dispatch({ type: "SET_UPDATE_CHECK_IN_PROGRESS", checking: true });
+      dispatch({ type: "SET_UPDATE_NOTICE", notice: null });
+    }
+
+    const result = await checkForUpdateDetailed(VERSION);
+
+    if (!manual) {
+      if (result.kind === "available") {
+        dispatch({ type: "SET_UPDATE_AVAILABLE", release: result.release });
+      }
+      return;
+    }
+
+    dispatch({ type: "SET_UPDATE_CHECK_IN_PROGRESS", checking: false });
+
+    if (result.kind === "available") {
+      dispatch({ type: "SET_UPDATE_AVAILABLE", release: result.release });
+      return;
+    }
+
+    if (result.kind === "current") {
+      dispatch({ type: "SET_UPDATE_AVAILABLE", release: null });
+      dispatch({ type: "SET_UPDATE_NOTICE", notice: `Already on v${VERSION}` });
+      return;
+    }
+
+    if (result.kind === "disabled") {
+      dispatch({ type: "SET_UPDATE_NOTICE", notice: "Update checks are unavailable in source mode" });
+      return;
+    }
+
+    dispatch({ type: "SET_UPDATE_NOTICE", notice: `Update check failed: ${result.error}` });
+  }, [dispatch]);
+
   // Check for updates on mount
   useEffect(() => {
-    checkForUpdate(VERSION).then((release) => {
-      if (release) dispatch({ type: "SET_UPDATE_AVAILABLE", release });
-    });
-  }, []);
+    void runUpdateCheck(false);
+  }, [runUpdateCheck]);
 
   // Load tickers on mount
   useEffect(() => {
@@ -1155,7 +1189,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       if (actions.length > 0 && ticker) {
         dispatch({ type: "SET_COMMAND_BAR", open: true, query: "" });
       }
-    } else if (event.name === "u" && state.updateAvailable && !state.updateProgress && canSelfUpdate(state.updateAvailable)) {
+    } else if (event.name === "u" && state.updateAvailable && !state.updateProgress && !state.updateCheckInProgress && canSelfUpdate(state.updateAvailable)) {
       performUpdate(state.updateAvailable, (progress) => {
         dispatch({ type: "SET_UPDATE_PROGRESS", progress });
       });
@@ -1186,6 +1220,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
           tickerRepository={tickerRepository}
           pluginRegistry={pluginRegistry}
           quitApp={() => renderer.destroy()}
+          onCheckForUpdates={() => runUpdateCheck(true)}
         />
       )}
       <Toaster position="bottom-right" />

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -218,6 +218,7 @@ function CommandBarHarness({
   configurePluginRegistry,
   dataProvider = makeDataProvider(),
   hasPaneSettings,
+  onCheckForUpdates,
 }: {
   query: string;
   disabledPlugins?: string[];
@@ -231,6 +232,7 @@ function CommandBarHarness({
   configurePluginRegistry?: (pluginRegistry: PluginRegistry) => void;
   dataProvider?: DataProvider;
   hasPaneSettings?: (paneId: string) => boolean;
+  onCheckForUpdates?: () => void | Promise<void>;
 }) {
   let config = {
     ...createDefaultConfig("/tmp/gloomberb-test"),
@@ -285,6 +287,7 @@ function CommandBarHarness({
             tickerRepository={tickerRepository as any}
             pluginRegistry={pluginRegistry}
             quitApp={() => {}}
+            onCheckForUpdates={onCheckForUpdates}
           />
         )}
       </DialogProvider>
@@ -302,6 +305,25 @@ describe("CommandBar", () => {
     await testSetup.renderOnce();
 
     expect(testSetup.captureCharFrame()).toMatchSnapshot();
+  });
+
+  test("runs check for updates from the command bar", async () => {
+    const calls = [];
+
+    testSetup = await testRender(<CommandBarHarness query="check for updates" live onCheckForUpdates={() => { calls.push(Date.now()); }} />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("Check for Updates");
+
+    await clickFrameText("Check for Updates");
+    await Bun.sleep(0);
+    await testSetup.renderOnce();
+
+    expect(calls).toHaveLength(1);
+    expect(testSetup.captureCharFrame()).not.toContain("Commands");
   });
 
   test("renders theme prefix results in the root query", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -118,6 +118,7 @@ interface CommandBarProps {
   tickerRepository: TickerRepository;
   pluginRegistry: PluginRegistry;
   quitApp: () => void;
+  onCheckForUpdates?: () => void | Promise<void>;
 }
 
 interface ResultItem {
@@ -204,7 +205,13 @@ function getVisibleMultiSelectPickerOptions(
   });
 }
 
-export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, quitApp }: CommandBarProps) {
+export function CommandBar({
+  dataProvider,
+  tickerRepository,
+  pluginRegistry,
+  quitApp,
+  onCheckForUpdates,
+}: CommandBarProps) {
   const { state, dispatch } = useAppState();
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -1985,6 +1992,10 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
         closeAll({ revertThemePreview: false });
         return;
       }
+      case "check-for-updates":
+        void onCheckForUpdates?.();
+        closeAll({ revertThemePreview: false });
+        return;
       case "search-ticker":
         void runTickerSearchShortcut(arg);
         return;
@@ -2016,6 +2027,7 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
     openModeRoute,
     openPaneSettingsRoute,
     openPickerRoute,
+    onCheckForUpdates,
     pluginRegistry,
     quitApp,
     runTickerSearchShortcut,
@@ -2219,6 +2231,11 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
             .filter(Boolean);
           return names?.length ? `from "${names.join(", ")}"` : command.description;
         }
+        case "check-for-updates":
+          if (state.updateCheckInProgress) return "Checking GitHub releases now";
+          if (state.updateAvailable) return `Latest available: v${state.updateAvailable.version}`;
+          if (state.updateNotice) return state.updateNotice;
+          return command.description;
         default:
           return command.description;
       }
@@ -2233,6 +2250,7 @@ export function CommandBar({ dataProvider, tickerRepository, pluginRegistry, qui
         category: command.category,
         kind: "command",
         right: command.prefix || undefined,
+        disabled: command.id === "check-for-updates" && (state.updateCheckInProgress || !!state.updateProgress),
         action: () => runDirectCommand(command, ""),
       };
     }

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -171,6 +171,14 @@ export const commands: Command[] = [
       dispatch({ type: "TOGGLE_STATUS_BAR" });
     },
   },
+  {
+    id: "check-for-updates",
+    prefix: "",
+    label: "Check for Updates",
+    description: "Check GitHub releases for a newer version",
+    category: "Config",
+    execute: () => {}, // handled by command bar
+  },
 
   // Theme
   {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -11,10 +11,19 @@ import { marketStateLabel, marketStateColor, getExtendedHoursInfo } from "../../
 import { VERSION } from "../../version";
 
 const SPY_REFRESH_MS = 5 * 60_000; // 5 min
+const UPDATE_NOTICE_DURATION_MS = 5_000;
 
 function UpdateStatus() {
-  const { state } = useAppState();
-  const { updateAvailable, updateProgress } = state;
+  const { state, dispatch } = useAppState();
+  const { updateAvailable, updateProgress, updateCheckInProgress, updateNotice } = state;
+
+  useEffect(() => {
+    if (!updateNotice || updateAvailable || updateProgress || updateCheckInProgress) return;
+    const timeout = setTimeout(() => {
+      dispatch({ type: "SET_UPDATE_NOTICE", notice: null });
+    }, UPDATE_NOTICE_DURATION_MS);
+    return () => clearTimeout(timeout);
+  }, [dispatch, updateAvailable, updateCheckInProgress, updateNotice, updateProgress]);
 
   if (updateProgress) {
     if (updateProgress.phase === "downloading") {
@@ -43,6 +52,15 @@ function UpdateStatus() {
     }
   }
 
+  if (updateCheckInProgress) {
+    return (
+      <box flexDirection="row" gap={1}>
+        <spinner name="dots" color={colors.headerText} />
+        <text fg={colors.headerText}>Checking for updates...</text>
+      </box>
+    );
+  }
+
   if (updateAvailable) {
     if (updateAvailable.updateAction.kind === "manual") {
       return (
@@ -56,6 +74,10 @@ function UpdateStatus() {
         v{updateAvailable.version} available — press <span fg={colors.headerText}>u</span> to update
       </text>
     );
+  }
+
+  if (updateNotice) {
+    return <text fg={colors.headerText}>{updateNotice}</text>;
   }
 
   return null;

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -160,11 +160,17 @@ function createHeaderDataProvider(): DataProvider {
 
 function HeaderHarness({
   updateAvailable = null,
+  updateCheckInProgress = false,
+  updateNotice = null,
 }: {
   updateAvailable?: ReturnType<typeof createInitialState>["updateAvailable"];
+  updateCheckInProgress?: boolean;
+  updateNotice?: string | null;
 }) {
   const initialState = createInitialState(createDefaultConfig("/tmp/gloomberb-header-test"));
   initialState.updateAvailable = updateAvailable;
+  initialState.updateCheckInProgress = updateCheckInProgress;
+  initialState.updateNotice = updateNotice;
   const [state, dispatch] = useReducer(appReducer, initialState);
 
   return (
@@ -289,6 +295,26 @@ describe("Header", () => {
     expect(frame).toContain("v0.3.0 available");
     expect(frame).toContain("run npm install -g gloomberb@latest");
     expect(frame).not.toContain("press u to update");
+  });
+
+  test("shows update check progress and notices", async () => {
+    testSetup = await testRender(
+      <HeaderHarness updateCheckInProgress />,
+      { width: 120, height: 2 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("Checking for updates...");
+
+    testSetup.renderer.destroy();
+
+    testSetup = await testRender(
+      <HeaderHarness updateNotice="Already on v0.3.1" />,
+      { width: 120, height: 2 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("Already on v0.3.1");
   });
 });
 

--- a/src/state/app-context.test.tsx
+++ b/src/state/app-context.test.tsx
@@ -129,4 +129,34 @@ describe("appReducer command bar state", () => {
       ? secondUndone.config.layout.dockRoot.ratio
       : null).toBe(0.4);
   });
+
+  test("tracks manual update-check feedback", () => {
+    const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    const checking = appReducer(initial, { type: "SET_UPDATE_CHECK_IN_PROGRESS", checking: true });
+    const noticed = appReducer(checking, { type: "SET_UPDATE_NOTICE", notice: "Already on v0.3.1" });
+
+    expect(checking.updateCheckInProgress).toBe(true);
+    expect(noticed.updateNotice).toBe("Already on v0.3.1");
+  });
+
+  test("clears stale update notices when an update becomes available", () => {
+    const initial = {
+      ...createInitialState(createDefaultConfig("/tmp/gloomberb-test")),
+      updateNotice: "Already on v0.3.1",
+    };
+    const next = appReducer(initial, {
+      type: "SET_UPDATE_AVAILABLE",
+      release: {
+        version: "0.3.2",
+        tagName: "v0.3.2",
+        downloadUrl: "https://example.com/gloomberb.gz",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+        compressed: true,
+      },
+    });
+
+    expect(next.updateAvailable?.version).toBe("0.3.2");
+    expect(next.updateNotice).toBeNull();
+  });
 });

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -78,6 +78,8 @@ export interface AppState {
   inputCaptured: boolean;
   updateAvailable: ReleaseInfo | null;
   updateProgress: UpdateProgress | null;
+  updateCheckInProgress: boolean;
+  updateNotice: string | null;
   layoutHistory: Record<number, LayoutHistoryEntry>;
 }
 
@@ -101,8 +103,10 @@ export type AppAction =
   | { type: "SHOW_GRIDLOCK_TIP" }
   | { type: "DISMISS_GRIDLOCK_TIP" }
   | { type: "SET_THEME"; theme: string }
-  | { type: "SET_UPDATE_AVAILABLE"; release: ReleaseInfo }
+  | { type: "SET_UPDATE_AVAILABLE"; release: ReleaseInfo | null }
   | { type: "SET_UPDATE_PROGRESS"; progress: UpdateProgress | null }
+  | { type: "SET_UPDATE_CHECK_IN_PROGRESS"; checking: boolean }
+  | { type: "SET_UPDATE_NOTICE"; notice: string | null }
   | { type: "TOGGLE_PLUGIN"; pluginId: string }
   | { type: "SET_INPUT_CAPTURED"; captured: boolean }
   | { type: "SET_EXCHANGE_RATE"; currency: string; rate: number }
@@ -548,10 +552,16 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, config: { ...state.config, theme: action.theme } };
 
     case "SET_UPDATE_AVAILABLE":
-      return { ...state, updateAvailable: action.release };
+      return { ...state, updateAvailable: action.release, updateNotice: action.release ? null : state.updateNotice };
 
     case "SET_UPDATE_PROGRESS":
-      return { ...state, updateProgress: action.progress };
+      return { ...state, updateProgress: action.progress, updateNotice: action.progress ? null : state.updateNotice };
+
+    case "SET_UPDATE_CHECK_IN_PROGRESS":
+      return { ...state, updateCheckInProgress: action.checking };
+
+    case "SET_UPDATE_NOTICE":
+      return { ...state, updateNotice: action.notice };
 
     case "TOGGLE_PLUGIN": {
       const disabledPlugins = state.config.disabledPlugins.includes(action.pluginId)
@@ -936,6 +946,8 @@ export function createInitialState(config: AppConfig, sessionSnapshot: AppSessio
     inputCaptured: false,
     updateAvailable: null,
     updateProgress: null,
+    updateCheckInProgress: false,
+    updateNotice: null,
     layoutHistory: {},
   };
 }

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -1,13 +1,30 @@
-import { describe, expect, it, test } from "bun:test";
+import { afterEach, describe, expect, it, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { gzipSync } from "zlib";
 import {
   canSelfUpdate,
   checkForUpdate,
+  checkForUpdateDetailed,
   detectUpdateAction,
   performUpdate,
   resolveSelfUpdateTargetPath,
   type ReleaseInfo,
   type UpdateProgress,
 } from "./updater";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function expectedAssetName(compressed = false): string {
+  const os = process.platform === "darwin" ? "darwin" : "linux";
+  const arch = os === "darwin" || process.arch === "arm64" ? "arm64" : "x64";
+  return compressed ? `gloomberb-${os}-${arch}.gz` : `gloomberb-${os}-${arch}`;
+}
 
 describe("detectUpdateAction", () => {
   test("uses self-update for standalone binaries", () => {
@@ -100,6 +117,66 @@ describe("checkForUpdate", () => {
       Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
     }
   });
+
+  it("finds gzipped release assets published on GitHub", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      tag_name: "v0.3.2",
+      published_at: "2026-04-03T00:00:00Z",
+      assets: [{
+        name: expectedAssetName(true),
+        browser_download_url: "https://example.com/gloomberb.gz",
+      }],
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: "/Applications/gloomberb", configurable: true });
+      Object.defineProperty(process, "argv", {
+        value: ["/Applications/gloomberb"],
+        configurable: true,
+      });
+
+      await expect(checkForUpdate("0.3.1")).resolves.toEqual({
+        version: "0.3.2",
+        tagName: "v0.3.2",
+        downloadUrl: "https://example.com/gloomberb.gz",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+        compressed: true,
+      });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+    }
+  });
+});
+
+describe("checkForUpdateDetailed", () => {
+  it("returns a useful error when GitHub rejects the request", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    globalThis.fetch = (async () => new Response("busy", { status: 503 })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: "/Applications/gloomberb", configurable: true });
+      Object.defineProperty(process, "argv", {
+        value: ["/Applications/gloomberb"],
+        configurable: true,
+      });
+
+      await expect(checkForUpdateDetailed("0.3.1")).resolves.toEqual({
+        kind: "error",
+        error: "GitHub returned 503",
+      });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+    }
+  });
 });
 
 describe("performUpdate", () => {
@@ -157,6 +234,49 @@ describe("performUpdate", () => {
     } finally {
       Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
       Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+    }
+  });
+
+  it("decompresses gzipped release assets before replacing the binary", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
+    const execPath = join(tempDir, "gloomberb");
+    const nextBinary = Buffer.from("new-binary");
+    const payload = gzipSync(nextBinary);
+    const progress: UpdateProgress[] = [];
+
+    writeFileSync(execPath, Buffer.from("old-binary"));
+    chmodSync(execPath, 0o755);
+    globalThis.fetch = (async () => new Response(payload, {
+      status: 200,
+      headers: { "content-length": String(payload.length) },
+    })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: execPath, configurable: true });
+      Object.defineProperty(process, "argv", {
+        value: [execPath],
+        configurable: true,
+      });
+
+      await performUpdate({
+        version: "9.9.9",
+        tagName: "v9.9.9",
+        downloadUrl: "https://example.com/gloomberb.gz",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+        compressed: true,
+      }, (entry) => {
+        progress.push(entry);
+      });
+
+      expect(readFileSync(execPath)).toEqual(nextBinary);
+      expect(progress.at(-1)).toEqual({ phase: "done" });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,5 +1,6 @@
 import { writeFileSync, renameSync, unlinkSync, chmodSync, realpathSync } from "fs";
 import { basename } from "path";
+import { gunzipSync } from "zlib";
 
 const REPO = "vincelwt/gloomberb";
 const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
@@ -10,6 +11,7 @@ export interface ReleaseInfo {
   downloadUrl: string;
   publishedAt: string;
   updateAction: UpdateAction;
+  compressed?: boolean;
 }
 
 export interface UpdateProgress {
@@ -22,6 +24,12 @@ export type UpdateAction =
   | { kind: "self" }
   | { kind: "manual"; command: string };
 
+export type UpdateCheckResult =
+  | { kind: "available"; release: ReleaseInfo }
+  | { kind: "current" }
+  | { kind: "disabled" }
+  | { kind: "error"; error: string };
+
 function compareSemver(a: string, b: string): number {
   const pa = a.split(".").map(Number);
   const pb = b.split(".").map(Number);
@@ -32,11 +40,28 @@ function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-function getAssetName(): string {
+function getAssetBaseName(): string {
   const os = process.platform === "darwin" ? "darwin" : "linux";
   // macOS x64 uses arm64 binary (runs via Rosetta 2)
   const arch = os === "darwin" || process.arch === "arm64" ? "arm64" : "x64";
   return `gloomberb-${os}-${arch}`;
+}
+
+function resolveReleaseAsset(
+  assets: { name: string; browser_download_url: string }[],
+): { name: string; browser_download_url: string; compressed: boolean } | null {
+  const assetBaseName = getAssetBaseName();
+  const gzAsset = assets.find((asset) => asset.name === `${assetBaseName}.gz`);
+  if (gzAsset) {
+    return { ...gzAsset, compressed: true };
+  }
+
+  const rawAsset = assets.find((asset) => asset.name === assetBaseName);
+  if (rawAsset) {
+    return { ...rawAsset, compressed: false };
+  }
+
+  return null;
 }
 
 function normalizePath(value: string): string {
@@ -123,23 +148,27 @@ export function canSelfUpdate(release: Pick<ReleaseInfo, "updateAction"> | null 
   return release?.updateAction.kind === "self";
 }
 
-export async function checkForUpdate(
+export async function checkForUpdateDetailed(
   currentVersion: string,
-): Promise<ReleaseInfo | null> {
+): Promise<UpdateCheckResult> {
   const updateAction = detectUpdateAction();
-  if (!updateAction) return null;
+  if (!updateAction) {
+    return { kind: "disabled" };
+  }
 
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
+    timeout = setTimeout(() => controller.abort(), 5000);
 
     const res = await fetch(API_URL, {
       signal: controller.signal,
       headers: { Accept: "application/vnd.github+json" },
     });
-    clearTimeout(timeout);
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      return { kind: "error", error: `GitHub returned ${res.status}` };
+    }
 
     const data = (await res.json()) as {
       tag_name: string;
@@ -148,22 +177,47 @@ export async function checkForUpdate(
     };
 
     const version = data.tag_name.replace(/^v/, "");
-    if (compareSemver(version, currentVersion) <= 0) return null;
+    if (compareSemver(version, currentVersion) <= 0) {
+      return { kind: "current" };
+    }
 
-    const assetName = getAssetName();
-    const asset = data.assets.find((a) => a.name === assetName);
-    if (!asset) return null;
+    const asset = resolveReleaseAsset(data.assets);
+    if (!asset) {
+      return {
+        kind: "error",
+        error: `No compatible release asset found for ${getAssetBaseName()}`,
+      };
+    }
 
     return {
-      version,
-      tagName: data.tag_name,
-      downloadUrl: asset.browser_download_url,
-      publishedAt: data.published_at,
-      updateAction,
+      kind: "available",
+      release: {
+        version,
+        tagName: data.tag_name,
+        downloadUrl: asset.browser_download_url,
+        publishedAt: data.published_at,
+        updateAction,
+        compressed: asset.compressed,
+      },
     };
-  } catch {
-    return null;
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return { kind: "error", error: "Update check timed out" };
+    }
+    return {
+      kind: "error",
+      error: error instanceof Error ? error.message : "Update check failed",
+    };
+  } finally {
+    if (timeout) clearTimeout(timeout);
   }
+}
+
+export async function checkForUpdate(
+  currentVersion: string,
+): Promise<ReleaseInfo | null> {
+  const result = await checkForUpdateDetailed(currentVersion);
+  return result.kind === "available" ? result.release : null;
 }
 
 export async function performUpdate(
@@ -219,7 +273,9 @@ export async function performUpdate(
     // Write to temp file
     const blob = new Blob(chunks);
     const buffer = await blob.arrayBuffer();
-    writeFileSync(updatePath, Buffer.from(buffer));
+    const downloaded = Buffer.from(buffer);
+    const nextBinary = release.compressed ? gunzipSync(downloaded) : downloaded;
+    writeFileSync(updatePath, nextBinary);
     chmodSync(updatePath, 0o755);
 
     // Swap binaries


### PR DESCRIPTION
Fix self-update detection to accept gzipped GitHub release assets and decompress them before replacing the installed binary.

Add detailed manual update-check results so the header can show checking, current, and failure states.

Expose manual checks through a Check for Updates command bar action instead of a dedicated shortcut.

Add regression coverage for the updater, update state, header messaging, and command bar action.