### PR TITLE
Centralize pane resolution across the TUI

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -25,8 +25,11 @@ import { colors, syncTheme } from "./theme/colors";
 import {
   createPaneInstance,
   findPaneInstance,
+  findPrimaryPaneInstance,
   isTickerPaneId,
   normalizePaneLayout,
+  resolveFollowBindingInstance,
+  resolvePaneInstance,
   type AppConfig,
   type BrokerInstanceConfig,
   type LayoutConfig,
@@ -102,6 +105,14 @@ const quoteRefreshInFlight: Set<string> = (globalThis as any).__quoteRefreshInFl
 const PANEL_RESOLUTION_BOUNDS = { x: 0, y: 0, width: 120, height: 40 };
 const appLog = debugLog.createLogger("app");
 
+function isCollectionPaneInstance(instance: PaneInstanceConfig): boolean {
+  return instance.paneId === "portfolio-list";
+}
+
+function isTickerContextPaneInstance(instance: PaneInstanceConfig): boolean {
+  return instance.paneId === "portfolio-list" || isTickerPaneId(instance.paneId);
+}
+
 function summarizeError(error: unknown): Record<string, string> {
   if (error instanceof Error) {
     return {
@@ -145,24 +156,9 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
     pluginRegistry.notify({ body, ...options });
   }, [pluginRegistry]);
 
-  const resolvePrimaryPaneInstanceId = useCallback((paneId: string, layout: LayoutConfig = state.config.layout): string | null => {
-    const instances = layout.instances.filter((instance) => instance.paneId === paneId);
-    if (instances.length === 0) return null;
-    if (isTickerPaneId(paneId)) {
-      return instances.find((instance) =>
-        instance.instanceId === `${paneId}:main` && instance.binding?.kind !== "fixed",
-      )?.instanceId
-        ?? instances.find((instance) => instance.binding?.kind !== "fixed")?.instanceId
-        ?? null;
-    }
-    return instances[0]?.instanceId ?? null;
-  }, [state.config.layout]);
-
   const resolvePaneTarget = useCallback((paneId: string, layout: LayoutConfig = state.config.layout): string | null => {
-    const byInstance = layout.instances.find((instance) => instance.instanceId === paneId);
-    if (byInstance) return byInstance.instanceId;
-    return resolvePrimaryPaneInstanceId(paneId, layout);
-  }, [resolvePrimaryPaneInstanceId, state.config.layout]);
+    return resolvePaneInstance(layout, paneId)?.instanceId ?? null;
+  }, [state.config.layout]);
 
   const getPreferredPortfolio = useCallback((ticker: TickerRecord | null) => {
     const focusedPortfolio = state.config.portfolios.find((portfolio) => portfolio.id === focusedCollectionId);
@@ -214,39 +210,17 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
   }, [dialog]);
 
   const resolveCollectionSourcePaneId = useCallback((preferredPaneId?: string | null) => {
-    const tryResolve = (candidate: string | null | undefined): string | null => {
-      if (!candidate) return null;
-      const instance = findPaneInstance(state.config.layout, candidate);
-      if (!instance) return null;
-      if (instance.paneId === "portfolio-list") return instance.instanceId;
-      if (instance.binding?.kind === "follow") {
-        return tryResolve(instance.binding.sourceInstanceId);
-      }
-      return null;
-    };
-
-    return tryResolve(preferredPaneId)
-      ?? tryResolve(state.focusedPaneId)
-      ?? state.config.layout.instances.find((instance) => instance.paneId === "portfolio-list")?.instanceId
+    return resolveFollowBindingInstance(state.config.layout, preferredPaneId, isCollectionPaneInstance)?.instanceId
+      ?? resolveFollowBindingInstance(state.config.layout, state.focusedPaneId, isCollectionPaneInstance)?.instanceId
+      ?? findPrimaryPaneInstance(state.config.layout, "portfolio-list")?.instanceId
       ?? null;
   }, [state.config.layout, state.focusedPaneId]);
 
   const resolveTickerContextSourcePaneId = useCallback((preferredPaneId?: string | null) => {
-    const tryResolve = (candidate: string | null | undefined): string | null => {
-      if (!candidate) return null;
-      const instance = findPaneInstance(state.config.layout, candidate);
-      if (!instance) return null;
-      if (instance.paneId === "portfolio-list" || isTickerPaneId(instance.paneId)) return instance.instanceId;
-      if (instance.binding?.kind === "follow") {
-        return tryResolve(instance.binding.sourceInstanceId);
-      }
-      return null;
-    };
-
-    return tryResolve(preferredPaneId)
-      ?? tryResolve(state.focusedPaneId)
-      ?? state.config.layout.instances.find((instance) => instance.paneId === "ticker-detail" && instance.binding?.kind !== "fixed")?.instanceId
-      ?? state.config.layout.instances.find((instance) => instance.paneId === "portfolio-list")?.instanceId
+    return resolveFollowBindingInstance(state.config.layout, preferredPaneId, isTickerContextPaneInstance)?.instanceId
+      ?? resolveFollowBindingInstance(state.config.layout, state.focusedPaneId, isTickerContextPaneInstance)?.instanceId
+      ?? findPrimaryPaneInstance(state.config.layout, "ticker-detail")?.instanceId
+      ?? findPrimaryPaneInstance(state.config.layout, "portfolio-list")?.instanceId
       ?? null;
   }, [state.config.layout, state.focusedPaneId]);
 
