### PR TITLE
Improve chart panning and loading behavior

### DIFF
--- a/src/components/chart/chart-controller.test.ts
+++ b/src/components/chart/chart-controller.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clampDateWindowToBounds,
+  getCanonicalZoomLevel,
+  needsCanonicalPresetViewportReset,
+  resolveCanonicalPresetViewport,
+  resolveVisibleActivePreset,
+  shiftDateWindow,
+} from "./chart-controller";
+
+const dayMs = 24 * 60 * 60_000;
+
+function utcDate(day: number): Date {
+  return new Date(Date.UTC(2026, 0, day));
+}
+
+function utcDates(count: number): Date[] {
+  return Array.from({ length: count }, (_, index) => utcDate(index + 1));
+}
+
+describe("chart-controller date windows", () => {
+  test("keeps the visible span when panning past the right edge", () => {
+    const current = {
+      start: utcDate(8),
+      end: utcDate(10),
+    };
+    const shifted = shiftDateWindow(current, -2);
+
+    const clamped = clampDateWindowToBounds(shifted, {
+      start: utcDate(1),
+      end: utcDate(11),
+    });
+
+    expect(clamped).toEqual({
+      start: utcDate(9),
+      end: utcDate(11),
+    });
+    expect(clamped!.end!.getTime() - clamped!.start!.getTime()).toBe(2 * dayMs);
+  });
+
+  test("keeps the visible span when panning past the left edge", () => {
+    const current = {
+      start: utcDate(2),
+      end: utcDate(4),
+    };
+    const shifted = shiftDateWindow(current, 2);
+
+    const clamped = clampDateWindowToBounds(shifted, {
+      start: utcDate(1),
+      end: utcDate(11),
+    });
+
+    expect(clamped).toEqual({
+      start: utcDate(1),
+      end: utcDate(3),
+    });
+    expect(clamped!.end!.getTime() - clamped!.start!.getTime()).toBe(2 * dayMs);
+  });
+
+  test("expands tiny windows around their center without crossing bounds", () => {
+    const clamped = clampDateWindowToBounds({
+      start: utcDate(11),
+      end: utcDate(11),
+    }, {
+      start: utcDate(1),
+      end: utcDate(11),
+    }, 2 * dayMs);
+
+    expect(clamped).toEqual({
+      start: utcDate(9),
+      end: utcDate(11),
+    });
+  });
+
+  test("keeps an active preset visible while loaded data still needs the canonical reset", () => {
+    const dates = utcDates(300);
+    const state = {
+      presetRange: "1M" as const,
+      activePreset: "1M" as const,
+      resolution: "15m" as const,
+      panOffset: 0,
+      zoomLevel: 1,
+      cursorX: 12,
+      cursorY: 3,
+    };
+
+    expect(needsCanonicalPresetViewportReset(dates, state)).toBe(true);
+    expect(resolveVisibleActivePreset(dates, state)).toBe("1M");
+
+    const resolved = resolveCanonicalPresetViewport(state, dates);
+    expect(resolved.zoomLevel).toBe(getCanonicalZoomLevel(dates, "1M"));
+    expect(resolved.panOffset).toBe(0);
+    expect(resolved.cursorX).toBeNull();
+    expect(resolved.cursorY).toBeNull();
+  });
+
+  test("does not keep a preset active after the viewport was panned", () => {
+    const dates = utcDates(300);
+    const state = {
+      presetRange: "1M" as const,
+      activePreset: "1M" as const,
+      resolution: "15m" as const,
+      panOffset: 2,
+      zoomLevel: 1,
+    };
+
+    expect(needsCanonicalPresetViewportReset(dates, state)).toBe(false);
+    expect(resolveVisibleActivePreset(dates, state)).toBeNull();
+  });
+});

