### PR TITLE
Add gridlock shortcut and revert toast

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -146,10 +146,25 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
     isAppActive: () => appActiveRef.current,
     renderToast: (notification) => {
       const type = notification.type ?? "info";
-      const duration = notification.duration;
-      if (type === "success") toast.success(notification.body, { duration });
-      else if (type === "error") toast.error(notification.body, { duration });
-      else toast.info(notification.body, { duration });
+      let toastId: string | number | undefined;
+      const options = {
+        duration: notification.duration,
+        action: notification.action
+          ? {
+            label: notification.action.label,
+            onClick: () => {
+              try {
+                notification.action?.onClick();
+              } finally {
+                if (toastId != null) toast.dismiss(toastId);
+              }
+            },
+          }
+          : undefined,
+      };
+      if (type === "success") toastId = toast.success(notification.body, options);
+      else if (type === "error") toastId = toast.error(notification.body, options);
+      else toastId = toast.info(notification.body, options);
     },
   }), []);
   const notify = useCallback((body: string, options?: { type?: "info" | "success" | "error" }) => {

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -352,6 +352,54 @@ describe("CommandBar", () => {
     expect(testSetup.captureCharFrame()).not.toContain("Commands");
   });
 
+  test("runs plugin command shortcuts from the root query", async () => {
+    const calls: string[] = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query="GL"
+      configurePluginRegistry={(pluginRegistry) => {
+        (pluginRegistry.commands as Map<string, any>).set("gridlock-all", {
+          id: "gridlock-all",
+          label: "Gridlock All Windows",
+          description: "Arrange all visible panes into a tiled grid",
+          keywords: ["grid", "gridlock", "tile", "arrange", "windows", "layout"],
+          shortcut: "GL",
+          category: "config",
+          execute: async () => {
+            calls.push("gridlock-all");
+          },
+        });
+        (pluginRegistry.allPlugins as Map<string, any>).set("layout-manager", {
+          id: "layout-manager",
+          name: "Layout Manager",
+          version: "1.0.0",
+          description: "Pane layout management commands",
+        });
+        const getCommandPluginId = pluginRegistry.getCommandPluginId;
+        pluginRegistry.getCommandPluginId = (commandId: string) => (
+          commandId === "gridlock-all" ? "layout-manager" : getCommandPluginId(commandId)
+        );
+      }}
+    />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Gridlock All Windows");
+    expect(frame).toContain("GL");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(calls).toEqual(["gridlock-all"]);
+  });
+
   test("renders theme prefix results in the root query", async () => {
     testSetup = await testRender(<CommandBarHarness query="TH " />, {
       width: 80,

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -54,6 +54,7 @@ import {
   removePane,
   swapPanes,
 } from "../../plugins/pane-manager";
+import { notifyGridlockComplete } from "../../plugins/gridlock-notification";
 import { CHART_RENDERER_PREFERENCES } from "../chart/chart-types";
 import {
   buildSections,
@@ -412,6 +413,12 @@ export function CommandBar({
   const persistLayoutChange = useCallback((nextLayout: LayoutConfig) => {
     pluginRegistry.updateLayoutFn(nextLayout);
   }, [pluginRegistry]);
+
+  const notifyGridlockRevert = useCallback(() => {
+    notifyGridlockComplete(pluginRegistry.notify.bind(pluginRegistry), () => {
+      dispatch({ type: "UNDO_LAYOUT" });
+    });
+  }, [dispatch, pluginRegistry]);
 
   const duplicatePane = useCallback((paneId: string) => {
     const currentState = stateRef.current;
@@ -1944,12 +1951,24 @@ export function CommandBar({
     });
   }, [getPaneTemplateContext, pluginRegistry, state.config.disabledPlugins]);
 
+  const getAvailablePluginCommands = useCallback((): CommandDef[] => {
+    const disabledPlugins = new Set(state.config.disabledPlugins || []);
+    return [...pluginRegistry.commands.values()]
+      .filter((command) => {
+        if (command.hidden?.()) return false;
+        const pluginId = pluginRegistry.getCommandPluginId(command.id);
+        if (pluginId && disabledPlugins.has(pluginId)) return false;
+        return true;
+      });
+  }, [pluginRegistry, state.config.disabledPlugins]);
+
   const rootShortcutIntent = useMemo(() => parseRootShortcutIntent({
     query: rootQuery,
     commands,
+    pluginCommands: getAvailablePluginCommands(),
     paneTemplates: getAvailablePaneShortcutTemplates(rootQuery),
     activeTicker: activeTickerSymbol,
-  }), [activeTickerSymbol, getAvailablePaneShortcutTemplates, rootQuery]);
+  }), [activeTickerSymbol, getAvailablePaneShortcutTemplates, getAvailablePluginCommands, rootQuery]);
 
   const createPaneTemplateItem = useCallback((
     template: PaneTemplateDef,
@@ -2040,56 +2059,52 @@ export function CommandBar({
     }
   }, [closeAll, notify, pluginRegistry]);
 
-  const pluginCommandItems = useCallback((): ResultItem[] => {
-    const disabledPlugins = new Set(state.config.disabledPlugins || []);
-    return [...pluginRegistry.commands.values()]
-      .filter((command) => {
-        if (command.hidden?.()) return false;
-        const pluginId = pluginRegistry.getCommandPluginId(command.id);
-        if (pluginId && disabledPlugins.has(pluginId)) return false;
-        return true;
-      })
-      .map((command) => {
-        const pluginId = pluginRegistry.getCommandPluginId(command.id);
-        const pluginName = pluginId ? pluginRegistry.allPlugins.get(pluginId)?.name : null;
-        return {
-          id: command.id,
-          label: command.label,
-          detail: command.description || "",
-          category: pluginName || "Plugin Commands",
-          kind: "command" as const,
-          action: () => {
-            if (command.wizard && command.wizard.length > 0) {
-              openPluginCommandWorkflow(command);
-              return;
-            }
-            const confirm = resolvePluginCommandConfirm(command);
-            if (confirm) {
-              openInlineConfirm({
-                confirmId: `plugin-command:${command.id}`,
-                title: confirm.title,
-                body: confirm.body,
-                confirmLabel: confirm.confirmLabel || command.label,
-                cancelLabel: confirm.cancelLabel || "Back",
-                tone: confirm.tone || "danger",
-                onConfirm: async () => {
-                  await command.execute();
-                },
-              });
-              return;
-            }
-            void runPluginCommandDirect(command);
-          },
-        };
-      });
+  const createPluginCommandItem = useCallback((command: CommandDef): ResultItem => {
+    const pluginId = pluginRegistry.getCommandPluginId(command.id);
+    const pluginName = pluginId ? pluginRegistry.allPlugins.get(pluginId)?.name : null;
+    const shortcut = command.shortcut?.trim() || undefined;
+    return {
+      id: command.id,
+      label: command.label,
+      detail: command.description || "",
+      category: pluginName || "Plugin Commands",
+      kind: "command",
+      right: shortcut,
+      searchText: `${command.label} ${command.description || ""} ${(command.keywords ?? []).join(" ")} ${shortcut || ""}`,
+      action: () => {
+        if (command.wizard && command.wizard.length > 0) {
+          openPluginCommandWorkflow(command);
+          return;
+        }
+        const confirm = resolvePluginCommandConfirm(command);
+        if (confirm) {
+          openInlineConfirm({
+            confirmId: `plugin-command:${command.id}`,
+            title: confirm.title,
+            body: confirm.body,
+            confirmLabel: confirm.confirmLabel || command.label,
+            cancelLabel: confirm.cancelLabel || "Back",
+            tone: confirm.tone || "danger",
+            onConfirm: async () => {
+              await command.execute();
+            },
+          });
+          return;
+        }
+        void runPluginCommandDirect(command);
+      },
+    };
   }, [
     openInlineConfirm,
     openPluginCommandWorkflow,
     pluginRegistry,
     resolvePluginCommandConfirm,
     runPluginCommandDirect,
-    state.config.disabledPlugins,
   ]);
+
+  const pluginCommandItems = useCallback((): ResultItem[] => {
+    return getAvailablePluginCommands().map((command) => createPluginCommandItem(command));
+  }, [createPluginCommandItem, getAvailablePluginCommands]);
 
   const tickerActionItems = useCallback((): ResultItem[] => {
     const ticker = activeTickerData;
@@ -2556,6 +2571,10 @@ export function CommandBar({
         });
       }
 
+      if (rootShortcutIntent.source === "plugin-command") {
+        return createPluginCommandItem(rootShortcutIntent.command);
+      }
+
       const { command } = rootShortcutIntent;
       if (command.id === "search-ticker") {
         const inferredSymbol = normalizeTickerInput(activeTickerSymbol, undefined);
@@ -2634,7 +2653,11 @@ export function CommandBar({
     let initialIdx = 0;
     const shortcutItem = buildRootShortcutItem();
 
-    if (rootShortcutIntent.kind !== "none" && rootShortcutIntent.source === "pane-template" && shortcutItem) {
+    if (
+      rootShortcutIntent.kind !== "none"
+      && (rootShortcutIntent.source === "pane-template" || rootShortcutIntent.source === "plugin-command")
+      && shortcutItem
+    ) {
       items.push(shortcutItem);
     } else if (match && match.command.id === "plugins") {
       const disabledPlugins = state.config.disabledPlugins || [];
@@ -2871,6 +2894,7 @@ export function CommandBar({
         action: () => {
           const { width, height } = pluginRegistry.getTermSizeFn();
           persistLayoutChange(gridlockAllPanes(currentLayout, { x: 0, y: 0, width, height }));
+          notifyGridlockRevert();
           closeAll({ revertThemePreview: false });
         },
       });
@@ -3020,12 +3044,14 @@ export function CommandBar({
     activeTickerData,
     activeTickerSymbol,
     closeAll,
+    createPluginCommandItem,
     currentRoute,
     dispatch,
     duplicatePane,
     executeCollectionCommand,
     localTickerSearchResultItems,
     nonShortcutPaneTemplateItems,
+    notifyGridlockRevert,
     openBuiltInWorkflow,
     openPickerRoute,
     paneShortcutItems,
@@ -3195,6 +3221,10 @@ export function CommandBar({
       return `Shortcut: ${rootShortcutIntent.label}`;
     }
 
+    if (rootShortcutIntent.source === "plugin-command") {
+      return `Shortcut: ${rootShortcutIntent.label}`;
+    }
+
     if (rootShortcutIntent.command.id === "search-ticker") {
       const symbol = normalizeTickerInput(activeTickerSymbol, rootShortcutIntent.argText);
       if (symbol) {
@@ -3245,6 +3275,7 @@ export function CommandBar({
     const intent = parseRootShortcutIntent({
       query: rootQueryRef.current,
       commands,
+      pluginCommands: getAvailablePluginCommands(),
       paneTemplates: getAvailablePaneShortcutTemplates(rootQueryRef.current),
       activeTicker: activeTickerSymbol,
     });
@@ -3269,6 +3300,10 @@ export function CommandBar({
       return false;
     }
 
+    if (intent.source === "plugin-command") {
+      return false;
+    }
+
     if (intent.command.id === "search-ticker") {
       openModeRoute("ticker-search", intent.argText);
       return true;
@@ -3283,6 +3318,7 @@ export function CommandBar({
     return false;
   }, [
     activeTickerSymbol,
+    getAvailablePluginCommands,
     getAvailablePaneShortcutTemplates,
     openModeRoute,
     openPaneTemplateWorkflow,
@@ -3293,6 +3329,7 @@ export function CommandBar({
     const intent = parseRootShortcutIntent({
       query,
       commands,
+      pluginCommands: getAvailablePluginCommands(),
       paneTemplates: getAvailablePaneShortcutTemplates(query),
       activeTicker: activeTickerSymbol,
     });
@@ -3303,6 +3340,10 @@ export function CommandBar({
         showShortcut: true,
         shortcutExecution: true,
       });
+    }
+
+    if (intent.kind !== "none" && intent.source === "plugin-command") {
+      return createPluginCommandItem(intent.command);
     }
 
     const match = matchPrefix(query);
@@ -3412,8 +3453,10 @@ export function CommandBar({
     return null;
   }, [
     createPaneTemplateItem,
+    createPluginCommandItem,
     activeTickerSymbol,
     executeCollectionCommand,
+    getAvailablePluginCommands,
     getAvailablePaneShortcutTemplates,
     openModeRoute,
     paneTemplateItems,
@@ -3715,6 +3758,7 @@ export function CommandBar({
             action: () => {
               const { width, height } = pluginRegistry.getTermSizeFn();
               persistLayoutChange(gridlockAllPanes(currentLayout, { x: 0, y: 0, width, height }));
+              notifyGridlockRevert();
               closeAll({ revertThemePreview: false });
             },
           });
@@ -3903,6 +3947,7 @@ export function CommandBar({
     localTickerSearchResultItems,
     mapTickerSearchCandidateToResultItem,
     nonShortcutPaneTemplateItems,
+    notifyGridlockRevert,
     openBuiltInWorkflow,
     openInlineConfirm,
     openPaneSettingsRoute,

--- a/src/components/command-bar/root-shortcuts.ts
+++ b/src/components/command-bar/root-shortcuts.ts
@@ -1,4 +1,4 @@
-import type { PaneTemplateDef } from "../../types/plugin";
+import type { CommandDef, PaneTemplateDef } from "../../types/plugin";
 import type { Command } from "./command-registry";
 import { getPaneTemplateDisplayLabel } from "./pane-template-display";
 
@@ -26,10 +26,16 @@ export interface PaneTemplateShortcutIntent extends ShortcutIntentBase {
   template: PaneTemplateDef;
 }
 
+export interface PluginCommandShortcutIntent extends ShortcutIntentBase {
+  source: "plugin-command";
+  command: CommandDef;
+}
+
 export type ShortcutIntent =
   | { kind: "none" }
   | CommandShortcutIntent
-  | PaneTemplateShortcutIntent;
+  | PaneTemplateShortcutIntent
+  | PluginCommandShortcutIntent;
 
 interface ShortcutParseCandidate {
   prefix: string;
@@ -37,8 +43,9 @@ interface ShortcutParseCandidate {
   description: string;
   argKind: RootShortcutArgKind | null;
   argPlaceholder?: string;
-  source: "command" | "pane-template";
+  source: "command" | "pane-template" | "plugin-command";
   command?: Command;
+  pluginCommand?: CommandDef;
   template?: PaneTemplateDef;
 }
 
@@ -71,6 +78,7 @@ function inferShortcutArg(argKind: RootShortcutArgKind | null, activeTicker: str
 
 function buildShortcutCandidates(
   commands: Command[],
+  pluginCommands: CommandDef[],
   paneTemplates: PaneTemplateDef[],
 ): ShortcutParseCandidate[] {
   return [
@@ -84,6 +92,16 @@ function buildShortcutCandidates(
         argPlaceholder: command.argPlaceholder,
         source: "command" as const,
         command,
+      })),
+    ...pluginCommands
+      .filter((command) => command.shortcut?.trim().length)
+      .map((command) => ({
+        prefix: normalizeShortcutPrefix(command.shortcut!),
+        label: command.label,
+        description: command.description ?? "",
+        argKind: null,
+        source: "plugin-command" as const,
+        pluginCommand: command,
       })),
     ...paneTemplates
       .filter((template) => template.shortcut?.prefix)
@@ -102,11 +120,13 @@ function buildShortcutCandidates(
 export function parseRootShortcutIntent({
   query,
   commands,
+  pluginCommands = [],
   paneTemplates,
   activeTicker,
 }: {
   query: string;
   commands: Command[];
+  pluginCommands?: CommandDef[];
   paneTemplates: PaneTemplateDef[];
   activeTicker: string | null;
 }): ShortcutIntent {
@@ -114,7 +134,7 @@ export function parseRootShortcutIntent({
   if (!trimmed) return { kind: "none" };
 
   const upper = trimmed.toUpperCase();
-  const match = buildShortcutCandidates(commands, paneTemplates).find((candidate) => (
+  const match = buildShortcutCandidates(commands, pluginCommands, paneTemplates).find((candidate) => (
     upper === candidate.prefix || upper.startsWith(`${candidate.prefix} `)
   ));
   if (!match) return { kind: "none" };
@@ -148,6 +168,14 @@ export function parseRootShortcutIntent({
       ...base,
       source: "command",
       command: match.command,
+    };
+  }
+
+  if (match.source === "plugin-command" && match.pluginCommand) {
+    return {
+      ...base,
+      source: "plugin-command",
+      command: match.pluginCommand,
     };
   }
 

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { AppContext, createInitialState } from "../../state/app-context";
-import { cloneLayout, createDefaultConfig } from "../../types/config";
+import { cloneLayout, createDefaultConfig, type LayoutConfig } from "../../types/config";
+import type { AppNotificationRequest } from "../../types/plugin";
 import { StatusBar } from "./status-bar";
 import { setSharedRegistryForTests } from "../../plugins/registry";
 
@@ -89,13 +90,13 @@ describe("StatusBar", () => {
 
     const actions: Array<{ type: string }> = [];
     let updatedLayout = null as ReturnType<typeof cloneLayout> | null;
-    const toasts: string[] = [];
+    const notifications: AppNotificationRequest[] = [];
 
     setSharedRegistryForTests({
       getLayoutFn: () => state.config.layout,
       getTermSizeFn: () => ({ width: 120, height: 40 }),
-      updateLayoutFn: (layout) => { updatedLayout = layout; },
-      notify: ({ body }: { body: string }) => { toasts.push(body); },
+      updateLayoutFn: (layout: LayoutConfig) => { updatedLayout = layout; },
+      notify: (notification: AppNotificationRequest) => { notifications.push(notification); },
       Slot: () => null,
     } as any);
 
@@ -119,8 +120,16 @@ describe("StatusBar", () => {
     await testSetup.renderOnce();
 
     expect(updatedLayout?.floating).toHaveLength(0);
-    expect(toasts).toEqual(["Retiled all panes"]);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      body: "Retiled all panes",
+      type: "success",
+      action: { label: "Revert" },
+    });
     expect(actions).toContainEqual({ type: "DISMISS_GRIDLOCK_TIP" });
+
+    notifications[0]!.action!.onClick();
+    expect(actions).toContainEqual({ type: "UNDO_LAYOUT" });
   });
 
   test("auto-dismisses the gridlock tip after its timeout", async () => {
@@ -136,7 +145,7 @@ describe("StatusBar", () => {
     const originalSetTimeout = globalThis.setTimeout;
     const originalClearTimeout = globalThis.clearTimeout;
 
-    globalThis.setTimeout = ((callback: TimerHandler, delay?: number) => {
+    globalThis.setTimeout = ((callback: Parameters<typeof setTimeout>[0], delay?: number) => {
       timers.push({ callback: typeof callback === "function" ? callback : null, delay });
       return 1 as unknown as ReturnType<typeof setTimeout>;
     }) as typeof setTimeout;

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../utils/market-status";
 import { getSharedRegistry } from "../../plugins/registry";
 import { gridlockAllPanes } from "../../plugins/pane-manager";
+import { notifyGridlockComplete } from "../../plugins/gridlock-notification";
 
 const GRIDLOCK_TIP_DURATION_MS = 60_000;
 
@@ -60,7 +61,9 @@ export function StatusBar() {
     if (!registry) return;
     const { width, height } = registry.getTermSizeFn();
     registry.updateLayoutFn(gridlockAllPanes(registry.getLayoutFn(), { x: 0, y: 0, width, height }));
-    registry.notify({ body: "Retiled all panes", type: "success" });
+    notifyGridlockComplete(registry.notify.bind(registry), () => {
+      dispatch({ type: "UNDO_LAYOUT" });
+    });
     dispatch({ type: "DISMISS_GRIDLOCK_TIP" });
   };
 

--- a/src/plugins/builtin/layout-manager.tsx
+++ b/src/plugins/builtin/layout-manager.tsx
@@ -1,8 +1,9 @@
 import { saveConfig } from "../../data/config-store";
 import { findPaneInstance, type LayoutConfig } from "../../types/config";
-import type { GloomPlugin, GloomPluginContext } from "../../types/plugin";
+import type { AppNotificationRequest, GloomPlugin, GloomPluginContext } from "../../types/plugin";
 import type { AppAction } from "../../state/app-context";
 import { getSharedRegistry } from "../registry";
+import { notifyGridlockComplete } from "../gridlock-notification";
 import {
   dockPane,
   floatPane,
@@ -54,7 +55,7 @@ export const layoutManagerPlugin: GloomPlugin = {
   description: "Pane layout management commands",
 
   setup(ctx) {
-    const notify = (body: string, options?: { type?: "info" | "success" | "error" }) => {
+    const notify = (body: string, options?: Omit<AppNotificationRequest, "body">) => {
       ctx.notify({ body, ...options });
     };
 
@@ -125,12 +126,15 @@ export const layoutManagerPlugin: GloomPlugin = {
       label: "Gridlock All Windows",
       description: "Arrange all visible panes into a tiled grid",
       keywords: ["grid", "gridlock", "tile", "arrange", "windows", "layout"],
+      shortcut: "GL",
       category: "config",
       execute: async () => {
         if (!getStateRef) return;
         const { layout, termWidth, termHeight } = getStateRef();
         persistLayout(gridlockAllPanes(layout, { x: 0, y: 0, width: termWidth, height: termHeight }));
-        notify("Retiled all panes", { type: "success" });
+        notifyGridlockComplete(ctx.notify, () => {
+          dispatchRef?.({ type: "UNDO_LAYOUT" });
+        });
       },
     });
 

--- a/src/plugins/gridlock-notification.ts
+++ b/src/plugins/gridlock-notification.ts
@@ -1,0 +1,15 @@
+import type { AppNotificationRequest } from "../types/plugin";
+
+export function notifyGridlockComplete(
+  notify: (notification: AppNotificationRequest) => void,
+  onRevert: () => void,
+): void {
+  notify({
+    body: "Retiled all panes",
+    type: "success",
+    action: {
+      label: "Revert",
+      onClick: onRevert,
+    },
+  });
+}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -366,6 +366,10 @@ export interface AppNotificationRequest {
   type?: AppNotificationType;
   toast?: boolean;
   desktop?: AppDesktopNotificationMode;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 
 export interface GloomPluginContext {


### PR DESCRIPTION
Adds `GL` as a root command-bar shortcut for the existing Gridlock All Windows plugin command and makes plugin command shortcuts searchable/executable from the root query.
Adds notification action support and centralizes gridlock success notifications so the command, layout menu, and status-bar tip all offer a `Revert` action that dispatches layout undo.
Tests: `bun test src/components/layout/status-bar.test.tsx src/components/command-bar/command-bar.test.tsx src/notifications/app-notifier.test.ts`; `bun test src/components/layout/shell.test.tsx`; tmux smoke confirmed `Retiled all panes [Revert]`.
Note: repo-wide `tsc` still has pre-existing type errors; a touched-file filter only reports the existing `command-bar` `wrapText`/`TextareaProps` issue.