### PR TITLE
Add technical indicators and enhanced ticker overview

### DIFF
--- a/src/components/chart/chart-control-hint.tsx
+++ b/src/components/chart/chart-control-hint.tsx
@@ -1,0 +1,39 @@
+import { TextAttributes } from "@opentui/core";
+import { colors } from "../../theme/colors";
+
+type HintMouseEvent = {
+  stopPropagation?: () => void;
+  preventDefault?: () => void;
+};
+
+interface ChartControlHintProps {
+  hotkey: string;
+  label: string;
+  disabled?: boolean;
+  onPress?: (event?: HintMouseEvent) => void;
+}
+
+function stopMouseEvent(event?: HintMouseEvent) {
+  event?.stopPropagation?.();
+  event?.preventDefault?.();
+}
+
+export function ChartControlHint({
+  hotkey,
+  label,
+  disabled = false,
+  onPress,
+}: ChartControlHintProps) {
+  const interactive = !!onPress && !disabled;
+
+  return (
+    <text
+      fg={disabled ? colors.textMuted : colors.textDim}
+      attributes={interactive ? TextAttributes.BOLD : 0}
+      onMouseDown={interactive ? stopMouseEvent : undefined}
+      onMouseUp={interactive ? onPress : undefined}
+    >
+      <span fg={disabled ? colors.textMuted : colors.textBright}>[{hotkey}]</span>{label}
+    </text>
+  );
+}

--- a/src/components/chart/chart-indicator-selector.tsx
+++ b/src/components/chart/chart-indicator-selector.tsx
@@ -1,0 +1,53 @@
+import { MultiSelectDialogButton } from "../ui";
+import { ChartControlHint } from "./chart-control-hint";
+import {
+  CHART_INDICATOR_OPTIONS,
+  normalizeChartIndicatorSelection,
+  type ChartIndicatorId,
+} from "./indicators/options";
+
+interface ChartIndicatorSelectorProps {
+  selectedIds: ChartIndicatorId[];
+  onChange: (selectedIds: ChartIndicatorId[]) => void;
+  width: number;
+  variant?: "button" | "hint";
+  shortcutActive?: boolean;
+}
+
+export function ChartIndicatorSelector({
+  selectedIds,
+  onChange,
+  width,
+  variant = "button",
+  shortcutActive = false,
+}: ChartIndicatorSelectorProps) {
+  const compact = width < 72;
+  const options = CHART_INDICATOR_OPTIONS.map((option) => ({
+    value: option.id,
+    label: compact ? option.compactLabel : option.label,
+    description: option.description,
+  }));
+
+  return (
+    <MultiSelectDialogButton
+      label={compact ? "IND" : "Indicators"}
+      title="Chart Indicators"
+      options={options}
+      selectedValues={selectedIds}
+      onChange={(values) => onChange(normalizeChartIndicatorSelection(values))}
+      idPrefix="chart-indicators"
+      shortcutKey={variant === "hint" ? "i" : undefined}
+      shortcutActive={shortcutActive}
+      renderTrigger={variant === "hint"
+        ? ({ disabled, openDialog }) => (
+          <ChartControlHint
+            hotkey="i"
+            label="ndicators"
+            disabled={disabled}
+            onPress={openDialog}
+          />
+        )
+        : undefined}
+    />
+  );
+}

--- a/src/components/chart/chart-pane-settings.ts
+++ b/src/components/chart/chart-pane-settings.ts
@@ -2,6 +2,7 @@ import { saveConfig } from "../../data/config-store";
 import { setPaneSettings } from "../../pane-settings";
 import { useAppState, usePaneInstance, usePaneInstanceId } from "../../state/app-context";
 import type { ChartResolution, TimeRange } from "./chart-types";
