### PR TITLE
Handle transient SQLite cache locks

### DIFF
--- a/src/data/plugin-state-store.ts
+++ b/src/data/plugin-state-store.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { safeParseJson, serializeJson } from "./sqlite-json";
+import { withSqliteBusyRetry } from "./sqlite-retry";
 
 export const DEFAULT_PLUGIN_STATE_SCHEMA_VERSION = 1;
 
@@ -23,11 +24,13 @@ export class PluginStateStore {
 
   get<T>(pluginId: string, key: string, schemaVersion = DEFAULT_PLUGIN_STATE_SCHEMA_VERSION): PluginStateRecord<T> | null {
     const cacheKey = `${pluginId}:${key}`;
-    const row = this.db
-      .query<{ schema_version: number; value: string; updated_at: number }, [string, string]>(
-        "SELECT schema_version, value, updated_at FROM plugin_state WHERE plugin_id = ? AND key = ?",
-      )
-      .get(pluginId, key);
+    const row = withSqliteBusyRetry("load plugin state", () => (
+      this.db
+        .query<{ schema_version: number; value: string; updated_at: number }, [string, string]>(
+          "SELECT schema_version, value, updated_at FROM plugin_state WHERE plugin_id = ? AND key = ?",
+        )
+        .get(pluginId, key)
+    ));
     if (!row) {
       this.cache.delete(cacheKey);
       return null;
@@ -63,12 +66,14 @@ export class PluginStateStore {
   set(pluginId: string, key: string, value: unknown, schemaVersion = DEFAULT_PLUGIN_STATE_SCHEMA_VERSION): void {
     const rawValue = serializeJson(value);
     const updatedAt = Date.now();
-    this.db
-      .query(
-        `INSERT OR REPLACE INTO plugin_state (plugin_id, key, schema_version, value, updated_at)
-         VALUES (?, ?, ?, ?, ?)`,
-      )
-      .run(pluginId, key, schemaVersion, rawValue, updatedAt);
+    withSqliteBusyRetry("save plugin state", () => {
+      this.db
+        .query(
+          `INSERT OR REPLACE INTO plugin_state (plugin_id, key, schema_version, value, updated_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(pluginId, key, schemaVersion, rawValue, updatedAt);
+    });
     this.cache.set(`${pluginId}:${key}`, {
       value,
       schemaVersion,
@@ -78,21 +83,27 @@ export class PluginStateStore {
   }
 
   delete(pluginId: string, key: string): void {
-    this.db.query("DELETE FROM plugin_state WHERE plugin_id = ? AND key = ?").run(pluginId, key);
+    withSqliteBusyRetry("delete plugin state", () => {
+      this.db.query("DELETE FROM plugin_state WHERE plugin_id = ? AND key = ?").run(pluginId, key);
+    });
     this.cache.delete(`${pluginId}:${key}`);
   }
 
   keys(pluginId: string): string[] {
-    return this.db
-      .query<{ key: string }, [string]>(
-        "SELECT key FROM plugin_state WHERE plugin_id = ? ORDER BY key",
-      )
-      .all(pluginId)
-      .map((row) => row.key);
+    return withSqliteBusyRetry("list plugin state keys", () => (
+      this.db
+        .query<{ key: string }, [string]>(
+          "SELECT key FROM plugin_state WHERE plugin_id = ? ORDER BY key",
+        )
+        .all(pluginId)
+        .map((row) => row.key)
+    ));
   }
 
   clear(pluginId: string): void {
-    this.db.query("DELETE FROM plugin_state WHERE plugin_id = ?").run(pluginId);
+    withSqliteBusyRetry("clear plugin state", () => {
+      this.db.query("DELETE FROM plugin_state WHERE plugin_id = ?").run(pluginId);
+    });
     for (const cacheKey of this.cache.keys()) {
       if (cacheKey.startsWith(`${pluginId}:`)) {
         this.cache.delete(cacheKey);

--- a/src/data/resource-store.ts
+++ b/src/data/resource-store.ts
@@ -2,6 +2,7 @@ import type { Database } from "bun:sqlite";
 import type { CachePolicy, PersistedResourceValue } from "../types/persistence";
 import type { JsonValue } from "./sqlite-json";
 import { safeParseJson, serializeJson } from "./sqlite-json";
+import { trySqliteBusyOperation, withSqliteBusyRetry } from "./sqlite-retry";
 
 const RESOURCE_CACHE_SOFT_ROW_LIMIT = 25_000;
 const RESOURCE_CACHE_SOFT_SIZE_LIMIT = 100 * 1024 * 1024;
@@ -113,95 +114,114 @@ export class ResourceStore {
   }
 
   private deleteExact(key: ResourceCacheKey): void {
-    this.db
-      .query(
-        `DELETE FROM resource_cache
-         WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
-      )
-      .run(
-        key.namespace,
-        key.kind,
-        key.entityKey,
-        normalizeVariantKey(key.variantKey),
-        normalizeSourceKey(key.sourceKey),
-      );
+    withSqliteBusyRetry("delete cached resource", () => {
+      this.db
+        .query(
+          `DELETE FROM resource_cache
+           WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
+        )
+        .run(
+          key.namespace,
+          key.kind,
+          key.entityKey,
+          normalizeVariantKey(key.variantKey),
+          normalizeSourceKey(key.sourceKey),
+        );
+    });
   }
 
-  private touch(key: ResourceCacheKey): void {
-    this.db
-      .query(
-        `UPDATE resource_cache
-         SET last_accessed_at = ?
-         WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
-      )
-      .run(
-        Date.now(),
-        key.namespace,
-        key.kind,
-        key.entityKey,
-        normalizeVariantKey(key.variantKey),
-        normalizeSourceKey(key.sourceKey),
-      );
+  private touch(key: ResourceCacheKey): number | null {
+    const touchedAt = Date.now();
+    const result = trySqliteBusyOperation("touch cached resource", () => {
+      this.db
+        .query(
+          `UPDATE resource_cache
+           SET last_accessed_at = ?
+           WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
+        )
+        .run(
+          touchedAt,
+          key.namespace,
+          key.kind,
+          key.entityKey,
+          normalizeVariantKey(key.variantKey),
+          normalizeSourceKey(key.sourceKey),
+        );
+      return touchedAt;
+    });
+    return result;
   }
 
   private pruneIfNeeded(): void {
-    const stats = this.db
-      .query<{ count: number; total_size: number }, []>(
-        "SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM resource_cache",
-      )
-      .get();
+    const stats = withSqliteBusyRetry("read resource cache size", () => (
+      this.db
+        .query<{ count: number; total_size: number }, []>(
+          "SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM resource_cache",
+        )
+        .get()
+    ));
     const count = stats?.count ?? 0;
     const totalSize = stats?.total_size ?? 0;
     if (count <= RESOURCE_CACHE_SOFT_ROW_LIMIT && totalSize <= RESOURCE_CACHE_SOFT_SIZE_LIMIT) return;
 
-    this.db.query("DELETE FROM resource_cache WHERE expires_at < ?").run(Date.now());
+    withSqliteBusyRetry("prune expired cached resources", () => {
+      this.db.query("DELETE FROM resource_cache WHERE expires_at < ?").run(Date.now());
+    });
 
-    const remaining = this.db
-      .query<{ count: number; total_size: number }, []>(
-        "SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM resource_cache",
-      )
-      .get();
+    const remaining = withSqliteBusyRetry("read pruned resource cache size", () => (
+      this.db
+        .query<{ count: number; total_size: number }, []>(
+          "SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM resource_cache",
+        )
+        .get()
+    ));
     const remainingCount = remaining?.count ?? 0;
     const remainingSize = remaining?.total_size ?? 0;
     if (remainingCount <= RESOURCE_CACHE_SOFT_ROW_LIMIT && remainingSize <= RESOURCE_CACHE_SOFT_SIZE_LIMIT) return;
 
-    const rowsToDelete = this.db
-      .query<{ namespace: string; kind: string; entity_key: string; variant_key: string; source_key: string }, [number]>(
-        `SELECT namespace, kind, entity_key, variant_key, source_key
-         FROM resource_cache
-         ORDER BY last_accessed_at ASC, fetched_at ASC
-         LIMIT ?`,
-      )
-      .all(Math.max(Math.ceil((remainingCount - RESOURCE_CACHE_SOFT_ROW_LIMIT) + 250), 250));
+    const rowsToDelete = withSqliteBusyRetry("select cached resources to prune", () => (
+      this.db
+        .query<{ namespace: string; kind: string; entity_key: string; variant_key: string; source_key: string }, [number]>(
+          `SELECT namespace, kind, entity_key, variant_key, source_key
+           FROM resource_cache
+           ORDER BY last_accessed_at ASC, fetched_at ASC
+           LIMIT ?`,
+        )
+        .all(Math.max(Math.ceil((remainingCount - RESOURCE_CACHE_SOFT_ROW_LIMIT) + 250), 250))
+    ));
 
     if (rowsToDelete.length === 0) return;
-    const remove = this.db.query(
-      `DELETE FROM resource_cache
-       WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
-    );
-    const tx = this.db.transaction(() => {
-      for (const row of rowsToDelete) {
-        remove.run(row.namespace, row.kind, row.entity_key, row.variant_key, row.source_key);
-      }
+    withSqliteBusyRetry("prune least recently used cached resources", () => {
+      const remove = this.db.query(
+        `DELETE FROM resource_cache
+         WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
+      );
+      const tx = this.db.transaction(() => {
+        for (const row of rowsToDelete) {
+          remove.run(row.namespace, row.kind, row.entity_key, row.variant_key, row.source_key);
+        }
+      });
+      tx();
     });
-    tx();
   }
 
   get<T>(key: ResourceCacheKey, options: GetResourceOptions = {}): CachedResourceRecord<T> | null {
-    const row = this.db
-      .query<ResourceCacheRow, [string, string, string, string, string]>(
-        `SELECT namespace, kind, entity_key, variant_key, source_key, schema_version, payload, provenance,
-                fetched_at, stale_at, expires_at, last_accessed_at, size_bytes
-         FROM resource_cache
-         WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
-      )
-      .get(
-        key.namespace,
-        key.kind,
-        key.entityKey,
-        normalizeVariantKey(key.variantKey),
-        normalizeSourceKey(key.sourceKey),
-      );
+    const row = withSqliteBusyRetry("load cached resource", () => (
+      this.db
+        .query<ResourceCacheRow, [string, string, string, string, string]>(
+          `SELECT namespace, kind, entity_key, variant_key, source_key, schema_version, payload, provenance,
+                  fetched_at, stale_at, expires_at, last_accessed_at, size_bytes
+           FROM resource_cache
+           WHERE namespace = ? AND kind = ? AND entity_key = ? AND variant_key = ? AND source_key = ?`,
+        )
+        .get(
+          key.namespace,
+          key.kind,
+          key.entityKey,
+          normalizeVariantKey(key.variantKey),
+          normalizeSourceKey(key.sourceKey),
+        )
+    ));
 
     if (!row) return null;
     if (!options.allowExpired && isExpired(row.expires_at)) return null;
@@ -217,8 +237,10 @@ export class ResourceStore {
     }
 
     if (options.touch !== false) {
-      this.touch(key);
-      record.lastAccessedAt = Date.now();
+      const touchedAt = this.touch(key);
+      if (touchedAt != null) {
+        record.lastAccessedAt = touchedAt;
+      }
     }
     return record;
   }
@@ -227,14 +249,16 @@ export class ResourceStore {
     key: Pick<ResourceCacheKey, "namespace" | "kind" | "entityKey">,
     options: ListResourceOptions = {},
   ): CachedResourceRecord<T>[] {
-    const rows = this.db
-      .query<ResourceCacheRow, [string, string, string]>(
-        `SELECT namespace, kind, entity_key, variant_key, source_key, schema_version, payload, provenance,
-                fetched_at, stale_at, expires_at, last_accessed_at, size_bytes
-         FROM resource_cache
-         WHERE namespace = ? AND kind = ? AND entity_key = ?`,
-      )
-      .all(key.namespace, key.kind, key.entityKey);
+    const rows = withSqliteBusyRetry("list cached resources", () => (
+      this.db
+        .query<ResourceCacheRow, [string, string, string]>(
+          `SELECT namespace, kind, entity_key, variant_key, source_key, schema_version, payload, provenance,
+                  fetched_at, stale_at, expires_at, last_accessed_at, size_bytes
+           FROM resource_cache
+           WHERE namespace = ? AND kind = ? AND entity_key = ?`,
+        )
+        .all(key.namespace, key.kind, key.entityKey)
+    ));
 
     const allowedVariantKeys = options.variantKeys ? new Set(options.variantKeys.map(normalizeVariantKey)) : null;
     const allowedSourceKeys = options.sourceKeys ? new Set(options.sourceKeys.map(normalizeSourceKey)) : null;
@@ -282,28 +306,30 @@ export class ResourceStore {
       sourceKey: normalizeSourceKey(key.sourceKey),
     };
 
-    this.db
-      .query(
-        `INSERT OR REPLACE INTO resource_cache (
-          namespace, kind, entity_key, variant_key, source_key, schema_version,
-          payload, provenance, fetched_at, stale_at, expires_at, last_accessed_at, size_bytes
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        rowKey.namespace,
-        rowKey.kind,
-        rowKey.entityKey,
-        rowKey.variantKey,
-        rowKey.sourceKey,
-        options.schemaVersion ?? DEFAULT_RESOURCE_SCHEMA_VERSION,
-        payload,
-        provenance,
-        now,
-        now + options.cachePolicy.staleMs,
-        now + options.cachePolicy.expireMs,
-        now,
-        Buffer.byteLength(payload, "utf8"),
-      );
+    withSqliteBusyRetry("save cached resource", () => {
+      this.db
+        .query(
+          `INSERT OR REPLACE INTO resource_cache (
+            namespace, kind, entity_key, variant_key, source_key, schema_version,
+            payload, provenance, fetched_at, stale_at, expires_at, last_accessed_at, size_bytes
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          rowKey.namespace,
+          rowKey.kind,
+          rowKey.entityKey,
+          rowKey.variantKey,
+          rowKey.sourceKey,
+          options.schemaVersion ?? DEFAULT_RESOURCE_SCHEMA_VERSION,
+          payload,
+          provenance,
+          now,
+          now + options.cachePolicy.staleMs,
+          now + options.cachePolicy.expireMs,
+          now,
+          Buffer.byteLength(payload, "utf8"),
+        );
+    });
 
     this.pruneIfNeeded();
     return this.get<T>(rowKey, { allowExpired: true, touch: false })!;
@@ -315,9 +341,13 @@ export class ResourceStore {
 
   clear(namespace?: string): void {
     if (!namespace) {
-      this.db.query("DELETE FROM resource_cache").run();
+      withSqliteBusyRetry("clear cached resources", () => {
+        this.db.query("DELETE FROM resource_cache").run();
+      });
       return;
     }
-    this.db.query("DELETE FROM resource_cache WHERE namespace = ?").run(namespace);
+    withSqliteBusyRetry("clear namespaced cached resources", () => {
+      this.db.query("DELETE FROM resource_cache WHERE namespace = ?").run(namespace);
+    });
   }
 }

--- a/src/data/session-store.ts
+++ b/src/data/session-store.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { safeParseJson, serializeJson } from "./sqlite-json";
+import { withSqliteBusyRetry } from "./sqlite-retry";
 
 export const DEFAULT_SESSION_SCHEMA_VERSION = 1;
 
@@ -14,11 +15,13 @@ export class SessionStore {
   constructor(private readonly db: Database) {}
 
   get<T>(sessionId = "app", schemaVersion = DEFAULT_SESSION_SCHEMA_VERSION): SessionSnapshotRecord<T> | null {
-    const row = this.db
-      .query<{ schema_version: number; value: string; updated_at: number }, [string]>(
-        "SELECT schema_version, value, updated_at FROM session_snapshots WHERE session_id = ?",
-      )
-      .get(sessionId);
+    const row = withSqliteBusyRetry("load session snapshot", () => (
+      this.db
+        .query<{ schema_version: number; value: string; updated_at: number }, [string]>(
+          "SELECT schema_version, value, updated_at FROM session_snapshots WHERE session_id = ?",
+        )
+        .get(sessionId)
+    ));
     if (!row) return null;
     if (row.schema_version !== schemaVersion) {
       this.delete(sessionId);
@@ -38,15 +41,19 @@ export class SessionStore {
   }
 
   set(sessionId: string, value: unknown, schemaVersion = DEFAULT_SESSION_SCHEMA_VERSION): void {
-    this.db
-      .query(
-        `INSERT OR REPLACE INTO session_snapshots (session_id, schema_version, value, updated_at)
-         VALUES (?, ?, ?, ?)`,
-      )
-      .run(sessionId, schemaVersion, serializeJson(value), Date.now());
+    withSqliteBusyRetry("save session snapshot", () => {
+      this.db
+        .query(
+          `INSERT OR REPLACE INTO session_snapshots (session_id, schema_version, value, updated_at)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run(sessionId, schemaVersion, serializeJson(value), Date.now());
+    });
   }
 
   delete(sessionId: string): void {
-    this.db.query("DELETE FROM session_snapshots WHERE session_id = ?").run(sessionId);
+    withSqliteBusyRetry("delete session snapshot", () => {
+      this.db.query("DELETE FROM session_snapshots WHERE session_id = ?").run(sessionId);
+    });
   }
 }

--- a/src/data/sqlite-cache.test.ts
+++ b/src/data/sqlite-cache.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { existsSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -14,7 +15,9 @@ function createTempDbPath(name: string): string {
 
 afterEach(() => {
   for (const path of tempPaths.splice(0)) {
-    if (existsSync(path)) rmSync(path, { force: true });
+    for (const candidate of [path, `${path}-wal`, `${path}-shm`]) {
+      if (existsSync(candidate)) rmSync(candidate, { force: true });
+    }
   }
 });
 
@@ -41,6 +44,37 @@ describe("AppPersistence", () => {
       sourceKey: "provider:yahoo",
     }, { allowExpired: true })?.value.price).toBe(123);
     persistence.close();
+  });
+
+  test("returns cached resources when last-access touch is locked", () => {
+    const dbPath = createTempDbPath("resource-touch-lock");
+    const persistence = new AppPersistence(dbPath);
+    const key = {
+      namespace: "market",
+      kind: "quote",
+      entityKey: "AAPL",
+      sourceKey: "provider:yahoo",
+    };
+
+    persistence.database.connection.exec("PRAGMA busy_timeout=1");
+    persistence.resources.set(key, {
+      price: 123,
+    }, {
+      cachePolicy: { staleMs: 60_000, expireMs: 120_000 },
+      schemaVersion: 1,
+    });
+
+    const locker = new Database(dbPath);
+    locker.exec("PRAGMA busy_timeout=1");
+    locker.exec("BEGIN IMMEDIATE");
+    try {
+      const record = persistence.resources.get<{ price: number }>(key, { allowExpired: true });
+      expect(record?.value.price).toBe(123);
+    } finally {
+      locker.exec("ROLLBACK");
+      locker.close();
+      persistence.close();
+    }
   });
 
   test("invalidates plugin state when schema versions differ", () => {
@@ -88,7 +122,8 @@ describe("AppPersistence", () => {
 
     expect(first).not.toBeNull();
     expect(second).not.toBeNull();
-    expect(second?.value).toBe(first?.value);
+    if (!first || !second) throw new Error("Expected persisted plugin state");
+    expect(second.value).toBe(first.value);
     persistence.close();
   });
 

--- a/src/data/sqlite-database.ts
+++ b/src/data/sqlite-database.ts
@@ -1,4 +1,5 @@
 import { Database } from "bun:sqlite";
+import { SQLITE_BUSY_TIMEOUT_MS, withSqliteBusyRetry } from "./sqlite-retry";
 
 const SCHEMA = `
   CREATE TABLE IF NOT EXISTS tickers (
@@ -52,8 +53,13 @@ export class SqliteDatabase {
 
   constructor(dbPath: string) {
     this.connection = new Database(dbPath);
-    this.connection.exec("PRAGMA journal_mode=WAL");
-    this.connection.exec(SCHEMA);
+    this.connection.exec(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}`);
+    withSqliteBusyRetry("enable sqlite wal", () => {
+      this.connection.exec("PRAGMA journal_mode=WAL");
+    });
+    withSqliteBusyRetry("initialize sqlite schema", () => {
+      this.connection.exec(SCHEMA);
+    });
   }
 
   close(): void {

--- a/src/data/sqlite-retry.test.ts
+++ b/src/data/sqlite-retry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { isSqliteBusyError, trySqliteBusyOperation, withSqliteBusyRetry } from "./sqlite-retry";
+
+function createBusyError(): Error & { code: string; errno: number } {
+  const error = new Error("database is locked") as Error & { code: string; errno: number };
+  error.code = "SQLITE_BUSY";
+  error.errno = 5;
+  return error;
+}
+
+describe("sqlite busy retry", () => {
+  test("recognizes Bun SQLite busy errors", () => {
+    expect(isSqliteBusyError(createBusyError())).toBe(true);
+    expect(isSqliteBusyError(new Error("other failure"))).toBe(false);
+  });
+
+  test("retries busy errors until the operation succeeds", () => {
+    let attempts = 0;
+
+    const result = withSqliteBusyRetry("test retry", () => {
+      attempts += 1;
+      if (attempts < 3) throw createBusyError();
+      return "ok";
+    }, {
+      attempts: 3,
+      initialDelayMs: 0,
+      maxDelayMs: 0,
+    });
+
+    expect(result).toBe("ok");
+    expect(attempts).toBe(3);
+  });
+
+  test("stops after the configured busy retry attempts", () => {
+    let attempts = 0;
+
+    expect(() => withSqliteBusyRetry("test exhaustion", () => {
+      attempts += 1;
+      throw createBusyError();
+    }, {
+      attempts: 2,
+      initialDelayMs: 0,
+      maxDelayMs: 0,
+    })).toThrow("database is locked");
+
+    expect(attempts).toBe(2);
+  });
+
+  test("optional operations only swallow exhausted busy errors", () => {
+    const result = trySqliteBusyOperation("optional busy", () => {
+      throw createBusyError();
+    }, {
+      attempts: 1,
+      initialDelayMs: 0,
+      maxDelayMs: 0,
+    });
+
+    expect(result).toBeNull();
+    expect(() => trySqliteBusyOperation("optional non-busy", () => {
+      throw new Error("not sqlite");
+    })).toThrow("not sqlite");
+  });
+});

--- a/src/data/sqlite-retry.ts
+++ b/src/data/sqlite-retry.ts
@@ -1,0 +1,66 @@
+const SQLITE_BUSY_RETRY_ATTEMPTS = 4;
+const SQLITE_BUSY_RETRY_INITIAL_DELAY_MS = 25;
+const SQLITE_BUSY_RETRY_MAX_DELAY_MS = 250;
+const SQLITE_BUSY_SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
+
+export const SQLITE_BUSY_TIMEOUT_MS = 2000;
+
+export interface SqliteBusyRetryOptions {
+  attempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export function isSqliteBusyError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { code?: unknown; errno?: unknown; message?: unknown };
+  const code = typeof candidate.code === "string" ? candidate.code.toUpperCase() : "";
+  if (code === "SQLITE_BUSY" || code === "SQLITE_LOCKED") return true;
+  if (candidate.errno === 5 || candidate.errno === 6) return true;
+  const message = typeof candidate.message === "string" ? candidate.message.toLowerCase() : "";
+  return message.includes("database is locked")
+    || message.includes("database is busy")
+    || message.includes("database table is locked");
+}
+
+function sleepSync(delayMs: number): void {
+  if (delayMs <= 0) return;
+  Atomics.wait(SQLITE_BUSY_SLEEP_BUFFER, 0, 0, delayMs);
+}
+
+export function withSqliteBusyRetry<T>(
+  operationName: string,
+  operation: () => T,
+  options: SqliteBusyRetryOptions = {},
+): T {
+  const attempts = Math.max(1, Math.floor(options.attempts ?? SQLITE_BUSY_RETRY_ATTEMPTS));
+  const maxDelayMs = Math.max(0, options.maxDelayMs ?? SQLITE_BUSY_RETRY_MAX_DELAY_MS);
+  let delayMs = Math.max(0, options.initialDelayMs ?? SQLITE_BUSY_RETRY_INITIAL_DELAY_MS);
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return operation();
+    } catch (error) {
+      if (!isSqliteBusyError(error) || attempt >= attempts) {
+        throw error;
+      }
+      sleepSync(delayMs);
+      delayMs = Math.min(maxDelayMs, delayMs === 0 ? maxDelayMs : delayMs * 2);
+    }
+  }
+
+  throw new Error(`SQLite operation failed without an error: ${operationName}`);
+}
+
+export function trySqliteBusyOperation<T>(
+  operationName: string,
+  operation: () => T,
+  options?: SqliteBusyRetryOptions,
+): T | null {
+  try {
+    return withSqliteBusyRetry(operationName, operation, options);
+  } catch (error) {
+    if (isSqliteBusyError(error)) return null;
+    throw error;
+  }
+}

--- a/src/data/ticker-store.ts
+++ b/src/data/ticker-store.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { serializeJson } from "./sqlite-json";
+import { withSqliteBusyRetry } from "./sqlite-retry";
 
 export interface StoredTickerRecord {
   symbol: string;
@@ -10,37 +11,47 @@ export class TickerStore {
   constructor(private readonly db: Database) {}
 
   getAll(): StoredTickerRecord[] {
-    return this.db
-      .query<StoredTickerRecord, []>(
-        "SELECT symbol, metadata FROM tickers ORDER BY symbol",
-      )
-      .all();
+    return withSqliteBusyRetry("load tickers", () => (
+      this.db
+        .query<StoredTickerRecord, []>(
+          "SELECT symbol, metadata FROM tickers ORDER BY symbol",
+        )
+        .all()
+    ));
   }
 
   get(symbol: string): string | null {
-    const row = this.db
-      .query<{ metadata: string }, [string]>(
-        "SELECT metadata FROM tickers WHERE symbol = ?",
-      )
-      .get(symbol);
+    const row = withSqliteBusyRetry("load ticker", () => (
+      this.db
+        .query<{ metadata: string }, [string]>(
+          "SELECT metadata FROM tickers WHERE symbol = ?",
+        )
+        .get(symbol)
+    ));
     return row?.metadata ?? null;
   }
 
   save(symbol: string, metadata: unknown): void {
-    this.db
-      .query(
-        `INSERT OR REPLACE INTO tickers (symbol, metadata, updated_at)
-         VALUES (?, ?, ?)`,
-      )
-      .run(symbol, serializeJson(metadata), Date.now());
+    withSqliteBusyRetry("save ticker", () => {
+      this.db
+        .query(
+          `INSERT OR REPLACE INTO tickers (symbol, metadata, updated_at)
+           VALUES (?, ?, ?)`,
+        )
+        .run(symbol, serializeJson(metadata), Date.now());
+    });
   }
 
   delete(symbol: string): void {
-    this.db.query("DELETE FROM tickers WHERE symbol = ?").run(symbol);
+    withSqliteBusyRetry("delete ticker", () => {
+      this.db.query("DELETE FROM tickers WHERE symbol = ?").run(symbol);
+    });
   }
 
   count(): number {
-    const row = this.db.query<{ count: number }, []>("SELECT COUNT(*) as count FROM tickers").get();
+    const row = withSqliteBusyRetry("count tickers", () => (
+      this.db.query<{ count: number }, []>("SELECT COUNT(*) as count FROM tickers").get()
+    ));
     return row?.count ?? 0;
   }
 }


### PR DESCRIPTION
This PR adds a shared SQLite busy retry helper and applies it to cache, ticker, plugin state, and session stores so transient locks from multiple instances or rapid reloads retry instead of surfacing as persistent errors. It also sets a busy timeout during database startup and treats resource-cache last-access touches as best-effort after retries, preserving valid cached reads when only the LRU update is locked. Regression tests cover retry behavior and a real two-connection locked touch path. Verification: bun test; targeted changed-file tsc; tmux smoke with two simultaneous app instances.