### PR TITLE
Fix compact charts and historical data parsing

### DIFF
--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -917,6 +917,7 @@ export interface RenderChartOptions {
   axisMode?: ChartAxisMode;
   currency?: string;
   colors: ResolvedChartPalette;
+  timeAxisDates?: Array<Date | string | number>;
 }
 
 export interface ChartScene {
@@ -1027,6 +1028,8 @@ export function buildChartScene(
     ? null
     : max - (cursorY / Math.max(chartRows - 1, 1)) * range;
 
+  const timeAxisDates = opts.timeAxisDates ?? points.map((point) => point.date);
+
   return {
     points,
     width: opts.width,
@@ -1045,7 +1048,7 @@ export function buildChartScene(
     dateAtCursor: activePoint.date,
     changeAtCursor: activePoint.close - points[0]!.close,
     changePctAtCursor: points[0]!.close ? ((activePoint.close - points[0]!.close) / points[0]!.close) * 100 : 0,
-    timeLabels: buildTimeAxis(points.map((point) => point.date), opts.width),
+    timeLabels: buildTimeAxis(timeAxisDates, opts.width),
     cursorX,
     cursorY,
     cursorColumn,
@@ -1138,10 +1141,12 @@ export function renderChart(
     );
   }
 
+  const timeAxisDates = opts.timeAxisDates ?? points.map((point) => point.date);
+
   return {
     lines: bufferToBrailleLines(buf, palette.bgColor),
     axisLabels: [...axisLabelsByRow.entries()].map(([row, label]) => ({ row, label })),
-    timeLabels: buildTimeAxis(points.map((point) => point.date), width),
+    timeLabels: buildTimeAxis(timeAxisDates, width),
     activePoint,
     priceAtCursor,
     crosshairPrice,

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -206,6 +206,32 @@ describe("renderChart", () => {
     expect(buildTimeAxis(yearlyDates, 48)).toBe("2020   2021      2022     2023      2024    2025");
   });
 
+  test("uses source time-axis dates instead of projected extrema dates when provided", () => {
+    const sourceHistory = Array.from({ length: 96 }, (_, index) => ({
+      date: new Date(Date.UTC(2026, 2, 25, index * 3)),
+      close: index % 2 === 0 ? 0.7 + index * 0.001 : 0.3 + index * 0.001,
+      volume: 100 + index,
+    })) as PricePoint[];
+    const sourceDates = sourceHistory.map((point) => point.date);
+    const projection = projectChartData(sourceHistory, 48, "area", true);
+
+    const result = renderChart(projection.points, {
+      width: 48,
+      height: 8,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "area",
+      axisMode: "price",
+      currency: "USD",
+      colors: palette,
+      timeAxisDates: sourceDates,
+    });
+
+    expect(result.timeLabels).toBe(buildTimeAxis(sourceDates, 48));
+  });
+
   test("maps active bucket metadata across all render modes", () => {
     const cases: Array<{ mode: ChartRenderMode; width: number; cursorX: number }> = [
       { mode: "area", width: 12, cursorX: 4 },

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -69,6 +69,8 @@ interface StockChartProps {
   interactive?: boolean;
   compact?: boolean;
   axisMode?: ChartAxisMode;
+  historyOverride?: PricePoint[] | null;
+  currencyOverride?: string | null;
 }
 
 interface DragState {
@@ -505,7 +507,16 @@ function resolveSelectionCursor(
   };
 }
 
-export function StockChart({ width, height, focused, interactive, compact, axisMode = "price" }: StockChartProps) {
+export function StockChart({
+  width,
+  height,
+  focused,
+  interactive,
+  compact,
+  axisMode = "price",
+  historyOverride = null,
+  currencyOverride = null,
+}: StockChartProps) {
   const renderer = useRenderer();
   const { state, dispatch } = useAppState();
   const paneId = usePaneInstanceId();
@@ -637,9 +648,10 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
   const chartWidth = Math.max(width - axisWidth - axisGap, compact ? 12 : 20);
   const maxCursorX = chartWidth - 1;
   const panStep = Math.max(Math.floor(chartWidth / 10), 1);
-  const baseHistory = rangeHistory && rangeHistory.length > 0
-    ? rangeHistory
-    : (financials?.priceHistory ?? []);
+  const baseHistory = historyOverride
+    ?? (rangeHistory && rangeHistory.length > 0
+      ? rangeHistory
+      : (financials?.priceHistory ?? []));
   const detailRequest = useMemo(() => {
     if (compact || !instrumentRef || baseHistory.length < 2 || viewState.zoomLevel <= 1) return null;
     const window = getVisibleWindow(baseHistory, viewState, chartWidth);
@@ -751,11 +763,18 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
     queueMicrotask(() => renderer.requestRender());
   }, [chartHeight, chartWidth, compact, historyRenderKey, renderer, ticker?.metadata.ticker, viewState.renderMode]);
 
-  const chartWindow = useMemo(() => (
-    isDetailView
+  const chartWindow = useMemo(() => {
+    if (historyOverride) {
+      return { points: history, startIdx: 0, endIdx: history.length };
+    }
+    return isDetailView
       ? { points: history, startIdx: 0, endIdx: history.length }
-      : getVisibleWindow(history, viewState, chartWidth)
-  ), [chartWidth, history, isDetailView, viewState.panOffset, viewState.timeRange, viewState.zoomLevel]);
+      : getVisibleWindow(history, viewState, chartWidth);
+  }, [chartWidth, history, historyOverride, isDetailView, viewState.panOffset, viewState.timeRange, viewState.zoomLevel]);
+  const timeAxisDates = useMemo(
+    () => chartWindow.points.map((point) => point.date),
+    [chartWindow.points],
+  );
 
   const projection = useMemo(() => (
     projectChartData(chartWindow.points, chartWidth, viewState.renderMode, !!compact)
@@ -891,7 +910,7 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
       negative: colors.negative,
     }, trend);
   }, [chartWindow.points]);
-  const chartCurrency = financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
+  const chartCurrency = currencyOverride ?? financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
 
   const cursorX = viewState.cursorX !== null ? clamp(viewState.cursorX, 0, chartWidth - 1) : null;
   const cursorY = viewState.cursorY !== null ? clamp(viewState.cursorY, 0, chartHeight - 1) : null;
@@ -918,7 +937,8 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
     mode: projection.effectiveMode,
     axisMode,
     colors: chartColors,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, selectionCursorX, selectionCursorY, showVolume, volumeHeight]);
+    timeAxisDates,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, selectionCursorX, selectionCursorY, showVolume, timeAxisDates, volumeHeight]);
   const snappedSelectionCursorX = selectionScene
     ? getPointTerminalColumn(selectionScene.activeIdx, projection.points.length, chartWidth, projection.effectiveMode)
     : null;
@@ -962,7 +982,8 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
     mode: projection.effectiveMode,
     axisMode,
     colors: chartColors,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+    timeAxisDates,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
   const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;
@@ -978,7 +999,8 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
     axisMode,
     currency: chartCurrency,
     colors: chartColors,
-  }), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+    timeAxisDates,
+  }), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const interactiveResult = useMemo(() => (
     effectiveRenderer === "kitty"
@@ -994,8 +1016,9 @@ export function StockChart({ width, height, focused, interactive, compact, axisM
         axisMode,
         currency: chartCurrency,
         colors: chartColors,
+        timeAxisDates,
       })
-  ), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, projection.effectiveMode, projection.points, showVolume, volumeHeight]);
+  ), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const result = effectiveRenderer === "kitty" ? staticResult : interactiveResult!;
 

