### PR TITLE
Add World Equity Indices (WEI) and Market Movers (TOP) plugins

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -15,7 +15,15 @@ export type DataTableColumn = Pick<
 export interface DataTableCell {
   text: string;
   color?: string;
+  attributes?: number;
   onMouseDown?: (event: any) => void;
+}
+
+export interface DataTableSectionHeader {
+  text: string;
+  color?: string;
+  backgroundColor?: string;
+  attributes?: number;
 }
 
 export interface DataTableProps<
@@ -43,6 +51,10 @@ export interface DataTableProps<
     index: number,
     rowState: { selected: boolean; hovered: boolean },
   ) => DataTableCell;
+  renderSectionHeader?: (
+    item: T,
+    index: number,
+  ) => DataTableSectionHeader | null;
   emptyStateTitle: string;
   emptyStateHint?: string;
   virtualize?: boolean;
@@ -71,6 +83,7 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
   onSelect,
   onActivate,
   renderCell,
+  renderSectionHeader,
   emptyStateTitle,
   emptyStateHint,
   virtualize = false,
@@ -182,6 +195,32 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
             {virtualize && startIndex > 0 && <box height={startIndex} />}
             {visibleItems.map((item, visibleIndex) => {
               const index = startIndex + visibleIndex;
+              const sectionHeader = renderSectionHeader?.(item, index) ?? null;
+
+              if (sectionHeader) {
+                return (
+                  <box
+                    key={getItemKey(item, index)}
+                    flexDirection="row"
+                    height={1}
+                    width="100%"
+                    paddingX={1}
+                    backgroundColor={sectionHeader.backgroundColor ?? colors.bg}
+                    onMouseDown={(event) => {
+                      focusPane();
+                      event.preventDefault();
+                    }}
+                  >
+                    <text
+                      attributes={sectionHeader.attributes ?? TextAttributes.BOLD}
+                      fg={sectionHeader.color ?? colors.textBright}
+                    >
+                      {sectionHeader.text}
+                    </text>
+                  </box>
+                );
+              }
+
               const selected = isSelected(item, index);
               const hovered = hoveredIdx === index && !selected;
               const rowBg = selected
@@ -231,6 +270,7 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
                         }}
                       >
                         <text
+                          attributes={cell.attributes ?? TextAttributes.NONE}
                           fg={
                             cell.color ??
                             (selected ? colors.selectedText : colors.text)

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,6 +6,7 @@ export type {
   DataTableCell,
   DataTableColumn,
   DataTableProps,
+  DataTableSectionHeader,
 } from "./data-table";
 
 export { Tabs } from "./tabs";

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -1,16 +1,22 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, useState } from "react";
+import { act, useRef, useState } from "react";
 import { testRender } from "@opentui/react/test-utils";
+import type { ScrollBoxRenderable } from "@opentui/core";
 import { Button } from "./button";
+import { DataTable } from "./data-table";
 import { TextField } from "./fields";
 import { ListView } from "./list-view";
 import { ProgressBar } from "./loading";
 import { Notice } from "./status";
 import { Tabs } from "./tabs";
 import { ToggleList } from "../toggle-list";
+import { AppContext, PaneInstanceProvider, createInitialState } from "../../state/app-context";
+import { createDefaultConfig } from "../../types/config";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let setListSelection: ((index: number) => void) | null = null;
+let selectedTableRow: string | null = null;
+let activatedTableRow: string | null = null;
 
 function ScrollableListHarness() {
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -29,12 +35,48 @@ function ScrollableListHarness() {
   );
 }
 
+function DataTableActivationHarness() {
+  const headerScrollRef = useRef<ScrollBoxRenderable>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+
+  return (
+    <DataTable
+      columns={[{ id: "name", label: "NAME", width: 12, align: "left" }]}
+      items={[{ id: "alpha", name: "Alpha" }]}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      headerScrollRef={headerScrollRef}
+      scrollRef={scrollRef}
+      syncHeaderScroll={() => {}}
+      onBodyScrollActivity={() => {}}
+      hoveredIdx={hoveredIdx}
+      setHoveredIdx={setHoveredIdx}
+      getItemKey={(row) => row.id}
+      isSelected={(row) => selectedId === row.id}
+      onSelect={(row) => {
+        selectedTableRow = row.id;
+        setSelectedId(row.id);
+      }}
+      onActivate={(row) => {
+        activatedTableRow = row.id;
+      }}
+      renderCell={(row) => ({ text: row.name })}
+      emptyStateTitle="No rows."
+    />
+  );
+}
+
 afterEach(() => {
   if (testSetup) {
     testSetup.renderer.destroy();
     testSetup = undefined;
   }
   setListSelection = null;
+  selectedTableRow = null;
+  activatedTableRow = null;
 });
 
 describe("shared UI kit", () => {
@@ -152,5 +194,35 @@ describe("shared UI kit", () => {
     });
 
     expect(testSetup.renderer.getSelection()).toBeNull();
+  });
+
+  test("activates data table rows on a second click", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="portfolio-list:main">
+          <DataTableActivationHarness />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 32, height: 5 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await testSetup!.mockMouse.click(2, 1);
+      await testSetup!.renderOnce();
+    });
+
+    expect(selectedTableRow).toBe("alpha");
+    expect(activatedTableRow).toBeNull();
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(2, 1);
+      await testSetup!.renderOnce();
+    });
+
+    expect(activatedTableRow).toBe("alpha");
   });
 });