--- a/src/components/chart/chart-controller.ts
+++ b/src/components/chart/chart-controller.ts
@@ -197,43 +197,44 @@ export function clampDateWindowToBounds(
   const effectiveMinimumSpanMs = availableSpanMs === 0
     ? 0
     : Math.min(Math.max(minimumSpanMs, 1), availableSpanMs);
+  const requestedSpanMs = Math.max(normalizedWindow.endMs - normalizedWindow.startMs, 0);
+  const targetSpanMs = Math.min(
+    Math.max(requestedSpanMs, effectiveMinimumSpanMs),
+    availableSpanMs,
+  );
 
-  let startMs = clamp(normalizedWindow.startMs, normalizedBounds.startMs, normalizedBounds.endMs);
-  let endMs = clamp(normalizedWindow.endMs, normalizedBounds.startMs, normalizedBounds.endMs);
-
-  if (endMs < startMs) {
-    [startMs, endMs] = [endMs, startMs];
+  if (availableSpanMs === 0 || targetSpanMs === 0) {
+    return {
+      start: new Date(normalizedBounds.startMs),
+      end: new Date(normalizedBounds.endMs),
+    };
   }
 
-  if (effectiveMinimumSpanMs > 0 && endMs - startMs < effectiveMinimumSpanMs) {
-    const centerMs = startMs + ((endMs - startMs) / 2);
-    startMs = centerMs - (effectiveMinimumSpanMs / 2);
-    endMs = centerMs + (effectiveMinimumSpanMs / 2);
+  if (targetSpanMs >= availableSpanMs) {
+    return {
+      start: new Date(normalizedBounds.startMs),
+      end: new Date(normalizedBounds.endMs),
+    };
+  }
+
+  let startMs: number;
+  let endMs: number;
+
+  if (requestedSpanMs < targetSpanMs) {
+    const centerMs = normalizedWindow.startMs + (requestedSpanMs / 2);
+    startMs = centerMs - (targetSpanMs / 2);
+    endMs = centerMs + (targetSpanMs / 2);
+  } else {
+    startMs = normalizedWindow.startMs;
+    endMs = normalizedWindow.startMs + targetSpanMs;
   }
 
   if (startMs < normalizedBounds.startMs) {
-    const shiftMs = normalizedBounds.startMs - startMs;
-    startMs += shiftMs;
-    endMs += shiftMs;
-  }
-
-  if (endMs > normalizedBounds.endMs) {
-    const shiftMs = endMs - normalizedBounds.endMs;
-    startMs -= shiftMs;
-    endMs -= shiftMs;
-  }
-
-  startMs = clamp(startMs, normalizedBounds.startMs, normalizedBounds.endMs);
-  endMs = clamp(endMs, normalizedBounds.startMs, normalizedBounds.endMs);
-
-  if (effectiveMinimumSpanMs > 0 && endMs - startMs < effectiveMinimumSpanMs) {
-    if (availableSpanMs <= effectiveMinimumSpanMs) {
-      startMs = normalizedBounds.startMs;
-      endMs = normalizedBounds.endMs;
-    } else {
-      endMs = Math.min(normalizedBounds.endMs, startMs + effectiveMinimumSpanMs);
-      startMs = Math.max(normalizedBounds.startMs, endMs - effectiveMinimumSpanMs);
-    }
+    startMs = normalizedBounds.startMs;
+    endMs = startMs + targetSpanMs;
+  } else if (endMs > normalizedBounds.endMs) {
+    endMs = normalizedBounds.endMs;
+    startMs = endMs - targetSpanMs;
   }
 
   return {
@@ -426,6 +427,52 @@ export function isCanonicalPresetViewport(
   if (state.panOffset !== 0) return false;
   const canonicalZoom = getCanonicalZoomLevel(dates, state.activePreset);
   return Math.abs(state.zoomLevel - canonicalZoom) < 0.001;
+}
+
+type CanonicalPresetViewportState = Pick<ViewStateWithViewport, "presetRange" | "activePreset" | "panOffset" | "zoomLevel" | "cursorX" | "cursorY">;
+
+export function needsCanonicalPresetViewportReset(
+  dates: readonly Date[],
+  state: Pick<CanonicalPresetViewportState, "presetRange" | "activePreset" | "panOffset" | "zoomLevel">,
+): boolean {
+  if (dates.length === 0) return false;
+  if (state.activePreset !== state.presetRange) return false;
+  if (state.panOffset !== 0) return false;
+  const canonicalZoom = getCanonicalZoomLevel(dates, state.presetRange);
+  return Math.abs(state.zoomLevel - canonicalZoom) >= 0.001;
+}
+
+export function resolvePresetRangeViewport<S extends CanonicalPresetViewportState>(
+  state: S,
+  dates: readonly Date[],
+): S {
+  if (dates.length === 0) return state;
+  const canonicalZoom = getCanonicalZoomLevel(dates, state.presetRange);
+  if (state.zoomLevel === canonicalZoom && state.panOffset === 0) return state;
+  return {
+    ...state,
+    panOffset: 0,
+    zoomLevel: canonicalZoom,
+    cursorX: null,
+    cursorY: null,
+  };
+}
+
+export function resolveCanonicalPresetViewport<S extends CanonicalPresetViewportState>(
+  state: S,
+  dates: readonly Date[],
+): S {
+  if (!needsCanonicalPresetViewportReset(dates, state)) return state;
+  return resolvePresetRangeViewport(state, dates);
+}
+
+export function resolveVisibleActivePreset(
+  dates: readonly Date[],
+  state: Pick<ViewStateWithViewport, "presetRange" | "activePreset" | "panOffset" | "zoomLevel" | "resolution">,
+): TimeRange | null {
+  if (!state.activePreset) return null;
+  if (isCanonicalPresetViewport(dates, state)) return state.activePreset;
+  return needsCanonicalPresetViewportReset(dates, state) ? state.activePreset : null;
 }
 
 export function resolvePresetSelectionWithResolution<S extends ViewStateWithViewport>(

--- a/src/components/chart/chart-data.ts
+++ b/src/components/chart/chart-data.ts
@@ -19,6 +19,23 @@ export interface ChartProjection {
   fallbackMode: ChartRenderMode | null;
 }
 
+export interface ProjectChartDataOptions {
+  ohlcBucketWidth?: number;
+  ohlcSourceBucketSize?: number;
+  ohlcTargetBucketCount?: number;
+  sourceIndexOffset?: number;
+}
+
+export interface StableOhlcProjectionOptionsInput {
+  pointCount: number;
+  sourceIndexOffset: number;
+  bucketWidth: number;
+  navigationPointCount?: number;
+  countRatioTolerance?: number;
+}
+
+const DEFAULT_OHLC_COUNT_RATIO_TOLERANCE = 1.2;
+
 function coerceDate(value: Date | string | number): Date {
   return value instanceof Date ? value : new Date(value);
 }
@@ -113,6 +130,104 @@ function normalizePoint(point: PricePoint): ProjectedChartPoint {
   };
 }
 
+function getMinimumPositiveDateGapMs(points: readonly ProjectedChartPoint[]): number | null {
+  let minimum = Number.POSITIVE_INFINITY;
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1]!.date.getTime();
+    const current = points[index]!.date.getTime();
+    const gap = current - previous;
+    if (Number.isFinite(gap) && gap > 0 && gap < minimum) {
+      minimum = gap;
+    }
+  }
+  return Number.isFinite(minimum) ? minimum : null;
+}
+
+function aggregateOhlcBucket(bucket: readonly ProjectedChartPoint[]): ProjectedChartPoint {
+  const first = bucket[0]!;
+  const last = bucket[bucket.length - 1]!;
+  let high = first.high;
+  let low = first.low;
+  let volume = 0;
+
+  for (const point of bucket) {
+    high = Math.max(high, point.high);
+    low = Math.min(low, point.low);
+    volume += point.volume;
+  }
+
+  return {
+    date: last.date,
+    open: first.open,
+    high,
+    low,
+    close: last.close,
+    volume,
+  };
+}
+
+function bucketOhlcBySourceIndex(
+  normalizedPoints: readonly ProjectedChartPoint[],
+  bucketSize: number,
+  sourceIndexOffset: number,
+  targetBucketCount?: number,
+): ProjectedChartPoint[] {
+  const normalizedBucketSize = Math.max(Math.floor(bucketSize), 1);
+  const normalizedSourceIndexOffset = Math.max(Math.floor(sourceIndexOffset), 0);
+  const maximumBucketCount = targetBucketCount === undefined
+    ? Number.POSITIVE_INFINITY
+    : Math.max(Math.floor(targetBucketCount), 1);
+  const result: ProjectedChartPoint[] = [];
+  const firstBucketStart = Math.floor(normalizedSourceIndexOffset / normalizedBucketSize) * normalizedBucketSize;
+  const endSourceIndex = normalizedSourceIndexOffset + normalizedPoints.length;
+
+  for (
+    let bucketStart = firstBucketStart;
+    bucketStart < endSourceIndex && result.length < maximumBucketCount;
+    bucketStart += normalizedBucketSize
+  ) {
+    const bucketEnd = bucketStart + normalizedBucketSize;
+    const start = Math.max(bucketStart - normalizedSourceIndexOffset, 0);
+    const end = Math.min(bucketEnd - normalizedSourceIndexOffset, normalizedPoints.length);
+    if (end <= start) continue;
+    const bucket = normalizedPoints.slice(start, end);
+    if (bucket.length === 0) continue;
+    result.push(aggregateOhlcBucket(bucket));
+  }
+
+  return result;
+}
+
+export function resolveStableOhlcProjectionOptions({
+  pointCount,
+  sourceIndexOffset,
+  bucketWidth,
+  navigationPointCount = 0,
+  countRatioTolerance = DEFAULT_OHLC_COUNT_RATIO_TOLERANCE,
+}: StableOhlcProjectionOptionsInput): ProjectChartDataOptions {
+  const ohlcBucketWidth = Math.max(Math.floor(bucketWidth), 1);
+  const ohlcProjectionWidth = Math.max(Math.floor(ohlcBucketWidth / 2), 1);
+  const normalizedPointCount = Math.max(Math.floor(pointCount), 0);
+  const normalizedNavigationPointCount = Math.max(Math.floor(navigationPointCount), 0);
+  const canUseNavigationCount = normalizedNavigationPointCount > 0
+    && normalizedPointCount > 0
+    && Math.max(normalizedNavigationPointCount, normalizedPointCount)
+      / Math.max(Math.min(normalizedNavigationPointCount, normalizedPointCount), 1)
+      <= countRatioTolerance;
+  const stableSourceCount = canUseNavigationCount
+    ? normalizedNavigationPointCount
+    : normalizedPointCount;
+  const ohlcSourceBucketSize = Math.max(Math.ceil(stableSourceCount / ohlcProjectionWidth), 1);
+  const ohlcTargetBucketCount = Math.max(Math.ceil(stableSourceCount / ohlcSourceBucketSize), 1);
+
+  return {
+    ohlcBucketWidth,
+    ohlcSourceBucketSize,
+    ohlcTargetBucketCount,
+    sourceIndexOffset,
+  };
+}
+
 /**
  * Downsample close-driven chart data to fit the target width.
  * Uses representative closes so line/area charts preserve the broad shape.
@@ -156,44 +271,75 @@ export function projectCloseSeries(
 
 /**
  * Bucket OHLC data so each rendered column preserves open, close, high, low, and volume.
+ *
+ * The default path aligns buckets by timestamp. Interactive manual panning can pass
+ * ohlcSourceBucketSize/ohlcTargetBucketCount to align buckets by source bar index,
+ * which keeps the rendered candle count stable as partial edge buckets enter/leave.
  */
 export function bucketOhlcSeries(
   points: PricePoint[],
   targetWidth: number,
+  options: ProjectChartDataOptions = {},
 ): ProjectedChartPoint[] {
   if (points.length === 0) return [];
-  if (points.length <= targetWidth) return points.map(normalizePoint);
+  const normalizedPoints = points.map(normalizePoint);
+  if (points.length <= targetWidth) return normalizedPoints;
+  if (options.ohlcSourceBucketSize !== undefined) {
+    return bucketOhlcBySourceIndex(
+      normalizedPoints,
+      options.ohlcSourceBucketSize,
+      options.sourceIndexOffset ?? 0,
+      options.ohlcTargetBucketCount,
+    );
+  }
 
   const result: ProjectedChartPoint[] = [];
-  const bucketSize = points.length / targetWidth;
+  const minimumGapMs = getMinimumPositiveDateGapMs(normalizedPoints);
+  const firstTime = normalizedPoints[0]!.date.getTime();
+  const lastTime = normalizedPoints[normalizedPoints.length - 1]!.date.getTime();
+  if (
+    minimumGapMs
+    && Number.isFinite(firstTime)
+    && Number.isFinite(lastTime)
+    && lastTime > firstTime
+  ) {
+    const spanMs = Math.max(lastTime - firstTime, minimumGapMs);
+    const rawBucketDurationMs = spanMs / Math.max(targetWidth, 1);
+    const bucketDurationMs = Math.max(Math.ceil(rawBucketDurationMs / minimumGapMs) * minimumGapMs, minimumGapMs);
+    let currentBucketKey: number | null = null;
+    let currentBucket: ProjectedChartPoint[] = [];
 
-  for (let i = 0; i < targetWidth; i++) {
-    const start = Math.floor(i * bucketSize);
-    const end = Math.min(points.length, Math.max(Math.floor((i + 1) * bucketSize), start + 1));
-    const bucket = points.slice(start, end);
-    if (bucket.length === 0) continue;
-
-    const first = bucket[0]!;
-    const last = bucket[bucket.length - 1]!;
-
-    let high = first.high ?? first.close;
-    let low = first.low ?? first.close;
-    let volume = 0;
-
-    for (const point of bucket) {
-      high = Math.max(high, point.high ?? point.close);
-      low = Math.min(low, point.low ?? point.close);
-      volume += point.volume ?? 0;
+    for (const point of normalizedPoints) {
+      const time = point.date.getTime();
+      const bucketKey = Math.floor(time / bucketDurationMs);
+      if (currentBucketKey !== null && bucketKey !== currentBucketKey) {
+        result.push(aggregateOhlcBucket(currentBucket));
+        currentBucket = [];
+      }
+      currentBucketKey = bucketKey;
+      currentBucket.push(point);
     }
 
-    result.push({
-      date: coerceDate(last.date as Date | string | number),
-      open: first.open ?? first.close,
-      high,
-      low,
-      close: last.close,
-      volume,
-    });
+    if (currentBucket.length > 0) {
+      result.push(aggregateOhlcBucket(currentBucket));
+    }
+
+    return result;
+  }
+
+  const bucketSize = Math.max(Math.ceil(normalizedPoints.length / Math.max(targetWidth, 1)), 1);
+  const sourceIndexOffset = Math.max(Math.floor(options.sourceIndexOffset ?? 0), 0);
+  const firstBucketStart = Math.floor(sourceIndexOffset / bucketSize) * bucketSize;
+  const endSourceIndex = sourceIndexOffset + normalizedPoints.length;
+
+  for (let bucketStart = firstBucketStart; bucketStart < endSourceIndex; bucketStart += bucketSize) {
+    const bucketEnd = bucketStart + bucketSize;
+    const start = Math.max(bucketStart - sourceIndexOffset, 0);
+    const end = Math.min(bucketEnd - sourceIndexOffset, normalizedPoints.length);
+    if (end <= start) continue;
+    const bucket = normalizedPoints.slice(start, end);
+    if (bucket.length === 0) continue;
+    result.push(aggregateOhlcBucket(bucket));
   }
 
   return result;
@@ -219,14 +365,16 @@ export function projectChartData(
   targetWidth: number,
   mode: ChartRenderMode | undefined,
   compact = false,
+  options: ProjectChartDataOptions = {},
 ): ChartProjection {
   const { requestedMode, effectiveMode, fallbackMode } = resolveRenderMode(mode, targetWidth, compact);
+  const ohlcBucketWidth = options.ohlcBucketWidth ?? targetWidth;
   const projectionWidth = effectiveMode === "candles" || effectiveMode === "ohlc"
-    ? Math.max(Math.floor(targetWidth / 2), 1)
+    ? Math.max(Math.floor(ohlcBucketWidth / 2), 1)
     : targetWidth;
 
   const projectedPoints = effectiveMode === "candles" || effectiveMode === "ohlc"
-    ? bucketOhlcSeries(points, projectionWidth)
+    ? bucketOhlcSeries(points, projectionWidth, options)
     : projectCloseSeries(points, projectionWidth);
 
   return {

--- a/src/components/chart/chart-scroll.test.ts
+++ b/src/components/chart/chart-scroll.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { applyBufferedPanExpansion, getMouseScrollStepCount, resolveHorizontalScrollPanDirection } from "./chart-scroll";
+import {
+  applyBufferedPanExpansion,
+  consumeScrollPanCellDelta,
+  consumeScrollPanMovement,
+  getDragPanPointDelta,
+  getDragPanWindowRatio,
+  getKeyboardPanCellCount,
+  resolveDragPanOffset,
+  resolveHorizontalScrollPanDirection,
+} from "./chart-scroll";
 
 describe("chart-scroll", () => {
   test("maps every wheel direction onto horizontal panning", () => {
@@ -9,12 +18,34 @@ describe("chart-scroll", () => {
     expect(resolveHorizontalScrollPanDirection("right")).toBe(-1);
   });
 
-  test("normalizes wheel delta into at least one scroll step", () => {
-    expect(getMouseScrollStepCount(undefined)).toBe(1);
-    expect(getMouseScrollStepCount(0)).toBe(1);
-    expect(getMouseScrollStepCount(0.4)).toBe(1);
-    expect(getMouseScrollStepCount(1.6)).toBe(2);
-    expect(getMouseScrollStepCount(-2.2)).toBe(2);
+  test("accumulates wheel input before panning a full cell", () => {
+    let result = consumeScrollPanCellDelta(100, 1, 1, 0);
+    expect(result.cells).toBe(0);
+    expect(result.remainder).toBeCloseTo(0.5);
+
+    result = consumeScrollPanCellDelta(100, 1, 1, result.remainder);
+    expect(result.cells).toBe(1);
+    expect(result.remainder).toBeCloseTo(0);
+
+    result = consumeScrollPanCellDelta(100, 0.4, -1, result.remainder);
+    expect(result.cells).toBe(0);
+    expect(result.remainder).toBeCloseTo(-0.2);
+  });
+
+  test("uses slower pan distances for keyboard and drag input", () => {
+    expect(getKeyboardPanCellCount(100)).toBe(2);
+    expect(getDragPanPointDelta(10, 100, 200)).toBe(4);
+    expect(getDragPanWindowRatio(10, 100)).toBeCloseTo(0.02);
+    expect(resolveDragPanOffset(20, 10, 100, 200, 40)).toBe(16);
+    expect(resolveDragPanOffset(2, 10, 100, 200, 40)).toBe(0);
+  });
+
+  test("resolves wheel direction, cell delta, remainder, and ratio together", () => {
+    const first = consumeScrollPanMovement(100, 1, "up", 0);
+    expect(first).toEqual({ cells: 0, remainder: 0.5, ratio: 0 });
+
+    const second = consumeScrollPanMovement(100, 1, "up", first.remainder);
+    expect(second).toEqual({ cells: 1, remainder: 0, ratio: 0.01 });
   });
 
   test("preserves the active cursor when widening the buffered pan range", () => {

--- a/src/components/chart/chart-scroll.ts
+++ b/src/components/chart/chart-scroll.ts
@@ -3,13 +3,83 @@ import type { TimeRange } from "./chart-types";
 
 export type ChartScrollDirection = "up" | "down" | "left" | "right";
 
+const KEYBOARD_PAN_WIDTH_RATIO = 0.02;
+const SCROLL_PAN_WIDTH_RATIO = 0.005;
+const DRAG_PAN_VISIBLE_RATIO = 0.2;
+
 interface BufferExpansionViewState {
   activePreset: TimeRange | null;
   bufferRange: TimeRange;
 }
 
-export function getMouseScrollStepCount(delta: number | undefined): number {
-  return Math.max(1, Math.round(Math.abs(delta ?? 1)));
+export interface ScrollPanCellDelta {
+  cells: number;
+  remainder: number;
+}
+
+export interface ScrollPanMovement extends ScrollPanCellDelta {
+  ratio: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function getKeyboardPanCellCount(chartWidth: number): number {
+  return Math.max(Math.round(chartWidth * KEYBOARD_PAN_WIDTH_RATIO), 1);
+}
+
+export function getDragPanPointDelta(deltaCells: number, chartWidth: number, visibleCount: number): number {
+  return Math.round((deltaCells / Math.max(chartWidth, 1)) * Math.max(visibleCount, 1) * DRAG_PAN_VISIBLE_RATIO);
+}
+
+export function getDragPanWindowRatio(deltaCells: number, chartWidth: number): number {
+  return (deltaCells / Math.max(chartWidth, 1)) * DRAG_PAN_VISIBLE_RATIO;
+}
+
+export function resolveDragPanOffset(
+  startPanOffset: number,
+  deltaCells: number,
+  chartWidth: number,
+  visibleCount: number,
+  maxPanOffset: number,
+): number {
+  return clamp(
+    startPanOffset - getDragPanPointDelta(deltaCells, chartWidth, visibleCount),
+    0,
+    Math.max(maxPanOffset, 0),
+  );
+}
+
+export function consumeScrollPanCellDelta(
+  chartWidth: number,
+  delta: number | undefined,
+  direction: 1 | -1,
+  remainder: number,
+): ScrollPanCellDelta {
+  const rawMagnitude = Math.abs(delta ?? 1);
+  const magnitude = rawMagnitude > 0 ? rawMagnitude : 1;
+  const next = remainder + direction * Math.max(chartWidth, 1) * SCROLL_PAN_WIDTH_RATIO * magnitude;
+  const rawCells = next >= 0 ? Math.floor(next) : Math.ceil(next);
+  const cells = Object.is(rawCells, -0) ? 0 : rawCells;
+  return {
+    cells,
+    remainder: next - cells,
+  };
+}
+
+export function consumeScrollPanMovement(
+  chartWidth: number,
+  delta: number | undefined,
+  scrollDirection: ChartScrollDirection,
+  remainder: number,
+): ScrollPanMovement {
+  const panDirection = resolveHorizontalScrollPanDirection(scrollDirection);
+  const result = consumeScrollPanCellDelta(chartWidth, delta, panDirection, remainder);
+  return {
+    ...result,
+    ratio: result.cells / Math.max(chartWidth, 1),
+  };
 }
 
 export function applyBufferedPanExpansion<S extends BufferExpansionViewState>(

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { bucketOhlcSeries, getVisibleWindow, projectChartData, resolveRenderMode } from "./chart-data";
+import {
+  bucketOhlcSeries,
+  getVisibleWindow,
+  projectChartData,
+  resolveRenderMode,
+  resolveStableOhlcProjectionOptions,
+} from "./chart-data";
 import { stepCursorTowards } from "./cursor-motion";
 import { buildChartScene, buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
 import type { PricePoint } from "../../types/financials";
@@ -63,6 +69,111 @@ describe("bucketOhlcSeries", () => {
       volume: 450,
     });
   });
+
+  test("keeps interior OHLC buckets aligned to source bars while panning", () => {
+    const source = Array.from({ length: 13 }, (_, index) => ({
+      date: new Date(Date.UTC(2024, 0, index + 1)),
+      open: index,
+      high: index + 10,
+      low: index - 10,
+      close: index + 0.5,
+      volume: index + 1,
+    })) as PricePoint[];
+
+    const firstView = bucketOhlcSeries(source.slice(0, 12), 3, { sourceIndexOffset: 0 });
+    const pannedView = bucketOhlcSeries(source.slice(1, 13), 3, { sourceIndexOffset: 1 });
+    const firstSharedBucket = firstView[1];
+    const secondSharedBucket = firstView[2];
+    if (!firstSharedBucket || !secondSharedBucket) {
+      throw new Error("Expected shared OHLC buckets");
+    }
+
+    expect(firstSharedBucket).toEqual({
+      date: source[4]!.date,
+      open: 1,
+      high: 14,
+      low: -9,
+      close: 4.5,
+      volume: 2 + 3 + 4 + 5,
+    });
+    expect(pannedView[0]).toEqual(firstSharedBucket);
+    expect(pannedView[1]).toEqual(secondSharedBucket);
+  });
+
+  test("keeps source-aligned bucket count stable across small pans", () => {
+    const source: PricePoint[] = [];
+    let cursor = new Date(Date.UTC(2024, 0, 1));
+    let sourceIndex = 0;
+    while (source.length < 220) {
+      const day = cursor.getUTCDay();
+      if (day !== 0 && day !== 6) {
+        source.push({
+          date: new Date(cursor),
+          open: sourceIndex,
+          high: sourceIndex + 1,
+          low: sourceIndex - 1,
+          close: sourceIndex + 0.5,
+          volume: sourceIndex + 1,
+        });
+        sourceIndex += 1;
+      }
+      cursor = new Date(cursor.getTime() + 24 * 3600_000);
+    }
+
+    const visibleCount = 160;
+    const targetWidth = 40;
+    const projectionOptions = resolveStableOhlcProjectionOptions({
+      pointCount: visibleCount,
+      sourceIndexOffset: 0,
+      bucketWidth: targetWidth * 2,
+      navigationPointCount: visibleCount,
+    });
+    const targetBucketCount = projectionOptions.ohlcTargetBucketCount!;
+    const projectWindow = (start: number) => bucketOhlcSeries(
+      source.slice(start, start + visibleCount),
+      targetWidth,
+      {
+        ...projectionOptions,
+        sourceIndexOffset: start,
+      },
+    );
+
+    const first = projectWindow(0);
+    const pannedOne = projectWindow(1);
+    const pannedTwo = projectWindow(2);
+
+    expect(first).toHaveLength(targetBucketCount);
+    expect(pannedOne).toHaveLength(targetBucketCount);
+    expect(pannedTwo).toHaveLength(targetBucketCount);
+    expect(pannedOne[1]!).toEqual(first[1]!);
+    expect(pannedTwo[1]!).toEqual(first[1]!);
+  });
+
+  test("plans stable OHLC buckets from navigation count when histories are comparable", () => {
+    expect(resolveStableOhlcProjectionOptions({
+      pointCount: 158,
+      sourceIndexOffset: 12,
+      bucketWidth: 80,
+      navigationPointCount: 160,
+    })).toMatchObject({
+      ohlcBucketWidth: 80,
+      ohlcSourceBucketSize: 4,
+      ohlcTargetBucketCount: 40,
+      sourceIndexOffset: 12,
+    });
+  });
+
+  test("plans OHLC buckets from rendered points when navigation count is too different", () => {
+    expect(resolveStableOhlcProjectionOptions({
+      pointCount: 84,
+      sourceIndexOffset: 0,
+      bucketWidth: 80,
+      navigationPointCount: 160,
+    })).toMatchObject({
+      ohlcSourceBucketSize: 3,
+      ohlcTargetBucketCount: 28,
+    });
+  });
 });
 
 describe("resolveRenderMode", () => {
@@ -90,9 +201,27 @@ describe("resolveRenderMode", () => {
       volume: 1_000 + i,
     })) as PricePoint[];
 
-    expect(projectChartData(denseSeries, 80, "candles", false).points).toHaveLength(40);
-    expect(projectChartData(denseSeries, 80, "ohlc", false).points).toHaveLength(40);
+    expect(projectChartData(denseSeries, 80, "candles", false).points).toHaveLength(34);
+    expect(projectChartData(denseSeries, 80, "ohlc", false).points).toHaveLength(34);
     expect(projectChartData(denseSeries, 80, "line", false).points).toHaveLength(80);
+  });
+
+  test("keeps candle buckets stable when axis width changes the plot by one column", () => {
+    const denseSeries = Array.from({ length: 121 }, (_, index) => ({
+      date: new Date(Date.UTC(2024, 0, index + 1)),
+      open: 100 + index,
+      high: 101 + index,
+      low: 99 + index,
+      close: 100.5 + index,
+      volume: 1_000 + index,
+    })) as PricePoint[];
+
+    const wide = projectChartData(denseSeries, 80, "candles", false, { ohlcBucketWidth: 80 }).points;
+    const narrowed = projectChartData(denseSeries, 78, "candles", false, { ohlcBucketWidth: 80 }).points;
+
+    expect(narrowed.map((point) => point.date.toISOString())).toEqual(wide.map((point) => point.date.toISOString()));
+    expect(narrowed.map((point) => point.open)).toEqual(wide.map((point) => point.open));
+    expect(narrowed.map((point) => point.close)).toEqual(wide.map((point) => point.close));
   });
 });
 
@@ -100,7 +229,10 @@ describe("getVisibleWindow", () => {
   test("shows the full selected range at default zoom and lets the renderer downsample it", () => {
     const history = buildDenseHistory(252);
     const viewState: ChartViewState = {
-      timeRange: "1Y",
+      presetRange: "1Y",
+      bufferRange: "1Y",
+      activePreset: "1Y",
+      resolution: "auto",
       panOffset: 0,
       zoomLevel: 1,
       cursorX: null,
@@ -110,14 +242,17 @@ describe("getVisibleWindow", () => {
     const window = getVisibleWindow(history, viewState, 80);
 
     expect(window.points).toHaveLength(history.length);
-    expect(window.points[0]?.date.toISOString()).toBe(history[0]?.date.toISOString());
-    expect(window.points.at(-1)?.date.toISOString()).toBe(history.at(-1)?.date.toISOString());
+    expect(window.points[0]?.date.toISOString()).toBe(history[0]!.date.toISOString());
+    expect(window.points.at(-1)?.date.toISOString()).toBe(history.at(-1)!.date.toISOString());
   });
 
   test("zooms into the selected range instead of pinning the default view to chart width", () => {
     const history = buildDenseHistory(252);
     const viewState: ChartViewState = {
-      timeRange: "1Y",
+      presetRange: "1Y",
+      bufferRange: "1Y",
+      activePreset: "1Y",
+      resolution: "auto",
       panOffset: 0,
       zoomLevel: 2,
       cursorX: null,
@@ -127,8 +262,8 @@ describe("getVisibleWindow", () => {
     const window = getVisibleWindow(history, viewState, 80);
 
     expect(window.points).toHaveLength(126);
-    expect(window.points[0]?.date.toISOString()).toBe(history[126]?.date.toISOString());
-    expect(window.points.at(-1)?.date.toISOString()).toBe(history.at(-1)?.date.toISOString());
+    expect(window.points[0]?.date.toISOString()).toBe(history[126]!.date.toISOString());
+    expect(window.points.at(-1)?.date.toISOString()).toBe(history.at(-1)!.date.toISOString());
   });
 });
 
@@ -512,6 +647,7 @@ describe("renderChart", () => {
       showVolume: false,
       volumeHeight: 0,
       cursorX: null,
+      cursorY: null,
       mode: projection.effectiveMode,
       axisMode: "percent",
       colors: palette,

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -17,17 +17,24 @@ import {
   projectComparisonChartData,
 } from "./comparison-chart-data";
 import { usePersistChartControlSelection } from "./chart-pane-settings";
-import { applyBufferedPanExpansion, getMouseScrollStepCount, resolveHorizontalScrollPanDirection } from "./chart-scroll";
+import {
+  applyBufferedPanExpansion,
+  consumeScrollPanMovement,
+  getKeyboardPanCellCount,
+  resolveDragPanOffset,
+} from "./chart-scroll";
 import {
   buildVisibleDateWindow,
   clearActivePreset,
   formatVisibleSpanLabel,
-  getCanonicalZoomLevel,
-  isCanonicalPresetViewport,
+  needsCanonicalPresetViewportReset,
   resolveChartBodyState,
+  resolveCanonicalPresetViewport,
   resolvePresetSelection,
+  resolvePresetRangeViewport,
   resolveResolutionSelection,
   resolveStoredChartSelection,
+  resolveVisibleActivePreset,
 } from "./chart-controller";
 import {
   buildChartResolutionSupportMap,
@@ -132,6 +139,8 @@ interface ChartMouseEvent {
   y: number;
   pixelX?: number;
   pixelY?: number;
+  stopPropagation?: () => void;
+  preventDefault?: () => void;
   modifiers: {
     shift: boolean;
     alt: boolean;
@@ -578,6 +587,7 @@ function ComparisonStockChartView({
   const pendingCanonicalResetRef = useRef(1);
   const appliedCanonicalResetRef = useRef(0);
   const pendingExpansionRef = useRef<PendingExpansionAction>(null);
+  const scrollPanCellRemainderRef = useRef(0);
 
   const axisSectionWidthBudget = 11;
   const axisRightPadding = 1;
@@ -895,22 +905,27 @@ function ComparisonStockChartView({
   const maxCursorX = chartWidth - 1;
   const seriesDates = useMemo(() => getUniqueSortedSeriesDates(series), [series]);
   const visibleDateWindow = useMemo(() => buildVisibleDateWindow(seriesDates, viewState.panOffset, viewState.zoomLevel), [seriesDates, viewState.panOffset, viewState.zoomLevel]);
-  const activePreset = isCanonicalPresetViewport(seriesDates, {
+  const activePreset = resolveVisibleActivePreset(seriesDates, {
+    presetRange: viewState.presetRange,
     activePreset: viewState.activePreset,
     panOffset: viewState.panOffset,
     zoomLevel: viewState.zoomLevel,
     resolution: effectiveResolution,
-  }) ? viewState.activePreset : null;
+  });
 
   useEffect(() => {
     if (seriesDates.length === 0) return;
-    if (appliedCanonicalResetRef.current < pendingCanonicalResetRef.current) {
-      const canonicalZoom = getCanonicalZoomLevel(seriesDates, viewState.presetRange);
-      appliedCanonicalResetRef.current = pendingCanonicalResetRef.current;
+    const hasPendingCanonicalReset = appliedCanonicalResetRef.current < pendingCanonicalResetRef.current;
+    const shouldReconcileActivePreset = !hasPendingCanonicalReset
+      && needsCanonicalPresetViewportReset(seriesDates, viewState);
+    if (hasPendingCanonicalReset || shouldReconcileActivePreset) {
+      if (hasPendingCanonicalReset) {
+        appliedCanonicalResetRef.current = pendingCanonicalResetRef.current;
+      }
       setViewState((current) => (
-        current.zoomLevel === canonicalZoom && current.panOffset === 0
-          ? current
-          : { ...current, zoomLevel: canonicalZoom, panOffset: 0, cursorX: null, cursorY: null }
+        hasPendingCanonicalReset
+          ? resolvePresetRangeViewport(current, seriesDates)
+          : resolveCanonicalPresetViewport(current, seriesDates)
       ));
       return;
     }
@@ -930,7 +945,15 @@ function ComparisonStockChartView({
         panOffset: clamp(pendingExpansion.targetPanOffset, 0, getMaxComparisonPanOffset(series, current.presetRange, current.zoomLevel, chartWidth)),
       };
     });
-  }, [chartWidth, series, seriesDates, viewState.presetRange]);
+  }, [
+    chartWidth,
+    series,
+    seriesDates,
+    viewState.activePreset,
+    viewState.panOffset,
+    viewState.presetRange,
+    viewState.zoomLevel,
+  ]);
 
   useEffect(() => {
     const refreshSupport = () => setKittySupport(getCachedKittySupport(renderer));
@@ -1326,24 +1349,28 @@ function ComparisonStockChartView({
           cursorY: null,
         }));
         return;
-      case "a":
+      case "a": {
+        const panStep = getKeyboardPanCellCount(chartWidth);
         if (viewState.panOffset >= getMaxComparisonPanOffset(series, viewState.presetRange, viewState.zoomLevel, chartWidth) && expandBufferRange({
           kind: "pan-left",
-          targetPanOffset: viewState.panOffset + Math.max(Math.floor(chartWidth / 10), 1),
+          targetPanOffset: viewState.panOffset + panStep,
         })) {
           return;
         }
         setViewState((current) => ({
           ...clearActivePreset(current),
-          panOffset: clamp(current.panOffset + Math.max(Math.floor(chartWidth / 10), 1), 0, getMaxComparisonPanOffset(series, current.presetRange, current.zoomLevel, chartWidth)),
+          panOffset: clamp(current.panOffset + panStep, 0, getMaxComparisonPanOffset(series, current.presetRange, current.zoomLevel, chartWidth)),
         }));
         return;
-      case "d":
+      }
+      case "d": {
+        const panStep = getKeyboardPanCellCount(chartWidth);
         setViewState((current) => ({
           ...clearActivePreset(current),
-          panOffset: clamp(current.panOffset - Math.max(Math.floor(chartWidth / 10), 1), 0, getMaxComparisonPanOffset(series, current.presetRange, current.zoomLevel, chartWidth)),
+          panOffset: clamp(current.panOffset - panStep, 0, getMaxComparisonPanOffset(series, current.presetRange, current.zoomLevel, chartWidth)),
         }));
         return;
+      }
       case "m":
         setViewState((current) => ({
           ...current,
@@ -1486,21 +1513,29 @@ function ComparisonStockChartView({
     if (!dragRef.current) return;
 
     const deltaCells = getGlobalMouseX(event, renderer) - dragRef.current.startGlobalX;
-    const pointDelta = Math.round((deltaCells / Math.max(chartWidth, 1)) * Math.max(visibleWindow.dates.length, 1));
-    const nextPan = clamp(
-      dragRef.current.startPanOffset - pointDelta,
-      0,
-      Math.max(visibleWindow.totalDates - visibleWindow.dates.length, 0),
+    const nextPan = resolveDragPanOffset(
+      dragRef.current.startPanOffset,
+      deltaCells,
+      chartWidth,
+      visibleWindow.dates.length,
+      visibleWindow.totalDates - visibleWindow.dates.length,
     );
     setViewState((current) => ({ ...clearActivePreset(current), panOffset: nextPan }));
   };
 
   const handlePlotScroll = (event: ChartMouseEvent) => {
+    event.stopPropagation?.();
+    event.preventDefault?.();
     const direction = event.scroll?.direction;
     if (!direction) return;
-    const scrollSteps = getMouseScrollStepCount(event.scroll?.delta);
-    const scrollPanCells = Math.max(Math.round(chartWidth * 0.08), 1) * scrollSteps;
-    const panDirection = resolveHorizontalScrollPanDirection(direction);
+    const scrollPan = consumeScrollPanMovement(
+      chartWidth,
+      event.scroll?.delta,
+      direction,
+      scrollPanCellRemainderRef.current,
+    );
+    scrollPanCellRemainderRef.current = scrollPan.remainder;
+    const scrollPanCells = scrollPan.cells;
 
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
 
@@ -1520,8 +1555,10 @@ function ComparisonStockChartView({
       commitSelectionCursor(selectionCursor);
     }
 
-    const targetPanOffset = viewState.panOffset + panDirection * scrollPanCells;
-    if (panDirection > 0 && viewState.panOffset >= getMaxComparisonPanOffset(series, viewState.presetRange, viewState.zoomLevel, chartWidth) && expandBufferRange({
+    if (scrollPanCells === 0) return;
+
+    const targetPanOffset = viewState.panOffset + scrollPanCells;
+    if (scrollPanCells > 0 && viewState.panOffset >= getMaxComparisonPanOffset(series, viewState.presetRange, viewState.zoomLevel, chartWidth) && expandBufferRange({
       kind: "pan-left",
       targetPanOffset,
     })) {
@@ -1530,7 +1567,7 @@ function ComparisonStockChartView({
     setViewState((current) => ({
       ...clearActivePreset(current),
       panOffset: clamp(
-        current.panOffset + panDirection * scrollPanCells,
+        current.panOffset + scrollPanCells,
         0,
         getMaxComparisonPanOffset(series, current.presetRange, current.zoomLevel, chartWidth),
       ),
@@ -1590,7 +1627,6 @@ function ComparisonStockChartView({
       onMouseOut={hasChartData && !isBlockingBody && !bodyMessage ? () => {
         dragRef.current = null;
       } : undefined}
-      onMouseScroll={hasChartData && !isBlockingBody && !bodyMessage ? handlePlotScroll : undefined}
     >
       {isBlockingBody
         ? (
@@ -1627,7 +1663,11 @@ function ComparisonStockChartView({
   ));
 
   return (
-    <box flexDirection="column" flexGrow={1}>
+    <box
+      flexDirection="column"
+      flexGrow={1}
+      onMouseScroll={hasChartData && !isBlockingBody && !bodyMessage ? handlePlotScroll : undefined}
+    >
       <box flexDirection="row" gap={2} height={1}>
         <text attributes={TextAttributes.BOLD} fg={colors.textBright}>
           {viewState.selectedSymbol ?? "Compare"} - {getChartResolutionLabel(effectiveResolution)}
@@ -1710,7 +1750,12 @@ function ComparisonStockChartView({
         </box>
       </box>
 
-      <box flexDirection="row" height={chartHeight} gap={axisGap}>
+      <box
+        flexDirection="row"
+        height={chartHeight}
+        gap={axisGap}
+        onMouseScroll={hasChartData && !isBlockingBody && !bodyMessage ? handlePlotScroll : undefined}
+      >
         {plotBox}
         {axisBox}
       </box>

--- a/src/components/chart/stock-chart-renderer-switch.test.tsx
+++ b/src/components/chart/stock-chart-renderer-switch.test.tsx
@@ -18,6 +18,7 @@ import type { TickerRecord } from "../../types/ticker";
 import { StockChart } from "./stock-chart";
 
 const TEST_PANE_ID = "ticker-detail:test";
+const CHART_DETAIL_REQUEST_DEBOUNCE_WAIT_MS = 220;
 
 let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | undefined;
 let root: ReturnType<typeof createRoot> | undefined;
@@ -145,9 +146,19 @@ function ChartHarness({
 async function flushFrames(count = 2) {
   for (let index = 0; index < count; index += 1) {
     await act(async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       await testSetup!.renderOnce();
+      await Promise.resolve();
     });
   }
+}
+
+async function flushDebouncedChartRequests() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, CHART_DETAIL_REQUEST_DEBOUNCE_WAIT_MS));
+  });
+  await flushFrames(2);
 }
 
 async function emitKeypress(event: { name?: string; sequence?: string }) {
@@ -213,14 +224,15 @@ function makeProvider(historyBySymbol: Record<string, PricePoint[]>): DataProvid
   };
 }
 
-afterEach(() => {
+afterEach(async () => {
   harnessDispatch = null;
   sharedCoordinator = null;
   setSharedMarketDataCoordinator(null);
   setSharedDataProviderForTests(undefined);
   if (root) {
-    act(() => {
+    await act(async () => {
       root!.unmount();
+      await Promise.resolve();
     });
     root = undefined;
   }
@@ -228,7 +240,6 @@ afterEach(() => {
     testSetup.renderer.destroy();
     testSetup = undefined;
   }
-  actEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
 });
 
 describe("StockChart renderer switching", () => {
@@ -346,6 +357,7 @@ describe("StockChart renderer switching", () => {
 
     await emitKeypress({ name: "3", sequence: "3" });
     await flushFrames(3);
+    await flushDebouncedChartRequests();
 
     const frame = testSetup.captureCharFrame();
     expect(frame).not.toContain("AAPL - AUTO");
@@ -411,6 +423,7 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames(6);
+    await flushDebouncedChartRequests();
     expect(testSetup.captureCharFrame()).toContain("AAPL - AUTO");
     expect(detailBarSizes).toContain("15m");
 
@@ -418,6 +431,7 @@ describe("StockChart renderer switching", () => {
       await emitKeypress({ name: "=", sequence: "=" });
       await flushFrames(3);
     }
+    await flushDebouncedChartRequests();
 
     expect(detailBarSizes).toContain("1m");
     expect(testSetup.captureCharFrame()).not.toContain("zoom:");
@@ -481,12 +495,14 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames(6);
+    await flushDebouncedChartRequests();
     expect(detailRequests.some((request) => request.barSize === "15m")).toBe(true);
 
     for (let index = 0; index < 8; index += 1) {
       await emitKeypress({ name: "=", sequence: "=" });
       await flushFrames(3);
     }
+    await flushDebouncedChartRequests();
 
     expect(detailRequests.some((request) => request.barSize === "1m")).toBe(true);
     expect(
@@ -552,6 +568,7 @@ describe("StockChart renderer switching", () => {
       await emitKeypress({ name: "=", sequence: "=" });
       await flushFrames(4);
     }
+    await flushDebouncedChartRequests();
 
     const frame = testSetup.captureCharFrame();
     expect(resolutionRequests.some((request) => request.resolution === "1d")).toBe(true);
@@ -560,7 +577,7 @@ describe("StockChart renderer switching", () => {
     expect(frame).toContain("Apr");
   });
 
-  test("mouse scroll pans auto without zooming into narrower detail windows", async () => {
+  test("mouse scroll at the auto edge does not zoom into narrower detail windows", async () => {
     const symbol = "AAPL";
     const config = makeChartConfig(symbol);
     const ticker = makeTicker(symbol);
@@ -611,6 +628,12 @@ describe("StockChart renderer switching", () => {
     const titleRow = getFrameRowContaining(initialFrame, "AAPL - AUTO");
     expect(titleRow).toBeGreaterThanOrEqual(0);
 
+    await act(async () => {
+      await testSetup!.mockMouse.scroll(1, titleRow, "up");
+      await testSetup!.renderOnce();
+    });
+    await flushFrames(2);
+
     for (let index = 0; index < 4; index += 1) {
       await act(async () => {
         await testSetup!.mockMouse.scroll(68, titleRow + 3, "up");
@@ -618,12 +641,258 @@ describe("StockChart renderer switching", () => {
       });
       await flushFrames(2);
     }
+    await flushDebouncedChartRequests();
 
     const pannedFrame = testSetup.captureCharFrame();
     const pannedHeader = getFrameLineContaining(pannedFrame, "AAPL - AUTO");
     expect(pannedHeader).not.toContain("view:");
-    expect(pannedFrame).not.toBe(initialFrame);
     expect(detailRequests.some((request) => /(m|h)$/i.test(request))).toBe(false);
+  });
+
+  test("keeps the chart interactive while a wider pan range is loading", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    config.layout.instances = config.layout.instances.map((instance) => ({
+      ...instance,
+      settings: {
+        chartRangePreset: "1Y",
+        chartResolution: "1d",
+      },
+    }));
+    config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+    const ticker = makeTicker(symbol);
+    const oneYearHistory = makeHistory(252, new Date(Date.UTC(2025, 0, 1)));
+    const fiveYearHistory = makeHistory(1260, new Date(Date.UTC(2021, 0, 1)));
+    const pendingResolvers: Array<(history: PricePoint[]) => void> = [];
+    const provider = {
+      ...makeProvider({ [symbol]: oneYearHistory }),
+      getPriceHistory: async (_requestSymbol, _exchange, range) => {
+        if (range === "5Y") {
+          return new Promise<PricePoint[]>((resolve) => {
+            pendingResolvers.push(resolve);
+          });
+        }
+        return oneYearHistory;
+      },
+      getPriceHistoryForResolution: async (_requestSymbol, _exchange, range) => {
+        if (range === "5Y") {
+          return new Promise<PricePoint[]>((resolve) => {
+            pendingResolvers.push(resolve);
+          });
+        }
+        return oneYearHistory;
+      },
+    } satisfies DataProvider;
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedDataProviderForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: oneYearHistory,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 32 });
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+        />,
+      );
+    });
+
+    await flushFrames(6);
+    expect(testSetup.captureCharFrame()).toContain("AAPL - 1D");
+
+    await emitKeypress({ name: "a", sequence: "a" });
+    await flushFrames(3);
+
+    const loadingFrame = testSetup.captureCharFrame();
+    expect(pendingResolvers.length).toBeGreaterThan(0);
+    expect(loadingFrame).toContain("AAPL - 1D");
+    expect(loadingFrame).not.toContain("Loading chart...");
+
+    await emitKeypress({ name: "a", sequence: "a" });
+    await flushFrames(3);
+    expect(testSetup.captureCharFrame()).not.toContain("Loading chart...");
+
+    await act(async () => {
+      for (const resolve of pendingResolvers) {
+        resolve(fiveYearHistory);
+      }
+      await Promise.resolve();
+    });
+    await flushFrames(4);
+    expect(testSetup.captureCharFrame()).not.toContain("Loading chart...");
+  });
+
+  test("keeps the last rendered chart while a manual detail window is loading", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    config.layout.instances = config.layout.instances.map((instance) => ({
+      ...instance,
+      settings: {
+        chartRangePreset: "1Y",
+        chartResolution: "1d",
+      },
+    }));
+    config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+    const ticker = makeTicker(symbol);
+    const baseHistory = makeHistory(600, new Date(Date.UTC(2024, 0, 1)));
+    let holdDetailRequests = false;
+    const pendingResolvers: Array<(history: PricePoint[]) => void> = [];
+    const provider = {
+      ...makeProvider({ [symbol]: baseHistory }),
+      getDetailedPriceHistory: async (
+        _requestSymbol,
+        _exchange,
+        startDate,
+        endDate,
+      ) => {
+        if (holdDetailRequests) {
+          return new Promise<PricePoint[]>((resolve) => {
+            pendingResolvers.push(resolve);
+          });
+        }
+        return baseHistory.filter((point) => {
+          const date = point.date instanceof Date ? point.date : new Date(point.date);
+          return date >= startDate && date <= endDate;
+        });
+      },
+    } satisfies DataProvider;
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedDataProviderForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: baseHistory,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 32 });
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+        />,
+      );
+    });
+
+    await flushFrames(6);
+    expect(testSetup.captureCharFrame()).toContain("AAPL - 1D");
+
+    holdDetailRequests = true;
+    for (let index = 0; index < 5; index += 1) {
+      await emitKeypress({ name: "a", sequence: "a" });
+    }
+    await flushFrames(3);
+    await flushDebouncedChartRequests();
+
+    const loadingFrame = testSetup.captureCharFrame();
+    expect(pendingResolvers.length).toBeGreaterThan(0);
+    expect(loadingFrame).toContain("AAPL - 1D");
+    expect(loadingFrame).not.toContain("Loading chart...");
+
+    await act(async () => {
+      for (const resolve of pendingResolvers) {
+        resolve(baseHistory);
+      }
+      await Promise.resolve();
+    });
+    await flushFrames(4);
+    expect(testSetup.captureCharFrame()).not.toContain("Loading chart...");
+  });
+
+  test("keeps panning on fallback data while the preferred detail request is loading", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    config.layout.instances = config.layout.instances.map((instance) => ({
+      ...instance,
+      settings: {
+        chartRangePreset: "1Y",
+        chartResolution: "1d",
+      },
+    }));
+    config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+    config.chartPreferences.defaultRenderMode = "candles";
+    const ticker = makeTicker(symbol);
+    const baseHistory = makeMonthlyHistory(84, new Date(Date.UTC(2019, 0, 1)));
+    const fallbackDetailHistory = makeHistory(900, new Date(Date.UTC(2023, 8, 1)));
+    const pendingOneDayResolvers: Array<(history: PricePoint[]) => void> = [];
+    let fallbackRequests = 0;
+    const provider = {
+      ...makeProvider({ [symbol]: baseHistory }),
+      getDetailedPriceHistory: async (
+        _requestSymbol,
+        _exchange,
+        startDate,
+        endDate,
+        barSize,
+      ) => {
+        if (barSize === "1d") {
+          return new Promise<PricePoint[]>((resolve) => {
+            pendingOneDayResolvers.push(resolve);
+          });
+        }
+        if (barSize === "1wk") {
+          fallbackRequests += 1;
+          return fallbackDetailHistory.filter((point) => {
+            const date = point.date instanceof Date ? point.date : new Date(point.date);
+            return date >= startDate && date <= endDate;
+          });
+        }
+        return [];
+      },
+    } satisfies DataProvider;
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedDataProviderForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: baseHistory,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 32 });
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+        />,
+      );
+    });
+
+    await flushFrames(6);
+    await flushDebouncedChartRequests();
+
+    const firstFrame = testSetup.captureCharFrame();
+    expect(pendingOneDayResolvers.length).toBeGreaterThan(0);
+    expect(fallbackRequests).toBeGreaterThan(0);
+    expect(firstFrame).toContain("AAPL - 1D");
+    expect(firstFrame).toContain("showing 1W");
+    expect(firstFrame).toContain("updating");
+    expect(firstFrame).not.toContain("Loading chart...");
+
+    await emitKeypress({ name: "a", sequence: "a" });
+    await flushFrames(3);
+    await flushDebouncedChartRequests();
+
+    const pannedFrame = testSetup.captureCharFrame();
+    expect(pannedFrame).toContain("showing 1W");
+    expect(pannedFrame).not.toContain("Loading chart...");
+    expect(pannedFrame).not.toBe(firstFrame);
   });
 
   test("falls back manual resolution without repeated input when finer resolutions are empty", async () => {
@@ -676,6 +945,7 @@ describe("StockChart renderer switching", () => {
     await flushFrames(6);
     await emitKeypress({ name: "r", sequence: "r" });
     await flushFrames(12);
+    await flushDebouncedChartRequests();
 
     const frame = testSetup.captureCharFrame();
     expect(detailRequests).toContain("1m");
@@ -741,6 +1011,7 @@ describe("StockChart renderer switching", () => {
       await flushFrames(4);
       frames.push(testSetup.captureCharFrame());
     }
+    await flushDebouncedChartRequests();
 
     expect(detailRequests).toContain("1d");
     expect(frames[6]).not.toBe(frames[7]);

--- a/src/components/chart/stock-chart.test.ts
+++ b/src/components/chart/stock-chart.test.ts
@@ -293,7 +293,7 @@ describe("stock chart auto helpers", () => {
     });
   });
 
-  test("stops auto zooming in once only two visible points remain", () => {
+  test("keeps shrinking the auto time span once only two visible points remain", () => {
     const history = makeDailyHistory(1, 10);
 
     const nextWindow = resolveAutoZoomWindow({
@@ -308,7 +308,7 @@ describe("stock chart auto helpers", () => {
     });
 
     expect(nextWindow).toEqual({
-      start: new Date("2026-01-09T00:00:00Z"),
+      start: new Date("2026-01-09T08:00:00Z"),
       end: new Date("2026-01-10T00:00:00Z"),
     });
   });

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type BoxRenderable, type CliRenderer } from "@opentui/core";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import { useAppDispatch, useAppSelector, usePaneInstance, usePaneInstanceId, usePaneSettingValue, usePaneTicker } from "../../state/app-context";
@@ -16,26 +16,35 @@ import { computeRSI, computeMACD } from "./indicators/oscillators";
 import { computeBollingerBands } from "./indicators/bands";
 import type { IndicatorConfig, MacdResult, OscillatorPoint, OverlayPoint } from "./indicators/types";
 import type { ChartIndicatorOverlays } from "./chart-types";
-import { applyBufferedPanExpansion, getMouseScrollStepCount, resolveHorizontalScrollPanDirection } from "./chart-scroll";
-import { getVisibleWindow, projectChartData, resolveBarSize, type ProjectedChartPoint } from "./chart-data";
+import {
+  applyBufferedPanExpansion,
+  consumeScrollPanMovement,
+  getDragPanWindowRatio,
+  getKeyboardPanCellCount,
+  resolveDragPanOffset,
+} from "./chart-scroll";
+import { getVisibleWindow, projectChartData, resolveBarSize, resolveStableOhlcProjectionOptions, type ProjectedChartPoint } from "./chart-data";
 import {
   buildPresetDateWindow,
   buildVisibleDateWindow,
   buildVisibleDateWindowFromRange,
   clampDateWindowToBounds,
   clearActivePreset,
-  getCanonicalZoomLevel,
   getDateWindowBounds,
   getMinimumDateStepMs,
   getVisibleWindowForDateRange,
   getPointDates,
-  isCanonicalPresetViewport,
+  needsCanonicalPresetViewportReset,
   resolveChartBodyState,
+  resolveCanonicalPresetViewport,
   resolvePresetSelection,
+  resolvePresetRangeViewport,
   resolveResolutionSelection,
   resolveStoredChartSelection,
+  resolveVisibleActivePreset,
   sameDateWindow,
   shiftDateWindow,
+  type ChartBodyState,
   type DateWindowRange,
 } from "./chart-controller";
 import {
@@ -139,6 +148,7 @@ const AXIS_MEASURE_PALETTE = resolveChartPalette({
 
 const EMPTY_INDICATOR_CONFIG: IndicatorConfig = {};
 const INDICATOR_RENDER_DEBOUNCE_MS = 120;
+const CHART_DETAIL_REQUEST_DEBOUNCE_MS = 160;
 
 interface StockChartProps {
   width: number;
@@ -184,6 +194,12 @@ interface ResolvedRenderCandidate {
 interface AutoRenderedView {
   window: DateWindowRange;
   resolution: ManualChartResolution;
+  data: PricePoint[];
+}
+
+interface CachedRenderedView {
+  window: DateWindowRange | null;
+  resolution: ManualChartResolution | null;
   data: PricePoint[];
 }
 
@@ -874,11 +890,14 @@ export function resolveAutoZoomWindow(options: {
   let targetVisibleCount: number;
   if (direction === "in") {
     if (currentVisibleCount <= 2) {
-      return buildDateWindowFromIndices(
-        navigationDates,
-        currentNavigationWindow.startIdx,
-        currentNavigationWindow.endIdx,
-      ) ?? currentWindow;
+      const currentSpanMs = Math.max(currentWindow.end.getTime() - currentWindow.start.getTime(), 1);
+      const targetSpanMs = Math.max(currentSpanMs / zoomFactor, 1);
+      const anchorMs = currentWindow.start.getTime() + currentSpanMs * ratio;
+      const nextStartMs = anchorMs - targetSpanMs * ratio;
+      return {
+        start: new Date(nextStartMs),
+        end: new Date(nextStartMs + targetSpanMs),
+      };
     }
     targetVisibleCount = Math.max(2, Math.floor(currentVisibleCount / zoomFactor));
     if (targetVisibleCount >= currentVisibleCount) {
@@ -1501,6 +1520,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const supportMap = useMemo(() => buildChartResolutionSupportMap(resolutionSupport ?? []), [resolutionSupport]);
   const [renderedAutoView, setRenderedAutoView] = useState<AutoRenderedView | null>(null);
   const [pendingAutoWindowOverride, setPendingAutoWindowOverride] = useState<DateWindowRange | null>(null);
+  const [lastReadyRenderView, setLastReadyRenderView] = useState<CachedRenderedView | null>(null);
   const showVolume = showVolumeOverride ?? !compact;
   const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
   const [displayCursor, setDisplayCursor] = useState<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
@@ -1526,6 +1546,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const appliedCanonicalResetRef = useRef(0);
   const pendingExpansionRef = useRef<PendingExpansionAction>(null);
   const pendingAutoWindowRef = useRef<DateWindowRange | null>(null);
+  const scrollPanCellRemainderRef = useRef(0);
   const lastAppliedStoredSelectionKeyRef = useRef<string | null>(null);
 
   const commitDisplayCursor = (next: DisplayCursorState) => {
@@ -1888,7 +1909,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         : [];
     }))
   ), [candidateResolutionEntries, effectiveResolution, plannedDateWindow, plannedManualResolution, renderCandidates]);
-  const candidateDetailEntries = useChartQueries(candidateDetailRequests);
+  const candidateDetailEntries = useChartQueries(candidateDetailRequests, {
+    debounceMs: CHART_DETAIL_REQUEST_DEBOUNCE_MS,
+  });
   const boundsHistoryCompatible = useMemo(() => (
     isSeriesAcceptedForRequest(boundsHistory, plannedDateWindow, plannedManualResolution, {
       requireAutoDensity: effectiveResolution === "auto",
@@ -2068,17 +2091,51 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       };
     }
 
+    if (firstCompatibleState) {
+      return {
+        bodyState: firstBlockingState
+          ? {
+            ...firstCompatibleState,
+            blocking: false,
+            updating: true,
+            emptyMessage: null,
+            errorMessage: null,
+          }
+          : firstCompatibleState,
+        resolvedManualResolution: firstCompatibleResolution ?? plannedManualResolution,
+      };
+    }
+
+    if (effectiveResolution === "auto" && firstBlockingState && boundsHistory.length > 0) {
+      return {
+        bodyState: {
+          data: boundsHistory,
+          blocking: false,
+          updating: true,
+          emptyMessage: null,
+          errorMessage: null,
+        },
+        resolvedManualResolution: plannedManualResolution,
+      };
+    }
+
+    if (effectiveResolution !== "auto" && firstBlockingState && boundsHistoryCompatible) {
+      return {
+        bodyState: {
+          data: boundsHistory,
+          blocking: false,
+          updating: true,
+          emptyMessage: null,
+          errorMessage: null,
+        },
+        resolvedManualResolution: plannedManualResolution,
+      };
+    }
+
     if (firstBlockingState) {
       return {
         bodyState: firstBlockingState,
         resolvedManualResolution: firstBlockingResolution ?? plannedManualResolution,
-      };
-    }
-
-    if (firstCompatibleState) {
-      return {
-        bodyState: firstCompatibleState,
-        resolvedManualResolution: firstCompatibleResolution ?? plannedManualResolution,
       };
     }
 
@@ -2168,6 +2225,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const shouldRejectPendingAutoView = effectiveResolution === "auto"
     && pendingAutoWindowOverride !== null
     && !plannedRenderBodyState.blocking
+    && !plannedRenderBodyState.updating
     && !canCommitPlannedAutoView;
   useEffect(() => {
     if (!shouldRejectPendingAutoView || !plannedDateWindow?.start || !plannedDateWindow.end) {
@@ -2189,13 +2247,13 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   useEffect(() => {
     setPendingAutoWindowOverride(null);
     setRenderedAutoView(null);
+    setLastReadyRenderView(null);
   }, [instrumentRef?.exchange, instrumentRef?.symbol]);
   const hasPendingAutoProposal = effectiveResolution === "auto" && pendingAutoWindowOverride !== null;
   const shouldUseRenderedAutoView = effectiveResolution === "auto"
     && !!renderedAutoView
     && (
-      hasPendingAutoProposal
-      || plannedRenderBodyState.blocking
+      plannedRenderBodyState.blocking
       || !plannedRenderBodyState.data?.length
       || !!plannedRenderBodyState.emptyMessage
       || !!plannedRenderBodyState.errorMessage
@@ -2218,15 +2276,54 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     renderedAutoView,
     shouldUseRenderedAutoView,
   ]);
-  const renderBodyState = effectiveResolution === "auto"
+  const baseRenderBodyState = effectiveResolution === "auto"
     ? autoDisplayState.bodyState
     : plannedRenderBodyState;
-  const resolvedManualResolution = effectiveResolution === "auto"
+  const baseResolvedManualResolution = effectiveResolution === "auto"
     ? autoDisplayState.resolution
     : plannedResolvedManualResolution;
-  const displayedDateWindow = effectiveResolution === "auto"
+  const baseDisplayedDateWindow = effectiveResolution === "auto"
     ? autoDisplayState.window
     : manualVisibleDateWindow;
+  useEffect(() => {
+    if (compact || baseRenderBodyState.blocking || !baseRenderBodyState.data?.length) return;
+
+    const nextView: CachedRenderedView = {
+      window: baseDisplayedDateWindow,
+      resolution: baseResolvedManualResolution,
+      data: baseRenderBodyState.data,
+    };
+    setLastReadyRenderView((current) => (
+      current
+      && current.data === nextView.data
+      && current.resolution === nextView.resolution
+      && sameDateWindow(current.window, nextView.window)
+        ? current
+        : nextView
+    ));
+  }, [
+    baseDisplayedDateWindow,
+    baseRenderBodyState.blocking,
+    baseRenderBodyState.data,
+    baseResolvedManualResolution,
+    compact,
+  ]);
+  const shouldUseLastReadyRenderView = !compact && baseRenderBodyState.blocking && !!lastReadyRenderView?.data.length;
+  const renderBodyState = shouldUseLastReadyRenderView
+    ? {
+      data: lastReadyRenderView!.data,
+      blocking: false,
+      updating: true,
+      emptyMessage: null,
+      errorMessage: null,
+    }
+    : baseRenderBodyState;
+  const resolvedManualResolution = shouldUseLastReadyRenderView
+    ? lastReadyRenderView!.resolution
+    : baseResolvedManualResolution;
+  const displayedDateWindow = shouldUseLastReadyRenderView
+    ? lastReadyRenderView!.window
+    : baseDisplayedDateWindow;
   const renderedResolution: ChartResolution = effectiveResolution === "auto"
     ? "auto"
     : (resolvedManualResolution ?? effectiveResolution);
@@ -2243,13 +2340,33 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const navigableDateWindow = effectiveResolution === "auto"
     ? (pendingAutoWindowOverride ?? displayedDateWindow ?? plannedDateWindow)
     : visibleDateWindow;
+  const navigationOhlcPointCount = !compact && effectiveResolution !== "auto"
+    ? manualVisibleDateWindow.dates.length
+    : 0;
+  const resolveOhlcProjectionOptions = useCallback((
+    pointCount: number,
+    sourceIndexOffset: number,
+  ) => (
+    resolveStableOhlcProjectionOptions({
+      pointCount,
+      sourceIndexOffset,
+      bucketWidth: measurementChartWidth,
+      navigationPointCount: navigationOhlcPointCount,
+    })
+  ), [measurementChartWidth, navigationOhlcPointCount]);
   const axisWidth = useMemo(() => {
     const measureAxisWidth = (targetWidth: number) => {
       const measuredWindow = historyOverride || !displayedDateWindow?.start || !displayedDateWindow.end
         ? { points: history, startIdx: 0, endIdx: history.length }
         : getVisibleWindowForDateRange(history, displayedDateWindow, 0);
       const measuredTimeAxisDates = measuredWindow.points.map((point) => point.date);
-      const measuredProjection = projectChartData(measuredWindow.points, targetWidth, viewState.renderMode, !!compact);
+      const measuredProjection = projectChartData(
+        measuredWindow.points,
+        targetWidth,
+        viewState.renderMode,
+        !!compact,
+        resolveOhlcProjectionOptions(measuredWindow.points.length, measuredWindow.startIdx),
+      );
       const measuredResult = renderChart(measuredProjection.points, {
         width: targetWidth,
         height: chartHeight,
@@ -2319,9 +2436,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     displayedDateWindow,
     history,
     historyOverride,
-    measurementChartWidth,
     minChartWidth,
     minimumAxisWidth,
+    resolveOhlcProjectionOptions,
     showVolume,
     viewState.renderMode,
     volumeHeight,
@@ -2330,38 +2447,35 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const axisSectionWidth = axisWidth + axisRightPadding;
   const chartWidth = Math.max(width - axisSectionWidth - axisGap, minChartWidth);
   const maxCursorX = chartWidth - 1;
-  const panStep = Math.max(Math.floor(chartWidth / 10), 1);
+  const panStep = getKeyboardPanCellCount(chartWidth);
   const activePreset = compact
     ? null
       : effectiveResolution === "auto"
       ? (canonicalAutoWindow && displayedDateWindow && sameDateWindow(displayedDateWindow, canonicalAutoWindow)
         ? viewState.presetRange
         : null)
-      : (!isCanonicalPresetViewport(boundsHistoryDates, {
+      : resolveVisibleActivePreset(boundsHistoryDates, {
+        presetRange: viewState.presetRange,
         activePreset: viewState.activePreset,
         panOffset: viewState.panOffset,
         zoomLevel: viewState.zoomLevel,
         resolution: effectiveResolution,
-      })
-        ? null
-        : viewState.activePreset);
+      });
 
   useEffect(() => {
     if (compact || effectiveResolution === "auto" || boundsHistoryDates.length === 0) return;
 
-    if (appliedCanonicalResetRef.current < pendingCanonicalResetRef.current) {
-      const canonicalZoom = getCanonicalZoomLevel(boundsHistoryDates, viewState.presetRange);
-      appliedCanonicalResetRef.current = pendingCanonicalResetRef.current;
+    const hasPendingCanonicalReset = appliedCanonicalResetRef.current < pendingCanonicalResetRef.current;
+    const shouldReconcileActivePreset = !hasPendingCanonicalReset
+      && needsCanonicalPresetViewportReset(boundsHistoryDates, viewState);
+    if (hasPendingCanonicalReset || shouldReconcileActivePreset) {
+      if (hasPendingCanonicalReset) {
+        appliedCanonicalResetRef.current = pendingCanonicalResetRef.current;
+      }
       setViewState((current) => (
-        current.zoomLevel === canonicalZoom && current.panOffset === 0
-          ? current
-          : {
-            ...current,
-            zoomLevel: canonicalZoom,
-            panOffset: 0,
-            cursorX: null,
-            cursorY: null,
-          }
+        hasPendingCanonicalReset
+          ? resolvePresetRangeViewport(current, boundsHistoryDates)
+          : resolveCanonicalPresetViewport(current, boundsHistoryDates)
       ));
       return;
     }
@@ -2388,7 +2502,16 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         panOffset: clamp(pendingExpansion.targetPanOffset, 0, getMaxPanOffset(boundsHistory, current.zoomLevel)),
       };
     });
-  }, [boundsHistory, boundsHistoryDates, compact, effectiveResolution, viewState.presetRange]);
+  }, [
+    boundsHistory,
+    boundsHistoryDates,
+    compact,
+    effectiveResolution,
+    viewState.activePreset,
+    viewState.panOffset,
+    viewState.presetRange,
+    viewState.zoomLevel,
+  ]);
 
   useEffect(() => {
     if (compact || effectiveResolution !== "auto" || !baseDateBounds) return;
@@ -2605,8 +2728,21 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   );
 
   const projection = useMemo(() => (
-    projectChartData(chartWindow.points, chartWidth, viewState.renderMode, !!compact)
-  ), [chartWindow.points, chartWidth, compact, viewState.renderMode]);
+    projectChartData(
+      chartWindow.points,
+      chartWidth,
+      viewState.renderMode,
+      !!compact,
+      resolveOhlcProjectionOptions(chartWindow.points.length, chartWindow.startIdx),
+    )
+  ), [
+    chartWindow.points,
+    chartWindow.startIdx,
+    chartWidth,
+    compact,
+    resolveOhlcProjectionOptions,
+    viewState.renderMode,
+  ]);
 
   const sourceIndicatorOverlays = useMemo(() => {
     if (!hasIndicators || !history.length) return null;
@@ -3305,7 +3441,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const bodyMessage = !compact
     ? (renderBodyState.errorMessage ?? renderBodyState.emptyMessage)
     : null;
-  const isUpdating = !compact && renderBodyState.updating;
+  const isUpdating = !compact && (renderBodyState.updating || boundsBodyState.updating);
 
   useEffect(() => {
     queueMicrotask(() => renderer.requestRender());
@@ -3383,20 +3519,22 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     if (!dragRef.current) return;
 
     if (effectiveResolution === "auto" && dragRef.current.startWindow) {
+      const deltaCells = getGlobalMouseX(event, renderer) - dragRef.current.startGlobalX;
       requestAutoWindow(shiftDateWindow(
         dragRef.current.startWindow,
-        -(getGlobalMouseX(event, renderer) - dragRef.current.startGlobalX) / Math.max(chartWidth, 1),
+        -getDragPanWindowRatio(deltaCells, chartWidth),
       ));
       return;
     }
 
     const visibleCount = getVisiblePointCount(boundsHistory.length, viewState.zoomLevel);
     const deltaCells = getGlobalMouseX(event, renderer) - dragRef.current.startGlobalX;
-    const pointDelta = Math.round((deltaCells / Math.max(chartWidth, 1)) * visibleCount);
-    const nextPan = clamp(
-      dragRef.current.startPanOffset - pointDelta,
-      0,
-      Math.max(boundsHistory.length - visibleCount, 0),
+    const nextPan = resolveDragPanOffset(
+      dragRef.current.startPanOffset,
+      deltaCells,
+      chartWidth,
+      visibleCount,
+      boundsHistory.length - visibleCount,
     );
     setViewState((current) => {
       const cleared = clearActivePreset(current);
@@ -3406,13 +3544,20 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
 
   const handlePlotScroll = (event: ChartMouseEvent) => {
     if (compact) return;
+    event.stopPropagation?.();
+    event.preventDefault?.();
     focusPaneForMouseInteraction(event);
     const direction = event.scroll?.direction;
     if (!direction) return;
-    const scrollSteps = getMouseScrollStepCount(event.scroll?.delta);
-    const scrollPanCells = Math.max(Math.round(chartWidth * 0.08), 1) * scrollSteps;
-    const scrollPanRatio = scrollPanCells / Math.max(chartWidth, 1);
-    const panDirection = resolveHorizontalScrollPanDirection(direction);
+    const scrollPan = consumeScrollPanMovement(
+      chartWidth,
+      event.scroll?.delta,
+      direction,
+      scrollPanCellRemainderRef.current,
+    );
+    scrollPanCellRemainderRef.current = scrollPan.remainder;
+    const scrollPanCells = scrollPan.cells;
+    const scrollPanRatio = scrollPan.ratio;
 
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
 
@@ -3432,13 +3577,15 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       commitSelectionCursor(selectionCursor);
     }
 
+    if (scrollPanCells === 0) return;
+
     if (effectiveResolution === "auto") {
-      requestAutoWindow(shiftDateWindow(navigableDateWindow, panDirection * scrollPanRatio));
+      requestAutoWindow(shiftDateWindow(navigableDateWindow, scrollPanRatio));
       return;
     }
 
-    const targetPanOffset = viewState.panOffset + panDirection * scrollPanCells;
-    if (panDirection > 0 && viewState.panOffset >= getMaxPanOffset(boundsHistory, viewState.zoomLevel) && expandBufferRange({
+    const targetPanOffset = viewState.panOffset + scrollPanCells;
+    if (scrollPanCells > 0 && viewState.panOffset >= getMaxPanOffset(boundsHistory, viewState.zoomLevel) && expandBufferRange({
       kind: "pan-left",
       targetPanOffset,
     })) {
@@ -3447,7 +3594,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     setViewState((current) => ({
       ...clearActivePreset(current),
       panOffset: clamp(
-        current.panOffset + panDirection * scrollPanCells,
+        current.panOffset + scrollPanCells,
         0,
         getMaxPanOffset(boundsHistory, current.zoomLevel),
       ),
@@ -3476,7 +3623,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       onMouseOut={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : () => {
         dragRef.current = null;
       }}
-      onMouseScroll={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : handlePlotScroll}
     >
       {isBlockingBody
         ? (
@@ -3640,7 +3786,12 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         )}
       </box>
 
-      <box flexDirection="row" height={chartHeight} gap={axisGap}>
+      <box
+        flexDirection="row"
+        height={chartHeight}
+        gap={axisGap}
+        onMouseScroll={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : handlePlotScroll}
+      >
         {plotBox}
         {axisBox}
       </box>

--- a/src/market-data/coordinator.test.ts
+++ b/src/market-data/coordinator.test.ts
@@ -92,6 +92,115 @@ describe("MarketDataCoordinator", () => {
     expect(second.lastGoodData?.length).toBe(2);
   });
 
+  it("uses cached chart data while a wider range request is loading", async () => {
+    const oneYearHistory = [
+      { date: new Date("2024-01-01"), close: 100 },
+      { date: new Date("2024-01-02"), close: 101 },
+    ];
+    const fiveYearHistory = [
+      { date: new Date("2020-01-01"), close: 80 },
+      ...oneYearHistory,
+    ];
+    let requestedFiveYear = false;
+    let resolveFiveYear: (history: PricePoint[] | PromiseLike<PricePoint[]>) => void = (_history) => {
+      throw new Error("expected pending 5Y request");
+    };
+    const provider = createProvider({
+      getPriceHistory: async (_symbol, _exchange, range) => {
+        if (range === "5Y") {
+          return new Promise<PricePoint[]>((resolve) => {
+            requestedFiveYear = true;
+            resolveFiveYear = resolve;
+          });
+        }
+        return oneYearHistory;
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+
+    await coordinator.loadChart({
+      instrument,
+      bufferRange: "1Y",
+      granularity: "range",
+    });
+    const pending = coordinator.loadChart({
+      instrument,
+      bufferRange: "5Y",
+      granularity: "range",
+    });
+
+    const loadingEntry = coordinator.getChartEntry({
+      instrument,
+      bufferRange: "5Y",
+      granularity: "range",
+    });
+    expect(loadingEntry.phase).toBe("refreshing");
+    expect(loadingEntry.data?.map((point) => point.close)).toEqual([100, 101]);
+
+    expect(requestedFiveYear).toBe(true);
+    resolveFiveYear(fiveYearHistory);
+    const readyEntry = await pending;
+    expect(readyEntry.phase).toBe("ready");
+    expect(readyEntry.data?.map((point) => point.close)).toEqual([80, 100, 101]);
+  });
+
+  it("uses cached manual-resolution data while a wider resolution range is loading", async () => {
+    const oneYearHistory = [
+      { date: new Date("2024-01-01"), close: 100 },
+      { date: new Date("2024-01-02"), close: 101 },
+    ];
+    const fiveYearHistory = [
+      { date: new Date("2020-01-01"), close: 80 },
+      ...oneYearHistory,
+    ];
+    let requestedFiveYear = false;
+    let resolveFiveYear: (history: PricePoint[] | PromiseLike<PricePoint[]>) => void = (_history) => {
+      throw new Error("expected pending 5Y request");
+    };
+    const provider = createProvider({
+      getPriceHistoryForResolution: async (_symbol, _exchange, range) => {
+        if (range === "5Y") {
+          return new Promise<PricePoint[]>((resolve) => {
+            requestedFiveYear = true;
+            resolveFiveYear = resolve;
+          });
+        }
+        return oneYearHistory;
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+
+    await coordinator.loadChart({
+      instrument,
+      bufferRange: "1Y",
+      granularity: "resolution",
+      resolution: "1d",
+    });
+    const pending = coordinator.loadChart({
+      instrument,
+      bufferRange: "5Y",
+      granularity: "resolution",
+      resolution: "1d",
+    });
+
+    const loadingEntry = coordinator.getChartEntry({
+      instrument,
+      bufferRange: "5Y",
+      granularity: "resolution",
+      resolution: "1d",
+    });
+    expect(loadingEntry.phase).toBe("refreshing");
+    expect(loadingEntry.data?.map((point) => point.close)).toEqual([100, 101]);
+
+    expect(requestedFiveYear).toBe(true);
+    resolveFiveYear(fiveYearHistory);
+    const readyEntry = await pending;
+    expect(readyEntry.phase).toBe("ready");
+    expect(readyEntry.data?.map((point) => point.close)).toEqual([80, 100, 101]);
+  });
+
   it("normalizes descending chart history before storing it", async () => {
     const provider = createProvider({
       getPriceHistory: async () => [
@@ -124,7 +233,7 @@ describe("MarketDataCoordinator", () => {
     const instrument = { symbol: "MSFT", exchange: "NASDAQ" };
 
     coordinator.subscribeQuotes([{ instrument }]);
-    const onStreamed = streamed;
+    const onStreamed = streamed as ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null;
     if (!onStreamed) throw new Error("expected streaming callback");
     onStreamed(
       { symbol: "MSFT", exchange: "NASDAQ" },
@@ -162,7 +271,7 @@ describe("MarketDataCoordinator", () => {
       resolution: "1d",
     });
 
-    expect(requested).toEqual({ range: "1Y", resolution: "1d" });
+    expect(requested as { range: string; resolution: string } | null).toEqual({ range: "1Y", resolution: "1d" });
     expect(entry.data?.length).toBe(2);
   });
 
@@ -196,7 +305,7 @@ describe("MarketDataCoordinator", () => {
 
     await coordinator.loadSnapshot(instrument);
     coordinator.subscribeQuotes([{ instrument }]);
-    const onStreamed = streamed;
+    const onStreamed = streamed as ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null;
     if (!onStreamed) throw new Error("expected streaming callback");
     onStreamed(
       {
@@ -292,7 +401,7 @@ describe("MarketDataCoordinator", () => {
 
     await coordinator.loadSnapshot(instrument);
     coordinator.subscribeQuotes([{ instrument }]);
-    const onStreamed = streamed;
+    const onStreamed = streamed as ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null;
     if (!onStreamed) throw new Error("expected streaming callback");
     onStreamed(
       { symbol: "IQE", exchange: "LSE" },
@@ -347,7 +456,7 @@ describe("MarketDataCoordinator", () => {
 
       await coordinator.loadSnapshot(instrument);
       coordinator.subscribeQuotes([{ instrument }]);
-      const onStreamed = streamed;
+      const onStreamed = streamed as ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null;
       if (!onStreamed) throw new Error("expected streaming callback");
       onStreamed(
         { symbol: "HY9H", exchange: "FWB2" },

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -8,6 +8,7 @@ import {
   buildArticleSummaryKey,
   buildChartKey,
   buildFxKey,
+  buildInstrumentKey,
   buildTickerFinancialsSnapshot,
   buildNewsKey,
   buildOptionsKey,
@@ -24,9 +25,11 @@ import {
 import { traceMarketData } from "./trace";
 import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../utils/price-history";
 import { hasFreshQuoteForCurrentSession, isQuoteStaleForCurrentSession } from "../utils/quote-freshness";
+import { TIME_RANGE_ORDER } from "../components/chart/chart-resolution";
 
 const EMPTY_MESSAGE = "No data available";
 const EXPECTED_EMPTY = /no data|not found|delisted|unavailable|unsupported/i;
+const TIME_RANGE_INDEX = new Map(TIME_RANGE_ORDER.map((range, index) => [range, index]));
 
 function createBaselineChartRequest(instrument: InstrumentRef): ChartRequest {
   return {
@@ -34,6 +37,27 @@ function createBaselineChartRequest(instrument: InstrumentRef): ChartRequest {
     bufferRange: "5Y",
     granularity: "range",
   };
+}
+
+function getChartGranularity(request: ChartRequest): NonNullable<ChartRequest["granularity"]> {
+  return request.granularity ?? "range";
+}
+
+function getTimeRangeIndex(range: ChartRequest["bufferRange"]): number {
+  return TIME_RANGE_INDEX.get(range) ?? 0;
+}
+
+function isSeedableChartRequest(
+  target: ChartRequest,
+  candidate: ChartRequest,
+): boolean {
+  const targetGranularity = getChartGranularity(target);
+  const candidateGranularity = getChartGranularity(candidate);
+  if (targetGranularity !== candidateGranularity) return false;
+  if (targetGranularity === "detail") return false;
+  if (targetGranularity === "resolution" && target.resolution !== candidate.resolution) return false;
+  if (buildInstrumentKey(target.instrument) !== buildInstrumentKey(candidate.instrument)) return false;
+  return getTimeRangeIndex(candidate.bufferRange) <= getTimeRangeIndex(target.bufferRange);
 }
 
 function classifyError(error: unknown): { reasonCode: ProviderReasonCode; message: string } {
@@ -125,6 +149,7 @@ export class MarketDataCoordinator {
   private version = 0;
   private readonly listeners = new Set<() => void>();
   private readonly inFlight = new Map<string, Promise<unknown>>();
+  private readonly chartRequests = new Map<string, ChartRequest>();
 
   private readonly quoteStore = new QueryStore<Quote>(() => this.bump());
   private readonly snapshotStore = new QueryStore<TickerFinancials>(() => this.bump());
@@ -281,6 +306,49 @@ export class MarketDataCoordinator {
     return promise;
   }
 
+  private findChartSeedEntry(
+    key: string,
+    request: ChartRequest,
+  ): { entry: QueryEntry<PricePoint[]>; data: PricePoint[]; score: number } | null {
+    let best: { entry: QueryEntry<PricePoint[]>; data: PricePoint[]; score: number } | null = null;
+    for (const [candidateKey, candidateRequest] of this.chartRequests) {
+      if (candidateKey === key) continue;
+      if (!isSeedableChartRequest(request, candidateRequest)) continue;
+      const entry = this.chartStore.get(candidateKey);
+      const data = resolveEntryData(entry);
+      if (!data?.length) continue;
+      const score = getTimeRangeIndex(candidateRequest.bufferRange);
+      if (!best || score > best.score) {
+        best = { entry, data, score };
+      }
+    }
+    return best;
+  }
+
+  private createChartLoadingEntry(
+    key: string,
+    request: ChartRequest,
+    current: QueryEntry<PricePoint[]>,
+  ): QueryEntry<PricePoint[]> {
+    if (resolveEntryData(current)?.length) {
+      return loadingEntry(current);
+    }
+
+    const seed = this.findChartSeedEntry(key, request);
+    if (!seed) {
+      return loadingEntry(current);
+    }
+
+    return loadingEntry({
+      ...current,
+      data: seed.data,
+      lastGoodData: seed.entry.lastGoodData?.length ? seed.entry.lastGoodData : seed.data,
+      source: seed.entry.source,
+      fetchedAt: seed.entry.fetchedAt,
+      staleAt: seed.entry.staleAt,
+    });
+  }
+
   async loadSnapshot(
     instrument: InstrumentRef,
     options: { forceRefresh?: boolean } = {},
@@ -379,9 +447,10 @@ export class MarketDataCoordinator {
     options: { forceRefresh?: boolean } = {},
   ): Promise<QueryEntry<PricePoint[]>> {
     const key = buildChartKey(request);
+    this.chartRequests.set(key, request);
     const flightKey = options.forceRefresh ? `${key}|refresh` : key;
     return this.runSingleFlight(flightKey, async () => {
-      this.chartStore.update(key, loadingEntry);
+      this.chartStore.update(key, (current) => this.createChartLoadingEntry(key, request, current));
       const startedAt = Date.now();
       try {
         const data = normalizePriceHistory(

--- a/src/market-data/hooks.test.tsx
+++ b/src/market-data/hooks.test.tsx
@@ -1,13 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, useState } from "react";
 import { testRender } from "@opentui/react/test-utils";
-import type { TickerFinancials } from "../types/financials";
+import type { PricePoint, TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "./coordinator";
-import { useFxRatesMap, useTickerFinancialsMap } from "./hooks";
+import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "./hooks";
+import type { ChartRequest } from "./request-types";
+import { createIdleEntry } from "./result-types";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let bumpHarness: (() => void) | null = null;
+let replaceChartRequests: ((requests: readonly ChartRequest[]) => void) | null = null;
 let latestFxRates: Map<string, number> | null = null;
 let latestFinancialsMap: Map<string, TickerFinancials> | null = null;
 
@@ -70,6 +73,31 @@ function HooksHarness() {
   return <text>{String(tick)}</text>;
 }
 
+function ChartQueriesHarness({
+  initialRequests,
+  debounceMs,
+}: {
+  initialRequests: readonly ChartRequest[];
+  debounceMs: number;
+}) {
+  const [requests, setRequests] = useState<readonly ChartRequest[]>(initialRequests);
+  replaceChartRequests = setRequests;
+  useChartQueries(requests, { debounceMs });
+
+  return <text>{String(requests.length)}</text>;
+}
+
+function makeChartRequest(bufferRange: ChartRequest["bufferRange"]): ChartRequest {
+  return {
+    instrument: {
+      symbol: "AAPL",
+      exchange: "NASDAQ",
+    },
+    bufferRange,
+    granularity: "range",
+  };
+}
+
 afterEach(async () => {
   if (testSetup) {
     await act(async () => {
@@ -78,6 +106,7 @@ afterEach(async () => {
     testSetup = undefined;
   }
   bumpHarness = null;
+  replaceChartRequests = null;
   latestFxRates = null;
   latestFinancialsMap = null;
   setSharedMarketDataCoordinator(null);
@@ -116,5 +145,47 @@ describe("market-data hooks", () => {
 
     expect(latestFxRates).toBe(initialFxRates);
     expect(latestFinancialsMap).toBe(initialFinancialsMap);
+  });
+
+  test("debounces chart query batches and cancels superseded schedules", async () => {
+    const loadedRanges: string[] = [];
+    const idleChartEntry = createIdleEntry<PricePoint[]>();
+    const coordinator = {
+      subscribe: () => () => {},
+      getVersion: () => 1,
+      getChartEntry: () => idleChartEntry,
+      loadChart: async (request: ChartRequest) => {
+        loadedRanges.push(request.bufferRange);
+        return idleChartEntry;
+      },
+    };
+    setSharedMarketDataCoordinator(coordinator as unknown as MarketDataCoordinator);
+
+    testSetup = await testRender(
+      <ChartQueriesHarness initialRequests={[makeChartRequest("1D")]} debounceMs={40} />,
+      {
+        width: 20,
+        height: 1,
+      },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      replaceChartRequests?.([makeChartRequest("1W")]);
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      replaceChartRequests?.([makeChartRequest("1M")]);
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await testSetup!.renderOnce();
+    });
+
+    expect(loadedRanges).toEqual(["1M"]);
   });
 });

--- a/src/market-data/hooks.tsx
+++ b/src/market-data/hooks.tsx
@@ -121,8 +121,12 @@ export function useChartQuery(request: ChartRequest | null | undefined): QueryEn
   return entry;
 }
 
-export function useChartQueries(requests: readonly ChartRequest[]): Map<string, QueryEntry<PricePoint[]>> {
+export function useChartQueries(
+  requests: readonly ChartRequest[],
+  options: { debounceMs?: number } = {},
+): Map<string, QueryEntry<PricePoint[]>> {
   const requestKey = requests.map((request) => buildChartKey(request)).join(",");
+  const debounceMs = Math.max(0, options.debounceMs ?? 0);
   const entries = useCoordinatorSelector((coordinator) => (
     requests.map((request) => [buildChartKey(request), coordinator.getChartEntry(request)] as const)
   ), [] as Array<readonly [string, QueryEntry<PricePoint[]>]>);
@@ -130,10 +134,18 @@ export function useChartQueries(requests: readonly ChartRequest[]): Map<string, 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator) return;
-    for (const request of requests) {
-      void coordinator.loadChart(request);
+    const loadRequests = () => {
+      for (const request of requests) {
+        void coordinator.loadChart(request);
+      }
+    };
+    if (debounceMs <= 0) {
+      loadRequests();
+      return;
     }
-  }, [requestKey]);
+    const timeout = setTimeout(loadRequests, debounceMs);
+    return () => clearTimeout(timeout);
+  }, [debounceMs, requestKey]);
 
   return useMemo(() => new Map(entries), [entries]);
 }

--- a/src/plugins/builtin/comparison-chart.test.tsx
+++ b/src/plugins/builtin/comparison-chart.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act } from "react";
-import { testRender } from "@opentui/react/test-utils";
+import { act, type ReactElement } from "react";
+import { createTestRenderer } from "@opentui/core/testing";
+import { createRoot } from "@opentui/react";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import {
   AppContext,
@@ -23,8 +24,10 @@ import {
 
 const TEST_PANE_ID = "comparison-chart:test";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | undefined;
+let root: ReturnType<typeof createRoot> | undefined;
 let sharedCoordinator: MarketDataCoordinator | null = null;
+const actEnvironment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
 
 function makeTicker(symbol: string, currency: string): TickerRecord {
   return {
@@ -132,7 +135,7 @@ function createComparisonHarness(
     focused: boolean;
     width: number;
     height: number;
-  }) => JSX.Element;
+  }) => ReactElement;
 
   return (
     <AppContext value={{ state, dispatch: () => {} }}>
@@ -153,12 +156,47 @@ async function flushFrames(count = 3) {
   for (let index = 0; index < count; index += 1) {
     await act(async () => {
       await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       await testSetup!.renderOnce();
+      await Promise.resolve();
     });
   }
 }
 
-afterEach(() => {
+async function mountComparisonHarness(
+  settings: Record<string, unknown>,
+  tickers: TickerRecord[],
+  financials: Array<[string, TickerFinancials]>,
+) {
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  testSetup = await createTestRenderer({ width: 120, height: 20 });
+  root = createRoot(testSetup.renderer);
+  await act(async () => {
+    root!.render(
+      createComparisonHarness(settings, tickers, financials),
+    );
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await testSetup!.renderOnce();
+  });
+}
+
+async function pressComparisonInput(action: () => void) {
+  await act(async () => {
+    action();
+    await testSetup!.renderOnce();
+    await Promise.resolve();
+  });
+}
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root!.unmount();
+      await Promise.resolve();
+    });
+    root = undefined;
+  }
   if (testSetup) {
     testSetup.renderer.destroy();
     testSetup = undefined;
@@ -172,7 +210,7 @@ afterEach(() => {
 describe("comparisonChartPlugin", () => {
   test("creates a configured comparison pane with percent as the default axis", () => {
     const template = comparisonChartPlugin.paneTemplates?.find((entry) => entry.id === COMPARISON_CHART_TEMPLATE_ID);
-    const paneDef = comparisonChartPlugin.panes.find((entry) => entry.id === COMPARISON_CHART_PANE_ID);
+    const paneDef = comparisonChartPlugin.panes?.find((entry) => entry.id === COMPARISON_CHART_PANE_ID);
 
     expect(template).toBeDefined();
     expect(paneDef?.defaultMode).toBe("floating");
@@ -223,24 +261,21 @@ describe("comparisonChartPlugin", () => {
     setSharedMarketDataCoordinator(sharedCoordinator);
     setSharedRegistryForTests(createRegistrySpy({ selected: [], focused: [] }));
 
-    testSetup = await testRender(
-      createComparisonHarness({
-        axisMode: "price",
-        symbols: ["AAPL", "7203"],
-        symbolsText: "AAPL, 7203",
-      }, [
-        makeTicker("AAPL", "USD"),
-        makeTicker("7203", "JPY"),
-      ], [
-        ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104, 106])],
-        ["7203", makeFinancials("7203", "JPY", [2000, 2020, 2050, 2100])],
-      ]),
-      { width: 120, height: 20 },
-    );
+    await mountComparisonHarness({
+      axisMode: "price",
+      symbols: ["AAPL", "7203"],
+      symbolsText: "AAPL, 7203",
+    }, [
+      makeTicker("AAPL", "USD"),
+      makeTicker("7203", "JPY"),
+    ], [
+      ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104, 106])],
+      ["7203", makeFinancials("7203", "JPY", [2000, 2020, 2050, 2100])],
+    ]);
 
     await flushFrames();
 
-    const frame = testSetup.captureCharFrame();
+    const frame = testSetup!.captureCharFrame();
     expect(frame).toContain("Mixed currencies detected; showing percent change.");
     expect(frame).toContain("1:1D");
     expect(frame).toContain("2:1W");
@@ -268,24 +303,21 @@ describe("comparisonChartPlugin", () => {
     setSharedMarketDataCoordinator(sharedCoordinator);
     setSharedRegistryForTests(createRegistrySpy({ selected: [], focused: [] }));
 
-    testSetup = await testRender(
-      createComparisonHarness({
-        axisMode: "price",
-        symbols: ["AAPL", "MSFT"],
-        symbolsText: "AAPL, MSFT",
-      }, [
-        makeTicker("AAPL", "USD"),
-        makeTicker("MSFT", "USD"),
-      ], [
-        ["AAPL", makeFinancials("AAPL", "USD", [])],
-        ["MSFT", makeFinancials("MSFT", "USD", [])],
-      ]),
-      { width: 120, height: 20 },
-    );
+    await mountComparisonHarness({
+      axisMode: "price",
+      symbols: ["AAPL", "MSFT"],
+      symbolsText: "AAPL, MSFT",
+    }, [
+      makeTicker("AAPL", "USD"),
+      makeTicker("MSFT", "USD"),
+    ], [
+      ["AAPL", makeFinancials("AAPL", "USD", [])],
+      ["MSFT", makeFinancials("MSFT", "USD", [])],
+    ]);
 
     await flushFrames();
 
-    const frame = testSetup.captureCharFrame();
+    const frame = testSetup!.captureCharFrame();
     expect(frame).toContain("No chart data yet.");
     expect(frame).toContain("1:1D");
     expect(frame).toContain("2:1W");
@@ -308,28 +340,23 @@ describe("comparisonChartPlugin", () => {
     setSharedMarketDataCoordinator(sharedCoordinator);
     setSharedRegistryForTests(createRegistrySpy(spy));
 
-    testSetup = await testRender(
-      createComparisonHarness({
-        axisMode: "percent",
-        symbols: ["AAPL", "MSFT", "NVDA"],
-        symbolsText: "AAPL, MSFT, NVDA",
-      }, [
-        makeTicker("AAPL", "USD"),
-        makeTicker("MSFT", "USD"),
-        makeTicker("NVDA", "USD"),
-      ], [
-        ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104])],
-        ["MSFT", makeFinancials("MSFT", "USD", [200, 202, 204])],
-        ["NVDA", makeFinancials("NVDA", "USD", [300, 305, 310])],
-      ]),
-      { width: 120, height: 20 },
-    );
+    await mountComparisonHarness({
+      axisMode: "percent",
+      symbols: ["AAPL", "MSFT", "NVDA"],
+      symbolsText: "AAPL, MSFT, NVDA",
+    }, [
+      makeTicker("AAPL", "USD"),
+      makeTicker("MSFT", "USD"),
+      makeTicker("NVDA", "USD"),
+    ], [
+      ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104])],
+      ["MSFT", makeFinancials("MSFT", "USD", [200, 202, 204])],
+      ["NVDA", makeFinancials("NVDA", "USD", [300, 305, 310])],
+    ]);
 
     await flushFrames();
-    testSetup.mockInput.pressArrow("right");
-    await flushFrames();
-    testSetup.mockInput.pressEnter();
-    await flushFrames();
+    await pressComparisonInput(() => testSetup!.mockInput.pressArrow("right"));
+    await pressComparisonInput(() => testSetup!.mockInput.pressEnter());
 
     expect(spy.selected).toEqual(["MSFT"]);
     expect(spy.focused).toEqual(["ticker-detail"]);


### PR DESCRIPTION
Improves chart interactions by slowing and smoothing keyboard, drag, and wheel panning while keeping mouse scroll handled by the chart surface.
Adds stable OHLC/candlestick bucketing and keeps existing chart data visible while wider/manual detail requests are loading, including debounced chart query batches.
Fixes range preset selection so selected chips stay active while data loads and canonical viewports reset against newly loaded data.
Adds regression coverage across chart controllers/rendering, market-data coordinator/hooks, and comparison chart harnesses.
Tests: bun test; tmux smoke test with bun run start.