### PR TITLE
Add Economic Calendar (ECON) plugin with FRED integration

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type RefObject } from "react";
+import { useCallback, useEffect, useMemo, useState, type RefObject } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
 import { colors, hoverBg } from "../../theme/colors";
 import type { ColumnConfig } from "../../types/config";
@@ -59,6 +59,7 @@ export interface DataTableProps<
   emptyStateHint?: string;
   virtualize?: boolean;
   overscan?: number;
+  showHorizontalScrollbar?: boolean;
 }
 
 interface DataTableRowPointerTarget<T> {
@@ -88,6 +89,7 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
   emptyStateHint,
   virtualize = false,
   overscan = 3,
+  showHorizontalScrollbar = true,
 }: DataTableProps<T, C>) {
   const dispatch = useAppDispatch();
   const paneInstanceId = usePaneInstance()?.instanceId ?? null;
@@ -126,6 +128,15 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
     if (!paneInstanceId) return;
     dispatch({ type: "FOCUS_PANE", paneId: paneInstanceId });
   }, [dispatch, paneInstanceId]);
+
+  useEffect(() => {
+    if (headerScrollRef.current) {
+      headerScrollRef.current.horizontalScrollBar.visible = false;
+    }
+    if (scrollRef.current) {
+      scrollRef.current.horizontalScrollBar.visible = showHorizontalScrollbar;
+    }
+  }, [columns.length, headerScrollRef, items.length, scrollRef, showHorizontalScrollbar]);
 
   return (
     <>

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -69,6 +69,49 @@ function DataTableActivationHarness() {
   );
 }
 
+type SectionTableRow =
+  | { kind: "header"; id: string; label: string }
+  | { kind: "row"; id: string; name: string };
+
+function DataTableSectionHarness() {
+  const headerScrollRef = useRef<ScrollBoxRenderable>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const rows: SectionTableRow[] = [
+    { kind: "header", id: "macro", label: "Macro Releases" },
+    { kind: "row", id: "cpi", name: "CPI" },
+  ];
+
+  return (
+    <DataTable
+      columns={[{ id: "name", label: "NAME", width: 16, align: "left" }]}
+      items={rows}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      headerScrollRef={headerScrollRef}
+      scrollRef={scrollRef}
+      syncHeaderScroll={() => {}}
+      onBodyScrollActivity={() => {}}
+      hoveredIdx={hoveredIdx}
+      setHoveredIdx={setHoveredIdx}
+      getItemKey={(row) => row.id}
+      isSelected={(row) => row.kind === "row" && row.id === selectedId}
+      onSelect={(row) => {
+        if (row.kind !== "row") return;
+        selectedTableRow = row.id;
+        setSelectedId(row.id);
+      }}
+      renderSectionHeader={(row) => (
+        row.kind === "header" ? { text: row.label } : null
+      )}
+      renderCell={(row) => ({ text: row.kind === "row" ? row.name : "" })}
+      emptyStateTitle="No rows."
+    />
+  );
+}
+
 afterEach(() => {
   if (testSetup) {
     testSetup.renderer.destroy();
@@ -224,5 +267,40 @@ describe("shared UI kit", () => {
     });
 
     expect(activatedTableRow).toBe("alpha");
+  });
+
+  test("renders data table section headers as non-selectable rows", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="portfolio-list:main">
+          <DataTableSectionHarness />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 32, height: 6 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Macro Releases");
+    expect(frame).toContain("CPI");
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(2, 1);
+      await testSetup!.renderOnce();
+    });
+    expect(selectedTableRow).toBeNull();
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(2, 2);
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(selectedTableRow).toBe("cpi");
+    expect(frame).toContain("CPI");
   });
 });

