### PR TITLE
Harden Polymarket market loading

### DIFF
--- a/src/plugins/prediction-markets/controller-data.ts
+++ b/src/plugins/prediction-markets/controller-data.ts
@@ -76,6 +76,14 @@ function formatPredictionLoadError(
     return `${venueLabel} is unavailable right now.`;
   }
 
+  if (
+    /socket connection|socket hang up|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|fetch failed|network connection|connection closed/i.test(
+      message,
+    )
+  ) {
+    return `${venueLabel} is unavailable right now.`;
+  }
+
   return `${fallback} ${message}`;
 }
 

--- a/src/plugins/prediction-markets/plugin.test.tsx
+++ b/src/plugins/prediction-markets/plugin.test.tsx
@@ -363,6 +363,53 @@ describe("prediction markets plugin registration and services", () => {
     expect(markets[0]?.marketLabel).toBe("April 30");
   });
 
+  test("keeps Polymarket catalog results when one page connection resets", async () => {
+    let resetFetchCount = 0;
+
+    globalThis.fetch = (async (input: Request | string | URL) => {
+      const url = String(input);
+      if (url.includes("gamma-api.polymarket.com/events?")) {
+        if (url.includes("offset=200")) {
+          resetFetchCount += 1;
+          throw Object.assign(
+            new Error("The socket connection was closed unexpectedly."),
+            { code: "ECONNRESET" },
+          );
+        }
+        return new Response(
+          JSON.stringify([
+            {
+              id: "event-stable",
+              title: "Stable catalog page",
+              tags: [{ label: "Macro", slug: "economy" }],
+              markets: [
+                {
+                  id: "pm-stable",
+                  question: "Will the stable page load?",
+                  conditionId: "cond-stable",
+                  outcomes: '["Yes","No"]',
+                  outcomePrices: '["0.57","0.43"]',
+                  clobTokenIds: '["yes-stable","no-stable"]',
+                  volume24hr: 125000,
+                  active: true,
+                  closed: false,
+                },
+              ],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const markets = await loadPolymarketCatalog("", "all");
+
+    expect(markets).toHaveLength(1);
+    expect(markets[0]?.marketId).toBe("pm-stable");
+    expect(resetFetchCount).toBe(3);
+  });
+
   test("uses remote catalog endpoints for search and category changes", async () => {
     const { fetchUrls } = installPredictionMarketMocks();
 
@@ -420,7 +467,7 @@ describe("prediction markets plugin registration and services", () => {
       }
       if (url.includes("gamma-api.polymarket.com/events/event-1")) {
         eventFetchCount += 1;
-        if (eventFetchCount === 1) {
+        if (eventFetchCount <= 3) {
           return new Response("{}", { status: 500 });
         }
         return new Response(

--- a/src/plugins/prediction-markets/services/fetch.ts
+++ b/src/plugins/prediction-markets/services/fetch.ts
@@ -1,6 +1,18 @@
 import type { PluginPersistence } from "../../../types/plugin";
+import { createThrottledFetch } from "../../../utils/throttled-fetch";
 
 const DEFAULT_SOURCE_KEY = "remote";
+const PREDICTION_FETCH = createThrottledFetch({
+  requestsPerMinute: 120,
+  maxRetries: 2,
+  timeoutMs: 10_000,
+  backoffBaseMs: 250,
+  dedupeGetRequests: false,
+  defaultHeaders: {
+    Accept: "application/json",
+    "User-Agent": "gloomberb-prediction-markets",
+  },
+});
 
 export const PREDICTION_CACHE_POLICIES = {
   catalog: { staleMs: 30_000, expireMs: 10 * 60_000 },
@@ -28,13 +40,7 @@ export function getPredictionMarketsPersistence(): PluginPersistence | null {
 }
 
 export async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
-    signal: AbortSignal.timeout(10_000),
-    headers: {
-      Accept: "application/json",
-      "User-Agent": "gloomberb-prediction-markets",
-    },
-  });
+  const response = await PREDICTION_FETCH.fetch(url);
   if (!response.ok) {
     throw new Error(`Request failed (${response.status}) for ${url}`);
   }

--- a/src/plugins/prediction-markets/services/polymarket-adapter.ts
+++ b/src/plugins/prediction-markets/services/polymarket-adapter.ts
@@ -219,6 +219,27 @@ function buildPolymarketSearchUrl(query: string): string {
   return url.toString();
 }
 
+async function loadPolymarketCatalogPages(
+  offsets: number[],
+  tagSlug?: string,
+): Promise<PolymarketEventRecord[]> {
+  const results = await Promise.allSettled(
+    offsets.map((offset) =>
+      fetchJson<PolymarketEventRecord[]>(
+        buildPolymarketCatalogUrl(offset, tagSlug),
+      ),
+    ),
+  );
+  const pages = results.flatMap((result) =>
+    result.status === "fulfilled" ? result.value : [],
+  );
+  if (pages.length > 0) return pages;
+
+  const rejected = results.find((result) => result.status === "rejected");
+  if (rejected?.status === "rejected") throw rejected.reason;
+  return [];
+}
+
 export function normalizePolymarketMarket(
   record: PolymarketMarketRecord,
   options?: {
@@ -360,12 +381,11 @@ export async function loadPolymarketCatalog(
       if (categoryId !== "all") {
         const tagSlugs = getPolymarketCategoryTagSlugs(categoryId);
         const categoryPages = await Promise.all(
-          tagSlugs.flatMap((tagSlug) =>
-            POLYMARKET_CATEGORY_OFFSETS.map((offset) =>
-              fetchJson<PolymarketEventRecord[]>(
-                buildPolymarketCatalogUrl(offset, tagSlug),
-              ).catch(() => []),
-            ),
+          tagSlugs.map((tagSlug) =>
+            loadPolymarketCatalogPages(
+              POLYMARKET_CATEGORY_OFFSETS,
+              tagSlug,
+            ).catch(() => []),
           ),
         );
         const categorized = sortPolymarketMarkets(
@@ -374,13 +394,11 @@ export async function loadPolymarketCatalog(
         if (categorized.length > 0) return categorized;
       }
 
-      const pages = await Promise.all(
-        POLYMARKET_CATALOG_OFFSETS.map((offset) =>
-          fetchJson<PolymarketEventRecord[]>(buildPolymarketCatalogUrl(offset)),
-        ),
+      const pages = await loadPolymarketCatalogPages(
+        POLYMARKET_CATALOG_OFFSETS,
       );
       return sortPolymarketMarkets(
-        flattenPolymarketEvents(pages.flat(), "", categoryId),
+        flattenPolymarketEvents(pages, "", categoryId),
       );
     },
     PREDICTION_CACHE_POLICIES.catalog,

--- a/src/plugins/prediction-markets/services/polymarket-ws.ts
+++ b/src/plugins/prediction-markets/services/polymarket-ws.ts
@@ -1,6 +1,8 @@
 import type { PredictionBookLevel, PredictionTrade } from "../types";
 import { parseFloatSafe } from "./fetch";
 
+const POLYMARKET_HEARTBEAT_MS = 10_000;
+
 interface PolymarketLiveCallbacks {
   onBestBidAsk?: (
     assetId: string,
@@ -38,8 +40,23 @@ export function subscribePolymarketMarket(
   let closed = false;
   let socket: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  const clearHeartbeat = () => {
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  };
+
+  const sendHeartbeat = () => {
+    try {
+      socket?.send("PING");
+    } catch {
+      // The close handler will schedule reconnects for broken sockets.
+    }
+  };
 
   const connect = () => {
+    clearHeartbeat();
     socket = new WebSocket(
       "wss://ws-subscriptions-clob.polymarket.com/ws/market",
     );
@@ -51,6 +68,7 @@ export function subscribePolymarketMarket(
           custom_feature_enabled: true,
         }),
       );
+      heartbeatTimer = setInterval(sendHeartbeat, POLYMARKET_HEARTBEAT_MS);
     });
     socket.addEventListener("message", (event) => {
       try {
@@ -89,6 +107,7 @@ export function subscribePolymarketMarket(
       }
     });
     socket.addEventListener("close", () => {
+      clearHeartbeat();
       socket = null;
       if (closed) return;
       reconnectTimer = setTimeout(connect, 1_500);
@@ -103,6 +122,7 @@ export function subscribePolymarketMarket(
   return () => {
     closed = true;
     if (reconnectTimer) clearTimeout(reconnectTimer);
+    clearHeartbeat();
     socket?.close();
   };
 }

--- a/src/utils/throttled-fetch.test.ts
+++ b/src/utils/throttled-fetch.test.ts
@@ -23,7 +23,7 @@ describe("createThrottledFetch", () => {
       defaultHeaders: { "X-Custom": "value" },
     });
     await client.fetch("https://api.example.com/test");
-    const callInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const callInit = fetchMock.mock.calls[0]![1] as RequestInit;
     expect((callInit.headers as Record<string, string>)["X-Custom"]).toBe("value");
   });
 
@@ -37,10 +37,11 @@ describe("createThrottledFetch", () => {
     const p1 = client.fetch("https://api.example.com/same");
     const p2 = client.fetch("https://api.example.com/same");
 
-    // Both should be the same promise
     resolveFirst!(new Response("ok", { status: 200 }));
     const [r1, r2] = await Promise.all([p1, p2]);
-    expect(r1).toBe(r2);
+    expect(r1).not.toBe(r2);
+    expect(await r1.text()).toBe("ok");
+    expect(await r2.text()).toBe("ok");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -64,7 +65,7 @@ describe("createThrottledFetch", () => {
     });
     globalThis.fetch = fetchMock as any;
 
-    const client = createThrottledFetch({ maxRetries: 1 });
+    const client = createThrottledFetch({ maxRetries: 1, backoffBaseMs: 0 });
     const resp = await client.fetch("https://api.example.com/test");
     expect(resp.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -81,7 +82,28 @@ describe("createThrottledFetch", () => {
     });
     globalThis.fetch = fetchMock as any;
 
-    const client = createThrottledFetch({ maxRetries: 1 });
+    const client = createThrottledFetch({ maxRetries: 1, backoffBaseMs: 0 });
+    const resp = await client.fetch("https://api.example.com/test");
+    expect(resp.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries transient fetch failures", async () => {
+    let callCount = 0;
+    fetchMock = mock(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(
+          Object.assign(new Error("The socket connection was closed unexpectedly."), {
+            code: "ECONNRESET",
+          }),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+    globalThis.fetch = fetchMock as any;
+
+    const client = createThrottledFetch({ maxRetries: 1, backoffBaseMs: 0 });
     const resp = await client.fetch("https://api.example.com/test");
     expect(resp.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -91,7 +113,7 @@ describe("createThrottledFetch", () => {
     fetchMock = mock(() => Promise.resolve(new Response("error", { status: 429 })));
     globalThis.fetch = fetchMock as any;
 
-    const client = createThrottledFetch({ maxRetries: 1 });
+    const client = createThrottledFetch({ maxRetries: 1, backoffBaseMs: 0 });
     const resp = await client.fetch("https://api.example.com/test");
     expect(resp.status).toBe(429);
     expect(fetchMock).toHaveBeenCalledTimes(2); // initial + 1 retry

--- a/src/utils/throttled-fetch.ts
+++ b/src/utils/throttled-fetch.ts
@@ -18,8 +18,12 @@ export interface ThrottledFetchOptions {
   maxRetries?: number;
   /** Request timeout in ms. Default: 10000 */
   timeoutMs?: number;
+  /** Initial retry backoff in ms. Default: 1000 */
+  backoffBaseMs?: number;
   /** Default headers applied to every request */
   defaultHeaders?: Record<string, string>;
+  /** Share concurrent GET requests to the same URL. Default: true */
+  dedupeGetRequests?: boolean;
 }
 
 interface QueueEntry {
@@ -35,11 +39,16 @@ export interface ThrottledFetchClient {
   fetchJson<T = unknown>(url: string, init?: RequestInit): Promise<T>;
 }
 
-export function createThrottledFetch(options: ThrottledFetchOptions = {}): ThrottledFetchClient {
-  const requestsPerMinute = options.requestsPerMinute ?? DEFAULT_REQUESTS_PER_MINUTE;
+export function createThrottledFetch(
+  options: ThrottledFetchOptions = {},
+): ThrottledFetchClient {
+  const requestsPerMinute =
+    options.requestsPerMinute ?? DEFAULT_REQUESTS_PER_MINUTE;
   const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const backoffBaseMs = options.backoffBaseMs ?? BACKOFF_BASE_MS;
   const defaultHeaders = options.defaultHeaders ?? {};
+  const dedupeGetRequests = options.dedupeGetRequests ?? true;
 
   // Sliding window: track timestamps of recent requests per host
   const hostTimestamps = new Map<string, number[]>();
@@ -81,7 +90,36 @@ export function createThrottledFetch(options: ThrottledFetchOptions = {}): Throt
     timestamps.push(Date.now());
   }
 
-  async function executeRequest(url: string, init: RequestInit | undefined, retriesLeft: number): Promise<Response> {
+  function getBackoffMs(retriesLeft: number, retryAfter?: string | null): number {
+    const attempt = maxRetries - retriesLeft + 1;
+    const backoff = backoffBaseMs * 2 ** (attempt - 1);
+    const retryAfterMs = retryAfter
+      ? (parseInt(retryAfter, 10) || 0) * 1000
+      : 0;
+    return Math.max(retryAfterMs, backoff);
+  }
+
+  function isRetryableFetchError(
+    error: unknown,
+    retryAbortError: boolean,
+  ): boolean {
+    const detail =
+      error instanceof Error
+        ? `${error.name} ${error.message} ${String((error as { code?: unknown }).code ?? "")}`
+        : String(error);
+    return (
+      /TimeoutError|ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket connection|socket hang up|fetch failed|network connection|connection closed/i.test(
+        detail,
+      ) ||
+      (retryAbortError && /AbortError/i.test(detail))
+    );
+  }
+
+  async function executeRequest(
+    url: string,
+    init: RequestInit | undefined,
+    retriesLeft: number,
+  ): Promise<Response> {
     const host = getHost(url);
 
     // Wait for rate limit window
@@ -94,22 +132,34 @@ export function createThrottledFetch(options: ThrottledFetchOptions = {}): Throt
 
     const mergedInit: RequestInit = {
       ...init,
-      headers: { ...defaultHeaders, ...(init?.headers as Record<string, string> ?? {}) },
+      headers: {
+        ...defaultHeaders,
+        ...((init?.headers as Record<string, string>) ?? {}),
+      },
       signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
     };
 
-    const resp = await fetch(url, mergedInit);
+    let resp: Response;
+    try {
+      resp = await fetch(url, mergedInit);
+    } catch (error) {
+      if (retriesLeft > 0 && isRetryableFetchError(error, !init?.signal)) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, getBackoffMs(retriesLeft)),
+        );
+        return executeRequest(url, init, retriesLeft - 1);
+      }
+      throw error;
+    }
 
     // Retry on 429 or 5xx
     if ((resp.status === 429 || resp.status >= 500) && retriesLeft > 0) {
-      const attempt = maxRetries - retriesLeft + 1;
-      const backoff = BACKOFF_BASE_MS * 2 ** (attempt - 1);
-      // Respect Retry-After header if present
-      const retryAfter = resp.headers.get("retry-after");
-      const retryMs = retryAfter ? (parseInt(retryAfter, 10) || 0) * 1000 : backoff;
-      const waitMs = Math.max(retryMs, backoff);
-
-      await new Promise((resolve) => setTimeout(resolve, waitMs));
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          getBackoffMs(retriesLeft, resp.headers.get("retry-after")),
+        ),
+      );
       return executeRequest(url, init, retriesLeft - 1);
     }
 
@@ -119,28 +169,41 @@ export function createThrottledFetch(options: ThrottledFetchOptions = {}): Throt
   function throttledFetch(url: string, init?: RequestInit): Promise<Response> {
     // Deduplicate concurrent GET requests to the same URL
     const method = (init?.method ?? "GET").toUpperCase();
-    if (method === "GET") {
+    if (dedupeGetRequests && method === "GET") {
       const existing = inflight.get(url);
-      if (existing) return existing;
+      if (existing) {
+        return existing.then(
+          (response): Response => response.clone() as unknown as Response,
+        );
+      }
     }
 
     const promise = executeRequest(url, init, maxRetries).finally(() => {
       inflight.delete(url);
     });
 
-    if (method === "GET") {
+    if (dedupeGetRequests && method === "GET") {
       inflight.set(url, promise);
     }
 
-    return promise;
+    return dedupeGetRequests && method === "GET"
+      ? promise.then(
+          (response): Response => response.clone() as unknown as Response,
+        )
+      : promise;
   }
 
-  async function fetchJson<T = unknown>(url: string, init?: RequestInit): Promise<T> {
+  async function fetchJson<T = unknown>(
+    url: string,
+    init?: RequestInit,
+  ): Promise<T> {
     const resp = await throttledFetch(url, init);
     if (!resp.ok) {
-      throw new Error(resp.status === 429
-        ? `Rate limited (${getHost(url)}) — try again later`
-        : `HTTP ${resp.status} from ${getHost(url)}`);
+      throw new Error(
+        resp.status === 429
+          ? `Rate limited (${getHost(url)}) — try again later`
+          : `HTTP ${resp.status} from ${getHost(url)}`,
+      );
     }
     return resp.json() as Promise<T>;
   }


### PR DESCRIPTION
Harden Polymarket prediction-market loading by routing catalog fetches through the throttled fetch helper with retries and backoff. Allow Polymarket catalog pagination to return successful pages when one page resets, and normalize transient socket/network errors into the existing venue-unavailable message. Add the documented Polymarket websocket PING heartbeat for live market subscriptions. Covered by targeted throttled-fetch, prediction-markets service, pane tests, a live catalog smoke check, and a tmux app smoke test.