### PR TITLE
Refine market formatting and chart behavior

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -482,14 +482,14 @@ describe("buildTickerReport", () => {
       title: "NVIDIA unveils next platform",
       source: "Example News",
       url: "https://example.com/nvda-platform",
-      publishedAt: new Date(Date.UTC(2026, 3, 1, 15, 45)),
+      publishedAt: "2026-04-01T15:45:00.000Z" as unknown as Date,
       summary: "Analysts expect the launch to expand datacenter demand.",
     }];
 
     const recentSecFilings: SecFilingItem[] = [{
       accessionNumber: "0000000000-26-000001",
       form: "8-K",
-      filingDate: new Date(Date.UTC(2026, 2, 31)),
+      filingDate: "2026-03-31T00:00:00.000Z" as unknown as Date,
       cik: "0001045810",
       filingUrl: "https://www.sec.gov/Archives/example-8k",
       primaryDocument: "nvda-8k.htm",
@@ -521,6 +521,7 @@ describe("buildTickerReport", () => {
     expect(report).toContain("Recent News");
     expect(report).toContain("NVIDIA unveils next platform");
     expect(report).toContain("Example News");
+    expect(report).toContain("Apr 1, 2026");
     expect(report).toContain("Recent SEC Filings");
     expect(report).toContain("8-K | Mar 31, 2026");
     expect(report).toContain("Current report announcing a product launch");

--- a/src/cli/commands/ticker.ts
+++ b/src/cli/commands/ticker.ts
@@ -4,6 +4,7 @@ import {
   formatNumber,
   formatPercent,
 } from "../../utils/format";
+import { formatMarketCostWithCurrency, formatMarketPriceWithCurrency, formatMarketQuantity } from "../../utils/market-format";
 import {
   cliStyles,
   colorBySign,
@@ -75,6 +76,30 @@ function appendTextSection(lines: string[], title: string, content: string | und
   lines.push("");
   lines.push(renderSection(title));
   lines.push(text);
+}
+
+function normalizeTimestamp(value: Date | string | number | undefined): number | null {
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const timestamp = new Date(value).getTime();
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+
+  return null;
+}
+
+function formatFeedDate(value: Date | string | number | undefined): string {
+  const timestamp = normalizeTimestamp(value);
+  if (timestamp == null) return "";
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
 }
 
 function appendFeedSection(
@@ -215,16 +240,16 @@ export async function buildTickerReport({
     : "—";
 
   appendMetricSection(lines, "Quote", [
-    ["Last", colorBySign(formatCurrency(quote.price, quote.currency), quote.change)],
+    ["Last", colorBySign(formatMarketPriceWithCurrency(quote.price, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory }), quote.change)],
     ["Change", colorBySign(`${formatSignedCurrency(quote.change, quote.currency)} (${formatSignedPercentRaw(quote.changePercent)})`, quote.change)],
-    ["Open", quote.open != null ? formatCurrency(quote.open, quote.currency) : "—"],
+    ["Open", quote.open != null ? formatMarketPriceWithCurrency(quote.open, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory }) : "—"],
     ["Day Range", quote.low != null || quote.high != null
-      ? `${quote.low != null ? formatCurrency(quote.low, quote.currency) : "—"} - ${quote.high != null ? formatCurrency(quote.high, quote.currency) : "—"}`
+      ? `${quote.low != null ? formatMarketPriceWithCurrency(quote.low, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory }) : "—"} - ${quote.high != null ? formatMarketPriceWithCurrency(quote.high, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory }) : "—"}`
       : "—"],
     ["52W Range", quote.low52w != null || quote.high52w != null
-      ? `${quote.low52w != null ? formatCurrency(quote.low52w, quote.currency) : "—"} - ${quote.high52w != null ? formatCurrency(quote.high52w, quote.currency) : "—"}`
+      ? `${quote.low52w != null ? formatMarketPriceWithCurrency(quote.low52w, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory }) : "—"} - ${quote.high52w != null ? formatMarketPriceWithCurrency(quote.high52w, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory }) : "—"}`
       : "—"],
-    ["Bid / Ask", formatBidAsk(quote.bid, quote.ask, quote.bidSize, quote.askSize, quote.currency)],
+    ["Bid / Ask", formatBidAsk(quote.bid, quote.ask, quote.bidSize, quote.askSize, quote.currency, tickerFile?.metadata.assetCategory)],
     ["Volume", quote.volume != null ? formatNumber(quote.volume, 0) : "—"],
     ["Updated", formatTimestamp(quote.lastUpdated)],
   ]);
@@ -232,13 +257,13 @@ export async function buildTickerReport({
   appendMetricSection(lines, "Extended Hours", [
     ["Pre-Market", quote.preMarketPrice != null
       ? colorBySign(
-        `${formatCurrency(quote.preMarketPrice, quote.currency)} (${formatSignedPercentRaw(quote.preMarketChangePercent ?? 0)})`,
+        `${formatMarketPriceWithCurrency(quote.preMarketPrice, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory })} (${formatSignedPercentRaw(quote.preMarketChangePercent ?? 0)})`,
         quote.preMarketChange ?? 0,
       )
       : "—"],
     ["After Hours", quote.postMarketPrice != null
       ? colorBySign(
-        `${formatCurrency(quote.postMarketPrice, quote.currency)} (${formatSignedPercentRaw(quote.postMarketChangePercent ?? 0)})`,
+        `${formatMarketPriceWithCurrency(quote.postMarketPrice, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory })} (${formatSignedPercentRaw(quote.postMarketChangePercent ?? 0)})`,
         quote.postMarketChange ?? 0,
       )
       : "—"],
@@ -288,18 +313,20 @@ export async function buildTickerReport({
     title: item.title,
     meta: [
       item.source,
-      Number.isNaN(item.publishedAt.getTime()) ? "" : formatTimestamp(item.publishedAt.getTime()),
+      (() => {
+        const publishedAt = normalizeTimestamp(item.publishedAt as Date | string | number | undefined);
+        return publishedAt == null ? "" : formatTimestamp(publishedAt);
+      })(),
     ],
     body: item.summary,
     link: item.url,
   })));
 
   appendFeedSection(lines, "Recent SEC Filings", recentSecFilings.map((filing) => ({
-    title: `${filing.form} | ${filing.filingDate.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    })}`,
+    title: (() => {
+      const filingDate = formatFeedDate(filing.filingDate as Date | string | number | undefined);
+      return filingDate ? `${filing.form} | ${filingDate}` : filing.form;
+    })(),
     meta: [
       filing.items ? `Items ${filing.items}` : "",
       getFilingDescription(filing) ?? "",
@@ -320,12 +347,15 @@ export async function buildTickerReport({
       const pnl = marketValueBase - costBasisBase;
 
       lines.push(cliStyles.bold(`${portfolioName} (${position.broker})`));
-      lines.push(renderStat("Position", `${position.shares} ${multiplier > 1 ? "contracts" : "shares"} @ ${formatCurrency(position.avgCost, positionCurrency)}`));
+      lines.push(renderStat(
+        "Position",
+        `${formatMarketQuantity(position.shares, { assetCategory: tickerFile.metadata.assetCategory, multiplier: position.multiplier })} ${multiplier > 1 ? "contracts" : "shares"} @ ${formatMarketCostWithCurrency(position.avgCost, positionCurrency, { assetCategory: tickerFile.metadata.assetCategory, multiplier: position.multiplier })}`,
+      ));
       lines.push(renderStat("Cost Basis", formatCurrency(costBasisBase, config.baseCurrency)));
       lines.push(renderStat("Market Value", formatCurrency(marketValueBase, config.baseCurrency)));
       lines.push(renderStat("P&L", colorBySign(formatSignedCurrency(pnl, config.baseCurrency), pnl)));
       if (position.markPrice != null) {
-        lines.push(renderStat("Mark", formatCurrency(position.markPrice, positionCurrency)));
+        lines.push(renderStat("Mark", formatMarketPriceWithCurrency(position.markPrice, positionCurrency, { assetCategory: tickerFile.metadata.assetCategory, multiplier: position.multiplier })));
       }
       if (index < tickerFile.metadata.positions.length - 1) {
         lines.push(cliStyles.muted("-".repeat(24)));

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -4,6 +4,7 @@ import {
   formatNumber,
   formatPercentRaw,
 } from "../utils/format";
+import { formatMarketPriceWithCurrency } from "../utils/market-format";
 export { slugifyName } from "../utils/slugify";
 import type { AppConfig } from "../types/config";
 import type { Watchlist, TickerRecord } from "../types/ticker";
@@ -42,13 +43,14 @@ export function formatBidAsk(
   bidSize: number | undefined,
   askSize: number | undefined,
   currency: string,
+  assetCategory?: string,
 ): string {
   if (bid == null && ask == null) return "—";
   const bidText = bid != null
-    ? `${formatCurrency(bid, currency)}${bidSize != null ? ` x ${formatNumber(bidSize, 0)}` : ""}`
+    ? `${formatMarketPriceWithCurrency(bid, currency, { assetCategory })}${bidSize != null ? ` x ${formatNumber(bidSize, 0)}` : ""}`
     : "—";
   const askText = ask != null
-    ? `${formatCurrency(ask, currency)}${askSize != null ? ` x ${formatNumber(askSize, 0)}` : ""}`
+    ? `${formatMarketPriceWithCurrency(ask, currency, { assetCategory })}${askSize != null ? ` x ${formatNumber(askSize, 0)}` : ""}`
     : "—";
   return `${bidText} / ${askText}`;
 }

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -1,7 +1,7 @@
 import { RGBA } from "@opentui/core";
 import type { ChartAxisMode, ChartColors, Pixel, PixelBuffer, ChartRenderMode } from "./chart-types";
 import type { ProjectedChartPoint } from "./chart-data";
-import { formatCurrency } from "../../utils/format";
+import { formatCompactMarketPriceWithCurrency, formatMarketPrice, resolveAssetDisplayKind } from "../../utils/market-format";
 
 // ---------------------------------------------------------------------------
 // Styled output types (unchanged public API)
@@ -574,8 +574,21 @@ export function bufferToBrailleLines(buf: PixelBuffer, bgColor: string): StyledC
 // Formatting helpers
 // ---------------------------------------------------------------------------
 
-export function formatPrice(value: number): string {
-  return formatPriceWithCurrency(value);
+export function formatPrice(
+  value: number,
+  assetCategory?: string,
+  priceRange?: number,
+  precisionOffset = 0,
+  minimumFractionDigits = 0,
+  fixedFractionDigits?: number,
+): string {
+  return formatMarketPrice(value, {
+    assetCategory,
+    fixedFractionDigits,
+    minimumFractionDigits,
+    precisionOffset,
+    priceRange,
+  });
 }
 
 function formatPercentAxisValue(value: number): string {
@@ -585,39 +598,125 @@ function formatPercentAxisValue(value: number): string {
   return `${prefix}${value.toFixed(decimals)}%`;
 }
 
-const currencySymbols = new Map<string, string>();
-
-function getCurrencySymbol(currency: string): string {
-  const cached = currencySymbols.get(currency);
-  if (cached) return cached;
-
-  const formatter = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    currencyDisplay: "symbol",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+export function formatPriceWithCurrency(
+  value: number,
+  currency = "USD",
+  assetCategory?: string,
+  priceRange?: number,
+  precisionOffset = 0,
+  minimumFractionDigits = 0,
+  fixedFractionDigits?: number,
+): string {
+  return formatCompactMarketPriceWithCurrency(value, currency, {
+    assetCategory,
+    fixedFractionDigits,
+    minimumFractionDigits,
+    precisionOffset,
+    priceRange,
   });
-  const symbol = formatter.formatToParts(0).find((part) => part.type === "currency")?.value ?? currency;
-  currencySymbols.set(currency, symbol);
-  return symbol;
 }
 
-export function formatPriceWithCurrency(value: number, currency = "USD"): string {
-  const abs = Math.abs(value);
-  const sign = value < 0 ? "-" : "";
-  const symbol = getCurrencySymbol(currency);
-
-  if (abs >= 1e6) return `${sign}${symbol}${(abs / 1e6).toFixed(1)}M`;
-  if (abs >= 1e3 && abs < 1e5) return `${sign}${symbol}${(abs / 1e3).toFixed(1)}K`;
-  return formatCurrency(value, currency);
+function hasDistinctAxisLabels(labels: string[]): boolean {
+  return new Set(labels).size === labels.length;
 }
 
-export function formatAxisValue(value: number, axisMode: ChartAxisMode, basePrice: number, currency = "USD"): string {
+function getAxisFractionDigitFloor(assetCategory: string | undefined, priceRange: number | undefined): number {
+  if (priceRange === undefined || !Number.isFinite(priceRange) || priceRange <= 0) return 0;
+
+  const kind = resolveAssetDisplayKind({ assetCategory });
+  const visibleStep = priceRange / 3;
+  if (!Number.isFinite(visibleStep) || visibleStep <= 0) return 0;
+
+  const offset = kind === "cash" ? 0 : 1;
+  return Math.max(0, Math.ceil(-Math.log10(visibleStep)) + offset);
+}
+
+export function resolveAxisFractionDigits(
+  prices: number[],
+  formatLabel: (value: number, fixedFractionDigits: number) => string,
+  minimumFractionDigits = 0,
+  maxFractionDigits = 8,
+): number {
+  for (let fixedFractionDigits = minimumFractionDigits; fixedFractionDigits <= maxFractionDigits; fixedFractionDigits += 1) {
+    const labels = prices.map((value) => formatLabel(value, fixedFractionDigits));
+    if (hasDistinctAxisLabels(labels)) return fixedFractionDigits;
+  }
+
+  return maxFractionDigits;
+}
+
+export function resolveChartAxisWidth(
+  labels: Array<string | null | undefined>,
+  minimumWidth: number,
+  maximumWidth: number,
+): number {
+  if (maximumWidth <= 0) return 0;
+
+  const longestLabel = labels.reduce((maxWidth, label) => (
+    Math.max(maxWidth, label?.length ?? 0)
+  ), 0);
+
+  return Math.min(Math.max(longestLabel, minimumWidth), maximumWidth);
+}
+
+export function formatAxisCell(label: string | null, width: number): string {
+  if (width <= 0) return "";
+  if (!label) return " ".repeat(width);
+  return label.length >= width ? label.slice(0, width) : label.padStart(width);
+}
+
+export function formatAxisValue(
+  value: number,
+  axisMode: ChartAxisMode,
+  basePrice: number,
+  currency = "USD",
+  assetCategory?: string,
+  priceRange?: number,
+  fixedFractionDigits?: number,
+): string {
   if (axisMode === "percent" && basePrice !== 0) {
     return formatPercentAxisValue(((value - basePrice) / basePrice) * 100);
   }
-  return formatPriceWithCurrency(value, currency);
+  return formatPriceWithCurrency(value, currency, assetCategory, priceRange, 0, 0, fixedFractionDigits);
+}
+
+function getCursorAxisMinimumFractionDigits(value: number, assetCategory?: string): number {
+  const kind = resolveAssetDisplayKind({ assetCategory });
+
+  switch (kind) {
+    case "cash":
+      return 4;
+    case "crypto":
+      return Math.abs(value) >= 1 ? 4 : 6;
+    case "equity":
+    case "contract":
+      return Math.abs(value) >= 1 ? 2 : 4;
+    case "other":
+    default:
+      return Math.abs(value) >= 1 ? 2 : 4;
+  }
+}
+
+export function formatCursorAxisValue(
+  value: number,
+  axisMode: ChartAxisMode,
+  basePrice: number,
+  currency = "USD",
+  assetCategory?: string,
+  priceRange?: number,
+): string {
+  if (axisMode === "percent" && basePrice !== 0) {
+    return formatPercentAxisValue(((value - basePrice) / basePrice) * 100);
+  }
+
+  return formatPriceWithCurrency(
+    value,
+    currency,
+    assetCategory,
+    priceRange,
+    2,
+    getCursorAxisMinimumFractionDigits(value, assetCategory),
+  );
 }
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -916,6 +1015,7 @@ export interface RenderChartOptions {
   mode: ChartRenderMode;
   axisMode?: ChartAxisMode;
   currency?: string;
+  assetCategory?: string;
   colors: ResolvedChartPalette;
   timeAxisDates?: Array<Date | string | number>;
 }
@@ -958,6 +1058,8 @@ export interface RenderChartResult {
   changePctAtCursor: number | null;
   cursorColumn: number | null;
   cursorRow: number | null;
+  axisFractionDigits: number | null;
+  priceRange: number | null;
   /** Raw pixel buffer for GPU/Kitty rendering path */
   pixelBuffer: PixelBuffer | null;
 }
@@ -1075,6 +1177,8 @@ export function renderChart(
       changePctAtCursor: null,
       cursorColumn: null,
       cursorRow: null,
+      axisFractionDigits: null,
+      priceRange: null,
       pixelBuffer: null,
     };
   }
@@ -1082,6 +1186,7 @@ export function renderChart(
   const { width, colors: palette, mode } = opts;
   const axisMode = opts.axisMode ?? "price";
   const currency = opts.currency ?? "USD";
+  const assetCategory = opts.assetCategory;
 
   // Braille resolution: 2 dot-columns per terminal column, 4 dot-rows per terminal row
   const dotWidth = width * 2;
@@ -1094,8 +1199,24 @@ export function renderChart(
 
   const buf = createPixelBuffer(dotWidth, totalDotH);
   const { min, max } = scene;
+  const priceRange = max - min;
 
   const gridLines = computeGridLines(min, max, 0, chartDotBottom, 3);
+  const axisFractionDigits = axisMode === "price"
+    ? resolveAxisFractionDigits(
+      gridLines.map((line) => line.price),
+      (price, fixedFractionDigits) => formatPriceWithCurrency(
+        price,
+        currency,
+        assetCategory,
+        priceRange,
+        0,
+        0,
+        fixedFractionDigits,
+      ),
+      getAxisFractionDigitFloor(assetCategory, priceRange),
+    )
+    : null;
   drawGridLines(buf, gridLines.map((line) => line.y), palette.gridColor);
 
   switch (mode) {
@@ -1137,7 +1258,7 @@ export function renderChart(
   for (const line of gridLines) {
     axisLabelsByRow.set(
       Math.min(Math.floor(line.y / 4), Math.max(chartTermRows - 1, 0)),
-      formatAxisValue(line.price, axisMode, points[0]!.close, currency),
+      formatAxisValue(line.price, axisMode, points[0]!.close, currency, assetCategory, priceRange, axisFractionDigits ?? undefined),
     );
   }
 
@@ -1155,6 +1276,8 @@ export function renderChart(
     changePctAtCursor,
     cursorColumn: scene.cursorColumn,
     cursorRow: scene.cursorRow,
+    axisFractionDigits,
+    priceRange,
     pixelBuffer: buf,
   };
 }

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bucketOhlcSeries, getVisibleWindow, projectChartData, resolveRenderMode } from "./chart-data";
 import { stepCursorTowards } from "./cursor-motion";
-import { buildTimeAxis, formatAxisValue, renderChart, resolveChartPalette } from "./chart-renderer";
+import { buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
 import type { PricePoint } from "../../types/financials";
 import type { ChartRenderMode, ChartViewState } from "./chart-types";
 
@@ -133,9 +133,81 @@ describe("getVisibleWindow", () => {
 });
 
 describe("renderChart", () => {
+  test("sizes the y-axis to the visible label width instead of a fixed gutter", () => {
+    expect(resolveChartAxisWidth(["$18", "$17", "$16", "$14"], 4, 10)).toBe(4);
+    expect(resolveChartAxisWidth(["$1.1678", "$1.1654"], 4, 10)).toBe(7);
+    expect(resolveChartAxisWidth(["+0.25%", "-0.10%"], 5, 11)).toBe(6);
+  });
+
   test("formats price axes with the instrument currency", () => {
     expect(formatAxisValue(21_970, "price", 0, "JPY")).toBe("¥22.0K");
     expect(formatAxisValue(12_340, "price", 0, "HKD")).toBe("HK$12.3K");
+    expect(formatAxisValue(1.17364, "price", 0, "USD", "CURRENCY")).toBe("$1.17364");
+  });
+
+  test("adapts FX axis precision to the visible price range", () => {
+    expect(formatAxisValue(1.167815, "price", 0, "USD", "CURRENCY", 0.12)).toBe("$1.17");
+    expect(formatAxisValue(1.167815, "price", 0, "USD", "CURRENCY", 0.0024)).toBe("$1.1678");
+  });
+
+  test("keeps the active price-axis label more precise than coarse grid ticks", () => {
+    expect(formatAxisValue(21.184, "price", 0, "USD", "STK", 11)).toBe("$21");
+    expect(formatCursorAxisValue(21.184, "price", 0, "USD", "STK", 11)).toBe("$21.18");
+    expect(formatCursorAxisValue(1.167815, "price", 0, "USD", "CURRENCY", 0.12)).toBe("$1.1678");
+  });
+
+  test("keeps zoomed equity axis labels distinct and decimal-aware", () => {
+    const narrowRangeFixture: PricePoint[] = [
+      { date: new Date("2024-01-02T09:30:00Z"), close: 18.02, volume: 100 },
+      { date: new Date("2024-01-02T09:31:00Z"), close: 17.91, volume: 120 },
+      { date: new Date("2024-01-02T09:32:00Z"), close: 17.84, volume: 140 },
+      { date: new Date("2024-01-02T09:33:00Z"), close: 17.73, volume: 160 },
+    ];
+
+    const result = renderChart(projectChartData(narrowRangeFixture, 32, "area", false).points, {
+      width: 32,
+      height: 8,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "area",
+      axisMode: "price",
+      currency: "USD",
+      assetCategory: "STK",
+      colors: palette,
+    });
+
+    expect(result.axisFractionDigits).toBeGreaterThanOrEqual(1);
+    expect(new Set(result.axisLabels.map((entry) => entry.label)).size).toBe(result.axisLabels.length);
+    expect(result.axisLabels.every((entry) => entry.label.includes("."))).toBe(true);
+  });
+
+  test("keeps one decimal on zoomed equity axes even when whole-dollar ticks are distinct", () => {
+    const mediumRangeFixture: PricePoint[] = [
+      { date: new Date("2024-01-02T09:30:00Z"), close: 233.82, volume: 100 },
+      { date: new Date("2024-01-02T09:45:00Z"), close: 232.14, volume: 120 },
+      { date: new Date("2024-01-02T10:00:00Z"), close: 230.21, volume: 140 },
+      { date: new Date("2024-01-02T10:15:00Z"), close: 231.67, volume: 160 },
+      { date: new Date("2024-01-02T10:30:00Z"), close: 228.94, volume: 180 },
+    ];
+
+    const result = renderChart(projectChartData(mediumRangeFixture, 28, "area", false).points, {
+      width: 28,
+      height: 8,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "area",
+      axisMode: "price",
+      currency: "USD",
+      assetCategory: "STK",
+      colors: palette,
+    });
+
+    expect(result.axisFractionDigits).toBe(1);
+    expect(result.axisLabels.every((entry) => entry.label.includes("."))).toBe(true);
   });
 
   test("eases coarse cursor motion quickly and settles without overshooting", () => {

--- a/src/components/chart/comparison-chart-renderer.test.ts
+++ b/src/components/chart/comparison-chart-renderer.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { projectComparisonChartData } from "./comparison-chart-data";
-import { buildComparisonChartScene, renderComparisonChart } from "./comparison-chart-renderer";
+import {
+  buildComparisonChartScene,
+  formatComparisonAxisValue,
+  formatComparisonCursorAxisValue,
+  renderComparisonChart,
+} from "./comparison-chart-renderer";
 import type { ComparisonChartSeries } from "./chart-types";
 
 function makeSeries(symbol: string, color: string, closes: number[]): ComparisonChartSeries {
@@ -21,6 +26,71 @@ function textLines(result: ReturnType<typeof renderComparisonChart>): string[] {
 }
 
 describe("renderComparisonChart", () => {
+  test("adapts price-axis precision to the visible range", () => {
+    expect(formatComparisonAxisValue(1.167815, "price", 0.12)).toBe("1.17");
+    expect(formatComparisonAxisValue(1.167815, "price", 0.0024)).toBe("1.1678");
+  });
+
+  test("keeps the active comparison-axis label more precise than coarse ticks", () => {
+    expect(formatComparisonAxisValue(21.184, "price", 11)).toBe("21");
+    expect(formatComparisonCursorAxisValue(21.184, "price", 11)).toBe("21.18");
+  });
+
+  test("keeps narrow comparison price axes distinct", () => {
+    const projection = projectComparisonChartData([
+      makeSeries("AAPL", "#00ff00", [18.02, 17.91, 17.84, 17.73]),
+    ], 24, {
+      timeRange: "ALL",
+      panOffset: 0,
+      zoomLevel: 1,
+      renderMode: "line",
+    }, "price");
+
+    const result = renderComparisonChart(projection, {
+      width: 24,
+      height: 6,
+      cursorX: null,
+      cursorY: null,
+      selectedSymbol: "AAPL",
+      colors: {
+        bgColor: "#000000",
+        gridColor: "#333333",
+        crosshairColor: "#ffffff",
+      },
+    });
+
+    expect(result.axisFractionDigits).toBeGreaterThanOrEqual(1);
+    expect(new Set(result.axisLabels.map((entry) => entry.label)).size).toBe(result.axisLabels.length);
+    expect(result.axisLabels.every((entry) => entry.label.includes("."))).toBe(true);
+  });
+
+  test("keeps one decimal on zoomed comparison price axes even when whole ticks are distinct", () => {
+    const projection = projectComparisonChartData([
+      makeSeries("AAPL", "#00ff00", [233.82, 232.14, 230.21, 231.67, 228.94]),
+    ], 24, {
+      timeRange: "ALL",
+      panOffset: 0,
+      zoomLevel: 1,
+      renderMode: "line",
+    }, "price");
+
+    const result = renderComparisonChart(projection, {
+      width: 24,
+      height: 6,
+      cursorX: null,
+      cursorY: null,
+      selectedSymbol: "AAPL",
+      colors: {
+        bgColor: "#000000",
+        gridColor: "#333333",
+        crosshairColor: "#ffffff",
+      },
+    });
+
+    expect(result.axisFractionDigits).toBe(1);
+    expect(result.axisLabels.every((entry) => entry.label.includes("."))).toBe(true);
+  });
+
   test("renders a shared multi-series line chart", () => {
     const projection = projectComparisonChartData([
       makeSeries("AAPL", "#00ff00", [10, 12, 11, 13]),

--- a/src/components/chart/comparison-chart-renderer.ts
+++ b/src/components/chart/comparison-chart-renderer.ts
@@ -12,6 +12,7 @@ import {
   drawGridLines,
   drawLine,
   formatPrice,
+  resolveAxisFractionDigits,
   type StyledContent,
 } from "./chart-renderer";
 import type { ChartAxisMode, ComparisonChartRenderMode } from "./chart-types";
@@ -71,6 +72,8 @@ export interface RenderComparisonChartResult {
   crosshairValue: number | null;
   cursorColumn: number | null;
   cursorRow: number | null;
+  axisFractionDigits: number | null;
+  priceRange: number | null;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -95,10 +98,32 @@ function formatPercentAxisValue(value: number): string {
   return `${prefix}${value.toFixed(decimals)}%`;
 }
 
-export function formatComparisonAxisValue(value: number, axisMode: ChartAxisMode): string {
+function getComparisonAxisFractionDigitFloor(priceRange: number | undefined): number {
+  if (priceRange === undefined || !Number.isFinite(priceRange) || priceRange <= 0) return 0;
+  const visibleStep = priceRange / 3;
+  if (!Number.isFinite(visibleStep) || visibleStep <= 0) return 0;
+  return Math.max(0, Math.ceil(-Math.log10(visibleStep)) + 1);
+}
+
+export function formatComparisonAxisValue(
+  value: number,
+  axisMode: ChartAxisMode,
+  priceRange?: number,
+  fixedFractionDigits?: number,
+): string {
   return axisMode === "percent"
     ? formatPercentAxisValue(value)
-    : formatPrice(value);
+    : formatPrice(value, undefined, priceRange, 0, 0, fixedFractionDigits);
+}
+
+export function formatComparisonCursorAxisValue(
+  value: number,
+  axisMode: ChartAxisMode,
+  priceRange?: number,
+): string {
+  return axisMode === "percent"
+    ? formatPercentAxisValue(value)
+    : formatPrice(value, undefined, priceRange, 2, Math.abs(value) >= 1 ? 2 : 4);
 }
 
 function fillColumn(
@@ -305,13 +330,23 @@ export function renderComparisonChart(
       crosshairValue: null,
       cursorColumn: null,
       cursorRow: null,
+      axisFractionDigits: null,
+      priceRange: null,
     };
   }
 
   const dotWidth = scene.width * 2;
   const chartDotBottom = scene.chartRows * 4 - 1;
+  const priceRange = scene.max - scene.min;
   const buf = createPixelBuffer(dotWidth, scene.height * 4);
   const gridLines = computeGridLines(scene.min, scene.max, 0, chartDotBottom, 3);
+  const axisFractionDigits = scene.axisMode === "price"
+    ? resolveAxisFractionDigits(
+      gridLines.map((line) => line.price),
+      (price, fixedFractionDigits) => formatComparisonAxisValue(price, scene.axisMode, priceRange, fixedFractionDigits),
+      getComparisonAxisFractionDigitFloor(priceRange),
+    )
+    : null;
   drawGridLines(buf, gridLines.map((line) => line.y), scene.colors.gridColor);
 
   const selectedSeries = getSelectedSeries(scene.series, scene.selectedSymbol);
@@ -336,7 +371,7 @@ export function renderComparisonChart(
   for (const line of gridLines) {
     axisLabelsByRow.set(
       Math.min(Math.floor(line.y / 4), Math.max(scene.chartRows - 1, 0)),
-      formatComparisonAxisValue(line.price, scene.axisMode),
+      formatComparisonAxisValue(line.price, scene.axisMode, priceRange, axisFractionDigits ?? undefined),
     );
   }
 
@@ -350,5 +385,7 @@ export function renderComparisonChart(
     crosshairValue: scene.crosshairValue,
     cursorColumn: scene.cursorColumn,
     cursorRow: scene.cursorRow,
+    axisFractionDigits,
+    priceRange,
   };
 }

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -7,7 +7,8 @@ import { useAppState, usePaneSettingValue } from "../../state/app-context";
 import { blendHex, colors, getComparisonSeriesColor, priceColor } from "../../theme/colors";
 import type { BrokerContractRef } from "../../types/instrument";
 import type { PricePoint } from "../../types/financials";
-import { formatCurrency, formatPercentRaw } from "../../utils/format";
+import { formatPercentRaw } from "../../utils/format";
+import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../utils/market-format";
 import { getSharedDataProvider } from "../../plugins/registry";
 import {
   applyComparisonZoomAroundAnchor,
@@ -47,6 +48,7 @@ import { RIGHT_EDGE_ANCHOR_RATIO } from "./chart-viewport";
 import {
   buildComparisonChartScene,
   formatComparisonAxisValue,
+  formatComparisonCursorAxisValue,
   renderComparisonChart,
 } from "./comparison-chart-renderer";
 import {
@@ -79,7 +81,7 @@ import { ensureKittySupport, getCachedKittySupport } from "./native/kitty-suppor
 import { resolveChartRendererState } from "./native/renderer-selection";
 import { getNativeSurfaceManager } from "./native/surface-manager";
 import { syncCachedNativeSurface } from "./native/surface-sync";
-import { formatDateShort, type StyledContent } from "./chart-renderer";
+import { formatAxisCell, formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
   area: "A",
@@ -407,11 +409,6 @@ function buildBlankPlotLines(width: number, height: number): string[] {
   return Array.from({ length: height }, () => " ".repeat(width));
 }
 
-function formatAxisCell(label: string | null, width: number): string {
-  if (!label) return " ".repeat(width);
-  return label.length >= width ? label.slice(0, width) : label.padStart(width);
-}
-
 function buildComparisonNativeBitmapKey(
   symbolCount: number,
   projection: ReturnType<typeof projectComparisonChartData>,
@@ -578,8 +575,10 @@ function ComparisonStockChartView({
   const appliedCanonicalResetRef = useRef(0);
   const pendingExpansionRef = useRef<PendingExpansionAction>(null);
 
-  const axisWidth = 11;
-  const axisGap = 1;
+  const axisSectionWidthBudget = 11;
+  const axisRightPadding = 1;
+  const minimumAxisWidth = axisMode === "percent" ? 5 : 4;
+  const axisGap = axisSectionWidthBudget > 0 ? 1 : 0;
   const headerRows = 1;
   const controlRows = 2;
   const timeAxisRows = 1;
@@ -589,9 +588,9 @@ function ComparisonStockChartView({
   const legendRows = legendNeededRows > 0
     ? Math.min(4, Math.max(Math.min(height - (headerRows + controlRows + timeAxisRows + helpRows + 4), legendNeededRows), 1))
     : 0;
-  const chartWidth = Math.max(width - axisWidth - axisGap, 20);
   const chartHeight = Math.max(height - headerRows - controlRows - timeAxisRows - helpRows - legendRows, 4);
-  const maxCursorX = chartWidth - 1;
+  const minChartWidth = 20;
+  const measurementChartWidth = Math.max(width - axisSectionWidthBudget - axisGap, minChartWidth);
   const legendItemWidth = Math.max(Math.floor((width - Math.max(legendColumns - 1, 0)) / legendColumns), 20);
   const chartColors = useMemo(() => ({
     bgColor: colors.bg,
@@ -819,6 +818,70 @@ function ComparisonStockChartView({
       points: history,
     };
   }), [chartEntries, chartRequests, colors.bg, symbolSources]);
+  const axisWidth = useMemo(() => {
+    const measureAxisWidth = (targetWidth: number) => {
+      const measuredProjection = projectComparisonChartData(series, targetWidth, viewState, axisMode);
+      const measuredResult = renderComparisonChart(measuredProjection, {
+        width: targetWidth,
+        height: chartHeight,
+        cursorX: null,
+        cursorY: null,
+        selectedSymbol: viewState.selectedSymbol,
+        colors: chartColors,
+      });
+      const measuredScene = buildComparisonChartScene(measuredProjection, {
+        width: targetWidth,
+        height: chartHeight,
+        cursorX: null,
+        cursorY: null,
+        selectedSymbol: viewState.selectedSymbol,
+        colors: chartColors,
+      });
+      const cursorSamples = measuredScene
+        ? [
+          formatComparisonCursorAxisValue(
+            measuredScene.min,
+            measuredProjection.effectiveAxisMode,
+            measuredResult.priceRange ?? undefined,
+          ),
+          formatComparisonCursorAxisValue(
+            measuredScene.max,
+            measuredProjection.effectiveAxisMode,
+            measuredResult.priceRange ?? undefined,
+          ),
+        ]
+        : [];
+
+      return resolveChartAxisWidth(
+        [...measuredResult.axisLabels.map((entry) => entry.label), ...cursorSamples],
+        minimumAxisWidth,
+        Math.max(axisSectionWidthBudget - axisRightPadding, minimumAxisWidth),
+      );
+    };
+
+    const firstPassWidth = measureAxisWidth(measurementChartWidth);
+    const refinedChartWidth = Math.max(width - firstPassWidth - axisRightPadding - axisGap, minChartWidth);
+    return refinedChartWidth === measurementChartWidth ? firstPassWidth : measureAxisWidth(refinedChartWidth);
+  }, [
+    axisGap,
+    axisMode,
+    axisRightPadding,
+    axisSectionWidthBudget,
+    chartColors,
+    chartHeight,
+    measurementChartWidth,
+    minChartWidth,
+    minimumAxisWidth,
+    series,
+    viewState.panOffset,
+    viewState.renderMode,
+    viewState.selectedSymbol,
+    viewState.zoomLevel,
+    width,
+  ]);
+  const axisSectionWidth = axisWidth + axisRightPadding;
+  const chartWidth = Math.max(width - axisSectionWidth - axisGap, minChartWidth);
+  const maxCursorX = chartWidth - 1;
   const seriesDates = useMemo(() => getUniqueSortedSeriesDates(series), [series]);
   const visibleDateWindow = useMemo(() => buildVisibleDateWindow(seriesDates, viewState.panOffset, viewState.zoomLevel), [seriesDates, viewState.panOffset, viewState.zoomLevel]);
   const activePreset = isCanonicalPresetViewport(seriesDates, {
@@ -1525,9 +1588,14 @@ function ComparisonStockChartView({
     : null;
   const selectedCurrency = selectedSeries?.currency ?? "USD";
   const displayDate = result.activeDate ?? staticResult.activeDate;
+  const visiblePriceRange = result.priceRange ?? staticResult.priceRange ?? undefined;
   const axisLabels = new Map(staticResult.axisLabels.map((entry) => [entry.row, entry.label]));
   const cursorAxisLabel = result.cursorRow !== null && result.crosshairValue !== null
-    ? formatComparisonAxisValue(result.crosshairValue, projection.effectiveAxisMode)
+    ? formatComparisonCursorAxisValue(
+      result.crosshairValue,
+      projection.effectiveAxisMode,
+      visiblePriceRange,
+    )
     : null;
   const visibleLabel = formatVisibleSpanLabel({
     start: visibleWindow.dates[0] ?? null,
@@ -1575,13 +1643,13 @@ function ComparisonStockChartView({
   );
 
   const axisBox = (
-    <box width={axisWidth} height={chartHeight} flexDirection="column">
+    <box width={axisSectionWidth} height={chartHeight} flexDirection="column">
       {Array.from({ length: chartHeight }, (_, row) => {
         const isCursorRow = cursorAxisLabel !== null && result.cursorRow === row;
         const label = isCursorRow ? cursorAxisLabel : (axisLabels.get(row) ?? null);
         return (
           <text key={row} fg={isCursorRow ? chartColors.crosshairColor : colors.textDim}>
-            {formatAxisCell(label, axisWidth)}
+            {formatAxisCell(label, axisWidth).padEnd(axisSectionWidth)}
           </text>
         );
       })}
@@ -1600,11 +1668,21 @@ function ComparisonStockChartView({
         </text>
         <text fg={colors.textDim}>{visibleLabel}</text>
         <text fg={selectedChange !== null ? priceColor(selectedChange) : colors.textDim}>
-          {selectedRawValue !== null ? formatCurrency(selectedRawValue, selectedCurrency) : "—"}
+          {selectedRawValue !== null
+            ? formatMarketPriceWithCurrency(selectedRawValue, selectedCurrency, {
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })
+            : "—"}
         </text>
         <text fg={selectedChange !== null ? priceColor(selectedChange) : colors.textDim}>
           {selectedChange !== null && selectedChangePct !== null
-            ? `${selectedChange >= 0 ? "+" : ""}${selectedChange.toFixed(2)} (${formatPercentRaw(selectedChangePct)})`
+            ? `${formatSignedMarketPrice(selectedChange, {
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })} (${formatPercentRaw(selectedChangePct)})`
             : "Waiting for data"}
         </text>
         {displayDate && <text fg={colors.textDim}>{formatDateShort(displayDate)}</text>}

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -5,7 +5,8 @@ import { useAppDispatch, useAppSelector, usePaneInstanceId, usePaneSettingValue,
 import { saveConfig } from "../../data/config-store";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { colors, priceColor } from "../../theme/colors";
-import { formatCompact, formatCurrency } from "../../utils/format";
+import { formatCompact, formatPercentRaw } from "../../utils/format";
+import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../utils/market-format";
 import { useChartQuery } from "../../market-data/hooks";
 import { instrumentFromTicker } from "../../market-data/request-types";
 import { usePersistChartControlSelection } from "./chart-pane-settings";
@@ -48,12 +49,14 @@ import {
 } from "./chart-viewport";
 import {
   buildChartScene,
+  formatAxisCell,
   formatDateShort,
-  formatAxisValue,
+  formatCursorAxisValue,
   getActivePointIndex,
   getPointTerminalColumn,
   renderChart,
   resolveChartPalette,
+  resolveChartAxisWidth,
   type StyledContent,
 } from "./chart-renderer";
 import {
@@ -100,6 +103,16 @@ const MODE_LABELS: Record<ChartRenderMode, string> = {
   candles: "CANDLES",
   ohlc: "OHLC",
 };
+
+const AXIS_MEASURE_PALETTE = resolveChartPalette({
+  bg: colors.bg,
+  border: colors.border,
+  borderFocused: colors.borderFocused,
+  text: colors.text,
+  textDim: colors.textDim,
+  positive: colors.positive,
+  negative: colors.negative,
+}, "neutral");
 
 interface StockChartProps {
   width: number;
@@ -443,11 +456,6 @@ function resolveVisibleRect(
 
 function buildBlankPlotLines(width: number, height: number): string[] {
   return Array.from({ length: height }, () => " ".repeat(width));
-}
-
-function formatAxisCell(label: string | null, width: number): string {
-  if (!label) return " ".repeat(width);
-  return label.length >= width ? label.slice(0, width) : label.padStart(width);
 }
 
 function getMaxPanOffset(history: PricePoint[], zoomLevel: number): number {
@@ -794,19 +802,27 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       : null,
   );
   const baseBodyState = resolveChartBodyState(baseChartEntry, (value) => Array.isArray(value) && value.length > 0, "No price history available.");
-  const axisWidth = compact
+  const axisSectionWidthBudget = compact
     ? axisMode === "percent" ? 11 : 8
     : axisMode === "percent" ? 11 : 10;
-  const axisGap = axisWidth > 0 ? 1 : 0;
-  const chartWidth = Math.max(width - axisWidth - axisGap, compact ? 12 : 20);
-  const maxCursorX = chartWidth - 1;
-  const panStep = Math.max(Math.floor(chartWidth / 10), 1);
+  const axisRightPadding = 1;
+  const minimumAxisWidth = axisMode === "percent" ? 5 : 4;
+  const axisGap = axisSectionWidthBudget > 0 ? 1 : 0;
+  const minChartWidth = compact ? 12 : 20;
+  const measurementChartWidth = Math.max(width - axisSectionWidthBudget - axisGap, minChartWidth);
+  const headerRows = compact ? 0 : 4;
+  const helpRow = compact ? 0 : 1;
+  const timeAxisRow = 1;
+  const volumeHeight = showVolume && !compact ? 3 : 0;
+  const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
   const baseHistory = compact
     ? (historyOverride ?? financials?.priceHistory ?? [])
     : (baseBodyState.data ?? []);
+  const chartCurrency = currencyOverride ?? financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
+  const chartAssetCategory = ticker?.metadata.assetCategory;
   const detailRequest = useMemo(() => {
     if (compact || effectiveResolution !== "auto" || !instrumentRef || baseHistory.length < 2 || viewState.zoomLevel <= 1) return null;
-    const window = getVisibleWindow(baseHistory, viewState, chartWidth);
+    const window = getVisibleWindow(baseHistory, viewState, measurementChartWidth);
     if (window.points.length < 2) return null;
 
     const startDate = coerceChartDate(window.points[0]!.date as Date | string | number);
@@ -824,12 +840,112 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       endDate,
       barSize,
     };
-  }, [baseHistory, chartWidth, compact, effectiveResolution, instrumentRef, viewState]);
+  }, [
+    baseHistory,
+    compact,
+    effectiveResolution,
+    instrumentRef,
+    measurementChartWidth,
+    viewState.bufferRange,
+    viewState.panOffset,
+    viewState.zoomLevel,
+  ]);
   const detailChartEntry = useChartQuery(detailRequest);
   const detailBodyState = resolveChartBodyState(detailChartEntry, (value) => Array.isArray(value) && value.length > 0, "No price history available.");
   const history = (effectiveResolution === "auto" && viewState.zoomLevel > 1 && detailBodyState.data) ? detailBodyState.data : baseHistory;
   const baseHistoryDates = useMemo(() => getPointDates(baseHistory), [baseHistory]);
   const visibleDateWindow = useMemo(() => buildVisibleDateWindow(baseHistoryDates, viewState.panOffset, viewState.zoomLevel), [baseHistoryDates, viewState.panOffset, viewState.zoomLevel]);
+  const isDetailView = effectiveResolution === "auto" && viewState.zoomLevel > 1 && !!detailBodyState.data?.length;
+  const axisWidth = useMemo(() => {
+    const measureAxisWidth = (targetWidth: number) => {
+      const measuredWindow = historyOverride || isDetailView
+        ? { points: history, startIdx: 0, endIdx: history.length }
+        : getVisibleWindow(history, viewState, targetWidth);
+      const measuredTimeAxisDates = measuredWindow.points.map((point) => point.date);
+      const measuredProjection = projectChartData(measuredWindow.points, targetWidth, viewState.renderMode, !!compact);
+      const measuredResult = renderChart(measuredProjection.points, {
+        width: targetWidth,
+        height: chartHeight,
+        showVolume: showVolume && !compact,
+        volumeHeight,
+        cursorX: null,
+        cursorY: null,
+        mode: measuredProjection.effectiveMode,
+        axisMode,
+        currency: chartCurrency,
+        assetCategory: chartAssetCategory,
+        colors: AXIS_MEASURE_PALETTE,
+        timeAxisDates: measuredTimeAxisDates,
+      });
+      const measuredScene = buildChartScene(measuredProjection.points, {
+        width: targetWidth,
+        height: chartHeight,
+        showVolume: showVolume && !compact,
+        volumeHeight,
+        cursorX: null,
+        cursorY: null,
+        mode: measuredProjection.effectiveMode,
+        axisMode,
+        colors: AXIS_MEASURE_PALETTE,
+        timeAxisDates: measuredTimeAxisDates,
+      });
+      const cursorSamples = measuredScene
+        ? [
+          formatCursorAxisValue(
+            measuredScene.min,
+            axisMode,
+            measuredProjection.points[0]?.close ?? 0,
+            chartCurrency,
+            chartAssetCategory,
+            measuredResult.priceRange ?? undefined,
+          ),
+          formatCursorAxisValue(
+            measuredScene.max,
+            axisMode,
+            measuredProjection.points[0]?.close ?? 0,
+            chartCurrency,
+            chartAssetCategory,
+        measuredResult.priceRange ?? undefined,
+          ),
+        ]
+        : [];
+
+      return resolveChartAxisWidth(
+        [...measuredResult.axisLabels.map((entry) => entry.label), ...cursorSamples],
+        minimumAxisWidth,
+        Math.max(axisSectionWidthBudget - axisRightPadding, minimumAxisWidth),
+      );
+    };
+
+    const firstPassWidth = measureAxisWidth(measurementChartWidth);
+    const refinedChartWidth = Math.max(width - firstPassWidth - axisRightPadding - axisGap, minChartWidth);
+    return refinedChartWidth === measurementChartWidth ? firstPassWidth : measureAxisWidth(refinedChartWidth);
+  }, [
+    axisGap,
+    axisMode,
+    axisRightPadding,
+    axisSectionWidthBudget,
+    chartAssetCategory,
+    chartCurrency,
+    chartHeight,
+    compact,
+    history,
+    historyOverride,
+    isDetailView,
+    measurementChartWidth,
+    minChartWidth,
+    minimumAxisWidth,
+    showVolume,
+    viewState.panOffset,
+    viewState.renderMode,
+    viewState.zoomLevel,
+    volumeHeight,
+    width,
+  ]);
+  const axisSectionWidth = axisWidth + axisRightPadding;
+  const chartWidth = Math.max(width - axisSectionWidth - axisGap, minChartWidth);
+  const maxCursorX = chartWidth - 1;
+  const panStep = Math.max(Math.floor(chartWidth / 10), 1);
   const activePreset = compact || !isCanonicalPresetViewport(baseHistoryDates, {
     activePreset: viewState.activePreset,
     panOffset: viewState.panOffset,
@@ -975,13 +1091,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     persistDefaultRenderMode(mode);
     setViewState((current) => ({ ...current, renderMode: mode }));
   };
-
-  const headerRows = compact ? 0 : 4;
-  const helpRow = compact ? 0 : 1;
-  const timeAxisRow = 1;
-  const volumeHeight = showVolume && !compact ? 3 : 0;
-  const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
-  const isDetailView = effectiveResolution === "auto" && viewState.zoomLevel > 1 && !!detailBodyState.data?.length;
   const historyRenderKey = history.length === 0
     ? "empty"
     : [
@@ -1187,7 +1296,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       negative: colors.negative,
     }, trend);
   }, [chartWindow.points]);
-  const chartCurrency = currencyOverride ?? financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
 
   const cursorX = viewState.cursorX !== null ? clamp(viewState.cursorX, 0, chartWidth - 1) : null;
   const cursorY = viewState.cursorY !== null ? clamp(viewState.cursorY, 0, chartHeight - 1) : null;
@@ -1275,9 +1383,10 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     mode: projection.effectiveMode,
     axisMode,
     currency: chartCurrency,
+    assetCategory: chartAssetCategory,
     colors: chartColors,
     timeAxisDates,
-  }), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+  }), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const interactiveResult = useMemo(() => (
     effectiveRenderer === "kitty"
@@ -1292,10 +1401,11 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         mode: projection.effectiveMode,
         axisMode,
         currency: chartCurrency,
+        assetCategory: chartAssetCategory,
         colors: chartColors,
         timeAxisDates,
       })
-  ), [axisMode, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+  ), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const result = effectiveRenderer === "kitty" ? staticResult : interactiveResult!;
 
@@ -1571,9 +1681,19 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     ? (selectionScene?.dateAtCursor ? formatDateShort(selectionScene.dateAtCursor) : null)
     : null;
   const activePoint = showOhlcSummary ? (selectionScene?.activePoint ?? null) : null;
+  const visiblePriceRange = selectionScene
+    ? Math.max(selectionScene.max - selectionScene.min, 0)
+    : (staticResult.priceRange ?? undefined);
   const axisLabels = new Map(staticResult.axisLabels.map((entry) => [entry.row, entry.label]));
   const cursorAxisLabel = hasDisplayCursor && cursorRow !== null && crosshairPrice !== null
-    ? formatAxisValue(crosshairPrice, axisMode, projection.points[0]?.close ?? 0, chartCurrency)
+    ? formatCursorAxisValue(
+      crosshairPrice,
+      axisMode,
+      projection.points[0]?.close ?? 0,
+      chartCurrency,
+      chartAssetCategory,
+      visiblePriceRange,
+    )
     : null;
   const visibleLabel = formatVisibleSpanLabel({
     start: chartWindow.points[0]?.date ? coerceChartDate(chartWindow.points[0].date as Date | string | number) : null,
@@ -1784,13 +1904,13 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   );
 
   const axisBox = (
-    <box width={axisWidth} height={chartHeight} flexDirection="column">
+    <box width={axisSectionWidth} height={chartHeight} flexDirection="column">
       {Array.from({ length: chartHeight }, (_, row) => {
         const isCursorRow = cursorAxisLabel !== null && cursorRow === row;
         const label = isCursorRow ? cursorAxisLabel : (axisLabels.get(row) ?? null);
         return (
           <text key={row} fg={isCursorRow ? chartColors.crosshairColor : colors.textDim}>
-            {formatAxisCell(label, axisWidth)}
+            {formatAxisCell(label, axisWidth).padEnd(axisSectionWidth)}
           </text>
         );
       })}
@@ -1819,20 +1939,52 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         </text>
         <text fg={colors.textDim}>{visibleLabel}</text>
         <text fg={displayChange !== null ? priceColor(displayChange) : colors.textDim}>
-          {displayPrice !== null ? formatCurrency(displayPrice, chartCurrency) : "—"}
+          {displayPrice !== null
+            ? formatMarketPriceWithCurrency(displayPrice, chartCurrency, {
+              assetCategory: chartAssetCategory,
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })
+            : "—"}
         </text>
         <text fg={displayChange !== null ? priceColor(displayChange) : colors.textDim}>
           {displayChange !== null && displayChangePct !== null
-            ? `${displayChange >= 0 ? "+" : ""}${displayChange.toFixed(2)} (${displayChangePct >= 0 ? "+" : ""}${displayChangePct.toFixed(2)}%)`
+            ? `${formatSignedMarketPrice(displayChange, {
+              assetCategory: chartAssetCategory,
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })} (${formatPercentRaw(displayChangePct)})`
             : "No data"}
         </text>
         {displayDate && <text fg={colors.textDim}>{displayDate}</text>}
         {showOhlcSummary && activePoint && (
           <>
-            <text fg={colors.textDim}>O {formatCurrency(activePoint.open, chartCurrency)}</text>
-            <text fg={colors.textDim}>H {formatCurrency(activePoint.high, chartCurrency)}</text>
-            <text fg={colors.textDim}>L {formatCurrency(activePoint.low, chartCurrency)}</text>
-            <text fg={colors.textDim}>C {formatCurrency(activePoint.close, chartCurrency)}</text>
+            <text fg={colors.textDim}>O {formatMarketPriceWithCurrency(activePoint.open, chartCurrency, {
+              assetCategory: chartAssetCategory,
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })}</text>
+            <text fg={colors.textDim}>H {formatMarketPriceWithCurrency(activePoint.high, chartCurrency, {
+              assetCategory: chartAssetCategory,
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })}</text>
+            <text fg={colors.textDim}>L {formatMarketPriceWithCurrency(activePoint.low, chartCurrency, {
+              assetCategory: chartAssetCategory,
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })}</text>
+            <text fg={colors.textDim}>C {formatMarketPriceWithCurrency(activePoint.close, chartCurrency, {
+              assetCategory: chartAssetCategory,
+              minimumFractionDigits: 2,
+              precisionOffset: 1,
+              priceRange: visiblePriceRange,
+            })}</text>
             <text fg={colors.textDim}>V {formatCompact(activePoint.volume)}</text>
           </>
         )}

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -659,11 +659,42 @@ describe("CommandBar", () => {
     expect(saved.at(-1)?.metadata.watchlists).toEqual(["watchlist"]);
   });
 
-  test("bare AW without a compatible active target opens inline target selection", async () => {
+  test("bare AW without a compatible active target adds to the sole watchlist directly", async () => {
+    const saved: TickerRecord[] = [];
+
     testSetup = await testRender(
       <CommandBarHarness
         query="AW"
         selectedTicker="AAPL"
+        onSaveTicker={(ticker) => {
+          saved.push(ticker);
+        }}
+      />,
+      { width: 100, height: 20 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(saved.at(-1)?.metadata.watchlists).toEqual(["watchlist"]);
+  });
+
+  test("bare AW without a compatible active target opens inline target selection when multiple watchlists exist", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="AW"
+        selectedTicker="AAPL"
+        configureConfig={(config) => ({
+          ...config,
+          watchlists: [
+            { id: "watchlist", name: "Watchlist" },
+            { id: "growth", name: "Growth Radar" },
+          ],
+        })}
       />,
       { width: 100, height: 20 },
     );
@@ -710,7 +741,6 @@ describe("CommandBar", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Add AAPL to Portfolio");
-    expect(frame).toContain('in "Research"');
   });
 
   test("AP opens the add-to-portfolio workflow and prefills avg cost from the current price", async () => {
@@ -720,7 +750,7 @@ describe("CommandBar", () => {
         selectedTicker="AAPL"
         configureConfig={(config) => ({
           ...config,
-          portfolios: [{ id: "research", name: "Research", currency: "USD" }],
+          portfolios: [{ id: "research", name: "Only Manual Portfolio", currency: "USD" }],
         })}
         configureState={(state) => ({
           ...state,
@@ -762,6 +792,7 @@ describe("CommandBar", () => {
     expect(frame).toContain("Shares");
     expect(frame).toContain("Avg Cost");
     expect(frame).toContain("205.5");
+    expect(frame).not.toContain("Only Manual Portfolio");
     expectSingleBackControl(frame);
   });
 
@@ -873,7 +904,6 @@ describe("CommandBar", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Set Position for AAPL");
-    expect(frame).toContain('in "Research"');
   });
 
   test("prefills the portfolio position workflow from the active manual portfolio and ticker", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -85,6 +85,7 @@ import {
   applyCollectionMembershipChange,
   getCollectionTargetOptions,
   resolvePreferredCollectionTarget,
+  resolveSoleCollectionTarget,
   resolveTickerInput,
   resolveTickerInputOrThrow,
   resolveTickerListInput,
@@ -1119,12 +1120,27 @@ export function CommandBar({
     }
 
     const targetId = explicitTargetId
-      ?? resolvePreferredCollectionTarget(
-        stateForCommand,
-        kind,
-        activeCollectionId,
-        action,
-        resolvedTicker.ticker,
+      ?? (
+        kind === "watchlist" && action === "add"
+          ? resolvePreferredCollectionTarget(
+            stateForCommand,
+            kind,
+            activeCollectionId,
+            action,
+            resolvedTicker.ticker,
+          ) ?? resolveSoleCollectionTarget(
+            stateForCommand,
+            kind,
+            action,
+            resolvedTicker.ticker,
+          )
+          : resolvePreferredCollectionTarget(
+            stateForCommand,
+            kind,
+            activeCollectionId,
+            action,
+            resolvedTicker.ticker,
+          )
       );
 
     if (!targetId) {
@@ -2567,12 +2583,22 @@ export function CommandBar({
             : manualPortfolios.length === 1
               ? manualPortfolios[0]!.id
               : null)
-          : resolvePreferredCollectionTarget(
-            state,
-            kind,
-            activeCollectionId,
-            action,
-            localTicker,
+          : (
+            resolvePreferredCollectionTarget(
+              state,
+              kind,
+              activeCollectionId,
+              action,
+              localTicker,
+            )
+            ?? (commandId === "add-watchlist"
+              ? resolveSoleCollectionTarget(
+                state,
+                kind,
+                action,
+                localTicker,
+              )
+              : null)
           );
         const preferredTargetName = preferredTargetId
           ? (kind === "watchlist"
@@ -3188,7 +3214,14 @@ export function CommandBar({
         activeCollectionId,
         action,
         localTicker,
-      );
+      ) ?? (commandId === "add-watchlist"
+        ? resolveSoleCollectionTarget(
+          state,
+          kind,
+          action,
+          localTicker,
+        )
+        : null);
       const preferredTargetName = preferredTargetId
         ? (kind === "watchlist"
           ? state.config.watchlists.find((entry) => entry.id === preferredTargetId)?.name

--- a/src/components/command-bar/workflow-ops.ts
+++ b/src/components/command-bar/workflow-ops.ts
@@ -152,6 +152,16 @@ export function resolvePreferredCollectionTarget(
   return options.some((option) => option.id === activeCollectionId) ? activeCollectionId : null;
 }
 
+export function resolveSoleCollectionTarget(
+  state: AppState,
+  kind: CollectionKind,
+  action: CollectionMembershipAction,
+  ticker: TickerRecord | null,
+): string | null {
+  const options = getCollectionTargetOptions(state, kind, action, ticker);
+  return options.length === 1 ? options[0]!.id : null;
+}
+
 export async function resolveTickerInput(
   rawInput: string | undefined,
   activeTicker: string | null,

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,6 +7,7 @@ import { useAppState } from "../../state/app-context";
 import { getSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { useQuoteEntry, useResolvedEntryValue } from "../../market-data/hooks";
 import { formatPercentRaw } from "../../utils/format";
+import { formatMarketPrice } from "../../utils/market-format";
 import { marketStateLabel, marketStateColor, getExtendedHoursInfo } from "../../utils/market-status";
 import { VERSION } from "../../version";
 
@@ -103,7 +104,7 @@ export function Header() {
 
   const spyColor = spyQuote ? priceColor(spyQuote.change) : colors.headerText;
   const spyText = spyQuote
-    ? `SPY ${spyQuote.price.toFixed(2)} ${formatPercentRaw(spyQuote.changePercent)}`
+    ? `SPY ${formatMarketPrice(spyQuote.price, { assetCategory: "ETF" })} ${formatPercentRaw(spyQuote.changePercent)}`
     : "SPY —";
 
   // Extended hours info

--- a/src/components/price-selector-dialog.tsx
+++ b/src/components/price-selector-dialog.tsx
@@ -4,6 +4,7 @@ import type { InputRenderable } from "@opentui/core";
 import { useDialogKeyboard, type PromptContext } from "@opentui-ui/dialog/react";
 import type { Quote } from "../types/financials";
 import { colors } from "../theme/colors";
+import { formatMarketPrice } from "../utils/market-format";
 import { DialogFrame, ListView, NumberField } from "./ui";
 import { padTo } from "../utils/format";
 
@@ -17,6 +18,7 @@ export interface PriceSelectorDialogProps {
   label: string;
   currentValue?: number;
   quote?: Quote;
+  assetCategory?: string;
 }
 
 function buildPresets(quote: Quote | undefined): PricePreset[] {
@@ -46,20 +48,22 @@ function buildPresets(quote: Quote | undefined): PricePreset[] {
   return presets;
 }
 
-function formatMarketContext(quote: Quote | undefined): string {
+function formatMarketContext(quote: Quote | undefined, assetCategory?: string): string {
   if (!quote) return "No quote data available";
   const parts: string[] = [];
-  parts.push(`Last ${quote.price.toFixed(2)}`);
+  parts.push(`Last ${formatMarketPrice(quote.price, { assetCategory })}`);
   if (quote.bid != null) {
-    const bidStr = quote.bidSize != null ? `Bid ${quote.bid.toFixed(2)} × ${quote.bidSize}` : `Bid ${quote.bid.toFixed(2)}`;
+    const bidValue = formatMarketPrice(quote.bid, { assetCategory });
+    const bidStr = quote.bidSize != null ? `Bid ${bidValue} × ${quote.bidSize}` : `Bid ${bidValue}`;
     parts.push(bidStr);
   }
   if (quote.ask != null) {
-    const askStr = quote.askSize != null ? `Ask ${quote.ask.toFixed(2)} × ${quote.askSize}` : `Ask ${quote.ask.toFixed(2)}`;
+    const askValue = formatMarketPrice(quote.ask, { assetCategory });
+    const askStr = quote.askSize != null ? `Ask ${askValue} × ${quote.askSize}` : `Ask ${askValue}`;
     parts.push(askStr);
   }
   if (quote.bid != null && quote.ask != null) {
-    parts.push(`Spd ${(quote.ask - quote.bid).toFixed(2)}`);
+    parts.push(`Spd ${formatMarketPrice(quote.ask - quote.bid, { assetCategory })}`);
   }
   return parts.join(" · ");
 }
@@ -72,6 +76,7 @@ export function PriceSelectorDialog({
   label,
   currentValue,
   quote,
+  assetCategory,
 }: PromptContext<string> & PriceSelectorDialogProps) {
   const presets = buildPresets(quote);
   const [index, setIndex] = useState(0);
@@ -135,7 +140,7 @@ export function PriceSelectorDialog({
       }
     >
       <box flexDirection="column">
-        <text fg={colors.textDim}>{formatMarketContext(quote)}</text>
+        <text fg={colors.textDim}>{formatMarketContext(quote, assetCategory)}</text>
         <box height={1} />
 
         {presets.length > 0 && (
@@ -163,7 +168,7 @@ export function PriceSelectorDialog({
                       {padTo(item.label, presetWidth)}
                     </text>
                     <text fg={state.selected ? colors.text : colors.textMuted}>
-                      {preset?.value.toFixed(2) ?? ""}
+                      {preset ? formatMarketPrice(preset.value, { assetCategory }) : ""}
                     </text>
                     {preset?.detail && (
                       <text fg={colors.textDim}>{`  ${preset.detail}`}</text>

--- a/src/components/ticker-badge.tsx
+++ b/src/components/ticker-badge.tsx
@@ -1,6 +1,6 @@
 import { TextAttributes } from "@opentui/core";
 import { colors, priceColor } from "../theme/colors";
-import { formatCurrency } from "../utils/format";
+import { formatMarketPriceWithCurrency } from "../utils/market-format";
 import type { Quote } from "../types/financials";
 
 export interface TickerBadgeProps {
@@ -50,7 +50,7 @@ export function TickerBadge({
 }: TickerBadgeProps) {
   const tone = status === "ready" && quote ? priceColor(quote.changePercent) : colors.borderFocused;
   const label = hovered && quote
-    ? `${symbol} ${formatCurrency(quote.price, quote.currency)}`
+    ? `${symbol} ${formatMarketPriceWithCurrency(quote.price, quote.currency)}`
     : status === "ready" && quote
     ? formatBadgeChange(quote.changePercent)
     : "…";

--- a/src/plugins/builtin/ai/ticker-context.ts
+++ b/src/plugins/builtin/ai/ticker-context.ts
@@ -1,4 +1,5 @@
 import { convertCurrency, formatCompact, formatCompactCurrency, formatCurrency, formatPercent } from "../../../utils/format";
+import { formatMarketPriceWithCurrency } from "../../../utils/market-format";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 
@@ -28,9 +29,9 @@ export function buildTickerAiContext(
   if (profile?.description) lines.push(`Description: ${profile.description}`);
 
   if (quote) {
-    lines.push(`Current Price: ${formatCurrency(quote.price, quote.currency)} (${quote.change >= 0 ? "+" : ""}${quote.changePercent.toFixed(2)}%)`);
+    lines.push(`Current Price: ${formatMarketPriceWithCurrency(quote.price, quote.currency, { assetCategory: metadata.assetCategory })} (${quote.change >= 0 ? "+" : ""}${quote.changePercent.toFixed(2)}%)`);
     if (quote.marketCap) lines.push(`Market Cap: ${formatCompactCurrency(toBase(quote.marketCap, quoteCurrency), baseCurrency)}`);
-    if (quote.high52w && quote.low52w) lines.push(`52W Range: ${formatCurrency(quote.low52w, quote.currency)} - ${formatCurrency(quote.high52w, quote.currency)}`);
+    if (quote.high52w && quote.low52w) lines.push(`52W Range: ${formatMarketPriceWithCurrency(quote.low52w, quote.currency, { assetCategory: metadata.assetCategory })} - ${formatMarketPriceWithCurrency(quote.high52w, quote.currency, { assetCategory: metadata.assetCategory })}`);
   }
 
   if (fundamentals) {

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -7,6 +7,7 @@ import { usePaneTicker } from "../../state/app-context";
 import { ListView, type ListViewItem } from "../../components/ui";
 import { colors, hoverBg } from "../../theme/colors";
 import { padTo, formatCompact, formatNumber } from "../../utils/format";
+import { formatMarketPrice } from "../../utils/market-format";
 import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../market-data/hooks";
 import { Spinner } from "../../components/spinner";
@@ -338,9 +339,9 @@ function formatContractRow(contract: { lastPrice: number; bid: number; ask: numb
     return padTo("—", w.last) + " " + padTo("—", w.bid) + " " + padTo("—", w.ask) + " " + padTo("—", w.vol) + " " + padTo("—", w.oi);
   }
   return (
-    padTo(contract.lastPrice.toFixed(2), w.last) + " " +
-    padTo(contract.bid.toFixed(2), w.bid) + " " +
-    padTo(contract.ask.toFixed(2), w.ask) + " " +
+    padTo(formatMarketPrice(contract.lastPrice, { assetCategory: "OPT", maxWidth: w.last }), w.last) + " " +
+    padTo(formatMarketPrice(contract.bid, { assetCategory: "OPT", maxWidth: w.bid }), w.bid) + " " +
+    padTo(formatMarketPrice(contract.ask, { assetCategory: "OPT", maxWidth: w.ask }), w.ask) + " " +
     padTo(formatCompact(contract.volume), w.vol) + " " +
     padTo(formatCompact(contract.openInterest), w.oi)
   );

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -463,6 +463,7 @@ describe("PortfolioListPane cash and margin UI", () => {
             netLiquidation: 125000,
             cashBalances: [
               { currency: "USD", quantity: -50000, baseValue: -50000, baseCurrency: "USD" },
+              { currency: "EUR", quantity: -351957.025, baseValue: -381000, baseCurrency: "USD" },
               { currency: "JPY", quantity: 0, baseValue: 0, baseCurrency: "USD" },
             ],
           }],
@@ -478,6 +479,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(frame).toContain("Cash & Margin");
     expect(frame).toContain("Net Liq");
     expect(frame).toContain("Flex Mar 27");
+    expect(frame).toContain("-351,957.025");
     expect(frame).not.toContain("Avail");
     expect(frame).not.toContain("JPY");
   });
@@ -654,7 +656,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(frame).toContain("SPREAD");
     expect(frame).toContain("124.95");
     expect(frame).toContain("125.05");
-    expect(frame).toContain("0.10");
+    expect(frame).toContain("0.1");
   });
 
   test("warms full financials for visible rows when only quote data is loaded", async () => {

--- a/src/plugins/builtin/portfolio-list/cli/commands.ts
+++ b/src/plugins/builtin/portfolio-list/cli/commands.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../../utils/cli-output";
 import { exchangeShortName } from "../../../../utils/market-status";
 import { formatCompact, formatCurrency } from "../../../../utils/format";
+import { formatMarketCostWithCurrency, formatMarketPriceWithCurrency, formatMarketQuantity } from "../../../../utils/market-format";
 import type { AppConfig } from "../../../../types/config";
 import type { CliCommandContext, CliCommandDef } from "../../../../types/plugin";
 import type { TickerRecord } from "../../../../types/ticker";
@@ -134,7 +135,9 @@ async function showCollection(name: string, ctx: CliCommandContext) {
     for (const ticker of filtered) {
       const quote = quotes.get(ticker.metadata.ticker);
       const positions = ticker.metadata.positions.filter((position) => position.portfolio === id);
-      const priceText = quote ? colorBySign(formatCurrency(quote.price, quote.currency), quote.change) : "—";
+      const priceText = quote
+        ? colorBySign(formatMarketPriceWithCurrency(quote.price, quote.currency, { assetCategory: ticker.metadata.assetCategory }), quote.change)
+        : "—";
       const changeText = quote ? colorBySign(formatSignedPercentRaw(quote.changePercent), quote.change) : "—";
 
       if (positions.length === 0) {
@@ -157,8 +160,8 @@ async function showCollection(name: string, ctx: CliCommandContext) {
           ticker.metadata.ticker,
           priceText,
           changeText,
-          String(position.shares),
-          formatCurrency(position.avgCost, positionCurrency),
+          formatMarketQuantity(position.shares, { assetCategory: ticker.metadata.assetCategory, multiplier: position.multiplier }),
+          formatMarketCostWithCurrency(position.avgCost, positionCurrency, { assetCategory: ticker.metadata.assetCategory, multiplier: position.multiplier }),
           pnl == null ? "—" : colorBySign(formatSignedCurrency(pnl, baseCurrency), pnl),
         ]);
       }
@@ -181,7 +184,9 @@ async function showCollection(name: string, ctx: CliCommandContext) {
     const rows: string[][] = [];
     for (const ticker of filtered) {
       const quote = quotes.get(ticker.metadata.ticker);
-      const priceText = quote ? colorBySign(formatCurrency(quote.price, quote.currency), quote.change) : "—";
+      const priceText = quote
+        ? colorBySign(formatMarketPriceWithCurrency(quote.price, quote.currency, { assetCategory: ticker.metadata.assetCategory }), quote.change)
+        : "—";
       const changeText = quote ? colorBySign(formatSignedPercentRaw(quote.changePercent), quote.change) : "—";
       const marketCapText = quote?.marketCap != null
         ? `${formatCompact(await toBase(quote.marketCap, quote.currency || ticker.metadata.currency || baseCurrency))} ${baseCurrency}`
@@ -343,8 +348,8 @@ async function setPositionCommand(
     });
     await store.saveTicker(result.ticker);
     console.log(cliStyles.success(`Set position for ${result.ticker.metadata.ticker} in "${portfolio.name}".`));
-    console.log(renderStat("Shares", String(shares)));
-    console.log(renderStat("Average Cost", formatCurrency(avgCost, currency)));
+    console.log(renderStat("Shares", formatMarketQuantity(shares, { assetCategory: result.ticker.metadata.assetCategory })));
+    console.log(renderStat("Average Cost", formatMarketCostWithCurrency(avgCost, currency, { assetCategory: result.ticker.metadata.assetCategory })));
     console.log(renderStat("Currency", currency));
   } catch (error: any) {
     ctx.closeAndFail(persistence, error?.message || `Failed to set position for ${symbol} in "${portfolioName}".`);

--- a/src/plugins/builtin/portfolio-list/command-bar.ts
+++ b/src/plugins/builtin/portfolio-list/command-bar.ts
@@ -15,6 +15,7 @@ interface ManualPortfolioPositionWorkflowOptions {
   pendingLabel: string;
   positionOptional?: boolean;
   defaultAvgCost?: number | null;
+  hidePortfolioFieldWhenSingleOption?: boolean;
 }
 
 function buildManualPortfolioPositionWorkflow(
@@ -28,19 +29,20 @@ function buildManualPortfolioPositionWorkflow(
   const preferredPosition = options.ticker
     ? getManualPortfolioPosition(options.ticker, preferredPortfolio.id)
     : null;
+  const showPortfolioField = !options.hidePortfolioFieldWhenSingleOption || manualPortfolios.length > 1;
 
   const fields: CommandBarWorkflowField[] = [
-    {
+    ...(showPortfolioField ? [{
       id: "portfolioId",
       label: "Portfolio",
-      type: "select",
+      type: "select" as const,
       options: manualPortfolios.map((portfolio) => ({
         label: portfolio.name,
         value: portfolio.id,
         description: portfolio.currency,
       })),
       required: true,
-    },
+    }] : []),
     {
       id: "ticker",
       label: "Ticker",
@@ -118,5 +120,6 @@ export function buildAddToPortfolioWorkflow(
     pendingLabel: "Adding to portfolio…",
     positionOptional: true,
     defaultAvgCost: options.defaultAvgCost,
+    hidePortfolioFieldWhenSingleOption: true,
   });
 }

--- a/src/plugins/builtin/portfolio-list/header.tsx
+++ b/src/plugins/builtin/portfolio-list/header.tsx
@@ -4,7 +4,8 @@ import type { AppState } from "../../../state/app-context";
 import { colors, priceColor } from "../../../theme/colors";
 import type { TickerFinancials } from "../../../types/financials";
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
-import { formatCompact, formatNumber, formatPercentRaw, padTo } from "../../../utils/format";
+import { formatCompact, formatPercentRaw, padTo } from "../../../utils/format";
+import { formatMarketQuantity } from "../../../utils/market-format";
 import { getMostRecentQuoteUpdate } from "../../../utils/quote-time";
 import { ibkrGatewayManager } from "../../ibkr/gateway-service";
 import { calculatePortfolioSummaryTotals } from "./metrics";
@@ -110,7 +111,7 @@ export function PortfolioCashMarginDrawer({
             <box key={balance.currency} height={1} flexDirection="row">
               <text fg={colors.textBright}>{padTo(balance.currency, 4)}</text>
               <text fg={colors.textDim}>{" qty "}</text>
-              <text fg={colors.text}>{padTo(formatNumber(balance.quantity, 2), 14, "right")}</text>
+              <text fg={colors.text}>{padTo(formatMarketQuantity(balance.quantity, { isCashBalance: true, maxWidth: 14 }), 14, "right")}</text>
               <text fg={colors.textDim}>{"  value "}</text>
               <text fg={colors.text}>{padTo(balance.baseValue != null ? formatCompact(balance.baseValue) : "—", 10, "right")}</text>
             </box>

--- a/src/plugins/builtin/portfolio-list/metrics.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.ts
@@ -4,7 +4,8 @@ import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { priceColor } from "../../../theme/colors";
 import { clampQuoteTimestamp, formatQuoteAgeWithSource } from "../../../utils/quote-time";
-import { convertCurrency, formatCompact, formatCurrency, formatNumber, formatPercentRaw, formatPrice } from "../../../utils/format";
+import { convertCurrency, formatCompact, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { formatMarketCost, formatMarketPrice, formatMarketQuantity, formatSignedMarketPrice, type MarketFormatOptions } from "../../../utils/market-format";
 import { getActiveQuoteDisplay, marketStateDot, type ActiveQuoteDisplay } from "../../../utils/market-status";
 import { formatOptionTicker } from "../../../utils/options";
 
@@ -21,6 +22,7 @@ interface PortfolioPositionMetrics {
   totalCost: number;
   totalCostUnits: number;
   totalPriceUnits: number;
+  multiplierHint: number;
   brokerMktValue: number;
   hasBrokerMktValue: boolean;
   brokerPnl: number;
@@ -95,6 +97,7 @@ function getPortfolioPositionMetrics(
   let totalCost = 0;
   let totalCostUnits = 0;
   let totalPriceUnits = 0;
+  let multiplierHint = 1;
   let brokerMktValue = 0;
   let hasBrokerMktValue = false;
   let brokerPnl = 0;
@@ -103,6 +106,7 @@ function getPortfolioPositionMetrics(
     const direction = position.side === "short" ? -1 : 1;
     const priceMultiplier = normalizePositionMultiplier(position.multiplier);
     const costMultiplier = resolvePositionCostMultiplier(position);
+    multiplierHint = Math.max(multiplierHint, priceMultiplier, costMultiplier);
 
     totalShares += position.shares * direction;
     totalCost += position.shares * position.avgCost * costMultiplier;
@@ -125,6 +129,7 @@ function getPortfolioPositionMetrics(
     totalCost,
     totalCostUnits,
     totalPriceUnits,
+    multiplierHint,
     brokerMktValue,
     hasBrokerMktValue,
     brokerPnl,
@@ -155,15 +160,17 @@ function resolveBrokerFallbackPnl(metrics: PortfolioPositionMetrics, brokerMarke
 export function resolvePortfolioPriceValue(
   activeQuote: ActiveQuoteDisplay | null,
   brokerMarkPrice: number | undefined,
+  formatOptions: MarketFormatOptions,
+  maxWidth?: number,
 ): { text: string; color?: string } {
   if (activeQuote) {
     return {
-      text: formatPrice(activeQuote.price),
+      text: formatMarketPrice(activeQuote.price, { ...formatOptions, maxWidth }),
       color: priceColor(activeQuote.change),
     };
   }
   if (brokerMarkPrice != null) {
-    return { text: formatPrice(brokerMarkPrice) };
+    return { text: formatMarketPrice(brokerMarkPrice, { ...formatOptions, maxWidth }) };
   }
   return { text: "—" };
 }
@@ -180,13 +187,17 @@ export function getColumnValue(
   const quoteCurrency = quote?.currency || ticker.metadata.currency || "USD";
 
   const positionMetrics = getPortfolioPositionMetrics(ticker, ctx.activeTab, quoteCurrency);
-  const { positionCurrency, totalShares, totalCost, totalCostUnits, totalPriceUnits, brokerMarkPrice } = positionMetrics;
+  const { positionCurrency, totalShares, totalCost, totalCostUnits, totalPriceUnits, multiplierHint, brokerMarkPrice } = positionMetrics;
   const brokerFallbackMktValue = resolveBrokerFallbackMarketValue(positionMetrics);
   const brokerFallbackPnl = resolveBrokerFallbackPnl(positionMetrics, brokerFallbackMktValue);
   const toBaseQuote = (value: number) =>
     convertCurrency(value, quoteCurrency, ctx.baseCurrency, ctx.exchangeRates);
   const toBasePosition = (value: number) =>
     convertCurrency(value, positionCurrency, ctx.baseCurrency, ctx.exchangeRates);
+  const formatOptions: MarketFormatOptions = {
+    assetCategory: ticker.metadata.assetCategory,
+    multiplier: multiplierHint,
+  };
 
   switch (col.id) {
     case "ticker": {
@@ -198,21 +209,21 @@ export function getColumnValue(
       return { text: `${statusDot} ${displayName}` };
     }
     case "price":
-      return resolvePortfolioPriceValue(activeQuote, brokerMarkPrice);
+      return resolvePortfolioPriceValue(activeQuote, brokerMarkPrice, formatOptions, col.width);
     case "change":
       if (!activeQuote) return { text: "—" };
       return {
-        text: (activeQuote.change >= 0 ? "+" : "") + activeQuote.change.toFixed(2),
+        text: formatSignedMarketPrice(activeQuote.change, { ...formatOptions, maxWidth: col.width }),
         color: priceColor(activeQuote.change),
       };
     case "bid":
-      return { text: quote?.bid != null ? formatPrice(quote.bid) : "—" };
+      return { text: quote?.bid != null ? formatMarketPrice(quote.bid, { ...formatOptions, maxWidth: col.width }) : "—" };
     case "ask":
-      return { text: quote?.ask != null ? formatPrice(quote.ask) : "—" };
+      return { text: quote?.ask != null ? formatMarketPrice(quote.ask, { ...formatOptions, maxWidth: col.width }) : "—" };
     case "spread":
       return {
         text: quote?.bid != null && quote?.ask != null
-          ? formatCurrency(quote.ask - quote.bid, quoteCurrency)
+          ? formatMarketPrice(quote.ask - quote.bid, { ...formatOptions, maxWidth: col.width })
           : "—",
       };
     case "change_pct":
@@ -241,10 +252,10 @@ export function getColumnValue(
       }
       return { text: "—" };
     case "shares":
-      return { text: totalShares !== 0 ? formatCompact(totalShares) : "—" };
+      return { text: totalShares !== 0 ? formatMarketQuantity(totalShares, { ...formatOptions, maxWidth: col.width }) : "—" };
     case "avg_cost":
       if (totalCostUnits === 0) return { text: "—" };
-      return { text: formatPrice(totalCost / Math.abs(totalCostUnits)) };
+      return { text: formatMarketCost(totalCost / Math.abs(totalCostUnits), { ...formatOptions, maxWidth: col.width }) };
     case "cost_basis":
       if (totalCost === 0) return { text: "—" };
       return { text: formatCompact(toBasePosition(totalCost)) };

--- a/src/plugins/builtin/portfolio-metrics.test.ts
+++ b/src/plugins/builtin/portfolio-metrics.test.ts
@@ -196,11 +196,23 @@ describe("portfolio-metrics", () => {
     const pnlColumn: ColumnConfig = { id: "pnl", label: "P&L", width: 10, align: "right", format: "compact" };
 
     expect(getColumnValue(avgCostColumn, ticker, financials, defaultColumnContext)).toEqual({
-      text: "5,095.07",
+      text: "5,095.073",
     });
     expect(getColumnValue(pnlColumn, ticker, financials, defaultColumnContext)).toEqual({
       text: "+7.9k",
       color: expect.any(String),
+    });
+  });
+
+  test("formats equity average cost with tighter precision than quote prices", () => {
+    const ticker = createTicker({
+      assetCategory: "STK",
+      positions: [{ portfolio: "main", shares: 10, avgCost: 119.3687, broker: "manual", currency: "HKD" }],
+    });
+    const avgCostColumn: ColumnConfig = { id: "avg_cost", label: "AVG COST", width: 10, align: "right", format: "currency" };
+
+    expect(getColumnValue(avgCostColumn, ticker, undefined, defaultColumnContext)).toEqual({
+      text: "119.37",
     });
   });
 

--- a/src/plugins/builtin/ticker-detail.test.tsx
+++ b/src/plugins/builtin/ticker-detail.test.tsx
@@ -586,12 +586,12 @@ describe("TickerDetailPane", () => {
     await flushFrame();
 
     const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("€125.00");
+    expect(frame).toContain("€125");
     expect(frame).toContain("2.2B USD");
-    expect(frame).toContain("@ €100.00");
+    expect(frame).toContain("@ €100");
     expect(frame).toContain("= $1,100.00");
     expect(frame).toContain("P&L: +$275.00");
-    expect(frame).toContain("Mark: €125.00");
+    expect(frame).toContain("Mark: €125");
     expect(frame).toContain("Mkt Value: $1,375.00");
   });
 

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -12,6 +12,7 @@ import {
   formatPercent,
   formatPercentRaw,
 } from "../../../utils/format";
+import { formatMarketCostWithCurrency, formatMarketPriceWithCurrency, formatMarketQuantity, formatSignedMarketPrice } from "../../../utils/market-format";
 import {
   exchangeShortName,
   marketStateColor,
@@ -101,22 +102,20 @@ export function OverviewTab({
           <box flexDirection="column" gap={0}>
             <box flexDirection="row" gap={2}>
               <text attributes={TextAttributes.BOLD} fg={priceColor(quote.change)}>
-                {formatCurrency(quote.price, quote.currency)}
+                {formatMarketPriceWithCurrency(quote.price, quote.currency, { assetCategory: ticker.metadata.assetCategory })}
               </text>
               <text fg={priceColor(quote.change)}>
-                {quote.change >= 0 ? "+" : ""}
-                {quote.change.toFixed(2)} ({formatPercentRaw(quote.changePercent)})
+                {formatSignedMarketPrice(quote.change, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.changePercent)})
               </text>
             </box>
             {(quote.marketState === "PRE" || quote.marketState === "PREPRE") && quote.preMarketPrice != null && (
               <box flexDirection="row" gap={2}>
                 <text fg={colors.textDim}>Pre-Market:</text>
                 <text fg={priceColor(quote.preMarketChange ?? 0)}>
-                  {formatCurrency(quote.preMarketPrice, quote.currency)}
+                  {formatMarketPriceWithCurrency(quote.preMarketPrice, quote.currency, { assetCategory: ticker.metadata.assetCategory })}
                 </text>
                 <text fg={priceColor(quote.preMarketChange ?? 0)}>
-                  {(quote.preMarketChange ?? 0) >= 0 ? "+" : ""}
-                  {(quote.preMarketChange ?? 0).toFixed(2)} ({formatPercentRaw(quote.preMarketChangePercent ?? 0)})
+                  {formatSignedMarketPrice(quote.preMarketChange ?? 0, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.preMarketChangePercent ?? 0)})
                 </text>
               </box>
             )}
@@ -124,11 +123,10 @@ export function OverviewTab({
               <box flexDirection="row" gap={2}>
                 <text fg={colors.textDim}>After-Hours:</text>
                 <text fg={priceColor(quote.postMarketChange ?? 0)}>
-                  {formatCurrency(quote.postMarketPrice, quote.currency)}
+                  {formatMarketPriceWithCurrency(quote.postMarketPrice, quote.currency, { assetCategory: ticker.metadata.assetCategory })}
                 </text>
                 <text fg={priceColor(quote.postMarketChange ?? 0)}>
-                  {(quote.postMarketChange ?? 0) >= 0 ? "+" : ""}
-                  {(quote.postMarketChange ?? 0).toFixed(2)} ({formatPercentRaw(quote.postMarketChangePercent ?? 0)})
+                  {formatSignedMarketPrice(quote.postMarketChange ?? 0, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.postMarketChangePercent ?? 0)})
                 </text>
               </box>
             )}
@@ -167,17 +165,21 @@ export function OverviewTab({
           <FieldRow label="Profit Margin" value={fundamentals?.profitMargin != null ? formatPercent(fundamentals.profitMargin) : "—"} />
           {(quote?.bid != null || quote?.ask != null) && (
             <>
-              <FieldRow label="Bid" value={quote?.bid != null ? formatCurrency(quote.bid, quote.currency) : "—"} />
-              <FieldRow label="Ask" value={quote?.ask != null ? formatCurrency(quote.ask, quote.currency) : "—"} />
+              <FieldRow label="Bid" value={quote?.bid != null ? formatMarketPriceWithCurrency(quote.bid, quote.currency, { assetCategory: ticker.metadata.assetCategory }) : "—"} />
+              <FieldRow label="Ask" value={quote?.ask != null ? formatMarketPriceWithCurrency(quote.ask, quote.currency, { assetCategory: ticker.metadata.assetCategory }) : "—"} />
               <FieldRow
                 label="Spread"
-                value={quote?.bid != null && quote?.ask != null ? formatCurrency(quote.ask - quote.bid, quote.currency) : "—"}
+                value={quote?.bid != null && quote?.ask != null
+                  ? formatMarketPriceWithCurrency(quote.ask - quote.bid, quote.currency, { assetCategory: ticker.metadata.assetCategory })
+                  : "—"}
               />
             </>
           )}
           <FieldRow
             label="52W Range"
-            value={quote?.low52w && quote?.high52w ? `${formatCurrency(quote.low52w, quoteCurrency)} - ${formatCurrency(quote.high52w, quoteCurrency)}` : "—"}
+            value={quote?.low52w && quote?.high52w
+              ? `${formatMarketPriceWithCurrency(quote.low52w, quoteCurrency, { assetCategory: ticker.metadata.assetCategory })} - ${formatMarketPriceWithCurrency(quote.high52w, quoteCurrency, { assetCategory: ticker.metadata.assetCategory })}`
+              : "—"}
           />
           <FieldRow
             label="1Y Return"
@@ -251,7 +253,7 @@ export function OverviewTab({
                   </box>
                   <box flexDirection="row" height={1}>
                     <text fg={colors.text}>
-                      {position.shares} {position.multiplier && position.multiplier > 1 ? "contracts" : "shares"} @ {formatCurrency(position.avgCost, positionCurrency)}
+                      {formatMarketQuantity(position.shares, { assetCategory: ticker.metadata.assetCategory, multiplier: position.multiplier })} {position.multiplier && position.multiplier > 1 ? "contracts" : "shares"} @ {formatMarketCostWithCurrency(position.avgCost, positionCurrency, { assetCategory: ticker.metadata.assetCategory, multiplier: position.multiplier })}
                       {" = "}{formatCurrency(costBasisBase, baseCurrency)}
                     </text>
                     {pnlText && (
@@ -260,7 +262,7 @@ export function OverviewTab({
                   </box>
                   {position.markPrice != null && (
                     <box flexDirection="row" height={1}>
-                      <text fg={colors.textDim}>Mark: {formatCurrency(position.markPrice, positionCurrency)}</text>
+                      <text fg={colors.textDim}>Mark: {formatMarketPriceWithCurrency(position.markPrice, positionCurrency, { assetCategory: ticker.metadata.assetCategory, multiplier: position.multiplier })}</text>
                       {marketValueBase != null && (
                         <text fg={colors.textDim}>{" "}Mkt Value: {formatCurrency(marketValueBase, baseCurrency)}</text>
                       )}

--- a/src/plugins/builtin/ticker-detail/quote-monitor.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor.tsx
@@ -5,7 +5,8 @@ import { quoteSubscriptionTargetFromTicker } from "../../../market-data/request-
 import { usePaneTicker } from "../../../state/app-context";
 import { useQuoteStreaming } from "../../../state/use-quote-streaming";
 import { colors, priceColor } from "../../../theme/colors";
-import { formatCurrency, formatPercentRaw } from "../../../utils/format";
+import { formatPercentRaw } from "../../../utils/format";
+import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../../utils/market-format";
 import { getActiveQuoteDisplay } from "../../../utils/market-status";
 import { EmptyState } from "../../../components";
 
@@ -65,14 +66,11 @@ export function QuoteMonitorPane({ focused, width }: PaneProps) {
 
             <box flexDirection="column" alignItems={compact ? "flex-start" : "flex-end"}>
               <text attributes={TextAttributes.BOLD} fg={changeColor}>
-                {formatCurrency(display.price, currency)}
+                {formatMarketPriceWithCurrency(display.price, currency, { assetCategory: ticker.metadata.assetCategory })}
               </text>
               <box flexDirection="row" gap={1}>
                 <text fg={changeColor}>{formatPercentRaw(display.changePercent)}</text>
-                <text fg={changeColor}>
-                  {display.change > 0 ? "+" : ""}
-                  {display.change.toFixed(2)}
-                </text>
+                <text fg={changeColor}>{formatSignedMarketPrice(display.change, { assetCategory: ticker.metadata.assetCategory })}</text>
               </box>
             </box>
           </box>

--- a/src/plugins/ibkr/__snapshots__/trade-tab.test.tsx.snap
+++ b/src/plugins/ibkr/__snapshots__/trade-tab.test.tsx.snap
@@ -1,11 +1,8 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`renders the compact trade tab layout 1`] = `
-" Trade AMD · Advanced Micro Devices, Inc.                                               
- $199.80  -3.97 · Bid 199.70 · Ask 199.90 · Spd 0.20                                    
-                                                                                        
-  Broker           Account     Net Liq                                                  
-   Paper Gateway    DU123456    —                                                       
+" Trade AMD · Advanced Micro Devices, Inc.        Broker           Account     Net Liq   
+ $199.8  -3.97 · Bid 199.7 · Ask 199.9 · Spd 0.2  Paper Gateway    DU123456    —        
                                                                                         
                                                                                         
   Next Submit order   Ticket Standby   Refresh  r                                       
@@ -30,6 +27,9 @@ exports[`renders the compact trade tab layout 1`] = `
  │  Maint 10.1k → 10.7k                    Equity 58.4k → 57.1k                       │ 
  │  Preview  p  Submit Order  Enter                                                   │ 
  ╰────────────────────────────────────────────────────────────────────────────────────╯ 
+                                                                                        
+                                                                                        
+                                                                                        
                                                                                         
 "
 `;

--- a/src/plugins/ibkr/trade-tab.tsx
+++ b/src/plugins/ibkr/trade-tab.tsx
@@ -8,7 +8,8 @@ import { useAppState, usePaneCollection, usePaneInstanceId, usePaneTicker } from
 import { colors, hoverBg } from "../../theme/colors";
 import type { DetailTabProps } from "../../types/plugin";
 import type { BrokerOrderRequest, BrokerOrderType } from "../../types/trading";
-import { formatCurrency, formatNumber } from "../../utils/format";
+import { formatCurrency } from "../../utils/format";
+import { formatMarketPrice, formatMarketQuantity } from "../../utils/market-format";
 import { getBrokerInstance } from "../../utils/broker-instances";
 import { isGatewayConfigured } from "./config";
 import { ChoiceDialog, InputDialog } from "./dialogs";
@@ -401,6 +402,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
           label={label}
           currentValue={currentValue}
           quote={financials?.quote}
+          assetCategory={ticker?.metadata.assetCategory}
         />
       ),
     });
@@ -818,7 +820,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               )}
             </box>
             <box height={1}>
-              <text fg={colors.textMuted}>{formatQuoteSummary(financials?.quote)}</text>
+              <text fg={colors.textMuted}>{formatQuoteSummary(financials?.quote, { assetCategory: ticker.metadata.assetCategory })}</text>
             </box>
           </box>
 
@@ -946,7 +948,11 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               {renderFieldPill({
                 id: "quantity",
                 label: "Qty [q]",
-                value: formatNumber(ticketState.draft.quantity, 0),
+                value: formatMarketQuantity(ticketState.draft.quantity, {
+                  assetCategory: ticker.metadata.assetCategory,
+                  contractSecType: activeContract.secType,
+                  maxWidth: fieldTextWidth,
+                }),
                 widthOverride: orderFieldWidth,
                 onPress: () => {
                   editNumericField("Quantity", ticketState.draft.quantity, (value) => {
@@ -957,7 +963,13 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               {showLimit && renderFieldPill({
                 id: "limitPrice",
                 label: "Limit [l]",
-                value: ticketState.draft.limitPrice != null ? ticketState.draft.limitPrice.toFixed(2) : "—",
+                value: ticketState.draft.limitPrice != null
+                  ? formatMarketPrice(ticketState.draft.limitPrice, {
+                    assetCategory: ticker.metadata.assetCategory,
+                    contractSecType: activeContract.secType,
+                    maxWidth: fieldTextWidth,
+                  })
+                  : "—",
                 widthOverride: orderFieldWidth,
                 onPress: () => {
                   editPriceField("Limit Price", ticketState.draft.limitPrice, (value) => {
@@ -968,7 +980,13 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               {showStop && renderFieldPill({
                 id: "stopPrice",
                 label: "Stop [x]",
-                value: ticketState.draft.stopPrice != null ? ticketState.draft.stopPrice.toFixed(2) : "—",
+                value: ticketState.draft.stopPrice != null
+                  ? formatMarketPrice(ticketState.draft.stopPrice, {
+                    assetCategory: ticker.metadata.assetCategory,
+                    contractSecType: activeContract.secType,
+                    maxWidth: fieldTextWidth,
+                  })
+                  : "—",
                 widthOverride: orderFieldWidth,
                 onPress: () => {
                   editPriceField("Stop Price", ticketState.draft.stopPrice, (value) => {

--- a/src/plugins/ibkr/trade-utils.test.ts
+++ b/src/plugins/ibkr/trade-utils.test.ts
@@ -125,7 +125,7 @@ describe("trade-utils", () => {
       bid: 190.2,
       ask: 190.3,
       lastUpdated: Date.now(),
-    })).toContain("Spd 0.10");
+    })).toContain("Spd 0.1");
     expect(formatPreviewSummary(null)).toContain("Preview required before submit");
     expect(formatPreviewSummary({
       initMarginBefore: 12000,

--- a/src/plugins/ibkr/trade-utils.ts
+++ b/src/plugins/ibkr/trade-utils.ts
@@ -5,6 +5,7 @@ import type { TickerRecord } from "../../types/ticker";
 import type { BrokerAccount, BrokerOrderPreview, BrokerOrderType } from "../../types/trading";
 import { colors } from "../../theme/colors";
 import { formatCompact, formatCurrency } from "../../utils/format";
+import { formatMarketPrice, formatMarketPriceWithCurrency, formatSignedMarketPrice, type AssetDisplayContext } from "../../utils/market-format";
 import { getConfiguredIbkrGatewayInstances } from "./instance-selection";
 
 export type TradeTone = "neutral" | "accent" | "positive" | "negative";
@@ -71,13 +72,13 @@ export function formatContractLabel(contract: BrokerContractRef): string {
   return `${base}${suffix}`;
 }
 
-export function formatQuoteSummary(quote?: Quote): string {
+export function formatQuoteSummary(quote?: Quote, formatContext: AssetDisplayContext = {}): string {
   if (!quote) return "No broker quote loaded";
-  const change = `${quote.change >= 0 ? "+" : ""}${quote.change.toFixed(2)}`;
-  const parts = [`${formatCurrency(quote.price, quote.currency)}  ${change}`];
-  if (quote.bid != null) parts.push(`Bid ${quote.bid.toFixed(2)}`);
-  if (quote.ask != null) parts.push(`Ask ${quote.ask.toFixed(2)}`);
-  if (quote.bid != null && quote.ask != null) parts.push(`Spd ${(quote.ask - quote.bid).toFixed(2)}`);
+  const change = formatSignedMarketPrice(quote.change, formatContext);
+  const parts = [`${formatMarketPriceWithCurrency(quote.price, quote.currency, formatContext)}  ${change}`];
+  if (quote.bid != null) parts.push(`Bid ${formatMarketPrice(quote.bid, formatContext)}`);
+  if (quote.ask != null) parts.push(`Ask ${formatMarketPrice(quote.ask, formatContext)}`);
+  if (quote.bid != null && quote.ask != null) parts.push(`Spd ${formatMarketPrice(quote.ask - quote.bid, formatContext)}`);
   return parts.join(" · ");
 }
 

--- a/src/plugins/ibkr/trading-pane.tsx
+++ b/src/plugins/ibkr/trading-pane.tsx
@@ -9,6 +9,7 @@ import { colors, priceColor } from "../../theme/colors";
 import type { PaneProps } from "../../types/plugin";
 import type { Quote } from "../../types/financials";
 import { formatCurrency, padTo } from "../../utils/format";
+import { formatMarketPrice, formatMarketQuantity } from "../../utils/market-format";
 import { getBrokerInstance } from "../../utils/broker-instances";
 import { getSharedRegistry } from "../registry";
 import { isGatewayConfigured } from "./config";
@@ -354,12 +355,12 @@ export function TradingPane({ focused, width, height }: PaneProps) {
                 const selected = index === tradeState.selectedOpenOrderIndex;
                 const orderSymbol = order.contract.symbol;
                 const orderQuote = getOrderQuote(orderSymbol);
-                const bidStr = orderQuote?.bid != null ? orderQuote.bid.toFixed(2) : "---";
-                const askStr = orderQuote?.ask != null ? orderQuote.ask.toFixed(2) : "---";
+                const bidStr = orderQuote?.bid != null ? formatMarketPrice(orderQuote.bid, { contractSecType: order.contract.secType, maxWidth: 6 }) : "---";
+                const askStr = orderQuote?.ask != null ? formatMarketPrice(orderQuote.ask, { contractSecType: order.contract.secType, maxWidth: 6 }) : "---";
                 const orderPrice = order.limitPrice != null
-                  ? order.limitPrice.toFixed(2)
+                  ? formatMarketPrice(order.limitPrice, { contractSecType: order.contract.secType, maxWidth: 9 })
                   : order.stopPrice != null
-                    ? order.stopPrice.toFixed(2)
+                    ? formatMarketPrice(order.stopPrice, { contractSecType: order.contract.secType, maxWidth: 9 })
                     : "MKT";
                 return (
                   <box
@@ -379,7 +380,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
                       {padTo(order.action, 5)}
                       {padTo(order.contract.localSymbol || order.contract.symbol, 14)}
                       {padTo(order.status, 10)}
-                      {padTo(String(order.remaining), 5, "right")}
+                      {padTo(formatMarketQuantity(order.remaining, { contractSecType: order.contract.secType, maxWidth: 5 }), 5, "right")}
                       {" "}
                       {padTo(orderPrice, 9)}
                       {padTo(`B:${bidStr}`, 10)}
@@ -415,9 +416,9 @@ export function TradingPane({ focused, width, height }: PaneProps) {
                   <text fg={priceColor(execution.side.toUpperCase() === "BOT" ? 1 : -1)}>
                     {padTo(execution.side, 5)}
                     {padTo(execution.contract.localSymbol || execution.contract.symbol, 18)}
-                    {padTo(String(execution.shares), 6, "right")}
+                    {padTo(formatMarketQuantity(execution.shares, { contractSecType: execution.contract.secType, maxWidth: 6 }), 6, "right")}
                     {" "}
-                    {execution.price.toFixed(2)}
+                    {formatMarketPrice(execution.price, { contractSecType: execution.contract.secType })}
                   </text>
                 </box>
               ))

--- a/src/utils/market-format.test.ts
+++ b/src/utils/market-format.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatMarketCost,
+  formatMarketCostWithCurrency,
+  formatCompactMarketPriceWithCurrency,
+  formatMarketPrice,
+  formatMarketPriceWithCurrency,
+  formatMarketQuantity,
+  formatSignedMarketPrice,
+  resolveAssetDisplayKind,
+} from "./market-format";
+
+describe("resolveAssetDisplayKind", () => {
+  test("prefers explicit cash balances", () => {
+    expect(resolveAssetDisplayKind({ isCashBalance: true, assetCategory: "STK" })).toBe("cash");
+  });
+
+  test("maps common broker security types", () => {
+    expect(resolveAssetDisplayKind({ assetCategory: "CRYPTO" })).toBe("crypto");
+    expect(resolveAssetDisplayKind({ assetCategory: "STK" })).toBe("equity");
+    expect(resolveAssetDisplayKind({ contractSecType: "OPT" })).toBe("contract");
+    expect(resolveAssetDisplayKind({ assetCategory: "FOREX" })).toBe("cash");
+    expect(resolveAssetDisplayKind({ assetCategory: "CURRENCY" })).toBe("cash");
+    expect(resolveAssetDisplayKind({ assetCategory: "CCY" })).toBe("cash");
+  });
+
+  test("falls back to contract formatting when only a multiplier is present", () => {
+    expect(resolveAssetDisplayKind({ multiplier: 100 })).toBe("contract");
+  });
+});
+
+describe("formatMarketQuantity", () => {
+  test("preserves additional FX precision while trimming trailing zeroes", () => {
+    expect(formatMarketQuantity(-351957.025, { isCashBalance: true })).toBe("-351,957.025");
+    expect(formatMarketQuantity(-303029.144938754, { isCashBalance: true })).toBe("-303,029.144939");
+  });
+
+  test("shows whole equities without decimals and fractional equities with up to four decimals", () => {
+    expect(formatMarketQuantity(10, { assetCategory: "STK" })).toBe("10");
+    expect(formatMarketQuantity(10.125, { assetCategory: "STK" })).toBe("10.125");
+    expect(formatMarketQuantity(10.123456, { assetCategory: "STK" })).toBe("10.1235");
+  });
+
+  test("uses higher precision for crypto quantities", () => {
+    expect(formatMarketQuantity(0.123456789, { assetCategory: "CRYPTO" })).toBe("0.12345679");
+  });
+});
+
+describe("formatMarketPrice", () => {
+  test("uses semantic precision for equities, cash, and crypto", () => {
+    expect(formatMarketPrice(190.2, { assetCategory: "STK" })).toBe("190.2");
+    expect(formatMarketPrice(259.7499, { assetCategory: "STK" })).toBe("259.75");
+    expect(formatMarketPrice(1.084567, { isCashBalance: true })).toBe("1.084567");
+    expect(formatMarketPrice(1.17364, { assetCategory: "CURRENCY" })).toBe("1.17364");
+    expect(formatMarketPrice(0.000123456789, { assetCategory: "CRYPTO" })).toBe("0.00012346");
+  });
+
+  test("can adapt chart precision to the visible price range", () => {
+    expect(formatMarketPrice(1.167815, { assetCategory: "CURRENCY", priceRange: 0.12 })).toBe("1.17");
+    expect(formatMarketPrice(1.167815, { assetCategory: "CURRENCY", priceRange: 0.0024 })).toBe("1.1678");
+    expect(formatMarketPrice(259.7499, {
+      assetCategory: "STK",
+      minimumFractionDigits: 2,
+      precisionOffset: 1,
+      priceRange: 80,
+    })).toBe("259.75");
+  });
+
+  test("can lock price displays to a specific number of decimals", () => {
+    expect(formatMarketPrice(18, { assetCategory: "STK", fixedFractionDigits: 1 })).toBe("18.0");
+    expect(formatMarketPriceWithCurrency(18, "USD", { assetCategory: "STK", fixedFractionDigits: 2 })).toBe("$18.00");
+  });
+
+  test("fits within the supplied width before falling back to truncation elsewhere", () => {
+    expect(formatMarketPrice(1.084567, { isCashBalance: true, maxWidth: 6 })).toBe("1.0846");
+    expect(formatMarketQuantity(123456.789, { assetCategory: "CRYPTO", maxWidth: 7 })).toBe("123,457");
+  });
+
+  test("formats signed price changes without double signs", () => {
+    expect(formatSignedMarketPrice(0.123456, { isCashBalance: true })).toBe("+0.123456");
+    expect(formatSignedMarketPrice(-0.123456, { isCashBalance: true })).toBe("-0.123456");
+  });
+});
+
+describe("formatMarketCost", () => {
+  test("keeps equity cost displays conservative while preserving FX and crypto precision", () => {
+    expect(formatMarketCost(119.3687, { assetCategory: "STK" })).toBe("119.37");
+    expect(formatMarketCost(1.084567, { isCashBalance: true })).toBe("1.084567");
+    expect(formatMarketCost(113905.720075, { assetCategory: "CRYPTO" })).toBe("113,905.720075");
+  });
+});
+
+describe("formatMarketPriceWithCurrency", () => {
+  test("renders price-like values with a symbol and variable decimals", () => {
+    expect(formatMarketPriceWithCurrency(190.25, "USD", { assetCategory: "STK" })).toBe("$190.25");
+    expect(formatMarketPriceWithCurrency(1.084567, "EUR", { isCashBalance: true })).toBe("€1.084567");
+    expect(formatMarketPriceWithCurrency(1.17364, "USD", { assetCategory: "CURRENCY" })).toBe("$1.17364");
+  });
+
+  test("preserves chart-style compact notation for large values", () => {
+    expect(formatCompactMarketPriceWithCurrency(21_970, "JPY")).toBe("¥22.0K");
+    expect(formatCompactMarketPriceWithCurrency(12_340, "HKD")).toBe("HK$12.3K");
+  });
+
+  test("formats position cost values with tighter equity precision", () => {
+    expect(formatMarketCostWithCurrency(119.3687, "HKD", { assetCategory: "STK" })).toBe("HK$119.37");
+    expect(formatMarketCostWithCurrency(50.9507, "USD", { assetCategory: "OPT", multiplier: 100 })).toBe("$50.9507");
+  });
+});

--- a/src/utils/market-format.ts
+++ b/src/utils/market-format.ts
@@ -1,0 +1,299 @@
+import { formatCurrency } from "./format";
+
+export type AssetDisplayKind = "cash" | "crypto" | "equity" | "contract" | "other";
+
+export interface AssetDisplayContext {
+  isCashBalance?: boolean;
+  assetCategory?: string;
+  contractSecType?: string;
+  multiplier?: number;
+}
+
+export interface MarketFormatOptions extends AssetDisplayContext {
+  maxWidth?: number;
+  minimumFractionDigits?: number;
+  precisionOffset?: number;
+  priceRange?: number;
+  fixedFractionDigits?: number;
+}
+
+const CASH_TYPES = new Set(["CASH", "FX", "FOREX", "CCY", "CURRENCY", "CURRENCYPAIR"]);
+const CRYPTO_TYPES = new Set(["CRYPTO", "CRYPTOCURRENCY", "COIN", "TOKEN"]);
+const EQUITY_TYPES = new Set(["STK", "STOCK", "EQUITY", "ETF", "ETN", "ETP", "FUND", "MUTUALFUND", "CEF", "ADR"]);
+const CONTRACT_TYPES = new Set(["OPT", "OPTION", "OPTIONS", "FUT", "FUTURE", "FUTURES", "FOP"]);
+
+const currencySymbols = new Map<string, string>();
+const numberFormatters = new Map<string, Intl.NumberFormat>();
+
+function normalizeType(value?: string): string {
+  return (value ?? "").trim().toUpperCase().replace(/[\s_-]+/g, "");
+}
+
+function getNumberFormatter(
+  minimumFractionDigits: number,
+  maximumFractionDigits: number,
+  useGrouping: boolean,
+): Intl.NumberFormat {
+  const key = `${minimumFractionDigits}:${maximumFractionDigits}:${useGrouping ? 1 : 0}`;
+  let formatter = numberFormatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat("en-US", {
+      minimumFractionDigits,
+      maximumFractionDigits,
+      useGrouping,
+    });
+    numberFormatters.set(key, formatter);
+  }
+  return formatter;
+}
+
+function getCurrencySymbol(currency: string): string {
+  const normalizedCurrency = currency.trim().toUpperCase() || "USD";
+  const cached = currencySymbols.get(normalizedCurrency);
+  if (cached) return cached;
+
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: normalizedCurrency,
+    currencyDisplay: "symbol",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const symbol = formatter.formatToParts(0).find((part) => part.type === "currency")?.value ?? normalizedCurrency;
+  currencySymbols.set(normalizedCurrency, symbol);
+  return symbol;
+}
+
+function fitsWidth(text: string, maxWidth: number | undefined): boolean {
+  return maxWidth == null || text.length <= maxWidth;
+}
+
+function isEffectivelyInteger(value: number): boolean {
+  return Math.abs(value - Math.round(value)) < 1e-9;
+}
+
+function formatVariableNumber(
+  value: number,
+  maxFractionDigits: number,
+  maxWidth: number | undefined,
+  minimumFractionDigits = 0,
+): string {
+  const groupedModes = [true, false];
+
+  for (const useGrouping of groupedModes) {
+    for (let decimals = maxFractionDigits; decimals >= minimumFractionDigits; decimals -= 1) {
+      const formatter = getNumberFormatter(Math.min(minimumFractionDigits, decimals), decimals, useGrouping);
+      const formatted = formatter.format(value);
+      if (fitsWidth(formatted, maxWidth)) return formatted;
+    }
+  }
+
+  return getNumberFormatter(0, 0, false).format(value);
+}
+
+function getQuantityMaxFractionDigits(kind: AssetDisplayKind, value: number): number {
+  if (isEffectivelyInteger(value)) return 0;
+
+  switch (kind) {
+    case "cash":
+      return 6;
+    case "crypto":
+      return 8;
+    case "equity":
+      return 4;
+    case "contract":
+      return 4;
+    case "other":
+    default:
+      return 4;
+  }
+}
+
+function getBasePriceMaxFractionDigits(kind: AssetDisplayKind, value: number): number {
+  switch (kind) {
+    case "cash":
+      return 6;
+    case "crypto":
+      return 8;
+    case "equity":
+      return Math.abs(value) >= 1 ? 2 : 4;
+    case "contract":
+      return 4;
+    case "other":
+    default:
+      return Math.abs(value) >= 1 ? 2 : 4;
+  }
+}
+
+function getAdaptivePriceFractionDigits(priceRange: number | undefined, precisionOffset = 0): number | null {
+  if (priceRange === undefined || !Number.isFinite(priceRange) || priceRange <= 0) return null;
+
+  // The chart price axis renders four labels by default, so the visible range
+  // divided across three intervals is a good proxy for the current zoom step.
+  const visibleStep = priceRange / 3;
+  if (!Number.isFinite(visibleStep) || visibleStep <= 0) return null;
+
+  return Math.max(0, Math.ceil(-Math.log10(visibleStep)) + precisionOffset);
+}
+
+function getPriceMaxFractionDigits(
+  kind: AssetDisplayKind,
+  value: number,
+  priceRange: number | undefined,
+  precisionOffset: number,
+): number {
+  const baseMaxFractionDigits = kind === "other" && priceRange !== undefined
+    ? 6
+    : getBasePriceMaxFractionDigits(kind, value);
+  const adaptiveFractionDigits = getAdaptivePriceFractionDigits(priceRange, precisionOffset);
+  return adaptiveFractionDigits === null
+    ? baseMaxFractionDigits
+    : Math.min(baseMaxFractionDigits, adaptiveFractionDigits);
+}
+
+function getCostMaxFractionDigits(kind: AssetDisplayKind): number {
+  switch (kind) {
+    case "cash":
+      return 6;
+    case "crypto":
+      return 8;
+    case "contract":
+      return 4;
+    case "equity":
+      return 2;
+    case "other":
+    default:
+      return 2;
+  }
+}
+
+function compactScaledPrice(
+  value: number,
+  divisor: number,
+  suffix: string,
+  currency: string,
+  maxWidth: number | undefined,
+): string {
+  const sign = value < 0 ? "-" : "";
+  const symbol = getCurrencySymbol(currency);
+  const numericWidth = maxWidth == null
+    ? undefined
+    : Math.max(1, maxWidth - sign.length - symbol.length - suffix.length);
+  const formatted = formatVariableNumber(Math.abs(value) / divisor, 1, numericWidth, 1);
+  return `${sign}${symbol}${formatted}${suffix}`;
+}
+
+export function resolveAssetDisplayKind({
+  isCashBalance,
+  assetCategory,
+  contractSecType,
+  multiplier,
+}: AssetDisplayContext): AssetDisplayKind {
+  if (isCashBalance) return "cash";
+
+  const normalizedType = normalizeType(contractSecType || assetCategory);
+  if (CASH_TYPES.has(normalizedType) || normalizedType.includes("FOREX") || normalizedType.includes("CURRENCY")) return "cash";
+  if (CRYPTO_TYPES.has(normalizedType) || normalizedType.includes("CRYPTO")) return "crypto";
+  if (EQUITY_TYPES.has(normalizedType)) return "equity";
+  if (CONTRACT_TYPES.has(normalizedType)) return "contract";
+  if ((multiplier ?? 1) > 1) return "contract";
+  return "other";
+}
+
+export function formatMarketQuantity(value: number | undefined, options: MarketFormatOptions = {}): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  const kind = resolveAssetDisplayKind(options);
+  const maxFractionDigits = getQuantityMaxFractionDigits(kind, value);
+  return formatVariableNumber(value, maxFractionDigits, options.maxWidth);
+}
+
+export function formatMarketPrice(value: number | undefined, options: MarketFormatOptions = {}): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  const kind = resolveAssetDisplayKind(options);
+  const fixedFractionDigits = options.fixedFractionDigits;
+  if (fixedFractionDigits !== undefined) {
+    const maxFractionDigits = kind === "other" && options.priceRange !== undefined
+      ? 6
+      : getBasePriceMaxFractionDigits(kind, value);
+    const clampedFixedFractionDigits = Math.max(0, Math.min(fixedFractionDigits, maxFractionDigits));
+    return formatVariableNumber(value, clampedFixedFractionDigits, options.maxWidth, clampedFixedFractionDigits);
+  }
+  const minimumFractionDigits = Math.max(
+    0,
+    Math.min(options.minimumFractionDigits ?? 0, getBasePriceMaxFractionDigits(kind, value)),
+  );
+  const maxFractionDigits = Math.max(
+    getPriceMaxFractionDigits(kind, value, options.priceRange, options.precisionOffset ?? 0),
+    minimumFractionDigits,
+  );
+  return formatVariableNumber(value, maxFractionDigits, options.maxWidth, minimumFractionDigits);
+}
+
+export function formatMarketCost(value: number | undefined, options: MarketFormatOptions = {}): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  const kind = resolveAssetDisplayKind(options);
+  return formatVariableNumber(value, getCostMaxFractionDigits(kind), options.maxWidth);
+}
+
+export function formatSignedMarketPrice(value: number | undefined, options: MarketFormatOptions = {}): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  if (value > 0) {
+    const maxWidth = options.maxWidth == null ? undefined : Math.max(1, options.maxWidth - 1);
+    return `+${formatMarketPrice(value, { ...options, maxWidth })}`;
+  }
+  return formatMarketPrice(value, options);
+}
+
+export function formatMarketPriceWithCurrency(
+  value: number | undefined,
+  currency = "USD",
+  options: MarketFormatOptions = {},
+): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  const normalizedCurrency = currency.trim().toUpperCase() || "USD";
+  const sign = value < 0 ? "-" : "";
+  const symbol = getCurrencySymbol(normalizedCurrency);
+  const numericWidth = options.maxWidth == null
+    ? undefined
+    : Math.max(1, options.maxWidth - sign.length - symbol.length);
+  const body = formatMarketPrice(Math.abs(value), { ...options, maxWidth: numericWidth });
+  return `${sign}${symbol}${body}`;
+}
+
+export function formatMarketCostWithCurrency(
+  value: number | undefined,
+  currency = "USD",
+  options: MarketFormatOptions = {},
+): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  const normalizedCurrency = currency.trim().toUpperCase() || "USD";
+  const sign = value < 0 ? "-" : "";
+  const symbol = getCurrencySymbol(normalizedCurrency);
+  const numericWidth = options.maxWidth == null
+    ? undefined
+    : Math.max(1, options.maxWidth - sign.length - symbol.length);
+  const body = formatMarketCost(Math.abs(value), { ...options, maxWidth: numericWidth });
+  return `${sign}${symbol}${body}`;
+}
+
+export function formatCompactMarketPriceWithCurrency(
+  value: number | undefined,
+  currency = "USD",
+  options: MarketFormatOptions = {},
+): string {
+  if (value === undefined || value === null || Number.isNaN(value)) return "—";
+  const abs = Math.abs(value);
+
+  if (abs >= 1e6) {
+    return compactScaledPrice(value, 1e6, "M", currency, options.maxWidth);
+  }
+  if (abs >= 1e3 && abs < 1e5) {
+    return compactScaledPrice(value, 1e3, "K", currency, options.maxWidth);
+  }
+
+  return formatMarketPriceWithCurrency(value, currency, options);
+}
+
+export function formatMarketMoney(value: number | undefined, currency = "USD"): string {
+  return formatCurrency(value, currency);
+}

--- a/src/utils/market-status.ts
+++ b/src/utils/market-status.ts
@@ -1,6 +1,7 @@
 import type { MarketState, Quote, QuoteFieldProvenance } from "../types/financials";
 import { colors, priceColor } from "../theme/colors";
 import { formatPercentRaw } from "./format";
+import { formatMarketPrice } from "./market-format";
 
 export interface ActiveQuoteDisplay {
   price: number;
@@ -107,11 +108,11 @@ export function getExtendedHoursInfo(quote: Quote | null | undefined): { text: s
   if (!quote) return null;
   if ((quote.marketState === "PRE" || quote.marketState === "PREPRE") && quote.preMarketPrice != null) {
     const chg = quote.preMarketChangePercent ?? 0;
-    return { text: `Pre ${quote.preMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
+    return { text: `Pre ${formatMarketPrice(quote.preMarketPrice)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
   }
   if ((quote.marketState === "POST" || quote.marketState === "POSTPOST") && quote.postMarketPrice != null) {
     const chg = quote.postMarketChangePercent ?? 0;
-    return { text: `AH ${quote.postMarketPrice.toFixed(2)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
+    return { text: `AH ${formatMarketPrice(quote.postMarketPrice)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
   }
   return null;
 }


### PR DESCRIPTION
Adds semantic market formatters for FX, crypto, equities, and contracts, and wires them through the CLI, portfolio list, ticker detail, trade panes, quote monitor, header, and related AI/context helpers.

Updates stock and comparison charts to size the y-axis from visible labels, preserve more useful zoom-dependent precision, and keep both idle and hover labels from clipping in narrow panes.

Also streamlines watchlist add flows in the command bar by auto-targeting the sole watchlist and refreshes the related tests and snapshots.

Testing: bun test src/utils/market-format.test.ts, src/components/chart/chart.test.ts, src/components/chart/comparison-chart-renderer.test.ts, src/components/chart/stock-chart-renderer-switch.test.tsx, src/components/command-bar/command-bar.test.tsx, src/cli.test.ts, src/plugins/builtin/portfolio-list.test.tsx, src/plugins/builtin/portfolio-metrics.test.ts, src/plugins/builtin/ticker-detail.test.tsx, src/plugins/ibkr/trade-utils.test.ts, src/plugins/ibkr/trade-tab.test.tsx, and src/plugins/builtin/quote-monitor.test.tsx.