--- a/src/plugins/ibkr/gateway-service.test.ts
+++ b/src/plugins/ibkr/gateway-service.test.ts
@@ -6,6 +6,7 @@ import {
   applyTickByTickBidAskToQuote,
   diagnoseLocalIbkrPortIssue,
   IbkrGatewayService,
+  parseIbkrHistoricalBarTime,
   resolveGatewayConnection,
   summarizeBrokerAccount,
 } from "./gateway-service";
@@ -236,6 +237,35 @@ describe("tick-by-tick quote updates", () => {
     expect(next?.bidSize).toBe(14);
     expect(next?.askSize).toBe(18);
     expect(next?.lastUpdated).toBe(1_700_000_100_000);
+  });
+});
+
+describe("parseIbkrHistoricalBarTime", () => {
+  test("parses compact day bars without treating them as epoch seconds", () => {
+    const date = parseIbkrHistoricalBarTime(20250328);
+
+    expect(Number.isNaN(date.getTime())).toBe(false);
+    expect(date.getFullYear()).toBe(2025);
+    expect(date.getMonth()).toBe(2);
+    expect(date.getDate()).toBe(28);
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+  });
+
+  test("parses compact intraday bar timestamps", () => {
+    const date = parseIbkrHistoricalBarTime("20250328 09:30:00");
+
+    expect(Number.isNaN(date.getTime())).toBe(false);
+    expect(date.getFullYear()).toBe(2025);
+    expect(date.getMonth()).toBe(2);
+    expect(date.getDate()).toBe(28);
+    expect(date.getHours()).toBe(9);
+    expect(date.getMinutes()).toBe(30);
+    expect(date.getSeconds()).toBe(0);
+  });
+
+  test("preserves epoch-second timestamps for streaming-style bars", () => {
+    expect(parseIbkrHistoricalBarTime(1_700_000_000).getTime()).toBe(1_700_000_000_000);
   });
 });
 

--- a/src/plugins/ibkr/gateway-service.ts
+++ b/src/plugins/ibkr/gateway-service.ts
@@ -310,6 +310,42 @@ const GENERIC_BAR_SIZE_MAP: Record<string, BarSizeSetting> = {
   "1w": BarSizeSetting.WEEKS_ONE,
 };
 
