### PR TITLE
Fix comparison chart symbol click navigating to wrong ticker

### DIFF
--- a/src/plugins/builtin/comparison-chart.tsx
+++ b/src/plugins/builtin/comparison-chart.tsx
@@ -106,8 +106,7 @@ function ComparisonChartPane({ paneId, focused, width, height }: PaneProps) {
   const settings = useMemo(() => getComparisonChartPaneSettings(pane?.settings), [pane?.settings]);
 
   const openTicker = useCallback((symbol: string) => {
-    registry?.selectTickerFn(symbol);
-    registry?.focusPaneFn("ticker-detail");
+    registry?.navigateTickerFn(symbol);
   }, [registry]);
 
   if (settings.symbols.length === 0) {


### PR DESCRIPTION
## Summary

Clicking a ticker symbol in the comparison chart legend navigates to the wrong security. The handler uses `selectTickerFn` (which moves the portfolio cursor) + `focusPaneFn` (which focuses an existing detail pane showing whatever the cursor was already on) instead of `navigateTickerFn` which properly retargets the detail pane to the clicked symbol.

One-line fix in `src/plugins/builtin/comparison-chart.tsx`.

## Test plan

- [ ] Open a CMP chart with multiple symbols (e.g., CMP IONQ, RGTI, QUBT)
- [ ] Click on each symbol in the legend
- [ ] Verify the ticker detail pane shows the clicked symbol, not the previously focused one