@@ -290,9 +264,9 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
 
   const switchDetailTab = useCallback((tabId: string, preferredPaneId?: string | null) => {
     const targetPaneId = (() => {
-      const target = preferredPaneId ? findPaneInstance(state.config.layout, preferredPaneId) : null;
+      const target = preferredPaneId ? resolvePaneInstance(state.config.layout, preferredPaneId) : null;
       if (target?.paneId === "ticker-detail") return target.instanceId;
-      const focused = state.focusedPaneId ? findPaneInstance(state.config.layout, state.focusedPaneId) : null;
+      const focused = state.focusedPaneId ? resolvePaneInstance(state.config.layout, state.focusedPaneId) : null;
       if (focused?.paneId === "ticker-detail") return focused.instanceId;
       const sourcePaneId = resolveCollectionSourcePaneId(preferredPaneId);
       if (!sourcePaneId) return null;

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -35,6 +35,8 @@ import {
   cloneLayout,
   createPaneInstance,
   findPaneInstance,
+  findPrimaryPaneInstance,
+  resolveFollowBindingInstance,
   type LayoutConfig,
 } from "../../types/config";
 import { resolveBrokerConfigFields, type BrokerConfigField } from "../../types/broker";
@@ -349,16 +351,12 @@ export function CommandBar({
 
   const setActiveCollection = useCallback((collectionId: string) => {
     const currentState = stateRef.current;
-    const resolvePortfolioPane = (candidate?: string | null): string | null => {
-      if (!candidate) return null;
-      const instance = findPaneInstance(currentState.config.layout, candidate);
-      if (!instance) return null;
-      if (instance.paneId === "portfolio-list") return instance.instanceId;
-      if (instance.binding?.kind === "follow") return resolvePortfolioPane(instance.binding.sourceInstanceId);
-      return null;
-    };
-    const targetPaneId = resolvePortfolioPane(currentState.focusedPaneId)
-      ?? currentState.config.layout.instances.find((instance) => instance.paneId === "portfolio-list")?.instanceId
+    const targetPaneId = resolveFollowBindingInstance(
+      currentState.config.layout,
+      currentState.focusedPaneId,
+      (instance) => instance.paneId === "portfolio-list",
+    )?.instanceId
+      ?? findPrimaryPaneInstance(currentState.config.layout, "portfolio-list")?.instanceId
       ?? null;
     if (!targetPaneId) return;
     dispatch({ type: "UPDATE_PANE_STATE", paneId: targetPaneId, patch: { collectionId } });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -28,7 +28,7 @@ import type {
 import type { TickerRecord } from "../types/ticker";
 import { addPaneFloating, removePane } from "./pane-manager";
 import { EventBus, type PluginEvents } from "./event-bus";
-import { createPaneInstance } from "../types/config";
+import { createPaneInstance, resolvePaneInstance } from "../types/config";
 import { createPluginPersistence } from "./plugin-persistence";
 import { debugLog } from "../utils/debug-log";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "./plugin-runtime";
@@ -277,16 +277,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
     return Object.keys(this.getConfigFn().pluginConfig[pluginId] ?? {}).sort();
   }
 
-  private resolvePrimaryPaneInstanceId(paneId: string): string | undefined {
-    const layout = this.getLayoutFn();
-    return layout.instances.find((instance) => instance.paneId === paneId)?.instanceId;
-  }
-
   private resolvePaneTarget(paneId: string): string | undefined {
-    const layout = this.getLayoutFn();
-    const isInstanceId = layout.instances.some((instance) => instance.instanceId === paneId);
-    if (isInstanceId) return paneId;
-    return this.resolvePrimaryPaneInstanceId(paneId);
+    return resolvePaneInstance(this.getLayoutFn(), paneId)?.instanceId;
   }
 
   resolvePaneSettings(paneId: string): {

--- a/src/types/config.test.ts
+++ b/src/types/config.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createPaneInstance,
+  findPrimaryPaneInstance,
+  resolveFollowBindingInstance,
+  resolvePaneInstance,
+  type LayoutConfig,
+  type PaneInstanceConfig,
+} from "./config";
+
+function createLayout(instances: PaneInstanceConfig[]): LayoutConfig {
+  return {
+    dockRoot: null,
+    instances,
+    floating: [],
+  };
+}
+
+describe("findPrimaryPaneInstance", () => {
+  test("prefers the main non-fixed ticker pane", () => {
+    const layout = createLayout([
+      createPaneInstance("portfolio-list", {
+        instanceId: "portfolio-list:main",
+        binding: { kind: "none" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:pinned",
+        binding: { kind: "fixed", symbol: "AAPL" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:main",
+        binding: { kind: "follow", sourceInstanceId: "portfolio-list:main" },
+      }),
+    ]);
+
+    expect(findPrimaryPaneInstance(layout, "ticker-detail")?.instanceId).toBe("ticker-detail:main");
+  });
+
+  test("does not treat fixed ticker panes as the primary pane", () => {
+    const layout = createLayout([
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:aapl",
+        binding: { kind: "fixed", symbol: "AAPL" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:msft",
+        binding: { kind: "fixed", symbol: "MSFT" },
+      }),
+    ]);
+
+    expect(findPrimaryPaneInstance(layout, "ticker-detail")).toBeUndefined();
+  });
+});
+
+describe("resolvePaneInstance", () => {
+  test("accepts either an instance id or a pane id", () => {
+    const layout = createLayout([
+      createPaneInstance("portfolio-list", {
+        instanceId: "portfolio-list:main",
+        binding: { kind: "none" },
+      }),
+    ]);
+
+    expect(resolvePaneInstance(layout, "portfolio-list:main")?.instanceId).toBe("portfolio-list:main");
+    expect(resolvePaneInstance(layout, "portfolio-list")?.instanceId).toBe("portfolio-list:main");
+  });
+});
+
+describe("resolveFollowBindingInstance", () => {
+  test("walks follow bindings until it finds a matching pane", () => {
+    const layout = createLayout([
+      createPaneInstance("portfolio-list", {
+        instanceId: "portfolio-list:main",
+        binding: { kind: "none" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:main",
+        binding: { kind: "follow", sourceInstanceId: "portfolio-list:main" },
+      }),
+      createPaneInstance("quote-monitor", {
+        instanceId: "quote-monitor:main",
+        binding: { kind: "follow", sourceInstanceId: "ticker-detail:main" },
+      }),
+    ]);
+
+    expect(
+      resolveFollowBindingInstance(layout, "quote-monitor:main", (instance) => instance.paneId === "portfolio-list")?.instanceId,
+    ).toBe("portfolio-list:main");
+  });
+
+  test("stops on follow cycles", () => {
+    const layout = createLayout([
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:first",
+        binding: { kind: "follow", sourceInstanceId: "quote-monitor:first" },
+      }),
+      createPaneInstance("quote-monitor", {
+        instanceId: "quote-monitor:first",
+        binding: { kind: "follow", sourceInstanceId: "ticker-detail:first" },
+      }),
+    ]);
+
+    expect(
+      resolveFollowBindingInstance(layout, "ticker-detail:first", (instance) => instance.paneId === "portfolio-list"),
+    ).toBeUndefined();
+  });
+});

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -317,6 +317,35 @@ export function isFixedTickerPane(instance: PaneInstanceConfig): boolean {
   return isTickerPaneInstance(instance) && instance.binding?.kind === "fixed";
 }
 
+export function findPrimaryPaneInstance(layout: LayoutConfig, paneId: string): PaneInstanceConfig | undefined {
+  const instances = layout.instances.filter((instance) => instance.paneId === paneId);
+  if (instances.length === 0) return undefined;
+  if (!isTickerPaneId(paneId)) return instances[0];
+  return instances.find((instance) => instance.instanceId === `${paneId}:main` && instance.binding?.kind !== "fixed")
+    ?? instances.find((instance) => instance.binding?.kind !== "fixed");
+}
+
+export function resolvePaneInstance(layout: LayoutConfig, paneIdOrInstanceId: string): PaneInstanceConfig | undefined {
+  return findPaneInstance(layout, paneIdOrInstanceId) ?? findPrimaryPaneInstance(layout, paneIdOrInstanceId);
+}
+
+export function resolveFollowBindingInstance(
+  layout: LayoutConfig,
+  paneIdOrInstanceId: string | null | undefined,
+  matcher: (instance: PaneInstanceConfig) => boolean,
+  seen = new Set<string>(),
+): PaneInstanceConfig | undefined {
+  if (!paneIdOrInstanceId) return undefined;
+  const instance = resolvePaneInstance(layout, paneIdOrInstanceId);
+  if (!instance || seen.has(instance.instanceId)) return undefined;
+  seen.add(instance.instanceId);
+  if (matcher(instance)) return instance;
+  if (instance.binding?.kind === "follow") {
+    return resolveFollowBindingInstance(layout, instance.binding.sourceInstanceId, matcher, seen);
+  }
+  return undefined;
+}
+
 export function createPaneInstance(
   paneId: string,
   options: Partial<PaneInstanceConfig> = {},


### PR DESCRIPTION
This centralizes pane target selection and follow-binding traversal in shared config helpers so app, registry, and command-bar code all use the same rules. It removes duplicated pane-resolution logic from the app shell, command bar, and plugin registry while keeping ticker-pane behavior the same. The branch also adds focused tests for primary-pane resolution, pane-id versus instance-id lookup, recursive follow traversal, and follow-cycle handling. Validation: bun test src/types/config.test.ts, bun test src/data/config-store.test.ts, bun test src/plugins/pane-manager.test.ts, bun test src/state/app-context.test.ts, bun test src/components/command-bar/command-bar.test.tsx, bun run dev help, and a tmux smoke test opening the real app and command bar.