### PR TITLE
Use DES for ticker detail shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a shortcut or command n
 | Shortcut | Opens |
 |----------|-------|
 | `PF` | Collection Pane |
+| `DES <ticker>` | Ticker Detail |
 | `QQ <ticker>` | Quote Monitor |
 | `CHAT` | New Chat Pane |
 | `IBKR` | New IBKR Trading Pane |

--- a/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
+++ b/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`CommandBar renders the default layout with opencode-style chrome 1`] = 
                 Quote Monitor                           QQ                      
                                                                                 
                 Search                                                          
-                Search Ticker                           T                       
+                Description                             DES                     
                                                                                 
                 Navigation                                                      
                 Help                                    HELP                    
@@ -100,7 +100,7 @@ exports[`CommandBar collapses the trailing column on narrow terminals 1`] = `
        Quote Monitor               QQ     
                                           
        Search                             
-       Search Ticker               T      
+       Description                 DES    
                                           
                                           
                                           
@@ -112,8 +112,8 @@ exports[`CommandBar groups ticker search sections and keeps saved matches above 
 "                                                                                
                                                                                 
                 Commands                                                        
-                T appl                                                          
-                Shortcut: Open APPL                                             
+                DES appl                                                        
+                Shortcut: DES APPL                                              
                 Saved                                                           
                 AAPL                                    NASDAQ                  
                                                                                 

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -754,7 +754,7 @@ describe("CommandBar", () => {
   });
 
   test("keeps typed prefixes in the root query until a result is activated", async () => {
-    testSetup = await testRender(<CommandBarHarness query="T " />, {
+    testSetup = await testRender(<CommandBarHarness query="DES " />, {
       width: 80,
       height: 24,
     });
@@ -763,7 +763,7 @@ describe("CommandBar", () => {
 
     let frame = testSetup.captureCharFrame();
     expect(frame).toContain("Commands");
-    expect(frame).toContain("T");
+    expect(frame).toContain("DES");
     expect(frame).toContain("Type a ticker symbol");
     expect(frame).not.toContain("Back");
   });
@@ -785,7 +785,7 @@ describe("CommandBar", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Back");
-    expect(frame).toContain("Search Ticker");
+    expect(frame).toContain("Security Description");
   });
 
   test("QQ with an active ticker shows ghost completion and tab inserts the symbol", async () => {
@@ -845,13 +845,13 @@ describe("CommandBar", () => {
   });
 
   test("clears the root query with cmd-backspace", async () => {
-    testSetup = await testRender(<CommandBarHarness query="T AMD" />, {
+    testSetup = await testRender(<CommandBarHarness query="DES AMD" />, {
       width: 80,
       height: 24,
     });
 
     await testSetup.renderOnce();
-    expect(testSetup.captureCharFrame()).toContain("T AMD");
+    expect(testSetup.captureCharFrame()).toContain("DES AMD");
 
     await act(async () => {
       testSetup!.mockInput.pressKey("backspace", { meta: true });
@@ -861,7 +861,7 @@ describe("CommandBar", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Commands");
     expect(frame).toContain("Search");
-    expect(frame).not.toContain("T AMD");
+    expect(frame).not.toContain("DES AMD");
   });
 
   test("pressing the close shortcut at the root closes the command bar", async () => {
@@ -883,7 +883,7 @@ describe("CommandBar", () => {
   test("loads provider-backed ticker search results in the root command results", async () => {
     testSetup = await testRender(
       <CommandBarHarness
-        query="T appl"
+        query="DES appl"
         dataProvider={makeDataProvider(async () => [
           { providerId: "yahoo", symbol: "IVSX", name: "Invsivx Holdings", exchange: "NYSE", type: "ETF" },
           { providerId: "yahoo", symbol: "AAPL", name: "Apple Inc", exchange: "NASDAQ", type: "EQUITY" },
@@ -903,12 +903,12 @@ describe("CommandBar", () => {
     expect(frame).toContain("AAOI");
   });
 
-  test("T MSFT opens an exact ticker directly", async () => {
+  test("DES MSFT opens an exact ticker directly", async () => {
     const pinned: string[] = [];
 
     testSetup = await testRender(
       <CommandBarHarness
-        query="T MSFT"
+        query="DES MSFT"
         configurePluginRegistry={(pluginRegistry) => {
           pluginRegistry.pinTickerFn = (symbol) => {
             pinned.push(symbol);
@@ -2476,7 +2476,7 @@ describe("CommandBar", () => {
   test("groups ticker search sections and keeps saved matches above looser provider results", async () => {
     testSetup = await testRender(
       <CommandBarHarness
-        query="T appl"
+        query="DES appl"
         dataProvider={makeDataProvider(async () => [
           { providerId: "yahoo", symbol: "IVSX", name: "Invsivx Holdings", exchange: "NYSE", type: "ETF" },
           { providerId: "yahoo", symbol: "AAPL", name: "Apple Inc", exchange: "NASDAQ", type: "EQUITY" },

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -1242,7 +1242,7 @@ export function CommandBar({
     pluginRegistry,
   ]);
 
-  const runTickerSearchShortcut = useCallback(async (query?: string) => {
+  const runSecurityDescriptionShortcut = useCallback(async (query?: string) => {
     const trimmed = query?.trim() || "";
     if (!trimmed) {
       const inferred = normalizeTickerInput(activeTickerSymbol, query);
@@ -2350,8 +2350,8 @@ export function CommandBar({
         void onCheckForUpdates?.();
         closeAll({ revertThemePreview: false });
         return;
-      case "search-ticker":
-        void runTickerSearchShortcut(arg);
+      case "security-description":
+        void runSecurityDescriptionShortcut(arg);
         return;
       case "remove-watchlist":
       case "remove-portfolio": {
@@ -2384,12 +2384,12 @@ export function CommandBar({
     onCheckForUpdates,
     pluginRegistry,
     quitApp,
-    runTickerSearchShortcut,
+    runSecurityDescriptionShortcut,
     executeCollectionCommand,
   ]);
 
   const activeMatch = matchPrefix(rootQuery);
-  const rootTickerSearchArg = activeMatch?.command.id === "search-ticker" && activeMatch.arg.length >= 1
+  const rootSecurityDescriptionArg = activeMatch?.command.id === "security-description" && activeMatch.arg.length >= 1
     ? activeMatch.arg
     : null;
 
@@ -2651,17 +2651,17 @@ export function CommandBar({
       }
 
       const { command } = rootShortcutIntent;
-      if (command.id === "search-ticker") {
+      if (command.id === "security-description") {
         const inferredSymbol = normalizeTickerInput(activeTickerSymbol, undefined);
         if (!rootShortcutIntent.argText && inferredSymbol) {
           return {
-            id: "search-ticker:inferred",
+            id: "security-description:inferred",
             label: inferredSymbol,
-            detail: `Open ${inferredSymbol}`,
+            detail: `Open security details for ${inferredSymbol}`,
             category: "Search",
             kind: "action",
             right: command.prefix,
-            action: () => { void runTickerSearchShortcut(inferredSymbol); },
+            action: () => { void runSecurityDescriptionShortcut(inferredSymbol); },
           };
         }
         return null;
@@ -3068,7 +3068,7 @@ export function CommandBar({
           },
         });
       });
-    } else if (match && match.command.id === "search-ticker") {
+    } else if (match && match.command.id === "security-description") {
       if (shortcutItem) {
         items.push(shortcutItem);
       }
@@ -3076,7 +3076,7 @@ export function CommandBar({
         items.push({
           id: "search-hint",
           label: "Type a ticker symbol",
-          detail: "Search Yahoo Finance and connected brokers",
+          detail: "Open security details after resolving a ticker",
           category: "Search",
           kind: "info",
           action: () => {},
@@ -3154,7 +3154,7 @@ export function CommandBar({
     rootQuery,
     rootShortcutIntent,
     runDirectCommand,
-    runTickerSearchShortcut,
+    runSecurityDescriptionShortcut,
     state,
     tickerActionItems,
   ]);
@@ -3191,7 +3191,7 @@ export function CommandBar({
       return;
     }
 
-    if (!rootTickerSearchArg) {
+    if (!rootSecurityDescriptionArg) {
       setRootSearching(false);
       setRootProviderResults(null);
       setRootProviderResultsQuery(null);
@@ -3200,7 +3200,7 @@ export function CommandBar({
       return;
     }
 
-    const searchQuery = rootTickerSearchArg;
+    const searchQuery = rootSecurityDescriptionArg;
     if (rootSearchTimerRef.current) clearTimeout(rootSearchTimerRef.current);
     if (rootLastSearchedQueryRef.current === searchQuery) {
       return;
@@ -3266,18 +3266,18 @@ export function CommandBar({
     currentRoute,
     dataProvider,
     readTickerSearchCache,
-    rootTickerSearchArg,
+    rootSecurityDescriptionArg,
     state.config.portfolios,
     state.tickers,
     writeTickerSearchCache,
   ]);
 
   const rootResults = useMemo(() => {
-    if (rootTickerSearchArg && rootProviderResultsQuery === rootTickerSearchArg && rootProviderResults) {
+    if (rootSecurityDescriptionArg && rootProviderResultsQuery === rootSecurityDescriptionArg && rootProviderResults) {
       return rootProviderResults;
     }
     return rootResultModel.items;
-  }, [rootProviderResults, rootProviderResultsQuery, rootResultModel.items, rootTickerSearchArg]);
+  }, [rootProviderResults, rootProviderResultsQuery, rootResultModel.items, rootSecurityDescriptionArg]);
 
   const rootGhostCompletion = !currentRoute && rootShortcutIntent.kind === "inferred-complete"
     ? rootShortcutIntent.completionQuery
@@ -3318,14 +3318,14 @@ export function CommandBar({
         : `Shortcut: ${rootShortcutIntent.label}`;
     }
 
-    if (rootShortcutIntent.command.id === "search-ticker") {
+    if (rootShortcutIntent.command.id === "security-description") {
       const symbol = normalizeTickerInput(activeTickerSymbol, rootShortcutIntent.argText);
       if (symbol) {
         return rootShortcutIntent.kind === "inferred-complete"
-          ? `Shortcut: Open ${symbol} · Tab to accept`
-          : `Shortcut: Open ${symbol}`;
+          ? `Shortcut: DES ${symbol} · Tab to accept`
+          : `Shortcut: DES ${symbol}`;
       }
-      return "Shortcut: Search ticker";
+      return "Shortcut: Description";
     }
 
     if (isCollectionCommand(rootShortcutIntent.command.id)) {
@@ -3397,7 +3397,7 @@ export function CommandBar({
       return false;
     }
 
-    if (intent.command.id === "search-ticker") {
+    if (intent.command.id === "security-description") {
       openModeRoute("ticker-search", intent.argText);
       return true;
     }
@@ -3446,37 +3446,37 @@ export function CommandBar({
       return null;
     }
 
-    if (match.command.id === "search-ticker") {
+    if (match.command.id === "security-description") {
       if (!match.arg) {
         const inferredTicker = normalizeTickerInput(activeTickerSymbol, undefined);
         if (inferredTicker) {
           return {
-            id: "search-ticker:inferred",
+            id: "security-description:inferred",
             label: inferredTicker,
-            detail: `Open ${inferredTicker}`,
+            detail: `Open security details for ${inferredTicker}`,
             category: "Search",
             kind: "action",
             right: match.command.prefix,
-            action: () => { void runTickerSearchShortcut(inferredTicker); },
+            action: () => { void runSecurityDescriptionShortcut(inferredTicker); },
           };
         }
         return {
-          id: "search-ticker-route",
-          label: "Search Ticker",
-          detail: "Search Yahoo Finance and connected brokers",
+          id: "security-description-route",
+          label: "Description",
+          detail: "Open security details for a ticker",
           category: "Search",
           kind: "command",
           action: () => openModeRoute("ticker-search", ""),
         };
       }
       return {
-        id: `search-ticker:${match.arg}`,
-        label: `Open ${match.arg.toUpperCase()}`,
-        detail: "Resolve the symbol exactly or open inline search",
+        id: `security-description:${match.arg}`,
+        label: `DES ${match.arg.toUpperCase()}`,
+        detail: "Open security details or resolve the ticker",
         category: "Search",
         kind: "command",
         right: match.command.prefix,
-        action: () => { void runTickerSearchShortcut(match.arg); },
+        action: () => { void runSecurityDescriptionShortcut(match.arg); },
       };
     }
 
@@ -3556,7 +3556,7 @@ export function CommandBar({
     openModeRoute,
     paneTemplateItems,
     runDirectCommand,
-    runTickerSearchShortcut,
+    runSecurityDescriptionShortcut,
   ]);
 
   const routeListState = useMemo<ListScreenState | null>(() => {
@@ -3564,7 +3564,7 @@ export function CommandBar({
       const emptyState = getEmptyState(
         rootModeInfo.kind,
         rootQuery,
-        activeMatch?.command.id === "search-ticker" ? activeMatch.arg : undefined,
+        activeMatch?.command.id === "security-description" ? activeMatch.arg : undefined,
       );
       return {
         kind: "root",
@@ -3944,8 +3944,8 @@ export function CommandBar({
           const emptyState = getEmptyState("search", currentRoute.query, currentRoute.query);
           return {
             kind: "mode",
-            title: "Search Ticker",
-            subtitle: "Search Yahoo Finance and connected brokers.",
+            title: "Security Description",
+            subtitle: "Resolve a ticker, then open its detail pane.",
             query: currentRoute.query,
             selectedIdx: currentRoute.selectedIdx,
             hoveredIdx: currentRoute.hoveredIdx,
@@ -5258,7 +5258,7 @@ export function CommandBar({
                   : currentRoute.screen === "plugins" ? "Manage Plugins"
                     : currentRoute.screen === "layout" ? "Layout Actions"
                       : currentRoute.screen === "new-pane" ? "New Pane"
-                        : "Search Ticker"
+                        : "Security Description"
                 : currentRoute?.kind === "picker" ? currentRoute.title
                   : currentRoute?.kind === "pane-settings" ? "Pane Settings"
                     : currentRoute?.kind === "workflow" ? currentRoute.title

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -10,10 +10,10 @@ export interface CommandContext {
 
 export interface Command {
   id: string;
-  prefix: string;        // e.g., "T", "AW", "RP"
+  prefix: string;        // e.g., "DES", "AW", "RP"
   label: string;
   description: string;
-  hasArg?: boolean;       // true if prefix takes an argument (e.g., "T AMD")
+  hasArg?: boolean;       // true if prefix takes an argument (e.g., "DES AMD")
   argPlaceholder?: string;
   shortcut?: string;
   category: string;
@@ -21,14 +21,14 @@ export interface Command {
 }
 
 export const commands: Command[] = [
-  // Ticker search
+  // Security description
   {
-    id: "search-ticker",
-    prefix: "T",
-    label: "Search Ticker",
-    description: "Search Yahoo Finance for a ticker",
+    id: "security-description",
+    prefix: "DES",
+    label: "Description",
+    description: "Open security details for a ticker",
     hasArg: true,
-    argPlaceholder: "symbol or name",
+    argPlaceholder: "ticker",
     category: "Search",
     execute: () => {}, // handled specially by command bar
   },

--- a/src/components/command-bar/helpers.ts
+++ b/src/components/command-bar/helpers.ts
@@ -13,7 +13,7 @@ import type {
 } from "./workflow-types";
 import type { CollectionKind, CollectionMembershipAction } from "./workflow-ops";
 
-export type RouteCommandId = "search-ticker" | "theme" | "plugins" | "layout" | "new-pane";
+export type RouteCommandId = "security-description" | "theme" | "plugins" | "layout" | "new-pane";
 export type CollectionCommandId = "add-watchlist" | "add-portfolio" | "remove-watchlist" | "remove-portfolio";
 
 export function summarizeError(error: unknown): Record<string, string> {
@@ -28,7 +28,7 @@ export function summarizeError(error: unknown): Record<string, string> {
 }
 
 export function isRouteCommandId(commandId: string): commandId is RouteCommandId {
-  return commandId === "search-ticker"
+  return commandId === "security-description"
     || commandId === "theme"
     || commandId === "plugins"
     || commandId === "layout"
@@ -239,7 +239,7 @@ export function normalizeWizardFields(steps: WizardStep[]): {
 
 export function routeCommandIdToScreen(commandId: RouteCommandId): "ticker-search" | "themes" | "plugins" | "layout" | "new-pane" {
   switch (commandId) {
-    case "search-ticker":
+    case "security-description":
       return "ticker-search";
     case "theme":
       return "themes";
@@ -341,7 +341,7 @@ export function getScreenFooterRight(route: CommandBarRoute | null): string {
 }
 
 export function isRootParsedCommand(commandId: string): boolean {
-  return commandId === "search-ticker"
+  return commandId === "security-description"
     || commandId === "add-watchlist"
     || commandId === "add-portfolio"
     || commandId === "remove-watchlist"

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -11,7 +11,7 @@ import {
 describe("command bar view model helpers", () => {
   test("resolves prefix-driven modes", () => {
     expect(resolveCommandBarMode("")).toMatchObject({ kind: "default", badge: "BROWSE" });
-    expect(resolveCommandBarMode("T NVDA")).toMatchObject({ kind: "search", badge: "SEARCH" });
+    expect(resolveCommandBarMode("DES NVDA")).toMatchObject({ kind: "search", badge: "DES" });
     expect(resolveCommandBarMode("TH ")).toMatchObject({ kind: "themes", badge: "THEMES" });
     expect(resolveCommandBarMode("PL notes")).toMatchObject({ kind: "plugins", badge: "PLUGINS" });
     expect(resolveCommandBarMode("LAY ")).toMatchObject({ kind: "layout", badge: "LAYOUT" });
@@ -58,11 +58,11 @@ describe("command bar view model helpers", () => {
   });
 
   test("returns specific empty states", () => {
-    expect(getEmptyState("search", "T ", "")).toEqual({
+    expect(getEmptyState("search", "DES ", "")).toEqual({
       label: "Type a ticker symbol",
-      detail: "Search Yahoo Finance and connected brokers",
+      detail: "Open security details after resolving a ticker",
     });
-    expect(getEmptyState("search", "T zom", "zom")).toEqual({
+    expect(getEmptyState("search", "DES zom", "zom")).toEqual({
       label: 'No matches for "zom"',
       detail: "Try a symbol, company name, or exchange variant",
     });

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -45,7 +45,7 @@ export interface CommandBarRowPresentation {
 }
 
 const MODE_STRIP_ENTRIES = [
-  { prefix: "T", label: "Search ticker", kind: "search" },
+  { prefix: "DES", label: "Description", kind: "search" },
   { prefix: "TH", label: "Change theme", kind: "themes" },
   { prefix: "PL", label: "Toggle plugins", kind: "plugins" },
   { prefix: "LAY", label: "Layout actions", kind: "layout" },
@@ -64,8 +64,8 @@ export function resolveCommandBarMode(query: string): CommandBarModeInfo {
   }
 
   switch (match.command.id) {
-    case "search-ticker":
-      return { kind: "search", badge: "SEARCH", hint: "Search Yahoo Finance and broker-backed symbols" };
+    case "security-description":
+      return { kind: "search", badge: "DES", hint: "Open security details for a ticker" };
     case "theme":
       return { kind: "themes", badge: "THEMES", hint: "Preview with arrows, Enter to save, Esc to revert" };
     case "plugins":
@@ -127,7 +127,7 @@ export function getEmptyState(mode: CommandBarMode, query: string, searchQuery?:
   switch (mode) {
     case "search":
       if (!searchQuery) {
-        return { label: "Type a ticker symbol", detail: "Search Yahoo Finance and connected brokers" };
+        return { label: "Type a ticker symbol", detail: "Open security details after resolving a ticker" };
       }
       return { label: `No matches for "${searchQuery}"`, detail: "Try a symbol, company name, or exchange variant" };
     case "plugins":

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -910,8 +910,8 @@ function PortfolioStep({
         </box>
         <box height={1} flexDirection="row">
           <text fg={colors.textDim}>{"type "}</text>
-          <text fg={colors.text} attributes={TextAttributes.BOLD}>{"T AAPL"}</text>
-          <text fg={colors.textDim}>{" to search and add any stock or ETF."}</text>
+          <text fg={colors.text} attributes={TextAttributes.BOLD}>{"DES AAPL"}</text>
+          <text fg={colors.textDim}>{" to open security details for a stock or ETF."}</text>
         </box>
       </box>
     );
@@ -1224,7 +1224,7 @@ function ShortcutsStep({
 
   const commandPrefixes = useMemo(() => {
     const builtIn = [
-      { key: "T AAPL", desc: "Search and add any ticker" },
+      { key: "DES AAPL", desc: "Open security details" },
       { key: "TH", desc: "Switch theme" },
       { key: "PL", desc: "Toggle plugins" },
       { key: "PS", desc: "Edit the current window settings" },

--- a/src/plugins/builtin/help.tsx
+++ b/src/plugins/builtin/help.tsx
@@ -172,8 +172,8 @@ export function HelpPane({ width, height }: PaneProps) {
               compact={compact}
             />
             <ShortcutRow
-              badges={["T <ticker>"]}
-              description="Search for a ticker or company and open it."
+              badges={["DES <ticker>"]}
+              description="Open security details for a ticker."
               compact={compact}
             />
             <ShortcutRow


### PR DESCRIPTION
Renames the command-bar ticker detail shortcut from T/Search Ticker to DES/Description, while keeping ticker search as the resolver behind the detail flow. Updates command-bar hints, onboarding, help, README, and related tests/snapshots. Tests: bun test; tmux smoke with Ctrl+P then DES AAPL showing Shortcut: DES AAPL.