--- a/src/plugins/builtin/econ/calendar-source.test.ts
+++ b/src/plugins/builtin/econ/calendar-source.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from "bun:test";
-import { parseCalendarJson } from "./calendar-source";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { PersistedResourceValue } from "../../../types/persistence";
+import type { PluginPersistence } from "../../../types/plugin";
+import {
+  attachEconCalendarPersistence,
+  ECON_CALENDAR_CACHE_POLICY,
+  fetchEconCalendar,
+  parseCalendarJson,
+  resetEconCalendarPersistence,
+} from "./calendar-source";
 
 const SAMPLE_DATA = [
   {
@@ -27,6 +35,110 @@ const SAMPLE_DATA = [
     previous: "",
   },
 ];
+
+const originalFetch = globalThis.fetch;
+
+class MemoryPluginPersistence implements PluginPersistence {
+  private readonly resources = new Map<string, PersistedResourceValue<unknown>>();
+  private readonly state = new Map<string, { schemaVersion: number; value: unknown }>();
+
+  getState<T = unknown>(key: string, options?: { schemaVersion?: number }): T | null {
+    const record = this.state.get(key);
+    if (!record) return null;
+    if (options?.schemaVersion != null && record.schemaVersion !== options.schemaVersion) return null;
+    return record.value as T;
+  }
+
+  setState(key: string, value: unknown, options?: { schemaVersion?: number }): void {
+    this.state.set(key, { schemaVersion: options?.schemaVersion ?? 1, value });
+  }
+
+  deleteState(key: string): void {
+    this.state.delete(key);
+  }
+
+  getResource<T = unknown>(
+    kind: string,
+    key: string,
+    options?: { sourceKey?: string; schemaVersion?: number; allowExpired?: boolean },
+  ): PersistedResourceValue<T> | null {
+    const record = this.resources.get(this.resourceKey(kind, key, options?.sourceKey));
+    if (!record) return null;
+    if (options?.schemaVersion != null && record.schemaVersion !== options.schemaVersion) return null;
+    const next = this.withFreshness(record);
+    if (!options?.allowExpired && next.expired) return null;
+    return next as PersistedResourceValue<T>;
+  }
+
+  setResource<T = unknown>(
+    kind: string,
+    key: string,
+    value: T,
+    options: {
+      cachePolicy: { staleMs: number; expireMs: number };
+      sourceKey?: string;
+      schemaVersion?: number;
+      provenance?: unknown;
+    },
+  ): PersistedResourceValue<T> {
+    const now = Date.now();
+    const record: PersistedResourceValue<T> = {
+      value,
+      fetchedAt: now,
+      staleAt: now + options.cachePolicy.staleMs,
+      expiresAt: now + options.cachePolicy.expireMs,
+      sourceKey: options.sourceKey ?? "",
+      schemaVersion: options.schemaVersion ?? 1,
+      provenance: options.provenance,
+      stale: false,
+      expired: false,
+    };
+    this.resources.set(this.resourceKey(kind, key, options.sourceKey), record);
+    return record;
+  }
+
+  deleteResource(kind: string, key: string, options?: { sourceKey?: string }): void {
+    this.resources.delete(this.resourceKey(kind, key, options?.sourceKey));
+  }
+
+  seedResource<T>(
+    kind: string,
+    key: string,
+    value: T,
+    options: { sourceKey?: string; stale?: boolean; expired?: boolean } = {},
+  ): void {
+    const now = Date.now();
+    const record: PersistedResourceValue<T> = {
+      value,
+      fetchedAt: now - 60_000,
+      staleAt: options.stale ? now - 1 : now + ECON_CALENDAR_CACHE_POLICY.staleMs,
+      expiresAt: options.expired ? now - 1 : now + ECON_CALENDAR_CACHE_POLICY.expireMs,
+      sourceKey: options.sourceKey ?? "",
+      schemaVersion: 1,
+      stale: !!options.stale,
+      expired: !!options.expired,
+    };
+    this.resources.set(this.resourceKey(kind, key, options.sourceKey), record);
+  }
+
+  private resourceKey(kind: string, key: string, sourceKey = ""): string {
+    return `${kind}:${key}:${sourceKey}`;
+  }
+
+  private withFreshness<T>(record: PersistedResourceValue<T>): PersistedResourceValue<T> {
+    const now = Date.now();
+    return {
+      ...record,
+      stale: now >= record.staleAt,
+      expired: now >= record.expiresAt,
+    };
+  }
+}
+
+afterEach(() => {
+  resetEconCalendarPersistence();
+  globalThis.fetch = originalFetch;
+});
 
 describe("parseCalendarJson", () => {
   test("parses events from JSON, skips holidays", () => {
@@ -63,5 +175,45 @@ describe("parseCalendarJson", () => {
     expect(parseCalendarJson(null)).toEqual([]);
     expect(parseCalendarJson({})).toEqual([]);
     expect(parseCalendarJson("")).toEqual([]);
+  });
+});
+
+describe("fetchEconCalendar cache", () => {
+  test("uses a fresh plugin resource cache without fetching", async () => {
+    const persistence = new MemoryPluginPersistence();
+    attachEconCalendarPersistence(persistence);
+    persistence.setResource("calendar", "this-week", SAMPLE_DATA, {
+      sourceKey: "forexfactory",
+      cachePolicy: ECON_CALENDAR_CACHE_POLICY,
+    });
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error("unexpected fetch");
+    }) as unknown as typeof fetch;
+
+    const events = await fetchEconCalendar();
+
+    expect(events).toHaveLength(2);
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("falls back to stale plugin resource cache when refresh fails", async () => {
+    const persistence = new MemoryPluginPersistence();
+    attachEconCalendarPersistence(persistence);
+    persistence.seedResource("calendar", "this-week", SAMPLE_DATA, {
+      sourceKey: "forexfactory",
+      stale: true,
+    });
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+
+    const events = await fetchEconCalendar();
+
+    expect(events).toHaveLength(2);
+    expect(fetchCalls).toBe(1);
   });
 });

--- a/src/plugins/builtin/econ/calendar-source.test.ts
+++ b/src/plugins/builtin/econ/calendar-source.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { parseCalendarJson } from "./calendar-source";
+
+const SAMPLE_DATA = [
+  {
+    title: "CPI m/m",
+    country: "USD",
+    date: "2026-04-10T08:30:00-04:00",
+    impact: "High",
+    forecast: "0.3%",
+    previous: "0.2%",
+  },
+  {
+    title: "ECB Rate Decision",
+    country: "EUR",
+    date: "2026-04-10T14:00:00-04:00",
+    impact: "Medium",
+    forecast: "4.50%",
+    previous: "4.50%",
+  },
+  {
+    title: "Bank Holiday",
+    country: "GBP",
+    date: "2026-04-10T03:00:00-04:00",
+    impact: "Holiday",
+    forecast: "",
+    previous: "",
+  },
+];
+
+describe("parseCalendarJson", () => {
+  test("parses events from JSON, skips holidays", () => {
+    const events = parseCalendarJson(SAMPLE_DATA);
+    expect(events).toHaveLength(2);
+  });
+
+  test("maps fields correctly", () => {
+    const events = parseCalendarJson(SAMPLE_DATA);
+    const ev = events[0]!;
+    expect(ev.event).toBe("CPI m/m");
+    expect(ev.country).toBe("US");
+    expect(ev.impact).toBe("high");
+    expect(ev.forecast).toBe("0.3%");
+    expect(ev.prior).toBe("0.2%");
+    expect(ev.time).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  test("resolves EUR to EU country code", () => {
+    const events = parseCalendarJson(SAMPLE_DATA);
+    expect(events[1]!.country).toBe("EU");
+    expect(events[1]!.impact).toBe("medium");
+  });
+
+  test("returns empty forecast/prior as null", () => {
+    const events = parseCalendarJson([
+      { title: "Test", country: "USD", date: "2026-04-10T10:00:00-04:00", impact: "Low", forecast: "", previous: "" },
+    ]);
+    expect(events[0]!.forecast).toBeNull();
+    expect(events[0]!.prior).toBeNull();
+  });
+
+  test("returns [] for non-array input", () => {
+    expect(parseCalendarJson(null)).toEqual([]);
+    expect(parseCalendarJson({})).toEqual([]);
+    expect(parseCalendarJson("")).toEqual([]);
+  });
+});

--- a/src/plugins/builtin/econ/calendar-source.ts
+++ b/src/plugins/builtin/econ/calendar-source.ts
@@ -1,10 +1,18 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
-import { join } from "path";
+import type { PersistedResourceValue } from "../../../types/persistence";
+import type { PluginPersistence } from "../../../types/plugin";
 import { createThrottledFetch } from "../../../utils/throttled-fetch";
 import type { EconEvent, EconImpact } from "./types";
 
 const CALENDAR_URL = "https://nfs.faireconomy.media/ff_calendar_thisweek.json";
-const DISK_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const CACHE_KIND = "calendar";
+const CACHE_KEY = "this-week";
+const CACHE_SOURCE = "forexfactory";
+export const ECON_CALENDAR_CACHE_POLICY = {
+  staleMs: 30 * 60 * 1000,
+  expireMs: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+let econCalendarPersistence: PluginPersistence | null = null;
 
 const calendarClient = createThrottledFetch({
   requestsPerMinute: 5,
@@ -16,25 +24,28 @@ const calendarClient = createThrottledFetch({
   },
 });
 
-function getCachePath(): string {
-  const dir = join(process.env.HOME || "~", ".gloomberb", "cache");
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  return join(dir, "econ-calendar.json");
+export function attachEconCalendarPersistence(persistence: PluginPersistence): void {
+  econCalendarPersistence = persistence;
 }
 
-function readDiskCache(): { data: unknown; fetchedAt: number } | null {
-  try {
-    const raw = readFileSync(getCachePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (parsed?.fetchedAt && Array.isArray(parsed?.data)) return parsed;
-  } catch { /* no cache or corrupt */ }
-  return null;
+export function resetEconCalendarPersistence(): void {
+  econCalendarPersistence = null;
 }
 
-function writeDiskCache(data: unknown, fetchedAt: number): void {
-  try {
-    writeFileSync(getCachePath(), JSON.stringify({ data, fetchedAt }));
-  } catch { /* ignore write failures */ }
+function readCalendarCache(options?: {
+  allowExpired?: boolean;
+}): PersistedResourceValue<unknown> | null {
+  return econCalendarPersistence?.getResource<unknown>(CACHE_KIND, CACHE_KEY, {
+    sourceKey: CACHE_SOURCE,
+    allowExpired: options?.allowExpired,
+  }) ?? null;
+}
+
+function writeCalendarCache(data: unknown): void {
+  econCalendarPersistence?.setResource(CACHE_KIND, CACHE_KEY, data, {
+    sourceKey: CACHE_SOURCE,
+    cachePolicy: ECON_CALENDAR_CACHE_POLICY,
+  });
 }
 
 const CURRENCY_TO_COUNTRY: Record<string, string> = {
@@ -91,20 +102,19 @@ export function parseCalendarJson(data: unknown): EconEvent[] {
 }
 
 export async function fetchEconCalendar(): Promise<EconEvent[]> {
-  // Try disk cache first
-  const cached = readDiskCache();
-  if (cached && Date.now() - cached.fetchedAt < DISK_CACHE_TTL_MS) {
-    return parseCalendarJson(cached.data);
+  const cached = readCalendarCache();
+  if (cached && !cached.stale) {
+    return parseCalendarJson(cached.value);
   }
 
   try {
     const data = await calendarClient.fetchJson(CALENDAR_URL);
-    writeDiskCache(data, Date.now());
+    writeCalendarCache(data);
     return parseCalendarJson(data);
   } catch (err) {
-    // If fetch fails but we have stale cache, use it
-    if (cached) {
-      return parseCalendarJson(cached.data);
+    const staleCache = cached ?? readCalendarCache({ allowExpired: true });
+    if (staleCache) {
+      return parseCalendarJson(staleCache.value);
     }
     throw err;
   }

--- a/src/plugins/builtin/econ/calendar-source.ts
+++ b/src/plugins/builtin/econ/calendar-source.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { createThrottledFetch } from "../../../utils/throttled-fetch";
+import type { EconEvent, EconImpact } from "./types";
+
+const CALENDAR_URL = "https://nfs.faireconomy.media/ff_calendar_thisweek.json";
+const DISK_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+const calendarClient = createThrottledFetch({
+  requestsPerMinute: 5,
+  maxRetries: 2,
+  timeoutMs: 15_000,
+  defaultHeaders: {
+    "User-Agent": "Gloomberb/0.4.1",
+    Accept: "application/json",
+  },
+});
+
+function getCachePath(): string {
+  const dir = join(process.env.HOME || "~", ".gloomberb", "cache");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return join(dir, "econ-calendar.json");
+}
+
+function readDiskCache(): { data: unknown; fetchedAt: number } | null {
+  try {
+    const raw = readFileSync(getCachePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed?.fetchedAt && Array.isArray(parsed?.data)) return parsed;
+  } catch { /* no cache or corrupt */ }
+  return null;
+}
+
+function writeDiskCache(data: unknown, fetchedAt: number): void {
+  try {
+    writeFileSync(getCachePath(), JSON.stringify({ data, fetchedAt }));
+  } catch { /* ignore write failures */ }
+}
+
+const CURRENCY_TO_COUNTRY: Record<string, string> = {
+  USD: "US", EUR: "EU", GBP: "GB", JPY: "JP", CAD: "CA",
+  AUD: "AU", CHF: "CH", CNY: "CN", NZD: "NZ", SEK: "SE",
+  All: "--",
+};
+
+function resolveCountry(currency: string): string {
+  return CURRENCY_TO_COUNTRY[currency] ?? currency.slice(0, 2);
+}
+
+function resolveImpact(raw: string): EconImpact {
+  const lower = raw.toLowerCase();
+  if (lower === "high") return "high";
+  if (lower === "medium") return "medium";
+  return "low";
+}
+
+interface RawCalendarEvent {
+  title: string;
+  country: string;
+  date: string;
+  impact: string;
+  forecast: string;
+  previous: string;
+}
+
+export function parseCalendarJson(data: unknown): EconEvent[] {
+  if (!Array.isArray(data)) return [];
+
+  return data
+    .filter((entry: any) => entry?.title && entry?.date)
+    .filter((entry: any) => entry.impact !== "Holiday")
+    .map((entry: any, idx: number): EconEvent => {
+      const raw = entry as RawCalendarEvent;
+      const date = new Date(raw.date);
+      const hours = date.getHours().toString().padStart(2, "0");
+      const minutes = date.getMinutes().toString().padStart(2, "0");
+      const time = `${hours}:${minutes}`;
+
+      return {
+        id: `ff-${idx}`,
+        date,
+        time,
+        country: resolveCountry(raw.country),
+        event: raw.title,
+        actual: null, // ForexFactory this-week feed doesn't include actuals
+        forecast: raw.forecast || null,
+        prior: raw.previous || null,
+        impact: resolveImpact(raw.impact),
+      };
+    });
+}
+
+export async function fetchEconCalendar(): Promise<EconEvent[]> {
+  // Try disk cache first
+  const cached = readDiskCache();
+  if (cached && Date.now() - cached.fetchedAt < DISK_CACHE_TTL_MS) {
+    return parseCalendarJson(cached.data);
+  }
+
+  try {
+    const data = await calendarClient.fetchJson(CALENDAR_URL);
+    writeDiskCache(data, Date.now());
+    return parseCalendarJson(data);
+  } catch (err) {
+    // If fetch fails but we have stale cache, use it
+    if (cached) {
+      return parseCalendarJson(cached.data);
+    }
+    throw err;
+  }
+}

--- a/src/plugins/builtin/econ/fred-client.test.ts
+++ b/src/plugins/builtin/econ/fred-client.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { resolveFredMapping, getFredSeriesId, getRelatedTickers } from "./fred-series-map";
+
+describe("resolveFredMapping", () => {
+  test("maps exact US event titles", () => {
+    const m = resolveFredMapping("CPI m/m", "US");
+    expect(m).not.toBeNull();
+    expect(m!.seriesId).toBe("CPIAUCSL");
+    expect(m!.relatedTickers).toContain("TIP");
+  });
+
+  test("case insensitive matching", () => {
+    expect(resolveFredMapping("cpi m/m", "US")?.seriesId).toBe("CPIAUCSL");
+    expect(resolveFredMapping("CPI M/M", "US")?.seriesId).toBe("CPIAUCSL");
+  });
+
+  test("strips prefixes for fuzzy match", () => {
+    expect(resolveFredMapping("Final GDP q/q", "US")?.seriesId).toBe("GDP");
+    expect(resolveFredMapping("Prelim GDP q/q", "US")?.seriesId).toBe("GDP");
+    expect(resolveFredMapping("Advance GDP q/q", "US")?.seriesId).toBe("GDP");
+  });
+
+  test("returns null for non-US events", () => {
+    expect(resolveFredMapping("CPI m/m", "EU")).toBeNull();
+    expect(resolveFredMapping("CPI m/m", "GB")).toBeNull();
+  });
+
+  test("returns null for unmapped events", () => {
+    expect(resolveFredMapping("President Trump Speaks", "US")).toBeNull();
+    expect(resolveFredMapping("Bank Holiday", "US")).toBeNull();
+  });
+
+  test("maps FOMC and Fed events", () => {
+    expect(resolveFredMapping("Federal Funds Rate", "US")?.seriesId).toBe("FEDFUNDS");
+  });
+
+  test("maps commodity indicators", () => {
+    expect(resolveFredMapping("Crude Oil Inventories", "US")?.seriesId).toBe("WCOILWTICO");
+    expect(resolveFredMapping("Natural Gas Storage", "US")?.seriesId).toBe("NATURALGAS");
+  });
+});
+
+describe("getFredSeriesId", () => {
+  test("returns series ID for known events", () => {
+    expect(getFredSeriesId("Unemployment Rate", "US")).toBe("UNRATE");
+  });
+
+  test("returns null for unknown events", () => {
+    expect(getFredSeriesId("Some Random Event", "US")).toBeNull();
+  });
+});
+
+describe("getRelatedTickers", () => {
+  test("returns related tickers for known events", () => {
+    const tickers = getRelatedTickers("CPI m/m", "US");
+    expect(tickers).toContain("TIP");
+    expect(tickers).toContain("DX-Y.NYB");
+  });
+
+  test("returns empty array for unknown events", () => {
+    expect(getRelatedTickers("Unknown Event", "US")).toEqual([]);
+  });
+});

--- a/src/plugins/builtin/econ/fred-client.ts
+++ b/src/plugins/builtin/econ/fred-client.ts
@@ -1,0 +1,79 @@
+import { createThrottledFetch, type ThrottledFetchClient } from "../../../utils/throttled-fetch";
+
+const FRED_BASE = "https://api.stlouisfed.org/fred";
+
+// FRED free tier: 120 requests per minute, but be conservative
+const fredFetch = createThrottledFetch({
+  requestsPerMinute: 30,
+  maxRetries: 2,
+  timeoutMs: 15_000,
+});
+
+export interface FredObservation {
+  date: string;       // "2024-01-01"
+  value: number | null; // null for missing/revised data
+}
+
+export interface FredSeriesInfo {
+  id: string;
+  title: string;
+  units: string;
+  frequency: string;
+  seasonalAdjustment: string;
+  source: string;
+  notes: string;
+}
+
+export async function fetchFredObservations(
+  apiKey: string,
+  seriesId: string,
+  options?: { startDate?: string; endDate?: string; limit?: number; sortOrder?: "asc" | "desc" },
+): Promise<FredObservation[]> {
+  const params = new URLSearchParams({
+    series_id: seriesId,
+    api_key: apiKey,
+    file_type: "json",
+    sort_order: options?.sortOrder ?? "desc",
+  });
+  if (options?.startDate) params.set("observation_start", options.startDate);
+  if (options?.endDate) params.set("observation_end", options.endDate);
+  if (options?.limit) params.set("limit", String(options.limit));
+
+  const url = `${FRED_BASE}/series/observations?${params}`;
+  const data = await fredFetch.fetchJson<any>(url);
+
+  if (!Array.isArray(data?.observations)) return [];
+
+  return data.observations
+    .map((obs: any) => ({
+      date: obs.date,
+      value: obs.value === "." ? null : parseFloat(obs.value),
+    }))
+    .filter((obs: FredObservation) => obs.value !== null && !isNaN(obs.value as number));
+}
+
+export async function fetchFredSeriesInfo(
+  apiKey: string,
+  seriesId: string,
+): Promise<FredSeriesInfo | null> {
+  const params = new URLSearchParams({
+    series_id: seriesId,
+    api_key: apiKey,
+    file_type: "json",
+  });
+  const url = `${FRED_BASE}/series?${params}`;
+  const data = await fredFetch.fetchJson<any>(url);
+
+  const series = data?.seriess?.[0];
+  if (!series) return null;
+
+  return {
+    id: series.id,
+    title: series.title ?? seriesId,
+    units: series.units ?? "",
+    frequency: series.frequency ?? "",
+    seasonalAdjustment: series.seasonal_adjustment ?? "",
+    source: "", // FRED doesn't include source in this endpoint
+    notes: series.notes ?? "",
+  };
+}

--- a/src/plugins/builtin/econ/fred-series-map.ts
+++ b/src/plugins/builtin/econ/fred-series-map.ts
@@ -1,0 +1,88 @@
+interface FredMapping {
+  seriesId: string;
+  /** How to display the value: "level" shows the raw number, "change" shows month-over-month or quarter-over-quarter percent change */
+  displayMode: "level" | "change";
+  relatedTickers: string[];
+}
+
+// Normalized event title → FRED mapping
+const SERIES_MAP: Record<string, FredMapping> = {
+  "cpi m/m": { seriesId: "CPIAUCSL", displayMode: "change", relatedTickers: ["TIP", "DX-Y.NYB", "^TNX"] },
+  "core cpi m/m": { seriesId: "CPILFESL", displayMode: "change", relatedTickers: ["TIP", "DX-Y.NYB", "^TNX"] },
+  "cpi y/y": { seriesId: "CPIAUCSL", displayMode: "level", relatedTickers: ["TIP", "DX-Y.NYB"] },
+  "core cpi y/y": { seriesId: "CPILFESL", displayMode: "level", relatedTickers: ["TIP", "DX-Y.NYB"] },
+  "ppi m/m": { seriesId: "PPIACO", displayMode: "change", relatedTickers: ["DX-Y.NYB"] },
+  "core pce price index m/m": { seriesId: "PCEPILFE", displayMode: "change", relatedTickers: ["TIP", "DX-Y.NYB", "^TNX"] },
+  "pce price index m/m": { seriesId: "PCEPI", displayMode: "change", relatedTickers: ["TIP", "DX-Y.NYB"] },
+  "final gdp q/q": { seriesId: "GDP", displayMode: "change", relatedTickers: ["SPY", "DX-Y.NYB"] },
+  "advance gdp q/q": { seriesId: "GDP", displayMode: "change", relatedTickers: ["SPY", "DX-Y.NYB"] },
+  "prelim gdp q/q": { seriesId: "GDP", displayMode: "change", relatedTickers: ["SPY", "DX-Y.NYB"] },
+  "gdp q/q": { seriesId: "GDP", displayMode: "change", relatedTickers: ["SPY", "DX-Y.NYB"] },
+  "unemployment rate": { seriesId: "UNRATE", displayMode: "level", relatedTickers: ["SPY", "DX-Y.NYB"] },
+  "unemployment claims": { seriesId: "ICSA", displayMode: "level", relatedTickers: ["SPY"] },
+  "non-farm employment change": { seriesId: "PAYEMS", displayMode: "change", relatedTickers: ["SPY", "DX-Y.NYB", "^TNX"] },
+  "adp non-farm employment change": { seriesId: "NPPTTL", displayMode: "change", relatedTickers: ["SPY"] },
+  "retail sales m/m": { seriesId: "RSAFS", displayMode: "change", relatedTickers: ["XRT", "SPY"] },
+  "core retail sales m/m": { seriesId: "RSFSXMV", displayMode: "change", relatedTickers: ["XRT", "SPY"] },
+  "ism manufacturing pmi": { seriesId: "NAPM", displayMode: "level", relatedTickers: ["SPY", "XLI"] },
+  "consumer confidence": { seriesId: "UMCSENT", displayMode: "level", relatedTickers: ["SPY"] },
+  "prelim uom consumer sentiment": { seriesId: "UMCSENT", displayMode: "level", relatedTickers: ["SPY"] },
+  "revised uom consumer sentiment": { seriesId: "UMCSENT", displayMode: "level", relatedTickers: ["SPY"] },
+  "cb consumer confidence": { seriesId: "CSCICP03USM665S", displayMode: "level", relatedTickers: ["SPY"] },
+  "federal funds rate": { seriesId: "FEDFUNDS", displayMode: "level", relatedTickers: ["^TNX", "TLT", "DX-Y.NYB"] },
+  "crude oil inventories": { seriesId: "WCOILWTICO", displayMode: "level", relatedTickers: ["CL=F", "USO"] },
+  "natural gas storage": { seriesId: "NATURALGAS", displayMode: "level", relatedTickers: ["NG=F", "UNG"] },
+  "housing starts": { seriesId: "HOUST", displayMode: "level", relatedTickers: ["XHB", "ITB"] },
+  "building permits": { seriesId: "PERMIT", displayMode: "level", relatedTickers: ["XHB", "ITB"] },
+  "existing home sales": { seriesId: "EXHOSLUSM495S", displayMode: "level", relatedTickers: ["XHB"] },
+  "new home sales": { seriesId: "HSN1F", displayMode: "level", relatedTickers: ["XHB", "ITB"] },
+  "durable goods orders m/m": { seriesId: "DGORDER", displayMode: "change", relatedTickers: ["XLI", "SPY"] },
+  "core durable goods orders m/m": { seriesId: "ADXTNO", displayMode: "change", relatedTickers: ["XLI"] },
+  "factory orders m/m": { seriesId: "AMTMNO", displayMode: "change", relatedTickers: ["XLI"] },
+  "trade balance": { seriesId: "BOPGSTB", displayMode: "level", relatedTickers: ["DX-Y.NYB"] },
+  "industrial production m/m": { seriesId: "INDPRO", displayMode: "change", relatedTickers: ["XLI", "SPY"] },
+  "capacity utilization rate": { seriesId: "TCU", displayMode: "level", relatedTickers: ["XLI"] },
+  "personal income m/m": { seriesId: "PI", displayMode: "change", relatedTickers: ["SPY"] },
+  "personal spending m/m": { seriesId: "PCE", displayMode: "change", relatedTickers: ["XRT", "SPY"] },
+  "current account": { seriesId: "NETFI", displayMode: "level", relatedTickers: ["DX-Y.NYB"] },
+  "import prices m/m": { seriesId: "IR", displayMode: "change", relatedTickers: ["DX-Y.NYB"] },
+  "export prices m/m": { seriesId: "IQ", displayMode: "change", relatedTickers: ["DX-Y.NYB"] },
+  "jolts job openings": { seriesId: "JTSJOL", displayMode: "level", relatedTickers: ["SPY"] },
+  "nonfarm productivity q/q": { seriesId: "OPHNFB", displayMode: "change", relatedTickers: ["SPY"] },
+  "unit labor costs q/q": { seriesId: "ULCNFB", displayMode: "change", relatedTickers: ["SPY", "^TNX"] },
+};
+
+function normalizeEventTitle(title: string): string {
+  return title.toLowerCase().trim();
+}
+
+export function resolveFredMapping(eventTitle: string, country: string): FredMapping | null {
+  // Only US events have FRED data
+  if (country !== "US" && country !== "USD") return null;
+
+  const normalized = normalizeEventTitle(eventTitle);
+
+  // Direct match
+  if (SERIES_MAP[normalized]) return SERIES_MAP[normalized];
+
+  // Fuzzy: try removing common prefixes
+  for (const prefix of ["final ", "prelim ", "revised ", "flash ", "advance "]) {
+    const stripped = normalized.startsWith(prefix) ? normalized.slice(prefix.length) : null;
+    if (stripped && SERIES_MAP[stripped]) return SERIES_MAP[stripped];
+  }
+
+  // Fuzzy: try partial match on key words
+  for (const [key, mapping] of Object.entries(SERIES_MAP)) {
+    if (normalized.includes(key) || key.includes(normalized)) return mapping;
+  }
+
+  return null;
+}
+
+export function getRelatedTickers(eventTitle: string, country: string): string[] {
+  return resolveFredMapping(eventTitle, country)?.relatedTickers ?? [];
+}
+
+export function getFredSeriesId(eventTitle: string, country: string): string | null {
+  return resolveFredMapping(eventTitle, country)?.seriesId ?? null;
+}

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -1,0 +1,983 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
+import type { GloomPlugin, PaneProps } from "../../../types/plugin";
+import { colors, hoverBg, blendHex } from "../../../theme/colors";
+import { getSharedRegistry } from "../../registry";
+import { fetchEconCalendar } from "./calendar-source";
+import type { EconEvent, EconImpact } from "./types";
+import { usePluginConfigState } from "../../plugin-runtime";
+import { resolveFredMapping } from "./fred-series-map";
+import { fetchFredObservations, fetchFredSeriesInfo, type FredObservation, type FredSeriesInfo } from "./fred-client";
+import { renderChart, resolveChartPalette, type StyledContent } from "../../../components/chart/chart-renderer";
+import type { ProjectedChartPoint } from "../../../components/chart/chart-data";
+import { useAppSelector } from "../../../state/app-context";
+
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+type ImpactFilter = "high" | "medium" | "low" | "all";
+type CountryFilter = "all" | "US" | "G7" | "EU";
+
+const FILTER_CYCLE: ImpactFilter[] = ["all", "high", "medium", "low"];
+const COUNTRY_CYCLE: CountryFilter[] = ["all", "US", "G7", "EU"];
+const G7_COUNTRIES = new Set(["US", "GB", "EU", "JP", "CA", "DE"]);
+
+const FLAG_MAP: Record<string, string> = {
+  US: "🇺🇸", GB: "🇬🇧", EU: "🇪🇺", JP: "🇯🇵", CA: "🇨🇦",
+  AU: "🇦🇺", CH: "🇨🇭", CN: "🇨🇳", NZ: "🇳🇿", SE: "🇸🇪", "--": "🌐",
+};
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
+
+function countryFlag(code: string): string {
+  return FLAG_MAP[code] ?? code;
+}
+
+function impactIndicator(impact: EconImpact): { text: string; color: string } {
+  switch (impact) {
+    case "high":
+      return { text: "●●●", color: colors.negative };
+    case "medium":
+      return { text: "●● ", color: colors.warning };
+    case "low":
+      return { text: "●  ", color: colors.textDim };
+  }
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function dayLabel(d: Date, today: Date): string {
+  const dk = dateKey(d);
+  const todayKey = dateKey(today);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  const dayName = DAY_NAMES[d.getDay()]!;
+  const monthName = MONTH_NAMES[d.getMonth()]!;
+  const dateNum = d.getDate();
+  const suffix = `${dayName} ${monthName} ${dateNum}`;
+
+  if (dk === todayKey) return `TODAY — ${suffix}`;
+  if (dk === dateKey(tomorrow)) return `TOMORROW — ${suffix}`;
+  if (dk === dateKey(yesterday)) return `YESTERDAY — ${suffix}`;
+  return suffix;
+}
+
+function matchesImpact(event: EconEvent, filter: ImpactFilter): boolean {
+  if (filter === "all") return true;
+  if (filter === "high") return event.impact === "high";
+  if (filter === "medium") return event.impact === "medium" || event.impact === "high";
+  return true; // "low" shows everything
+}
+
+function matchesCountry(event: EconEvent, filter: CountryFilter): boolean {
+  if (filter === "all") return true;
+  if (filter === "US") return event.country === "US";
+  if (filter === "G7") return G7_COUNTRIES.has(event.country);
+  if (filter === "EU") return event.country === "EU";
+  return true;
+}
+
+function formatCountdown(ms: number): string {
+  if (ms <= 60_000) return "in <1m";
+  const totalMin = Math.floor(ms / 60_000);
+  if (totalMin < 60) return `in ${totalMin}m`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m > 0 ? `in ${h}h ${m}m` : `in ${h}h`;
+}
+
+function formatStaleness(fetchedAt: number, now: number): string {
+  const elapsed = now - fetchedAt;
+  if (elapsed < 60_000) return "updated just now";
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 60) return `updated ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `updated ${hours}h ago`;
+}
+
+// Module-level cache shared across all pane instances and survives pane close/reopen
+let sharedCache: { data: EconEvent[]; fetchedAt: number } | null = null;
+let activeFetch: Promise<EconEvent[]> | null = null;
+
+async function loadCalendar(force = false): Promise<EconEvent[]> {
+  if (!force && sharedCache && Date.now() - sharedCache.fetchedAt < CACHE_TTL_MS) {
+    return sharedCache.data;
+  }
+  // Deduplicate concurrent fetches
+  if (activeFetch) return activeFetch;
+  activeFetch = fetchEconCalendar().then((data) => {
+    sharedCache = { data, fetchedAt: Date.now() };
+    activeFetch = null;
+    return data;
+  }).catch((err) => {
+    activeFetch = null;
+    throw err;
+  });
+  return activeFetch;
+}
+
+type DisplayRow =
+  | { kind: "separator"; label: string }
+  | { kind: "now" }
+  | { kind: "event"; event: EconEvent; eventIdx: number };
+
+// ---------------------------------------------------------------------------
+// Detail View — drills into a single economic indicator with FRED history
+// ---------------------------------------------------------------------------
+
+interface FredCache {
+  observations: FredObservation[];
+  info: FredSeriesInfo | null;
+}
+
+interface EconDetailViewProps {
+  event: EconEvent;
+  width: number;
+  height: number;
+  focused: boolean;
+  onBack: () => void;
+}
+
+function EconDetailView({ event, width, height, focused, onBack }: EconDetailViewProps) {
+  const [fredApiKey] = usePluginConfigState<string>("fredApiKey", "");
+  const cacheRef = useRef<Map<string, FredCache>>(new Map());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<FredCache | null>(null);
+  const [detailScrollOffset, setDetailScrollOffset] = useState(0);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  const mapping = useMemo(() => resolveFredMapping(event.event, event.country), [event.event, event.country]);
+
+  useEffect(() => {
+    if (!mapping) return;
+    if (!fredApiKey) return;
+
+    const cached = cacheRef.current.get(mapping.seriesId);
+    if (cached) {
+      setData(cached);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const fiveYearsAgo = new Date();
+    fiveYearsAgo.setFullYear(fiveYearsAgo.getFullYear() - 5);
+    const startDate = `${fiveYearsAgo.getFullYear()}-${String(fiveYearsAgo.getMonth() + 1).padStart(2, "0")}-${String(fiveYearsAgo.getDate()).padStart(2, "0")}`;
+
+    Promise.all([
+      fetchFredObservations(fredApiKey, mapping.seriesId, { startDate, sortOrder: "asc" }),
+      fetchFredSeriesInfo(fredApiKey, mapping.seriesId),
+    ])
+      .then(([observations, info]) => {
+        const entry: FredCache = { observations, info };
+        cacheRef.current.set(mapping.seriesId, entry);
+        setData(entry);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [mapping?.seriesId, fredApiKey]);
+
+  useKeyboard((ev) => {
+    if (!focused) return;
+    if (ev.name === "escape") {
+      onBack();
+      return;
+    }
+    if (ev.name === "j" || ev.name === "down") {
+      setDetailScrollOffset((prev) => prev + 1);
+    } else if (ev.name === "k" || ev.name === "up") {
+      setDetailScrollOffset((prev) => Math.max(0, prev - 1));
+    }
+  });
+
+  // No FRED mapping
+  if (!mapping) {
+    return (
+      <box flexDirection="column" width={width} height={height}>
+        <box height={1} paddingX={1} flexDirection="row">
+          <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+            {"◂ "}{event.event}
+          </text>
+        </box>
+        <box flexGrow={1} justifyContent="center" alignItems="center">
+          <text fg={colors.textMuted}>No historical data available for this indicator</text>
+        </box>
+        <box height={1} paddingX={1}>
+          <text fg={colors.textMuted}>Esc back</text>
+        </box>
+      </box>
+    );
+  }
+
+  // No API key
+  if (!fredApiKey) {
+    return (
+      <box flexDirection="column" width={width} height={height}>
+        <box height={1} paddingX={1} flexDirection="row">
+          <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+            {"◂ "}{event.event}
+          </text>
+          <box flexGrow={1} />
+          <text fg={colors.textDim}>{mapping.seriesId}</text>
+        </box>
+        <box flexGrow={1} justifyContent="center" alignItems="center">
+          <text fg={colors.textMuted}>Configure FRED API key: type 'Set FRED' in command bar</text>
+        </box>
+        <box height={1} paddingX={1}>
+          <text fg={colors.textMuted}>Esc back</text>
+        </box>
+      </box>
+    );
+  }
+
+  // Loading
+  if (loading) {
+    return (
+      <box flexDirection="column" width={width} height={height}>
+        <box height={1} paddingX={1} flexDirection="row">
+          <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+            {"◂ "}{event.event}
+          </text>
+          <box flexGrow={1} />
+          <text fg={colors.textDim}>{mapping.seriesId}</text>
+        </box>
+        <box flexGrow={1} justifyContent="center" alignItems="center">
+          <text fg={colors.textMuted}>Loading...</text>
+        </box>
+        <box height={1} paddingX={1}>
+          <text fg={colors.textMuted}>Esc back</text>
+        </box>
+      </box>
+    );
+  }
+
+  // Error
+  if (error) {
+    return (
+      <box flexDirection="column" width={width} height={height}>
+        <box height={1} paddingX={1} flexDirection="row">
+          <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+            {"◂ "}{event.event}
+          </text>
+          <box flexGrow={1} />
+          <text fg={colors.textDim}>{mapping.seriesId}</text>
+        </box>
+        <box flexGrow={1} justifyContent="center" alignItems="center">
+          <text fg={colors.negative}>{error}</text>
+        </box>
+        <box height={1} paddingX={1}>
+          <text fg={colors.textMuted}>Esc back</text>
+        </box>
+      </box>
+    );
+  }
+
+  if (!data) return null;
+
+  const { observations, info } = data;
+  const chartWidth = Math.max(10, width - 2);
+  const chartHeight = Math.min(16, Math.max(8, Math.floor(height * 0.3)));
+
+  // Build chart points (ascending order for chart), exclude null values
+  const chartPoints: ProjectedChartPoint[] = observations
+    .filter((obs): obs is FredObservation & { value: number } => obs.value != null)
+    .map((obs) => ({
+      date: new Date(obs.date),
+      open: obs.value,
+      high: obs.value,
+      low: obs.value,
+      close: obs.value,
+      volume: 0,
+    }));
+
+  const palette = resolveChartPalette(colors, "positive");
+
+  let chartResult: ReturnType<typeof renderChart> | null = null;
+  if (chartPoints.length >= 2) {
+    chartResult = renderChart(chartPoints, {
+      width: chartWidth,
+      height: chartHeight,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "area",
+      colors: palette,
+      timeAxisDates: chartPoints.map((p) => p.date),
+    });
+  }
+
+  // Table rows (descending for display, last 12)
+  // For "change" mode, compute m/m or q/q percent change from consecutive observations
+  const descObs = [...observations].reverse();
+  const ascObs = observations; // already ascending from FRED
+  const tableRows = descObs.slice(0, 12).map((obs, i) => {
+    if (mapping.displayMode !== "change" || obs.value == null) {
+      return { date: obs.date, display: obs.value != null ? obs.value.toLocaleString("en-US", { maximumFractionDigits: 1 }) : "—" };
+    }
+    // Find the prior observation in ascending order
+    const ascIdx = ascObs.findIndex((o) => o.date === obs.date);
+    if (ascIdx > 0 && ascObs[ascIdx - 1]!.value != null) {
+      const prior = ascObs[ascIdx - 1]!.value!;
+      const pct = ((obs.value - prior) / Math.abs(prior)) * 100;
+      return { date: obs.date, display: `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%` };
+    }
+    return { date: obs.date, display: obs.value.toLocaleString("en-US", { maximumFractionDigits: 1 }) };
+  });
+  const units = info?.units ?? "";
+  const source = info?.source || "";
+  const title = info?.title ?? event.event;
+
+  // Value color for table rows
+  const valueColor = (display: string): string => {
+    if (display.startsWith("+")) return colors.positive;
+    if (display.startsWith("-")) return colors.negative;
+    return colors.text;
+  };
+
+  const dateColWidth = 14;
+  const valueColWidth = Math.max(14, Math.floor((width - 4) * 0.3));
+  const separatorLine = "─".repeat(Math.max(0, width - 2));
+
+  return (
+    <box flexDirection="column" width={width} height={height}>
+      {/* Header */}
+      <box height={1} paddingX={1} flexDirection="row">
+        <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+          {"◂ "}{title}
+        </text>
+        <box flexGrow={1} />
+        <text fg={colors.textDim}>{mapping.seriesId}</text>
+      </box>
+      <box height={1} paddingX={1} flexDirection="row">
+        <text fg={colors.textMuted}>
+          {[units, info?.frequency, info?.seasonalAdjustment].filter(Boolean).join(" · ")}
+        </text>
+      </box>
+
+      {/* Event context — scheduled time, forecast, prior */}
+      <box paddingX={1} flexDirection="row" height={1}>
+        <text fg={colors.textDim}>Scheduled: </text>
+        <text fg={colors.text}>{event.time}</text>
+        {event.forecast ? (
+          <>
+            <text fg={colors.textDim}>  Forecast: </text>
+            <text fg={colors.text}>{event.forecast}</text>
+          </>
+        ) : null}
+        {event.prior ? (
+          <>
+            <text fg={colors.textDim}>  Prior: </text>
+            <text fg={colors.text}>{event.prior}</text>
+          </>
+        ) : null}
+      </box>
+
+      {/* Scrollable content */}
+      <scrollbox ref={scrollRef} flexGrow={1} scrollY focusable={false}>
+        <box flexDirection="column">
+          {/* Chart */}
+          {chartResult ? (
+            <box flexDirection="column" paddingX={1} marginTop={1}>
+              <box flexDirection="column" height={chartHeight} backgroundColor={palette.bgColor}>
+                {chartResult.lines.map((line, i) => (
+                  <text key={i} content={line} />
+                ))}
+              </box>
+              <text fg={colors.textDim}>{chartResult.timeLabels}</text>
+            </box>
+          ) : (
+            <box paddingX={1} marginTop={1}>
+              <text fg={colors.textMuted}>Not enough data for chart</text>
+            </box>
+          )}
+
+          {/* Separator */}
+          <box paddingX={1} height={1} marginTop={1}>
+            <text fg={colors.border}>{separatorLine}</text>
+          </box>
+
+          {/* Historical readings */}
+          <box paddingX={1} height={1}>
+            <text fg={colors.textBright} attributes={TextAttributes.BOLD}>HISTORICAL READINGS</text>
+          </box>
+          <box paddingX={1} flexDirection="row" height={1}>
+            <box width={dateColWidth}>
+              <text fg={colors.textDim}>DATE</text>
+            </box>
+            <box width={valueColWidth} justifyContent="flex-end">
+              <text fg={colors.textDim}>VALUE</text>
+            </box>
+          </box>
+          {tableRows.map((row) => (
+            <box key={row.date} paddingX={1} flexDirection="row" height={1}>
+              <box width={dateColWidth}>
+                <text fg={colors.textDim}>{row.date}</text>
+              </box>
+              <box width={valueColWidth} justifyContent="flex-end">
+                <text fg={valueColor(row.display)}>{row.display}</text>
+              </box>
+            </box>
+          ))}
+
+          {/* Separator */}
+          {mapping.relatedTickers.length > 0 ? (
+            <box paddingX={1} height={1} marginTop={1}>
+              <text fg={colors.border}>{separatorLine}</text>
+            </box>
+          ) : null}
+
+          {/* Related tickers */}
+          {mapping.relatedTickers.length > 0 ? (
+            <box paddingX={1} height={1} flexDirection="row">
+              <text fg={colors.textDim}>Related: </text>
+              {mapping.relatedTickers.map((ticker, i) => (
+                <box
+                  key={ticker}
+                  marginLeft={i > 0 ? 2 : 0}
+                  onMouseDown={() => {
+                    getSharedRegistry()?.navigateTickerFn(ticker);
+                  }}
+                >
+                  <text fg={colors.textBright} attributes={TextAttributes.UNDERLINE}>{ticker}</text>
+                </box>
+              ))}
+            </box>
+          ) : null}
+        </box>
+      </scrollbox>
+
+      {/* Footer */}
+      <box height={1} paddingX={1}>
+        <text fg={colors.textMuted}>Esc back · j/k scroll</text>
+      </box>
+    </box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for actual value beat/miss coloring
+// ---------------------------------------------------------------------------
+
+function parseNumeric(value: string | null): number | null {
+  if (!value) return null;
+  const cleaned = value.replace(/[%,KMBTkmbts]/g, "").trim();
+  const n = parseFloat(cleaned);
+  return isNaN(n) ? null : n;
+}
+
+function actualColor(actual: string | null, forecast: string | null): string {
+  const a = parseNumeric(actual);
+  const f = parseNumeric(forecast);
+  if (a === null || f === null) return colors.text;
+  if (a > f) return colors.positive;
+  if (a < f) return colors.negative;
+  return colors.text;
+}
+
+// ---------------------------------------------------------------------------
+// Main Calendar Pane
+// ---------------------------------------------------------------------------
+
+export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
+  const [events, setEvents] = useState<EconEvent[]>(sharedCache?.data ?? []);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [impactFilter, setImpactFilter] = useState<ImpactFilter>("all");
+  const [countryFilter, setCountryFilter] = useState<CountryFilter>("all");
+  const [now, setNow] = useState(Date.now());
+  const [detailEvent, setDetailEvent] = useState<EconEvent | null>(null);
+
+  const fetchGenRef = useRef(0);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const backfilledSeriesRef = useRef<Set<string>>(new Set());
+
+  const config = useAppSelector((s) => s.config);
+  const fredApiKey = config.pluginConfig?.["econ-calendar"]?.fredApiKey as string | undefined;
+
+  const load = async (force = false) => {
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await loadCalendar(force);
+      if (fetchGenRef.current !== gen) return;
+      setEvents(data);
+      if (force) setSelectedIdx(0);
+    } catch (err) {
+      if (fetchGenRef.current !== gen) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (fetchGenRef.current === gen) setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (sharedCache && Date.now() - sharedCache.fetchedAt < CACHE_TTL_MS) {
+      setEvents(sharedCache.data);
+      return;
+    }
+    load();
+  }, []);
+
+  // Tick every 30s to update staleness + countdown
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Backfill actual values for past US events using FRED
+  useEffect(() => {
+    if (!fredApiKey || events.length === 0) return;
+
+    const nowTs = Date.now();
+    const pastEvents = events.filter(
+      (ev) =>
+        ev.date.getTime() < nowTs &&
+        ev.actual === null &&
+        resolveFredMapping(ev.event, ev.country),
+    );
+
+    // Group by series ID to deduplicate fetches
+    const seriesGroups = new Map<string, { mapping: ReturnType<typeof resolveFredMapping>; events: EconEvent[] }>();
+    for (const ev of pastEvents) {
+      const mapping = resolveFredMapping(ev.event, ev.country)!;
+      if (backfilledSeriesRef.current.has(mapping.seriesId)) continue;
+      const group = seriesGroups.get(mapping.seriesId);
+      if (group) {
+        group.events.push(ev);
+      } else {
+        seriesGroups.set(mapping.seriesId, { mapping, events: [ev] });
+      }
+    }
+
+    if (seriesGroups.size === 0) return;
+
+    (async () => {
+      const results = await Promise.allSettled(
+        [...seriesGroups.entries()].map(async ([seriesId, { mapping }]) => {
+          const obs = await fetchFredObservations(fredApiKey, seriesId, {
+            limit: mapping!.displayMode === "change" ? 2 : 1,
+            sortOrder: "desc",
+          });
+          backfilledSeriesRef.current.add(seriesId);
+          if (obs.length === 0 || obs[0]!.value === null) return null;
+
+          let formatted: string;
+          if (mapping!.displayMode === "change" && obs.length >= 2 && obs[1]!.value) {
+            // Compute month-over-month percent change
+            const current = obs[0]!.value!;
+            const prior = obs[1]!.value!;
+            const pctChange = ((current - prior) / Math.abs(prior)) * 100;
+            formatted = `${pctChange >= 0 ? "" : "-"}${Math.abs(pctChange).toFixed(1)}%`;
+          } else {
+            const value = obs[0]!.value!;
+            formatted = value.toLocaleString("en-US", { maximumFractionDigits: 1 });
+          }
+          return { seriesId, formatted };
+        }),
+      );
+
+      const actuals = new Map<string, string>();
+      for (const result of results) {
+        if (result.status === "fulfilled" && result.value) {
+          actuals.set(result.value.seriesId, result.value.formatted);
+        }
+      }
+
+      if (actuals.size === 0) return;
+
+      setEvents((prev) =>
+        prev.map((ev) => {
+          if (ev.actual !== null) return ev;
+          const mapping = resolveFredMapping(ev.event, ev.country);
+          if (!mapping) return ev;
+          const actual = actuals.get(mapping.seriesId);
+          if (!actual) return ev;
+          return { ...ev, actual };
+        }),
+      );
+    })();
+  }, [events, fredApiKey]);
+
+  const filtered = events.filter(
+    (ev) => matchesImpact(ev, impactFilter) && matchesCountry(ev, countryFilter),
+  );
+
+  // Build display rows with separator headers and NOW marker
+  const today = new Date(now);
+  const rows: DisplayRow[] = [];
+  let lastDateKey = "";
+  let nowInserted = false;
+
+  for (let i = 0; i < filtered.length; i++) {
+    const ev = filtered[i]!;
+    const dk = dateKey(ev.date);
+
+    // Insert date separator if new day
+    if (dk !== lastDateKey) {
+      lastDateKey = dk;
+      rows.push({ kind: "separator", label: dayLabel(ev.date, today) });
+    }
+
+    // Insert NOW marker between last past event and first upcoming event
+    if (!nowInserted && ev.date.getTime() > now) {
+      nowInserted = true;
+      rows.push({ kind: "now" });
+    }
+
+    rows.push({ kind: "event", event: ev, eventIdx: i });
+  }
+
+  // Map from eventIdx to flat row index (for scroll tracking)
+  const eventIdxToRowIdx = new Map<number, number>();
+  let nowRowIdx = -1;
+  let firstUpcomingEventIdx = -1;
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r]!;
+    if (row.kind === "event") {
+      eventIdxToRowIdx.set(row.eventIdx, r);
+      if (firstUpcomingEventIdx === -1 && row.event.date.getTime() > now) {
+        firstUpcomingEventIdx = row.eventIdx;
+      }
+    } else if (row.kind === "now") {
+      nowRowIdx = r;
+    }
+  }
+
+  // On initial load, scroll to NOW and select the first upcoming event
+  const initialScrollDone = useRef(false);
+  useEffect(() => {
+    if (initialScrollDone.current || filtered.length === 0) return;
+    if (firstUpcomingEventIdx >= 0) {
+      setSelectedIdx(firstUpcomingEventIdx);
+    }
+    const sb = scrollRef.current;
+    if (sb?.viewport && nowRowIdx >= 0) {
+      // Position NOW a few rows from the top so you can see context
+      const scrollTarget = Math.max(0, nowRowIdx - 3);
+      sb.scrollTo(scrollTarget);
+    }
+    initialScrollDone.current = true;
+  }, [filtered.length]);
+
+  // Next upcoming event for countdown
+  const nextEvent = filtered.find((ev) => ev.date.getTime() > now);
+  const nextCountdown = nextEvent ? formatCountdown(nextEvent.date.getTime() - now) : null;
+
+  useKeyboard((event) => {
+    if (!focused) return;
+
+    // Detail mode handles its own keys
+    if (detailEvent) return;
+
+    if (event.name === "j" || event.name === "down") {
+      setSelectedIdx((prev) => Math.min(prev + 1, filtered.length - 1));
+    } else if (event.name === "k" || event.name === "up") {
+      setSelectedIdx((prev) => Math.max(prev - 1, 0));
+    } else if (event.name === "return") {
+      const ev = filtered[selectedIdx];
+      if (ev) setDetailEvent(ev);
+    } else if (event.name === "r") {
+      load(true);
+    } else if (event.name === "f") {
+      setImpactFilter((prev) => {
+        const idx = FILTER_CYCLE.indexOf(prev);
+        return FILTER_CYCLE[(idx + 1) % FILTER_CYCLE.length]!;
+      });
+      setSelectedIdx(0);
+    } else if (event.name === "c") {
+      setCountryFilter((prev) => {
+        const idx = COUNTRY_CYCLE.indexOf(prev);
+        return COUNTRY_CYCLE[(idx + 1) % COUNTRY_CYCLE.length]!;
+      });
+      setSelectedIdx(0);
+    } else if (event.name === "escape") {
+      close?.();
+    }
+  });
+
+  // Scroll to keep selected row visible
+  useEffect(() => {
+    const sb = scrollRef.current;
+    if (!sb?.viewport || filtered.length === 0 || selectedIdx < 0) return;
+    const flatIdx = eventIdxToRowIdx.get(selectedIdx) ?? selectedIdx;
+    const viewportHeight = Math.max(sb.viewport.height, 1);
+    if (flatIdx < sb.scrollTop) {
+      sb.scrollTo(flatIdx);
+    } else if (flatIdx >= sb.scrollTop + viewportHeight) {
+      sb.scrollTo(flatIdx - viewportHeight + 1);
+    }
+  }, [selectedIdx, filtered.length]);
+
+  // Column widths
+  const timeWidth = 6;
+  const impactWidth = 4;
+  const flagWidth = 3;
+  const actualWidth = 9;
+  const forecastWidth = 10;
+  const priorWidth = 9;
+  const minEventWidth = 12;
+  const eventWidth = Math.max(
+    minEventWidth,
+    width - timeWidth - impactWidth - flagWidth - actualWidth - forecastWidth - priorWidth - 2,
+  );
+
+  const separatorBg = blendHex(colors.bg, colors.border, 0.3);
+  const staleness = sharedCache ? formatStaleness(sharedCache.fetchedAt, now) : "";
+
+  if (detailEvent) {
+    return (
+      <EconDetailView
+        event={detailEvent}
+        width={width}
+        height={height}
+        focused={focused}
+        onBack={() => setDetailEvent(null)}
+      />
+    );
+  }
+
+  return (
+    <box flexDirection="column" width={width} height={height}>
+      {/* Header */}
+      <box flexDirection="row" height={1} paddingX={1}>
+        <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+          Economic Calendar
+        </text>
+        <box marginLeft={1}>
+          <text fg={colors.textDim}>[{impactFilter}]</text>
+        </box>
+        <box marginLeft={0}>
+          <text fg={colors.textDim}>[{countryFilter}]</text>
+        </box>
+        <box marginLeft={1}>
+          <text fg={colors.textMuted}>{filtered.length} events</text>
+        </box>
+        {nextEvent && nextCountdown && (
+          <box marginLeft={1}>
+            <text fg={colors.textMuted}>
+              Next: {nextEvent.event.length > 16 ? nextEvent.event.slice(0, 16).trimEnd() : nextEvent.event} {nextCountdown}
+            </text>
+          </box>
+        )}
+        {loading && (
+          <box marginLeft={1}>
+            <text fg={colors.textMuted}>loading…</text>
+          </box>
+        )}
+        <box flexGrow={1} />
+        {staleness ? <text fg={colors.textMuted}>{staleness}</text> : null}
+      </box>
+
+      {/* Column headers */}
+      <box flexDirection="row" paddingX={1} height={1}>
+        <box width={timeWidth}>
+          <text fg={colors.textDim}>TIME</text>
+        </box>
+        <box width={impactWidth}>
+          <text fg={colors.textDim}>IMP</text>
+        </box>
+        <box width={flagWidth}>
+          <text fg={colors.textDim}>🏳</text>
+        </box>
+        <box width={eventWidth} flexShrink={1}>
+          <text fg={colors.textDim}>EVENT</text>
+        </box>
+        <box width={actualWidth} justifyContent="flex-end" paddingRight={1}>
+          <text fg={colors.textDim}>ACTUAL</text>
+        </box>
+        <box width={forecastWidth} justifyContent="flex-end" paddingRight={1}>
+          <text fg={colors.textDim}>FORECAST</text>
+        </box>
+        <box width={priorWidth} justifyContent="flex-end">
+          <text fg={colors.textDim}>PRIOR</text>
+        </box>
+      </box>
+
+      {/* Error state */}
+      {error && (
+        <box paddingX={1} paddingY={1}>
+          <text fg={colors.negative}>Error: {error}</text>
+        </box>
+      )}
+
+      {/* Rows */}
+      <scrollbox ref={scrollRef} flexGrow={1} scrollY focusable={false}>
+        <box flexDirection="column">
+          {rows.map((row, flatIdx) => {
+            if (row.kind === "separator") {
+              return (
+                <box
+                  key={`sep-${flatIdx}`}
+                  flexDirection="row"
+                  width={width}
+                  backgroundColor={separatorBg}
+                  paddingX={1}
+                  height={1}
+                >
+                  <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+                    {row.label}
+                  </text>
+                </box>
+              );
+            }
+
+            if (row.kind === "now") {
+              const lineChar = "─";
+              const label = " ▸ NOW ";
+              const remaining = Math.max(0, width - label.length - 2);
+              const line = lineChar.repeat(remaining);
+              return (
+                <box
+                  key={`now-${flatIdx}`}
+                  flexDirection="row"
+                  width={width}
+                  paddingX={1}
+                  height={1}
+                >
+                  <text fg={colors.warning}>{label}{line}</text>
+                </box>
+              );
+            }
+
+            const { event: ev, eventIdx } = row;
+            const isSelected = eventIdx === selectedIdx;
+            const isHovered = eventIdx === hoveredIdx;
+            const bg = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
+            const fg = isSelected ? colors.selectedText : colors.text;
+            const indicator = impactIndicator(ev.impact);
+            const flag = countryFlag(ev.country);
+
+            return (
+              <box
+                key={`${ev.id}-${flatIdx}`}
+                flexDirection="row"
+                width={width}
+                backgroundColor={bg}
+                paddingX={1}
+                onMouseMove={() => setHoveredIdx(eventIdx)}
+                onMouseOut={() => setHoveredIdx(null)}
+                onMouseDown={(mouseEvent: any) => {
+                  mouseEvent.preventDefault?.();
+                  if (selectedIdx === eventIdx) {
+                    setDetailEvent(ev);
+                  } else {
+                    setSelectedIdx(eventIdx);
+                  }
+                }}
+              >
+                <box width={timeWidth} flexShrink={0}>
+                  <text fg={isSelected ? colors.selectedText : colors.textMuted}>{ev.time}</text>
+                </box>
+                <box width={impactWidth} flexShrink={0}>
+                  <text fg={isSelected ? colors.selectedText : indicator.color}>{indicator.text}</text>
+                </box>
+                <box width={flagWidth} flexShrink={0}>
+                  <text>{flag}</text>
+                </box>
+                <box width={eventWidth} flexShrink={1} overflow="hidden">
+                  <text fg={fg}>{ev.event}</text>
+                </box>
+                <box width={actualWidth} justifyContent="flex-end" paddingRight={1}>
+                  <text fg={isSelected ? colors.selectedText : actualColor(ev.actual, ev.forecast)}>
+                    {ev.actual ?? "—"}
+                  </text>
+                </box>
+                <box width={forecastWidth} justifyContent="flex-end" paddingRight={1}>
+                  <text fg={isSelected ? colors.selectedText : colors.textDim}>{ev.forecast ?? "—"}</text>
+                </box>
+                <box width={priorWidth} justifyContent="flex-end">
+                  <text fg={isSelected ? colors.selectedText : colors.textDim}>{ev.prior ?? "—"}</text>
+                </box>
+              </box>
+            );
+          })}
+
+          {!loading && !error && filtered.length === 0 && (
+            <box paddingX={1} paddingY={1}>
+              <text fg={colors.textMuted}>
+                No events{impactFilter !== "all" ? ` for impact: ${impactFilter}` : ""}{countryFilter !== "all" ? ` for country: ${countryFilter}` : ""}
+              </text>
+            </box>
+          )}
+        </box>
+      </scrollbox>
+
+      <box height={1} paddingX={1}>
+        <text fg={colors.textMuted}>j/k navigate · [f]ilter · [c]ountry · [r]efresh · Enter detail · Esc close</text>
+      </box>
+    </box>
+  );
+}
+
+export const econCalendarPlugin: GloomPlugin = {
+  id: "econ-calendar",
+  name: "Economic Calendar",
+  version: "1.0.0",
+  description: "Upcoming economic events and releases",
+  toggleable: true,
+
+  setup(ctx) {
+    ctx.registerCommand({
+      id: "econ-set-fred-key",
+      label: "Set FRED API Key",
+      keywords: ["fred", "api", "key", "economic", "econ", "configure", "setup"],
+      category: "config",
+      description: "Configure your free FRED API key for historical economic data (fred.stlouisfed.org)",
+      wizard: [
+        {
+          key: "apiKey",
+          label: "FRED API Key",
+          placeholder: "Paste your FRED API key",
+          type: "password",
+        },
+      ],
+      async execute(values) {
+        const key = values?.apiKey?.trim();
+        if (!key) return;
+        await ctx.configState.set("fredApiKey", key);
+        ctx.notify({ body: "FRED API key saved", type: "success" });
+      },
+    });
+  },
+
+  panes: [
+    {
+      id: "econ-calendar",
+      name: "Economic Calendar",
+      icon: "E",
+      component: EconCalendarPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 30 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "econ-calendar-pane",
+      paneId: "econ-calendar",
+      label: "Economic Calendar",
+      description: "Upcoming economic events, releases, and indicators.",
+      keywords: ["econ", "economic", "calendar", "events", "macro", "releases", "fed", "cpi", "gdp"],
+      shortcut: { prefix: "ECON" },
+    },
+  ],
+};

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -1,17 +1,20 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { StyledText, TextAttributes, type ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
+import { DataTable, PageStackView, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
-import { colors, hoverBg, blendHex } from "../../../theme/colors";
-import { getSharedRegistry } from "../../registry";
-import { fetchEconCalendar } from "./calendar-source";
+import { colors, blendHex } from "../../../theme/colors";
+import {
+  attachEconCalendarPersistence,
+  fetchEconCalendar,
+  resetEconCalendarPersistence,
+} from "./calendar-source";
 import type { EconEvent, EconImpact } from "./types";
-import { usePluginConfigState } from "../../plugin-runtime";
+import { usePluginConfigState, usePluginTickerActions } from "../../plugin-runtime";
 import { resolveFredMapping } from "./fred-series-map";
 import { fetchFredObservations, fetchFredSeriesInfo, type FredObservation, type FredSeriesInfo } from "./fred-client";
 import { renderChart, resolveChartPalette, type StyledContent } from "../../../components/chart/chart-renderer";
 import type { ProjectedChartPoint } from "../../../components/chart/chart-data";
-import { useAppSelector } from "../../../state/app-context";
 
 const CACHE_TTL_MS = 15 * 60 * 1000;
 
@@ -123,9 +126,19 @@ async function loadCalendar(force = false): Promise<EconEvent[]> {
 }
 
 type DisplayRow =
-  | { kind: "separator"; label: string }
-  | { kind: "now" }
-  | { kind: "event"; event: EconEvent; eventIdx: number };
+  | { kind: "separator"; key: string; label: string }
+  | { kind: "now"; key: string }
+  | { kind: "event"; key: string; event: EconEvent; eventIdx: number };
+
+type EconCalendarColumnId =
+  | "time"
+  | "impact"
+  | "country"
+  | "event"
+  | "actual"
+  | "forecast"
+  | "prior";
+type EconCalendarColumn = DataTableColumn & { id: EconCalendarColumnId };
 
 // ---------------------------------------------------------------------------
 // Detail View — drills into a single economic indicator with FRED history
@@ -141,16 +154,15 @@ interface EconDetailViewProps {
   width: number;
   height: number;
   focused: boolean;
-  onBack: () => void;
 }
 
-function EconDetailView({ event, width, height, focused, onBack }: EconDetailViewProps) {
+function EconDetailView({ event, width, height, focused }: EconDetailViewProps) {
   const [fredApiKey] = usePluginConfigState<string>("fredApiKey", "");
+  const { navigateTicker } = usePluginTickerActions();
   const cacheRef = useRef<Map<string, FredCache>>(new Map());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [data, setData] = useState<FredCache | null>(null);
-  const [detailScrollOffset, setDetailScrollOffset] = useState(0);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
 
   const mapping = useMemo(() => resolveFredMapping(event.event, event.country), [event.event, event.country]);
@@ -189,16 +201,23 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
       });
   }, [mapping?.seriesId, fredApiKey]);
 
+  const scrollDetailBy = useCallback((delta: number) => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const maxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
+    scrollBox.scrollTop = Math.max(0, Math.min(maxScrollTop, scrollBox.scrollTop + delta));
+  }, []);
+
   useKeyboard((ev) => {
     if (!focused) return;
-    if (ev.name === "escape") {
-      onBack();
-      return;
-    }
     if (ev.name === "j" || ev.name === "down") {
-      setDetailScrollOffset((prev) => prev + 1);
+      ev.stopPropagation?.();
+      ev.preventDefault?.();
+      scrollDetailBy(1);
     } else if (ev.name === "k" || ev.name === "up") {
-      setDetailScrollOffset((prev) => Math.max(0, prev - 1));
+      ev.stopPropagation?.();
+      ev.preventDefault?.();
+      scrollDetailBy(-1);
     }
   });
 
@@ -208,14 +227,11 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
       <box flexDirection="column" width={width} height={height}>
         <box height={1} paddingX={1} flexDirection="row">
           <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-            {"◂ "}{event.event}
+            {event.event}
           </text>
         </box>
         <box flexGrow={1} justifyContent="center" alignItems="center">
           <text fg={colors.textMuted}>No historical data available for this indicator</text>
-        </box>
-        <box height={1} paddingX={1}>
-          <text fg={colors.textMuted}>Esc back</text>
         </box>
       </box>
     );
@@ -227,16 +243,13 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
       <box flexDirection="column" width={width} height={height}>
         <box height={1} paddingX={1} flexDirection="row">
           <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-            {"◂ "}{event.event}
+            {event.event}
           </text>
           <box flexGrow={1} />
           <text fg={colors.textDim}>{mapping.seriesId}</text>
         </box>
         <box flexGrow={1} justifyContent="center" alignItems="center">
           <text fg={colors.textMuted}>Configure FRED API key: type 'Set FRED' in command bar</text>
-        </box>
-        <box height={1} paddingX={1}>
-          <text fg={colors.textMuted}>Esc back</text>
         </box>
       </box>
     );
@@ -248,16 +261,13 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
       <box flexDirection="column" width={width} height={height}>
         <box height={1} paddingX={1} flexDirection="row">
           <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-            {"◂ "}{event.event}
+            {event.event}
           </text>
           <box flexGrow={1} />
           <text fg={colors.textDim}>{mapping.seriesId}</text>
         </box>
         <box flexGrow={1} justifyContent="center" alignItems="center">
           <text fg={colors.textMuted}>Loading...</text>
-        </box>
-        <box height={1} paddingX={1}>
-          <text fg={colors.textMuted}>Esc back</text>
         </box>
       </box>
     );
@@ -269,16 +279,13 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
       <box flexDirection="column" width={width} height={height}>
         <box height={1} paddingX={1} flexDirection="row">
           <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-            {"◂ "}{event.event}
+            {event.event}
           </text>
           <box flexGrow={1} />
           <text fg={colors.textDim}>{mapping.seriesId}</text>
         </box>
         <box flexGrow={1} justifyContent="center" alignItems="center">
           <text fg={colors.negative}>{error}</text>
-        </box>
-        <box height={1} paddingX={1}>
-          <text fg={colors.textMuted}>Esc back</text>
         </box>
       </box>
     );
@@ -356,7 +363,7 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
       {/* Header */}
       <box height={1} paddingX={1} flexDirection="row">
         <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          {"◂ "}{title}
+          {title}
         </text>
         <box flexGrow={1} />
         <text fg={colors.textDim}>{mapping.seriesId}</text>
@@ -393,7 +400,7 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
             <box flexDirection="column" paddingX={1} marginTop={1}>
               <box flexDirection="column" height={chartHeight} backgroundColor={palette.bgColor}>
                 {chartResult.lines.map((line, i) => (
-                  <text key={i} content={line} />
+                  <text key={i} content={chartLineContent(line)} />
                 ))}
               </box>
               <text fg={colors.textDim}>{chartResult.timeLabels}</text>
@@ -448,7 +455,7 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
                   key={ticker}
                   marginLeft={i > 0 ? 2 : 0}
                   onMouseDown={() => {
-                    getSharedRegistry()?.navigateTickerFn(ticker);
+                    navigateTicker(ticker);
                   }}
                 >
                   <text fg={colors.textBright} attributes={TextAttributes.UNDERLINE}>{ticker}</text>
@@ -459,10 +466,6 @@ function EconDetailView({ event, width, height, focused, onBack }: EconDetailVie
         </box>
       </scrollbox>
 
-      {/* Footer */}
-      <box height={1} paddingX={1}>
-        <text fg={colors.textMuted}>Esc back · j/k scroll</text>
-      </box>
     </box>
   );
 }
@@ -487,6 +490,10 @@ function actualColor(actual: string | null, forecast: string | null): string {
   return colors.text;
 }
 
+function chartLineContent(line: string | StyledContent): string | StyledText {
+  return typeof line === "string" ? line : new StyledText(line.chunks);
+}
+
 // ---------------------------------------------------------------------------
 // Main Calendar Pane
 // ---------------------------------------------------------------------------
@@ -496,7 +503,7 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedIdx, setSelectedIdx] = useState(0);
-  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [hoveredRowIdx, setHoveredRowIdx] = useState<number | null>(null);
   const [impactFilter, setImpactFilter] = useState<ImpactFilter>("all");
   const [countryFilter, setCountryFilter] = useState<CountryFilter>("all");
   const [now, setNow] = useState(Date.now());
@@ -504,10 +511,22 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
 
   const fetchGenRef = useRef(0);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const headerScrollRef = useRef<ScrollBoxRenderable>(null);
   const backfilledSeriesRef = useRef<Set<string>>(new Set());
 
-  const config = useAppSelector((s) => s.config);
-  const fredApiKey = config.pluginConfig?.["econ-calendar"]?.fredApiKey as string | undefined;
+  const [fredApiKey] = usePluginConfigState<string>("fredApiKey", "");
+
+  const syncHeaderScroll = useCallback(() => {
+    const bodyScrollBox = scrollRef.current;
+    const headerScrollBox = headerScrollRef.current;
+    if (bodyScrollBox && headerScrollBox && headerScrollBox.scrollLeft !== bodyScrollBox.scrollLeft) {
+      headerScrollBox.scrollLeft = bodyScrollBox.scrollLeft;
+    }
+  }, []);
+
+  const handleBodyScrollActivity = useCallback(() => {
+    syncHeaderScroll();
+  }, [syncHeaderScroll]);
 
   const load = async (force = false) => {
     fetchGenRef.current += 1;
@@ -616,15 +635,18 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
     })();
   }, [events, fredApiKey]);
 
-  const filtered = events.filter(
-    (ev) => matchesImpact(ev, impactFilter) && matchesCountry(ev, countryFilter),
-  );
+  const filtered = useMemo(() => events
+    .filter((ev) => matchesImpact(ev, impactFilter) && matchesCountry(ev, countryFilter))
+    .sort((a, b) => b.date.getTime() - a.date.getTime()),
+  [countryFilter, events, impactFilter]);
 
   // Build display rows with separator headers and NOW marker
   const today = new Date(now);
   const rows: DisplayRow[] = [];
   let lastDateKey = "";
   let nowInserted = false;
+  const hasPastEvents = filtered.some((ev) => ev.date.getTime() <= now);
+  const hasFutureEvents = filtered.some((ev) => ev.date.getTime() > now);
 
   for (let i = 0; i < filtered.length; i++) {
     const ev = filtered[i]!;
@@ -633,28 +655,31 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
     // Insert date separator if new day
     if (dk !== lastDateKey) {
       lastDateKey = dk;
-      rows.push({ kind: "separator", label: dayLabel(ev.date, today) });
+      rows.push({ kind: "separator", key: `separator-${dk}`, label: dayLabel(ev.date, today) });
     }
 
-    // Insert NOW marker between last past event and first upcoming event
-    if (!nowInserted && ev.date.getTime() > now) {
+    // Reverse chronological order puts upcoming events above the present marker.
+    if (hasPastEvents && hasFutureEvents && !nowInserted && ev.date.getTime() <= now) {
       nowInserted = true;
-      rows.push({ kind: "now" });
+      rows.push({ kind: "now", key: "now" });
     }
 
-    rows.push({ kind: "event", event: ev, eventIdx: i });
+    rows.push({ kind: "event", key: `event-${ev.id}-${i}`, event: ev, eventIdx: i });
   }
 
   // Map from eventIdx to flat row index (for scroll tracking)
   const eventIdxToRowIdx = new Map<number, number>();
   let nowRowIdx = -1;
-  let firstUpcomingEventIdx = -1;
+  let nextUpcomingEventIdx = -1;
+  let nextUpcomingTime = Number.POSITIVE_INFINITY;
   for (let r = 0; r < rows.length; r++) {
     const row = rows[r]!;
     if (row.kind === "event") {
       eventIdxToRowIdx.set(row.eventIdx, r);
-      if (firstUpcomingEventIdx === -1 && row.event.date.getTime() > now) {
-        firstUpcomingEventIdx = row.eventIdx;
+      const eventTime = row.event.date.getTime();
+      if (eventTime > now && eventTime < nextUpcomingTime) {
+        nextUpcomingEventIdx = row.eventIdx;
+        nextUpcomingTime = eventTime;
       }
     } else if (row.kind === "now") {
       nowRowIdx = r;
@@ -665,8 +690,8 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
   const initialScrollDone = useRef(false);
   useEffect(() => {
     if (initialScrollDone.current || filtered.length === 0) return;
-    if (firstUpcomingEventIdx >= 0) {
-      setSelectedIdx(firstUpcomingEventIdx);
+    if (nextUpcomingEventIdx >= 0) {
+      setSelectedIdx(nextUpcomingEventIdx);
     }
     const sb = scrollRef.current;
     if (sb?.viewport && nowRowIdx >= 0) {
@@ -678,7 +703,7 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
   }, [filtered.length]);
 
   // Next upcoming event for countdown
-  const nextEvent = filtered.find((ev) => ev.date.getTime() > now);
+  const nextEvent = nextUpcomingEventIdx >= 0 ? filtered[nextUpcomingEventIdx] : undefined;
   const nextCountdown = nextEvent ? formatCountdown(nextEvent.date.getTime() - now) : null;
 
   useKeyboard((event) => {
@@ -691,7 +716,7 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
       setSelectedIdx((prev) => Math.min(prev + 1, filtered.length - 1));
     } else if (event.name === "k" || event.name === "up") {
       setSelectedIdx((prev) => Math.max(prev - 1, 0));
-    } else if (event.name === "return") {
+    } else if (event.name === "enter" || event.name === "return") {
       const ev = filtered[selectedIdx];
       if (ev) setDetailEvent(ev);
     } else if (event.name === "r") {
@@ -726,35 +751,104 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
     }
   }, [selectedIdx, filtered.length]);
 
-  // Column widths
-  const timeWidth = 6;
-  const impactWidth = 4;
-  const flagWidth = 3;
-  const actualWidth = 9;
-  const forecastWidth = 10;
-  const priorWidth = 9;
-  const minEventWidth = 12;
-  const eventWidth = Math.max(
-    minEventWidth,
-    width - timeWidth - impactWidth - flagWidth - actualWidth - forecastWidth - priorWidth - 2,
-  );
+  const columns = useMemo<EconCalendarColumn[]>(() => {
+    const timeWidth = 6;
+    const impactWidth = 4;
+    const flagWidth = 2;
+    const actualWidth = 9;
+    const forecastWidth = 10;
+    const priorWidth = 9;
+    const minEventWidth = 12;
+    const fixedWidth = timeWidth + impactWidth + flagWidth + actualWidth + forecastWidth + priorWidth;
+    const columnCount = 7;
+    const eventWidth = Math.max(minEventWidth, width - 2 - columnCount - fixedWidth);
 
+    return [
+      { id: "time", label: "TIME", width: timeWidth, align: "left" },
+      { id: "impact", label: "IMP", width: impactWidth, align: "left" },
+      { id: "country", label: "🌐", width: flagWidth, align: "left" },
+      { id: "event", label: "EVENT", width: eventWidth, align: "left" },
+      { id: "actual", label: "ACTUAL", width: actualWidth, align: "right" },
+      { id: "forecast", label: "FORECAST", width: forecastWidth, align: "right" },
+      { id: "prior", label: "PRIOR", width: priorWidth, align: "right" },
+    ];
+  }, [width]);
   const separatorBg = blendHex(colors.bg, colors.border, 0.3);
   const staleness = sharedCache ? formatStaleness(sharedCache.fetchedAt, now) : "";
+  const emptyStateHint = !loading && !error
+    ? [
+        impactFilter !== "all" ? `impact: ${impactFilter}` : null,
+        countryFilter !== "all" ? `country: ${countryFilter}` : null,
+      ].filter(Boolean).join(" · ") || undefined
+    : undefined;
 
-  if (detailEvent) {
-    return (
-      <EconDetailView
-        event={detailEvent}
-        width={width}
-        height={height}
-        focused={focused}
-        onBack={() => setDetailEvent(null)}
-      />
-    );
-  }
+  const handleHeaderClick = useCallback(() => {}, []);
+  const selectDisplayRow = useCallback((row: DisplayRow) => {
+    if (row.kind !== "event") return;
+    setSelectedIdx(row.eventIdx);
+  }, []);
+  const openDisplayRow = useCallback((row: DisplayRow) => {
+    if (row.kind !== "event") return;
+    setDetailEvent(row.event);
+  }, []);
+  const renderSectionHeader = useCallback((row: DisplayRow) => {
+    if (row.kind === "separator") {
+      return {
+        text: row.label,
+        backgroundColor: separatorBg,
+        color: colors.textBright,
+        attributes: TextAttributes.BOLD,
+      };
+    }
+    if (row.kind === "now") {
+      const label = " ▸ NOW ";
+      const line = "─".repeat(Math.max(0, width - label.length - 2));
+      return {
+        text: `${label}${line}`,
+        color: colors.warning,
+        attributes: 0,
+      };
+    }
+    return null;
+  }, [separatorBg, width]);
+  const renderCell = useCallback((
+    row: DisplayRow,
+    column: EconCalendarColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    if (row.kind !== "event") return { text: "" };
 
-  return (
+    const ev = row.event;
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+
+    switch (column.id) {
+      case "time":
+        return { text: ev.time, color: selectedColor ?? colors.textMuted };
+      case "impact": {
+        const indicator = impactIndicator(ev.impact);
+        return {
+          text: indicator.text,
+          color: selectedColor ?? indicator.color,
+        };
+      }
+      case "country":
+        return { text: countryFlag(ev.country), color: selectedColor };
+      case "event":
+        return { text: ev.event, color: selectedColor ?? colors.text };
+      case "actual":
+        return {
+          text: ev.actual ?? "—",
+          color: selectedColor ?? actualColor(ev.actual, ev.forecast),
+        };
+      case "forecast":
+        return { text: ev.forecast ?? "—", color: selectedColor ?? colors.textDim };
+      case "prior":
+        return { text: ev.prior ?? "—", color: selectedColor ?? colors.textDim };
+    }
+  }, []);
+
+  const calendarContent = (
     <box flexDirection="column" width={width} height={height}>
       {/* Header */}
       <box flexDirection="row" height={1} paddingX={1}>
@@ -786,31 +880,6 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
         {staleness ? <text fg={colors.textMuted}>{staleness}</text> : null}
       </box>
 
-      {/* Column headers */}
-      <box flexDirection="row" paddingX={1} height={1}>
-        <box width={timeWidth}>
-          <text fg={colors.textDim}>TIME</text>
-        </box>
-        <box width={impactWidth}>
-          <text fg={colors.textDim}>IMP</text>
-        </box>
-        <box width={flagWidth}>
-          <text fg={colors.textDim}>🏳</text>
-        </box>
-        <box width={eventWidth} flexShrink={1}>
-          <text fg={colors.textDim}>EVENT</text>
-        </box>
-        <box width={actualWidth} justifyContent="flex-end" paddingRight={1}>
-          <text fg={colors.textDim}>ACTUAL</text>
-        </box>
-        <box width={forecastWidth} justifyContent="flex-end" paddingRight={1}>
-          <text fg={colors.textDim}>FORECAST</text>
-        </box>
-        <box width={priorWidth} justifyContent="flex-end">
-          <text fg={colors.textDim}>PRIOR</text>
-        </box>
-      </box>
-
       {/* Error state */}
       {error && (
         <box paddingX={1} paddingY={1}>
@@ -818,112 +887,54 @@ export function EconCalendarPane({ focused, width, height, close }: PaneProps) {
         </box>
       )}
 
-      {/* Rows */}
-      <scrollbox ref={scrollRef} flexGrow={1} scrollY focusable={false}>
-        <box flexDirection="column">
-          {rows.map((row, flatIdx) => {
-            if (row.kind === "separator") {
-              return (
-                <box
-                  key={`sep-${flatIdx}`}
-                  flexDirection="row"
-                  width={width}
-                  backgroundColor={separatorBg}
-                  paddingX={1}
-                  height={1}
-                >
-                  <text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-                    {row.label}
-                  </text>
-                </box>
-              );
-            }
-
-            if (row.kind === "now") {
-              const lineChar = "─";
-              const label = " ▸ NOW ";
-              const remaining = Math.max(0, width - label.length - 2);
-              const line = lineChar.repeat(remaining);
-              return (
-                <box
-                  key={`now-${flatIdx}`}
-                  flexDirection="row"
-                  width={width}
-                  paddingX={1}
-                  height={1}
-                >
-                  <text fg={colors.warning}>{label}{line}</text>
-                </box>
-              );
-            }
-
-            const { event: ev, eventIdx } = row;
-            const isSelected = eventIdx === selectedIdx;
-            const isHovered = eventIdx === hoveredIdx;
-            const bg = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
-            const fg = isSelected ? colors.selectedText : colors.text;
-            const indicator = impactIndicator(ev.impact);
-            const flag = countryFlag(ev.country);
-
-            return (
-              <box
-                key={`${ev.id}-${flatIdx}`}
-                flexDirection="row"
-                width={width}
-                backgroundColor={bg}
-                paddingX={1}
-                onMouseMove={() => setHoveredIdx(eventIdx)}
-                onMouseOut={() => setHoveredIdx(null)}
-                onMouseDown={(mouseEvent: any) => {
-                  mouseEvent.preventDefault?.();
-                  if (selectedIdx === eventIdx) {
-                    setDetailEvent(ev);
-                  } else {
-                    setSelectedIdx(eventIdx);
-                  }
-                }}
-              >
-                <box width={timeWidth} flexShrink={0}>
-                  <text fg={isSelected ? colors.selectedText : colors.textMuted}>{ev.time}</text>
-                </box>
-                <box width={impactWidth} flexShrink={0}>
-                  <text fg={isSelected ? colors.selectedText : indicator.color}>{indicator.text}</text>
-                </box>
-                <box width={flagWidth} flexShrink={0}>
-                  <text>{flag}</text>
-                </box>
-                <box width={eventWidth} flexShrink={1} overflow="hidden">
-                  <text fg={fg}>{ev.event}</text>
-                </box>
-                <box width={actualWidth} justifyContent="flex-end" paddingRight={1}>
-                  <text fg={isSelected ? colors.selectedText : actualColor(ev.actual, ev.forecast)}>
-                    {ev.actual ?? "—"}
-                  </text>
-                </box>
-                <box width={forecastWidth} justifyContent="flex-end" paddingRight={1}>
-                  <text fg={isSelected ? colors.selectedText : colors.textDim}>{ev.forecast ?? "—"}</text>
-                </box>
-                <box width={priorWidth} justifyContent="flex-end">
-                  <text fg={isSelected ? colors.selectedText : colors.textDim}>{ev.prior ?? "—"}</text>
-                </box>
-              </box>
-            );
-          })}
-
-          {!loading && !error && filtered.length === 0 && (
-            <box paddingX={1} paddingY={1}>
-              <text fg={colors.textMuted}>
-                No events{impactFilter !== "all" ? ` for impact: ${impactFilter}` : ""}{countryFilter !== "all" ? ` for country: ${countryFilter}` : ""}
-              </text>
-            </box>
-          )}
-        </box>
-      </scrollbox>
+      <DataTable<DisplayRow, EconCalendarColumn>
+        columns={columns}
+        items={rows}
+        sortColumnId={null}
+        sortDirection="asc"
+        onHeaderClick={handleHeaderClick}
+        headerScrollRef={headerScrollRef}
+        scrollRef={scrollRef}
+        syncHeaderScroll={syncHeaderScroll}
+        onBodyScrollActivity={handleBodyScrollActivity}
+        hoveredIdx={hoveredRowIdx}
+        setHoveredIdx={setHoveredRowIdx}
+        getItemKey={(row) => row.key}
+        isSelected={(row) => row.kind === "event" && row.eventIdx === selectedIdx}
+        onSelect={selectDisplayRow}
+        onActivate={openDisplayRow}
+        renderSectionHeader={renderSectionHeader}
+        renderCell={renderCell}
+        emptyStateTitle={loading ? "Loading economic events..." : "No events"}
+        emptyStateHint={emptyStateHint}
+        showHorizontalScrollbar={false}
+      />
 
       <box height={1} paddingX={1}>
-        <text fg={colors.textMuted}>j/k navigate · [f]ilter · [c]ountry · [r]efresh · Enter detail · Esc close</text>
+        <text fg={colors.textMuted}>[f]ilter · [c]ountry · [r]efresh</text>
       </box>
     </box>
+  );
+
+  const detailContent = detailEvent ? (
+    <EconDetailView
+      event={detailEvent}
+      width={width}
+      height={Math.max(height - 1, 1)}
+      focused={focused}
+    />
+  ) : (
+    <box flexGrow={1} />
+  );
+
+  return (
+    <PageStackView
+      focused={focused}
+      detailOpen={!!detailEvent}
+      onBack={() => setDetailEvent(null)}
+      rootContent={calendarContent}
+      detailContent={detailContent}
+    />
   );
 }
 
@@ -935,6 +946,8 @@ export const econCalendarPlugin: GloomPlugin = {
   toggleable: true,
 
   setup(ctx) {
+    attachEconCalendarPersistence(ctx.persistence);
+
     ctx.registerCommand({
       id: "econ-set-fred-key",
       label: "Set FRED API Key",
@@ -956,6 +969,10 @@ export const econCalendarPlugin: GloomPlugin = {
         ctx.notify({ body: "FRED API key saved", type: "success" });
       },
     });
+  },
+
+  dispose() {
+    resetEconCalendarPersistence();
   },
 
   panes: [

--- a/src/plugins/builtin/econ/types.ts
+++ b/src/plugins/builtin/econ/types.ts
@@ -1,0 +1,13 @@
+export type EconImpact = "high" | "medium" | "low";
+
+export interface EconEvent {
+  id: string;
+  date: Date;
+  time: string; // "08:30" or "All Day"
+  country: string; // "US", "GB", etc.
+  event: string;
+  actual: string | null;
+  forecast: string | null;
+  prior: string | null;
+  impact: EconImpact;
+}

--- a/src/plugins/catalog.ts
+++ b/src/plugins/catalog.ts
@@ -12,6 +12,7 @@ import { aiPlugin } from "./builtin/ai";
 import { gloomberbCloudPlugin } from "./builtin/chat";
 import { helpPlugin } from "./builtin/help";
 import { comparisonChartPlugin } from "./builtin/comparison-chart";
+import { econCalendarPlugin } from "./builtin/econ";
 import { debugPlugin } from "./builtin/debug";
 import { layoutManagerPlugin } from "./builtin/layout-manager";
 import { yahooPlugin } from "./builtin/yahoo";
@@ -40,6 +41,7 @@ export const builtinPlugins: GloomPlugin[] = [
   helpPlugin,
   comparisonChartPlugin,
   predictionMarketsPlugin,
+  econCalendarPlugin,
   debugPlugin,
 ];
 

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatTimeAgo } from "./format";
+import { displayWidth, formatTimeAgo, padTo } from "./format";
 
 describe("formatTimeAgo", () => {
   test("handles UTC ISO timestamps with explicit offsets", () => {
@@ -10,5 +10,15 @@ describe("formatTimeAgo", () => {
   test("treats space-separated chat timestamps without a timezone as UTC", () => {
     const fiveMinutesAgo = new Date(Date.now() - 5 * 60_000).toISOString().replace("T", " ").replace("Z", "");
     expect(formatTimeAgo(fiveMinutesAgo)).toBe("5m ago");
+  });
+});
+
+describe("padTo", () => {
+  test("pads and truncates by display width instead of UTF-16 length", () => {
+    expect(displayWidth("🇺🇸")).toBe(2);
+    expect(padTo("🇺🇸", 2)).toBe("🇺🇸");
+    expect(padTo("🇺🇸", 3)).toBe("🇺🇸 ");
+    expect(padTo("🇺🇸", 1)).toBe(" ");
+    expect(padTo("🇺🇸 CPI", 6)).toBe("🇺🇸 CPI");
   });
 });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -116,17 +116,95 @@ export function formatWithDivisor(value: number | undefined, divisor: number): s
   return scaled.toFixed(decimals);
 }
 
-/** Pad/truncate a string to a fixed width */
-export function padTo(str: string, width: number, align: "left" | "right" | "center" = "left"): string {
-  if (str.length > width) return str.slice(0, width);
-  if (align === "right") return str.padStart(width);
-  if (align === "center") {
-    const totalPadding = width - str.length;
-    const leftPadding = Math.floor(totalPadding / 2);
-    const rightPadding = totalPadding - leftPadding;
-    return " ".repeat(leftPadding) + str + " ".repeat(rightPadding);
+const COMBINING_MARK_RE = /\p{Mark}/u;
+const EMOJI_PRESENTATION_RE = /\p{Emoji_Presentation}/u;
+const EXTENDED_PICTOGRAPHIC_RE = /\p{Extended_Pictographic}/u;
+const REGIONAL_INDICATOR_RE = /\p{Regional_Indicator}/u;
+
+function segmentGraphemes(value: string): string[] {
+  const Segmenter = (Intl as any).Segmenter;
+  if (typeof Segmenter === "function") {
+    return Array.from(
+      new Segmenter(undefined, { granularity: "grapheme" }).segment(value),
+      (entry: any) => entry.segment as string,
+    );
   }
-  return str.padEnd(width);
+  return Array.from(value);
+}
+
+function isFullwidthCodePoint(codePoint: number): boolean {
+  return codePoint >= 0x1100 && (
+    codePoint <= 0x115f ||
+    codePoint === 0x2329 ||
+    codePoint === 0x232a ||
+    (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1f300 && codePoint <= 0x1faff) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  );
+}
+
+function graphemeWidth(segment: string): number {
+  if (
+    REGIONAL_INDICATOR_RE.test(segment) ||
+    EMOJI_PRESENTATION_RE.test(segment) ||
+    EXTENDED_PICTOGRAPHIC_RE.test(segment)
+  ) {
+    return 2;
+  }
+
+  let width = 0;
+  for (const char of Array.from(segment)) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    if (
+      codePoint === 0 ||
+      codePoint < 32 ||
+      (codePoint >= 0x7f && codePoint < 0xa0) ||
+      codePoint === 0x200d ||
+      (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+      COMBINING_MARK_RE.test(char)
+    ) {
+      continue;
+    }
+    width += isFullwidthCodePoint(codePoint) ? 2 : 1;
+  }
+  return width;
+}
+
+export function displayWidth(value: string): number {
+  return segmentGraphemes(value).reduce((total, segment) => total + graphemeWidth(segment), 0);
+}
+
+function truncateToWidth(value: string, width: number): string {
+  if (width <= 0) return "";
+  let output = "";
+  let used = 0;
+  for (const segment of segmentGraphemes(value)) {
+    const nextWidth = graphemeWidth(segment);
+    if (used + nextWidth > width) break;
+    output += segment;
+    used += nextWidth;
+  }
+  return output;
+}
+
+/** Pad/truncate a string to a fixed display width */
+export function padTo(str: string, width: number, align: "left" | "right" | "center" = "left"): string {
+  const clipped = displayWidth(str) > width ? truncateToWidth(str, width) : str;
+  const clippedWidth = displayWidth(clipped);
+  const padding = Math.max(0, width - clippedWidth);
+  if (align === "right") return " ".repeat(padding) + clipped;
+  if (align === "center") {
+    const leftPadding = Math.floor(padding / 2);
+    const rightPadding = padding - leftPadding;
+    return " ".repeat(leftPadding) + clipped + " ".repeat(rightPadding);
+  }
+  return clipped + " ".repeat(padding);
 }
 
 /** Convert a value from one currency to base currency using cached exchange rates */


### PR DESCRIPTION
Economic calendar plugin with ForexFactory data and FRED API historical drill-in.

**Calendar grid:**
- Date group headers (Today/Tomorrow/day name) with visual separators
- NOW marker between past and upcoming events, auto-scrolls to it on load
- Countdown to next release in header
- Country filter (All/US/G7/EU) and impact filter (high/medium/low/all)
- Flag emoji for countries, colored impact bullets (●●●/●●/●)
- FRED-backfilled actual values with beat/miss coloring
- Disk cache for offline/rate-limited resilience

**Detail view (Enter on an event):**
- 5-year FRED historical chart (inline area chart)
- Historical readings table with computed percent changes
- Related tickers (clickable via navigateTicker)
- Series metadata (units, frequency, seasonal adjustment)

**Data layer:**
- FRED API client with throttled-fetch (30 req/min)
- 44 US economic indicator mappings to FRED series (CPI, GDP, NFP, FOMC, etc.)
- Event-to-series fuzzy matching with prefix stripping
- FRED API key config command (type "Set FRED" in command bar)

Shortcut: `ECON`

Depends on #150.

Testing: `bun test src/plugins/builtin/econ/`