--- a/src/plugins/builtin/ai/screener-pane.test.tsx
+++ b/src/plugins/builtin/ai/screener-pane.test.tsx
@@ -21,6 +21,8 @@ function makeRuntime(): PluginRuntimeAccess {
   const listeners = new Map<string, Set<() => void>>();
 
   return {
+    pinTicker() {},
+    navigateTicker() {},
     subscribeResumeState(pluginId, key, listener) {
       const storeKey = `${pluginId}:${key}`;
       if (!listeners.has(storeKey)) listeners.set(storeKey, new Set());

--- a/src/plugins/builtin/ask-ai.test.tsx
+++ b/src/plugins/builtin/ask-ai.test.tsx
@@ -17,6 +17,8 @@ function makeRuntime(): PluginRuntimeAccess {
   const listeners = new Map<string, Set<() => void>>();
 
   return {
+    pinTicker() {},
+    navigateTicker() {},
     subscribeResumeState(pluginId, key, listener) {
       const storeKey = `${pluginId}:${key}`;
       if (!listeners.has(storeKey)) listeners.set(storeKey, new Set());

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -1,0 +1,438 @@
+import { useEffect, useRef, useState } from "react";
+import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
+import type { GloomPlugin, PaneProps } from "../../../types/plugin";
+import { colors, hoverBg, priceColor, blendHex } from "../../../theme/colors";
+import { formatCurrency, formatCompact, formatPercentRaw } from "../../../utils/format";
+import { getSharedDataProvider, getSharedRegistry } from "../../registry";
+import {
+  fetchScreener,
+  fetchTrending,
+  MARKET_SUMMARY_SYMBOLS,
+  type ScreenerCategory,
+  type ScreenerQuote,
+  type MarketSummaryQuote,
+} from "./screener";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+type TabId = "gainers" | "losers" | "actives" | "trending";
+
+const TABS: Array<{ id: TabId; label: string }> = [
+  { id: "gainers", label: "Gainers" },
+  { id: "losers", label: "Losers" },
+  { id: "actives", label: "Most Active" },
+  { id: "trending", label: "Trending" },
+];
+
+const CATEGORY_MAP: Record<Exclude<TabId, "trending">, ScreenerCategory> = {
+  gainers: "day_gainers",
+  losers: "day_losers",
+  actives: "most_actives",
+};
+
+interface TabCache {
+  data: ScreenerQuote[];
+  fetchedAt: number;
+}
+
+function formatVolRatio(ratio: number): string {
+  if (ratio <= 0) return "—";
+  if (ratio >= 10) return `${Math.round(ratio)}x`;
+  return `${ratio.toFixed(1)}x`;
+}
+
+function volRatioColor(ratio: number): string {
+  if (ratio >= 3) return colors.textBright;
+  if (ratio >= 1.5) return colors.text;
+  return colors.textDim;
+}
+
+function fiftyTwoWeekPosition(price: number, low: number | undefined, high: number | undefined): string {
+  if (low == null || high == null || high <= low) return "—";
+  const pct = ((price - low) / (high - low)) * 100;
+  return `${Math.round(pct)}%`;
+}
+
+const INDEX_SHORT: Record<string, string> = {
+  "^GSPC": "SPX",
+  "^DJI": "DJIA",
+  "^IXIC": "COMP",
+  "^RUT": "RUT",
+};
+
+export function MarketMoversPane({ focused, width, height }: PaneProps) {
+  const registry = getSharedRegistry();
+  const [activeTab, setActiveTab] = useState<TabId>("gainers");
+  const [quotes, setQuotes] = useState<ScreenerQuote[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [summaryQuotes, setSummaryQuotes] = useState<MarketSummaryQuote[]>([]);
+
+  const cacheRef = useRef<Map<TabId, TabCache>>(new Map());
+  const fetchGenRef = useRef(0);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  // Fetch market summary via the provider router
+  useEffect(() => {
+    const provider = getSharedDataProvider();
+    const loadSummary = async () => {
+      const results: MarketSummaryQuote[] = [];
+      await Promise.allSettled(
+        MARKET_SUMMARY_SYMBOLS.map(async (symbol) => {
+          try {
+            const q = await provider.getQuote(symbol, "");
+            if (q) {
+              results.push({
+                symbol,
+                name: q.name ?? symbol,
+                price: q.price,
+                change: q.change,
+                changePercent: q.changePercent,
+              });
+            }
+          } catch { /* skip */ }
+        }),
+      );
+      // Preserve the original symbol order
+      setSummaryQuotes(
+        MARKET_SUMMARY_SYMBOLS
+          .map((s) => results.find((r) => r.symbol === s))
+          .filter((r): r is MarketSummaryQuote => r !== undefined),
+      );
+    };
+    loadSummary();
+    const interval = setInterval(loadSummary, 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const loadTab = async (tab: TabId) => {
+    const cached = cacheRef.current.get(tab);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      setQuotes(cached.data);
+      setSelectedIdx(0);
+      return;
+    }
+
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setLoading(true);
+
+    try {
+      let data: ScreenerQuote[];
+
+      if (tab === "trending") {
+        const trending = await fetchTrending(25);
+        if (fetchGenRef.current !== gen) return;
+
+        const provider = getSharedDataProvider();
+        const resolved: ScreenerQuote[] = [];
+
+        await Promise.allSettled(
+          trending.slice(0, 25).map(async ({ symbol }) => {
+            try {
+              const q = await provider.getQuote(symbol, "");
+              if (fetchGenRef.current !== gen) return;
+              if (q) {
+                resolved.push({
+                  symbol,
+                  name: q.name ?? symbol,
+                  price: q.price ?? 0,
+                  change: q.change ?? 0,
+                  changePercent: q.changePercent ?? 0,
+                  volume: q.volume ?? 0,
+                  avgVolume: 0,
+                  volumeRatio: 0,
+                  marketCap: undefined,
+                  currency: q.currency ?? "USD",
+                  fiftyTwoWeekHigh: undefined,
+                  fiftyTwoWeekLow: undefined,
+                  dayHigh: undefined,
+                  dayLow: undefined,
+                  exchange: "",
+                });
+              }
+            } catch { /* skip */ }
+          }),
+        );
+
+        if (fetchGenRef.current !== gen) return;
+        data = trending
+          .map((t) => resolved.find((r) => r.symbol === t.symbol))
+          .filter((r): r is ScreenerQuote => r !== undefined);
+      } else {
+        data = await fetchScreener(CATEGORY_MAP[tab], 25);
+        if (fetchGenRef.current !== gen) return;
+      }
+
+      cacheRef.current.set(tab, { data, fetchedAt: Date.now() });
+      setQuotes(data);
+      setSelectedIdx(0);
+    } catch { /* leave existing data */ }
+    finally {
+      if (fetchGenRef.current === gen) setLoading(false);
+    }
+  };
+
+  useEffect(() => { loadTab(activeTab); }, [activeTab]);
+
+  const openSelected = (idx: number) => {
+    const q = quotes[idx];
+    if (!q) return;
+    registry?.navigateTickerFn(q.symbol);
+  };
+
+  useKeyboard((event) => {
+    if (!focused) return;
+
+    if (event.name === "tab" || event.name === "right" || event.name === "l") {
+      const currentTabIdx = TABS.findIndex((t) => t.id === activeTab);
+      setActiveTab(TABS[(currentTabIdx + 1) % TABS.length]!.id);
+      setSelectedIdx(0);
+    } else if (event.name === "left" || event.name === "h") {
+      const currentTabIdx = TABS.findIndex((t) => t.id === activeTab);
+      setActiveTab(TABS[(currentTabIdx - 1 + TABS.length) % TABS.length]!.id);
+      setSelectedIdx(0);
+    } else if (event.name === "j" || event.name === "down") {
+      setSelectedIdx((prev) => Math.min(prev + 1, quotes.length - 1));
+    } else if (event.name === "k" || event.name === "up") {
+      setSelectedIdx((prev) => Math.max(prev - 1, 0));
+    } else if (event.name === "return") {
+      openSelected(selectedIdx);
+    } else if (event.name === "r") {
+      cacheRef.current.delete(activeTab);
+      loadTab(activeTab);
+    }
+  });
+
+  // Scroll to keep selected row visible
+  useEffect(() => {
+    const sb = scrollRef.current;
+    if (!sb?.viewport || quotes.length === 0 || selectedIdx < 0) return;
+    const viewportHeight = Math.max(sb.viewport.height, 1);
+    if (selectedIdx < sb.scrollTop) {
+      sb.scrollTo(selectedIdx);
+    } else if (selectedIdx >= sb.scrollTop + viewportHeight) {
+      sb.scrollTo(selectedIdx - viewportHeight + 1);
+    }
+  }, [selectedIdx, quotes.length]);
+
+  // Column widths — adaptive based on pane width
+  const compact = width < 90;
+  const rankWidth = 3;
+  const tickerWidth = 8;
+  const priceWidth = 11;
+  const chgWidth = 9;
+  const volWidth = compact ? 0 : 8;
+  const volRatioWidth = compact ? 0 : 6;
+  const rangeWidth = compact ? 0 : 6;
+  const mcapWidth = compact ? 0 : 8;
+  const fixedWidth = rankWidth + tickerWidth + priceWidth + chgWidth + volWidth + volRatioWidth + rangeWidth + mcapWidth + 2;
+  const nameWidth = Math.max(6, width - fixedWidth);
+
+  const summaryBg = blendHex(colors.bg, colors.border, 0.2);
+
+  return (
+    <box flexDirection="column" width={width} height={height}>
+      {/* Market Summary Bar */}
+      {summaryQuotes.length > 0 ? (
+        <box flexDirection="row" height={1} backgroundColor={summaryBg} paddingX={1} gap={2}>
+          {summaryQuotes.map((idx) => {
+            const short = INDEX_SHORT[idx.symbol] ?? idx.symbol;
+            const chgColor = priceColor(idx.changePercent);
+            return (
+              <box key={idx.symbol} flexDirection="row" gap={1}>
+                <text fg={colors.textBright} attributes={TextAttributes.BOLD}>{short}</text>
+                <text fg={colors.text}>{formatCurrency(idx.price, "USD")}</text>
+                <text fg={chgColor}>{formatPercentRaw(idx.changePercent)}</text>
+              </box>
+            );
+          })}
+          {loading && <text fg={colors.textMuted}> loading…</text>}
+        </box>
+      ) : null}
+
+      {/* Tab bar */}
+      <box flexDirection="row" height={1} paddingX={1}>
+        {TABS.map((tab) => {
+          const isActive = tab.id === activeTab;
+          return (
+            <box
+              key={tab.id}
+              paddingX={1}
+              marginRight={1}
+              onMouseDown={(event: any) => {
+                event.preventDefault?.();
+                setActiveTab(tab.id);
+                setSelectedIdx(0);
+              }}
+            >
+              <text
+                fg={isActive ? colors.textBright : colors.textDim}
+                attributes={isActive ? TextAttributes.BOLD | TextAttributes.UNDERLINE : TextAttributes.NORMAL}
+              >
+                {tab.label}
+              </text>
+            </box>
+          );
+        })}
+        <box flexGrow={1} />
+        <text fg={colors.textMuted}>{quotes.length} stocks</text>
+      </box>
+
+      {/* Column headers */}
+      <box flexDirection="row" paddingX={1} height={1}>
+        <box width={rankWidth}>
+          <text fg={colors.textDim}>#</text>
+        </box>
+        <box width={tickerWidth}>
+          <text fg={colors.textDim}>TICKER</text>
+        </box>
+        <box width={nameWidth} flexShrink={1}>
+          <text fg={colors.textDim}>NAME</text>
+        </box>
+        <box width={priceWidth} justifyContent="flex-end" paddingRight={1}>
+          <text fg={colors.textDim}>LAST</text>
+        </box>
+        <box width={chgWidth} justifyContent="flex-end" paddingRight={1}>
+          <text fg={colors.textDim}>CHG%</text>
+        </box>
+        {!compact && (
+          <>
+            <box width={volWidth} justifyContent="flex-end" paddingRight={1}>
+              <text fg={colors.textDim}>VOL</text>
+            </box>
+            <box width={volRatioWidth} justifyContent="flex-end" paddingRight={1}>
+              <text fg={colors.textDim}>V/AVG</text>
+            </box>
+            <box width={rangeWidth} justifyContent="flex-end" paddingRight={1}>
+              <text fg={colors.textDim}>52W%</text>
+            </box>
+            <box width={mcapWidth} justifyContent="flex-end">
+              <text fg={colors.textDim}>MCAP</text>
+            </box>
+          </>
+        )}
+      </box>
+
+      {/* Rows */}
+      <scrollbox ref={scrollRef} flexGrow={1} scrollY focusable={false}>
+        <box flexDirection="column">
+          {quotes.map((q, idx) => {
+            const isSelected = idx === selectedIdx;
+            const isHovered = idx === hoveredIdx;
+            const bg = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
+            const fg = isSelected ? colors.selectedText : colors.text;
+            const chgColor = isSelected ? colors.selectedText : priceColor(q.changePercent);
+
+            return (
+              <box
+                key={`${q.symbol}-${idx}`}
+                flexDirection="row"
+                width={width}
+                backgroundColor={bg}
+                paddingX={1}
+                onMouseMove={() => setHoveredIdx(idx)}
+                onMouseOut={() => setHoveredIdx(null)}
+                onMouseDown={(event: any) => {
+                  event.preventDefault?.();
+                  if (selectedIdx === idx) {
+                    openSelected(idx);
+                  } else {
+                    setSelectedIdx(idx);
+                  }
+                }}
+              >
+                <box width={rankWidth} flexShrink={0}>
+                  <text fg={isSelected ? colors.selectedText : colors.textDim}>{idx + 1}</text>
+                </box>
+                <box width={tickerWidth} flexShrink={0}>
+                  <text fg={isSelected ? colors.selectedText : colors.textBright} attributes={TextAttributes.BOLD}>
+                    {q.symbol}
+                  </text>
+                </box>
+                <box width={nameWidth} flexShrink={1} overflow="hidden">
+                  <text fg={fg}>{q.name}</text>
+                </box>
+                <box width={priceWidth} justifyContent="flex-end" paddingRight={1}>
+                  <text fg={fg}>{formatCurrency(q.price, q.currency)}</text>
+                </box>
+                <box width={chgWidth} justifyContent="flex-end" paddingRight={1}>
+                  <text fg={chgColor}>
+                    {formatPercentRaw(q.changePercent)}
+                  </text>
+                </box>
+                {!compact && (
+                  <>
+                    <box width={volWidth} justifyContent="flex-end" paddingRight={1}>
+                      <text fg={isSelected ? colors.selectedText : colors.textDim}>
+                        {formatCompact(q.volume)}
+                      </text>
+                    </box>
+                    <box width={volRatioWidth} justifyContent="flex-end" paddingRight={1}>
+                      <text fg={isSelected ? colors.selectedText : volRatioColor(q.volumeRatio)}>
+                        {formatVolRatio(q.volumeRatio)}
+                      </text>
+                    </box>
+                    <box width={rangeWidth} justifyContent="flex-end" paddingRight={1}>
+                      <text fg={isSelected ? colors.selectedText : colors.textDim}>
+                        {fiftyTwoWeekPosition(q.price, q.fiftyTwoWeekLow, q.fiftyTwoWeekHigh)}
+                      </text>
+                    </box>
+                    <box width={mcapWidth} justifyContent="flex-end">
+                      <text fg={isSelected ? colors.selectedText : colors.textDim}>
+                        {q.marketCap != null ? formatCompact(q.marketCap) : "—"}
+                      </text>
+                    </box>
+                  </>
+                )}
+              </box>
+            );
+          })}
+
+          {!loading && quotes.length === 0 && (
+            <box paddingX={1} paddingY={1}>
+              <text fg={colors.textMuted}>No data</text>
+            </box>
+          )}
+        </box>
+      </scrollbox>
+
+      <box height={1} paddingX={1}>
+        <text fg={colors.textMuted}>←/→ tabs · ↑/↓ navigate · Enter open · [r]efresh</text>
+      </box>
+    </box>
+  );
+}
+
+export const marketMoversPlugin: GloomPlugin = {
+  id: "market-movers",
+  name: "Market Movers",
+  version: "1.0.0",
+  description: "Top gainers, losers, most active, and trending tickers",
+  toggleable: true,
+
+  panes: [
+    {
+      id: "market-movers",
+      name: "Market Movers",
+      icon: "T",
+      component: MarketMoversPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 36 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "market-movers-pane",
+      paneId: "market-movers",
+      label: "Market Movers",
+      description: "Top gainers, losers, most active, and trending tickers.",
+      keywords: ["movers", "gainers", "losers", "active", "trending", "screener", "top"],
+      shortcut: { prefix: "TOP" },
+    },
+  ],
+};

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
+import { DataTable, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
-import { colors, hoverBg, priceColor, blendHex } from "../../../theme/colors";
+import { colors, priceColor, blendHex } from "../../../theme/colors";
 import { formatCurrency, formatCompact, formatPercentRaw } from "../../../utils/format";
-import { getSharedDataProvider, getSharedRegistry } from "../../registry";
+import { usePluginTickerActions } from "../../plugin-runtime";
+import { getSharedDataProvider } from "../../registry";
 import {
   fetchScreener,
   fetchTrending,
@@ -36,6 +38,30 @@ interface TabCache {
   fetchedAt: number;
 }
 
+type MarketMoverColumnId =
+  | "rank"
+  | "symbol"
+  | "name"
+  | "price"
+  | "changePercent"
+  | "volume"
+  | "volumeRatio"
+  | "range"
+  | "marketCap";
+type MarketMoverColumn = DataTableColumn & { id: MarketMoverColumnId };
+type SortDirection = "asc" | "desc";
+type MarketMoverRow = ScreenerQuote & { rank: number };
+
+interface MarketMoverSortPreference {
+  columnId: MarketMoverColumnId | null;
+  direction: SortDirection;
+}
+
+const DEFAULT_SORT_PREFERENCE: MarketMoverSortPreference = {
+  columnId: null,
+  direction: "asc",
+};
+
 function formatVolRatio(ratio: number): string {
   if (ratio <= 0) return "—";
   if (ratio >= 10) return `${Math.round(ratio)}x`;
@@ -48,10 +74,115 @@ function volRatioColor(ratio: number): string {
   return colors.textDim;
 }
 
+function fiftyTwoWeekPositionPercent(price: number, low: number | undefined, high: number | undefined): number | null {
+  if (low == null || high == null || high <= low) return null;
+  return ((price - low) / (high - low)) * 100;
+}
+
 function fiftyTwoWeekPosition(price: number, low: number | undefined, high: number | undefined): string {
-  if (low == null || high == null || high <= low) return "—";
-  const pct = ((price - low) / (high - low)) * 100;
-  return `${Math.round(pct)}%`;
+  const pct = fiftyTwoWeekPositionPercent(price, low, high);
+  return pct == null ? "—" : `${Math.round(pct)}%`;
+}
+
+function getSortValue(
+  columnId: MarketMoverColumnId,
+  row: MarketMoverRow,
+): string | number | null {
+  switch (columnId) {
+    case "rank":
+      return row.rank;
+    case "symbol":
+      return row.symbol;
+    case "name":
+      return row.name;
+    case "price":
+      return row.price;
+    case "changePercent":
+      return row.changePercent;
+    case "volume":
+      return row.volume;
+    case "volumeRatio":
+      return row.volumeRatio;
+    case "range":
+      return fiftyTwoWeekPositionPercent(row.price, row.fiftyTwoWeekLow, row.fiftyTwoWeekHigh);
+    case "marketCap":
+      return row.marketCap ?? null;
+  }
+}
+
+function compareSortValues(
+  left: string | number | null,
+  right: string | number | null,
+  direction: SortDirection,
+): number {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+
+  const comparison = typeof left === "string" && typeof right === "string"
+    ? left.localeCompare(right)
+    : Number(left) - Number(right);
+  return direction === "asc" ? comparison : -comparison;
+}
+
+function sortRows(
+  rows: MarketMoverRow[],
+  sortPreference: MarketMoverSortPreference,
+): MarketMoverRow[] {
+  const sortColumnId = sortPreference.columnId;
+  if (!sortColumnId) return rows;
+  return [...rows].sort((left, right) => compareSortValues(
+    getSortValue(sortColumnId, left),
+    getSortValue(sortColumnId, right),
+    sortPreference.direction,
+  ));
+}
+
+function nextSortPreference(
+  current: MarketMoverSortPreference,
+  columnId: string,
+): MarketMoverSortPreference {
+  const typedColumnId = columnId as MarketMoverColumnId;
+  if (current.columnId !== typedColumnId) {
+    return { columnId: typedColumnId, direction: "asc" };
+  }
+  if (current.direction === "asc") {
+    return { columnId: typedColumnId, direction: "desc" };
+  }
+  return DEFAULT_SORT_PREFERENCE;
+}
+
+function createRows(quotes: ScreenerQuote[]): MarketMoverRow[] {
+  return quotes.map((quote, index) => ({
+    ...quote,
+    rank: index + 1,
+  }));
+}
+
+function buildColumns(width: number): MarketMoverColumn[] {
+  const rankWidth = 3;
+  const tickerWidth = 8;
+  const priceWidth = 11;
+  const chgWidth = 9;
+  const volWidth = 8;
+  const volRatioWidth = 6;
+  const rangeWidth = 6;
+  const mcapWidth = 8;
+  const columnCount = 9;
+  const fixedWidth = rankWidth + tickerWidth + priceWidth + chgWidth + volWidth + volRatioWidth + rangeWidth + mcapWidth;
+  const nameWidth = Math.max(6, width - 2 - columnCount - fixedWidth);
+
+  return [
+    { id: "rank", label: "#", width: rankWidth, align: "left" },
+    { id: "symbol", label: "TICKER", width: tickerWidth, align: "left" },
+    { id: "name", label: "NAME", width: nameWidth, align: "left" },
+    { id: "price", label: "LAST", width: priceWidth, align: "right" },
+    { id: "changePercent", label: "CHG%", width: chgWidth, align: "right" },
+    { id: "volume", label: "VOL", width: volWidth, align: "right" },
+    { id: "volumeRatio", label: "V/AVG", width: volRatioWidth, align: "right" },
+    { id: "range", label: "52W%", width: rangeWidth, align: "right" },
+    { id: "marketCap", label: "MCAP", width: mcapWidth, align: "right" },
+  ];
 }
 
 const INDEX_SHORT: Record<string, string> = {
@@ -62,21 +193,66 @@ const INDEX_SHORT: Record<string, string> = {
 };
 
 export function MarketMoversPane({ focused, width, height }: PaneProps) {
-  const registry = getSharedRegistry();
+  const { pinTicker } = usePluginTickerActions();
   const [activeTab, setActiveTab] = useState<TabId>("gainers");
   const [quotes, setQuotes] = useState<ScreenerQuote[]>([]);
   const [loading, setLoading] = useState(false);
-  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [sortPreference, setSortPreference] = useState<MarketMoverSortPreference>(DEFAULT_SORT_PREFERENCE);
   const [summaryQuotes, setSummaryQuotes] = useState<MarketSummaryQuote[]>([]);
 
   const cacheRef = useRef<Map<TabId, TabCache>>(new Map());
   const fetchGenRef = useRef(0);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const headerScrollRef = useRef<ScrollBoxRenderable>(null);
+
+  const columns = useMemo(() => buildColumns(width), [width]);
+  const rankedRows = useMemo(() => createRows(quotes), [quotes]);
+  const rows = useMemo(() => sortRows(rankedRows, sortPreference), [rankedRows, sortPreference]);
+  const selectedIdx = selectedSymbol
+    ? rows.findIndex((row) => row.symbol === selectedSymbol)
+    : -1;
+  const activeIdx = selectedIdx >= 0 ? selectedIdx : (rows.length > 0 ? 0 : -1);
+
+  const syncHeaderScroll = useCallback(() => {
+    const bodyScrollBox = scrollRef.current;
+    const headerScrollBox = headerScrollRef.current;
+    if (bodyScrollBox && headerScrollBox && headerScrollBox.scrollLeft !== bodyScrollBox.scrollLeft) {
+      headerScrollBox.scrollLeft = bodyScrollBox.scrollLeft;
+    }
+  }, []);
+
+  const handleBodyScrollActivity = useCallback(() => {
+    syncHeaderScroll();
+  }, [syncHeaderScroll]);
+
+  const resetTableScroll = useCallback(() => {
+    const bodyScrollBox = scrollRef.current;
+    if (bodyScrollBox) {
+      bodyScrollBox.scrollTop = 0;
+      bodyScrollBox.scrollLeft = 0;
+    }
+    const headerScrollBox = headerScrollRef.current;
+    if (headerScrollBox) {
+      headerScrollBox.scrollLeft = 0;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedSymbol && selectedIdx >= 0) return;
+    const firstRow = rows[0];
+    if (firstRow) {
+      setSelectedSymbol(firstRow.symbol);
+    } else if (selectedSymbol !== null) {
+      setSelectedSymbol(null);
+    }
+  }, [rows, selectedIdx, selectedSymbol]);
 
   // Fetch market summary via the provider router
   useEffect(() => {
     const provider = getSharedDataProvider();
+    if (!provider) return;
     const loadSummary = async () => {
       const results: MarketSummaryQuote[] = [];
       await Promise.allSettled(
@@ -111,7 +287,8 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
     const cached = cacheRef.current.get(tab);
     if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
       setQuotes(cached.data);
-      setSelectedIdx(0);
+      setSelectedSymbol(null);
+      resetTableScroll();
       return;
     }
 
@@ -129,33 +306,35 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
         const provider = getSharedDataProvider();
         const resolved: ScreenerQuote[] = [];
 
-        await Promise.allSettled(
-          trending.slice(0, 25).map(async ({ symbol }) => {
-            try {
-              const q = await provider.getQuote(symbol, "");
-              if (fetchGenRef.current !== gen) return;
-              if (q) {
-                resolved.push({
-                  symbol,
-                  name: q.name ?? symbol,
-                  price: q.price ?? 0,
-                  change: q.change ?? 0,
-                  changePercent: q.changePercent ?? 0,
-                  volume: q.volume ?? 0,
-                  avgVolume: 0,
-                  volumeRatio: 0,
-                  marketCap: undefined,
-                  currency: q.currency ?? "USD",
-                  fiftyTwoWeekHigh: undefined,
-                  fiftyTwoWeekLow: undefined,
-                  dayHigh: undefined,
-                  dayLow: undefined,
-                  exchange: "",
-                });
-              }
-            } catch { /* skip */ }
-          }),
-        );
+        if (provider) {
+          await Promise.allSettled(
+            trending.slice(0, 25).map(async ({ symbol }) => {
+              try {
+                const q = await provider.getQuote(symbol, "");
+                if (fetchGenRef.current !== gen) return;
+                if (q) {
+                  resolved.push({
+                    symbol,
+                    name: q.name ?? symbol,
+                    price: q.price ?? 0,
+                    change: q.change ?? 0,
+                    changePercent: q.changePercent ?? 0,
+                    volume: q.volume ?? 0,
+                    avgVolume: 0,
+                    volumeRatio: 0,
+                    marketCap: undefined,
+                    currency: q.currency ?? "USD",
+                    fiftyTwoWeekHigh: undefined,
+                    fiftyTwoWeekLow: undefined,
+                    dayHigh: undefined,
+                    dayLow: undefined,
+                    exchange: "",
+                  });
+                }
+              } catch { /* skip */ }
+            }),
+          );
+        }
 
         if (fetchGenRef.current !== gen) return;
         data = trending
@@ -168,7 +347,8 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
 
       cacheRef.current.set(tab, { data, fetchedAt: Date.now() });
       setQuotes(data);
-      setSelectedIdx(0);
+      setSelectedSymbol(null);
+      resetTableScroll();
     } catch { /* leave existing data */ }
     finally {
       if (fetchGenRef.current === gen) setLoading(false);
@@ -177,30 +357,53 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
 
   useEffect(() => { loadTab(activeTab); }, [activeTab]);
 
-  const openSelected = (idx: number) => {
-    const q = quotes[idx];
-    if (!q) return;
-    registry?.navigateTickerFn(q.symbol);
-  };
+  const openSymbol = useCallback((symbol: string) => {
+    pinTicker(symbol, { floating: true, paneType: "ticker-detail" });
+  }, [pinTicker]);
+
+  const openSelected = useCallback((idx: number) => {
+    const row = rows[idx];
+    if (!row) return;
+    openSymbol(row.symbol);
+  }, [openSymbol, rows]);
+
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextSortPreference(current, columnId));
+  }, []);
 
   useKeyboard((event) => {
     if (!focused) return;
 
-    if (event.name === "tab" || event.name === "right" || event.name === "l") {
+    const key = event.name;
+    const isEnter = key === "enter" || key === "return";
+
+    if (key === "tab" || key === "right" || key === "l") {
+      event.preventDefault?.();
       const currentTabIdx = TABS.findIndex((t) => t.id === activeTab);
       setActiveTab(TABS[(currentTabIdx + 1) % TABS.length]!.id);
-      setSelectedIdx(0);
-    } else if (event.name === "left" || event.name === "h") {
+      setSelectedSymbol(null);
+      resetTableScroll();
+    } else if (key === "left" || key === "h") {
+      event.preventDefault?.();
       const currentTabIdx = TABS.findIndex((t) => t.id === activeTab);
       setActiveTab(TABS[(currentTabIdx - 1 + TABS.length) % TABS.length]!.id);
-      setSelectedIdx(0);
-    } else if (event.name === "j" || event.name === "down") {
-      setSelectedIdx((prev) => Math.min(prev + 1, quotes.length - 1));
-    } else if (event.name === "k" || event.name === "up") {
-      setSelectedIdx((prev) => Math.max(prev - 1, 0));
-    } else if (event.name === "return") {
-      openSelected(selectedIdx);
-    } else if (event.name === "r") {
+      setSelectedSymbol(null);
+      resetTableScroll();
+    } else if (key === "j" || key === "down") {
+      event.preventDefault?.();
+      if (rows.length === 0) return;
+      const nextIdx = activeIdx >= 0 ? Math.min(activeIdx + 1, rows.length - 1) : 0;
+      setSelectedSymbol(rows[nextIdx]!.symbol);
+    } else if (key === "k" || key === "up") {
+      event.preventDefault?.();
+      if (rows.length === 0) return;
+      const nextIdx = activeIdx > 0 ? activeIdx - 1 : 0;
+      setSelectedSymbol(rows[nextIdx]!.symbol);
+    } else if (isEnter) {
+      event.preventDefault?.();
+      openSelected(activeIdx);
+    } else if (key === "r") {
+      event.preventDefault?.();
       cacheRef.current.delete(activeTab);
       loadTab(activeTab);
     }
@@ -209,27 +412,60 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
   // Scroll to keep selected row visible
   useEffect(() => {
     const sb = scrollRef.current;
-    if (!sb?.viewport || quotes.length === 0 || selectedIdx < 0) return;
+    if (!sb?.viewport || rows.length === 0 || activeIdx < 0) return;
     const viewportHeight = Math.max(sb.viewport.height, 1);
-    if (selectedIdx < sb.scrollTop) {
-      sb.scrollTo(selectedIdx);
-    } else if (selectedIdx >= sb.scrollTop + viewportHeight) {
-      sb.scrollTo(selectedIdx - viewportHeight + 1);
+    if (activeIdx < sb.scrollTop) {
+      sb.scrollTo(activeIdx);
+    } else if (activeIdx >= sb.scrollTop + viewportHeight) {
+      sb.scrollTo(activeIdx - viewportHeight + 1);
     }
-  }, [selectedIdx, quotes.length]);
+  }, [activeIdx, rows.length]);
 
-  // Column widths — adaptive based on pane width
-  const compact = width < 90;
-  const rankWidth = 3;
-  const tickerWidth = 8;
-  const priceWidth = 11;
-  const chgWidth = 9;
-  const volWidth = compact ? 0 : 8;
-  const volRatioWidth = compact ? 0 : 6;
-  const rangeWidth = compact ? 0 : 6;
-  const mcapWidth = compact ? 0 : 8;
-  const fixedWidth = rankWidth + tickerWidth + priceWidth + chgWidth + volWidth + volRatioWidth + rangeWidth + mcapWidth + 2;
-  const nameWidth = Math.max(6, width - fixedWidth);
+  const renderCell = useCallback((
+    row: MarketMoverRow,
+    column: MarketMoverColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+
+    switch (column.id) {
+      case "rank":
+        return { text: String(row.rank), color: selectedColor ?? colors.textDim };
+      case "symbol":
+        return {
+          text: row.symbol,
+          color: selectedColor ?? colors.textBright,
+          attributes: TextAttributes.BOLD,
+        };
+      case "name":
+        return { text: row.name, color: selectedColor };
+      case "price":
+        return { text: formatCurrency(row.price, row.currency), color: selectedColor };
+      case "changePercent":
+        return {
+          text: formatPercentRaw(row.changePercent),
+          color: selectedColor ?? priceColor(row.changePercent),
+        };
+      case "volume":
+        return { text: formatCompact(row.volume), color: selectedColor ?? colors.textDim };
+      case "volumeRatio":
+        return {
+          text: formatVolRatio(row.volumeRatio),
+          color: selectedColor ?? volRatioColor(row.volumeRatio),
+        };
+      case "range":
+        return {
+          text: fiftyTwoWeekPosition(row.price, row.fiftyTwoWeekLow, row.fiftyTwoWeekHigh),
+          color: selectedColor ?? colors.textDim,
+        };
+      case "marketCap":
+        return {
+          text: row.marketCap != null ? formatCompact(row.marketCap) : "—",
+          color: selectedColor ?? colors.textDim,
+        };
+    }
+  }, []);
 
   const summaryBg = blendHex(colors.bg, colors.border, 0.2);
 
@@ -265,12 +501,13 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
               onMouseDown={(event: any) => {
                 event.preventDefault?.();
                 setActiveTab(tab.id);
-                setSelectedIdx(0);
+                setSelectedSymbol(null);
+                resetTableScroll();
               }}
             >
               <text
                 fg={isActive ? colors.textBright : colors.textDim}
-                attributes={isActive ? TextAttributes.BOLD | TextAttributes.UNDERLINE : TextAttributes.NORMAL}
+                attributes={isActive ? TextAttributes.BOLD | TextAttributes.UNDERLINE : TextAttributes.NONE}
               >
                 {tab.label}
               </text>
@@ -281,127 +518,25 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
         <text fg={colors.textMuted}>{quotes.length} stocks</text>
       </box>
 
-      {/* Column headers */}
-      <box flexDirection="row" paddingX={1} height={1}>
-        <box width={rankWidth}>
-          <text fg={colors.textDim}>#</text>
-        </box>
-        <box width={tickerWidth}>
-          <text fg={colors.textDim}>TICKER</text>
-        </box>
-        <box width={nameWidth} flexShrink={1}>
-          <text fg={colors.textDim}>NAME</text>
-        </box>
-        <box width={priceWidth} justifyContent="flex-end" paddingRight={1}>
-          <text fg={colors.textDim}>LAST</text>
-        </box>
-        <box width={chgWidth} justifyContent="flex-end" paddingRight={1}>
-          <text fg={colors.textDim}>CHG%</text>
-        </box>
-        {!compact && (
-          <>
-            <box width={volWidth} justifyContent="flex-end" paddingRight={1}>
-              <text fg={colors.textDim}>VOL</text>
-            </box>
-            <box width={volRatioWidth} justifyContent="flex-end" paddingRight={1}>
-              <text fg={colors.textDim}>V/AVG</text>
-            </box>
-            <box width={rangeWidth} justifyContent="flex-end" paddingRight={1}>
-              <text fg={colors.textDim}>52W%</text>
-            </box>
-            <box width={mcapWidth} justifyContent="flex-end">
-              <text fg={colors.textDim}>MCAP</text>
-            </box>
-          </>
-        )}
-      </box>
-
-      {/* Rows */}
-      <scrollbox ref={scrollRef} flexGrow={1} scrollY focusable={false}>
-        <box flexDirection="column">
-          {quotes.map((q, idx) => {
-            const isSelected = idx === selectedIdx;
-            const isHovered = idx === hoveredIdx;
-            const bg = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
-            const fg = isSelected ? colors.selectedText : colors.text;
-            const chgColor = isSelected ? colors.selectedText : priceColor(q.changePercent);
-
-            return (
-              <box
-                key={`${q.symbol}-${idx}`}
-                flexDirection="row"
-                width={width}
-                backgroundColor={bg}
-                paddingX={1}
-                onMouseMove={() => setHoveredIdx(idx)}
-                onMouseOut={() => setHoveredIdx(null)}
-                onMouseDown={(event: any) => {
-                  event.preventDefault?.();
-                  if (selectedIdx === idx) {
-                    openSelected(idx);
-                  } else {
-                    setSelectedIdx(idx);
-                  }
-                }}
-              >
-                <box width={rankWidth} flexShrink={0}>
-                  <text fg={isSelected ? colors.selectedText : colors.textDim}>{idx + 1}</text>
-                </box>
-                <box width={tickerWidth} flexShrink={0}>
-                  <text fg={isSelected ? colors.selectedText : colors.textBright} attributes={TextAttributes.BOLD}>
-                    {q.symbol}
-                  </text>
-                </box>
-                <box width={nameWidth} flexShrink={1} overflow="hidden">
-                  <text fg={fg}>{q.name}</text>
-                </box>
-                <box width={priceWidth} justifyContent="flex-end" paddingRight={1}>
-                  <text fg={fg}>{formatCurrency(q.price, q.currency)}</text>
-                </box>
-                <box width={chgWidth} justifyContent="flex-end" paddingRight={1}>
-                  <text fg={chgColor}>
-                    {formatPercentRaw(q.changePercent)}
-                  </text>
-                </box>
-                {!compact && (
-                  <>
-                    <box width={volWidth} justifyContent="flex-end" paddingRight={1}>
-                      <text fg={isSelected ? colors.selectedText : colors.textDim}>
-                        {formatCompact(q.volume)}
-                      </text>
-                    </box>
-                    <box width={volRatioWidth} justifyContent="flex-end" paddingRight={1}>
-                      <text fg={isSelected ? colors.selectedText : volRatioColor(q.volumeRatio)}>
-                        {formatVolRatio(q.volumeRatio)}
-                      </text>
-                    </box>
-                    <box width={rangeWidth} justifyContent="flex-end" paddingRight={1}>
-                      <text fg={isSelected ? colors.selectedText : colors.textDim}>
-                        {fiftyTwoWeekPosition(q.price, q.fiftyTwoWeekLow, q.fiftyTwoWeekHigh)}
-                      </text>
-                    </box>
-                    <box width={mcapWidth} justifyContent="flex-end">
-                      <text fg={isSelected ? colors.selectedText : colors.textDim}>
-                        {q.marketCap != null ? formatCompact(q.marketCap) : "—"}
-                      </text>
-                    </box>
-                  </>
-                )}
-              </box>
-            );
-          })}
-
-          {!loading && quotes.length === 0 && (
-            <box paddingX={1} paddingY={1}>
-              <text fg={colors.textMuted}>No data</text>
-            </box>
-          )}
-        </box>
-      </scrollbox>
-
-      <box height={1} paddingX={1}>
-        <text fg={colors.textMuted}>←/→ tabs · ↑/↓ navigate · Enter open · [r]efresh</text>
-      </box>
+      <DataTable<MarketMoverRow, MarketMoverColumn>
+        columns={columns}
+        items={rows}
+        sortColumnId={sortPreference.columnId}
+        sortDirection={sortPreference.direction}
+        onHeaderClick={handleHeaderClick}
+        headerScrollRef={headerScrollRef}
+        scrollRef={scrollRef}
+        syncHeaderScroll={syncHeaderScroll}
+        onBodyScrollActivity={handleBodyScrollActivity}
+        hoveredIdx={hoveredIdx}
+        setHoveredIdx={setHoveredIdx}
+        getItemKey={(row) => `${row.symbol}-${row.rank}`}
+        isSelected={(row) => row.symbol === selectedSymbol}
+        onSelect={(row) => setSelectedSymbol(row.symbol)}
+        onActivate={(row) => openSymbol(row.symbol)}
+        renderCell={renderCell}
+        emptyStateTitle={loading ? "Loading movers..." : "No data"}
+      />
     </box>
   );
 }

--- a/src/plugins/builtin/market-movers/screener.test.ts
+++ b/src/plugins/builtin/market-movers/screener.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { parseScreenerResponse, parseTrendingResponse } from "./screener";
+
+const SAMPLE_SCREENER_RESPONSE = {
+  finance: {
+    result: [
+      {
+        quotes: [
+          {
+            symbol: "AAPL",
+            shortName: "Apple Inc.",
+            regularMarketPrice: 185.5,
+            regularMarketChange: 3.25,
+            regularMarketChangePercent: 1.78,
+            regularMarketVolume: 52_000_000,
+            averageDailyVolume3Month: 20_000_000,
+            marketCap: 2_900_000_000_000,
+            currency: "USD",
+            fiftyTwoWeekHigh: 199.62,
+            fiftyTwoWeekLow: 140.0,
+            regularMarketDayHigh: 186.0,
+            regularMarketDayLow: 182.0,
+            fullExchangeName: "NasdaqGS",
+          },
+          {
+            symbol: "MSFT",
+            shortName: "Microsoft Corporation",
+            regularMarketPrice: 415.0,
+            regularMarketChange: -2.1,
+            regularMarketChangePercent: -0.5,
+            regularMarketVolume: 18_000_000,
+            averageDailyVolume3Month: 25_000_000,
+            marketCap: 3_100_000_000_000,
+            currency: "USD",
+            fullExchangeName: "NasdaqGS",
+          },
+        ],
+      },
+    ],
+    error: null,
+  },
+};
+
+const SAMPLE_TRENDING_RESPONSE = {
+  finance: {
+    result: [
+      {
+        quotes: [
+          { symbol: "NVDA" },
+          { symbol: "TSLA" },
+        ],
+      },
+    ],
+    error: null,
+  },
+};
+
+describe("parseScreenerResponse", () => {
+  test("maps Yahoo Finance fields to ScreenerQuote", () => {
+    const results = parseScreenerResponse(SAMPLE_SCREENER_RESPONSE);
+    expect(results).toHaveLength(2);
+
+    const apple = results[0]!;
+    expect(apple.symbol).toBe("AAPL");
+    expect(apple.name).toBe("Apple Inc.");
+    expect(apple.price).toBe(185.5);
+    expect(apple.change).toBe(3.25);
+    expect(apple.changePercent).toBe(1.78);
+    expect(apple.volume).toBe(52_000_000);
+    expect(apple.avgVolume).toBe(20_000_000);
+    expect(apple.volumeRatio).toBeCloseTo(2.6, 1);
+    expect(apple.marketCap).toBe(2_900_000_000_000);
+    expect(apple.currency).toBe("USD");
+    expect(apple.fiftyTwoWeekHigh).toBe(199.62);
+    expect(apple.fiftyTwoWeekLow).toBe(140.0);
+    expect(apple.exchange).toBe("NasdaqGS");
+
+    const msft = results[1]!;
+    expect(msft.symbol).toBe("MSFT");
+    expect(msft.change).toBe(-2.1);
+    expect(msft.changePercent).toBe(-0.5);
+    expect(msft.volumeRatio).toBeCloseTo(0.72, 1);
+  });
+
+  test("returns [] for missing finance.result", () => {
+    expect(parseScreenerResponse({})).toEqual([]);
+    expect(parseScreenerResponse(null)).toEqual([]);
+    expect(parseScreenerResponse({ finance: {} })).toEqual([]);
+    expect(parseScreenerResponse({ finance: { result: [] } })).toEqual([]);
+  });
+
+  test("returns [] for non-array quotes", () => {
+    expect(parseScreenerResponse({ finance: { result: [{ quotes: null }] } })).toEqual([]);
+    expect(parseScreenerResponse({ finance: { result: [{}] } })).toEqual([]);
+  });
+
+  test("skips entries without a string symbol", () => {
+    const data = {
+      finance: {
+        result: [{ quotes: [{ symbol: 123 }, { symbol: "AMD", regularMarketPrice: 100 }] }],
+      },
+    };
+    const results = parseScreenerResponse(data);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.symbol).toBe("AMD");
+  });
+
+  test("falls back to symbol when shortName and longName are absent", () => {
+    const data = {
+      finance: {
+        result: [{ quotes: [{ symbol: "XYZ", regularMarketPrice: 10 }] }],
+      },
+    };
+    const results = parseScreenerResponse(data);
+    expect(results[0]!.name).toBe("XYZ");
+  });
+});
+
+describe("parseTrendingResponse", () => {
+  test("extracts symbols from trending response", () => {
+    const results = parseTrendingResponse(SAMPLE_TRENDING_RESPONSE);
+    expect(results).toHaveLength(2);
+    expect(results[0]!.symbol).toBe("NVDA");
+    expect(results[1]!.symbol).toBe("TSLA");
+  });
+
+  test("returns [] for malformed input", () => {
+    expect(parseTrendingResponse({})).toEqual([]);
+    expect(parseTrendingResponse(null)).toEqual([]);
+    expect(parseTrendingResponse({ finance: { result: [{ quotes: "bad" }] } })).toEqual([]);
+  });
+
+  test("skips entries without a string symbol", () => {
+    const data = {
+      finance: {
+        result: [{ quotes: [{ symbol: null }, { symbol: "SPY" }] }],
+      },
+    };
+    const results = parseTrendingResponse(data);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.symbol).toBe("SPY");
+  });
+});

--- a/src/plugins/builtin/market-movers/screener.ts
+++ b/src/plugins/builtin/market-movers/screener.ts
@@ -1,0 +1,105 @@
+import { createThrottledFetch } from "../../../utils/throttled-fetch";
+
+const screenerClient = createThrottledFetch({
+  requestsPerMinute: 15,
+  maxRetries: 2,
+  timeoutMs: 10_000,
+  defaultHeaders: {
+    "User-Agent": "Gloomberb/0.4.1",
+    Accept: "application/json",
+  },
+});
+
+export type ScreenerCategory = "day_gainers" | "day_losers" | "most_actives";
+
+export interface ScreenerQuote {
+  symbol: string;
+  name: string;
+  price: number;
+  change: number;
+  changePercent: number;
+  volume: number;
+  avgVolume: number;
+  volumeRatio: number; // volume / avgVolume
+  marketCap: number | undefined;
+  currency: string;
+  fiftyTwoWeekHigh: number | undefined;
+  fiftyTwoWeekLow: number | undefined;
+  dayHigh: number | undefined;
+  dayLow: number | undefined;
+  exchange: string;
+}
+
+export interface TrendingSymbol {
+  symbol: string;
+}
+
+export interface MarketSummaryQuote {
+  symbol: string;
+  name: string;
+  price: number;
+  change: number;
+  changePercent: number;
+}
+
+export function parseScreenerResponse(data: any): ScreenerQuote[] {
+  try {
+    const quotes = data?.finance?.result?.[0]?.quotes;
+    if (!Array.isArray(quotes)) return [];
+    const result: ScreenerQuote[] = [];
+    for (const q of quotes) {
+      if (!q || typeof q.symbol !== "string") continue;
+      const volume = q.regularMarketVolume ?? 0;
+      const avgVolume = q.averageDailyVolume3Month ?? q.averageDailyVolume10Day ?? 0;
+      result.push({
+        symbol: q.symbol,
+        name: q.shortName ?? q.longName ?? q.symbol,
+        price: q.regularMarketPrice ?? 0,
+        change: q.regularMarketChange ?? 0,
+        changePercent: q.regularMarketChangePercent ?? 0,
+        volume,
+        avgVolume,
+        volumeRatio: avgVolume > 0 ? volume / avgVolume : 0,
+        marketCap: q.marketCap ?? undefined,
+        currency: q.currency ?? "USD",
+        fiftyTwoWeekHigh: q.fiftyTwoWeekHigh ?? undefined,
+        fiftyTwoWeekLow: q.fiftyTwoWeekLow ?? undefined,
+        dayHigh: q.regularMarketDayHigh ?? undefined,
+        dayLow: q.regularMarketDayLow ?? undefined,
+        exchange: q.fullExchangeName ?? q.exchange ?? "",
+      });
+    }
+    return result;
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchScreener(category: ScreenerCategory, count = 25): Promise<ScreenerQuote[]> {
+  const url = `https://query2.finance.yahoo.com/v1/finance/screener/predefined/saved?scrIds=${category}&count=${count}`;
+  const data = await screenerClient.fetchJson(url);
+  return parseScreenerResponse(data);
+}
+
+export function parseTrendingResponse(data: any): TrendingSymbol[] {
+  try {
+    const quotes = data?.finance?.result?.[0]?.quotes;
+    if (!Array.isArray(quotes)) return [];
+    const result: TrendingSymbol[] = [];
+    for (const q of quotes) {
+      if (!q || typeof q.symbol !== "string") continue;
+      result.push({ symbol: q.symbol });
+    }
+    return result;
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchTrending(count = 25): Promise<TrendingSymbol[]> {
+  const url = `https://query2.finance.yahoo.com/v1/finance/trending/US?count=${count}`;
+  const data = await screenerClient.fetchJson(url);
+  return parseTrendingResponse(data);
+}
+
+export const MARKET_SUMMARY_SYMBOLS = ["^GSPC", "^DJI", "^IXIC", "^RUT"] as const;

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useRef, useState } from "react";
+import { TextAttributes } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
+import type { GloomPlugin, PaneProps } from "../../../types/plugin";
+import type { Quote } from "../../../types/financials";
+import type { MarketState } from "../../../types/financials";
+import { colors, hoverBg, priceColor } from "../../../theme/colors";
+import { formatCurrency, formatPercentRaw } from "../../../utils/format";
+import { getSharedDataProvider, getSharedRegistry } from "../../registry";
+import { WORLD_INDICES, REGION_LABELS, REGION_ORDER, getIndicesByRegion, type IndexEntry } from "./indices";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+interface IndexQuoteState {
+  quote: Quote | null;
+  loading: boolean;
+  error: string | null;
+}
+
+type QuoteMap = Map<string, IndexQuoteState>;
+
+function marketStatusDot(state: MarketState | undefined): { char: string; color: string } {
+  switch (state) {
+    case "REGULAR":
+      return { char: "●", color: colors.positive };
+    case "PRE":
+    case "POST":
+    case "PREPRE":
+    case "POSTPOST":
+      return { char: "●", color: colors.warning };
+    case "CLOSED":
+    default:
+      return { char: "●", color: colors.negative };
+  }
+}
+
+function buildFlatRows(indicesByRegion: Map<IndexEntry["region"], IndexEntry[]>): Array<{ type: "header"; region: IndexEntry["region"] } | { type: "row"; entry: IndexEntry }> {
+  const rows: Array<{ type: "header"; region: IndexEntry["region"] } | { type: "row"; entry: IndexEntry }> = [];
+  for (const region of REGION_ORDER) {
+    const entries = indicesByRegion.get(region) ?? [];
+    if (entries.length === 0) continue;
+    rows.push({ type: "header", region });
+    for (const entry of entries) {
+      rows.push({ type: "row", entry });
+    }
+  }
+  return rows;
+}
+
+// Returns only the row-type indices (for navigation purposes)
+function rowIndicesOf(flatRows: ReturnType<typeof buildFlatRows>): number[] {
+  return flatRows.reduce<number[]>((acc, row, i) => {
+    if (row.type === "row") acc.push(i);
+    return acc;
+  }, []);
+}
+
+export function WorldIndicesPane({ focused, width, height }: PaneProps) {
+  const registry = getSharedRegistry();
+  const [quotes, setQuotes] = useState<QuoteMap>(new Map());
+  const [selectedFlatIdx, setSelectedFlatIdx] = useState<number>(-1);
+  const [hoveredFlatIdx, setHoveredFlatIdx] = useState<number | null>(null);
+  const fetchGenRef = useRef(0);
+
+  const indicesByRegion = getIndicesByRegion();
+  const flatRows = buildFlatRows(indicesByRegion);
+  const navigableIndices = rowIndicesOf(flatRows);
+
+  // Initialize selection to first navigable row
+  useEffect(() => {
+    if (selectedFlatIdx === -1 && navigableIndices.length > 0) {
+      setSelectedFlatIdx(navigableIndices[0]!);
+    }
+  }, []);
+
+  const fetchAll = () => {
+    const provider = getSharedDataProvider();
+    if (!provider) return;
+
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+
+    for (const entry of WORLD_INDICES) {
+      setQuotes((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(entry.symbol);
+        next.set(entry.symbol, { quote: existing?.quote ?? null, loading: true, error: null });
+        return next;
+      });
+
+      provider.getQuote(entry.symbol, "").then((quote) => {
+        if (fetchGenRef.current !== gen) return;
+        setQuotes((prev) => {
+          const next = new Map(prev);
+          next.set(entry.symbol, { quote, loading: false, error: null });
+          return next;
+        });
+      }).catch((err: unknown) => {
+        if (fetchGenRef.current !== gen) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setQuotes((prev) => {
+          const next = new Map(prev);
+          next.set(entry.symbol, { quote: null, loading: false, error: msg });
+          return next;
+        });
+      });
+    }
+  };
+
+  useEffect(() => {
+    fetchAll();
+    const interval = setInterval(fetchAll, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  const openSelected = (flatIdx: number) => {
+    const row = flatRows[flatIdx];
+    if (!row || row.type !== "row") return;
+    registry?.navigateTickerFn(row.entry.symbol);
+  };
+
+  useKeyboard((event) => {
+    if (!focused) return;
+
+    const currentPos = navigableIndices.indexOf(selectedFlatIdx);
+
+    if (event.name === "j" || event.name === "down") {
+      const next = navigableIndices[currentPos + 1];
+      if (next !== undefined) setSelectedFlatIdx(next);
+    } else if (event.name === "k" || event.name === "up") {
+      const next = navigableIndices[currentPos - 1];
+      if (next !== undefined) setSelectedFlatIdx(next);
+    } else if (event.name === "return") {
+      openSelected(selectedFlatIdx);
+    }
+  });
+
+  const shortNameWidth = 8;
+  const priceWidth = 16;
+  const changeWidth = 10;
+  const dotWidth = 2;
+  const minNameWidth = 10;
+  const nameWidth = Math.max(minNameWidth, width - shortNameWidth - priceWidth - changeWidth - dotWidth - 4);
+
+  return (
+    <box flexDirection="column" width={width} height={height}>
+      <scrollbox flexGrow={1} scrollY focusable={false}>
+        <box flexDirection="column">
+          {flatRows.map((row, flatIdx) => {
+            if (row.type === "header") {
+              return (
+                <box key={`header-${row.region}`} flexDirection="row" paddingX={1} paddingTop={flatIdx === 0 ? 0 : 1}>
+                  <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+                    {REGION_LABELS[row.region]}
+                  </text>
+                </box>
+              );
+            }
+
+            const { entry } = row;
+            const state = quotes.get(entry.symbol);
+            const quote = state?.quote;
+            const isSelected = flatIdx === selectedFlatIdx;
+            const isHovered = flatIdx === hoveredFlatIdx;
+            const bg = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
+            const fg = isSelected ? colors.selectedText : colors.text;
+            const dot = marketStatusDot(quote?.marketState);
+            const changePercent = quote?.changePercent;
+            const price = quote?.price;
+
+            return (
+              <box
+                key={entry.symbol}
+                flexDirection="row"
+                width={width}
+                backgroundColor={bg}
+                onMouseMove={() => setHoveredFlatIdx(flatIdx)}
+                onMouseOut={() => setHoveredFlatIdx(null)}
+                onMouseDown={(event: any) => {
+                  event.preventDefault?.();
+                  if (selectedFlatIdx === flatIdx) {
+                    openSelected(flatIdx);
+                  } else {
+                    setSelectedFlatIdx(flatIdx);
+                  }
+                }}
+              >
+                <box width={dotWidth} paddingLeft={1}>
+                  <text fg={dot.color}>{dot.char}</text>
+                </box>
+                <box width={shortNameWidth} flexShrink={0}>
+                  <text fg={isSelected ? colors.selectedText : colors.textBright} attributes={TextAttributes.BOLD}>
+                    {entry.shortName}
+                  </text>
+                </box>
+                <box width={nameWidth} flexShrink={1} overflow="hidden">
+                  <text fg={fg}>{entry.name}</text>
+                </box>
+                <box width={priceWidth} justifyContent="flex-end" paddingRight={1}>
+                  {state?.loading && !quote ? (
+                    <text fg={colors.textDim}>…</text>
+                  ) : state?.error ? (
+                    <text fg={colors.textDim}>—</text>
+                  ) : (
+                    <text fg={fg}>
+                      {price !== undefined ? formatCurrency(price, quote?.currency ?? "USD") : "—"}
+                    </text>
+                  )}
+                </box>
+                <box width={changeWidth} justifyContent="flex-end" paddingRight={1}>
+                  {quote && changePercent !== undefined ? (
+                    <text fg={isSelected ? colors.selectedText : priceColor(changePercent)}>
+                      {formatPercentRaw(changePercent)}
+                    </text>
+                  ) : (
+                    <text fg={colors.textDim}>—</text>
+                  )}
+                </box>
+              </box>
+            );
+          })}
+        </box>
+      </scrollbox>
+
+      <box height={1} paddingX={1}>
+        <text fg={colors.textMuted}>j/k navigate · Enter opens ticker</text>
+      </box>
+    </box>
+  );
+}
+
+export const worldIndicesPlugin: GloomPlugin = {
+  id: "world-indices",
+  name: "World Equity Indices",
+  version: "1.0.0",
+  description: "Global equity index monitor grouped by region",
+  toggleable: true,
+
+  panes: [
+    {
+      id: "world-indices",
+      name: "World Indices",
+      icon: "W",
+      component: WorldIndicesPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 72, height: 32 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "world-indices-pane",
+      paneId: "world-indices",
+      label: "World Equity Indices",
+      description: "Monitor global equity indices grouped by region.",
+      keywords: ["world", "indices", "global", "equity", "markets", "international"],
+      shortcut: { prefix: "WEI" },
+    },
+  ],
+};

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useRef, useState } from "react";
-import { TextAttributes } from "@opentui/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
+import { DataTable, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import type { Quote } from "../../../types/financials";
 import type { MarketState } from "../../../types/financials";
-import { colors, hoverBg, priceColor } from "../../../theme/colors";
+import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
-import { getSharedDataProvider, getSharedRegistry } from "../../registry";
+import { usePluginTickerActions } from "../../plugin-runtime";
+import { getSharedDataProvider } from "../../registry";
 import { WORLD_INDICES, REGION_LABELS, REGION_ORDER, getIndicesByRegion, type IndexEntry } from "./indices";
 
 const REFRESH_INTERVAL_MS = 60_000;
@@ -18,6 +20,31 @@ interface IndexQuoteState {
 }
 
 type QuoteMap = Map<string, IndexQuoteState>;
+type WorldIndexTableRow =
+  | { type: "header"; region: IndexEntry["region"] }
+  | { type: "row"; entry: IndexEntry };
+type WorldIndexColumnId = "status" | "symbol" | "name" | "price" | "changePercent";
+type WorldIndexColumn = DataTableColumn & { id: WorldIndexColumnId };
+type SortDirection = "asc" | "desc";
+
+interface WorldIndexSortPreference {
+  columnId: WorldIndexColumnId | null;
+  direction: SortDirection;
+}
+
+const DEFAULT_SORT_PREFERENCE: WorldIndexSortPreference = {
+  columnId: null,
+  direction: "asc",
+};
+
+const MARKET_STATE_SORT_ORDER: Partial<Record<MarketState, number>> = {
+  REGULAR: 0,
+  PREPRE: 1,
+  PRE: 1,
+  POST: 1,
+  POSTPOST: 1,
+  CLOSED: 2,
+};
 
 function marketStatusDot(state: MarketState | undefined): { char: string; color: string } {
   switch (state) {
@@ -34,10 +61,64 @@ function marketStatusDot(state: MarketState | undefined): { char: string; color:
   }
 }
 
-function buildFlatRows(indicesByRegion: Map<IndexEntry["region"], IndexEntry[]>): Array<{ type: "header"; region: IndexEntry["region"] } | { type: "row"; entry: IndexEntry }> {
-  const rows: Array<{ type: "header"; region: IndexEntry["region"] } | { type: "row"; entry: IndexEntry }> = [];
+function getSortValue(
+  columnId: WorldIndexColumnId,
+  entry: IndexEntry,
+  quotes: QuoteMap,
+): string | number | null {
+  const quote = quotes.get(entry.symbol)?.quote;
+
+  switch (columnId) {
+    case "status":
+      return quote?.marketState ? (MARKET_STATE_SORT_ORDER[quote.marketState] ?? 3) : 3;
+    case "symbol":
+      return entry.shortName;
+    case "name":
+      return entry.name;
+    case "price":
+      return quote?.price ?? null;
+    case "changePercent":
+      return quote?.changePercent ?? null;
+  }
+}
+
+function compareSortValues(
+  left: string | number | null,
+  right: string | number | null,
+  direction: SortDirection,
+): number {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+
+  const comparison = typeof left === "string" && typeof right === "string"
+    ? left.localeCompare(right)
+    : Number(left) - Number(right);
+  return direction === "asc" ? comparison : -comparison;
+}
+
+function sortEntries(
+  entries: IndexEntry[],
+  sortPreference: WorldIndexSortPreference,
+  quotes: QuoteMap,
+): IndexEntry[] {
+  const sortColumnId = sortPreference.columnId;
+  if (!sortColumnId) return entries;
+  return [...entries].sort((left, right) => compareSortValues(
+    getSortValue(sortColumnId, left, quotes),
+    getSortValue(sortColumnId, right, quotes),
+    sortPreference.direction,
+  ));
+}
+
+function buildFlatRows(
+  indicesByRegion: Map<IndexEntry["region"], IndexEntry[]>,
+  sortPreference: WorldIndexSortPreference,
+  quotes: QuoteMap,
+): WorldIndexTableRow[] {
+  const rows: WorldIndexTableRow[] = [];
   for (const region of REGION_ORDER) {
-    const entries = indicesByRegion.get(region) ?? [];
+    const entries = sortEntries(indicesByRegion.get(region) ?? [], sortPreference, quotes);
     if (entries.length === 0) continue;
     rows.push({ type: "header", region });
     for (const entry of entries) {
@@ -55,23 +136,50 @@ function rowIndicesOf(flatRows: ReturnType<typeof buildFlatRows>): number[] {
   }, []);
 }
 
+function nextSortPreference(
+  current: WorldIndexSortPreference,
+  columnId: string,
+): WorldIndexSortPreference {
+  const typedColumnId = columnId as WorldIndexColumnId;
+  if (current.columnId !== typedColumnId) {
+    return { columnId: typedColumnId, direction: "asc" };
+  }
+  if (current.direction === "asc") {
+    return { columnId: typedColumnId, direction: "desc" };
+  }
+  return DEFAULT_SORT_PREFERENCE;
+}
+
 export function WorldIndicesPane({ focused, width, height }: PaneProps) {
-  const registry = getSharedRegistry();
+  const { pinTicker } = usePluginTickerActions();
   const [quotes, setQuotes] = useState<QuoteMap>(new Map());
-  const [selectedFlatIdx, setSelectedFlatIdx] = useState<number>(-1);
+  const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [hoveredFlatIdx, setHoveredFlatIdx] = useState<number | null>(null);
+  const [sortPreference, setSortPreference] = useState<WorldIndexSortPreference>(DEFAULT_SORT_PREFERENCE);
   const fetchGenRef = useRef(0);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const headerScrollRef = useRef<ScrollBoxRenderable>(null);
 
-  const indicesByRegion = getIndicesByRegion();
-  const flatRows = buildFlatRows(indicesByRegion);
-  const navigableIndices = rowIndicesOf(flatRows);
+  const indicesByRegion = useMemo(() => getIndicesByRegion(), []);
+  const flatRows = useMemo(
+    () => buildFlatRows(indicesByRegion, sortPreference, quotes),
+    [indicesByRegion, quotes, sortPreference],
+  );
+  const navigableIndices = useMemo(() => rowIndicesOf(flatRows), [flatRows]);
+  const selectedFlatIdx = selectedSymbol
+    ? flatRows.findIndex((row) => row.type === "row" && row.entry.symbol === selectedSymbol)
+    : -1;
+  const activeFlatIdx = selectedFlatIdx >= 0 ? selectedFlatIdx : (navigableIndices[0] ?? -1);
 
-  // Initialize selection to first navigable row
   useEffect(() => {
-    if (selectedFlatIdx === -1 && navigableIndices.length > 0) {
-      setSelectedFlatIdx(navigableIndices[0]!);
+    if (selectedSymbol && selectedFlatIdx >= 0) return;
+    const firstRow = flatRows.find((row) => row.type === "row");
+    if (firstRow?.type === "row") {
+      setSelectedSymbol(firstRow.entry.symbol);
+    } else if (selectedSymbol !== null) {
+      setSelectedSymbol(null);
     }
-  }, []);
+  }, [flatRows, selectedFlatIdx, selectedSymbol]);
 
   const fetchAll = () => {
     const provider = getSharedDataProvider();
@@ -113,118 +221,159 @@ export function WorldIndicesPane({ focused, width, height }: PaneProps) {
     return () => clearInterval(interval);
   }, []);
 
-  const openSelected = (flatIdx: number) => {
+  const syncHeaderScroll = useCallback(() => {
+    const bodyScrollBox = scrollRef.current;
+    const headerScrollBox = headerScrollRef.current;
+    if (bodyScrollBox && headerScrollBox && headerScrollBox.scrollLeft !== bodyScrollBox.scrollLeft) {
+      headerScrollBox.scrollLeft = bodyScrollBox.scrollLeft;
+    }
+  }, []);
+
+  const handleBodyScrollActivity = useCallback(() => {
+    syncHeaderScroll();
+  }, [syncHeaderScroll]);
+
+  const openSelected = useCallback((flatIdx: number) => {
     const row = flatRows[flatIdx];
     if (!row || row.type !== "row") return;
-    registry?.navigateTickerFn(row.entry.symbol);
-  };
+    pinTicker(row.entry.symbol, { floating: true, paneType: "ticker-detail" });
+  }, [flatRows, pinTicker]);
+
+  const selectFlatIndex = useCallback((flatIdx: number) => {
+    const row = flatRows[flatIdx];
+    if (!row || row.type !== "row") return;
+    setSelectedSymbol(row.entry.symbol);
+  }, [flatRows]);
+
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextSortPreference(current, columnId));
+  }, []);
 
   useKeyboard((event) => {
     if (!focused) return;
 
-    const currentPos = navigableIndices.indexOf(selectedFlatIdx);
+    const currentPos = navigableIndices.indexOf(activeFlatIdx);
+    const key = event.name;
+    const isEnter = key === "enter" || key === "return";
 
-    if (event.name === "j" || event.name === "down") {
-      const next = navigableIndices[currentPos + 1];
-      if (next !== undefined) setSelectedFlatIdx(next);
-    } else if (event.name === "k" || event.name === "up") {
-      const next = navigableIndices[currentPos - 1];
-      if (next !== undefined) setSelectedFlatIdx(next);
-    } else if (event.name === "return") {
-      openSelected(selectedFlatIdx);
+    if (key === "j" || key === "down") {
+      event.preventDefault?.();
+      const next = navigableIndices[currentPos >= 0 ? currentPos + 1 : 0];
+      if (next !== undefined) selectFlatIndex(next);
+    } else if (key === "k" || key === "up") {
+      event.preventDefault?.();
+      const next = navigableIndices[currentPos > 0 ? currentPos - 1 : 0];
+      if (next !== undefined) selectFlatIndex(next);
+    } else if (isEnter) {
+      event.preventDefault?.();
+      openSelected(activeFlatIdx);
     }
   });
 
-  const shortNameWidth = 8;
-  const priceWidth = 16;
-  const changeWidth = 10;
-  const dotWidth = 2;
-  const minNameWidth = 10;
-  const nameWidth = Math.max(minNameWidth, width - shortNameWidth - priceWidth - changeWidth - dotWidth - 4);
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox?.viewport || activeFlatIdx < 0) return;
+    const viewportHeight = Math.max(scrollBox.viewport.height, 1);
+    if (activeFlatIdx < scrollBox.scrollTop) {
+      scrollBox.scrollTo(activeFlatIdx);
+    } else if (activeFlatIdx >= scrollBox.scrollTop + viewportHeight) {
+      scrollBox.scrollTo(activeFlatIdx - viewportHeight + 1);
+    }
+  }, [activeFlatIdx]);
+
+  const columns = useMemo<WorldIndexColumn[]>(() => {
+    const statusWidth = 1;
+    const symbolWidth = 8;
+    const priceWidth = 15;
+    const changeWidth = 9;
+    const columnCount = 5;
+    const fixedWidth = statusWidth + symbolWidth + priceWidth + changeWidth;
+    const nameWidth = Math.max(10, width - 2 - columnCount - fixedWidth);
+
+    return [
+      { id: "status", label: "", width: statusWidth, align: "left" },
+      { id: "symbol", label: "INDEX", width: symbolWidth, align: "left" },
+      { id: "name", label: "NAME", width: nameWidth, align: "left" },
+      { id: "price", label: "LAST", width: priceWidth, align: "right" },
+      { id: "changePercent", label: "CHG%", width: changeWidth, align: "right" },
+    ];
+  }, [width]);
+
+  const renderCell = useCallback((
+    row: WorldIndexTableRow,
+    column: WorldIndexColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    if (row.type === "header") return { text: "" };
+
+    const { entry } = row;
+    const state = quotes.get(entry.symbol);
+    const quote = state?.quote;
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+
+    switch (column.id) {
+      case "status": {
+        const dot = marketStatusDot(quote?.marketState);
+        return { text: dot.char, color: dot.color };
+      }
+      case "symbol":
+        return {
+          text: entry.shortName,
+          color: selectedColor ?? colors.textBright,
+          attributes: TextAttributes.BOLD,
+        };
+      case "name":
+        return {
+          text: entry.name,
+          color: selectedColor,
+        };
+      case "price":
+        if (state?.loading && !quote) {
+          return { text: "…", color: rowState.selected ? colors.selectedText : colors.textDim };
+        }
+        if (state?.error || quote?.price === undefined) {
+          return { text: "—", color: rowState.selected ? colors.selectedText : colors.textDim };
+        }
+        return {
+          text: formatCurrency(quote.price, quote.currency ?? "USD"),
+          color: selectedColor,
+        };
+      case "changePercent":
+        if (!quote || quote.changePercent === undefined) {
+          return { text: "—", color: rowState.selected ? colors.selectedText : colors.textDim };
+        }
+        return {
+          text: formatPercentRaw(quote.changePercent),
+          color: selectedColor ?? priceColor(quote.changePercent),
+        };
+    }
+  }, [quotes]);
 
   return (
     <box flexDirection="column" width={width} height={height}>
-      <scrollbox flexGrow={1} scrollY focusable={false}>
-        <box flexDirection="column">
-          {flatRows.map((row, flatIdx) => {
-            if (row.type === "header") {
-              return (
-                <box key={`header-${row.region}`} flexDirection="row" paddingX={1} paddingTop={flatIdx === 0 ? 0 : 1}>
-                  <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-                    {REGION_LABELS[row.region]}
-                  </text>
-                </box>
-              );
-            }
-
-            const { entry } = row;
-            const state = quotes.get(entry.symbol);
-            const quote = state?.quote;
-            const isSelected = flatIdx === selectedFlatIdx;
-            const isHovered = flatIdx === hoveredFlatIdx;
-            const bg = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
-            const fg = isSelected ? colors.selectedText : colors.text;
-            const dot = marketStatusDot(quote?.marketState);
-            const changePercent = quote?.changePercent;
-            const price = quote?.price;
-
-            return (
-              <box
-                key={entry.symbol}
-                flexDirection="row"
-                width={width}
-                backgroundColor={bg}
-                onMouseMove={() => setHoveredFlatIdx(flatIdx)}
-                onMouseOut={() => setHoveredFlatIdx(null)}
-                onMouseDown={(event: any) => {
-                  event.preventDefault?.();
-                  if (selectedFlatIdx === flatIdx) {
-                    openSelected(flatIdx);
-                  } else {
-                    setSelectedFlatIdx(flatIdx);
-                  }
-                }}
-              >
-                <box width={dotWidth} paddingLeft={1}>
-                  <text fg={dot.color}>{dot.char}</text>
-                </box>
-                <box width={shortNameWidth} flexShrink={0}>
-                  <text fg={isSelected ? colors.selectedText : colors.textBright} attributes={TextAttributes.BOLD}>
-                    {entry.shortName}
-                  </text>
-                </box>
-                <box width={nameWidth} flexShrink={1} overflow="hidden">
-                  <text fg={fg}>{entry.name}</text>
-                </box>
-                <box width={priceWidth} justifyContent="flex-end" paddingRight={1}>
-                  {state?.loading && !quote ? (
-                    <text fg={colors.textDim}>…</text>
-                  ) : state?.error ? (
-                    <text fg={colors.textDim}>—</text>
-                  ) : (
-                    <text fg={fg}>
-                      {price !== undefined ? formatCurrency(price, quote?.currency ?? "USD") : "—"}
-                    </text>
-                  )}
-                </box>
-                <box width={changeWidth} justifyContent="flex-end" paddingRight={1}>
-                  {quote && changePercent !== undefined ? (
-                    <text fg={isSelected ? colors.selectedText : priceColor(changePercent)}>
-                      {formatPercentRaw(changePercent)}
-                    </text>
-                  ) : (
-                    <text fg={colors.textDim}>—</text>
-                  )}
-                </box>
-              </box>
-            );
-          })}
-        </box>
-      </scrollbox>
-
-      <box height={1} paddingX={1}>
-        <text fg={colors.textMuted}>j/k navigate · Enter opens ticker</text>
-      </box>
+      <DataTable<WorldIndexTableRow, WorldIndexColumn>
+        columns={columns}
+        items={flatRows}
+        sortColumnId={sortPreference.columnId}
+        sortDirection={sortPreference.direction}
+        onHeaderClick={handleHeaderClick}
+        headerScrollRef={headerScrollRef}
+        scrollRef={scrollRef}
+        syncHeaderScroll={syncHeaderScroll}
+        onBodyScrollActivity={handleBodyScrollActivity}
+        hoveredIdx={hoveredFlatIdx}
+        setHoveredIdx={setHoveredFlatIdx}
+        getItemKey={(row) => row.type === "header" ? `header-${row.region}` : row.entry.symbol}
+        isSelected={(row) => row.type === "row" && row.entry.symbol === selectedSymbol}
+        onSelect={(_row, index) => selectFlatIndex(index)}
+        onActivate={(_row, index) => openSelected(index)}
+        renderSectionHeader={(row) => row.type === "header"
+          ? { text: REGION_LABELS[row.region] }
+          : null}
+        renderCell={renderCell}
+        emptyStateTitle="No indices configured."
+      />
     </box>
   );
 }

--- a/src/plugins/builtin/world-indices/indices.ts
+++ b/src/plugins/builtin/world-indices/indices.ts
@@ -1,0 +1,52 @@
+export interface IndexEntry {
+  symbol: string;
+  name: string;
+  shortName: string;
+  region: "americas" | "europe" | "asia-pacific" | "other";
+}
+
+export const WORLD_INDICES: IndexEntry[] = [
+  // Americas
+  { symbol: "^GSPC", name: "S&P 500", shortName: "SPX", region: "americas" },
+  { symbol: "^DJI", name: "Dow Jones Industrial Average", shortName: "DJIA", region: "americas" },
+  { symbol: "^IXIC", name: "Nasdaq Composite", shortName: "COMP", region: "americas" },
+  { symbol: "^RUT", name: "Russell 2000", shortName: "RUT", region: "americas" },
+  { symbol: "^GSPTSE", name: "S&P/TSX Composite", shortName: "TSX", region: "americas" },
+  { symbol: "^BVSP", name: "Bovespa", shortName: "BVSP", region: "americas" },
+
+  // Europe
+  { symbol: "^FTSE", name: "FTSE 100", shortName: "FTSE", region: "europe" },
+  { symbol: "^GDAXI", name: "DAX", shortName: "DAX", region: "europe" },
+  { symbol: "^FCHI", name: "CAC 40", shortName: "CAC", region: "europe" },
+  { symbol: "^STOXX50E", name: "Euro Stoxx 50", shortName: "SX5E", region: "europe" },
+  { symbol: "^SSMI", name: "Swiss Market Index", shortName: "SMI", region: "europe" },
+
+  // Asia-Pacific
+  { symbol: "^N225", name: "Nikkei 225", shortName: "NKY", region: "asia-pacific" },
+  { symbol: "^HSI", name: "Hang Seng Index", shortName: "HSI", region: "asia-pacific" },
+  { symbol: "000001.SS", name: "Shanghai Composite", shortName: "SHCOMP", region: "asia-pacific" },
+  { symbol: "^KS11", name: "KOSPI", shortName: "KOSPI", region: "asia-pacific" },
+  { symbol: "^AXJO", name: "ASX 200", shortName: "ASX", region: "asia-pacific" },
+  { symbol: "^BSESN", name: "BSE Sensex", shortName: "SENSEX", region: "asia-pacific" },
+
+  // Other
+  { symbol: "^VIX", name: "CBOE Volatility Index", shortName: "VIX", region: "other" },
+  { symbol: "DX-Y.NYB", name: "US Dollar Index", shortName: "DXY", region: "other" },
+];
+
+export const REGION_LABELS: Record<IndexEntry["region"], string> = {
+  americas: "Americas",
+  europe: "Europe",
+  "asia-pacific": "Asia-Pacific",
+  other: "Other",
+};
+
+export const REGION_ORDER: IndexEntry["region"][] = ["americas", "europe", "asia-pacific", "other"];
+
+export function getIndicesByRegion(): Map<IndexEntry["region"], IndexEntry[]> {
+  const map = new Map<IndexEntry["region"], IndexEntry[]>();
+  for (const region of REGION_ORDER) {
+    map.set(region, WORLD_INDICES.filter((entry) => entry.region === region));
+  }
+  return map;
+}

--- a/src/plugins/catalog.ts
+++ b/src/plugins/catalog.ts
@@ -12,6 +12,8 @@ import { aiPlugin } from "./builtin/ai";
 import { gloomberbCloudPlugin } from "./builtin/chat";
 import { helpPlugin } from "./builtin/help";
 import { comparisonChartPlugin } from "./builtin/comparison-chart";
+import { worldIndicesPlugin } from "./builtin/world-indices";
+import { marketMoversPlugin } from "./builtin/market-movers";
 import { debugPlugin } from "./builtin/debug";
 import { layoutManagerPlugin } from "./builtin/layout-manager";
 import { yahooPlugin } from "./builtin/yahoo";
@@ -40,6 +42,8 @@ export const builtinPlugins: GloomPlugin[] = [
   helpPlugin,
   comparisonChartPlugin,
   predictionMarketsPlugin,
+  worldIndicesPlugin,
+  marketMoversPlugin,
   debugPlugin,
 ];
 

--- a/src/plugins/plugin-runtime.test.tsx
+++ b/src/plugins/plugin-runtime.test.tsx
@@ -59,6 +59,8 @@ describe("plugin runtime hooks", () => {
     const listeners = new Map<string, Set<() => void>>();
 
     const runtime: PluginRuntimeAccess = {
+      pinTicker() {},
+      navigateTicker() {},
       subscribeResumeState(pluginId, key, listener) {
         const listenerKey = `${pluginId}:${key}`;
         if (!listeners.has(listenerKey)) listeners.set(listenerKey, new Set());

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -10,6 +10,8 @@ import {
 import { useAppState, usePaneInstanceId, type PaneRuntimeState } from "../state/app-context";
 
 export interface PluginRuntimeAccess {
+  pinTicker(symbol: string, options?: { floating?: boolean; paneType?: string }): void;
+  navigateTicker(symbol: string): void;
   subscribeResumeState(pluginId: string, key: string, listener: () => void): () => void;
   getResumeState<T = unknown>(pluginId: string, key: string, schemaVersion?: number): T | null;
   setResumeState(pluginId: string, key: string, value: unknown, schemaVersion?: number): void;
@@ -49,6 +51,14 @@ function usePluginRenderContext(): PluginRenderContextValue {
     throw new Error("Plugin runtime hooks must be used inside a plugin render context");
   }
   return context;
+}
+
+export function usePluginTickerActions() {
+  const { runtime } = usePluginRenderContext();
+  return {
+    pinTicker: runtime.pinTicker,
+    navigateTicker: runtime.navigateTicker,
+  };
 }
 
 export function getPluginPaneStateValue<T>(

--- a/src/plugins/prediction-markets/test-helpers.tsx
+++ b/src/plugins/prediction-markets/test-helpers.tsx
@@ -137,6 +137,8 @@ export function createRuntime(): PluginRuntimeAccess {
   const listeners = new Map<string, Set<() => void>>();
 
   return {
+    pinTicker() {},
+    navigateTicker() {},
     subscribeResumeState(pluginId, key, listener) {
       const listenerKey = `${pluginId}:${key}`;
       if (!listeners.has(listenerKey)) listeners.set(listenerKey, new Set());

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -113,6 +113,12 @@ export class PluginRegistry implements PluginRuntimeAccess {
   focusPaneFn: ((paneId: string) => void) = () => {};
   pinTickerFn: ((symbol: string, options?: { floating?: boolean; paneType?: string }) => void) = () => {};
   navigateTickerFn: ((symbol: string) => void) = () => {};
+  pinTicker = (symbol: string, options?: { floating?: boolean; paneType?: string }) => {
+    this.pinTickerFn(symbol, options);
+  };
+  navigateTicker = (symbol: string) => {
+    this.navigateTickerFn(symbol);
+  };
 
   getLayoutFn: (() => LayoutConfig) = () => ({ dockRoot: null, instances: [], floating: [] });
   updateLayoutFn: ((layout: LayoutConfig) => void) = () => {};
@@ -512,8 +518,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
       createPaneFromTemplate: (templateId, options) => this.createPaneFromTemplateFn(templateId, options),
       hidePane: (paneId) => this.hidePaneFn(paneId),
       focusPane: (paneId) => this.focusPaneFn(paneId),
-      pinTicker: (symbol, options) => this.pinTickerFn(symbol, options),
-      navigateTicker: (symbol) => this.navigateTickerFn(symbol),
+      pinTicker: this.pinTicker,
+      navigateTicker: this.navigateTicker,
       openPaneSettings: (paneId) => this.openPaneSettingsFn(paneId),
 
       on: <K extends keyof PluginEvents>(event: K, handler: (payload: PluginEvents[K]) => void) => {


### PR DESCRIPTION
Two new built-in plugins for market overview.

**World Equity Indices (WEI):** 19 global indices grouped by Americas, Europe, Asia-Pacific, and Other. Live quotes with market status indicators (green=open, yellow=pre/post, red=closed). j/k navigation, Enter navigates the detail pane. Shortcut: `WEI`

**Market Movers (TOP):** Gainers/Losers/Most Active/Trending tabs via Yahoo Finance screener API. Market summary bar at top showing SPX, DJIA, COMP, RUT with live quotes. Columns: rank, ticker, name, price, change%, volume, volume ratio (vs 3-month avg), 52-week range position, market cap. Adaptive layout hides extra columns on narrow panes. Left/right arrows switch tabs. Uses throttled-fetch for rate limiting. Shortcut: `TOP`

Both plugins use `navigateTicker` for click/Enter behavior — retargets the active detail pane instead of spawning new windows. Single click selects, second click navigates.

Depends on #150.

Testing: `bun test src/plugins/builtin/market-movers/screener.test.ts`