### PR TITLE
Fix cloud login session refresh

### DIFF
--- a/src/utils/api-client.test.ts
+++ b/src/utils/api-client.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AuthUser } from "./api-client";
+import { apiClient } from "./api-client";
+
+const originalFetch = globalThis.fetch;
+
+const verifiedUser: AuthUser = {
+  id: "user-1",
+  name: "Test User",
+  email: "test@example.com",
+  username: "test",
+  emailVerified: true,
+  image: null,
+  createdAt: "2026-03-30T00:00:00.000Z",
+  updatedAt: "2026-03-30T00:00:00.000Z",
+};
+
+function createResponse(body: unknown, options: { status?: number; cookies?: string[] } = {}): Response {
+  const headers = {
+    getSetCookie: () => options.cookies ?? [],
+    get: (name: string) => {
+      if (name.toLowerCase() !== "set-cookie") return null;
+      return options.cookies?.[0] ?? null;
+    },
+  } as Headers;
+
+  return {
+    ok: (options.status ?? 200) >= 200 && (options.status ?? 200) < 300,
+    status: options.status ?? 200,
+    headers,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  apiClient.setSessionToken(null);
+  apiClient.setWebSocketToken(null);
+});
+
+describe("apiClient auth cookies", () => {
+  test("captures secure session cookies after login and reuses them on session refresh", async () => {
+    const seenCookies: Array<string | null> = [];
+
+    globalThis.fetch = (async (_input: Request | string | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      seenCookies.push(headers.get("Cookie"));
+
+      if (seenCookies.length === 1) {
+        return createResponse(
+          { token: "ws-token", user: verifiedUser },
+          { cookies: ["__Secure-gloomberb.session_token=signed-token.value; Path=/; HttpOnly; Secure; SameSite=Lax"] },
+        );
+      }
+
+      return createResponse({ user: verifiedUser });
+    }) as typeof fetch;
+
+    await apiClient.signIn("test@example.com", "password");
+    await apiClient.getSession();
+
+    expect(apiClient.getSessionToken()).toBe("signed-token.value");
+    expect(apiClient.getWebSocketToken()).toBe("ws-token");
+    expect(seenCookies).toEqual([
+      null,
+      "__Secure-gloomberb.session_token=signed-token.value",
+    ]);
+  });
+
+  test("replays both supported cookie names when restoring a saved session token", async () => {
+    const seenCookies: Array<string | null> = [];
+    apiClient.setSessionToken("persisted-token.value");
+
+    globalThis.fetch = (async (_input: Request | string | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      seenCookies.push(headers.get("Cookie"));
+      return createResponse({ user: verifiedUser });
+    }) as typeof fetch;
+
+    await apiClient.getSession();
+
+    expect(seenCookies).toEqual([
+      "__Secure-gloomberb.session_token=persisted-token.value; gloomberb.session_token=persisted-token.value",
+    ]);
+  });
+});

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -3,6 +3,7 @@ import type { InstrumentSearchResult } from "../types/instrument";
 import { debugLog } from "./debug-log";
 
 const DEFAULT_API_URL = "https://api.gloom.sh";
+const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
 const cloudApiLog = debugLog.createLogger("cloud-api");
 
 export interface ChatMessage {
@@ -107,6 +108,7 @@ function marketKey(symbol: string, exchange?: string): string {
 
 type ChannelListener = (message: ChatMessage) => void;
 type QuoteListener = (target: QuoteStreamTarget, quote: CloudQuotePayload) => void;
+type SessionCookieName = (typeof SESSION_COOKIE_NAMES)[number];
 
 class ApiRequestError extends Error {
   constructor(message: string, readonly status?: number) {
@@ -117,6 +119,7 @@ class ApiRequestError extends Error {
 
 class GloomApiClient {
   private sessionToken: string | null = null;
+  private sessionCookieName: SessionCookieName | null = null;
   private websocketToken: string | null = null;
   private currentUser: AuthUser | null = null;
   private readonly baseUrl: string;
@@ -142,6 +145,9 @@ class GloomApiClient {
   }
 
   setSessionToken(token: string | null): void {
+    if (this.sessionToken !== token) {
+      this.sessionCookieName = null;
+    }
     this.sessionToken = token;
     if (!token) {
       this.websocketToken = null;
@@ -195,11 +201,32 @@ class GloomApiClient {
 
   private extractSessionCookie(res: Response): void {
     const setCookie = res.headers.getSetCookie?.() ?? [];
+    const fallbackHeader = res.headers.get("set-cookie");
+    if (fallbackHeader) {
+      setCookie.push(fallbackHeader);
+    }
     for (const cookie of setCookie) {
-      const match = cookie.match(/gloomberb\.session_token=([^;]+)/);
-      if (match) {
+      for (const cookieName of SESSION_COOKIE_NAMES) {
+        const escapedCookieName = cookieName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const match = cookie.match(new RegExp(`${escapedCookieName}=([^;]+)`));
+        if (!match) continue;
         this.sessionToken = match[1] ?? null;
+        this.sessionCookieName = cookieName;
+        return;
       }
+    }
+  }
+
+  private buildSessionCookieHeader(): string | null {
+    if (!this.sessionToken) return null;
+    const cookieNames = this.sessionCookieName ? [this.sessionCookieName] : SESSION_COOKIE_NAMES;
+    return cookieNames.map((cookieName) => `${cookieName}=${this.sessionToken}`).join("; ");
+  }
+
+  private setSessionCookieHeader(headers: Headers): void {
+    const cookieHeader = this.buildSessionCookieHeader();
+    if (cookieHeader) {
+      headers.set("Cookie", cookieHeader);
     }
   }
 
@@ -208,9 +235,7 @@ class GloomApiClient {
     if (!headers.has("Content-Type") && options?.method && options.method !== "GET") {
       headers.set("Content-Type", "application/json");
     }
-    if (this.sessionToken) {
-      headers.set("Cookie", `gloomberb.session_token=${this.sessionToken}`);
-    }
+    this.setSessionCookieHeader(headers);
     headers.set("Origin", this.baseUrl);
 
     const res = await fetch(`${this.baseUrl}${path}`, {


### PR DESCRIPTION
This updates the cloud auth client to recognize both `__Secure-gloomberb.session_token` and `gloomberb.session_token`, remember the server-provided cookie name, and replay compatible cookies when restoring a saved session. It also adds focused regression tests for secure-cookie login and saved-session refresh behavior in `src/utils/api-client.test.ts`. Verified with `bun test src/utils/api-client.test.ts src/plugins/builtin/chat-controller.test.ts src/plugins/builtin/chat.test.tsx` and a tmux login/restart smoke test against the live cloud flow.