### PR TITLE
Reset terminal mouse state before watch restart

### DIFF
--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -676,6 +676,33 @@ describe("Shell", () => {
     expect(updateLayout?.layout.dockRoot).toEqual({ kind: "pane", instanceId: "portfolio-list:main" });
   });
 
+  test("keeps a floating pane at the preview rect after a free drag release", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-drag-test");
+    const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+    if (!detailPane) throw new Error("missing detail pane");
+    const floatingOnlyLayout = {
+      dockRoot: null,
+      instances: [{ ...detailPane, binding: { kind: "fixed" as const, symbol: "AAPL" } }],
+      floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8, zIndex: 75 }],
+    };
+
+    const result = finalizePaneDragRelease(
+      floatingOnlyLayout,
+      "ticker-detail:main",
+      { x: 14, y: 4, width: 30, height: 8 },
+      null,
+    );
+
+    expect(result.shouldShowGridlockTip).toBe(false);
+    expect(result.nextLayout.floating[0]).toEqual(expect.objectContaining({
+      instanceId: "ticker-detail:main",
+      x: 14,
+      y: 4,
+      width: 30,
+      height: 8,
+    }));
+  });
+
   test("keeps the last floating pane body row visible above the border", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-shell-footer-test");
     const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync } from "fs";
 import { dispatchCli } from "./cli/index";
 import { loadExternalPlugins } from "./plugins/loader";
 import { debugLog } from "./utils/debug-log";
+import { resetTerminalInputState } from "./utils/terminal-input-reset";
 
 async function main() {
   // Intercept console.log/warn/error to capture in debug log
@@ -43,6 +44,10 @@ async function main() {
   // Load or create config
   const config = await initDataDir(dataDir);
 
+  // `bun run --watch` does not guarantee the previous run's renderer can cleanly
+  // restore mouse/raw terminal modes before the next run starts.
+  resetTerminalInputState();
+
   // Create renderer
   const renderer = await createCliRenderer({
     exitOnCtrlC: true,
@@ -63,5 +68,5 @@ async function main() {
 
 main().catch((err) => {
   console.error("Fatal error:", err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/src/utils/terminal-input-reset.test.ts
+++ b/src/utils/terminal-input-reset.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { resetTerminalInputState, TERMINAL_MOUSE_RESET_SEQUENCE } from "./terminal-input-reset";
+
+describe("resetTerminalInputState", () => {
+  test("disables mouse tracking and exits raw mode before renderer startup", () => {
+    const writes: string[] = [];
+    const rawModeCalls: boolean[] = [];
+
+    resetTerminalInputState(
+      {
+        isTTY: true,
+        setRawMode(mode: boolean) {
+          rawModeCalls.push(mode);
+        },
+      },
+      {
+        isTTY: true,
+        write(chunk: string) {
+          writes.push(chunk);
+        },
+      },
+    );
+
+    expect(writes).toEqual([TERMINAL_MOUSE_RESET_SEQUENCE]);
+    expect(rawModeCalls).toEqual([false]);
+  });
+
+  test("does not write terminal escapes when stdout is not a tty", () => {
+    const writes: string[] = [];
+    const rawModeCalls: boolean[] = [];
+
+    resetTerminalInputState(
+      {
+        isTTY: true,
+        setRawMode(mode: boolean) {
+          rawModeCalls.push(mode);
+        },
+      },
+      {
+        isTTY: false,
+        write(chunk: string) {
+          writes.push(chunk);
+        },
+      },
+    );
+
+    expect(writes).toEqual([]);
+    expect(rawModeCalls).toEqual([false]);
+  });
+});

--- a/src/utils/terminal-input-reset.ts
+++ b/src/utils/terminal-input-reset.ts
@@ -1,0 +1,24 @@
+export const TERMINAL_MOUSE_RESET_SEQUENCE = "\x1B[?1016l\x1B[?1006l\x1B[?1005l\x1B[?1015l\x1B[?1003l\x1B[?1002l\x1B[?1000l";
+
+interface TerminalResetStdin {
+  isTTY?: boolean;
+  setRawMode?: (mode: boolean) => void;
+}
+
+interface TerminalResetStdout {
+  isTTY?: boolean;
+  write: (chunk: string) => unknown;
+}
+
+export function resetTerminalInputState(
+  stdin: TerminalResetStdin = process.stdin,
+  stdout: TerminalResetStdout = process.stdout,
+): void {
+  if (stdout.isTTY) {
+    stdout.write(TERMINAL_MOUSE_RESET_SEQUENCE);
+  }
+
+  if (stdin.isTTY !== false && typeof stdin.setRawMode === "function") {
+    stdin.setRawMode(false);
+  }
+}


### PR DESCRIPTION
Reset mouse tracking and raw mode before OpenTUI boot so bun run dev restarts do not inherit stale terminal input state and break floating pane drag/resize.
Add a small terminal reset helper plus targeted tests for the reset sequence and free-drag layout persistence.
Switch the fatal startup path from process.exit(1) to process.exitCode = 1 so startup failures do not bypass cleanup.
Testing: bun test src/utils/terminal-input-reset.test.ts src/components/layout/shell.test.tsx