+export function parseIbkrHistoricalBarTime(value: string | number): Date {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return new Date(Number.NaN);
+
+    const compactDate = String(Math.trunc(value));
+    if (/^\d{8}$/.test(compactDate)) {
+      return parseIbkrHistoricalBarTime(compactDate);
+    }
+
+    return new Date(value > 10_000_000_000 ? value : value * 1000);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return new Date(Number.NaN);
+
+  const parsed = Date.parse(trimmed);
+  if (Number.isFinite(parsed)) {
+    return new Date(parsed);
+  }
+
+  const compactMatch = trimmed.match(/^(\d{4})(\d{2})(\d{2})(?:\D+(\d{2}):(\d{2}):(\d{2}))?/);
+  if (!compactMatch) {
+    return new Date(Number.NaN);
+  }
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText] = compactMatch;
+  const year = Number(yearText);
+  const month = Number(monthText) - 1;
+  const day = Number(dayText);
+  const hour = Number(hourText ?? "0");
+  const minute = Number(minuteText ?? "0");
+  const second = Number(secondText ?? "0");
+
+  return new Date(year, month, day, hour, minute, second);
+}
+
 function normalizeQuoteStreamTarget(target: QuoteSubscriptionTarget): QuoteSubscriptionTarget | null {
   const symbol = target.symbol.trim().toUpperCase();
   if (!symbol) return null;
@@ -1006,7 +1042,7 @@ export class IbkrGatewayService {
       const priceDivisor = getIbkrPriceDivisor(contract, details);
 
       return bars.map((bar) => ({
-        date: new Date(typeof bar.time === "number" ? bar.time * 1000 : Date.parse(String(bar.time))),
+        date: parseIbkrHistoricalBarTime(bar.time),
         open: normalizeIbkrPriceValue(bar.open, priceDivisor),
         high: normalizeIbkrPriceValue(bar.high, priceDivisor),
         low: normalizeIbkrPriceValue(bar.low, priceDivisor),
@@ -1064,7 +1100,7 @@ export class IbkrGatewayService {
       const priceDivisor = getIbkrPriceDivisor(contract, details);
 
       return bars.map((bar) => ({
-        date: new Date(typeof bar.time === "number" ? bar.time * 1000 : Date.parse(String(bar.time))),
+        date: parseIbkrHistoricalBarTime(bar.time),
         open: normalizeIbkrPriceValue(bar.open, priceDivisor),
         high: normalizeIbkrPriceValue(bar.high, priceDivisor),
         low: normalizeIbkrPriceValue(bar.low, priceDivisor),

--- a/src/plugins/prediction-markets/chart.test.tsx
+++ b/src/plugins/prediction-markets/chart.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ScrollBoxRenderable } from "@opentui/core";
+import { createTestRenderer } from "@opentui/core/testing";
+import { createRoot } from "@opentui/react";
+import { act, useEffect, useReducer, useRef } from "react";
+import {
+  AppContext,
+  PaneInstanceProvider,
+  appReducer,
+  createInitialState,
+} from "../../state/app-context";
+import { createDefaultConfig } from "../../types/config";
+import { getNativeSurfaceManager } from "../../components/chart/native/surface-manager";
+import { PredictionMarketChart } from "./chart";
+
+const TEST_PANE_ID = "prediction-scroll:test";
+const SURFACE_ID = `chart-surface:${TEST_PANE_ID}:compact:base`;
+
+let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | undefined;
+let root: ReturnType<typeof createRoot> | undefined;
+let scrollBoxRef: ScrollBoxRenderable | null = null;
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function ChartScrollHarness() {
+  const [state, dispatch] = useReducer(
+    appReducer,
+    (() => {
+      const config = createDefaultConfig("/tmp/gloomberb-test");
+      config.chartPreferences.renderer = "kitty";
+      const initial = createInitialState(config);
+      initial.focusedPaneId = TEST_PANE_ID;
+      return initial;
+    })(),
+  );
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  useEffect(() => {
+    scrollBoxRef = scrollRef.current;
+  });
+
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <scrollbox ref={scrollRef} height={10} scrollY>
+          <box flexDirection="column">
+            <box height={14}>
+              <text>filler</text>
+            </box>
+            <PredictionMarketChart
+              history={[
+                { date: new Date("2026-04-01T00:00:00Z"), close: 0.45 },
+                { date: new Date("2026-04-02T00:00:00Z"), close: 0.48 },
+                { date: new Date("2026-04-03T00:00:00Z"), close: 0.51 },
+                { date: new Date("2026-04-04T00:00:00Z"), close: 0.49 },
+              ]}
+              width={60}
+              height={12}
+              range="1M"
+              onRangeSelect={() => {}}
+            />
+          </box>
+        </scrollbox>
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function flushFrames(count = 4) {
+  for (let index = 0; index < count; index += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+  }
+}
+
+afterEach(() => {
+  scrollBoxRef = null;
+  if (root) {
+    act(() => {
+      root!.unmount();
+    });
+    root = undefined;
+  }
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
+});
+
+describe("PredictionMarketChart kitty scrolling", () => {
+  test("creates a native chart surface when scrolled into view", async () => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 100, height: 24 });
+    (testSetup.renderer as { _capabilities: unknown })._capabilities = {
+      kitty_graphics: true,
+    };
+    (testSetup.renderer as { _resolution: unknown })._resolution = {
+      width: 1000,
+      height: 720,
+    };
+
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(<ChartScrollHarness />);
+    });
+
+    await flushFrames();
+
+    const manager = getNativeSurfaceManager(testSetup.renderer as never) as unknown as {
+      surfaces: Map<
+        string,
+        {
+          snapshot: {
+            visibleRect: { x: number; y: number; width: number; height: number } | null;
+          };
+        }
+      >;
+    };
+
+    const hiddenSurface = manager.surfaces.get(SURFACE_ID);
+    expect(hiddenSurface).toBeUndefined();
+
+    act(() => {
+      scrollBoxRef!.scrollTop = 14;
+    });
+
+    await flushFrames();
+
+    const visibleSurface = manager.surfaces.get(SURFACE_ID);
+    expect(visibleSurface).toBeDefined();
+    expect(visibleSurface?.snapshot.visibleRect).not.toBeNull();
+    expect(testSetup.captureCharFrame()).toContain("1M");
+  });
+});

--- a/src/plugins/prediction-markets/chart.tsx
+++ b/src/plugins/prediction-markets/chart.tsx
@@ -1,27 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { TextAttributes, type BoxRenderable } from "@opentui/core";
-import { useRenderer } from "@opentui/react";
-import {
-  buildChartScene,
-  renderChart,
-  resolveChartPalette,
-  type StyledContent,
-} from "../../components/chart/chart-renderer";
-import {
-  computeBitmapSize,
-  renderNativeChartBase,
-  type CellRect,
-  type NativeChartBitmap,
-} from "../../components/chart/native/chart-rasterizer";
-import {
-  ensureKittySupport,
-  getCachedKittySupport,
-} from "../../components/chart/native/kitty-support";
-import { resolveChartRendererState } from "../../components/chart/native/renderer-selection";
-import { getNativeSurfaceManager } from "../../components/chart/native/surface-manager";
-import { syncCachedNativeSurface } from "../../components/chart/native/surface-sync";
-import { projectChartData } from "../../components/chart/chart-data";
-import { useAppState, usePaneInstanceId } from "../../state/app-context";
+import { useMemo } from "react";
+import { TextAttributes } from "@opentui/core";
+import { StockChart } from "../../components/chart/stock-chart";
 import { EmptyState } from "../../components/ui/status";
 import { colors } from "../../theme/colors";
 import { formatNumber, formatPercentRaw } from "../../utils/format";
@@ -29,15 +8,6 @@ import type { PricePoint } from "../../types/financials";
 import type { PredictionHistoryPoint, PredictionHistoryRange } from "./types";
 
 const RANGES: PredictionHistoryRange[] = ["1D", "1W", "1M", "ALL"];
-const AXIS_WIDTH = 8;
-
-interface RenderableNode {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  parent: RenderableNode | null;
-}
 
 function coercePredictionPointDate(value: unknown): Date | null {
   if (value instanceof Date) {
@@ -54,79 +24,47 @@ function toPricePoints(points: PredictionHistoryPoint[]): PricePoint[] {
   return points.flatMap((point) => {
     const date = coercePredictionPointDate(point.date);
     if (!date) return [];
-    return [
-      {
-        date,
-        close: point.close,
-        open: point.open,
-        high: point.high,
-        low: point.low,
-        volume: point.volume,
-      },
-    ];
+    return [{
+      date,
+      close: point.close,
+      open: point.open,
+      high: point.high,
+      low: point.low,
+      volume: point.volume,
+    }];
   });
 }
 
-function extractCellRect(renderable: RenderableNode): CellRect {
-  return {
-    x: renderable.x,
-    y: renderable.y,
-    width: renderable.width,
-    height: renderable.height,
-  };
-}
-
-function intersectCellRects(left: CellRect, right: CellRect): CellRect | null {
-  const x = Math.max(left.x, right.x);
-  const y = Math.max(left.y, right.y);
-  const maxX = Math.min(left.x + left.width, right.x + right.width);
-  const maxY = Math.min(left.y + left.height, right.y + right.height);
-  if (maxX <= x || maxY <= y) return null;
-  return { x, y, width: maxX - x, height: maxY - y };
-}
-
-function resolveVisibleRect(
-  renderable: RenderableNode | null,
-  terminalWidth: number,
-  terminalHeight: number,
-): CellRect | null {
-  if (!renderable) return null;
-
-  let visible: CellRect = {
-    x: 0,
-    y: 0,
-    width: terminalWidth,
-    height: terminalHeight,
-  };
-  let current: RenderableNode | null = renderable;
-
-  while (current) {
-    const nextVisible = intersectCellRects(visible, extractCellRect(current));
-    if (!nextVisible) return null;
-    visible = nextVisible;
-    current = current.parent;
-  }
-
-  return visible;
-}
-
-function buildBlankPlotLines(width: number, height: number): string[] {
-  return Array.from({ length: height }, () => " ".repeat(width));
-}
-
-function buildNativeBitmapKey(
-  points: PricePoint[],
-  pixelWidth: number,
-  pixelHeight: number,
-  paletteId: string,
-): string {
-  const fingerprint = points
-    .map(
-      (point) =>
-        `${point.date.getTime()}:${point.open}:${point.high}:${point.low}:${point.close}:${point.volume ?? 0}`,
-    )
-    .join("|");
-  return [pixelWidth, pixelHeight, paletteId, fingerprint].join("::");
+function PredictionRangeTabs({
+  activeRange,
+  onRangeSelect,
+}: {
+  activeRange: PredictionHistoryRange;
+  onRangeSelect: (range: PredictionHistoryRange) => void;
+}) {
+  return (
+    <box flexDirection="row" gap={1}>
+      {RANGES.map((entry) => {
+        const active = entry === activeRange;
+        return (
+          <box
+            key={entry}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              onRangeSelect(entry);
+            }}
+          >
+            <text
+              fg={active ? colors.textBright : colors.textDim}
+              attributes={active ? TextAttributes.BOLD : 0}
+            >
+              {entry}
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
 }
 
 export function PredictionMarketChart({
@@ -142,299 +80,16 @@ export function PredictionMarketChart({
   range: PredictionHistoryRange;
   onRangeSelect: (range: PredictionHistoryRange) => void;
 }) {
-  const { state } = useAppState();
-  const renderer = useRenderer();
-  const paneId = usePaneInstanceId();
-  const nativeSurfaceManager = useMemo(
-    () => getNativeSurfaceManager(renderer),
-    [renderer],
-  );
-  const [kittySupport, setKittySupport] = useState<boolean | null>(() =>
-    getCachedKittySupport(renderer),
-  );
-  const plotRef = useRef<BoxRenderable>(null);
-  const nativeSurfaceIdRef = useRef(`prediction-chart-surface:${paneId}`);
-  const lastNativeBitmapRef = useRef<{
-    key: string;
-    bitmap: NativeChartBitmap;
-  } | null>(null);
-  const lastNativeGeometryRef = useRef<{
-    rect: CellRect;
-    visibleRect: CellRect | null;
-  } | null>(null);
-
-  const chartWidth = Math.max(width - AXIS_WIDTH - 2, 18);
-  const chartHeight = Math.max(height - 2, 6);
-  const hasHistory = history.length > 0;
-
-  useEffect(() => {
-    if (kittySupport !== null) return;
-    let disposed = false;
-    ensureKittySupport(renderer)
-      .then((supported) => {
-        if (!disposed) setKittySupport(supported);
-      })
-      .catch(() => {
-        if (!disposed) setKittySupport(false);
-      });
-    return () => {
-      disposed = true;
-    };
-  }, [kittySupport, renderer]);
-
   const pricePoints = useMemo(() => toPricePoints(history), [history]);
-  const projection = useMemo(
-    () => projectChartData(pricePoints, chartWidth, "area"),
-    [chartWidth, pricePoints],
-  );
-  const first = projection.points[0] ?? null;
-  const last = projection.points[projection.points.length - 1] ?? null;
-  const delta = first && last ? last.close - first.close : 0;
-  const deltaPct = first?.close ? (delta / first.close) * 100 : 0;
-  const palette = useMemo(
-    () =>
-      resolveChartPalette(
-        colors,
-        delta > 0 ? "positive" : delta < 0 ? "negative" : "neutral",
-      ),
-    [delta],
-  );
-  const rendererState = resolveChartRendererState(
-    state.config.chartPreferences.renderer,
-    kittySupport,
-    renderer.resolution,
-  );
-  const effectiveRenderer = rendererState.renderer;
 
-  const rendered = useMemo(
-    () =>
-      renderChart(projection.points, {
-        width: chartWidth,
-        height: chartHeight,
-        mode: "area",
-        showVolume: false,
-        volumeHeight: 0,
-        cursorX: null,
-        cursorY: null,
-        colors: palette,
-        axisMode: "price",
-        currency: "USD",
-      }),
-    [chartHeight, chartWidth, palette, projection.points],
-  );
-
-  const nativeScene = useMemo(
-    () =>
-      buildChartScene(projection.points, {
-        width: chartWidth,
-        height: chartHeight,
-        showVolume: false,
-        volumeHeight: 0,
-        cursorX: null,
-        cursorY: null,
-        mode: "area",
-        axisMode: "price",
-        colors: palette,
-      }),
-    [chartHeight, chartWidth, palette, projection.points],
-  );
-
-  const axisByRow = useMemo(
-    () => new Map(rendered.axisLabels.map((entry) => [entry.row, entry.label])),
-    [rendered.axisLabels],
-  );
-  const blankPlotLines = useMemo(
-    () => buildBlankPlotLines(chartWidth, chartHeight),
-    [chartHeight, chartWidth],
-  );
-
-  useEffect(
-    () => () => {
-      lastNativeBitmapRef.current = null;
-      lastNativeGeometryRef.current = null;
-      nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
-      renderer.requestRender();
-    },
-    [nativeSurfaceManager, renderer],
-  );
-
-  useEffect(() => {
-    if (effectiveRenderer === "kitty" && rendererState.nativeReady) return;
-    lastNativeBitmapRef.current = null;
-    lastNativeGeometryRef.current = null;
-    nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
-  }, [effectiveRenderer, nativeSurfaceManager, rendererState.nativeReady]);
-
-  useEffect(() => {
-    if (
-      effectiveRenderer !== "kitty" ||
-      !rendererState.nativeReady ||
-      !plotRef.current
-    )
-      return;
-    const plot = plotRef.current;
-    let mountTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const syncPlacement = () => {
-      if (
-        effectiveRenderer !== "kitty" ||
-        !rendererState.nativeReady ||
-        !plotRef.current
-      )
-        return;
-      const rect = extractCellRect(plotRef.current);
-      const visibleRect = resolveVisibleRect(
-        plotRef.current,
-        renderer.terminalWidth,
-        renderer.terminalHeight,
-      );
-      const previous = lastNativeGeometryRef.current;
-      if (
-        previous &&
-        previous.rect.x === rect.x &&
-        previous.rect.y === rect.y &&
-        previous.rect.width === rect.width &&
-        previous.rect.height === rect.height &&
-        previous.visibleRect?.x === visibleRect?.x &&
-        previous.visibleRect?.y === visibleRect?.y &&
-        previous.visibleRect?.width === visibleRect?.width &&
-        previous.visibleRect?.height === visibleRect?.height
-      ) {
-        return;
-      }
-      lastNativeGeometryRef.current = { rect, visibleRect };
-      syncCachedNativeSurface(
-        nativeSurfaceManager,
-        nativeSurfaceIdRef.current,
-        { paneId, rect, visibleRect },
-        lastNativeBitmapRef.current,
-      );
-    };
-
-    plot.onLifecyclePass = syncPlacement;
-    renderer.registerLifecyclePass(plot);
-    syncPlacement();
-    mountTimer = setTimeout(() => {
-      syncPlacement();
-      renderer.requestRender();
-    }, 0);
-
-    return () => {
-      if (mountTimer) clearTimeout(mountTimer);
-      plot.onLifecyclePass = null;
-      renderer.unregisterLifecyclePass(plot);
-      lastNativeGeometryRef.current = null;
-    };
-  }, [
-    effectiveRenderer,
-    nativeSurfaceManager,
-    paneId,
-    renderer,
-    rendererState.nativeReady,
-  ]);
-
-  useEffect(() => {
-    if (
-      effectiveRenderer !== "kitty" ||
-      !rendererState.nativeReady ||
-      !renderer.resolution ||
-      !plotRef.current ||
-      !nativeScene
-    ) {
-      lastNativeBitmapRef.current = null;
-      nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
-      return;
-    }
-
-    const plotRect = extractCellRect(plotRef.current);
-    const visibleRect = resolveVisibleRect(
-      plotRef.current,
-      renderer.terminalWidth,
-      renderer.terminalHeight,
-    );
-    if (!visibleRect) {
-      nativeSurfaceManager.removeSurface(nativeSurfaceIdRef.current);
-      return;
-    }
-
-    const bitmapSize = computeBitmapSize(
-      plotRect,
-      renderer.resolution,
-      renderer.terminalWidth,
-      renderer.terminalHeight,
-    );
-    const bitmapKey = buildNativeBitmapKey(
-      pricePoints,
-      bitmapSize.pixelWidth,
-      bitmapSize.pixelHeight,
-      [palette.lineColor, palette.fillColor, palette.gridColor].join(","),
-    );
-    const cachedBitmap =
-      lastNativeBitmapRef.current?.key === bitmapKey
-        ? lastNativeBitmapRef.current.bitmap
-        : null;
-    const bitmap =
-      cachedBitmap ??
-      renderNativeChartBase(
-        nativeScene,
-        bitmapSize.pixelWidth,
-        bitmapSize.pixelHeight,
-      );
-    if (!cachedBitmap) {
-      lastNativeBitmapRef.current = { key: bitmapKey, bitmap };
-    }
-
-    nativeSurfaceManager.upsertSurface({
-      id: nativeSurfaceIdRef.current,
-      paneId,
-      rect: plotRect,
-      visibleRect,
-      bitmap,
-      bitmapKey,
-    });
-    renderer.requestRender();
-  }, [
-    effectiveRenderer,
-    nativeScene,
-    nativeSurfaceManager,
-    paneId,
-    palette.fillColor,
-    palette.gridColor,
-    palette.lineColor,
-    pricePoints,
-    renderer,
-    rendererState.nativeReady,
-  ]);
-
-  const plotLines: Array<string | StyledContent> =
-    effectiveRenderer === "kitty" ? blankPlotLines : rendered.lines;
-  const plotContent = plotLines.map((line, index) => (
-    <text key={index} content={line as any} />
-  ));
-
-  if (!hasHistory) {
+  if (pricePoints.length === 0) {
     return (
       <box flexDirection="column" height={height}>
-        <box flexDirection="row" gap={1} height={1}>
-          {RANGES.map((entry) => {
-            const active = entry === range;
-            return (
-              <box
-                key={entry}
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  onRangeSelect(entry);
-                }}
-              >
-                <text
-                  fg={active ? colors.textBright : colors.textDim}
-                  attributes={active ? TextAttributes.BOLD : 0}
-                >
-                  {entry}
-                </text>
-              </box>
-            );
-          })}
+        <box flexDirection="row" height={1}>
+          <PredictionRangeTabs
+            activeRange={range}
+            onRangeSelect={onRangeSelect}
+          />
         </box>
         <box flexGrow={1} justifyContent="center">
           <EmptyState
@@ -446,30 +101,19 @@ export function PredictionMarketChart({
     );
   }
 
+  const first = pricePoints[0] ?? null;
+  const last = pricePoints[pricePoints.length - 1] ?? null;
+  const delta = first && last ? last.close - first.close : 0;
+  const deltaPct = first?.close ? (delta / first.close) * 100 : 0;
+  const chartHeight = Math.max(height - 1, 2);
+
   return (
     <box flexDirection="column" height={height}>
       <box flexDirection="row" height={1}>
-        <box flexDirection="row" gap={1}>
-          {RANGES.map((entry) => {
-            const active = entry === range;
-            return (
-              <box
-                key={entry}
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  onRangeSelect(entry);
-                }}
-              >
-                <text
-                  fg={active ? colors.textBright : colors.textDim}
-                  attributes={active ? TextAttributes.BOLD : 0}
-                >
-                  {entry}
-                </text>
-              </box>
-            );
-          })}
-        </box>
+        <PredictionRangeTabs
+          activeRange={range}
+          onRangeSelect={onRangeSelect}
+        />
         <box flexGrow={1} />
         <text
           fg={
@@ -484,29 +128,14 @@ export function PredictionMarketChart({
         </text>
       </box>
 
-      <box flexDirection="row" height={chartHeight}>
-        <box
-          ref={plotRef}
-          width={chartWidth}
-          height={chartHeight}
-          flexDirection="column"
-          backgroundColor={palette.bgColor}
-        >
-          {plotContent}
-        </box>
-        <box width={1} />
-        <box width={AXIS_WIDTH} flexDirection="column" height={chartHeight}>
-          {Array.from({ length: chartHeight }, (_, index) => (
-            <text key={index} fg={colors.textDim}>
-              {axisByRow.get(index) ?? ""}
-            </text>
-          ))}
-        </box>
-      </box>
-
-      <box height={1}>
-        <text fg={colors.textDim}>{rendered.timeLabels}</text>
-      </box>
+      <StockChart
+        width={width}
+        height={chartHeight}
+        focused={false}
+        compact
+        historyOverride={pricePoints}
+        currencyOverride="USD"
+      />
     </box>
   );
 }

--- a/src/plugins/prediction-markets/controller-data.ts
+++ b/src/plugins/prediction-markets/controller-data.ts
@@ -431,14 +431,18 @@ export function usePredictionMarketsDataState({
       setTransportState("idle");
       return;
     }
-    const detailSummary = selectedSummaryRef.current ?? selectedSummary;
+    const detailSummary = selectedSummaryRef.current;
+    if (!detailSummary) {
+      setTransportState("idle");
+      return;
+    }
     const delayMs = detailLoadDelayRef.current;
     detailLoadDelayRef.current = 0;
     const timeoutId = setTimeout(() => {
       void loadSelectedDetail(detailSummary);
     }, delayMs);
     return () => clearTimeout(timeoutId);
-  }, [loadSelectedDetail, selectedSummaryKey, selectedSummary]);
+  }, [loadSelectedDetail, selectedSummaryKey]);
 
   useEffect(() => {
     if (!focused || selectedSummaryVenue !== "kalshi" || !selectedSummaryKey) {

--- a/src/plugins/prediction-markets/detail.test.tsx
+++ b/src/plugins/prediction-markets/detail.test.tsx
@@ -43,5 +43,9 @@ describe("prediction markets detail views", () => {
     expect(frame).toContain("Outcomes");
     expect(frame).toContain("Above 4.25%");
     expect(frame).toContain("Above 4.50%");
+    expect(frame).not.toContain("Ranked by implied YES probability.");
+    expect(frame).not.toContain("TOP Above 4.25%");
+    expect(frame).not.toContain("Kalshi");
+    expect(frame).not.toContain("targets");
   });
 });

--- a/src/plugins/prediction-markets/detail/outcomes.tsx
+++ b/src/plugins/prediction-markets/detail/outcomes.tsx
@@ -27,11 +27,10 @@ export function PredictionMarketOutcomesView({
 
   return (
     <box flexDirection="column">
-      <box flexDirection="column">
+      <box height={1}>
         <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
           Outcomes
         </text>
-        <text fg={colors.textDim}>Ranked by implied YES probability.</text>
       </box>
 
       <box flexDirection="row" height={1}>
@@ -64,10 +63,7 @@ export function PredictionMarketOutcomesView({
                 fg={selected ? colors.selectedText : colors.text}
                 attributes={selected ? TextAttributes.BOLD : 0}
               >
-                {padTo(
-                  `${index === 0 ? "TOP " : ""}${market.marketLabel}`,
-                  labelWidth,
-                )}
+                {padTo(market.marketLabel, labelWidth)}
               </text>
             </box>
             <box width={8}>

--- a/src/plugins/prediction-markets/detail/pane.tsx
+++ b/src/plugins/prediction-markets/detail/pane.tsx
@@ -8,7 +8,6 @@ import { DETAIL_TABS } from "../navigation";
 import {
   formatPredictionEndsAt,
   formatPredictionMetric,
-  formatPredictionPercent,
   formatPredictionProbability,
   formatPredictionSpread,
   getPredictionProbabilityColor,
@@ -32,10 +31,6 @@ interface MetricCell {
   value: string;
   width: number;
   color?: string;
-}
-
-function formatVenueLabel(venue: PredictionMarketSummary["venue"]): string {
-  return venue === "polymarket" ? "Polymarket" : "Kalshi";
 }
 
 function MetricLabelRow({ metrics }: { metrics: MetricCell[] }) {
@@ -114,14 +109,9 @@ export function PredictionMarketDetailPane({
   const summaryMetrics = detail?.summary ?? selectedSummary;
   const detailTitle =
     selectedRow?.kind === "group" ? selectedRow.title : summaryMetrics.title;
-  const selectedLabel = truncatePredictionText(
-    selectedSummary.marketLabel,
-    Math.max(detailWidth - 18, 12),
-  );
-  const detailSubtitleParts = [formatVenueLabel(summaryMetrics.venue)];
+  const detailSubtitleParts: string[] = [];
   if (selectedRow?.kind === "group") {
     if (summaryMetrics.category) detailSubtitleParts.push(summaryMetrics.category);
-    detailSubtitleParts.push(`${selectedRow.marketCount} targets`);
   } else if (
     summaryMetrics.eventLabel &&
     summaryMetrics.eventLabel !== summaryMetrics.title
@@ -195,7 +185,7 @@ export function PredictionMarketDetailPane({
             0,
             Math.max(Math.min(Math.floor((detailWidth - 10) / 18), 3), 0),
           ) ?? []);
-  const headerHeight = selectedRow?.kind === "group" ? 4 : 3;
+  const headerHeight = detailSubtitle.length > 0 ? 3 : 2;
   const detailLoading = detailLoadCount > 0 && !detail;
   const titleColor = focused ? colors.textBright : colors.text;
 
@@ -207,20 +197,9 @@ export function PredictionMarketDetailPane({
             {detailTitle}
           </text>
         </box>
-        <box flexDirection="row" height={1}>
-          <text fg={colors.textDim}>{detailSubtitle}</text>
-        </box>
-        {selectedRow?.kind === "group" && (
+        {detailSubtitle.length > 0 && (
           <box flexDirection="row" height={1}>
-            <text fg={colors.textDim}>Top target:</text>
-            <box width={1} />
-            <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-              {selectedLabel}
-            </text>
-            <box width={1} />
-            <text fg={getPredictionProbabilityColor(selectedSummary.yesPrice)}>
-              {formatPredictionPercent(selectedSummary.yesPrice)}
-            </text>
+            <text fg={colors.textDim}>{detailSubtitle}</text>
           </box>
         )}
       </box>

--- a/src/plugins/prediction-markets/detail/shared.tsx
+++ b/src/plugins/prediction-markets/detail/shared.tsx
@@ -20,7 +20,6 @@ export function SummaryLink({
 }) {
   return (
     <box height={1} onMouseDown={() => openUrl(url)}>
-      <text fg={colors.textDim}>{"Venue: "}</text>
       <text fg={colors.textBright} attributes={TextAttributes.UNDERLINE}>
         {truncatePredictionText(url, maxLength)}
       </text>

--- a/src/plugins/prediction-markets/pane.test.tsx
+++ b/src/plugins/prediction-markets/pane.test.tsx
@@ -90,7 +90,8 @@ describe("prediction markets pane interactions", () => {
     await flushFrames(testSetup);
 
     let frame = testSetup.captureCharFrame();
-    expect(frame).toContain("Prediction Markets");
+    expect(frame).toContain("All venues");
+    expect(frame).not.toContain("VOL = native venue units");
     expect(frame).toContain("Will inflation fall?");
     expect(frame).toContain("Kalshi");
 
@@ -115,6 +116,45 @@ describe("prediction markets pane interactions", () => {
     frame = testSetup.captureCharFrame();
     expect(frame).toContain("Will the Fed cut rates?");
     expect(frame).toContain("Kalshi primary rule");
+  });
+
+  test("loads selected detail once instead of refetching in a render loop", async () => {
+    const { fetchUrls } = installPredictionMarketMocks();
+
+    testSetup = await testRender(<Harness />, { width: 120, height: 34 });
+    await flushFrames(testSetup);
+
+    const frame = testSetup.captureCharFrame();
+    const lines = frame.split("\n");
+    const kalshiRow = lines.findIndex((line) =>
+      line.includes("Will the Fed cut rates?"),
+    );
+    const kalshiCol = lines[kalshiRow]?.indexOf("Will the Fed cut rates?") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(kalshiCol + 1, kalshiRow);
+      await testSetup!.renderOnce();
+    });
+    await flushFrames(testSetup, 8);
+
+    const eventFetches = fetchUrls.filter((url) =>
+      url.includes("/trade-api/v2/events/FED-1"),
+    );
+    const orderbookFetches = fetchUrls.filter((url) =>
+      url.includes("/trade-api/v2/markets/KAL-1/orderbook"),
+    );
+    const tradeFetches = fetchUrls.filter((url) =>
+      url.includes("/trade-api/v2/markets/trades?ticker=KAL-1"),
+    );
+    const historyFetches = fetchUrls.filter((url) =>
+      url.includes("/trade-api/v2/series/FED/markets/KAL-1/candlesticks"),
+    );
+
+    expect(eventFetches).toHaveLength(2);
+    expect(orderbookFetches).toHaveLength(1);
+    expect(tradeFetches).toHaveLength(1);
+    expect(historyFetches).toHaveLength(1);
+    expect(testSetup.captureCharFrame()).not.toContain("Loading market detail...");
   });
 
   test("moves selection through the list with keyboard navigation", async () => {

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -1,16 +1,14 @@
 import { useRef } from "react";
 import { TextAttributes, type BoxRenderable } from "@opentui/core";
-import { Spinner, TabBar } from "../../components";
+import { TabBar } from "../../components";
 import { usePredictionMarketsController } from "./controller";
 import { PredictionMarketDetailPane } from "./detail/pane";
 import { BROWSE_TABS, VENUE_TABS } from "./navigation";
 import { PredictionMarketsTable } from "./table";
-import { formatPredictionTransportBadge } from "./status";
 import { PREDICTION_CATEGORY_OPTIONS } from "./categories";
 import type { PredictionBrowseTab, PredictionCategoryId } from "./types";
 import type { PaneProps } from "../../types/plugin";
 import { colors } from "../../theme/colors";
-import { formatTimeAgo } from "../../utils/format";
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -22,12 +20,6 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
   const splitDragRef = useRef<{ startX: number; startRatio: number } | null>(
     null,
   );
-  const statusBadge = formatPredictionTransportBadge(
-    controller.catalogLoadCount > 0 || controller.detailLoadCount > 0
-      ? "loading"
-      : controller.transportState,
-  );
-  const showSummaryUnitsHint = controller.effectiveVenueScope === "all";
   const minTableWidth = 44;
   const minDetailWidth = 36;
   const effectiveMinTableWidth = controller.selectedSummary
@@ -108,28 +100,6 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       backgroundColor={colors.panel}
       onMouse={handlePaneMouse}
     >
-      {!controller.paneSettings.hideHeader && (
-        <box flexDirection="row" height={1} paddingX={1}>
-          <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-            Prediction Markets
-          </text>
-          <box flexGrow={1} />
-          {showSummaryUnitsHint && (
-            <text fg={colors.textDim}>VOL = native venue units</text>
-          )}
-          <box width={1} />
-          {controller.searchLoading && <Spinner />}
-          {controller.searchLoading && <box width={1} />}
-          <text fg={statusBadge.color}>{statusBadge.label}</text>
-          <box width={1} />
-          <text fg={colors.textDim}>
-            {controller.lastRefreshAt
-              ? `refresh ${formatTimeAgo(new Date(controller.lastRefreshAt))}`
-              : "waiting"}
-          </text>
-        </box>
-      )}
-
       {!controller.paneSettings.hideTabs && (
         <TabBar
           tabs={VENUE_TABS.map((tab) => ({

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -1355,6 +1355,49 @@ describe("ProviderRouter", () => {
     expect(history.map((point) => point.close)).toEqual([101, 102, 103]);
   });
 
+  test("ignores poisoned cached chart history and refetches clean data", async () => {
+    const dbPath = createTempDbPath("poisoned-chart-cache");
+    const persistence = new AppPersistence(dbPath);
+
+    persistence.resources.set(
+      {
+        namespace: "market",
+        kind: "price-history",
+        entityKey: "AAPL",
+        variantKey: "exchange=NASDAQ;range=1Y",
+        sourceKey: "provider:yahoo",
+      },
+      [
+        { date: null as any, close: 101 },
+        { date: null as any, close: 102 },
+      ],
+      {
+        cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
+      },
+    );
+
+    let providerCalls = 0;
+    const router = new ProviderRouter({
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      async getPriceHistory() {
+        providerCalls += 1;
+        return [
+          { date: new Date("2026-03-27T00:00:00Z"), close: 201 },
+          { date: new Date("2026-03-28T00:00:00Z"), close: 202 },
+        ];
+      },
+    }, [], persistence.resources);
+
+    const history = await router.getPriceHistory("AAPL", "NASDAQ", "1Y");
+
+    expect(providerCalls).toBe(1);
+    expect(history.map((point) => point.close)).toEqual([201, 202]);
+
+    persistence.close();
+  });
+
   test("bypasses cached financials on explicit refresh requests", async () => {
     const dbPath = createTempDbPath("forced-financial-refresh");
     const persistence = new AppPersistence(dbPath);

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -483,9 +483,10 @@ export class ProviderRouter implements DataProvider {
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedArrayResource<PricePoint>("price-history", entityKey, variantKeys, sourceKeys, false);
+    const cachedValue = cached ? normalizePriceHistory(cached.value) : [];
     const forceRefresh = context?.cacheMode === "refresh";
-    if (cached && !forceRefresh && !cached.stale) {
-      return cached.value;
+    if (cachedValue.length > 0 && !forceRefresh && cached && !cached.stale) {
+      return cachedValue;
     }
 
     const brokerHistory = await withBrokerTimeout(this.fetchBrokerPriceHistory(ticker, exchange, range, context));
@@ -495,7 +496,7 @@ export class ProviderRouter implements DataProvider {
     if (providerHistory && providerHistory.value.length > 0) {
       return providerHistory.value;
     }
-    if (cached) return cached.value;
+    if (cachedValue.length > 0) return cachedValue;
     if (!providerHistory) {
       throw new Error(`No history provider available for ${ticker}`);
     }
@@ -520,9 +521,10 @@ export class ProviderRouter implements DataProvider {
       ...this.getProviderSourceKeys(),
     ];
     const cached = this.selectCachedArrayResource<PricePoint>("detailed-price-history", entityKey, variantKeys, sourceKeys, false);
+    const cachedValue = cached ? normalizePriceHistory(cached.value) : [];
     const forceRefresh = context?.cacheMode === "refresh";
-    if (cached && !forceRefresh && !cached.stale) {
-      return cached.value;
+    if (cachedValue.length > 0 && !forceRefresh && cached && !cached.stale) {
+      return cachedValue;
     }
 
     const brokerResult = await withBrokerTimeout(this.fetchBrokerDetailedPriceHistory(ticker, exchange, startDate, endDate, barSize, context));
@@ -532,7 +534,7 @@ export class ProviderRouter implements DataProvider {
     if (providerResult && providerResult.value.length > 0) {
       return providerResult.value;
     }
-    return cached?.value ?? providerResult?.value ?? [];
+    return cachedValue.length > 0 ? cachedValue : (providerResult?.value ?? []);
   }
 
   async getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, context?: MarketDataRequestContext): Promise<OptionsChain> {

--- a/src/utils/price-history.test.ts
+++ b/src/utils/price-history.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { normalizePriceHistory } from "./price-history";
+
+describe("normalizePriceHistory", () => {
+  test("drops poisoned cached history when every timestamp collapses to the same value", () => {
+    const history = normalizePriceHistory([
+      { date: null as any, close: 101 },
+      { date: null as any, close: 102 },
+      { date: null as any, close: 103 },
+    ]);
+
+    expect(history).toEqual([]);
+  });
+
+  test("filters invalid dates and keeps the remaining points in chronological order", () => {
+    const history = normalizePriceHistory([
+      { date: new Date("2026-03-29T00:00:00Z"), close: 103 },
+      { date: null as any, close: 999 },
+      { date: new Date("2026-03-27T00:00:00Z"), close: 101 },
+      { date: new Date("2026-03-28T00:00:00Z"), close: 102 },
+    ]);
+
+    expect(history.map((point) => point.close)).toEqual([101, 102, 103]);
+  });
+});

--- a/src/utils/price-history.ts
+++ b/src/utils/price-history.ts
@@ -1,7 +1,10 @@
 import type { PricePoint, TickerFinancials } from "../types/financials";
 
 function getPointTimestamp(point: PricePoint): number {
-  return point.date instanceof Date ? point.date.getTime() : new Date(point.date).getTime();
+  const value = point.date as Date | string | number | null | undefined;
+  if (value instanceof Date) return value.getTime();
+  if (value == null) return Number.NaN;
+  return new Date(value).getTime();
 }
 
 function comparePricePointsByDate(left: PricePoint, right: PricePoint): number {
@@ -17,18 +20,39 @@ function comparePricePointsByDate(left: PricePoint, right: PricePoint): number {
 }
 
 export function normalizePriceHistory(points: PricePoint[]): PricePoint[] {
-  if (points.length <= 1) return points;
+  if (points.length === 0) return points;
 
+  const validPoints: PricePoint[] = [];
+  let sawDistinctTimestamp = false;
+  let firstTimestamp: number | null = null;
   let previousTime = Number.NEGATIVE_INFINITY;
+  let requiresSort = false;
+
   for (const point of points) {
     const time = getPointTimestamp(point);
-    if (!Number.isFinite(time) || time < previousTime) {
-      return [...points].sort(comparePricePointsByDate);
+    if (!Number.isFinite(time)) continue;
+
+    if (firstTimestamp === null) {
+      firstTimestamp = time;
+    } else if (time !== firstTimestamp) {
+      sawDistinctTimestamp = true;
+    }
+
+    if (time < previousTime) {
+      requiresSort = true;
     }
     previousTime = time;
+    validPoints.push(point);
   }
 
-  return points;
+  if (validPoints.length === 0) return [];
+  if (validPoints.length === 1) return validPoints;
+  if (!sawDistinctTimestamp) return [];
+
+  if (requiresSort) {
+    return [...validPoints].sort(comparePricePointsByDate);
+  }
+  return validPoints.length === points.length ? points : validPoints;
 }
 
 export function normalizeTickerFinancialsPriceHistory(financials: TickerFinancials): TickerFinancials {


### PR DESCRIPTION
Prediction market detail now reuses the shared compact StockChart path, removes redundant detail chrome, and fixes the detail refetch/loading loop. Compact chart time axes now derive labels from the original visible history instead of projected extrema, which fixes the uneven x-axis spacing that showed up in prediction market charts. IBKR historical bars now parse compact date and timestamp formats correctly, and poisoned cached price history is filtered or refetched instead of being reused. Tests cover the shared chart path, prediction market scrolling and detail behavior, IBKR bar parsing, and cache normalization and router fallback handling.