+import type { IndicatorConfig } from "./indicators/types";
 
 export function usePersistChartControlSelection(rangePresetKey: string): (
   range: TimeRange,
@@ -16,6 +17,25 @@ export function usePersistChartControlSelection(rangePresetKey: string): (
       ...(pane?.settings ?? {}),
       [rangePresetKey]: range,
       chartResolution: resolution,
+    });
+    const layouts = state.config.layouts.map((savedLayout, index) => (
+      index === state.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
+    ));
+    const nextConfig = { ...state.config, layout, layouts };
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    saveConfig(nextConfig).catch(() => {});
+  };
+}
+
+export function usePersistIndicatorConfig(): (config: IndicatorConfig) => void {
+  const { state, dispatch } = useAppState();
+  const paneId = usePaneInstanceId();
+  const pane = usePaneInstance();
+
+  return (indicatorConfig) => {
+    const layout = setPaneSettings(state.config.layout, paneId, {
+      ...(pane?.settings ?? {}),
+      indicators: indicatorConfig,
     });
     const layouts = state.config.layouts.map((savedLayout, index) => (
       index === state.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -1,5 +1,5 @@
 import { RGBA } from "@opentui/core";
-import type { ChartAxisMode, ChartColors, Pixel, PixelBuffer, ChartRenderMode } from "./chart-types";
+import type { ChartAxisMode, ChartColors, ChartIndicatorOverlays, Pixel, PixelBuffer, ChartRenderMode } from "./chart-types";
 import type { ProjectedChartPoint } from "./chart-data";
 import { formatCompactMarketPriceWithCurrency, formatMarketPrice, resolveAssetDisplayKind } from "../../utils/market-format";
 
@@ -26,6 +26,7 @@ export interface StyledContent {
 const LAYER_GRID = 0;
 const LAYER_FILL = 1;
 const LAYER_DATA = 2;
+const LAYER_OVERLAY = 2;
 const LAYER_CROSSHAIR = 3;
 
 // ---------------------------------------------------------------------------
@@ -1018,6 +1019,7 @@ export interface RenderChartOptions {
   assetCategory?: string;
   colors: ResolvedChartPalette;
   timeAxisDates?: Array<Date | string | number>;
+  indicators?: ChartIndicatorOverlays | null;
 }
 
 export interface ChartScene {
@@ -1159,6 +1161,41 @@ export function buildChartScene(
   };
 }
 
+function drawIndicatorOverlays(
+  buf: PixelBuffer,
+  indicators: ChartIndicatorOverlays,
+  pointCount: number,
+  dotTop: number,
+  dotBottom: number,
+  min: number,
+  max: number,
+  mode: ChartRenderMode,
+): void {
+  const drawOverlay = (overlayPoints: { index: number; value: number }[], color: string) => {
+    for (let i = 0; i < overlayPoints.length - 1; i++) {
+      const p0 = overlayPoints[i]!;
+      const p1 = overlayPoints[i + 1]!;
+      const x0 = getDotX(p0.index, pointCount, buf.width, mode);
+      const y0 = getScaledY(p0.value, min, max, dotTop, dotBottom);
+      const x1 = getDotX(p1.index, pointCount, buf.width, mode);
+      const y1 = getScaledY(p1.value, min, max, dotTop, dotBottom);
+      drawLine(buf, x0, y0, x1, y1, color, LAYER_OVERLAY);
+    }
+  };
+
+  for (const sma of indicators.smaLines) {
+    drawOverlay(sma.points, sma.color);
+  }
+  for (const ema of indicators.emaLines) {
+    drawOverlay(ema.points, ema.color);
+  }
+  if (indicators.bollinger) {
+    drawOverlay(indicators.bollinger.upper, indicators.bollinger.color);
+    drawOverlay(indicators.bollinger.middle, indicators.bollinger.color);
+    drawOverlay(indicators.bollinger.lower, indicators.bollinger.color);
+  }
+}
+
 export function renderChart(
   points: ProjectedChartPoint[],
   opts: RenderChartOptions,
@@ -1245,6 +1282,10 @@ export function renderChart(
       mode === "candles" || mode === "ohlc" ? "openClose" : "previousClose",
       mode,
     );
+  }
+
+  if (opts.indicators) {
+    drawIndicatorOverlays(buf, opts.indicators, points.length, 0, chartDotBottom, min, max, mode);
   }
 
   // Cursor mapping stays in terminal-column space

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -1031,6 +1031,7 @@ export interface ChartScene {
   chartRows: number;
   mode: ChartRenderMode;
   colors: ResolvedChartPalette;
+  indicators: ChartIndicatorOverlays | null;
   min: number;
   max: number;
   activeIdx: number;
@@ -1092,18 +1093,42 @@ export function getActivePointIndex(
   return bestIndex;
 }
 
+function getIndicatorOverlayValues(indicators: ChartIndicatorOverlays | null | undefined): number[] {
+  if (!indicators) return [];
+
+  const values: number[] = [];
+  for (const line of indicators.smaLines) {
+    values.push(...line.points.map((point) => point.value));
+  }
+  for (const line of indicators.emaLines) {
+    values.push(...line.points.map((point) => point.value));
+  }
+  if (indicators.bollinger) {
+    values.push(
+      ...indicators.bollinger.upper.map((point) => point.value),
+      ...indicators.bollinger.middle.map((point) => point.value),
+      ...indicators.bollinger.lower.map((point) => point.value),
+    );
+  }
+
+  return values.filter((value) => Number.isFinite(value));
+}
+
 export function buildChartScene(
   points: ProjectedChartPoint[],
   opts: RenderChartOptions,
 ): ChartScene | null {
   if (points.length === 0) return null;
 
-  const min = opts.mode === "candles" || opts.mode === "ohlc"
+  const dataMin = opts.mode === "candles" || opts.mode === "ohlc"
     ? Math.min(...points.map((point) => point.low))
     : Math.min(...points.map((point) => point.close));
-  const max = opts.mode === "candles" || opts.mode === "ohlc"
+  const dataMax = opts.mode === "candles" || opts.mode === "ohlc"
     ? Math.max(...points.map((point) => point.high))
     : Math.max(...points.map((point) => point.close));
+  const indicatorValues = getIndicatorOverlayValues(opts.indicators);
+  const min = indicatorValues.length > 0 ? Math.min(dataMin, ...indicatorValues) : dataMin;
+  const max = indicatorValues.length > 0 ? Math.max(dataMax, ...indicatorValues) : dataMax;
   const activeIdx = getActivePointIndex(points.length, opts.width, opts.cursorX, opts.mode);
   const activePoint = points[activeIdx]!;
   const range = max - min || 1;
@@ -1143,6 +1168,7 @@ export function buildChartScene(
     chartRows,
     mode: opts.mode,
     colors: opts.colors,
+    indicators: opts.indicators ?? null,
     min,
     max,
     activeIdx,

--- a/src/components/chart/chart-types.ts
+++ b/src/components/chart/chart-types.ts
@@ -88,3 +88,15 @@ export interface ComparisonChartViewState {
   renderMode?: ComparisonChartRenderMode;
   selectedSymbol: string | null;
 }
+
+import type { IndicatorConfig, OverlayPoint, OscillatorPoint, MacdResult, BollingerResult } from "./indicators/types";
+
+export interface ChartIndicatorOverlays {
+  smaLines: { period: number; points: OverlayPoint[]; color: string }[];
+  emaLines: { period: number; points: OverlayPoint[]; color: string }[];
+  bollinger: (BollingerResult & { color: string }) | null;
+  rsi: OscillatorPoint[] | null;
+  macd: MacdResult | null;
+}
+
+export type { IndicatorConfig };

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bucketOhlcSeries, getVisibleWindow, projectChartData, resolveRenderMode } from "./chart-data";
 import { stepCursorTowards } from "./cursor-motion";
-import { buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
+import { buildChartScene, buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
 import type { PricePoint } from "../../types/financials";
 import type { ChartRenderMode, ChartViewState } from "./chart-types";
 
@@ -181,6 +181,37 @@ describe("renderChart", () => {
     expect(result.axisFractionDigits).toBeGreaterThanOrEqual(1);
     expect(new Set(result.axisLabels.map((entry) => entry.label)).size).toBe(result.axisLabels.length);
     expect(result.axisLabels.every((entry) => entry.label.includes("."))).toBe(true);
+  });
+
+  test("includes visible indicator overlays in the chart price range", () => {
+    const projection = projectChartData(chartFixture, 12, "line", false);
+    const scene = buildChartScene(projection.points, {
+      width: 12,
+      height: 6,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: projection.effectiveMode,
+      colors: palette,
+      indicators: {
+        smaLines: [{
+          period: 2,
+          color: "#ff00ff",
+          points: [
+            { index: 0, value: 6 },
+            { index: 1, value: 18 },
+          ],
+        }],
+        emaLines: [],
+        bollinger: null,
+        rsi: null,
+        macd: null,
+      },
+    });
+
+    expect(scene?.min).toBe(6);
+    expect(scene?.max).toBe(18);
   });
 
   test("keeps one decimal on zoomed equity axes even when whole-dollar ticks are distinct", () => {

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -84,6 +84,7 @@ import { resolveChartRendererState } from "./native/renderer-selection";
 import { getNativeSurfaceManager } from "./native/surface-manager";
 import { syncCachedNativeSurface } from "./native/surface-sync";
 import { formatAxisCell, formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
+import { ChartControlHint } from "./chart-control-hint";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
   area: "A",
@@ -1764,9 +1765,14 @@ function ComparisonStockChartView({
       )}
 
       <box height={1}>
-        <text fg={colors.textMuted}>
-          mouse hover inspect  drag pan  wheel pan  h/l cursor  arrows legend  Enter open  1-7 presets  r res  m mode  0 reset
-        </text>
+        <box flexDirection="row" gap={1}>
+          <ChartControlHint hotkey="m" label="ode" />
+          <ChartControlHint hotkey="r" label="es" />
+          <ChartControlHint hotkey="+/-" label="zoom" />
+          <ChartControlHint hotkey="0" label="reset" />
+          {width >= 72 && <ChartControlHint hotkey="1-7" label="range" />}
+          {width >= 88 && <ChartControlHint hotkey="up/down" label="legend" />}
+        </box>
       </box>
     </box>
   );

--- a/src/components/chart/indicators/bands.test.ts
+++ b/src/components/chart/indicators/bands.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { computeBollingerBands } from "./bands";
+
+describe("computeBollingerBands", () => {
+  const closes = [10, 12, 11, 13, 15, 14, 13, 12, 14, 16];
+
+  it("upper > middle > lower for all points with period 5", () => {
+    const result = computeBollingerBands(closes, 5, 2);
+    expect(result.upper.length).toBeGreaterThan(0);
+    expect(result.middle.length).toBeGreaterThan(0);
+    expect(result.lower.length).toBeGreaterThan(0);
+    for (let i = 0; i < result.middle.length; i++) {
+      expect(result.upper[i].value).toBeGreaterThan(result.middle[i].value);
+      expect(result.middle[i].value).toBeGreaterThan(result.lower[i].value);
+    }
+  });
+
+  it("indices match across all three bands", () => {
+    const result = computeBollingerBands(closes, 5, 2);
+    for (let i = 0; i < result.middle.length; i++) {
+      expect(result.upper[i].index).toBe(result.middle[i].index);
+      expect(result.lower[i].index).toBe(result.middle[i].index);
+    }
+  });
+
+  it("first point starts at index period-1", () => {
+    const result = computeBollingerBands(closes, 5, 2);
+    expect(result.middle[0].index).toBe(4);
+  });
+
+  it("returns empty for insufficient data", () => {
+    const result = computeBollingerBands([1, 2, 3], 5, 2);
+    expect(result.upper.length).toBe(0);
+    expect(result.middle.length).toBe(0);
+    expect(result.lower.length).toBe(0);
+  });
+
+  it("returns empty for empty input", () => {
+    const result = computeBollingerBands([], 20, 2);
+    expect(result.upper.length).toBe(0);
+    expect(result.middle.length).toBe(0);
+    expect(result.lower.length).toBe(0);
+  });
+
+  it("middle values match SMA", () => {
+    // For period 5: first SMA = (10+12+11+13+15)/5 = 61/5 = 12.2
+    const result = computeBollingerBands(closes, 5, 2);
+    expect(result.middle[0].value).toBeCloseTo(12.2);
+  });
+});

--- a/src/components/chart/indicators/bands.ts
+++ b/src/components/chart/indicators/bands.ts
@@ -1,0 +1,29 @@
+import type { BollingerResult } from "./types";
+import { computeSMA } from "./moving-averages";
+
+export function computeBollingerBands(
+  closes: number[],
+  period = 20,
+  stdDev = 2
+): BollingerResult {
+  const empty: BollingerResult = { upper: [], middle: [], lower: [] };
+  const sma = computeSMA(closes, period);
+  if (sma.length === 0) return empty;
+
+  for (const midPoint of sma) {
+    const end = midPoint.index;
+    const start = end - period + 1;
+    const slice = closes.slice(start, end + 1);
+
+    const mean = midPoint.value;
+    const variance = slice.reduce((sum, v) => sum + (v - mean) ** 2, 0) / period;
+    const sd = Math.sqrt(variance);
+
+    const upper = mean + stdDev * sd;
+    empty.upper.push({ index: midPoint.index, value: upper });
+    empty.middle.push({ index: midPoint.index, value: mean });
+    empty.lower.push({ index: midPoint.index, value: mean - stdDev * sd });
+  }
+
+  return empty;
+}

--- a/src/components/chart/indicators/moving-averages.test.ts
+++ b/src/components/chart/indicators/moving-averages.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "bun:test";
+import { computeSMA, computeEMA } from "./moving-averages";
+
+describe("computeSMA", () => {
+  const closes = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+
+  it("starts at index period-1 with correct value", () => {
+    const result = computeSMA(closes, 5);
+    expect(result[0].index).toBe(4);
+    expect(result[0].value).toBe(12); // (10+11+12+13+14)/5 = 60/5 = 12
+  });
+
+  it("produces correct number of points", () => {
+    const result = computeSMA(closes, 5);
+    expect(result.length).toBe(6); // 10 - 5 + 1
+  });
+
+  it("returns [] when period > data length", () => {
+    expect(computeSMA([1, 2, 3], 5)).toEqual([]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(computeSMA([], 5)).toEqual([]);
+  });
+
+  it("handles period equal to data length", () => {
+    const result = computeSMA(closes, 10);
+    expect(result.length).toBe(1);
+    expect(result[0].index).toBe(9);
+    expect(result[0].value).toBeCloseTo(14.5);
+  });
+});
+
+describe("computeEMA", () => {
+  it("seeds with SMA and applies multiplier correctly", () => {
+    // period 3, k = 2/(3+1) = 0.5
+    // seed = (10+11+12)/3 = 11 at index 2
+    // EMA[3] = 13*0.5 + 11*0.5 = 12
+    const closes = [10, 11, 12, 13, 14, 15];
+    const result = computeEMA(closes, 3);
+    expect(result[0].index).toBe(2);
+    expect(result[0].value).toBeCloseTo(11);
+    expect(result[1].index).toBe(3);
+    expect(result[1].value).toBeCloseTo(12);
+  });
+
+  it("returns [] when period > data length", () => {
+    expect(computeEMA([1, 2], 5)).toEqual([]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(computeEMA([], 3)).toEqual([]);
+  });
+});

--- a/src/components/chart/indicators/moving-averages.ts
+++ b/src/components/chart/indicators/moving-averages.ts
@@ -1,0 +1,42 @@
+import type { OverlayPoint } from "./types";
+
+export function computeSMA(closes: number[], period: number): OverlayPoint[] {
+  if (closes.length < period || period <= 0) return [];
+
+  const result: OverlayPoint[] = [];
+  let sum = 0;
+
+  for (let i = 0; i < period; i++) {
+    sum += closes[i];
+  }
+  result.push({ index: period - 1, value: sum / period });
+
+  for (let i = period; i < closes.length; i++) {
+    sum += closes[i] - closes[i - period];
+    result.push({ index: i, value: sum / period });
+  }
+
+  return result;
+}
+
+export function computeEMA(closes: number[], period: number): OverlayPoint[] {
+  if (closes.length < period || period <= 0) return [];
+
+  const k = 2 / (period + 1);
+  const result: OverlayPoint[] = [];
+
+  // Seed with SMA of first `period` values
+  let sum = 0;
+  for (let i = 0; i < period; i++) {
+    sum += closes[i];
+  }
+  let ema = sum / period;
+  result.push({ index: period - 1, value: ema });
+
+  for (let i = period; i < closes.length; i++) {
+    ema = closes[i] * k + ema * (1 - k);
+    result.push({ index: i, value: ema });
+  }
+
+  return result;
+}

--- a/src/components/chart/indicators/options.test.ts
+++ b/src/components/chart/indicators/options.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildIndicatorConfigFromSelection,
+  CURRENT_CHART_INDICATORS_CONFIG_VERSION,
+  normalizeChartIndicatorSelection,
+  resolveChartIndicatorSelection,
+} from "./options";
+
+describe("chart indicator options", () => {
+  test("normalizes persisted indicator selections into supported option order", () => {
+    expect(normalizeChartIndicatorSelection(["ema20", "unknown", "volume", "sma20", "ema20"])).toEqual([
+      "volume",
+      "sma20",
+      "ema20",
+    ]);
+    expect(normalizeChartIndicatorSelection("sma20")).toEqual([]);
+  });
+
+  test("keeps volume enabled by default and migrates legacy selections", () => {
+    expect(resolveChartIndicatorSelection(undefined, undefined)).toEqual(["volume"]);
+    expect(resolveChartIndicatorSelection(["sma20"], undefined)).toEqual(["volume", "sma20"]);
+    expect(resolveChartIndicatorSelection(["sma20"], CURRENT_CHART_INDICATORS_CONFIG_VERSION)).toEqual(["sma20"]);
+  });
+
+  test("builds chart indicator config from selected overlay ids", () => {
+    expect(buildIndicatorConfigFromSelection(["volume", "sma20", "sma50", "ema20", "bollinger20"])).toEqual({
+      sma: [20, 50],
+      ema: [20],
+      bollinger: { period: 20, stdDev: 2 },
+    });
+  });
+});

--- a/src/components/chart/indicators/options.ts
+++ b/src/components/chart/indicators/options.ts
@@ -1,0 +1,107 @@
+import type { IndicatorConfig } from "./types";
+
+export const CHART_INDICATORS_PLUGIN_CONFIG_KEY = "chartIndicators";
+export const CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY = "chartIndicatorsVersion";
+export const CURRENT_CHART_INDICATORS_CONFIG_VERSION = 2;
+
+export type ChartIndicatorId =
+  | "volume"
+  | "sma20"
+  | "sma50"
+  | "sma200"
+  | "ema20"
+  | "bollinger20";
+
+export interface ChartIndicatorOption {
+  id: ChartIndicatorId;
+  label: string;
+  compactLabel: string;
+  description: string;
+}
+
+export const CHART_INDICATOR_OPTIONS: ChartIndicatorOption[] = [
+  {
+    id: "volume",
+    label: "Volume",
+    compactLabel: "VOL",
+    description: "Volume bars below the price chart.",
+  },
+  {
+    id: "sma20",
+    label: "SMA 20",
+    compactLabel: "S20",
+    description: "20-period simple moving average.",
+  },
+  {
+    id: "sma50",
+    label: "SMA 50",
+    compactLabel: "S50",
+    description: "50-period simple moving average.",
+  },
+  {
+    id: "sma200",
+    label: "SMA 200",
+    compactLabel: "S200",
+    description: "200-period simple moving average.",
+  },
+  {
+    id: "ema20",
+    label: "EMA 20",
+    compactLabel: "E20",
+    description: "20-period exponential moving average.",
+  },
+  {
+    id: "bollinger20",
+    label: "Bollinger 20",
+    compactLabel: "BB20",
+    description: "20-period Bollinger Bands at two standard deviations.",
+  },
+];
+
+const CHART_INDICATOR_IDS = new Set<string>(CHART_INDICATOR_OPTIONS.map((option) => option.id));
+export const DEFAULT_CHART_INDICATOR_SELECTION: ChartIndicatorId[] = ["volume"];
+
+export function isChartIndicatorId(value: unknown): value is ChartIndicatorId {
+  return typeof value === "string" && CHART_INDICATOR_IDS.has(value);
+}
+
+export function normalizeChartIndicatorSelection(value: unknown): ChartIndicatorId[] {
+  if (!Array.isArray(value)) return [];
+
+  const selected = new Set(value.filter(isChartIndicatorId));
+  return CHART_INDICATOR_OPTIONS
+    .map((option) => option.id)
+    .filter((id) => selected.has(id));
+}
+
+export function resolveChartIndicatorSelection(value: unknown, version: unknown): ChartIndicatorId[] {
+  if (!Array.isArray(value)) return [...DEFAULT_CHART_INDICATOR_SELECTION];
+
+  const normalized = normalizeChartIndicatorSelection(value);
+  if (version === CURRENT_CHART_INDICATORS_CONFIG_VERSION) return normalized;
+
+  return normalizeChartIndicatorSelection([
+    ...DEFAULT_CHART_INDICATOR_SELECTION,
+    ...normalized,
+  ]);
+}
+
+export function buildIndicatorConfigFromSelection(selection: readonly ChartIndicatorId[]): IndicatorConfig {
+  const selected = new Set(selection);
+  const sma: number[] = [];
+  const ema: number[] = [];
+  const config: IndicatorConfig = {};
+
+  if (selected.has("sma20")) sma.push(20);
+  if (selected.has("sma50")) sma.push(50);
+  if (selected.has("sma200")) sma.push(200);
+  if (selected.has("ema20")) ema.push(20);
+
+  if (sma.length > 0) config.sma = sma;
+  if (ema.length > 0) config.ema = ema;
+  if (selected.has("bollinger20")) {
+    config.bollinger = { period: 20, stdDev: 2 };
+  }
+
+  return config;
+}

--- a/src/components/chart/indicators/oscillators.test.ts
+++ b/src/components/chart/indicators/oscillators.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "bun:test";
+import { computeRSI, computeMACD } from "./oscillators";
+
+describe("computeRSI", () => {
+  it("produces at least one result with 15 data points and period 14", () => {
+    const closes = [44, 46, 44, 45, 47, 43, 44, 46, 48, 47, 45, 46, 47, 48, 50];
+    const result = computeRSI(closes, 14);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("all values are between 0 and 100", () => {
+    const closes = [44, 46, 44, 45, 47, 43, 44, 46, 48, 47, 45, 46, 47, 48, 50];
+    const result = computeRSI(closes, 14);
+    for (const p of result) {
+      expect(p.value).toBeGreaterThanOrEqual(0);
+      expect(p.value).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("all-increasing data gives RSI > 99", () => {
+    const closes = Array.from({ length: 20 }, (_, i) => i + 1);
+    const result = computeRSI(closes, 14);
+    expect(result.length).toBeGreaterThan(0);
+    for (const p of result) {
+      expect(p.value).toBeGreaterThan(99);
+    }
+  });
+
+  it("returns [] for insufficient data", () => {
+    expect(computeRSI([1, 2, 3], 14)).toEqual([]);
+    expect(computeRSI([], 14)).toEqual([]);
+    // Exactly period data points (need period+1)
+    const closes = Array.from({ length: 14 }, (_, i) => i + 1);
+    expect(computeRSI(closes, 14)).toEqual([]);
+  });
+
+  it("first result starts at index equal to period", () => {
+    const closes = [44, 46, 44, 45, 47, 43, 44, 46, 48, 47, 45, 46, 47, 48, 50];
+    const result = computeRSI(closes, 14);
+    expect(result[0].index).toBe(14);
+  });
+});
+
+describe("computeMACD", () => {
+  const closes50 = Array.from({ length: 50 }, (_, i) => 100 + Math.sin(i * 0.3) * 10);
+
+  it("produces non-empty macd, signal, histogram with 50 data points", () => {
+    const result = computeMACD(closes50, 12, 26, 9);
+    expect(result.macd.length).toBeGreaterThan(0);
+    expect(result.signal.length).toBeGreaterThan(0);
+    expect(result.histogram.length).toBeGreaterThan(0);
+  });
+
+  it("histogram[i] = macd[i] - signal[i] at matching indices", () => {
+    const result = computeMACD(closes50, 12, 26, 9);
+    const macdByIndex = new Map(result.macd.map((p) => [p.index, p.value]));
+    for (const h of result.histogram) {
+      const m = macdByIndex.get(h.index);
+      const s = result.signal.find((p) => p.index === h.index);
+      expect(m).toBeDefined();
+      expect(s).toBeDefined();
+      expect(h.value).toBeCloseTo(m! - s!.value, 10);
+    }
+  });
+
+  it("returns empty result for insufficient data", () => {
+    const result = computeMACD([1, 2, 3], 12, 26, 9);
+    expect(result.macd.length).toBe(0);
+    expect(result.signal.length).toBe(0);
+    expect(result.histogram.length).toBe(0);
+  });
+
+  it("returns empty result for empty input", () => {
+    const result = computeMACD([], 12, 26, 9);
+    expect(result.macd.length).toBe(0);
+    expect(result.signal.length).toBe(0);
+    expect(result.histogram.length).toBe(0);
+  });
+});

--- a/src/components/chart/indicators/oscillators.ts
+++ b/src/components/chart/indicators/oscillators.ts
@@ -1,0 +1,92 @@
+import type { OscillatorPoint, MacdResult } from "./types";
+import { computeEMA } from "./moving-averages";
+
+export function computeRSI(closes: number[], period = 14): OscillatorPoint[] {
+  // Need at least period+1 data points (period changes)
+  if (closes.length < period + 1) return [];
+
+  const result: OscillatorPoint[] = [];
+
+  // Compute initial average gain/loss over first `period` changes
+  let avgGain = 0;
+  let avgLoss = 0;
+  for (let i = 1; i <= period; i++) {
+    const change = closes[i] - closes[i - 1];
+    if (change > 0) avgGain += change;
+    else avgLoss += -change;
+  }
+  avgGain /= period;
+  avgLoss /= period;
+
+  const rs = avgLoss === 0 ? Infinity : avgGain / avgLoss;
+  const rsi = avgLoss === 0 ? 100 : 100 - 100 / (1 + rs);
+  result.push({ index: period, value: rsi });
+
+  // Wilder's smoothing for subsequent values
+  for (let i = period + 1; i < closes.length; i++) {
+    const change = closes[i] - closes[i - 1];
+    const gain = change > 0 ? change : 0;
+    const loss = change < 0 ? -change : 0;
+    avgGain = (avgGain * (period - 1) + gain) / period;
+    avgLoss = (avgLoss * (period - 1) + loss) / period;
+
+    const rs = avgLoss === 0 ? Infinity : avgGain / avgLoss;
+    const rsi = avgLoss === 0 ? 100 : 100 - 100 / (1 + rs);
+    result.push({ index: i, value: rsi });
+  }
+
+  return result;
+}
+
+export function computeMACD(
+  closes: number[],
+  fast = 12,
+  slow = 26,
+  signal = 9
+): MacdResult {
+  const empty: MacdResult = { macd: [], signal: [], histogram: [] };
+
+  const fastEma = computeEMA(closes, fast);
+  const slowEma = computeEMA(closes, slow);
+
+  if (fastEma.length === 0 || slowEma.length === 0) return empty;
+
+  // Build a map of index -> fast EMA value for alignment
+  const fastByIndex = new Map<number, number>();
+  for (const p of fastEma) fastByIndex.set(p.index, p.value);
+
+  // MACD line = fast EMA - slow EMA (only where both exist)
+  const macdLine: OscillatorPoint[] = [];
+  for (const p of slowEma) {
+    const fv = fastByIndex.get(p.index);
+    if (fv !== undefined) {
+      macdLine.push({ index: p.index, value: fv - p.value });
+    }
+  }
+
+  if (macdLine.length < signal) return empty;
+
+  // Signal line = EMA of MACD values
+  const macdValues = macdLine.map((p) => p.value);
+  const signalEma = computeEMA(macdValues, signal);
+
+  if (signalEma.length === 0) return empty;
+
+  // Map signal EMA positions back to original indices
+  // signalEma[i].index is an offset into macdValues; macdLine[offset].index is the original index
+  const signalLine: OscillatorPoint[] = signalEma.map((p) => ({
+    index: macdLine[p.index].index,
+    value: p.value,
+  }));
+
+  // Histogram: MACD - Signal at matching original indices
+  const macdByIndex = new Map<number, number>();
+  for (const p of macdLine) macdByIndex.set(p.index, p.value);
+
+  const histogram: OscillatorPoint[] = signalLine.map((p) => ({
+    index: p.index,
+    value: (macdByIndex.get(p.index) ?? 0) - p.value,
+  }));
+
+  return { macd: macdLine, signal: signalLine, histogram };
+}

--- a/src/components/chart/indicators/types.ts
+++ b/src/components/chart/indicators/types.ts
@@ -1,0 +1,36 @@
+/** A single data point for an overlay line drawn on the main chart */
+export interface OverlayPoint {
+  index: number;
+  value: number;
+}
+
+/** A single data point for an oscillator drawn in a sub-panel */
+export interface OscillatorPoint {
+  index: number;
+  value: number;
+}
+
+/** MACD has three series: macd line, signal line, histogram */
+export interface MacdResult {
+  macd: OscillatorPoint[];
+  signal: OscillatorPoint[];
+  histogram: OscillatorPoint[];
+}
+
+/** Bollinger Bands: upper, middle (SMA), lower */
+export interface BollingerResult {
+  upper: OverlayPoint[];
+  middle: OverlayPoint[];
+  lower: OverlayPoint[];
+}
+
+/** Active indicator configuration for a chart pane */
+export interface IndicatorConfig {
+  sma?: number[];        // e.g. [20, 50, 200]
+  ema?: number[];        // e.g. [12, 26]
+  rsi?: number | null;   // e.g. 14
+  macd?: { fast: number; slow: number; signal: number } | null;
+  bollinger?: { period: number; stdDev: number } | null;
+}
+
+export const DEFAULT_INDICATOR_CONFIG: IndicatorConfig = {};

--- a/src/components/chart/native/chart-rasterizer.ts
+++ b/src/components/chart/native/chart-rasterizer.ts
@@ -256,6 +256,20 @@ function projectX(index: number, count: number, left: number, right: number): nu
   return lerp(left, right, index / (count - 1));
 }
 
+function projectChartX(index: number, count: number, width: number, mode: ChartRenderMode): number {
+  if (mode !== "candles" && mode !== "ohlc") {
+    return projectX(index, count, 0, Math.max(width - 1, 0));
+  }
+
+  const spacing = width / Math.max(count, 1);
+  const bodyWidth = clamp(spacing * 0.58, 2, Math.max(spacing - 1, 2));
+  const tickLength = clamp(spacing * 0.34, 2, Math.max(spacing * 0.48, 2));
+  const horizontalPad = mode === "ohlc"
+    ? Math.ceil(Math.max(tickLength - 1, 0))
+    : Math.ceil(bodyWidth / 2);
+  return projectX(index, count, horizontalPad, Math.max(width - 1 - horizontalPad, horizontalPad));
+}
+
 function projectY(value: number, min: number, max: number, top: number, bottom: number): number {
   const range = max - min || 1;
   return lerp(bottom, top, (value - min) / range);
@@ -398,6 +412,42 @@ function drawVolume(
   }
 }
 
+function drawIndicatorOverlays(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  scene: ChartScene,
+  top: number,
+  bottom: number,
+) {
+  if (!scene.indicators) return;
+
+  const drawOverlay = (points: { index: number; value: number }[], color: string) => {
+    const lineColor = parseHex(color, 0.95);
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const p0 = points[index]!;
+      const p1 = points[index + 1]!;
+      const x0 = projectChartX(p0.index, scene.points.length, width, scene.mode);
+      const y0 = projectY(p0.value, scene.min, scene.max, top, bottom);
+      const x1 = projectChartX(p1.index, scene.points.length, width, scene.mode);
+      const y1 = projectY(p1.value, scene.min, scene.max, top, bottom);
+      drawLine(data, width, height, x0, y0, x1, y1, lineColor, 1.2);
+    }
+  };
+
+  for (const sma of scene.indicators.smaLines) {
+    drawOverlay(sma.points, sma.color);
+  }
+  for (const ema of scene.indicators.emaLines) {
+    drawOverlay(ema.points, ema.color);
+  }
+  if (scene.indicators.bollinger) {
+    drawOverlay(scene.indicators.bollinger.upper, scene.indicators.bollinger.color);
+    drawOverlay(scene.indicators.bollinger.middle, scene.indicators.bollinger.color);
+    drawOverlay(scene.indicators.bollinger.lower, scene.indicators.bollinger.color);
+  }
+}
+
 function drawCrosshairOverlay(
   data: Uint8Array,
   width: number,
@@ -447,6 +497,7 @@ export function renderNativeChartBase(scene: ChartScene, pixelWidth: number, pix
       break;
   }
 
+  drawIndicatorOverlays(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
   drawVolume(pixels, pixelWidth, pixelHeight, scene, layout.volumeTop, layout.volumeBottom);
 
   return { width: pixelWidth, height: pixelHeight, pixels };

--- a/src/components/chart/native/kitty.test.ts
+++ b/src/components/chart/native/kitty.test.ts
@@ -206,6 +206,74 @@ describe("renderNativeChartBase", () => {
     const withCursor = renderNativeChartBase(sceneWithCursor!, 120, 60);
     expect(withCursor.pixels).toEqual(withoutCursor.pixels);
   });
+
+  test("renders indicator overlays into the native chart bitmap", () => {
+    const palette = resolveChartPalette({
+      bg: "#112233",
+      border: "#333333",
+      borderFocused: "#ffff00",
+      text: "#ffffff",
+      textDim: "#777777",
+      positive: "#00ff00",
+      negative: "#ff0000",
+    }, "positive");
+    const points = [
+      { date: new Date("2024-01-02"), open: 10, high: 12, low: 9, close: 11, volume: 100 },
+      { date: new Date("2024-01-03"), open: 11, high: 13, low: 10, close: 12, volume: 120 },
+      { date: new Date("2024-01-04"), open: 12, high: 14, low: 11, close: 13, volume: 130 },
+    ];
+    const baseScene = buildChartScene(points, {
+      width: 18,
+      height: 8,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "line",
+      colors: palette,
+    });
+    const sceneWithIndicator = buildChartScene(points, {
+      width: 18,
+      height: 8,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "line",
+      colors: palette,
+      indicators: {
+        smaLines: [{
+          period: 2,
+          color: "#ff00ff",
+          points: [
+            { index: 0, value: 9.5 },
+            { index: 1, value: 10.5 },
+            { index: 2, value: 11.5 },
+          ],
+        }],
+        emaLines: [],
+        bollinger: null,
+        rsi: null,
+        macd: null,
+      },
+    });
+
+    expect(baseScene).not.toBeNull();
+    expect(sceneWithIndicator).not.toBeNull();
+
+    const baseBitmap = renderNativeChartBase(baseScene!, 120, 60);
+    const indicatorBitmap = renderNativeChartBase(sceneWithIndicator!, 120, 60);
+    expect(indicatorBitmap.pixels).not.toEqual(baseBitmap.pixels);
+
+    let magentaPixels = 0;
+    for (let offset = 0; offset < indicatorBitmap.pixels.length; offset += 4) {
+      const red = indicatorBitmap.pixels[offset]!;
+      const green = indicatorBitmap.pixels[offset + 1]!;
+      const blue = indicatorBitmap.pixels[offset + 2]!;
+      if (red > 180 && blue > 180 && green < 120) magentaPixels += 1;
+    }
+    expect(magentaPixels).toBeGreaterThan(0);
+  });
 });
 
 describe("renderNativeComparisonChartBase", () => {

--- a/src/components/chart/stock-chart-renderer-switch.test.tsx
+++ b/src/components/chart/stock-chart-renderer-switch.test.tsx
@@ -349,7 +349,9 @@ describe("StockChart renderer switching", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).not.toContain("AAPL - AUTO");
-    expect(frame).toContain("view:May 28-Jun 28");
+    expect(frame).toContain("AAPL - 15M");
+    expect(frame).toContain("May 28");
+    expect(frame).not.toContain("view:");
   });
 
   test("chooses supported auto detail resolutions as the visible window changes", async () => {
@@ -608,7 +610,6 @@ describe("StockChart renderer switching", () => {
     const initialFrame = testSetup.captureCharFrame();
     const titleRow = getFrameRowContaining(initialFrame, "AAPL - AUTO");
     expect(titleRow).toBeGreaterThanOrEqual(0);
-    const initialHeader = getFrameLineContaining(initialFrame, "AAPL - AUTO");
 
     for (let index = 0; index < 4; index += 1) {
       await act(async () => {
@@ -620,8 +621,8 @@ describe("StockChart renderer switching", () => {
 
     const pannedFrame = testSetup.captureCharFrame();
     const pannedHeader = getFrameLineContaining(pannedFrame, "AAPL - AUTO");
-    expect(pannedHeader).toContain("view:");
-    expect(pannedHeader).not.toBe(initialHeader);
+    expect(pannedHeader).not.toContain("view:");
+    expect(pannedFrame).not.toBe(initialFrame);
     expect(detailRequests.some((request) => /(m|h)$/i.test(request))).toBe(false);
   });
 
@@ -734,17 +735,15 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames(6);
-    const headerLines: string[] = [];
+    const frames: string[] = [];
     for (let index = 0; index < 10; index += 1) {
       await emitKeypress({ name: "=", sequence: "=" });
       await flushFrames(4);
-      headerLines.push(
-        testSetup.captureCharFrame().split("\n").find((line) => line.includes("AAPL - AUTO")) ?? "",
-      );
+      frames.push(testSetup.captureCharFrame());
     }
 
     expect(detailRequests).toContain("1d");
-    expect(headerLines[6]).not.toBe(headerLines[7]);
-    expect(headerLines[7]).not.toContain("view:Mar 1-Apr 9");
+    expect(frames[6]).not.toBe(frames[7]);
+    expect(frames[7]).not.toContain("view:");
   });
 });

--- a/src/components/chart/stock-chart.test.ts
+++ b/src/components/chart/stock-chart.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, test } from "bun:test";
 import type { BoxRenderable, CliRenderer } from "@opentui/core";
 import {
   getLocalPlotPointer,
+  computeProjectedIndicatorOverlays,
   projectCellCursorToLocalPixels,
   resolveAutoDisplayState,
   resolveAutoZoomWindow,
   resolveAdjacentSelectionCursorX,
+  resolveChartKeyboardKey,
+  resolveIndicatorBufferRange,
   resolveVisibleChartDateWindow,
   resolveSelectionDisplayCursorState,
 } from "./stock-chart";
@@ -113,6 +116,17 @@ describe("stock chart pointer helpers", () => {
 
     expect(resolveAdjacentSelectionCursorX(width - 1, -1, pointCount, width, "candles")).toBe(previous);
     expect(resolveAdjacentSelectionCursorX(previous, 1, pointCount, width, "candles")).toBe(rightmost);
+  });
+});
+
+describe("stock chart keyboard helpers", () => {
+  test("normalizes terminal zoom key variants", () => {
+    expect(resolveChartKeyboardKey({ sequence: "+" })).toBe("zoom-in");
+    expect(resolveChartKeyboardKey({ sequence: "=" })).toBe("zoom-in");
+    expect(resolveChartKeyboardKey({ name: "plus" })).toBe("zoom-in");
+    expect(resolveChartKeyboardKey({ sequence: "-" })).toBe("zoom-out");
+    expect(resolveChartKeyboardKey({ name: "minus" })).toBe("zoom-out");
+    expect(resolveChartKeyboardKey({ name: "A" })).toBe("a");
   });
 });
 
@@ -297,5 +311,36 @@ describe("stock chart auto helpers", () => {
       start: new Date("2026-01-09T00:00:00Z"),
       end: new Date("2026-01-10T00:00:00Z"),
     });
+  });
+});
+
+describe("stock chart indicator helpers", () => {
+  test("computes indicators from warmup history and reindexes them onto the visible projection", () => {
+    const source = makeDailyHistory(1, 30);
+    const projected = source.slice(20).map((point) => ({
+      date: point.date,
+      open: point.close,
+      high: point.close,
+      low: point.close,
+      close: point.close,
+      volume: 0,
+    }));
+
+    const overlays = computeProjectedIndicatorOverlays(source, projected, {
+      sma: [20],
+      bollinger: { period: 20, stdDev: 2 },
+    });
+
+    expect(overlays.smaLines[0]?.points).toHaveLength(projected.length);
+    expect(overlays.smaLines[0]?.points[0]?.index).toBe(0);
+    expect(overlays.smaLines[0]?.points.at(-1)?.index).toBe(projected.length - 1);
+    expect(overlays.bollinger?.upper[0]?.index).toBe(0);
+  });
+
+  test("widens the data buffer enough for selected indicator warmup periods", () => {
+    expect(resolveIndicatorBufferRange("3M", "3M", { sma: [20] })).toBe("6M");
+    expect(resolveIndicatorBufferRange("3M", "6M", { sma: [20] })).toBe("6M");
+    expect(resolveIndicatorBufferRange("3M", "3M", { sma: [200] })).toBe("5Y");
+    expect(resolveIndicatorBufferRange("3M", "3M", {})).toBe("3M");
   });
 });

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1,12 +1,12 @@
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type BoxRenderable, type CliRenderer } from "@opentui/core";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import { useAppDispatch, useAppSelector, usePaneInstance, usePaneInstanceId, usePaneSettingValue, usePaneTicker } from "../../state/app-context";
 import { saveConfig } from "../../data/config-store";
 import { getSharedDataProvider } from "../../plugins/registry";
-import { colors, priceColor } from "../../theme/colors";
-import { formatCompact, formatPercentRaw } from "../../utils/format";
-import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../utils/market-format";
+import { colors } from "../../theme/colors";
+import { formatCompact } from "../../utils/format";
+import { formatMarketPriceWithCurrency } from "../../utils/market-format";
 import { useChartQueries, useChartQuery } from "../../market-data/hooks";
 import { instrumentFromTicker, type ChartRequest } from "../../market-data/request-types";
 import { buildChartKey } from "../../market-data/selectors";
@@ -14,17 +14,16 @@ import { usePersistChartControlSelection } from "./chart-pane-settings";
 import { computeSMA, computeEMA } from "./indicators/moving-averages";
 import { computeRSI, computeMACD } from "./indicators/oscillators";
 import { computeBollingerBands } from "./indicators/bands";
-import type { IndicatorConfig } from "./indicators/types";
+import type { IndicatorConfig, MacdResult, OscillatorPoint, OverlayPoint } from "./indicators/types";
 import type { ChartIndicatorOverlays } from "./chart-types";
 import { applyBufferedPanExpansion, getMouseScrollStepCount, resolveHorizontalScrollPanDirection } from "./chart-scroll";
-import { getVisibleWindow, projectChartData, resolveBarSize } from "./chart-data";
+import { getVisibleWindow, projectChartData, resolveBarSize, type ProjectedChartPoint } from "./chart-data";
 import {
   buildPresetDateWindow,
   buildVisibleDateWindow,
   buildVisibleDateWindowFromRange,
   clampDateWindowToBounds,
   clearActivePreset,
-  formatVisibleSpanLabel,
   getCanonicalZoomLevel,
   getDateWindowBounds,
   getMinimumDateStepMs,
@@ -55,6 +54,7 @@ import {
   getTimeRangeForDateWindow,
   isIntradayResolution,
   isRangePresetSupported,
+  maxTimeRange,
   normalizeChartResolutionSupport,
   sortChartResolutions,
   subtractTimeRange,
@@ -87,6 +87,7 @@ import {
 } from "./cursor-motion";
 import {
   CHART_RENDER_MODES,
+  RANGE_DAYS,
   TIME_RANGES,
   type ChartAxisMode,
   type ChartRenderMode,
@@ -95,6 +96,7 @@ import {
   type ChartViewState,
   type ResolvedChartRenderer,
 } from "./chart-types";
+import { ChartControlHint } from "./chart-control-hint";
 import {
   computeBitmapSize,
   intersectCellRects,
@@ -135,6 +137,9 @@ const AXIS_MEASURE_PALETTE = resolveChartPalette({
   negative: colors.negative,
 }, "neutral");
 
+const EMPTY_INDICATOR_CONFIG: IndicatorConfig = {};
+const INDICATOR_RENDER_DEBOUNCE_MS = 120;
+
 interface StockChartProps {
   width: number;
   height: number;
@@ -144,6 +149,9 @@ interface StockChartProps {
   axisMode?: ChartAxisMode;
   historyOverride?: PricePoint[] | null;
   currencyOverride?: string | null;
+  indicatorConfig?: IndicatorConfig;
+  showVolume?: boolean;
+  footerControls?: ReactNode;
 }
 
 interface ResolvedStockChartProps extends StockChartProps {
@@ -193,6 +201,11 @@ type PendingExpansionAction =
   | { kind: "pan-left"; targetPanOffset: number }
   | null;
 
+interface DeferredIndicatorState {
+  key: string;
+  overlays: ChartIndicatorOverlays;
+}
+
 interface ChartMouseEvent {
   x: number;
   y: number;
@@ -209,6 +222,22 @@ interface ChartMouseEvent {
     direction: "up" | "down" | "left" | "right";
     delta: number;
   };
+}
+
+export function resolveChartKeyboardKey(event: { name?: string; sequence?: string }): string {
+  const name = event.name ?? "";
+  const sequence = event.sequence ?? "";
+  const candidates = [name, sequence];
+
+  if (candidates.some((key) => key === "=" || key === "+" || key === "plus")) {
+    return "zoom-in";
+  }
+  if (candidates.some((key) => key === "-" || key === "_" || key === "minus")) {
+    return "zoom-out";
+  }
+
+  const key = name || sequence;
+  return key.length === 1 ? key.toLowerCase() : key;
 }
 
 export interface LocalPlotPointer {
@@ -585,6 +614,7 @@ function buildBufferedDetailWindow(
   maxRange: TimeRange,
   bounds: DateWindowRange | null | undefined,
   minimumSpanMs: number,
+  minimumBufferRange: TimeRange | null = null,
 ): DateWindowRange | null {
   if (!requestedWindow?.end) return null;
 
@@ -597,6 +627,9 @@ function buildBufferedDetailWindow(
         break;
       }
     }
+  }
+  if (minimumBufferRange) {
+    bufferRange = maxTimeRange(bufferRange, clampTimeRangeToMaxRange(minimumBufferRange, maxRange));
   }
 
   return clampDateWindowToBounds(
@@ -931,6 +964,7 @@ function buildResolvedChartRequestPlan(options: {
   effectiveManualResolution: ManualChartResolution | null;
   bounds: DateWindowRange | null;
   bufferRange: TimeRange;
+  minimumBufferRange?: TimeRange | null;
   support: ReadonlyMap<ManualChartResolution, TimeRange>;
   hasResolutionHistoryApi: boolean;
   hasDetailedHistoryApi: boolean;
@@ -945,6 +979,7 @@ function buildResolvedChartRequestPlan(options: {
     effectiveManualResolution,
     bounds,
     bufferRange,
+    minimumBufferRange = null,
     support,
     hasResolutionHistoryApi,
     hasDetailedHistoryApi,
@@ -975,7 +1010,13 @@ function buildResolvedChartRequestPlan(options: {
   const latestDate = bounds?.end ?? null;
   let resolutionRequest: ChartRequest | null = null;
   if (hasResolutionHistoryApi && maxRange && latestDate) {
-    const anchoredRange = getMinimumAnchoredBufferRange(requestedWindow, latestDate, maxRange);
+    const baseAnchoredRange = getMinimumAnchoredBufferRange(requestedWindow, latestDate, maxRange);
+    const minimumAnchoredRange = minimumBufferRange
+      ? clampTimeRangeToMaxRange(minimumBufferRange, maxRange)
+      : null;
+    const anchoredRange = baseAnchoredRange && minimumAnchoredRange
+      ? maxTimeRange(baseAnchoredRange, minimumAnchoredRange)
+      : baseAnchoredRange;
     if (anchoredRange) {
       resolutionRequest = {
         instrument: instrumentRef,
@@ -988,7 +1029,7 @@ function buildResolvedChartRequestPlan(options: {
 
   let detailRequest: ChartRequest | null = null;
   if (hasDetailedHistoryApi && maxRange) {
-    const bufferedWindow = buildBufferedDetailWindow(requestedWindow, maxRange, bounds, minimumSpanMs);
+    const bufferedWindow = buildBufferedDetailWindow(requestedWindow, maxRange, bounds, minimumSpanMs, minimumBufferRange);
     if (bufferedWindow?.start && bufferedWindow.end) {
       detailRequest = {
         instrument: instrumentRef,
@@ -1073,6 +1114,7 @@ function buildNativeBitmapKey(
   mode: ChartRenderMode,
   showVolume: boolean,
   paletteId: string,
+  indicatorKey: string,
 ): string {
   const fingerprint = points
     .map((point) => {
@@ -1080,7 +1122,7 @@ function buildNativeBitmapKey(
       return `${date}:${point.open}:${point.high}:${point.low}:${point.close}:${point.volume ?? 0}`;
     })
     .join("|");
-  return [pointCount, pixelWidth, pixelHeight, mode, showVolume ? "1" : "0", paletteId, fingerprint].join("::");
+  return [pointCount, pixelWidth, pixelHeight, mode, showVolume ? "1" : "0", paletteId, indicatorKey, fingerprint].join("::");
 }
 
 function buildNativeCrosshairBitmapKey(
@@ -1143,6 +1185,115 @@ const INDICATOR_COLORS = [
   "#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8",
 ];
 
+export function getIndicatorWarmupPeriod(config: IndicatorConfig): number {
+  const periods = [
+    ...(config.sma ?? []),
+    ...(config.ema ?? []),
+    config.bollinger?.period,
+    config.rsi ?? undefined,
+    config.macd ? config.macd.slow + config.macd.signal : undefined,
+  ].filter((period): period is number => typeof period === "number" && Number.isFinite(period) && period > 0);
+
+  return periods.length > 0 ? Math.max(...periods) : 0;
+}
+
+export function resolveIndicatorBufferRange(
+  visibleRange: TimeRange,
+  currentBufferRange: TimeRange,
+  config: IndicatorConfig,
+): TimeRange {
+  const warmupPeriod = getIndicatorWarmupPeriod(config);
+  if (warmupPeriod <= 0) return currentBufferRange;
+
+  const visibleDays = RANGE_DAYS[visibleRange];
+  if (!Number.isFinite(visibleDays)) return currentBufferRange;
+
+  const targetDays = visibleDays + warmupPeriod;
+  const warmupRange = TIME_RANGE_ORDER.find((range) => RANGE_DAYS[range] >= targetDays) ?? "ALL";
+  return maxTimeRange(currentBufferRange, warmupRange);
+}
+
+function getPricePointTime(point: Pick<PricePoint, "date"> | Pick<ProjectedChartPoint, "date">): number {
+  return coerceChartDate(point.date as Date | string | number).getTime();
+}
+
+function buildProjectedSourceIndexMap(
+  sourcePoints: readonly PricePoint[],
+  projectedPoints: readonly ProjectedChartPoint[],
+  sourceIndexOffset = 0,
+): Map<number, number> {
+  const sourceIndexByTime = new Map<number, number>();
+  sourcePoints.forEach((point, index) => {
+    sourceIndexByTime.set(getPricePointTime(point), sourceIndexOffset + index);
+  });
+
+  const projectedIndexBySourceIndex = new Map<number, number>();
+  projectedPoints.forEach((point, projectedIndex) => {
+    const sourceIndex = sourceIndexByTime.get(getPricePointTime(point));
+    if (sourceIndex !== undefined) {
+      projectedIndexBySourceIndex.set(sourceIndex, projectedIndex);
+    }
+  });
+  return projectedIndexBySourceIndex;
+}
+
+function findPointBySourceIndex<TPoint extends { index: number }>(
+  points: readonly TPoint[],
+  sourceIndex: number,
+): TPoint | null {
+  let low = 0;
+  let high = points.length - 1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const point = points[mid]!;
+    if (point.index === sourceIndex) return point;
+    if (point.index < sourceIndex) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return null;
+}
+
+function reindexOverlayPoints(
+  points: readonly OverlayPoint[],
+  projectedIndexBySourceIndex: ReadonlyMap<number, number>,
+): OverlayPoint[] {
+  const reindexed: OverlayPoint[] = [];
+  projectedIndexBySourceIndex.forEach((projectedIndex, sourceIndex) => {
+    const point = findPointBySourceIndex(points, sourceIndex);
+    if (point) reindexed.push({ index: projectedIndex, value: point.value });
+  });
+  return reindexed;
+}
+
+function reindexOscillatorPoints(
+  points: readonly OscillatorPoint[],
+  projectedIndexBySourceIndex: ReadonlyMap<number, number>,
+): OscillatorPoint[] {
+  const reindexed: OscillatorPoint[] = [];
+  projectedIndexBySourceIndex.forEach((projectedIndex, sourceIndex) => {
+    const point = findPointBySourceIndex(points, sourceIndex);
+    if (point) reindexed.push({ index: projectedIndex, value: point.value });
+  });
+  return reindexed;
+}
+
+function reindexMacdResult(
+  result: MacdResult | null,
+  projectedIndexBySourceIndex: ReadonlyMap<number, number>,
+): MacdResult | null {
+  if (!result) return null;
+  return {
+    macd: reindexOscillatorPoints(result.macd, projectedIndexBySourceIndex),
+    signal: reindexOscillatorPoints(result.signal, projectedIndexBySourceIndex),
+    histogram: reindexOscillatorPoints(result.histogram, projectedIndexBySourceIndex),
+  };
+}
+
 function computeIndicatorOverlays(
   closes: number[],
   config: IndicatorConfig,
@@ -1174,6 +1325,126 @@ function computeIndicatorOverlays(
   return { smaLines, emaLines, bollinger, rsi, macd };
 }
 
+export function computeProjectedIndicatorOverlays(
+  sourcePoints: readonly PricePoint[],
+  projectedPoints: readonly ProjectedChartPoint[],
+  config: IndicatorConfig,
+): ChartIndicatorOverlays {
+  const closes = sourcePoints.map((point) => point.close);
+  const overlays = computeIndicatorOverlays(closes, config);
+  return reindexIndicatorOverlaysForProjection(overlays, sourcePoints, projectedPoints);
+}
+
+export function reindexIndicatorOverlaysForProjection(
+  overlays: ChartIndicatorOverlays,
+  sourcePoints: readonly PricePoint[],
+  projectedPoints: readonly ProjectedChartPoint[],
+  sourceIndexOffset = 0,
+): ChartIndicatorOverlays {
+  const projectedIndexBySourceIndex = buildProjectedSourceIndexMap(
+    sourcePoints,
+    projectedPoints,
+    sourceIndexOffset,
+  );
+
+  return {
+    smaLines: overlays.smaLines.map((line) => ({
+      ...line,
+      points: reindexOverlayPoints(line.points, projectedIndexBySourceIndex),
+    })),
+    emaLines: overlays.emaLines.map((line) => ({
+      ...line,
+      points: reindexOverlayPoints(line.points, projectedIndexBySourceIndex),
+    })),
+    bollinger: overlays.bollinger
+      ? {
+        ...overlays.bollinger,
+        upper: reindexOverlayPoints(overlays.bollinger.upper, projectedIndexBySourceIndex),
+        middle: reindexOverlayPoints(overlays.bollinger.middle, projectedIndexBySourceIndex),
+        lower: reindexOverlayPoints(overlays.bollinger.lower, projectedIndexBySourceIndex),
+      }
+      : null,
+    rsi: overlays.rsi ? reindexOscillatorPoints(overlays.rsi, projectedIndexBySourceIndex) : null,
+    macd: reindexMacdResult(overlays.macd, projectedIndexBySourceIndex),
+  };
+}
+
+function buildIndicatorRenderKey(indicators: ChartIndicatorOverlays | null): string {
+  if (!indicators) return "none";
+
+  const pointKey = (points: readonly OverlayPoint[]) => {
+    const first = points[0];
+    const last = points[points.length - 1];
+    return first && last
+      ? `${points.length}:${first.index}:${first.value.toFixed(6)}:${last.index}:${last.value.toFixed(6)}`
+      : "0";
+  };
+
+  return [
+    indicators.smaLines.map((line) => `sma:${line.period}:${line.color}:${pointKey(line.points)}`).join(","),
+    indicators.emaLines.map((line) => `ema:${line.period}:${line.color}:${pointKey(line.points)}`).join(","),
+    indicators.bollinger
+      ? [
+        `bb:${indicators.bollinger.color}`,
+        pointKey(indicators.bollinger.upper),
+        pointKey(indicators.bollinger.middle),
+        pointKey(indicators.bollinger.lower),
+      ].join(":")
+      : "",
+  ].join("|");
+}
+
+function buildIndicatorConfigKey(config: IndicatorConfig): string {
+  return [
+    `sma:${(config.sma ?? []).join(",")}`,
+    `ema:${(config.ema ?? []).join(",")}`,
+    config.bollinger ? `bb:${config.bollinger.period}:${config.bollinger.stdDev}` : "bb:",
+    `rsi:${config.rsi ?? ""}`,
+    config.macd ? `macd:${config.macd.fast}:${config.macd.slow}:${config.macd.signal}` : "macd:",
+  ].join("|");
+}
+
+function buildIndicatorSourceKey(
+  sourcePoints: readonly PricePoint[],
+  config: IndicatorConfig,
+): string {
+  const first = sourcePoints[0];
+  const last = sourcePoints[sourcePoints.length - 1];
+  return [
+    buildIndicatorConfigKey(config),
+    sourcePoints.length,
+    first ? getPricePointTime(first) : "",
+    first?.close ?? "",
+    last ? getPricePointTime(last) : "",
+    last?.close ?? "",
+  ].join(":");
+}
+
+function buildIndicatorProjectionKey(options: {
+  sourceKey: string;
+  sourcePoints: readonly PricePoint[];
+  sourceIndexOffset: number;
+  projectedPoints: readonly ProjectedChartPoint[];
+  mode: ChartRenderMode;
+}): string {
+  const firstSource = options.sourcePoints[0];
+  const lastSource = options.sourcePoints[options.sourcePoints.length - 1];
+  const firstProjected = options.projectedPoints[0];
+  const lastProjected = options.projectedPoints[options.projectedPoints.length - 1];
+
+  return [
+    options.sourceKey,
+    options.sourceIndexOffset,
+    options.sourcePoints.length,
+    firstSource ? getPricePointTime(firstSource) : "",
+    lastSource ? getPricePointTime(lastSource) : "",
+    options.projectedPoints.length,
+    firstProjected ? getPricePointTime(firstProjected) : "",
+    lastProjected ? getPricePointTime(lastProjected) : "",
+    options.mode,
+  ].join(":");
+}
+
 export function StockChart(props: StockChartProps) {
   const { symbol, ticker, financials } = usePaneTicker();
   return <ResolvedStockChart {...props} symbol={symbol} ticker={ticker} financials={financials} />;
@@ -1188,6 +1459,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   axisMode = "price",
   historyOverride = null,
   currencyOverride = null,
+  indicatorConfig: indicatorConfigOverride,
+  showVolume: showVolumeOverride,
+  footerControls,
   symbol,
   ticker,
   financials,
@@ -1213,6 +1487,13 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     cursorY: null,
     renderMode: defaultRenderMode,
   });
+  // Read indicator config from the chart caller, falling back to legacy pane settings.
+  const indicatorConfig: IndicatorConfig = indicatorConfigOverride ?? ((pane?.settings?.indicators as IndicatorConfig) ?? EMPTY_INDICATOR_CONFIG);
+  const hasIndicators = !!(indicatorConfig.sma?.length || indicatorConfig.ema?.length || indicatorConfig.rsi || indicatorConfig.macd || indicatorConfig.bollinger);
+  const indicatorBufferRange = useMemo(
+    () => resolveIndicatorBufferRange(viewState.presetRange, viewState.bufferRange, indicatorConfig),
+    [indicatorConfig, viewState.bufferRange, viewState.presetRange],
+  );
   const [requestedResolution, setRequestedResolution] = useState<ChartResolution>(
     compact ? "auto" : storedResolution,
   );
@@ -1220,7 +1501,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const supportMap = useMemo(() => buildChartResolutionSupportMap(resolutionSupport ?? []), [resolutionSupport]);
   const [renderedAutoView, setRenderedAutoView] = useState<AutoRenderedView | null>(null);
   const [pendingAutoWindowOverride, setPendingAutoWindowOverride] = useState<DateWindowRange | null>(null);
-  const [showVolume, setShowVolume] = useState(!compact);
+  const showVolume = showVolumeOverride ?? !compact;
   const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
   const [displayCursor, setDisplayCursor] = useState<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
   const plotRef = useRef<BoxRenderable | null>(null);
@@ -1435,7 +1716,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     !compact && instrumentRef
       ? {
         instrument: instrumentRef,
-        bufferRange: viewState.bufferRange,
+        bufferRange: indicatorBufferRange,
         granularity: "range",
       }
       : null,
@@ -1548,7 +1829,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         effectiveResolution,
         effectiveManualResolution: candidateResolution,
         bounds: baseDateBounds,
-        bufferRange: viewState.bufferRange,
+        bufferRange: indicatorBufferRange,
+        minimumBufferRange: hasIndicators ? indicatorBufferRange : null,
         support: supportMap,
         hasResolutionHistoryApi: !!dataProvider?.getPriceHistoryForResolution,
         hasDetailedHistoryApi: !!dataProvider?.getDetailedPriceHistory,
@@ -1573,7 +1855,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     plannedDateWindow,
     plannedWindowRange,
     supportMap,
-    viewState.bufferRange,
+    indicatorBufferRange,
+    hasIndicators,
   ]);
   const candidateResolutionRequests = useMemo(
     () => dedupeChartRequests(renderCandidates.map((candidate) => candidate.plan.resolutionRequest)),
@@ -2316,10 +2599,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     queueMicrotask(() => renderer.requestRender());
   }, [chartHeight, chartWidth, compact, historyRenderKey, renderer, ticker?.metadata.ticker, viewState.renderMode]);
 
-  const visibleChartDateWindow = useMemo(
-    () => resolveVisibleChartDateWindow(chartWindow.points, displayedDateWindow),
-    [chartWindow.points, displayedDateWindow],
-  );
   const timeAxisDates = useMemo(
     () => chartWindow.points.map((point) => point.date),
     [chartWindow.points],
@@ -2329,22 +2608,71 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     projectChartData(chartWindow.points, chartWidth, viewState.renderMode, !!compact)
   ), [chartWindow.points, chartWidth, compact, viewState.renderMode]);
 
-  // Read indicator config from pane settings
-  const indicatorConfig: IndicatorConfig = (pane?.settings?.indicators as IndicatorConfig) ?? {};
-  const hasIndicators = !!(indicatorConfig.sma?.length || indicatorConfig.ema?.length || indicatorConfig.rsi || indicatorConfig.macd || indicatorConfig.bollinger);
+  const sourceIndicatorOverlays = useMemo(() => {
+    if (!hasIndicators || !history.length) return null;
+    return computeIndicatorOverlays(history.map((point) => point.close), indicatorConfig);
+  }, [history, hasIndicators, indicatorConfig]);
 
-  const indicators = useMemo(() => {
-    if (!hasIndicators || !projection.points.length) return null;
-    const closes = projection.points.map((p) => p.close);
-    return computeIndicatorOverlays(closes, indicatorConfig);
-  }, [projection.points, hasIndicators, indicatorConfig]);
+  const indicatorSourceKey = useMemo(() => (
+    sourceIndicatorOverlays ? buildIndicatorSourceKey(history, indicatorConfig) : "none"
+  ), [history, indicatorConfig, sourceIndicatorOverlays]);
+  const indicatorProjectionKey = useMemo(() => {
+    if (!sourceIndicatorOverlays || !chartWindow.points.length || !projection.points.length) return "none";
+    return buildIndicatorProjectionKey({
+      sourceKey: indicatorSourceKey,
+      sourcePoints: chartWindow.points,
+      sourceIndexOffset: chartWindow.startIdx,
+      projectedPoints: projection.points,
+      mode: projection.effectiveMode,
+    });
+  }, [
+    chartWindow.points,
+    chartWindow.startIdx,
+    indicatorSourceKey,
+    projection.effectiveMode,
+    projection.points,
+    sourceIndicatorOverlays,
+  ]);
+  const [deferredIndicators, setDeferredIndicators] = useState<DeferredIndicatorState | null>(null);
+
+  useEffect(() => {
+    if (!sourceIndicatorOverlays || indicatorProjectionKey === "none" || !chartWindow.points.length || !projection.points.length) {
+      setDeferredIndicators((current) => (current === null ? current : null));
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setDeferredIndicators({
+        key: indicatorProjectionKey,
+        overlays: reindexIndicatorOverlaysForProjection(
+          sourceIndicatorOverlays,
+          chartWindow.points,
+          projection.points,
+          chartWindow.startIdx,
+        ),
+      });
+    }, INDICATOR_RENDER_DEBOUNCE_MS);
+
+    return () => clearTimeout(timeout);
+  }, [
+    chartWindow.points,
+    chartWindow.startIdx,
+    indicatorProjectionKey,
+    projection.points,
+    sourceIndicatorOverlays,
+  ]);
+
+  const indicators = deferredIndicators?.key === indicatorProjectionKey ? deferredIndicators.overlays : null;
+  const indicatorRenderKey = useMemo(() => {
+    return buildIndicatorRenderKey(indicators);
+  }, [indicators]);
 
   useKeyboard((event) => {
     if (!focused || compact) return;
+    const key = resolveChartKeyboardKey(event);
 
-    switch (event.name) {
-      case "=":
-      case "+":
+    switch (key) {
+      case "zoom-in":
         if (effectiveResolution === "auto") {
           requestAutoWindow(resolveAutoZoomWindow({
             historyPoints: history,
@@ -2357,8 +2685,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         }
         setViewState((current) => applyZoomAroundAnchor(current, current.zoomLevel * 1.5, RIGHT_EDGE_ANCHOR_RATIO, boundsHistory));
         return;
-      case "-":
-      case "_":
+      case "zoom-out":
         if (effectiveResolution === "auto") {
           requestAutoWindow(resolveAutoZoomWindow({
             historyPoints: history,
@@ -2410,9 +2737,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
           };
         });
         return;
-      case "v":
-        setShowVolume((value) => !value);
-        return;
       case "a":
         if (effectiveResolution === "auto") {
           requestAutoWindow(shiftDateWindow(navigableDateWindow, panStep / Math.max(chartWidth, 1)));
@@ -2424,14 +2748,21 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         })) {
           return;
         }
-        setViewState((current) => ({ ...clearActivePreset(current), panOffset: current.panOffset + panStep }));
+        setViewState((current) => {
+          const cleared = clearActivePreset(current);
+          return { ...cleared, panOffset: current.panOffset + panStep };
+        });
         return;
       case "d":
         if (effectiveResolution === "auto") {
           requestAutoWindow(shiftDateWindow(navigableDateWindow, -panStep / Math.max(chartWidth, 1)));
           return;
         }
-        setViewState((current) => ({ ...clearActivePreset(current), panOffset: Math.max(current.panOffset - panStep, 0) }));
+        setViewState((current) => {
+          const cleared = clearActivePreset(current);
+          const nextPanOffset = Math.max(current.panOffset - panStep, 0);
+          return cleared.panOffset === nextPanOffset ? cleared : { ...cleared, panOffset: nextPanOffset };
+        });
         return;
       case "m":
         setViewState((current) => {
@@ -2450,15 +2781,15 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       }
     }
 
-    if (event.name >= "1" && event.name <= "7") {
-      const index = parseInt(event.name) - 1;
+    if (key >= "1" && key <= "7") {
+      const index = parseInt(key) - 1;
       if (index < TIME_RANGES.length) setRange(TIME_RANGES[index]!);
       return;
     }
 
     if (!interactive) return;
 
-    switch (event.name) {
+    switch (key) {
       case "left":
         if (event.shift) {
           if (effectiveResolution === "auto") {
@@ -2471,7 +2802,10 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
           })) {
             return;
           }
-          setViewState((current) => ({ ...clearActivePreset(current), panOffset: current.panOffset + panStep }));
+          setViewState((current) => {
+            const cleared = clearActivePreset(current);
+            return { ...cleared, panOffset: current.panOffset + panStep };
+          });
         } else {
           cursorMotionKindRef.current = "discrete";
           const pointCount = projection.points.length;
@@ -2518,7 +2852,11 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
             requestAutoWindow(shiftDateWindow(navigableDateWindow, -panStep / Math.max(chartWidth, 1)));
             return;
           }
-          setViewState((current) => ({ ...clearActivePreset(current), panOffset: Math.max(current.panOffset - panStep, 0) }));
+          setViewState((current) => {
+            const cleared = clearActivePreset(current);
+            const nextPanOffset = Math.max(current.panOffset - panStep, 0);
+            return cleared.panOffset === nextPanOffset ? cleared : { ...cleared, panOffset: nextPanOffset };
+          });
         } else {
           cursorMotionKindRef.current = "discrete";
           const pointCount = projection.points.length;
@@ -2648,7 +2986,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     axisMode,
     colors: chartColors,
     timeAxisDates,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+    indicators,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
   const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;
@@ -2820,6 +3159,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         chartColors.candleUp,
         chartColors.candleDown,
       ].join(","),
+      indicatorRenderKey,
     );
     const cachedBitmap = lastNativeBaseBitmapRef.current?.key === bitmapKey
       ? lastNativeBaseBitmapRef.current.bitmap
@@ -2853,6 +3193,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     chartColors.volumeUp,
     compact,
     effectiveRenderer,
+    indicatorRenderKey,
     nativeBaseScene,
     nativeBaseSurfaceId,
     nativeSurfaceManager,
@@ -2938,29 +3279,10 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   ]);
 
   const hasHistory = chartWindow.points.length > 0;
-  const firstPrice = chartWindow.points[0]?.close ?? 0;
-  const lastPrice = chartWindow.points[chartWindow.points.length - 1]?.close ?? 0;
-  const change = lastPrice - firstPrice;
-  const changePct = firstPrice ? (change / firstPrice) * 100 : 0;
   const requestedMode = projection.requestedMode;
   const showOhlcSummary = projection.effectiveMode === "candles" || projection.effectiveMode === "ohlc";
   const hasSelectionCursor = selectionCursorX !== null;
   const hasDisplayCursor = displayCursorX !== null && displayCursorY !== null;
-  const displayPrice = !hasHistory
-    ? null
-    : hasSelectionCursor
-      ? (selectionScene?.priceAtCursor ?? lastPrice)
-      : lastPrice;
-  const displayChange = !hasHistory
-    ? null
-    : hasSelectionCursor
-      ? (selectionScene?.changeAtCursor ?? change)
-      : change;
-  const displayChangePct = !hasHistory
-    ? null
-    : hasSelectionCursor
-      ? (selectionScene?.changePctAtCursor ?? changePct)
-      : changePct;
   const displayDate = hasSelectionCursor || showOhlcSummary
     ? (selectionScene?.dateAtCursor ? formatDateShort(selectionScene.dateAtCursor) : null)
     : null;
@@ -2979,12 +3301,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       visiblePriceRange,
     )
     : null;
-  const visibleLabel = formatVisibleSpanLabel(
-    visibleChartDateWindow ?? {
-      start: null,
-      end: null,
-    },
-  );
   const isBlockingBody = !compact && renderBodyState.blocking;
   const bodyMessage = !compact
     ? (renderBodyState.errorMessage ?? renderBodyState.emptyMessage)
@@ -3000,7 +3316,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     isUpdating,
     renderer,
     selectedResolution,
-    visibleLabel,
   ]);
 
   const handlePlotMove = (event: ChartMouseEvent) => {
@@ -3083,7 +3398,10 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       0,
       Math.max(boundsHistory.length - visibleCount, 0),
     );
-    setViewState((current) => ({ ...clearActivePreset(current), panOffset: nextPan }));
+    setViewState((current) => {
+      const cleared = clearActivePreset(current);
+      return cleared.panOffset === nextPan ? cleared : { ...cleared, panOffset: nextPan };
+    });
   };
 
   const handlePlotScroll = (event: ChartMouseEvent) => {
@@ -3214,30 +3532,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         <text attributes={TextAttributes.BOLD} fg={colors.textBright}>
           {ticker?.metadata.ticker ?? ""} - {getChartResolutionLabel(selectedResolution)}
         </text>
-        <text fg={colors.textDim}>{visibleLabel}</text>
         {fallbackResolutionLabel && (
           <text fg={colors.textDim}>{fallbackResolutionLabel}</text>
         )}
-        <text fg={displayChange !== null ? priceColor(displayChange) : colors.textDim}>
-          {displayPrice !== null
-            ? formatMarketPriceWithCurrency(displayPrice, chartCurrency, {
-              assetCategory: chartAssetCategory,
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })
-            : "—"}
-        </text>
-        <text fg={displayChange !== null ? priceColor(displayChange) : colors.textDim}>
-          {displayChange !== null && displayChangePct !== null
-            ? `${formatSignedMarketPrice(displayChange, {
-              assetCategory: chartAssetCategory,
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })} (${formatPercentRaw(displayChangePct)})`
-            : "No data"}
-        </text>
         {displayDate && <text fg={colors.textDim}>{displayDate}</text>}
         {showOhlcSummary && activePoint && (
           <>
@@ -3352,12 +3649,13 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         <text fg={colors.textDim}>{selectionScene?.timeLabels ?? staticResult.timeLabels}</text>
       </box>
 
-      <box height={1}>
-        <text fg={colors.textMuted}>
-          {interactive
-            ? "←→ cursor  ⇧←→ pan  m mode  r res  v vol  0 reset  Esc exit"
-            : "a/d pan  +/- zoom  m mode  r res  v volume  0 reset"}
-        </text>
+      <box height={1} flexDirection="row" gap={1}>
+        <ChartControlHint hotkey="m" label="ode" />
+        {footerControls}
+        <ChartControlHint hotkey="r" label="es" />
+        <ChartControlHint hotkey="+/-" label="zoom" />
+        <ChartControlHint hotkey="0" label="reset" />
+        {width >= 72 && <ChartControlHint hotkey="1-7" label="range" />}
       </box>
     </box>
   );

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type BoxRenderable, type CliRenderer } from "@opentui/core";
 import { useKeyboard, useRenderer } from "@opentui/react";
-import { useAppDispatch, useAppSelector, usePaneInstanceId, usePaneSettingValue, usePaneTicker } from "../../state/app-context";
+import { useAppDispatch, useAppSelector, usePaneInstance, usePaneInstanceId, usePaneSettingValue, usePaneTicker } from "../../state/app-context";
 import { saveConfig } from "../../data/config-store";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { colors, priceColor } from "../../theme/colors";
@@ -10,6 +10,11 @@ import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../ut
 import { useChartQuery } from "../../market-data/hooks";
 import { instrumentFromTicker } from "../../market-data/request-types";
 import { usePersistChartControlSelection } from "./chart-pane-settings";
+import { computeSMA, computeEMA } from "./indicators/moving-averages";
+import { computeRSI, computeMACD } from "./indicators/oscillators";
+import { computeBollingerBands } from "./indicators/bands";
+import type { IndicatorConfig } from "./indicators/types";
+import type { ChartIndicatorOverlays } from "./chart-types";
 import { getVisibleWindow, projectChartData, resolveBarSize } from "./chart-data";
 import {
   buildVisibleDateWindow,
@@ -559,6 +564,41 @@ function resolveSelectionCursor(
   };
 }
 
+const INDICATOR_COLORS = [
+  "#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8",
+];
+
+function computeIndicatorOverlays(
+  closes: number[],
+  config: IndicatorConfig,
+): ChartIndicatorOverlays {
+  let colorIdx = 0;
+  const nextColor = () => INDICATOR_COLORS[colorIdx++ % INDICATOR_COLORS.length]!;
+
+  const smaLines = (config.sma ?? []).map((period) => ({
+    period,
+    points: computeSMA(closes, period),
+    color: nextColor(),
+  }));
+
+  const emaLines = (config.ema ?? []).map((period) => ({
+    period,
+    points: computeEMA(closes, period),
+    color: nextColor(),
+  }));
+
+  const bollinger = config.bollinger
+    ? { ...computeBollingerBands(closes, config.bollinger.period, config.bollinger.stdDev), color: nextColor() }
+    : null;
+
+  const rsi = config.rsi ? computeRSI(closes, config.rsi) : null;
+  const macd = config.macd
+    ? computeMACD(closes, config.macd.fast, config.macd.slow, config.macd.signal)
+    : null;
+
+  return { smaLines, emaLines, bollinger, rsi, macd };
+}
+
 export function StockChart(props: StockChartProps) {
   const { symbol, ticker, financials } = usePaneTicker();
   return <ResolvedStockChart {...props} symbol={symbol} ticker={ticker} financials={financials} />;
@@ -581,6 +621,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const dispatch = useAppDispatch();
   const config = useAppSelector((state) => state.config);
   const paneId = usePaneInstanceId();
+  const pane = usePaneInstance();
   const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);
   const defaultRenderMode = config.chartPreferences.defaultRenderMode;
   const preferredRenderer = config.chartPreferences.renderer;
@@ -1121,6 +1162,16 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     projectChartData(chartWindow.points, chartWidth, viewState.renderMode, !!compact)
   ), [chartWindow.points, chartWidth, compact, viewState.renderMode]);
 
+  // Read indicator config from pane settings
+  const indicatorConfig: IndicatorConfig = (pane?.settings?.indicators as IndicatorConfig) ?? {};
+  const hasIndicators = !!(indicatorConfig.sma?.length || indicatorConfig.ema?.length || indicatorConfig.rsi || indicatorConfig.macd || indicatorConfig.bollinger);
+
+  const indicators = useMemo(() => {
+    if (!hasIndicators || !projection.points.length) return null;
+    const closes = projection.points.map((p) => p.close);
+    return computeIndicatorOverlays(closes, indicatorConfig);
+  }, [projection.points, hasIndicators, indicatorConfig]);
+
   useKeyboard((event) => {
     if (!focused || compact) return;
 
@@ -1386,7 +1437,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     assetCategory: chartAssetCategory,
     colors: chartColors,
     timeAxisDates,
-  }), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+    indicators,
+  }), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const interactiveResult = useMemo(() => (
     effectiveRenderer === "kitty"
@@ -1404,8 +1456,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         assetCategory: chartAssetCategory,
         colors: chartColors,
         timeAxisDates,
+        indicators,
       })
-  ), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+  ), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const result = effectiveRenderer === "kitty" ? staticResult : interactiveResult!;
 

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -3,15 +3,12 @@ import { useDialog, useDialogKeyboard, type AlertContext } from "@opentui-ui/dia
 import { useEffect, useRef, useState } from "react";
 import type {
   PaneSettingField,
-  PaneSettingOption,
-  PaneSettingOrderedMultiSelectField,
   PaneSettingTextField,
 } from "../types/plugin";
 import type { PluginRegistry } from "../plugins/registry";
 import { useAppState } from "../state/app-context";
 import { colors } from "../theme/colors";
-import { ToggleList } from "./toggle-list";
-import { Button, DialogFrame, ListView, TextField } from "./ui";
+import { Button, DialogFrame, ListView, MultiSelectDialogContent, TextField } from "./ui";
 
 interface PaneSettingsDialogContentProps extends AlertContext {
   paneId: string;
@@ -54,37 +51,6 @@ function coerceSelectedValues(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === "string")
     : [];
-}
-
-function toggleSelectedValue(currentValues: string[], value: string): string[] {
-  return currentValues.includes(value)
-    ? currentValues.filter((entry) => entry !== value)
-    : [...currentValues, value];
-}
-
-function moveSelectedValue(
-  field: PaneSettingOrderedMultiSelectField,
-  currentValues: string[],
-  selectedOption: string,
-  direction: "up" | "down",
-): string[] {
-  if (!currentValues.includes(selectedOption)) return currentValues;
-
-  const optionValueSet = new Set(field.options.map((option) => option.value));
-  const ordered = currentValues.filter((value) => optionValueSet.has(value));
-  const index = ordered.indexOf(selectedOption);
-  if (index < 0) return currentValues;
-
-  const targetIndex = direction === "up"
-    ? Math.max(0, index - 1)
-    : Math.min(ordered.length - 1, index + 1);
-  if (targetIndex === index) return currentValues;
-
-  const next = [...ordered];
-  const [entry] = next.splice(index, 1);
-  next.splice(targetIndex, 0, entry!);
-  const unknownValues = currentValues.filter((value) => !optionValueSet.has(value));
-  return [...next, ...unknownValues];
 }
 
 function SelectFieldDialog({
@@ -216,121 +182,16 @@ function MultiSelectFieldDialog({
   currentValue: unknown;
   onApply: (value: string[]) => Promise<void>;
 }) {
-  const optionByValue = new Map(field.options.map((option) => [option.value, option]));
-  const [selectedValues, setSelectedValues] = useState(() => coerceSelectedValues(currentValue));
-  const knownSelectedValues = selectedValues.filter((value) => optionByValue.has(value));
-  const orderedOptions = field.options;
-  const [selectedOptionId, setSelectedOptionId] = useState(orderedOptions[0]?.value ?? "");
-  const selectedIndex = Math.max(0, orderedOptions.findIndex((option) => option.value === selectedOptionId));
-  const selectedOptionValue = orderedOptions[selectedIndex]?.value ?? "";
-  const selectedValueOrder = knownSelectedValues.indexOf(selectedOptionValue);
-  const canMoveUp = field.type === "ordered-multi-select" && selectedValueOrder > 0;
-  const canMoveDown = field.type === "ordered-multi-select"
-    && selectedValueOrder >= 0
-    && selectedValueOrder < knownSelectedValues.length - 1;
-
-  useEffect(() => {
-    setSelectedValues(coerceSelectedValues(currentValue));
-  }, [currentValue]);
-
-  useEffect(() => {
-    if (orderedOptions.some((option) => option.value === selectedOptionId)) return;
-    setSelectedOptionId(orderedOptions[0]?.value ?? "");
-  }, [orderedOptions, selectedOptionId]);
-
-  const toggleItems = orderedOptions.map((option) => {
-    const order = knownSelectedValues.indexOf(option.value);
-    const orderDescription = field.type === "ordered-multi-select" && order >= 0
-      ? `Order ${order + 1} of ${knownSelectedValues.length}.`
-      : null;
-
-    return {
-      id: option.value,
-      label: option.label,
-      enabled: selectedValues.includes(option.value),
-      description: [option.description, orderDescription].filter((entry): entry is string => !!entry).join(" "),
-    };
-  });
-  const listHeight = Math.min(12, Math.max(6, toggleItems.length));
-
-  const applySelectedValues = async (nextValues: string[]) => {
-    const previousValues = selectedValues;
-    setSelectedValues(nextValues);
-    try {
-      await onApply(nextValues);
-    } catch (error) {
-      setSelectedValues(previousValues);
-      throw error;
-    }
-  };
-
-  const toggleOption = async (option: PaneSettingOption | undefined) => {
-    if (!option) return;
-    await applySelectedValues(toggleSelectedValue(selectedValues, option.value));
-  };
-
-  const moveOption = async (direction: "up" | "down") => {
-    if (field.type !== "ordered-multi-select") return;
-    const option = orderedOptions[selectedIndex];
-    if (!option) return;
-    await applySelectedValues(moveSelectedValue(field, selectedValues, option.value, direction));
-  };
-
-  useDialogKeyboard((event) => {
-    event.stopPropagation();
-    if (event.name === "up" || event.name === "k") {
-      const nextIndex = Math.max(0, selectedIndex - 1);
-      setSelectedOptionId(orderedOptions[nextIndex]?.value ?? selectedOptionId);
-    } else if (event.name === "down" || event.name === "j") {
-      const nextIndex = Math.min(orderedOptions.length - 1, selectedIndex + 1);
-      setSelectedOptionId(orderedOptions[nextIndex]?.value ?? selectedOptionId);
-    }
-    else if (isSpaceKey(event)) {
-      void toggleOption(orderedOptions[selectedIndex]).catch(() => {});
-    } else if (event.name === "[" && field.type === "ordered-multi-select") {
-      void moveOption("up").catch(() => {});
-    } else if (event.name === "]" && field.type === "ordered-multi-select") {
-      void moveOption("down").catch(() => {});
-    } else if (event.name === "enter" || event.name === "return") {
-      dismiss();
-    } else if (event.name === "escape") {
-      dismiss();
-    }
-  }, dialogId);
-
   return (
-    <DialogFrame
+    <MultiSelectDialogContent
+      dismiss={dismiss}
+      dialogId={dialogId}
       title={field.label}
-      footer={field.type === "ordered-multi-select"
-        ? "space toggle · [ ] reorder · enter done"
-        : "space toggle · enter done"}
-    >
-      <box flexDirection="column" gap={1}>
-        <ToggleList
-          items={toggleItems}
-          selectedIdx={selectedIndex}
-          bgColor={colors.commandBg}
-          height={listHeight}
-          scrollable
-          showSelectedDescription={false}
-          onSelect={(index) => setSelectedOptionId(orderedOptions[index]?.value ?? selectedOptionId)}
-          onToggle={(id) => {
-            setSelectedOptionId(id);
-            void toggleOption(optionByValue.get(id)).catch(() => {});
-          }}
-        />
-        <box flexDirection="row" gap={1}>
-          <Button label="Toggle" variant="secondary" onPress={() => { void toggleOption(orderedOptions[selectedIndex]).catch(() => {}); }} />
-          {field.type === "ordered-multi-select" && (
-            <>
-              <Button label="Move Up" variant="ghost" disabled={!canMoveUp} onPress={() => { void moveOption("up").catch(() => {}); }} />
-              <Button label="Move Down" variant="ghost" disabled={!canMoveDown} onPress={() => { void moveOption("down").catch(() => {}); }} />
-            </>
-          )}
-          <Button label="Done" variant="primary" onPress={dismiss} />
-        </box>
-      </box>
-    </DialogFrame>
+      options={field.options}
+      selectedValues={coerceSelectedValues(currentValue)}
+      onChange={onApply}
+      ordered={field.type === "ordered-multi-select"}
+    />
   );
 }
 

--- a/src/components/toggle-list.tsx
+++ b/src/components/toggle-list.tsx
@@ -20,6 +20,7 @@ export interface ToggleListProps {
   flexGrow?: number;
   scrollable?: boolean;
   showSelectedDescription?: boolean;
+  rowIdPrefix?: string;
 }
 
 export function ToggleList({
@@ -32,6 +33,7 @@ export function ToggleList({
   flexGrow,
   scrollable,
   showSelectedDescription = true,
+  rowIdPrefix,
 }: ToggleListProps) {
   const listItems: ListViewItem[] = items.map((item) => ({
     id: item.id,
@@ -52,17 +54,28 @@ export function ToggleList({
       onActivate={(item) => {
         onToggle?.(item.id);
       }}
-      renderRow={(item, state) => {
+      renderRow={(item, state, index) => {
         const toggleItem = items.find((entry) => entry.id === item.id);
         const checked = toggleItem?.enabled ? "\u2713" : " ";
+        const activate = (event: any) => {
+          event.stopPropagation?.();
+          if (state.disabled) return;
+          onSelect?.(index);
+          onToggle?.(item.id);
+        };
         return (
-          <box flexDirection="row">
+          <box
+            id={rowIdPrefix ? `${rowIdPrefix}:${item.id}` : undefined}
+            flexDirection="row"
+            onMouseDown={activate}
+          >
             <text fg={state.selected ? colors.selectedText : colors.textDim}>
               {state.selected ? "\u25b8 " : "  "}
             </text>
             <text
               fg={state.selected ? colors.text : colors.textDim}
               attributes={state.selected ? TextAttributes.BOLD : 0}
+              onMouseDown={activate}
             >
               {`[${checked}] ${item.label}`}
             </text>

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,6 +15,12 @@ export type { TabItem, TabsProps } from "./tabs";
 export { Button, IconButton } from "./button";
 export type { ButtonProps, ButtonVariant, IconButtonProps } from "./button";
 
+export { MultiSelectChips } from "./multi-select-chips";
+export type { MultiSelectChipsProps, MultiSelectChipOption } from "./multi-select-chips";
+export { MultiSelectDialogButton, MultiSelectDialogContent } from "./multi-select-dialog";
+export type { MultiSelectDialogButtonProps, MultiSelectDialogContentProps } from "./multi-select-dialog";
+export type { MultiSelectOption } from "./multi-select";
+
 export { Checkbox, Switch, RadioGroup, SegmentedControl } from "./toggle";
 export type {
   CheckboxProps,

--- a/src/components/ui/multi-select-chips.tsx
+++ b/src/components/ui/multi-select-chips.tsx
@@ -1,0 +1,69 @@
+import { TextAttributes } from "@opentui/core";
+import { colors } from "../../theme/colors";
+import { toggleMultiSelectValue, type MultiSelectOption } from "./multi-select";
+
+export type MultiSelectChipOption = MultiSelectOption;
+
+export interface MultiSelectChipsProps {
+  label?: string;
+  options: MultiSelectChipOption[];
+  selectedValues: string[];
+  onChange?: (values: string[]) => void;
+  disabled?: boolean;
+  emptyLabel?: string;
+  idPrefix?: string;
+}
+
+export function MultiSelectChips({
+  label,
+  options,
+  selectedValues,
+  onChange,
+  disabled = false,
+  emptyLabel = "No options",
+  idPrefix,
+}: MultiSelectChipsProps) {
+  const selectedSet = new Set(selectedValues);
+
+  return (
+    <box flexDirection="row" height={1} gap={1}>
+      {label && <text fg={colors.textDim}>{`${label}:`}</text>}
+      {options.length === 0 && <text fg={colors.textMuted}>{emptyLabel}</text>}
+      {options.map((option) => {
+        const selected = selectedSet.has(option.value);
+        const optionDisabled = disabled || option.disabled;
+        const bg = selected ? colors.selected : colors.panel;
+        const fg = optionDisabled
+          ? colors.textMuted
+          : selected
+            ? colors.selectedText
+            : colors.textDim;
+        const marker = selected ? "[x]" : "[ ]";
+        const text = `${marker} ${option.label}`;
+        const toggle = () => {
+          if (optionDisabled) return;
+          onChange?.(toggleMultiSelectValue(options, selectedValues, option.value));
+        };
+
+        return (
+          <box
+            key={option.value}
+            id={idPrefix ? `${idPrefix}:${option.value}` : undefined}
+            height={1}
+            width={text.length}
+            backgroundColor={bg}
+            onMouseDown={toggle}
+          >
+            <text
+              fg={fg}
+              attributes={selected ? TextAttributes.BOLD : 0}
+              onMouseDown={toggle}
+            >
+              {text}
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}

--- a/src/components/ui/multi-select-dialog.tsx
+++ b/src/components/ui/multi-select-dialog.tsx
@@ -1,0 +1,267 @@
+import { TextAttributes } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
+import { useDialog, useDialogKeyboard, type AlertContext } from "@opentui-ui/dialog/react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { colors } from "../../theme/colors";
+import { ToggleList } from "../toggle-list";
+import { Button } from "./button";
+import { DialogFrame } from "./frame";
+import {
+  moveMultiSelectValue,
+  normalizeMultiSelectValues,
+  summarizeMultiSelectValues,
+  toggleMultiSelectValue,
+  type MultiSelectOption,
+} from "./multi-select";
+
+export interface MultiSelectDialogContentProps extends AlertContext {
+  title: string;
+  options: MultiSelectOption[];
+  selectedValues: string[];
+  onChange: (values: string[]) => Promise<void> | void;
+  ordered?: boolean;
+  emptyLabel?: string;
+  idPrefix?: string;
+}
+
+export interface MultiSelectDialogButtonProps {
+  label: string;
+  title?: string;
+  options: MultiSelectOption[];
+  selectedValues: string[];
+  onChange: (values: string[]) => Promise<void> | void;
+  disabled?: boolean;
+  emptyLabel?: string;
+  ordered?: boolean;
+  idPrefix?: string;
+  renderTrigger?: (props: MultiSelectDialogTriggerProps) => ReactNode;
+  shortcutKey?: string | string[];
+  shortcutActive?: boolean;
+}
+
+type DialogTriggerEvent = { stopPropagation?: () => void; preventDefault?: () => void };
+
+export interface MultiSelectDialogTriggerProps {
+  buttonLabel: string;
+  buttonText: string;
+  summary: string;
+  disabled: boolean;
+  openDialog: (event?: DialogTriggerEvent) => void;
+  stopMouseEvent: (event?: DialogTriggerEvent) => void;
+}
+
+function isSpaceKey(event: { name?: string; sequence?: string }): boolean {
+  return event.name === "space" || event.name === " " || event.sequence === " ";
+}
+
+function stopMouseEvent(event?: DialogTriggerEvent) {
+  event?.stopPropagation?.();
+  event?.preventDefault?.();
+}
+
+function matchesShortcut(event: { name?: string; sequence?: string }, shortcutKey: string | string[] | undefined): boolean {
+  if (!shortcutKey) return false;
+  const keys = Array.isArray(shortcutKey) ? shortcutKey : [shortcutKey];
+  const name = event.name?.toLowerCase() ?? "";
+  const sequence = event.sequence?.toLowerCase() ?? "";
+  return keys.some((key) => {
+    const normalized = key.toLowerCase();
+    return normalized === name || normalized === sequence;
+  });
+}
+
+export function MultiSelectDialogContent({
+  dismiss,
+  dialogId,
+  title,
+  options,
+  selectedValues: selectedValuesProp,
+  onChange,
+  ordered = false,
+  idPrefix,
+}: MultiSelectDialogContentProps) {
+  const optionByValue = useMemo(() => new Map(options.map((option) => [option.value, option])), [options]);
+  const [selectedValues, setSelectedValues] = useState(() => normalizeMultiSelectValues(options, selectedValuesProp));
+  const knownSelectedValues = selectedValues.filter((value) => optionByValue.has(value));
+  const [selectedOptionId, setSelectedOptionId] = useState(options[0]?.value ?? "");
+  const selectedIndex = Math.max(0, options.findIndex((option) => option.value === selectedOptionId));
+  const selectedOption = options[selectedIndex];
+  const selectedOptionValue = selectedOption?.value ?? "";
+  const selectedValueOrder = knownSelectedValues.indexOf(selectedOptionValue);
+  const canMoveUp = ordered && selectedValueOrder > 0;
+  const canMoveDown = ordered
+    && selectedValueOrder >= 0
+    && selectedValueOrder < knownSelectedValues.length - 1;
+
+  useEffect(() => {
+    setSelectedValues(normalizeMultiSelectValues(options, selectedValuesProp));
+  }, [options, selectedValuesProp]);
+
+  useEffect(() => {
+    if (options.some((option) => option.value === selectedOptionId)) return;
+    setSelectedOptionId(options[0]?.value ?? "");
+  }, [options, selectedOptionId]);
+
+  const toggleItems = options.map((option) => {
+    const order = knownSelectedValues.indexOf(option.value);
+    const orderDescription = ordered && order >= 0
+      ? `Order ${order + 1} of ${knownSelectedValues.length}.`
+      : null;
+
+    return {
+      id: option.value,
+      label: option.label,
+      enabled: selectedValues.includes(option.value),
+      description: [option.description, orderDescription].filter((entry): entry is string => !!entry).join(" "),
+    };
+  });
+  const listHeight = Math.min(12, Math.max(6, toggleItems.length));
+
+  const applySelectedValues = async (nextValues: string[]) => {
+    const previousValues = selectedValues;
+    setSelectedValues(nextValues);
+    try {
+      await onChange(nextValues);
+    } catch (error) {
+      setSelectedValues(previousValues);
+      throw error;
+    }
+  };
+
+  const toggleOption = async (option: MultiSelectOption | undefined) => {
+    if (!option || option.disabled) return;
+    await applySelectedValues(toggleMultiSelectValue(options, selectedValues, option.value));
+  };
+
+  const moveOption = async (direction: "up" | "down") => {
+    if (!ordered || !selectedOption) return;
+    await applySelectedValues(moveMultiSelectValue(options, selectedValues, selectedOption.value, direction));
+  };
+
+  useDialogKeyboard((event) => {
+    event.stopPropagation();
+    if (event.name === "up" || event.name === "k") {
+      const nextIndex = Math.max(0, selectedIndex - 1);
+      setSelectedOptionId(options[nextIndex]?.value ?? selectedOptionId);
+    } else if (event.name === "down" || event.name === "j") {
+      const nextIndex = Math.min(options.length - 1, selectedIndex + 1);
+      setSelectedOptionId(options[nextIndex]?.value ?? selectedOptionId);
+    } else if (isSpaceKey(event)) {
+      void toggleOption(selectedOption).catch(() => {});
+    } else if (event.name === "[" && ordered) {
+      void moveOption("up").catch(() => {});
+    } else if (event.name === "]" && ordered) {
+      void moveOption("down").catch(() => {});
+    } else if (event.name === "enter" || event.name === "return" || event.name === "escape") {
+      dismiss();
+    }
+  }, dialogId);
+
+  return (
+    <DialogFrame title={title}>
+      <box flexDirection="column" gap={1}>
+        <ToggleList
+          items={toggleItems}
+          selectedIdx={selectedIndex}
+          bgColor={colors.commandBg}
+          height={listHeight}
+          scrollable
+          showSelectedDescription={false}
+          rowIdPrefix={idPrefix ? `${idPrefix}:option` : undefined}
+          onSelect={(index) => setSelectedOptionId(options[index]?.value ?? selectedOptionId)}
+          onToggle={(id) => {
+            setSelectedOptionId(id);
+            void toggleOption(optionByValue.get(id)).catch(() => {});
+          }}
+        />
+        <box flexDirection="row" gap={1}>
+          {ordered && (
+            <>
+              <Button label="Move Up" variant="ghost" disabled={!canMoveUp} onPress={() => { void moveOption("up").catch(() => {}); }} />
+              <Button label="Move Down" variant="ghost" disabled={!canMoveDown} onPress={() => { void moveOption("down").catch(() => {}); }} />
+            </>
+          )}
+          <Button label="Done" variant="primary" onPress={dismiss} />
+        </box>
+      </box>
+    </DialogFrame>
+  );
+}
+
+export function MultiSelectDialogButton({
+  label,
+  title,
+  options,
+  selectedValues,
+  onChange,
+  disabled = false,
+  emptyLabel = "None",
+  ordered = false,
+  idPrefix,
+  renderTrigger,
+  shortcutKey,
+  shortcutActive = false,
+}: MultiSelectDialogButtonProps) {
+  const dialog = useDialog();
+  const summary = summarizeMultiSelectValues({ options, selectedValues, emptyLabel });
+  const buttonLabel = `${label}: ${summary}`;
+  const buttonText = ` ${buttonLabel} `;
+  const openDialog = (event?: DialogTriggerEvent) => {
+    stopMouseEvent(event);
+    if (disabled) return;
+    void dialog.alert({
+      closeOnClickOutside: true,
+      content: (ctx) => (
+        <MultiSelectDialogContent
+          {...ctx}
+          title={title ?? label}
+          options={options}
+          selectedValues={selectedValues}
+          onChange={onChange}
+          ordered={ordered}
+          emptyLabel={emptyLabel}
+          idPrefix={idPrefix}
+        />
+      ),
+    }).catch(() => {});
+  };
+
+  useKeyboard((event) => {
+    if (!shortcutActive || disabled || !matchesShortcut(event, shortcutKey)) return;
+    openDialog(event);
+  });
+
+  if (renderTrigger) {
+    return renderTrigger({
+      buttonLabel,
+      buttonText,
+      summary,
+      disabled,
+      openDialog,
+      stopMouseEvent,
+    });
+  }
+
+  return (
+    <box
+      id={idPrefix ? `${idPrefix}:button` : undefined}
+      height={1}
+      width={buttonText.length}
+      flexDirection="row"
+      backgroundColor={disabled ? colors.panel : colors.selected}
+      onMouseDown={stopMouseEvent}
+      onMouseUp={openDialog}
+    >
+      <text
+        fg={disabled ? colors.textMuted : colors.selectedText}
+        attributes={TextAttributes.BOLD}
+        onMouseDown={stopMouseEvent}
+        onMouseUp={openDialog}
+      >
+        {buttonText}
+      </text>
+    </box>
+  );
+}
+
+export type { MultiSelectOption };

--- a/src/components/ui/multi-select.ts
+++ b/src/components/ui/multi-select.ts
@@ -1,0 +1,78 @@
+export interface MultiSelectOption {
+  value: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+export function normalizeMultiSelectValues(
+  options: readonly MultiSelectOption[],
+  values: readonly string[],
+): string[] {
+  const knownValues = new Set(options.map((option) => option.value));
+  return [
+    ...options
+      .map((option) => option.value)
+      .filter((optionValue) => values.includes(optionValue)),
+    ...values.filter((optionValue) => !knownValues.has(optionValue)),
+  ];
+}
+
+export function toggleMultiSelectValue(
+  options: readonly MultiSelectOption[],
+  selectedValues: readonly string[],
+  value: string,
+): string[] {
+  const nextSelected = new Set(selectedValues);
+  if (nextSelected.has(value)) {
+    nextSelected.delete(value);
+  } else {
+    nextSelected.add(value);
+  }
+
+  return normalizeMultiSelectValues(options, [...nextSelected]);
+}
+
+export function moveMultiSelectValue(
+  options: readonly MultiSelectOption[],
+  selectedValues: readonly string[],
+  selectedOption: string,
+  direction: "up" | "down",
+): string[] {
+  if (!selectedValues.includes(selectedOption)) return [...selectedValues];
+
+  const optionValueSet = new Set(options.map((option) => option.value));
+  const ordered = selectedValues.filter((value) => optionValueSet.has(value));
+  const index = ordered.indexOf(selectedOption);
+  if (index < 0) return [...selectedValues];
+
+  const targetIndex = direction === "up"
+    ? Math.max(0, index - 1)
+    : Math.min(ordered.length - 1, index + 1);
+  if (targetIndex === index) return [...selectedValues];
+
+  const next = [...ordered];
+  const [entry] = next.splice(index, 1);
+  next.splice(targetIndex, 0, entry!);
+  const unknownValues = selectedValues.filter((value) => !optionValueSet.has(value));
+  return [...next, ...unknownValues];
+}
+
+export function summarizeMultiSelectValues({
+  options,
+  selectedValues,
+  emptyLabel = "None",
+  maxLabels = 2,
+}: {
+  options: readonly MultiSelectOption[];
+  selectedValues: readonly string[];
+  emptyLabel?: string;
+  maxLabels?: number;
+}): string {
+  const selectedLabels = selectedValues
+    .map((selectedValue) => options.find((option) => option.value === selectedValue)?.label ?? selectedValue);
+
+  if (selectedLabels.length === 0) return emptyLabel;
+  if (selectedLabels.length <= maxLabels) return selectedLabels.join(", ");
+  return `${selectedLabels.length} selected`;
+}

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -1,11 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, useRef, useState } from "react";
 import { testRender } from "@opentui/react/test-utils";
-import type { ScrollBoxRenderable } from "@opentui/core";
+import { DialogProvider } from "@opentui-ui/dialog/react";
+import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core";
 import { Button } from "./button";
 import { DataTable } from "./data-table";
 import { TextField } from "./fields";
 import { ListView } from "./list-view";
+import { MultiSelectChips } from "./multi-select-chips";
+import { MultiSelectDialogButton } from "./multi-select-dialog";
+import { toggleMultiSelectValue } from "./multi-select";
 import { ProgressBar } from "./loading";
 import { Notice } from "./status";
 import { Tabs } from "./tabs";
@@ -17,6 +21,7 @@ let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let setListSelection: ((index: number) => void) | null = null;
 let selectedTableRow: string | null = null;
 let activatedTableRow: string | null = null;
+let selectedChips: string[] = [];
 
 function ScrollableListHarness() {
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -112,6 +117,44 @@ function DataTableSectionHarness() {
   );
 }
 
+function MultiSelectChipsHarness() {
+  const [values, setValues] = useState(["sma"]);
+  selectedChips = values;
+
+  return (
+    <MultiSelectChips
+      label="IND"
+      selectedValues={values}
+      onChange={setValues}
+      idPrefix="indicator-chip"
+      options={[
+        { value: "sma", label: "SMA" },
+        { value: "ema", label: "EMA" },
+      ]}
+    />
+  );
+}
+
+function MultiSelectDialogButtonHarness() {
+  const [values, setValues] = useState(["sma"]);
+
+  return (
+    <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+      <MultiSelectDialogButton
+        label="IND"
+        title="Chart Indicators"
+        selectedValues={values}
+        onChange={setValues}
+        idPrefix="indicator-dialog"
+        options={[
+          { value: "sma", label: "SMA" },
+          { value: "ema", label: "EMA" },
+        ]}
+      />
+    </DialogProvider>
+  );
+}
+
 afterEach(() => {
   if (testSetup) {
     testSetup.renderer.destroy();
@@ -120,6 +163,7 @@ afterEach(() => {
   setListSelection = null;
   selectedTableRow = null;
   activatedTableRow = null;
+  selectedChips = [];
 });
 
 describe("shared UI kit", () => {
@@ -173,6 +217,79 @@ describe("shared UI kit", () => {
     expect(frame).toContain("[✓] News");
     expect(frame).toContain("Notes");
     expect(frame).toContain("Headlines and previews");
+  });
+
+  test("toggles multi-select chips with the mouse", async () => {
+    testSetup = await testRender(<MultiSelectChipsHarness />, { width: 32, height: 3 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("[x] SMA");
+    expect(frame).toContain("[ ] EMA");
+    const emaChip = testSetup.renderer.root.findDescendantById("indicator-chip:ema") as BoxRenderable | undefined;
+    expect(emaChip).toBeDefined();
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(emaChip!.x + 1, emaChip!.y);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("[x] SMA");
+    expect(frame).toContain("[x] EMA");
+    expect(selectedChips).toEqual(["sma", "ema"]);
+  });
+
+  test("opens compact multi-select dialogs from a button", async () => {
+    testSetup = await testRender(<MultiSelectDialogButtonHarness />, { width: 60, height: 18 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("IND: SMA");
+    const button = testSetup.renderer.root.findDescendantById("indicator-dialog:button") as BoxRenderable | undefined;
+    expect(button).toBeDefined();
+    expect(button!.width).toBe(" IND: SMA ".length);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(button!.x + 1, button!.y);
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Chart Indicators");
+    expect(frame).toContain("[✓] SMA");
+    expect(frame).toContain("[ ] EMA");
+    expect(frame).not.toContain("Toggle");
+    expect(frame).not.toContain("space toggle");
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(0, 0);
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).not.toContain("Chart Indicators");
+  });
+
+  test("keeps shared multi-select values in option order when toggling", () => {
+    const options = [
+      { value: "sma", label: "SMA" },
+      { value: "ema", label: "EMA" },
+    ];
+
+    expect(toggleMultiSelectValue(options, ["sma"], "ema")).toEqual(["sma", "ema"]);
+    expect(toggleMultiSelectValue(options, ["sma", "ema"], "sma")).toEqual(["ema"]);
   });
 
   test("auto-scrolls a scrollable list to keep the selected row visible", async () => {

--- a/src/plugins/builtin/comparison-chart.test.tsx
+++ b/src/plugins/builtin/comparison-chart.test.tsx
@@ -246,8 +246,11 @@ describe("comparisonChartPlugin", () => {
     expect(frame).toContain("2:1W");
     expect(frame).toContain("1D");
     expect(frame).toContain("view:");
-    expect(frame).toContain("arrows legend");
-    expect(frame).toContain("wheel pan");
+    expect(frame).toContain("[m]ode");
+    expect(frame).toContain("[r]es");
+    expect(frame).toContain("[up/down]legend");
+    expect(frame).not.toContain("arrows legend");
+    expect(frame).not.toContain("wheel pan");
     expect(frame).not.toContain("wheel zoom");
     expect(frame).not.toContain("side by side");
   });

--- a/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
+++ b/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createTestRenderer } from "@opentui/core/testing";
 import { createRoot } from "@opentui/react";
+import { DialogProvider } from "@opentui-ui/dialog/react";
 import { act, useReducer, type ReactElement } from "react";
 import {
   AppContext,
@@ -97,17 +98,19 @@ function DetailHarness({
   harnessDispatch = dispatch;
 
   return (
-    <AppContext value={{ state, dispatch }}>
-      <PaneInstanceProvider paneId={TEST_PANE_ID}>
-        <DetailPane
-          paneId={TEST_PANE_ID}
-          paneType="ticker-detail"
-          focused
-          width={90}
-          height={28}
-        />
-      </PaneInstanceProvider>
-    </AppContext>
+    <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+      <AppContext value={{ state, dispatch }}>
+        <PaneInstanceProvider paneId={TEST_PANE_ID}>
+          <DetailPane
+            paneId={TEST_PANE_ID}
+            paneType="ticker-detail"
+            focused
+            width={90}
+            height={28}
+          />
+        </PaneInstanceProvider>
+      </AppContext>
+    </DialogProvider>
   );
 }
 
@@ -174,7 +177,9 @@ describe("Ticker detail chart tab switching", () => {
     });
 
     await flushFrames();
-    expect(testSetup.captureCharFrame()).toContain("AAPL");
+    const chartTabFrame = testSetup.captureCharFrame();
+    expect(chartTabFrame).toContain("AAPL");
+    expect(chartTabFrame).toContain("[i]ndicators");
     expect(manager.surfaces.has("chart-surface:ticker-detail:test:full:base")).toBe(true);
 
     act(() => {

--- a/src/plugins/builtin/ticker-detail/chart-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/chart-tab.tsx
@@ -1,8 +1,24 @@
 import { useTerminalDimensions } from "@opentui/react";
+import { useCallback, useMemo } from "react";
+import { saveConfig } from "../../../data/config-store";
+import { ChartIndicatorSelector } from "../../../components/chart/chart-indicator-selector";
+import {
+  buildIndicatorConfigFromSelection,
+  CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY,
+  CURRENT_CHART_INDICATORS_CONFIG_VERSION,
+  CHART_INDICATORS_PLUGIN_CONFIG_KEY,
+  resolveChartIndicatorSelection,
+  normalizeChartIndicatorSelection,
+  type ChartIndicatorId,
+} from "../../../components/chart/indicators/options";
 import type { ChartAxisMode } from "../../../components/chart/chart-types";
 import { ResolvedStockChart } from "../../../components/chart/stock-chart";
+import { useAppState } from "../../../state/app-context";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
+import { getSharedRegistry } from "../../registry";
+
+const TICKER_DETAIL_PLUGIN_ID = "ticker-detail";
 
 export function ChartTab({
   width,
@@ -26,29 +42,75 @@ export function ChartTab({
   financials: TickerFinancials | null;
 }) {
   const { width: termWidth, height: termHeight } = useTerminalDimensions();
+  const { state, dispatch } = useAppState();
 
   const chartWidth = Math.max((width || Math.floor(termWidth * 0.55)) - 2, 30);
   const chartHeight = Math.max((height || termHeight - 8) - 2, 10);
+  const rawIndicatorSelection = state.config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_KEY];
+  const indicatorSelectionVersion = state.config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY];
+  const hasStoredIndicatorSelection = Array.isArray(rawIndicatorSelection);
+  const selectedIndicatorIds = useMemo(
+    () => resolveChartIndicatorSelection(rawIndicatorSelection, indicatorSelectionVersion),
+    [indicatorSelectionVersion, rawIndicatorSelection],
+  );
+  const selectedIndicatorConfig = useMemo(
+    () => buildIndicatorConfigFromSelection(selectedIndicatorIds),
+    [selectedIndicatorIds],
+  );
+  const showVolume = selectedIndicatorIds.includes("volume");
+  const persistIndicatorSelection = useCallback((nextSelection: ChartIndicatorId[]) => {
+    const normalized = normalizeChartIndicatorSelection(nextSelection);
+    const nextConfig = {
+      ...state.config,
+      pluginConfig: {
+        ...state.config.pluginConfig,
+        [TICKER_DETAIL_PLUGIN_ID]: {
+          ...(state.config.pluginConfig[TICKER_DETAIL_PLUGIN_ID] ?? {}),
+          [CHART_INDICATORS_PLUGIN_CONFIG_KEY]: normalized,
+          [CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY]: CURRENT_CHART_INDICATORS_CONFIG_VERSION,
+        },
+      },
+    };
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    saveConfig(nextConfig).catch(() => {});
+    getSharedRegistry()?.events.emit("config:changed", { config: nextConfig });
+  }, [dispatch, state.config]);
 
   return (
     <box
       flexDirection="column"
       paddingX={1}
       flexGrow={1}
-      onMouseDown={() => {
-        if (!interactive) onActivate?.();
-      }}
     >
-      <ResolvedStockChart
-        width={chartWidth}
-        height={chartHeight}
-        focused={focused}
-        interactive={interactive}
-        axisMode={axisMode}
-        symbol={symbol}
-        ticker={ticker}
-        financials={financials}
-      />
+      <box
+        flexDirection="column"
+        flexGrow={1}
+        onMouseDown={() => {
+          if (!interactive) onActivate?.();
+        }}
+      >
+        <ResolvedStockChart
+          width={chartWidth}
+          height={chartHeight}
+          focused={focused}
+          interactive={interactive}
+          axisMode={axisMode}
+          symbol={symbol}
+          ticker={ticker}
+          financials={financials}
+          indicatorConfig={hasStoredIndicatorSelection ? selectedIndicatorConfig : undefined}
+          showVolume={showVolume}
+          footerControls={(
+            <ChartIndicatorSelector
+              width={chartWidth}
+              selectedIds={selectedIndicatorIds}
+              onChange={persistIndicatorSelection}
+              variant="hint"
+              shortcutActive={focused}
+            />
+          )}
+        />
+      </box>
     </box>
   );
 }

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -2,7 +2,7 @@ import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
 import { useFxRatesMap } from "../../../market-data/hooks";
 import { useAppSelector } from "../../../state/app-context";
-import { colors, priceColor } from "../../../theme/colors";
+import { colors, priceColor, blendHex } from "../../../theme/colors";
 import {
   convertCurrency,
   formatCompact,
@@ -20,10 +20,139 @@ import {
   quoteSourceLabel,
 } from "../../../utils/market-status";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
-import { EmptyState, FieldRow } from "../../../components";
+import { EmptyState } from "../../../components";
 import { ResolvedStockChart } from "../../../components/chart/stock-chart";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
+
+// ─── Visual range bar ────────────────────────────────────────────────────────
+
+function RangeBar({
+  current,
+  low,
+  high,
+  label,
+  barWidth,
+  currency,
+  assetCategory,
+}: {
+  current: number;
+  low: number;
+  high: number;
+  label: string;
+  barWidth: number;
+  currency: string;
+  assetCategory?: string;
+}) {
+  const range = high - low;
+  if (range <= 0) return null;
+  const position = Math.max(0, Math.min(1, (current - low) / range));
+  const filledWidth = Math.max(1, Math.round(position * barWidth));
+  const emptyWidth = Math.max(0, barWidth - filledWidth);
+  const pctLabel = `${Math.round(position * 100)}%`;
+  const fillColor = blendHex(colors.negative, colors.positive, position);
+  const trackChar = "─";
+  const fillChar = "━";
+
+  return (
+    <box flexDirection="column">
+      <box flexDirection="row" height={1}>
+        <box width={12}>
+          <text fg={colors.textDim}>{label}</text>
+        </box>
+        <text fg={colors.textDim}>
+          {formatMarketPriceWithCurrency(low, currency, { assetCategory })}
+        </text>
+        <box marginLeft={1} marginRight={1} flexDirection="row">
+          <text fg={fillColor}>{fillChar.repeat(filledWidth)}</text>
+          <text fg={colors.border}>{trackChar.repeat(emptyWidth)}</text>
+        </box>
+        <text fg={colors.textDim}>
+          {formatMarketPriceWithCurrency(high, currency, { assetCategory })}
+        </text>
+        <box marginLeft={1}>
+          <text fg={fillColor}>{pctLabel}</text>
+        </box>
+      </box>
+    </box>
+  );
+}
+
+// ─── Volume bar ──────────────────────────────────────────────────────────────
+
+function VolumeBar({ volume, avgVolume, barWidth }: { volume: number; avgVolume: number; barWidth: number }) {
+  if (!volume || !avgVolume) return null;
+  const ratio = volume / avgVolume;
+  const maxRatio = Math.max(ratio, 1);
+  const volWidth = Math.max(1, Math.round((Math.min(ratio, maxRatio) / maxRatio) * barWidth));
+  const avgWidth = Math.max(1, Math.round((1 / maxRatio) * barWidth));
+  const ratioColor = ratio >= 2 ? colors.textBright : ratio >= 1 ? colors.text : colors.textDim;
+
+  return (
+    <box flexDirection="row" height={1}>
+      <box width={12}>
+        <text fg={colors.textDim}>Volume</text>
+      </box>
+      <text fg={colors.textDim}>{formatCompact(volume)}</text>
+      <box marginLeft={1} marginRight={1} flexDirection="row">
+        <text fg={ratioColor}>{"━".repeat(volWidth)}</text>
+        <text fg={colors.border}>{"─".repeat(Math.max(0, barWidth - volWidth))}</text>
+      </box>
+      <text fg={colors.textDim}>avg {formatCompact(avgVolume)}</text>
+      <box marginLeft={1}>
+        <text fg={ratioColor}>{ratio.toFixed(1)}x</text>
+      </box>
+    </box>
+  );
+}
+
+// ─── Two-column stat grid ────────────────────────────────────────────────────
+
+interface StatField {
+  label: string;
+  value: string;
+  valueColor?: string;
+}
+
+function StatGrid({ fields, width }: { fields: StatField[]; width: number }) {
+  const colWidth = Math.floor(width / 2);
+  const rows: Array<[StatField | null, StatField | null]> = [];
+  for (let i = 0; i < fields.length; i += 2) {
+    rows.push([fields[i] ?? null, fields[i + 1] ?? null]);
+  }
+
+  return (
+    <box flexDirection="column">
+      {rows.map((row, i) => (
+        <box key={i} flexDirection="row" height={1}>
+          {row.map((field, j) => {
+            if (!field) return <box key={j} width={colWidth} />;
+            return (
+              <box key={j} width={colWidth} flexDirection="row">
+                <box width={14}>
+                  <text fg={colors.textDim}>{field.label}</text>
+                </box>
+                <text fg={field.valueColor ?? colors.text}>{field.value}</text>
+              </box>
+            );
+          })}
+        </box>
+      ))}
+    </box>
+  );
+}
+
+// ─── Section header ──────────────────────────────────────────────────────────
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <box height={1}>
+      <text attributes={TextAttributes.BOLD} fg={colors.textBright}>{title}</text>
+    </box>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
 
 export function OverviewTab({
   width,
@@ -71,12 +200,82 @@ export function OverviewTab({
     routingVenue && routingVenue !== listingVenue ? `Route: ${routingVenue}` : "",
   ].filter((part) => part.length > 0);
 
-  const chartWidth = Math.max((width || Math.floor(termWidth * 0.5)) - 4, 20);
+  const contentWidth = Math.max((width || Math.floor(termWidth * 0.5)) - 4, 20);
+  const chartWidth = contentWidth;
+  const barWidth = Math.max(10, contentWidth - 50);
   const hasHistory = (financials?.priceHistory?.length ?? 0) > 2;
+
+  // Build the two-column stat grid
+  const stats: StatField[] = [];
+
+  if (quote?.marketCap) {
+    stats.push({ label: "Market Cap", value: formatCompactCurrency(toBase(quote.marketCap, quoteCurrency), baseCurrency) });
+  }
+  if (fundamentals?.sharesOutstanding) {
+    stats.push({ label: "Shares Out", value: formatCompact(fundamentals.sharesOutstanding) });
+  }
+  if (fundamentals?.trailingPE) {
+    stats.push({ label: "P/E (TTM)", value: formatNumber(fundamentals.trailingPE, 1) });
+  }
+  if (fundamentals?.forwardPE) {
+    stats.push({ label: "Fwd P/E", value: formatNumber(fundamentals.forwardPE, 1) });
+  }
+  if (fundamentals?.eps) {
+    stats.push({ label: "EPS", value: formatCurrency(fundamentals.eps, quoteCurrency) });
+  }
+  if (fundamentals?.pegRatio) {
+    stats.push({ label: "PEG", value: formatNumber(fundamentals.pegRatio, 2) });
+  }
+  if (fundamentals?.dividendYield != null) {
+    stats.push({ label: "Div Yield", value: formatPercent(fundamentals.dividendYield) });
+  }
+  if (fundamentals?.revenue) {
+    stats.push({ label: "Revenue", value: formatCompact(fundamentals.revenue) });
+  }
+  if (fundamentals?.netIncome) {
+    stats.push({ label: "Net Income", value: formatCompact(fundamentals.netIncome) });
+  }
+  if (fundamentals?.freeCashFlow) {
+    stats.push({ label: "FCF", value: formatCompact(fundamentals.freeCashFlow) });
+  }
+  if (fundamentals?.operatingMargin != null) {
+    stats.push({ label: "Op Margin", value: formatPercent(fundamentals.operatingMargin) });
+  }
+  if (fundamentals?.profitMargin != null) {
+    stats.push({ label: "Profit Marg", value: formatPercent(fundamentals.profitMargin) });
+  }
+  if (fundamentals?.revenueGrowth != null) {
+    stats.push({
+      label: "Rev Growth",
+      value: formatPercent(fundamentals.revenueGrowth),
+      valueColor: priceColor(fundamentals.revenueGrowth),
+    });
+  }
+  if (fundamentals?.return1Y != null) {
+    stats.push({
+      label: "1Y Return",
+      value: formatPercent(fundamentals.return1Y),
+      valueColor: priceColor(fundamentals.return1Y),
+    });
+  }
+  if (fundamentals?.return3Y != null) {
+    stats.push({
+      label: "3Y Return",
+      value: formatPercent(fundamentals.return3Y),
+      valueColor: priceColor(fundamentals.return3Y),
+    });
+  }
+  if (fundamentals?.enterpriseValue) {
+    stats.push({ label: "EV", value: formatCompact(fundamentals.enterpriseValue) });
+  }
+
+  // Bid/ask
+  const hasBidAsk = quote?.bid != null || quote?.ask != null;
 
   return (
     <scrollbox flexGrow={1} scrollY>
       <box flexDirection="column" paddingX={1} paddingBottom={1} gap={1}>
+        {/* Ticker header */}
         <box flexDirection="row">
           <text attributes={TextAttributes.BOLD} fg={colors.textBright}>
             {ticker.metadata.ticker}
@@ -87,9 +286,7 @@ export function OverviewTab({
             </text>
           )}
           {listingVenue && (
-            <text fg={colors.textDim}>
-              {" "}({listingVenue})
-            </text>
+            <text fg={colors.textDim}>{" "}({listingVenue})</text>
           )}
           {quote?.marketState && (
             <text fg={marketStateColor(quote.marketState)}>
@@ -98,6 +295,7 @@ export function OverviewTab({
           )}
         </box>
 
+        {/* Price block */}
         {quote && (
           <box flexDirection="column" gap={0}>
             <box flexDirection="row" gap={2}>
@@ -136,10 +334,42 @@ export function OverviewTab({
           </box>
         )}
 
+        {/* Range bars */}
+        {quote?.low != null && quote?.high != null && quote.high > quote.low && (
+          <RangeBar
+            current={quote.price}
+            low={quote.low}
+            high={quote.high}
+            label="Day Range"
+            barWidth={barWidth}
+            currency={quoteCurrency}
+            assetCategory={ticker.metadata.assetCategory}
+          />
+        )}
+        {quote?.low52w != null && quote?.high52w != null && quote.high52w > quote.low52w && (
+          <RangeBar
+            current={quote.price}
+            low={quote.low52w}
+            high={quote.high52w}
+            label="52W Range"
+            barWidth={barWidth}
+            currency={quoteCurrency}
+            assetCategory={ticker.metadata.assetCategory}
+          />
+        )}
+        {quote?.volume != null && fundamentals?.sharesOutstanding && (
+          <VolumeBar
+            volume={quote.volume}
+            avgVolume={Math.round((fundamentals.sharesOutstanding * 0.01) || quote.volume)}
+            barWidth={barWidth}
+          />
+        )}
+
+        {/* Chart */}
         {hasHistory && (
           <ResolvedStockChart
             width={chartWidth}
-            height={8}
+            height={10}
             focused={false}
             compact
             symbol={symbol}
@@ -148,56 +378,46 @@ export function OverviewTab({
           />
         )}
 
-        <box flexDirection="column">
-          <FieldRow
-            label="Market Cap"
-            value={quote?.marketCap ? formatCompactCurrency(toBase(quote.marketCap, quoteCurrency), baseCurrency) : "—"}
-          />
-          <FieldRow label="P/E (TTM)" value={fundamentals?.trailingPE ? formatNumber(fundamentals.trailingPE, 1) : "—"} />
-          <FieldRow label="Forward P/E" value={fundamentals?.forwardPE ? formatNumber(fundamentals.forwardPE, 1) : "—"} />
-          <FieldRow label="PEG Ratio" value={fundamentals?.pegRatio ? formatNumber(fundamentals.pegRatio, 2) : "—"} />
-          <FieldRow label="EPS" value={fundamentals?.eps ? formatCurrency(fundamentals.eps, quoteCurrency) : "—"} />
-          <FieldRow label="Div Yield" value={fundamentals?.dividendYield != null ? formatPercent(fundamentals.dividendYield) : "—"} />
-          <FieldRow label="Revenue" value={fundamentals?.revenue ? formatCompact(fundamentals.revenue) : "—"} />
-          <FieldRow label="Net Income" value={fundamentals?.netIncome ? formatCompact(fundamentals.netIncome) : "—"} />
-          <FieldRow label="FCF" value={fundamentals?.freeCashFlow ? formatCompact(fundamentals.freeCashFlow) : "—"} />
-          <FieldRow label="Op. Margin" value={fundamentals?.operatingMargin != null ? formatPercent(fundamentals.operatingMargin) : "—"} />
-          <FieldRow label="Profit Margin" value={fundamentals?.profitMargin != null ? formatPercent(fundamentals.profitMargin) : "—"} />
-          {(quote?.bid != null || quote?.ask != null) && (
-            <>
-              <FieldRow label="Bid" value={quote?.bid != null ? formatMarketPriceWithCurrency(quote.bid, quote.currency, { assetCategory: ticker.metadata.assetCategory }) : "—"} />
-              <FieldRow label="Ask" value={quote?.ask != null ? formatMarketPriceWithCurrency(quote.ask, quote.currency, { assetCategory: ticker.metadata.assetCategory }) : "—"} />
-              <FieldRow
-                label="Spread"
-                value={quote?.bid != null && quote?.ask != null
-                  ? formatMarketPriceWithCurrency(quote.ask - quote.bid, quote.currency, { assetCategory: ticker.metadata.assetCategory })
-                  : "—"}
-              />
-            </>
-          )}
-          <FieldRow
-            label="52W Range"
-            value={quote?.low52w && quote?.high52w
-              ? `${formatMarketPriceWithCurrency(quote.low52w, quoteCurrency, { assetCategory: ticker.metadata.assetCategory })} - ${formatMarketPriceWithCurrency(quote.high52w, quoteCurrency, { assetCategory: ticker.metadata.assetCategory })}`
-              : "—"}
-          />
-          <FieldRow
-            label="1Y Return"
-            value={fundamentals?.return1Y != null ? formatPercent(fundamentals.return1Y) : "—"}
-            valueColor={fundamentals?.return1Y != null ? priceColor(fundamentals.return1Y) : undefined}
-          />
-          <FieldRow
-            label="3Y Return"
-            value={fundamentals?.return3Y != null ? formatPercent(fundamentals.return3Y) : "—"}
-            valueColor={fundamentals?.return3Y != null ? priceColor(fundamentals.return3Y) : undefined}
-          />
-        </box>
+        {/* Bid/Ask */}
+        {hasBidAsk && quote && (
+          <box flexDirection="row" height={1} gap={3}>
+            <box flexDirection="row">
+              <text fg={colors.textDim}>Bid: </text>
+              <text fg={colors.text}>
+                {quote.bid != null ? formatMarketPriceWithCurrency(quote.bid, quote.currency, { assetCategory: ticker.metadata.assetCategory }) : "—"}
+                {quote.bidSize != null ? ` ×${quote.bidSize}` : ""}
+              </text>
+            </box>
+            <box flexDirection="row">
+              <text fg={colors.textDim}>Ask: </text>
+              <text fg={colors.text}>
+                {quote.ask != null ? formatMarketPriceWithCurrency(quote.ask, quote.currency, { assetCategory: ticker.metadata.assetCategory }) : "—"}
+                {quote.askSize != null ? ` ×${quote.askSize}` : ""}
+              </text>
+            </box>
+            {quote.bid != null && quote.ask != null && (
+              <box flexDirection="row">
+                <text fg={colors.textDim}>Spread: </text>
+                <text fg={colors.text}>
+                  {formatMarketPriceWithCurrency(quote.ask - quote.bid, quote.currency, { assetCategory: ticker.metadata.assetCategory })}
+                </text>
+              </box>
+            )}
+          </box>
+        )}
 
+        {/* Two-column stats grid */}
+        {stats.length > 0 && (
+          <box flexDirection="column">
+            <SectionHeader title="Fundamentals" />
+            <StatGrid fields={stats} width={contentWidth} />
+          </box>
+        )}
+
+        {/* Positions */}
         {ticker.metadata.positions.length > 0 && (
           <box flexDirection="column">
-            <box height={1}>
-              <text attributes={TextAttributes.BOLD} fg={colors.textBright}>Positions</text>
-            </box>
+            <SectionHeader title="Positions" />
             {ticker.metadata.positions.map((position, index) => {
               const costBasis = position.shares * position.avgCost * (position.multiplier || 1);
               const positionCurrency = position.currency || quoteCurrency;
@@ -248,29 +468,43 @@ export function OverviewTab({
           </box>
         )}
 
-        {description && (
-          <box flexDirection="column">
-            <box height={1}>
-              <text attributes={TextAttributes.BOLD} fg={colors.textBright}>Description</text>
-            </box>
-            <text fg={colors.text}>{description}</text>
+        {/* Sector / Industry / Type */}
+        {(sector || industry || ticker.metadata.assetCategory) && (
+          <box flexDirection="row" height={1} gap={3}>
+            {ticker.metadata.assetCategory && (
+              <box flexDirection="row">
+                <text fg={colors.textDim}>Type: </text>
+                <text fg={colors.text}>{ticker.metadata.assetCategory}</text>
+              </box>
+            )}
+            {sector && (
+              <box flexDirection="row">
+                <text fg={colors.textDim}>Sector: </text>
+                <text fg={colors.text}>{sector}</text>
+              </box>
+            )}
+            {industry && (
+              <box flexDirection="row">
+                <text fg={colors.textDim}>Industry: </text>
+                <text fg={colors.text}>{industry}</text>
+              </box>
+            )}
           </box>
         )}
 
-        {(sector || industry || ticker.metadata.assetCategory || ticker.metadata.isin) && (
+        {/* ISIN */}
+        {ticker.metadata.isin && (
+          <box flexDirection="row" height={1}>
+            <text fg={colors.textDim}>ISIN: </text>
+            <text fg={colors.text}>{ticker.metadata.isin}</text>
+          </box>
+        )}
+
+        {/* Description — last, collapsed */}
+        {description && (
           <box flexDirection="column">
-            {ticker.metadata.assetCategory && (
-              <FieldRow label="Type" value={ticker.metadata.assetCategory} />
-            )}
-            {sector && (
-              <FieldRow label="Sector" value={sector} />
-            )}
-            {industry && (
-              <FieldRow label="Industry" value={industry} />
-            )}
-            {ticker.metadata.isin && (
-              <FieldRow label="ISIN" value={ticker.metadata.isin} />
-            )}
+            <SectionHeader title="Description" />
+            <text fg={colors.text}>{description}</text>
           </box>
         )}
       </box>


### PR DESCRIPTION
Technical indicators for the chart system and a redesigned ticker overview tab.

**Technical indicators:**
- SMA, EMA computation (configurable periods)
- RSI oscillator (Wilder's smoothing)
- MACD (fast/slow EMA + signal line + histogram)
- Bollinger Bands (SMA ± N standard deviations)
- Drawn as overlays on the chart renderer via new LAYER_OVERLAY
- Wired into StockChart with per-pane indicator config persistence
- Configure via pane settings: `{ "indicators": { "sma": [20, 50] } }`

**Enhanced ticker overview:**
- Day range bar with color gradient showing price position between low/high
- 52-week range bar with same visual treatment
- Volume bar showing today vs average with ratio
- Two-column fundamentals grid (market cap, shares out, P/E, fwd P/E, EPS, PEG, div yield, revenue, net income, FCF, margins, returns, EV)
- Bid/ask inline with sizes and spread on one row
- Sector/industry/type on one compact row
- Taller inline chart (10 rows)
- Section headers for Fundamentals, Positions, Description
- Only shows fields with available data (no padding with dashes)

Testing: `bun test src/components/chart/`