### PR TITLE
Improve Tauri responsiveness and pane footer hints

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -470,6 +470,9 @@ import {
   SkeletonRow,
   LoadingBlock,
   PriceSelectorDialog,
+  PaneFooterBar,
+  usePaneFooter,
+  usePaneHints,
   colors,
   priceColor,
   hoverBg,
@@ -503,6 +506,9 @@ Available components:
 - `Section`, `FieldRow`, `DialogFrame` — shared framing/layout helpers
 - `Spinner`, `ProgressBar`, `SkeletonRow`, `LoadingBlock` — loading states
 - `PriceSelectorDialog` — ticker price picker dialog
+- `PaneFooterBar` — shared pane footer renderer used by the shell
+- `usePaneFooter(registrationId, factory, deps)` — register pane footer info and action hints from a pane or detail tab
+- `usePaneHints(registrationId, factory, deps)` — register only footer hints
 - `colors` — theme color palette
 - `priceColor(change)` — returns green/red/neutral color for a price change
 - `hoverBg` — standard hover background color
@@ -511,6 +517,22 @@ Available components:
 - `useFocusedTicker()` — get the currently focused ticker
 - `useSelectedTicker()` — alias for `usePaneTicker()`
 - `formatCurrency`, `formatCompact`, `formatPercent`, `formatPercentRaw`, `formatNumber`, `padTo` — number formatting utilities
+
+Pane footers are the shared place for pane status and non-obvious keyboard actions. Register informational segments on the left and hints on the right:
+
+```typescript
+usePaneFooter("my-pane", () => ({
+  info: [
+    { id: "status", parts: [{ text: "12 rows", tone: "muted" }] },
+  ],
+  hints: [
+    { id: "refresh", key: "r", label: "efresh", onPress: refresh },
+    { id: "filter", key: "f", label: "ilter", onPress: openFilter },
+  ],
+}), [refresh, openFilter]);
+```
+
+Do not register basic navigation hints. Pane hints must omit `Esc`, `Enter`, arrows, `up/down`, `left/right`, `j`, `k`, `j/k`, and tab-switching hints such as `h/l`. Keep only pane-specific actions such as `[r]efresh`, `[/]search`, `[f]ilter`, `[Ctrl+S]save`, `[Shift+R]force refresh`, or chart controls.
 
 ### Plugin runtime hooks
 
@@ -624,6 +646,7 @@ export default {
 
 - Prefer `ListView`, `Tabs`, `Button`, `Checkbox`, and `Notice` before custom rows.
 - Support both mouse and keyboard for anything interactive.
+- Put pane status and non-obvious shortcuts in `usePaneFooter()` / `usePaneHints()` instead of ad hoc body rows.
 - Use `colors` and the shared components instead of hard-coded palette values when possible.
 - Use `usePaneTicker()` inside pane/tab components so multi-pane layouts keep working correctly.
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@opentui/core": "^0.1.90",
         "@opentui/react": "^0.1.90",
         "@stoqey/ib": "^1.5.3",
+        "@tanstack/react-virtual": "^3.13.23",
         "@tauri-apps/api": "^2",
         "gray-matter": "^4.0.3",
         "opentui-spinner": "^0.0.6",
@@ -114,6 +115,10 @@
     "@opentui/react": ["@opentui/react@0.1.90", "", { "dependencies": { "@opentui/core": "0.1.90", "react-reconciler": "^0.32.0" }, "peerDependencies": { "react": ">=19.0.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-uYojzdqDanib5zj/fN2ikHZe+D6zZckZrTgz45ndunozeGPTSt64oRqi9GDCrt26tzTSJHqjJGGJSoIRhNvwyg=="],
 
     "@stoqey/ib": ["@stoqey/ib@1.5.3", "", { "dependencies": { "colors": "^1.4.0", "command-buffer": "^0.1.0", "dotenv": "^16.4.7", "eventemitter3": "^5.0.1", "function-rate-limit": "^1.1.0", "rxjs": "^7.8.1" } }, "sha512-gT+IEgJy1eo3KHwwOqdvmQp3gqumU4cgbddv4n7JE6fqfiKetx4uxkkE5b6R+SRfuzWoFj9ORmaswuSbrNZzPA=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.23", "", {}, "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@opentui/core": "^0.1.90",
     "@opentui/react": "^0.1.90",
     "@stoqey/ib": "^1.5.3",
+    "@tanstack/react-virtual": "^3.13.23",
     "@tauri-apps/api": "^2",
     "gray-matter": "^4.0.3",
     "opentui-spinner": "^0.0.6",

--- a/scripts/build-tauri-web.ts
+++ b/scripts/build-tauri-web.ts
@@ -85,10 +85,28 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
       [data-gloom-role="pane-window"] {
         background-clip: padding-box;
       }
+      [data-gloom-role="app-header"][data-titlebar-overlay="true"] {
+        cursor: default;
+        -webkit-user-select: none;
+        user-select: none;
+      }
+      [data-gloom-role="app-header"][data-titlebar-overlay="true"] * {
+        cursor: inherit;
+      }
       [data-gloom-role="pane-window"][data-floating="true"] {
-        border: 1px solid var(--pane-border-color, #3a4148);
+        border: 0;
         border-radius: 6px;
+        overflow: hidden;
         box-shadow: 0 18px 38px rgba(0, 0, 0, .46);
+      }
+      [data-gloom-role="pane-window"][data-floating="true"]::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border: 1px solid var(--pane-border-color, #3a4148);
+        border-radius: inherit;
+        pointer-events: none;
+        z-index: 100;
       }
       [data-gloom-role="pane-window"][data-focused="true"] {
         box-shadow: 0 0 0 1px color-mix(in srgb, var(--pane-border-color, #54c99f) 30%, transparent), 0 18px 40px rgba(0, 0, 0, .5);
@@ -134,6 +152,29 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
       [data-gloom-role="status-bar"] span {
         line-height: var(--cell-h);
       }
+      [data-gloom-role="pane-footer"] {
+        min-height: var(--cell-h);
+        max-height: var(--cell-h);
+        align-items: center;
+        border-top: 1px solid color-mix(in srgb, var(--pane-footer-border-color, #3a4148) 72%, transparent);
+        font-size: 11.5px;
+        overflow: hidden;
+      }
+      [data-gloom-role="pane-footer"][data-empty="true"] {
+        border-top-color: transparent;
+      }
+      [data-gloom-role="pane-footer"] span,
+      [data-gloom-role="pane-hint"] span {
+        line-height: var(--cell-h);
+      }
+      [data-gloom-role="pane-hint"] {
+        cursor: pointer;
+        border-radius: 4px;
+        padding-inline: 2px;
+      }
+      [data-gloom-role="pane-hint"]:hover {
+        background: rgba(255,255,255,.08);
+      }
       [data-gloom-role="pane-action"],
       [data-gloom-role="pane-close"] {
         border-radius: 4px;
@@ -148,6 +189,30 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
       }
       [data-gloom-role="chart-surface"] {
         cursor: crosshair;
+      }
+      [data-gloom-role="tab-list"] {
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+      }
+      [data-gloom-role="tab-list"]::-webkit-scrollbar {
+        width: 0;
+        height: 0;
+        display: none;
+      }
+      [data-gloom-role="tab-button"] {
+        all: unset;
+        box-sizing: border-box;
+      }
+      [data-gloom-role="tab-button"]:not(:disabled):hover {
+        --tab-fg: var(--tab-hover-fg);
+        background: var(--tab-hover-bg);
+      }
+      [data-gloom-role="tab-button"]:not(:disabled):not([data-active="true"]):hover {
+        --tab-underline: var(--tab-hover-underline);
+      }
+      [data-gloom-role="tab-button"]:focus-visible {
+        outline: 1px solid var(--tab-hover-underline);
+        outline-offset: -1px;
       }
       [data-gloom-scrollbar-x="hidden"]::-webkit-scrollbar:horizontal {
         height: 0;

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,8 @@
   "identifier": "default",
   "description": "Default desktop permissions for the Gloomberb Tauri renderer.",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging"
+  ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,10 +1,16 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
+    collections::HashMap,
+    future::Future,
     io::{BufRead, BufReader, Write},
     path::PathBuf,
+    pin::Pin,
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
-    sync::Mutex,
+    sync::{mpsc, Arc, Mutex},
+    task::{Context, Poll, Waker},
+    thread,
+    time::Instant,
 };
 use tauri::{AppHandle, State};
 
@@ -35,8 +41,6 @@ struct BackendLineResponse {
 struct BackendProcess {
     child: Child,
     stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
-    next_id: u64,
 }
 
 impl Drop for BackendProcess {
@@ -47,7 +51,80 @@ impl Drop for BackendProcess {
 }
 
 struct BackendState {
-    process: Mutex<Option<BackendProcess>>,
+    client: BackendClient,
+}
+
+#[derive(Clone)]
+struct BackendClient {
+    tx: mpsc::Sender<BackendActorMessage>,
+}
+
+struct BackendCommand {
+    method: String,
+    payload: Value,
+    response: AsyncResponseSender,
+}
+
+enum BackendActorMessage {
+    Request(BackendCommand),
+    Response(Result<BackendLineResponse, String>),
+    BackendExited(String),
+}
+
+struct AsyncResponseState {
+    result: Option<Result<Value, String>>,
+    waker: Option<Waker>,
+}
+
+struct AsyncResponseSender {
+    state: Arc<Mutex<AsyncResponseState>>,
+}
+
+struct AsyncResponseReceiver {
+    state: Arc<Mutex<AsyncResponseState>>,
+}
+
+fn async_response_channel() -> (AsyncResponseSender, AsyncResponseReceiver) {
+    let state = Arc::new(Mutex::new(AsyncResponseState {
+        result: None,
+        waker: None,
+    }));
+    (
+        AsyncResponseSender {
+            state: Arc::clone(&state),
+        },
+        AsyncResponseReceiver { state },
+    )
+}
+
+impl AsyncResponseSender {
+    fn send(self, result: Result<Value, String>) {
+        let waker = {
+            let mut state = self.state.lock().unwrap();
+            if state.result.is_some() {
+                return;
+            }
+            state.result = Some(result);
+            state.waker.take()
+        };
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+impl Future for AsyncResponseReceiver {
+    type Output = Result<Value, String>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.state.lock().unwrap();
+        if let Some(result) = state.result.take() {
+            Poll::Ready(result)
+        } else {
+            state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
 }
 
 fn backend_entry() -> Result<PathBuf, String> {
@@ -62,7 +139,33 @@ fn backend_entry() -> Result<PathBuf, String> {
         .ok_or_else(|| "Could not locate Tauri backend entrypoint.".to_string())
 }
 
-fn spawn_backend() -> Result<BackendProcess, String> {
+fn read_backend_stdout(stdout: ChildStdout, tx: mpsc::Sender<BackendActorMessage>) {
+    let mut reader = BufReader::new(stdout);
+    loop {
+        let mut response_line = String::new();
+        match reader.read_line(&mut response_line) {
+            Ok(0) => {
+                let _ = tx.send(BackendActorMessage::BackendExited(
+                    "Backend exited without a response.".to_string(),
+                ));
+                return;
+            }
+            Ok(_) => {
+                let response = serde_json::from_str::<BackendLineResponse>(&response_line)
+                    .map_err(|err| format!("Invalid backend response: {err}"));
+                let _ = tx.send(BackendActorMessage::Response(response));
+            }
+            Err(err) => {
+                let _ = tx.send(BackendActorMessage::BackendExited(format!(
+                    "Failed to read backend response: {err}",
+                )));
+                return;
+            }
+        }
+    }
+}
+
+fn spawn_backend(tx: mpsc::Sender<BackendActorMessage>) -> Result<BackendProcess, String> {
     let entry = backend_entry()?;
     let mut child = Command::new("bun")
         .arg(entry)
@@ -81,61 +184,148 @@ fn spawn_backend() -> Result<BackendProcess, String> {
         .take()
         .ok_or_else(|| "Backend stdout was unavailable.".to_string())?;
 
-    Ok(BackendProcess {
-        child,
-        stdin,
-        stdout: BufReader::new(stdout),
-        next_id: 1,
-    })
+    thread::spawn(move || read_backend_stdout(stdout, tx));
+
+    Ok(BackendProcess { child, stdin })
 }
 
-fn backend_request(state: &BackendState, method: &str, payload: &Value) -> Result<Value, String> {
-    let mut process_guard = state
-        .process
-        .lock()
-        .map_err(|_| "Backend process lock was poisoned.".to_string())?;
-
-    if process_guard.is_none() {
-        *process_guard = Some(spawn_backend()?);
+fn reject_pending(pending: &mut HashMap<u64, AsyncResponseSender>, error: &str) {
+    for (_, response) in pending.drain() {
+        response.send(Err(error.to_string()));
     }
+}
 
-    let process = process_guard.as_mut().unwrap();
-    let id = process.next_id;
-    process.next_id += 1;
-
-    let line = serde_json::to_string(&BackendLineRequest {
-        id,
-        method,
-        payload,
-    })
-    .map_err(|err| err.to_string())?;
-
-    process
-        .stdin
-        .write_all(line.as_bytes())
-        .and_then(|_| process.stdin.write_all(b"\n"))
-        .and_then(|_| process.stdin.flush())
-        .map_err(|err| format!("Failed to write backend request: {err}"))?;
-
-    let mut response_line = String::new();
-    process
-        .stdout
-        .read_line(&mut response_line)
-        .map_err(|err| format!("Failed to read backend response: {err}"))?;
-    if response_line.trim().is_empty() {
-        return Err("Backend exited without a response.".to_string());
-    }
-
-    let response: BackendLineResponse =
-        serde_json::from_str(&response_line).map_err(|err| format!("Invalid backend response: {err}"))?;
-    if response.id != id {
-        return Err(format!("Backend response id mismatch: expected {id}, got {}", response.id));
-    }
-    if response.ok {
+fn deliver_backend_response(
+    pending: &mut HashMap<u64, AsyncResponseSender>,
+    response: BackendLineResponse,
+) -> bool {
+    let Some(sender) = pending.remove(&response.id) else {
+        return false;
+    };
+    let result = if response.ok {
         Ok(response.result)
     } else {
         Err(response.error)
+    };
+    sender.send(result);
+    true
+}
+
+fn fail_backend(
+    process: &mut Option<BackendProcess>,
+    pending: &mut HashMap<u64, AsyncResponseSender>,
+    error: String,
+) {
+    reject_pending(pending, &error);
+    if let Some(mut existing) = process.take() {
+        let _ = existing.child.kill();
+        let _ = existing.child.wait();
     }
+}
+
+fn run_backend_actor(
+    rx: mpsc::Receiver<BackendActorMessage>,
+    tx: mpsc::Sender<BackendActorMessage>,
+) {
+    let mut process: Option<BackendProcess> = None;
+    let mut pending: HashMap<u64, AsyncResponseSender> = HashMap::new();
+    let mut next_id = 1_u64;
+
+    for message in rx {
+        match message {
+            BackendActorMessage::Request(command) => {
+                if process.is_none() {
+                    match spawn_backend(tx.clone()) {
+                        Ok(next_process) => {
+                            process = Some(next_process);
+                        }
+                        Err(error) => {
+                            let _ = command.response.send(Err(error));
+                            continue;
+                        }
+                    }
+                }
+
+                let id = next_id;
+                next_id += 1;
+                let line = match serde_json::to_string(&BackendLineRequest {
+                    id,
+                    method: &command.method,
+                    payload: &command.payload,
+                }) {
+                    Ok(line) => line,
+                    Err(error) => {
+                        let _ = command.response.send(Err(error.to_string()));
+                        continue;
+                    }
+                };
+
+                let write_result = if let Some(existing) = process.as_mut() {
+                    existing
+                        .stdin
+                        .write_all(line.as_bytes())
+                        .and_then(|_| existing.stdin.write_all(b"\n"))
+                        .and_then(|_| existing.stdin.flush())
+                } else {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "backend process missing",
+                    ))
+                };
+
+                if let Err(error) = write_result {
+                    let message = format!("Failed to write backend request: {error}");
+                    let _ = command.response.send(Err(message.clone()));
+                    fail_backend(&mut process, &mut pending, message);
+                    continue;
+                }
+
+                pending.insert(id, command.response);
+            }
+            BackendActorMessage::Response(response) => match response {
+                Ok(response) => {
+                    deliver_backend_response(&mut pending, response);
+                }
+                Err(error) => {
+                    fail_backend(&mut process, &mut pending, error);
+                }
+            },
+            BackendActorMessage::BackendExited(error) => {
+                fail_backend(&mut process, &mut pending, error);
+            }
+        }
+    }
+}
+
+fn create_backend_client() -> BackendClient {
+    let (tx, rx) = mpsc::channel::<BackendActorMessage>();
+    let actor_tx = tx.clone();
+    thread::spawn(move || run_backend_actor(rx, actor_tx));
+    BackendClient { tx }
+}
+
+async fn backend_request(
+    client: BackendClient,
+    method: String,
+    payload: Value,
+) -> Result<Value, String> {
+    let started_at = Instant::now();
+    let (response_tx, response_rx) = async_response_channel();
+    client
+        .tx
+        .send(BackendActorMessage::Request(BackendCommand {
+            method: method.clone(),
+            payload,
+            response: response_tx,
+        }))
+        .map_err(|err| format!("Backend request channel is closed: {err}"))?;
+
+    let result = response_rx.await;
+    let duration_ms = started_at.elapsed().as_millis();
+    if duration_ms >= 50 {
+        eprintln!("perf backend.request method={method} duration_ms={duration_ms}");
+    }
+    result
 }
 
 fn open_external(url: &str) -> Result<Value, String> {
@@ -171,16 +361,24 @@ fn copy_text(text: &str) -> Result<Value, String> {
             .write_all(text.as_bytes())
             .map_err(|err| err.to_string())?;
         let status = child.wait().map_err(|err| err.to_string())?;
-        return if status.success() { Ok(Value::Null) } else { Err(format!("pbcopy exited with {status}")) };
+        return if status.success() {
+            Ok(Value::Null)
+        } else {
+            Err(format!("pbcopy exited with {status}"))
+        };
     }
     Err("Clipboard copy is not implemented for this platform yet.".to_string())
 }
 
 fn read_text() -> Result<Value, String> {
     if cfg!(target_os = "macos") {
-        let output = Command::new("pbpaste").output().map_err(|err| err.to_string())?;
+        let output = Command::new("pbpaste")
+            .output()
+            .map_err(|err| err.to_string())?;
         if output.status.success() {
-            return Ok(Value::String(String::from_utf8_lossy(&output.stdout).to_string()));
+            return Ok(Value::String(
+                String::from_utf8_lossy(&output.stdout).to_string(),
+            ));
         }
         return Err(format!("pbpaste exited with {}", output.status));
     }
@@ -213,7 +411,7 @@ fn handle_host_request(app: &AppHandle, request: &BackendRequest) -> Option<Resu
 }
 
 #[tauri::command]
-fn tauri_backend_request(
+async fn tauri_backend_request(
     app: AppHandle,
     state: State<'_, BackendState>,
     request: BackendRequest,
@@ -221,15 +419,82 @@ fn tauri_backend_request(
     if let Some(result) = handle_host_request(&app, &request) {
         return result;
     }
-    backend_request(&state, &request.method, &request.payload)
+    let client = state.client.clone();
+    backend_request(client, request.method, request.payload).await
 }
 
 fn main() {
     tauri::Builder::default()
         .manage(BackendState {
-            process: Mutex::new(None),
+            client: create_backend_client(),
         })
         .invoke_handler(tauri::generate_handler![tauri_backend_request])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn routes_backend_responses_by_id_out_of_order() {
+        let (first_tx, first_rx) = async_response_channel();
+        let (second_tx, second_rx) = async_response_channel();
+        let mut pending = HashMap::new();
+        pending.insert(1, first_tx);
+        pending.insert(2, second_tx);
+
+        assert!(deliver_backend_response(
+            &mut pending,
+            BackendLineResponse {
+                id: 2,
+                ok: true,
+                result: json!({ "value": "second" }),
+                error: String::new(),
+            },
+        ));
+        assert!(deliver_backend_response(
+            &mut pending,
+            BackendLineResponse {
+                id: 1,
+                ok: true,
+                result: json!({ "value": "first" }),
+                error: String::new(),
+            },
+        ));
+
+        assert_eq!(
+            tauri::async_runtime::block_on(second_rx).unwrap(),
+            json!({ "value": "second" })
+        );
+        assert_eq!(
+            tauri::async_runtime::block_on(first_rx).unwrap(),
+            json!({ "value": "first" })
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn routes_backend_errors_by_id() {
+        let (response_tx, response_rx) = async_response_channel();
+        let mut pending = HashMap::new();
+        pending.insert(7, response_tx);
+
+        assert!(deliver_backend_response(
+            &mut pending,
+            BackendLineResponse {
+                id: 7,
+                ok: false,
+                result: Value::Null,
+                error: "failed".to_string(),
+            },
+        ));
+
+        assert_eq!(
+            tauri::async_runtime::block_on(response_rx).unwrap_err(),
+            "failed"
+        );
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,13 @@
       {
         "title": "Gloomberb",
         "width": 1200,
-        "height": 800
+        "height": 800,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 12,
+          "y": 12
+        }
       }
     ]
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,7 +8,10 @@ import {
   getFocusedTickerSymbol,
   resolveCollectionForPane,
   resolveTickerForPane,
-  useAppState,
+  useAppDispatch,
+  useAppSelector,
+  useAppStateRef,
+  type AppState,
 } from "./state/app-context";
 import { bindAppActivity, useAppActive } from "./state/app-activity";
 import { copyActiveSelection, isCopyShortcut, isPasteShortcut, pasteSystemClipboard } from "./utils/selection-clipboard";
@@ -51,7 +54,6 @@ import {
 import { getIbkrConfigIdentity } from "./plugins/ibkr/config";
 import { chatController } from "./plugins/builtin/chat-controller";
 import { setLayoutManagerDispatch } from "./plugins/builtin/layout-manager";
-import { saveConfig } from "./data/config-store";
 import { canSelfUpdate, checkForUpdateDetailed, performUpdate, type ReleaseInfo } from "./updater";
 import { VERSION } from "./version";
 import {
@@ -95,6 +97,11 @@ import { instrumentFromTicker } from "./market-data/request-types";
 import { syncBrokerInstance } from "./brokers/sync-broker-instance";
 import { createAppNotifier } from "./notifications/app-notifier";
 import { createAppServices } from "./core/app-services";
+import {
+  saveConfigImmediately,
+  scheduleConfigSave,
+} from "./state/config-save-scheduler";
+import { measurePerf, measurePerfAsync } from "./utils/perf-marks";
 
 /** Global-level dedup: prevents concurrent refresh calls for the same symbol. */
 const refreshInFlight: Set<string> = (globalThis as any).__refreshInFlight ??= new Set<string>();
@@ -130,15 +137,49 @@ interface AppInnerProps {
 }
 
 function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, sessionSnapshot = null }: AppInnerProps) {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const stateRef = useAppStateRef();
+  const config = useAppSelector((state) => state.config);
+  const tickers = useAppSelector((state) => state.tickers);
+  const paneState = useAppSelector((state) => state.paneState);
+  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
+  const initialized = useAppSelector((state) => state.initialized);
+  const commandBarOpen = useAppSelector((state) => state.commandBarOpen);
+  const inputCaptured = useAppSelector((state) => state.inputCaptured);
+  const updateAvailable = useAppSelector((state) => state.updateAvailable);
+  const updateProgress = useAppSelector((state) => state.updateProgress);
+  const updateCheckInProgress = useAppSelector((state) => state.updateCheckInProgress);
+  const state = useMemo(() => ({
+    ...stateRef.current,
+    config,
+    tickers,
+    paneState,
+    focusedPaneId,
+    initialized,
+    commandBarOpen,
+    inputCaptured,
+    updateAvailable,
+    updateProgress,
+    updateCheckInProgress,
+  }) as AppState, [
+    commandBarOpen,
+    config,
+    focusedPaneId,
+    initialized,
+    inputCaptured,
+    paneState,
+    stateRef,
+    tickers,
+    updateAvailable,
+    updateCheckInProgress,
+    updateProgress,
+  ]);
   const appActive = useAppActive();
   const appActiveRef = useRef(appActive);
   const rendererHost = useRendererHost();
   const nativeRenderer = useNativeRenderer();
   const dialog = useDialog();
   const toast = useToastHost();
-  const stateRef = useRef(state);
-  stateRef.current = state;
   appActiveRef.current = appActive;
   const focusedCollectionId = getFocusedCollectionId(state);
   const appNotifier = useMemo(() => createAppNotifier({
@@ -292,7 +333,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
           index === state.config.activeLayoutIndex ? { ...savedLayout, layout: ensured.layout } : savedLayout
         ));
         dispatch({ type: "UPDATE_LAYOUT", layout: ensured.layout });
-        saveConfig({ ...state.config, layout: ensured.layout, layouts }).catch(() => {});
+        scheduleConfigSave({ ...state.config, layout: ensured.layout, layouts });
       }
       return ensured.instance.instanceId;
     })();
@@ -492,7 +533,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
 
     if (result.config !== state.config) {
       dispatch({ type: "SET_CONFIG", config: result.config });
-      await saveConfig(result.config);
+      await saveConfigImmediately(result.config);
       pluginRegistry.events.emit("config:changed", { config: result.config });
     }
 
@@ -597,7 +638,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
             state.config.brokerInstances,
           );
         } catch {}
-        await initializeAppState({
+        await measurePerfAsync("startup.app.initialize-state", () => initializeAppState({
           config: state.config,
           tickerRepository,
           dataProvider,
@@ -608,6 +649,10 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
           refreshQuote,
           autoImportBrokerPositions,
           persistedBrokerAccounts,
+        }), {
+          brokerInstanceCount: state.config.brokerInstances.length,
+          layoutPaneCount: state.config.layout.instances.length,
+          sessionHydrationTargetCount: sessionSnapshot?.hydrationTargets.length ?? 0,
         });
       } catch (err) {
         // Will show empty state
@@ -621,6 +666,10 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
     if (!focusedTickerSymbol) return;
     const ticker = state.tickers.get(focusedTickerSymbol);
     if (!ticker) return;
+    appLog.info("focused ticker prefetch scheduled", {
+      symbol: ticker.metadata.ticker,
+      exchange: ticker.metadata.exchange,
+    });
     marketData.prefetchTicker(instrumentFromTicker(ticker, ticker.metadata.ticker));
   }, [focusedTickerSymbol, marketData, state.tickers]);
 
@@ -651,7 +700,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       },
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    await saveConfig(nextConfig);
+    await saveConfigImmediately(nextConfig);
     pluginRegistry.events.emit("config:changed", { config: nextConfig });
   };
   pluginRegistry.deletePluginConfigValueFn = async (pluginId, key) => {
@@ -673,7 +722,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       pluginConfig: nextAllPluginConfig,
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    await saveConfig(nextConfig);
+    await saveConfigImmediately(nextConfig);
     pluginRegistry.events.emit("config:changed", { config: nextConfig });
   };
   const configurableProvider = dataProvider as DataProvider & {
@@ -701,7 +750,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       brokerInstances: [...state.config.brokerInstances, instance],
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    await saveConfig(nextConfig);
+    await saveConfigImmediately(nextConfig);
     pluginRegistry.events.emit("config:changed", { config: nextConfig });
     return instance;
   };
@@ -728,7 +777,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       brokerInstances: nextInstances,
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    await saveConfig(nextConfig);
+    await saveConfigImmediately(nextConfig);
     pluginRegistry.events.emit("config:changed", { config: nextConfig });
   };
   pluginRegistry.syncBrokerInstanceFn = async (instanceId) => {
@@ -795,7 +844,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
 
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     dispatch({ type: "SET_TICKERS", tickers: nextTickers });
-    await saveConfig(nextConfig);
+    await saveConfigImmediately(nextConfig);
     pluginRegistry.events.emit("config:changed", { config: nextConfig });
   };
 
@@ -822,7 +871,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
       dispatch({ type: "PUSH_LAYOUT_HISTORY" });
     }
     dispatch({ type: "UPDATE_LAYOUT", layout: normalizedLayout });
-    saveConfig({ ...currentState.config, layout: normalizedLayout, layouts }).catch(() => {});
+    scheduleConfigSave({ ...currentState.config, layout: normalizedLayout, layouts });
   };
   const resolvePanelForPane = useCallback((paneId: string, layout: LayoutConfig = state.config.layout): "left" | "right" => {
     const instanceId = resolvePaneTarget(paneId, layout);
@@ -1196,7 +1245,7 @@ function AppInner({ pluginRegistry, tickerRepository, dataProvider, marketData, 
   useEffect(() => {
     if (state.config.layouts !== prevLayouts.current) {
       prevLayouts.current = state.config.layouts;
-      saveConfig(state.config).catch(() => {});
+      scheduleConfigSave(state.config);
     }
   }, [state.config.layouts, state.config]);
 
@@ -1365,7 +1414,13 @@ export function App({
   useEffect(() => bindAppActivity(renderer), [renderer]);
 
   const services = useMemo(() => {
-    return createAppServices({ config, externalPlugins });
+    return measurePerf("startup.app.create-services", () => (
+      createAppServices({ config, externalPlugins })
+    ), {
+      externalPluginCount: externalPlugins.length,
+      disabledPluginCount: config.disabledPlugins.length,
+      brokerInstanceCount: config.brokerInstances.length,
+    });
   }, [config.dataDir, externalPlugins]);
 
   useEffect(() => {

--- a/src/components/chart/chart-indicator-selector.tsx
+++ b/src/components/chart/chart-indicator-selector.tsx
@@ -1,4 +1,5 @@
 import { MultiSelectDialogButton } from "../ui";
+import { usePaneHints } from "../layout/pane-footer";
 import { ChartControlHint } from "./chart-control-hint";
 import {
   CHART_INDICATOR_OPTIONS,
@@ -10,8 +11,26 @@ interface ChartIndicatorSelectorProps {
   selectedIds: ChartIndicatorId[];
   onChange: (selectedIds: ChartIndicatorId[]) => void;
   width: number;
-  variant?: "button" | "hint";
+  variant?: "button" | "hint" | "pane-hint";
   shortcutActive?: boolean;
+}
+
+function ChartIndicatorPaneHint({
+  disabled,
+  openDialog,
+}: {
+  disabled?: boolean;
+  openDialog: () => void;
+}) {
+  usePaneHints("chart-indicators", () => [{
+    id: "indicators",
+    key: "i",
+    label: "ndicators",
+    disabled,
+    onPress: openDialog,
+  }], [disabled, openDialog]);
+
+  return null;
 }
 
 export function ChartIndicatorSelector({
@@ -36,9 +55,13 @@ export function ChartIndicatorSelector({
       selectedValues={selectedIds}
       onChange={(values) => onChange(normalizeChartIndicatorSelection(values))}
       idPrefix="chart-indicators"
-      shortcutKey={variant === "hint" ? "i" : undefined}
+      shortcutKey={variant === "hint" || variant === "pane-hint" ? "i" : undefined}
       shortcutActive={shortcutActive}
-      renderTrigger={variant === "hint"
+      renderTrigger={variant === "pane-hint"
+        ? ({ disabled, openDialog }) => (
+          <ChartIndicatorPaneHint disabled={disabled} openDialog={openDialog} />
+        )
+        : variant === "hint"
         ? ({ disabled, openDialog }) => (
           <ChartControlHint
             hotkey="i"

--- a/src/components/chart/chart-pane-settings.ts
+++ b/src/components/chart/chart-pane-settings.ts
@@ -1,6 +1,11 @@
-import { saveConfig } from "../../data/config-store";
 import { setPaneSettings } from "../../pane-settings";
-import { useAppState, usePaneInstance, usePaneInstanceId } from "../../state/app-context";
+import {
+  useAppDispatch,
+  useAppStateRef,
+  usePaneInstance,
+  usePaneInstanceId,
+} from "../../state/app-context";
+import { scheduleConfigSave } from "../../state/config-save-scheduler";
 import type { ChartResolution, TimeRange } from "./chart-types";
 import type { IndicatorConfig } from "./indicators/types";
 
@@ -8,40 +13,44 @@ export function usePersistChartControlSelection(rangePresetKey: string): (
   range: TimeRange,
   resolution: ChartResolution,
 ) => void {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const stateRef = useAppStateRef();
   const paneId = usePaneInstanceId();
   const pane = usePaneInstance();
 
   return (range, resolution) => {
-    const layout = setPaneSettings(state.config.layout, paneId, {
+    const currentState = stateRef.current;
+    const layout = setPaneSettings(currentState.config.layout, paneId, {
       ...(pane?.settings ?? {}),
       [rangePresetKey]: range,
       chartResolution: resolution,
     });
-    const layouts = state.config.layouts.map((savedLayout, index) => (
-      index === state.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
+    const layouts = currentState.config.layouts.map((savedLayout, index) => (
+      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
     ));
-    const nextConfig = { ...state.config, layout, layouts };
+    const nextConfig = { ...currentState.config, layout, layouts };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    saveConfig(nextConfig).catch(() => {});
+    scheduleConfigSave(nextConfig);
   };
 }
 
 export function usePersistIndicatorConfig(): (config: IndicatorConfig) => void {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const stateRef = useAppStateRef();
   const paneId = usePaneInstanceId();
   const pane = usePaneInstance();
 
   return (indicatorConfig) => {
-    const layout = setPaneSettings(state.config.layout, paneId, {
+    const currentState = stateRef.current;
+    const layout = setPaneSettings(currentState.config.layout, paneId, {
       ...(pane?.settings ?? {}),
       indicators: indicatorConfig,
     });
-    const layouts = state.config.layouts.map((savedLayout, index) => (
-      index === state.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
+    const layouts = currentState.config.layouts.map((savedLayout, index) => (
+      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
     ));
-    const nextConfig = { ...state.config, layout, layouts };
+    const nextConfig = { ...currentState.config, layout, layouts };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    saveConfig(nextConfig).catch(() => {});
+    scheduleConfigSave(nextConfig);
   };
 }

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -29,6 +29,27 @@ const LAYER_DATA = 2;
 const LAYER_OVERLAY = 2;
 const LAYER_CROSSHAIR = 3;
 
+function normalizeCount(value: number, min: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(Math.floor(value), min);
+}
+
+function normalizeRenderDimensions(opts: RenderChartOptions) {
+  const width = normalizeCount(opts.width, 1);
+  const height = normalizeCount(opts.height, 1);
+  const volumeHeight = opts.showVolume
+    ? Math.min(normalizeCount(opts.volumeHeight, 0), Math.max(height - 1, 0))
+    : 0;
+  const showVolume = opts.showVolume && volumeHeight > 0;
+  return {
+    width,
+    height,
+    showVolume,
+    volumeHeight,
+    chartRows: Math.max(height - volumeHeight, 1),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Braille character mapping
 // Each terminal cell maps to a 2×4 dot grid. Unicode braille = U+2800 + bits.
@@ -125,11 +146,13 @@ export function resolveChartPalette(
 // ---------------------------------------------------------------------------
 
 export function createPixelBuffer(width: number, heightPixels: number): PixelBuffer {
+  const bufferWidth = normalizeCount(width, 0);
+  const bufferHeight = normalizeCount(heightPixels, 0);
   const pixels: (Pixel | null)[][] = [];
-  for (let y = 0; y < heightPixels; y++) {
-    pixels.push(new Array(width).fill(null));
+  for (let y = 0; y < bufferHeight; y++) {
+    pixels.push(new Array(bufferWidth).fill(null));
   }
-  return { width, height: heightPixels, pixels };
+  return { width: bufferWidth, height: bufferHeight, pixels };
 }
 
 function setPixel(buf: PixelBuffer, x: number, y: number, color: string, layer: number) {
@@ -901,24 +924,25 @@ function writeAxisLabel(axis: string[], start: number, label: string) {
 }
 
 export function buildTimeAxis(dates: Array<Date | string | number>, width: number): string {
-  if (dates.length === 0 || width <= 0) return "";
+  const axisWidth = normalizeCount(width, 0);
+  if (dates.length === 0 || axisWidth <= 0) return "";
 
   const normalizedDates = dates.map((value) => (value instanceof Date ? value : new Date(value)));
   const first = normalizedDates[0]!;
   const last = normalizedDates[normalizedDates.length - 1]!;
   const rawSpanMs = last.getTime() - first.getTime();
   const spanMs = Math.max(rawSpanMs, 1);
-  const roughLabelCount = Math.max(Math.floor(width / 10), 2);
+  const roughLabelCount = Math.max(Math.floor(axisWidth / 10), 2);
   const minGapMs = getMinPositiveGapMs(normalizedDates);
   const effectiveStepMs = Math.max(spanMs / Math.max(roughLabelCount - 1, 1), minGapMs || 0);
   const unit = resolveAxisLabelUnit(effectiveStepMs);
   const allSameTimestamp = rawSpanMs === 0 && minGapMs === 0;
-  const axis = new Array(width).fill(" ");
+  const axis = new Array(axisWidth).fill(" ");
   const minGap = unit === "year" || unit === "month" ? 2 : 1;
   const idealLabelWidth = estimateAxisLabelWidth(unit, first, last);
   const targetLabelCount = Math.min(
     normalizedDates.length,
-    Math.max(Math.floor(width / (idealLabelWidth + minGap)), 2),
+    Math.max(Math.floor(axisWidth / (idealLabelWidth + minGap)), 2),
   );
   const candidateIndices = [...new Set(
     Array.from({ length: targetLabelCount }, (_, index) => (
@@ -930,33 +954,33 @@ export function buildTimeAxis(dates: Array<Date | string | number>, width: numbe
 
   const firstLabel = formatTimeAxisBoundaryLabel(first, unit, last);
   if (allSameTimestamp) {
-    const centeredStart = resolveCenteredAxisLabelStart(firstLabel, width);
+    const centeredStart = resolveCenteredAxisLabelStart(firstLabel, axisWidth);
     writeAxisLabel(axis, centeredStart, firstLabel);
     return axis.join("");
   }
 
-  const firstStart = resolveAxisLabelStart(0, firstLabel, width);
+  const firstStart = resolveAxisLabelStart(0, firstLabel, axisWidth);
   writeAxisLabel(axis, firstStart, firstLabel);
   const placedLabels = new Set<string>([firstLabel]);
 
   let lastPlacedDate = first;
   let lastEnd = firstStart + firstLabel.length - 1;
 
-  const lastPos = width - 1;
+  const lastPos = axisWidth - 1;
   const lastLabel = normalizedDates.length === 1
     ? firstLabel
     : formatTimeAxisBoundaryLabel(last, unit, first);
-  const lastStart = resolveAxisLabelStart(lastPos, lastLabel, width);
+  const lastStart = resolveAxisLabelStart(lastPos, lastLabel, axisWidth);
   const lastFits = normalizedDates.length === 1 || lastStart > lastEnd + minGap;
 
   for (const index of candidateIndices.slice(1, -1)) {
     const date = normalizedDates[index]!;
     if (isNaN(date.getTime())) continue;
 
-    const pos = Math.round((index / (normalizedDates.length - 1)) * (width - 1));
+    const pos = Math.round((index / (normalizedDates.length - 1)) * (axisWidth - 1));
     const label = formatTimeAxisLabel(date, lastPlacedDate, unit);
     if (placedLabels.has(label)) continue;
-    const start = resolveAxisLabelStart(pos, label, width);
+    const start = resolveAxisLabelStart(pos, label, axisWidth);
     const end = start + label.length - 1;
 
     if (label === axis.slice(start, end + 1).join("")) continue;
@@ -1120,6 +1144,7 @@ export function buildChartScene(
 ): ChartScene | null {
   if (points.length === 0) return null;
 
+  const dimensions = normalizeRenderDimensions(opts);
   const dataMin = opts.mode === "candles" || opts.mode === "ohlc"
     ? Math.min(...points.map((point) => point.low))
     : Math.min(...points.map((point) => point.close));
@@ -1129,43 +1154,42 @@ export function buildChartScene(
   const indicatorValues = getIndicatorOverlayValues(opts.indicators);
   const min = indicatorValues.length > 0 ? Math.min(dataMin, ...indicatorValues) : dataMin;
   const max = indicatorValues.length > 0 ? Math.max(dataMax, ...indicatorValues) : dataMax;
-  const activeIdx = getActivePointIndex(points.length, opts.width, opts.cursorX, opts.mode);
+  const activeIdx = getActivePointIndex(points.length, dimensions.width, opts.cursorX, opts.mode);
   const activePoint = points[activeIdx]!;
   const range = max - min || 1;
-  const chartRows = opts.height - (opts.showVolume ? opts.volumeHeight : 0);
   const cursorX = opts.cursorX === null
     ? null
-    : Math.min(Math.max(opts.cursorX, 0), Math.max(opts.width - 1, 0));
+    : Math.min(Math.max(opts.cursorX, 0), Math.max(dimensions.width - 1, 0));
   const cursorColumn = cursorX === null
     ? null
     : Math.round(cursorX);
   const cursorDotX = cursorX === null
     ? null
-    : Math.round((cursorX / Math.max(opts.width - 1, 1)) * Math.max(opts.width * 2 - 1, 0));
+    : Math.round((cursorX / Math.max(dimensions.width - 1, 1)) * Math.max(dimensions.width * 2 - 1, 0));
   const cursorY = cursorX === null
     ? null
     : opts.cursorY !== null
-      ? Math.min(Math.max(opts.cursorY, 0), Math.max(chartRows - 1, 0))
+      ? Math.min(Math.max(opts.cursorY, 0), Math.max(dimensions.chartRows - 1, 0))
       : Math.min(
-        Math.max(Math.round((1 - (activePoint.close - min) / range) * Math.max(chartRows - 1, 0)), 0),
-        Math.max(chartRows - 1, 0),
+        Math.max(Math.round((1 - (activePoint.close - min) / range) * Math.max(dimensions.chartRows - 1, 0)), 0),
+        Math.max(dimensions.chartRows - 1, 0),
       );
   const cursorRow = cursorY === null
     ? null
     : Math.round(cursorY);
   const crosshairPrice = cursorY === null
     ? null
-    : max - (cursorY / Math.max(chartRows - 1, 1)) * range;
+    : max - (cursorY / Math.max(dimensions.chartRows - 1, 1)) * range;
 
   const timeAxisDates = opts.timeAxisDates ?? points.map((point) => point.date);
 
   return {
     points,
-    width: opts.width,
-    height: opts.height,
-    showVolume: opts.showVolume,
-    volumeHeight: opts.volumeHeight,
-    chartRows,
+    width: dimensions.width,
+    height: dimensions.height,
+    showVolume: dimensions.showVolume,
+    volumeHeight: dimensions.volumeHeight,
+    chartRows: dimensions.chartRows,
     mode: opts.mode,
     colors: opts.colors,
     indicators: opts.indicators ?? null,
@@ -1178,7 +1202,7 @@ export function buildChartScene(
     dateAtCursor: activePoint.date,
     changeAtCursor: activePoint.close - points[0]!.close,
     changePctAtCursor: points[0]!.close ? ((activePoint.close - points[0]!.close) / points[0]!.close) * 100 : 0,
-    timeLabels: buildTimeAxis(timeAxisDates, opts.width),
+    timeLabels: buildTimeAxis(timeAxisDates, dimensions.width),
     cursorX,
     cursorY,
     cursorColumn,
@@ -1246,16 +1270,16 @@ export function renderChart(
     };
   }
 
-  const { width, colors: palette, mode } = opts;
+  const { width, height, showVolume, volumeHeight, colors: palette, mode } = scene;
   const axisMode = opts.axisMode ?? "price";
   const currency = opts.currency ?? "USD";
   const assetCategory = opts.assetCategory;
 
   // Braille resolution: 2 dot-columns per terminal column, 4 dot-rows per terminal row
   const dotWidth = width * 2;
-  const volTermRows = opts.showVolume ? opts.volumeHeight : 0;
-  const chartTermRows = opts.height - volTermRows;
-  const totalDotH = opts.height * 4;
+  const volTermRows = showVolume ? volumeHeight : 0;
+  const chartTermRows = height - volTermRows;
+  const totalDotH = height * 4;
   const chartDotBottom = chartTermRows * 4 - 1;
   const volDotTop = chartTermRows * 4;
   const volDotBottom = totalDotH - 1;
@@ -1297,7 +1321,7 @@ export function renderChart(
       break;
   }
 
-  if (opts.showVolume && volTermRows > 0) {
+  if (showVolume && volTermRows > 0) {
     drawVolumeBars(
       buf,
       points,
@@ -1318,7 +1342,7 @@ export function renderChart(
   const { activePoint, priceAtCursor, crosshairPrice, dateAtCursor, changeAtCursor, changePctAtCursor } = scene;
 
   if (scene.cursorDotX !== null) {
-    drawCrosshair(buf, scene.cursorDotX, 0, opts.showVolume ? volDotBottom : chartDotBottom, palette.crosshairColor);
+    drawCrosshair(buf, scene.cursorDotX, 0, showVolume ? volDotBottom : chartDotBottom, palette.crosshairColor);
   }
 
   const axisLabelsByRow = new Map<number, string>();

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -349,6 +349,25 @@ describe("renderChart", () => {
     expect(scene?.max).toBe(18);
   });
 
+  test("normalizes fractional web dimensions before drawing volume bars", () => {
+    const projection = projectChartData(chartFixture, 12, "area", false);
+    const result = renderChart(projection.points, {
+      width: 12.5,
+      height: 7.3,
+      showVolume: true,
+      volumeHeight: 3,
+      cursorX: null,
+      cursorY: null,
+      mode: projection.effectiveMode,
+      colors: palette,
+    });
+
+    expect(result.lines).toHaveLength(7);
+    expect(result.pixelBuffer?.width).toBe(24);
+    expect(result.pixelBuffer?.height).toBe(28);
+    expect(result.axisLabels.every((entry) => Number.isInteger(entry.row))).toBe(true);
+  });
+
   test("keeps one decimal on zoomed equity axes even when whole-dollar ticks are distinct", () => {
     const mediumRangeFixture: PricePoint[] = [
       { date: new Date("2024-01-02T09:30:00Z"), close: 233.82, volume: 100 },

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -5,7 +5,8 @@ import { useShortcut } from "../../react/input";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useChartQueries } from "../../market-data/hooks";
 import { buildChartKey } from "../../market-data/selectors";
-import { useAppState, usePaneSettingValue } from "../../state/app-context";
+import { useAppSelector, usePaneSettingValue } from "../../state/app-context";
+import { usePaneFooter, type PaneHint } from "../layout/pane-footer";
 import { blendHex, colors, getComparisonSeriesColor, priceColor } from "../../theme/colors";
 import type { BrokerContractRef } from "../../types/instrument";
 import type { PricePoint } from "../../types/financials";
@@ -93,7 +94,6 @@ import { resolveChartRendererState } from "./native/renderer-selection";
 import { getNativeSurfaceManager } from "./native/surface-manager";
 import { syncCachedNativeSurface } from "./native/surface-sync";
 import { formatAxisCell, formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
-import { ChartControlHint } from "./chart-control-hint";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
   area: "A",
@@ -601,7 +601,7 @@ function ComparisonStockChartView({
   const headerRows = 1;
   const controlRows = 2;
   const timeAxisRows = 1;
-  const helpRows = 1;
+  const helpRows = 0;
   const legendColumns = getLegendColumns(width);
   const legendNeededRows = symbols.length > 0 ? Math.ceil(symbols.length / legendColumns) : 0;
   const legendRows = legendNeededRows > 0
@@ -1099,6 +1099,63 @@ function ComparisonStockChartView({
   ), [chartColors, chartHeight, chartWidth, displayCursorX, displayCursorY, effectiveRenderer, projection, useCanvasChart, viewState.selectedSymbol]);
 
   const result = effectiveRenderer === "kitty" || useCanvasChart ? staticResult : interactiveResult!;
+  const timeAxisLabel = result.timeLabels || staticResult.timeLabels;
+  const footerHints = useMemo<PaneHint[]>(() => {
+    const zoomIn = () => {
+      setViewState((current) => applyComparisonZoomAroundAnchor(
+        clearActivePreset(current),
+        current.zoomLevel * 1.5,
+        RIGHT_EDGE_ANCHOR_RATIO,
+        series,
+      ));
+    };
+    const resetView = () => {
+      pendingCanonicalResetRef.current += 1;
+      updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
+      setViewState((current) => ({
+        ...(resolveResolutionSelection(current, effectiveResolution, supportMap, visibleDateWindow) ?? current),
+        panOffset: 0,
+        zoomLevel: 1,
+        cursorX: null,
+        cursorY: null,
+      }));
+    };
+    const cycleRange = () => {
+      const currentIndex = TIME_RANGES.indexOf(viewState.presetRange);
+      setRangePreset(TIME_RANGES[(currentIndex + 1) % TIME_RANGES.length] ?? TIME_RANGES[0]!);
+    };
+
+    return [
+      {
+        id: "mode",
+        key: "m",
+        label: "ode",
+        onPress: () => setViewState((current) => ({
+          ...current,
+          renderMode: current.renderMode === "line" ? "area" : "line",
+        })),
+      },
+      {
+        id: "resolution",
+        key: "r",
+        label: "es",
+        onPress: () => {
+          const currentIndex = resolutionChips.indexOf(effectiveResolution);
+          const nextResolution = resolutionChips[(currentIndex + 1) % resolutionChips.length] ?? "auto";
+          setResolution(nextResolution);
+        },
+      },
+      { id: "zoom", key: "+/-", label: "zoom", onPress: zoomIn },
+      { id: "reset", key: "0", label: "reset", onPress: resetView },
+      ...(width >= 72 ? [{ id: "range", key: "1-7", label: "range", onPress: cycleRange }] : []),
+    ];
+  }, [effectiveResolution, resolutionChips, series, supportMap, viewState.presetRange, visibleDateWindow, width]);
+
+  usePaneFooter("comparison-chart", () => ({
+    order: 10,
+    hints: footerHints,
+  }), [footerHints]);
+
   const liveScene = useMemo(() => (
     effectiveRenderer === "kitty"
       ? staticScene
@@ -1901,8 +1958,8 @@ function ComparisonStockChartView({
         {axisBox}
       </Box>
 
-      <Box height={1}>
-        <Text fg={colors.textDim}>{result.timeLabels || staticResult.timeLabels}</Text>
+      <Box height={timeAxisRows}>
+        <Text fg={colors.textDim}>{timeAxisLabel}</Text>
       </Box>
 
       {legendRows > 0 && (
@@ -1950,16 +2007,6 @@ function ComparisonStockChartView({
         </ScrollBox>
       )}
 
-      <Box height={1}>
-        <Box flexDirection="row" gap={1}>
-          <ChartControlHint hotkey="m" label="ode" />
-          <ChartControlHint hotkey="r" label="es" />
-          <ChartControlHint hotkey="+/-" label="zoom" />
-          <ChartControlHint hotkey="0" label="reset" />
-          {width >= 72 && <ChartControlHint hotkey="1-7" label="range" />}
-          {width >= 88 && <ChartControlHint hotkey="up/down" label="legend" />}
-        </Box>
-      </Box>
     </Box>
   );
 }
@@ -1967,30 +2014,32 @@ function ComparisonStockChartView({
 const MemoizedComparisonStockChartView = memo(ComparisonStockChartView);
 
 export function ComparisonStockChart(props: ComparisonStockChartProps) {
-  const { state } = useAppState();
+  const tickers = useAppSelector((state) => state.tickers);
+  const financials = useAppSelector((state) => state.financials);
+  const chartPreferences = useAppSelector((state) => state.config.chartPreferences);
   const symbolsKey = props.symbols.join("|");
   const stableSymbols = useMemo(() => props.symbols, [symbolsKey]);
   const symbolSources = useMemo<ComparisonChartSymbolSource[]>(() => stableSymbols.map((symbol) => {
-    const ticker = state.tickers.get(symbol) ?? null;
-    const financials = state.financials.get(symbol) ?? null;
+    const ticker = tickers.get(symbol) ?? null;
+    const financial = financials.get(symbol) ?? null;
     const instrument = ticker?.metadata.broker_contracts?.[0] ?? null;
     return {
       symbol,
-      currency: financials?.quote?.currency ?? ticker?.metadata.currency,
+      currency: financial?.quote?.currency ?? ticker?.metadata.currency,
       exchange: ticker?.metadata.exchange ?? "",
       brokerId: instrument?.brokerId,
       brokerInstanceId: instrument?.brokerInstanceId,
       instrument,
-      priceHistory: financials?.priceHistory ?? [],
+      priceHistory: financial?.priceHistory ?? [],
     };
-  }), [stableSymbols, state.financials, state.tickers]);
+  }), [financials, stableSymbols, tickers]);
 
   return (
     <MemoizedComparisonStockChartView
       {...props}
       symbols={stableSymbols}
-      defaultRenderMode={state.config.chartPreferences.defaultRenderMode}
-      preferredRenderer={state.config.chartPreferences.renderer}
+      defaultRenderMode={chartPreferences.defaultRenderMode}
+      preferredRenderer={chartPreferences.renderer}
       symbolSources={symbolSources}
     />
   );

--- a/src/components/chart/native/chart-rasterizer.ts
+++ b/src/components/chart/native/chart-rasterizer.ts
@@ -1,4 +1,5 @@
 import { type PixelResolution } from "../../../ui";
+import { measurePerf } from "../../../utils/perf-marks";
 import { computeGridLines, type ChartScene } from "../chart-renderer";
 import type { ComparisonChartScene } from "../comparison-chart-renderer";
 import type { ChartRenderMode } from "../chart-types";
@@ -475,32 +476,34 @@ function getOverlayPlotBottom(overlay: NativeCrosshairOverlay, pixelHeight: numb
 }
 
 export function renderNativeChartBase(scene: ChartScene, pixelWidth: number, pixelHeight: number): NativeChartBitmap {
-  const pixels = new Uint8Array(pixelWidth * pixelHeight * 4);
-  if (scene.points.length === 0 || pixelWidth <= 0 || pixelHeight <= 0) {
-    return { width: Math.max(pixelWidth, 1), height: Math.max(pixelHeight, 1), pixels };
-  }
+  return measurePerf("chart.native.base", () => {
+    const pixels = new Uint8Array(pixelWidth * pixelHeight * 4);
+    if (scene.points.length === 0 || pixelWidth <= 0 || pixelHeight <= 0) {
+      return { width: Math.max(pixelWidth, 1), height: Math.max(pixelHeight, 1), pixels };
+    }
 
-  fillBackground(pixels, pixelWidth, pixelHeight, parseHex(scene.colors.bgColor, 1));
-  const layout = getChartPixelLayout(scene, pixelWidth, pixelHeight);
-  drawPriceGrid(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
+    fillBackground(pixels, pixelWidth, pixelHeight, parseHex(scene.colors.bgColor, 1));
+    const layout = getChartPixelLayout(scene, pixelWidth, pixelHeight);
+    drawPriceGrid(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
 
-  switch (scene.mode) {
-    case "area":
-    case "line":
-      drawLineSeries(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
-      break;
-    case "candles":
-      drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "candles");
-      break;
-    case "ohlc":
-      drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "ohlc");
-      break;
-  }
+    switch (scene.mode) {
+      case "area":
+      case "line":
+        drawLineSeries(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
+        break;
+      case "candles":
+        drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "candles");
+        break;
+      case "ohlc":
+        drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "ohlc");
+        break;
+    }
 
-  drawIndicatorOverlays(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
-  drawVolume(pixels, pixelWidth, pixelHeight, scene, layout.volumeTop, layout.volumeBottom);
+    drawIndicatorOverlays(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
+    drawVolume(pixels, pixelWidth, pixelHeight, scene, layout.volumeTop, layout.volumeBottom);
 
-  return { width: pixelWidth, height: pixelHeight, pixels };
+    return { width: pixelWidth, height: pixelHeight, pixels };
+  }, { pixelWidth, pixelHeight, points: scene.points.length, mode: scene.mode });
 }
 
 interface ComparisonPathSample {
@@ -642,14 +645,16 @@ export function renderNativeCrosshairOverlay(
   pixelWidth: number,
   pixelHeight: number,
 ): NativeChartBitmap {
-  const pixels = new Uint8Array(Math.max(pixelWidth, 1) * Math.max(pixelHeight, 1) * 4);
-  if (pixelWidth <= 0 || pixelHeight <= 0) {
-    return { width: Math.max(pixelWidth, 1), height: Math.max(pixelHeight, 1), pixels };
-  }
+  return measurePerf("chart.native.crosshair", () => {
+    const pixels = new Uint8Array(Math.max(pixelWidth, 1) * Math.max(pixelHeight, 1) * 4);
+    if (pixelWidth <= 0 || pixelHeight <= 0) {
+      return { width: Math.max(pixelWidth, 1), height: Math.max(pixelHeight, 1), pixels };
+    }
 
-  const plotBottom = getOverlayPlotBottom(overlay, pixelHeight);
-  drawCrosshairOverlay(pixels, pixelWidth, pixelHeight, overlay, 0, plotBottom);
-  return { width: pixelWidth, height: pixelHeight, pixels };
+    const plotBottom = getOverlayPlotBottom(overlay, pixelHeight);
+    drawCrosshairOverlay(pixels, pixelWidth, pixelHeight, overlay, 0, plotBottom);
+    return { width: pixelWidth, height: pixelHeight, pixels };
+  }, { pixelWidth, pixelHeight });
 }
 
 export function intersectCellRects(a: CellRect, b: CellRect): CellRect | null {

--- a/src/components/chart/stock-chart-renderer-switch.test.tsx
+++ b/src/components/chart/stock-chart-renderer-switch.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { createTestRenderer } from "@opentui/core/testing";
 import { createOpenTuiTestRoot as createRoot } from "../../renderers/opentui/test-utils";
 import { act, useReducer } from "react";
+import { PaneFooterBar, PaneFooterProvider } from "../layout/pane-footer";
 import {
   AppContext,
   PaneInstanceProvider,
@@ -15,6 +16,7 @@ import { cloneLayout, createDefaultConfig, type AppConfig } from "../../types/co
 import type { DataProvider } from "../../types/data-provider";
 import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
+import { Box } from "../../ui";
 import { StockChart } from "./stock-chart";
 
 const TEST_PANE_ID = "ticker-detail:test";
@@ -137,7 +139,14 @@ function ChartHarness({
   return (
     <AppContext value={{ state, dispatch }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
-        <StockChart width={84} height={16} focused />
+        <PaneFooterProvider>
+          {(footer) => (
+            <Box flexDirection="column" width={84} height={16}>
+              <StockChart width={84} height={15} focused />
+              <PaneFooterBar footer={footer} focused width={84} />
+            </Box>
+          )}
+        </PaneFooterProvider>
       </PaneInstanceProvider>
     </AppContext>
   );
@@ -276,6 +285,45 @@ describe("StockChart renderer switching", () => {
     expect(frame).toContain("1:1D");
     expect(frame).toContain("2:1W");
     expect(frame).toContain("AUTO");
+  });
+
+  test("keeps the time axis above the pane footer", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    const ticker = makeTicker(symbol);
+    const history = makeMonthlyHistory(72, new Date(Date.UTC(2019, 0, 1)));
+    const provider = makeProvider({ [symbol]: history });
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedDataProviderForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: history,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 32 });
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+        />,
+      );
+    });
+
+    await flushFrames(4);
+    const lines = testSetup.captureCharFrame().split("\n");
+    const chartAndFooterLines = lines.slice(0, 16);
+    const footerLine = chartAndFooterLines.at(-1) ?? "";
+
+    expect(chartAndFooterLines.join("\n")).toContain("Dec 2019");
+    expect(footerLine).toContain("[m]ode");
+    expect(footerLine).not.toContain("Dec 2019");
+    expect(footerLine).not.toContain("Dec 2024");
   });
 
   test("switches from braille to kitty without crashing text updates", async () => {
@@ -574,7 +622,7 @@ describe("StockChart renderer switching", () => {
     expect(resolutionRequests.some((request) => request.resolution === "1d")).toBe(true);
     expect(detailRequests).toHaveLength(0);
     expect(frame).not.toContain("No price history available.");
-    expect(frame).toContain("Apr");
+    expect(frame).toMatch(/\b[A-Z][a-z]{2} \d{1,2}/);
   });
 
   test("mouse scroll at the auto edge does not zoom into narrower detail windows", async () => {

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -4,6 +4,7 @@ import { TextAttributes, type BoxRenderable, type NativeRendererHost as CliRende
 import { useNativeRenderer, useUiCapabilities } from "../../ui";
 import { useShortcut } from "../../react/input";
 import { useAppDispatch, useAppSelector, usePaneInstance, usePaneInstanceId, usePaneSettingValue, usePaneTicker } from "../../state/app-context";
+import { usePaneFooter, type PaneHint } from "../layout/pane-footer";
 import { saveConfig } from "../../data/config-store";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { colors } from "../../theme/colors";
@@ -164,6 +165,7 @@ interface StockChartProps {
   indicatorConfig?: IndicatorConfig;
   showVolume?: boolean;
   footerControls?: ReactNode;
+  footerHints?: PaneHint[];
 }
 
 interface ResolvedStockChartProps extends StockChartProps {
@@ -1483,6 +1485,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   indicatorConfig: indicatorConfigOverride,
   showVolume: showVolumeOverride,
   footerControls,
+  footerHints,
   symbol,
   ticker,
   financials,
@@ -1753,11 +1756,14 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     (value) => Array.isArray(value) && value.length > 0,
     "No price history available.",
   );
-  const boundsBodyState = !compact && !boundsChartEntry && fallbackPriceHistory.length > 0
+  const shouldUseBoundsFallback = !compact
+    && fallbackPriceHistory.length > 0
+    && (!boundsChartEntry || (rawBoundsBodyState.blocking && !rawBoundsBodyState.data?.length));
+  const boundsBodyState = shouldUseBoundsFallback
     ? {
       data: fallbackPriceHistory,
       blocking: false,
-      updating: false,
+      updating: !!boundsChartEntry && rawBoundsBodyState.blocking,
       emptyMessage: null,
       errorMessage: null,
     }
@@ -1771,7 +1777,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const minChartWidth = compact ? 12 : 20;
   const measurementChartWidth = Math.max(width - axisSectionWidthBudget - axisGap, minChartWidth);
   const headerRows = compact ? 0 : 4;
-  const helpRow = compact ? 0 : 1;
+  const helpRow = compact ? 1 : 0;
   const timeAxisRow = 1;
   const volumeHeight = showVolume && !compact ? 3 : 0;
   const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
@@ -3448,6 +3454,102 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     ? (renderBodyState.errorMessage ?? renderBodyState.emptyMessage)
     : null;
   const isUpdating = !compact && (renderBodyState.updating || boundsBodyState.updating);
+  const timeAxisLabel = selectionScene?.timeLabels ?? staticResult.timeLabels;
+  const chartFooterHints = useMemo<PaneHint[]>(() => {
+    if (compact) return [];
+
+    const cycleMode = () => {
+      setViewState((current) => {
+        const activeMode = current.renderMode ?? "area";
+        const index = CHART_RENDER_MODES.indexOf(activeMode);
+        const nextMode = CHART_RENDER_MODES[(index + 1) % CHART_RENDER_MODES.length]!;
+        persistDefaultRenderMode(nextMode);
+        return { ...current, renderMode: nextMode };
+      });
+    };
+    const cycleResolution = () => {
+      const currentIndex = resolutionChips.indexOf(selectedResolution);
+      const nextResolution = resolutionChips[(currentIndex + 1) % resolutionChips.length] ?? "auto";
+      setResolution(nextResolution);
+    };
+    const zoomIn = () => {
+      if (effectiveResolution === "auto") {
+        requestAutoWindow(resolveAutoZoomWindow({
+          historyPoints: history,
+          boundsDates: boundsHistoryDates,
+          currentWindow: navigableDateWindow,
+          direction: "in",
+          anchorRatio: RIGHT_EDGE_ANCHOR_RATIO,
+        }));
+        return;
+      }
+      setViewState((current) => applyZoomAroundAnchor(current, current.zoomLevel * 1.5, RIGHT_EDGE_ANCHOR_RATIO, boundsHistory));
+    };
+    const resetView = () => {
+      if (effectiveResolution === "auto") {
+        pendingAutoWindowRef.current = null;
+        setPendingAutoWindowOverride(null);
+        setRenderedAutoView(null);
+        updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
+        setViewState((current) => clearAutoViewportState(current));
+        return;
+      }
+      pendingCanonicalResetRef.current += 1;
+      updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
+      setViewState((current) => {
+        const nextState = resolveViewportResolutionSelection(
+          current,
+          effectiveResolution,
+          selectionSupportMap,
+          visibleDateWindow,
+        ) ?? current;
+        return {
+          ...nextState,
+          panOffset: 0,
+          zoomLevel: 1,
+          cursorX: null,
+          cursorY: null,
+        };
+      });
+    };
+    const cycleRange = () => {
+      const currentIndex = activePreset ? TIME_RANGES.indexOf(activePreset) : -1;
+      const nextRange = TIME_RANGES[(currentIndex + 1) % TIME_RANGES.length] ?? TIME_RANGES[0]!;
+      setRange(nextRange);
+    };
+
+    return [
+      { id: "mode", key: "m", label: "ode", onPress: cycleMode },
+      ...(footerHints ?? []),
+      { id: "resolution", key: "r", label: "es", onPress: cycleResolution },
+      { id: "zoom", key: "+/-", label: "zoom", onPress: zoomIn },
+      { id: "reset", key: "0", label: "reset", onPress: resetView },
+      ...(width >= 72 ? [{ id: "range", key: "1-7", label: "range", onPress: cycleRange }] : []),
+    ];
+  }, [
+    activePreset,
+    boundsHistory,
+    boundsHistoryDates,
+    compact,
+    effectiveResolution,
+    footerHints,
+    history,
+    navigableDateWindow,
+    resolutionChips,
+    selectedResolution,
+    selectionSupportMap,
+    visibleDateWindow,
+    width,
+  ]);
+
+  usePaneFooter("stock-chart", () => (
+    compact
+      ? null
+      : {
+          order: 10,
+          hints: chartFooterHints,
+        }
+  ), [chartFooterHints, compact]);
 
   useEffect(() => {
     queueMicrotask(() => renderer.requestRender());
@@ -3977,17 +4079,21 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       </Box>
 
       <Box height={1}>
-        <Text fg={colors.textDim}>{selectionScene?.timeLabels ?? staticResult.timeLabels}</Text>
+        <Text fg={colors.textDim}>{timeAxisLabel}</Text>
       </Box>
 
-      <Box height={1} flexDirection="row" gap={1}>
-        <ChartControlHint hotkey="m" label="ode" />
-        {footerControls}
-        <ChartControlHint hotkey="r" label="es" />
-        <ChartControlHint hotkey="+/-" label="zoom" />
-        <ChartControlHint hotkey="0" label="reset" />
-        {width >= 72 && <ChartControlHint hotkey="1-7" label="range" />}
-      </Box>
+      {compact && (
+        <>
+          <Box height={1} flexDirection="row" gap={1}>
+            <ChartControlHint hotkey="m" label="ode" />
+            {footerControls}
+            <ChartControlHint hotkey="r" label="es" />
+            <ChartControlHint hotkey="+/-" label="zoom" />
+            <ChartControlHint hotkey="0" label="reset" />
+            {width >= 72 && <ChartControlHint hotkey="1-7" label="range" />}
+          </Box>
+        </>
+      )}
     </Box>
   );
 });

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -17,7 +17,13 @@ import {
   commandBarSubtleText,
   commandBarText,
 } from "../../theme/colors";
-import { getFocusedCollectionId, useAppState, useFocusedTicker } from "../../state/app-context";
+import {
+  getFocusedCollectionId,
+  useAppDispatch,
+  useAppSelector,
+  useFocusedTicker,
+  type AppState,
+} from "../../state/app-context";
 import { fuzzyFilter } from "../../utils/fuzzy-search";
 import { commands, getThemeOptions, matchPrefix, type Command } from "./command-registry";
 import { applyTheme } from "../../theme/colors";
@@ -240,7 +246,52 @@ export function CommandBar({
   quitApp,
   onCheckForUpdates,
 }: CommandBarProps) {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config);
+  const paneState = useAppSelector((state) => state.paneState);
+  const tickers = useAppSelector((state) => state.tickers);
+  const financials = useAppSelector((state) => state.financials);
+  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
+  const layoutHistory = useAppSelector((state) => state.layoutHistory);
+  const recentTickers = useAppSelector((state) => state.recentTickers);
+  const commandBarOpen = useAppSelector((state) => state.commandBarOpen);
+  const commandBarQuery = useAppSelector((state) => state.commandBarQuery);
+  const commandBarLaunchRequest = useAppSelector((state) => state.commandBarLaunchRequest);
+  const updateAvailable = useAppSelector((state) => state.updateAvailable);
+  const updateProgress = useAppSelector((state) => state.updateProgress);
+  const updateCheckInProgress = useAppSelector((state) => state.updateCheckInProgress);
+  const updateNotice = useAppSelector((state) => state.updateNotice);
+  const state = useMemo(() => ({
+    config,
+    paneState,
+    tickers,
+    financials,
+    focusedPaneId,
+    layoutHistory,
+    recentTickers,
+    commandBarOpen,
+    commandBarQuery,
+    commandBarLaunchRequest,
+    updateAvailable,
+    updateProgress,
+    updateCheckInProgress,
+    updateNotice,
+  }) as AppState, [
+    commandBarLaunchRequest,
+    commandBarOpen,
+    commandBarQuery,
+    config,
+    financials,
+    focusedPaneId,
+    layoutHistory,
+    paneState,
+    recentTickers,
+    tickers,
+    updateAvailable,
+    updateCheckInProgress,
+    updateNotice,
+    updateProgress,
+  ]);
   const stateRef = useRef(state);
   stateRef.current = state;
   const { symbol: activeTickerSymbol, ticker: activeTickerData, financials: activeFinancials } = useFocusedTicker();
@@ -4154,11 +4205,12 @@ export function CommandBar({
 
   const setHoveredIndex = useCallback((index: number | null) => {
     if (!currentRoute) {
-      setRootHoveredIdx(index);
+      setRootHoveredIdx((current) => (current === index ? current : index));
       return;
     }
     updateTopRoute((route) => {
       if (route.kind === "mode" || route.kind === "picker" || route.kind === "pane-settings") {
+        if (route.hoveredIdx === index) return route;
         return { ...route, hoveredIdx: index };
       }
       return route;

--- a/src/components/data-table-stack-view.tsx
+++ b/src/components/data-table-stack-view.tsx
@@ -1,5 +1,5 @@
 import { Box } from "../ui";
-import { useShortcut } from "../react/input";
+import { useShortcut, useViewport } from "../react/input";
 import { type ScrollBoxRenderable } from "../ui";
 import {
   useCallback,
@@ -90,7 +90,7 @@ export function DataTableStackView<
   renderSectionHeader,
   emptyStateTitle,
   emptyStateHint,
-  virtualize,
+  virtualize = true,
   overscan,
   showHorizontalScrollbar,
 }: DataTableStackViewProps<T, C>) {
@@ -99,6 +99,7 @@ export function DataTableStackView<
   const [internalHoveredIdx, setInternalHoveredIdx] = useState<number | null>(
     null,
   );
+  const appViewport = useViewport();
 
   const effectiveHeaderScrollRef = headerScrollRef ?? internalHeaderScrollRef;
   const effectiveScrollRef = scrollRef ?? internalScrollRef;
@@ -183,13 +184,16 @@ export function DataTableStackView<
   useEffect(() => {
     const scrollBox = effectiveScrollRef.current;
     if (!scrollBox?.viewport || selectedIndex < 0) return;
-    const viewportHeight = Math.max(scrollBox.viewport.height, 1);
+    const viewportHeight = Math.max(
+      1,
+      Math.min(scrollBox.viewport.height, Math.ceil(appViewport.height)),
+    );
     if (selectedIndex < scrollBox.scrollTop) {
       scrollBox.scrollTo(selectedIndex);
     } else if (selectedIndex >= scrollBox.scrollTop + viewportHeight) {
       scrollBox.scrollTo(selectedIndex - viewportHeight + 1);
     }
-  }, [effectiveScrollRef, items.length, selectedIndex]);
+  }, [appViewport.height, effectiveScrollRef, items.length, selectedIndex]);
 
   const rootContent = (
     <Box
@@ -198,6 +202,7 @@ export function DataTableStackView<
       width={rootWidth}
       height={rootHeight}
       backgroundColor={rootBackgroundColor}
+      overflow="hidden"
     >
       {rootBefore}
       <DataTable<T, C>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,6 +17,13 @@ export { DataTableStackView } from "./data-table-stack-view";
 export type { DataTableStackViewProps } from "./data-table-stack-view";
 export { FeedDataTableStackView } from "./feed-data-table-stack-view";
 export type { FeedDataTableItem } from "./feed-data-table-stack-view";
+export { PaneFooterBar, usePaneFooter, usePaneHints } from "./layout/pane-footer";
+export type {
+  PaneFooterRegistration,
+  PaneFooterSegment,
+  PaneFooterPart,
+  PaneHint,
+} from "./layout/pane-footer";
 
 // Theme
 export { colors, priceColor, hoverBg } from "../theme/colors";

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -2,7 +2,8 @@ import { Box, Text, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
-import { getPaneBodyHeight, getPaneBodyHorizontalInset } from "./pane-sizing";
+import { PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
+import { getPaneBodyHeight } from "./pane-sizing";
 
 interface FloatingPaneWrapperProps {
   title: string;
@@ -23,6 +24,7 @@ interface FloatingPaneWrapperProps {
   onResizeMouseDown?: (event: any) => void;
   onResizeMouseDrag?: (event: any) => void;
   onResizeMouseDragEnd?: (event: any) => void;
+  footer?: CombinedPaneFooter | null;
   children: ReactNode;
 }
 
@@ -46,12 +48,12 @@ export function FloatingPaneWrapper({
   onResizeMouseDown,
   onResizeMouseDrag,
   onResizeMouseDragEnd,
+  footer,
   children,
 }: FloatingPaneWrapperProps) {
   const { nativePaneChrome } = useUiCapabilities();
   const bg = floatingPaneBg(focused);
-  const bodyHeight = nativePaneChrome ? Math.max(1, height - 1) : getPaneBodyHeight(height);
-  const bodyInset = nativePaneChrome ? 0 : getPaneBodyHorizontalInset(focused);
+  const bodyHeight = getPaneBodyHeight(height);
 
   return (
     <Box
@@ -63,6 +65,7 @@ export function FloatingPaneWrapper({
       zIndex={zIndex}
       backgroundColor={bg}
       flexDirection="column"
+      overflow="hidden"
       {...(nativePaneChrome ? {
         "data-gloom-role": "pane-window",
         "data-floating": "true",
@@ -86,9 +89,11 @@ export function FloatingPaneWrapper({
       />
 
       {/* Content */}
-      <Box height={bodyHeight} overflow="hidden" paddingLeft={bodyInset} paddingRight={bodyInset}>
+      <Box height={bodyHeight} overflow="hidden">
         {children}
       </Box>
+
+      <PaneFooterBar footer={footer} focused={focused} width={width} reserveRight={2} />
 
       {nativePaneChrome ? (
         <Box

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,9 +1,15 @@
-import { Box, SpinnerMark, Text } from "../../ui";
-import { useState, useEffect } from "react";
-import { TextAttributes } from "../../ui";
+import { Box, SpinnerMark, Text, TextAttributes, useRendererHost, useUiCapabilities } from "../../ui";
+import { useCallback, useEffect } from "react";
 import { colors, priceColor } from "../../theme/colors";
 import { useAppActive } from "../../state/app-activity";
-import { useAppState } from "../../state/app-context";
+import { useAppDispatch, useAppSelector } from "../../state/app-context";
+import {
+  selectBaseCurrency,
+  selectUpdateAvailable,
+  selectUpdateCheckInProgress,
+  selectUpdateNotice,
+  selectUpdateProgress,
+} from "../../state/selectors-ui";
 import { getSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { useQuoteEntry, useResolvedEntryValue } from "../../market-data/hooks";
 import { formatPercentRaw } from "../../utils/format";
@@ -13,10 +19,19 @@ import { VERSION } from "../../version";
 
 const SPY_REFRESH_MS = 5 * 60_000; // 5 min
 const UPDATE_NOTICE_DURATION_MS = 5_000;
+const TITLEBAR_TRAFFIC_LIGHT_WIDTH = 11;
+
+interface HeaderMouseEvent {
+  button?: number;
+  preventDefault?: () => void;
+}
 
 function UpdateStatus() {
-  const { state, dispatch } = useAppState();
-  const { updateAvailable, updateProgress, updateCheckInProgress, updateNotice } = state;
+  const dispatch = useAppDispatch();
+  const updateAvailable = useAppSelector(selectUpdateAvailable);
+  const updateProgress = useAppSelector(selectUpdateProgress);
+  const updateCheckInProgress = useAppSelector(selectUpdateCheckInProgress);
+  const updateNotice = useAppSelector(selectUpdateNotice);
 
   useEffect(() => {
     if (!updateNotice || updateAvailable || updateProgress || updateCheckInProgress) return;
@@ -85,8 +100,10 @@ function UpdateStatus() {
 }
 
 export function Header() {
-  const { state } = useAppState();
+  const baseCurrency = useAppSelector(selectBaseCurrency);
   const appActive = useAppActive();
+  const rendererHost = useRendererHost();
+  const { titleBarOverlay } = useUiCapabilities();
   const spyQuoteEntry = useQuoteEntry("SPY", null);
   const spyQuote = useResolvedEntryValue(spyQuoteEntry);
 
@@ -114,14 +131,23 @@ export function Header() {
   const mktState = spyQuote?.marketState;
   const mktLabel = mktState ? marketStateLabel(mktState) : "";
   const mktColor = mktState ? marketStateColor(mktState) : colors.headerText;
+  const handleMouseDown = useCallback((event: HeaderMouseEvent) => {
+    if (!titleBarOverlay || !rendererHost.startWindowDrag) return;
+    if (typeof event.button === "number" && event.button !== 0) return;
+    event.preventDefault?.();
+    void Promise.resolve(rendererHost.startWindowDrag()).catch(() => {});
+  }, [rendererHost, titleBarOverlay]);
 
   return (
     <Box
       flexDirection="row"
       height={1}
       backgroundColor={colors.header}
+      data-gloom-role="app-header"
+      data-titlebar-overlay={titleBarOverlay ? "true" : undefined}
+      onMouseDown={handleMouseDown}
     >
-      <Box paddingLeft={1}>
+      <Box paddingLeft={titleBarOverlay ? TITLEBAR_TRAFFIC_LIGHT_WIDTH : 1}>
         <Text attributes={TextAttributes.BOLD} fg={colors.headerText}>
           Gloomberb v{VERSION}
         </Text>
@@ -144,7 +170,7 @@ export function Header() {
       )}
       <Box paddingRight={1}>
         <Text fg={colors.headerText}>
-          {state.config.baseCurrency}
+          {baseCurrency}
         </Text>
       </Box>
     </Box>

--- a/src/components/layout/pane-footer.test.tsx
+++ b/src/components/layout/pane-footer.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { Box } from "../../ui";
+import { testRender } from "../../renderers/opentui/test-utils";
+import {
+  PaneFooterBar,
+  PaneFooterProvider,
+  usePaneFooter,
+} from "./pane-footer";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+});
+
+function Registration({
+  visible = true,
+  onRefresh,
+}: {
+  visible?: boolean;
+  onRefresh?: () => void;
+}) {
+  usePaneFooter("test", () => {
+    if (!visible) return null;
+    return {
+      info: [
+        {
+          id: "rows",
+          parts: [
+            { text: "Rows", tone: "label" },
+            { text: "12", tone: "value", bold: true },
+          ],
+        },
+      ],
+      hints: [
+        { id: "refresh", key: "r", label: "efresh", onPress: onRefresh },
+      ],
+    };
+  }, [onRefresh, visible]);
+  return null;
+}
+
+function FooterHarness({
+  focused = false,
+  visible = true,
+  onRefresh,
+}: {
+  focused?: boolean;
+  visible?: boolean;
+  onRefresh?: () => void;
+}) {
+  return (
+    <PaneFooterProvider>
+      {(footer) => (
+        <Box width={64} height={1}>
+          <Registration visible={visible} onRefresh={onRefresh} />
+          <PaneFooterBar footer={footer} focused={focused} width={64} />
+        </Box>
+      )}
+    </PaneFooterProvider>
+  );
+}
+
+describe("PaneFooterBar", () => {
+  test("renders info left and hints right", async () => {
+    testSetup = await testRender(<FooterHarness />, { width: 64, height: 1 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Rows 12");
+    expect(frame).toContain("[r]efresh");
+  });
+
+  test("calls hint onPress from mouse interaction", async () => {
+    let refreshCount = 0;
+    testSetup = await testRender(<FooterHarness onRefresh={() => { refreshCount += 1; }} />, { width: 64, height: 1 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const line = testSetup.captureCharFrame().split("\n")[0] ?? "";
+    const col = line.indexOf("[r]efresh");
+    expect(col).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(col + 1, 0);
+      await testSetup!.renderOnce();
+    });
+    expect(refreshCount).toBe(1);
+  });
+
+  test("keeps focused border from hiding content", async () => {
+    testSetup = await testRender(<FooterHarness focused />, { width: 64, height: 1 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("└");
+    expect(frame).toContain("┘");
+    expect(frame).toContain("Rows 12");
+    expect(frame).toContain("[r]efresh");
+  });
+
+  test("clears a registration when the component unmounts", async () => {
+    testSetup = await testRender(<FooterHarness visible={false} />, { width: 64, height: 1 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).not.toContain("Rows 12");
+    expect(frame).not.toContain("[r]efresh");
+  });
+});

--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -1,0 +1,401 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type DependencyList,
+  type ReactNode,
+} from "react";
+import { Box, Span, StyledText, Text, TextAttributes, useUiCapabilities } from "../../ui";
+import { colors, blendHex } from "../../theme/colors";
+
+export interface PaneFooterRegistration {
+  order?: number;
+  info?: PaneFooterSegment[];
+  hints?: PaneHint[];
+}
+
+export interface PaneFooterSegment {
+  id: string;
+  parts: PaneFooterPart[];
+  onPress?: () => void;
+  disabled?: boolean;
+}
+
+export interface PaneFooterPart {
+  text: string;
+  tone?: "label" | "value" | "muted" | "positive" | "negative" | "warning";
+  color?: string;
+  bold?: boolean;
+}
+
+export interface PaneHint {
+  id: string;
+  key: string;
+  label: string;
+  onPress?: () => void;
+  disabled?: boolean;
+}
+
+export interface CombinedPaneFooter {
+  info: PaneFooterSegment[];
+  hints: PaneHint[];
+}
+
+interface PaneFooterContextValue {
+  register(registrationId: string, registration: PaneFooterRegistration | null): void;
+  unregister(registrationId: string): void;
+}
+
+const PaneFooterContext = createContext<PaneFooterContextValue | null>(null);
+
+const EMPTY_FOOTER: CombinedPaneFooter = { info: [], hints: [] };
+
+function combineRegistrations(registrations: Map<string, PaneFooterRegistration>): CombinedPaneFooter {
+  if (registrations.size === 0) return EMPTY_FOOTER;
+
+  const ordered = Array.from(registrations.entries()).sort(([idA, a], [idB, b]) => {
+    const orderDelta = (a.order ?? 0) - (b.order ?? 0);
+    return orderDelta || idA.localeCompare(idB);
+  });
+
+  const info: PaneFooterSegment[] = [];
+  const hints: PaneHint[] = [];
+  for (const [, registration] of ordered) {
+    if (registration.info) info.push(...registration.info);
+    if (registration.hints) hints.push(...registration.hints);
+  }
+
+  if (info.length === 0 && hints.length === 0) return EMPTY_FOOTER;
+  return { info, hints };
+}
+
+function sameFooterParts(left: PaneFooterPart[], right: PaneFooterPart[]): boolean {
+  return left.length === right.length && left.every((part, index) => {
+    const other = right[index];
+    return !!other
+      && part.text === other.text
+      && part.tone === other.tone
+      && part.color === other.color
+      && part.bold === other.bold;
+  });
+}
+
+function sameFooterRegistration(
+  left: PaneFooterRegistration | null,
+  right: PaneFooterRegistration | null,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  const leftInfo = left.info ?? [];
+  const rightInfo = right.info ?? [];
+  const leftHints = left.hints ?? [];
+  const rightHints = right.hints ?? [];
+  return (left.order ?? 0) === (right.order ?? 0)
+    && leftInfo.length === rightInfo.length
+    && leftHints.length === rightHints.length
+    && leftInfo.every((segment, index) => {
+      const other = rightInfo[index];
+      return !!other
+        && segment.id === other.id
+        && segment.disabled === other.disabled
+        && sameFooterParts(segment.parts, other.parts);
+    })
+    && leftHints.every((hint, index) => {
+      const other = rightHints[index];
+      return !!other
+        && hint.id === other.id
+        && hint.key === other.key
+        && hint.label === other.label
+        && hint.disabled === other.disabled;
+    });
+}
+
+export function PaneFooterProvider({
+  children,
+}: {
+  children: (footer: CombinedPaneFooter) => ReactNode;
+}) {
+  const [registrations, setRegistrations] = useState<Map<string, PaneFooterRegistration>>(() => new Map());
+
+  const register = useCallback((registrationId: string, registration: PaneFooterRegistration | null) => {
+    setRegistrations((current) => {
+      const next = new Map(current);
+      if (registration && ((registration.info?.length ?? 0) > 0 || (registration.hints?.length ?? 0) > 0)) {
+        next.set(registrationId, registration);
+      } else {
+        next.delete(registrationId);
+      }
+      return next;
+    });
+  }, []);
+
+  const unregister = useCallback((registrationId: string) => {
+    setRegistrations((current) => {
+      if (!current.has(registrationId)) return current;
+      const next = new Map(current);
+      next.delete(registrationId);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(() => ({ register, unregister }), [register, unregister]);
+  const footer = useMemo(() => combineRegistrations(registrations), [registrations]);
+
+  return (
+    <PaneFooterContext.Provider value={value}>
+      {children(footer)}
+    </PaneFooterContext.Provider>
+  );
+}
+
+export function usePaneFooter(
+  registrationId: string,
+  factory: () => PaneFooterRegistration | null | undefined,
+  deps: DependencyList,
+) {
+  const context = useContext(PaneFooterContext);
+  const previousRegistrationRef = useRef<PaneFooterRegistration | null>(null);
+
+  useEffect(() => {
+    return () => {
+      previousRegistrationRef.current = null;
+      context?.unregister(registrationId);
+    };
+  }, [context, registrationId]);
+
+  useEffect(() => {
+    if (!context) return;
+    const nextRegistration = factory() ?? null;
+    if (sameFooterRegistration(previousRegistrationRef.current, nextRegistration)) return;
+    previousRegistrationRef.current = nextRegistration;
+    context.register(registrationId, nextRegistration);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context, registrationId, ...deps]);
+}
+
+export function usePaneHints(
+  registrationId: string,
+  factory: () => PaneHint[] | null | undefined,
+  deps: DependencyList,
+) {
+  usePaneFooter(registrationId, () => {
+    const hints = factory();
+    return hints && hints.length > 0 ? { hints } : null;
+  }, deps);
+}
+
+function footerToneColor(part: PaneFooterPart): string {
+  if (part.color) return part.color;
+  switch (part.tone) {
+    case "label":
+      return colors.textDim;
+    case "muted":
+      return colors.textMuted;
+    case "positive":
+      return colors.positive;
+    case "negative":
+      return colors.negative;
+    case "warning":
+      return colors.warning;
+    case "value":
+    default:
+      return colors.text;
+  }
+}
+
+function stopMouseEvent(event?: { stopPropagation?: () => void; preventDefault?: () => void }) {
+  event?.stopPropagation?.();
+  event?.preventDefault?.();
+}
+
+function SegmentView({ segment }: { segment: PaneFooterSegment }) {
+  const interactive = !!segment.onPress && !segment.disabled;
+  const attributes = segment.parts.some((part) => part.bold) || interactive ? TextAttributes.BOLD : 0;
+
+  return (
+    <Text
+      fg={segment.disabled ? colors.textMuted : colors.textDim}
+      attributes={attributes}
+      onMouseDown={interactive ? stopMouseEvent : undefined}
+      onMouseUp={interactive ? segment.onPress : undefined}
+      {...(interactive ? { "data-gloom-interactive": "true" } : {})}
+    >
+      {segment.parts.map((part, index) => (
+        <Span
+          key={`${segment.id}:part:${index}`}
+          fg={segment.disabled ? colors.textMuted : footerToneColor(part)}
+          attributes={part.bold ? TextAttributes.BOLD : 0}
+        >
+          {index > 0 ? " " : ""}{part.text}
+        </Span>
+      ))}
+    </Text>
+  );
+}
+
+function hintTextLength(hint: PaneHint, index: number): number {
+  return (index > 0 ? 1 : 0) + hint.key.length + hint.label.length + 2;
+}
+
+function totalHintsWidth(hints: PaneHint[]): number {
+  return hints.reduce((total, hint, index) => total + hintTextLength(hint, index), 0);
+}
+
+function HintView({ hint, prefixSpace }: { hint: PaneHint; prefixSpace: boolean }) {
+  const interactive = !!hint.onPress && !hint.disabled;
+  const keyColor = hint.disabled ? colors.textMuted : colors.textBright;
+  const labelColor = hint.disabled ? colors.textMuted : colors.textDim;
+  const prefix = prefixSpace ? " " : "";
+  const text = `${prefix}[${hint.key}]${hint.label}`;
+
+  return (
+    <Text
+      width={text.length}
+      content={new StyledText([
+        ...(prefix ? [{ text: prefix, fg: labelColor }] : []),
+        { text: `[${hint.key}]`, fg: keyColor },
+        { text: hint.label, fg: labelColor },
+      ])}
+      fg={hint.disabled ? colors.textMuted : colors.textDim}
+      attributes={interactive ? TextAttributes.BOLD : 0}
+      data-gloom-role="pane-hint"
+      onMouseDown={interactive ? stopMouseEvent : undefined}
+      onMouseUp={interactive ? hint.onPress : undefined}
+      {...(interactive ? { "data-gloom-interactive": "true" } : {})}
+    />
+  );
+}
+
+function FooterContent({
+  footer,
+  focused,
+  width,
+  showBackground = true,
+}: {
+  footer: CombinedPaneFooter;
+  focused: boolean;
+  width?: number;
+  showBackground?: boolean;
+}) {
+  const hasInfo = footer.info.length > 0;
+  const hasHints = footer.hints.length > 0;
+  const dividerColor = focused ? colors.borderFocused : colors.border;
+  const backgroundColor = showBackground ? blendHex(colors.bg, dividerColor, focused ? 0.12 : 0.06) : undefined;
+  const availableWidth = width && width > 0 ? Math.floor(width) : null;
+  const hintsWidth = hasHints
+    ? Math.min(availableWidth ?? totalHintsWidth(footer.hints), totalHintsWidth(footer.hints))
+    : 0;
+  const infoWidth = availableWidth !== null && hasInfo
+    ? Math.max(0, availableWidth - hintsWidth)
+    : undefined;
+
+  if (!hasInfo && !hasHints) {
+    return <Box flexGrow={1} height={1} />;
+  }
+
+  return (
+    <Box
+      height={1}
+      flexGrow={1}
+      flexDirection="row"
+      justifyContent="space-between"
+      overflow="hidden"
+      backgroundColor={backgroundColor}
+    >
+      {hasInfo && (
+        <Box
+          flexDirection="row"
+          overflow="hidden"
+          flexShrink={1}
+          {...(infoWidth != null ? { width: infoWidth } : {})}
+        >
+          {footer.info.map((segment, index) => (
+            <Box key={segment.id} flexDirection="row" marginRight={index === footer.info.length - 1 ? 0 : 1}>
+              <SegmentView segment={segment} />
+            </Box>
+          ))}
+        </Box>
+      )}
+      {hasHints && (
+        <>
+          <Box flexGrow={1} />
+          <Box
+            flexDirection="row"
+            justifyContent="flex-end"
+            flexShrink={0}
+            overflow="hidden"
+            {...(availableWidth !== null ? { width: hintsWidth } : { flexGrow: 1 })}
+          >
+          {footer.hints.map((hint, index) => (
+            <Box key={hint.id} flexDirection="row">
+              <HintView hint={hint} prefixSpace={index > 0} />
+            </Box>
+          ))}
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}
+
+export function PaneFooterBar({
+  footer = EMPTY_FOOTER,
+  focused,
+  width = 0,
+  reserveRight = 0,
+}: {
+  footer?: CombinedPaneFooter | null;
+  focused: boolean;
+  width?: number;
+  reserveRight?: number;
+}) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const resolvedFooter = footer ?? EMPTY_FOOTER;
+  const empty = resolvedFooter.info.length === 0 && resolvedFooter.hints.length === 0;
+  const borderColor = focused ? colors.borderFocused : colors.border;
+  const reservedRight = Math.max(0, reserveRight);
+
+  if (nativePaneChrome) {
+    const nativeContentWidth = width > 0 ? Math.max(0, Math.floor(width) - reservedRight - 2) : undefined;
+    return (
+      <Box
+        height={1}
+        flexDirection="row"
+        paddingLeft={1}
+        paddingRight={reservedRight + 1}
+        data-gloom-role="pane-footer"
+        data-focused={focused ? "true" : "false"}
+        data-empty={empty ? "true" : "false"}
+        style={{ "--pane-footer-border-color": borderColor }}
+      >
+        <FooterContent footer={resolvedFooter} focused={focused} width={nativeContentWidth} showBackground={false} />
+      </Box>
+    );
+  }
+
+  if (focused) {
+    const contentWidth = Math.max(0, Math.floor(width) - 1 - reservedRight - (reservedRight > 0 ? 0 : 1));
+    return (
+      <Box height={1} width={width} flexDirection="row" data-gloom-role="pane-footer" data-focused="true" data-empty={empty ? "true" : "false"}>
+        <Text fg={borderColor} selectable={false}>└</Text>
+        <Box width={contentWidth} height={1} overflow="hidden">
+          <FooterContent footer={resolvedFooter} focused width={contentWidth} />
+        </Box>
+        {reservedRight === 0 && <Text fg={borderColor} selectable={false}>┘</Text>}
+      </Box>
+    );
+  }
+
+  const contentWidth = Math.max(0, Math.floor(width) - reservedRight);
+  return (
+    <Box height={1} width={width} flexDirection="row" data-gloom-role="pane-footer" data-focused="false" data-empty={empty ? "true" : "false"}>
+      <Box width={contentWidth} height={1} overflow="hidden">
+        <FooterContent footer={resolvedFooter} focused={false} width={contentWidth} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/layout/pane-sizing.ts
+++ b/src/components/layout/pane-sizing.ts
@@ -1,17 +1,11 @@
 
 const RESERVED_PANE_CHROME_ROWS = 2;
-const FOCUSED_PANE_BODY_INSET = 1;
-const RESERVED_FOCUSED_PANE_CHROME_COLUMNS = FOCUSED_PANE_BODY_INSET * 2;
 
 export function getPaneBodyHeight(height: number): number {
-  // Reserve the header row plus the bottom border/resize row.
+  // Reserve the header row plus the shared pane footer row.
   return Math.max(1, height - RESERVED_PANE_CHROME_ROWS);
 }
 
-export function getPaneBodyHorizontalInset(focused: boolean): number {
-  return focused ? FOCUSED_PANE_BODY_INSET : 0;
-}
-
-export function getPaneBodyWidth(width: number, focused: boolean): number {
-  return Math.max(1, width - (focused ? RESERVED_FOCUSED_PANE_CHROME_COLUMNS : 0));
+export function getPaneBodyWidth(width: number): number {
+  return Math.max(1, width);
 }

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -2,7 +2,8 @@ import { Box, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
 import { colors, paneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
-import { getPaneBodyHeight, getPaneBodyHorizontalInset } from "./pane-sizing";
+import { PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
+import { getPaneBodyHeight } from "./pane-sizing";
 
 interface PaneWrapperProps {
   title?: string;
@@ -17,6 +18,7 @@ interface PaneWrapperProps {
   onHeaderMouseDrag?: (event: any) => void;
   onHeaderMouseDragEnd?: (event: any) => void;
   onActionMouseDown?: (event: any) => void;
+  footer?: CombinedPaneFooter | null;
   children: ReactNode;
 }
 
@@ -33,14 +35,14 @@ export function PaneWrapper({
   onHeaderMouseDrag,
   onHeaderMouseDragEnd,
   onActionMouseDown,
+  footer,
   children,
 }: PaneWrapperProps) {
   const { nativePaneChrome } = useUiCapabilities();
   const bg = paneBg(focused);
   const bodyHeight = typeof height === "number"
-    ? title ? nativePaneChrome ? Math.max(1, height - 1) : getPaneBodyHeight(height) : height
+    ? title ? getPaneBodyHeight(height) : height
     : undefined;
-  const bodyInset = nativePaneChrome ? 0 : getPaneBodyHorizontalInset(focused);
 
   return (
     <Box
@@ -74,12 +76,18 @@ export function PaneWrapper({
       <Box
         height={bodyHeight}
         flexGrow={bodyHeight == null ? 1 : 0}
+        flexBasis={bodyHeight == null ? 0 : undefined}
         overflow="hidden"
-        paddingLeft={bodyInset}
-        paddingRight={bodyInset}
       >
         {children}
       </Box>
+      {title && (
+        <PaneFooterBar
+          footer={footer}
+          focused={focused}
+          width={typeof width === "number" ? width : undefined}
+        />
+      )}
     </Box>
   );
 }

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -282,20 +282,6 @@ function BrokerShellHarness({ pluginRegistry }: { pluginRegistry: PluginRegistry
   );
 }
 
-function FocusBorderProbe({ width, height }: Pick<PaneProps, "width" | "height">) {
-  return (
-    <box flexDirection="column" width={width} height={height}>
-      <box height={1} width={width}>
-        <text>Read Probe</text>
-      </box>
-      <box height={1} width={width} flexDirection="row">
-        <box flexGrow={1} />
-        <text>Right</text>
-      </box>
-    </box>
-  );
-}
-
 function ChartShellHarness({
   pluginRegistry,
   config,
@@ -715,84 +701,6 @@ describe("Shell", () => {
     expect(harnessState?.paneState["portfolio-list:main"]?.cashDrawerExpanded).toBe(false);
     expect(layoutUpdates.length).toBe(1);
     expect(toasts).toEqual(["Retiled all panes"]);
-  });
-
-  test("keeps focused docked pane body text inside the focus border", async () => {
-    const config = createDefaultConfig("/tmp/gloomberb-shell-focus-border-test");
-    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
-    if (!mainPane) throw new Error("missing default portfolio pane");
-
-    const singlePaneLayout = {
-      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
-      instances: [{ ...mainPane }],
-      floating: [],
-    };
-    const state = {
-      ...createInitialState({
-        ...config,
-        layout: cloneLayout(singlePaneLayout),
-        layouts: [{ name: "Default", layout: cloneLayout(singlePaneLayout) }],
-      }),
-      focusedPaneId: "portfolio-list:main",
-    };
-
-    testSetup = await testRender(
-      <AppContext value={{ state, dispatch: () => {} }}>
-        <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
-          <Shell pluginRegistry={createShellPluginRegistry({
-            portfolioListComponent: FocusBorderProbe,
-          })} />
-        </DialogProvider>
-      </AppContext>,
-      { width: 40, height: 10 },
-    );
-
-    await testSetup.renderOnce();
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("│Read Probe");
-    expect(frame).toContain("Right│");
-    expect(frame).not.toContain("│ead Probe");
-    expect(frame).not.toContain("Righ│");
-  });
-
-  test("keeps focused floating pane body text inside the focus border", async () => {
-    const config = createDefaultConfig("/tmp/gloomberb-shell-floating-focus-border-test");
-    const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
-    if (!detailPane) throw new Error("missing detail pane");
-
-    const floatingOnlyLayout = {
-      dockRoot: null,
-      instances: [{ ...detailPane }],
-      floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8, zIndex: 75 }],
-    };
-    const state = {
-      ...createInitialState({
-        ...config,
-        layout: cloneLayout(floatingOnlyLayout),
-        layouts: [{ name: "Default", layout: cloneLayout(floatingOnlyLayout) }],
-      }),
-      focusedPaneId: "ticker-detail:main",
-    };
-
-    testSetup = await testRender(
-      <AppContext value={{ state, dispatch: () => {} }}>
-        <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
-          <Shell pluginRegistry={createShellPluginRegistry({
-            tickerDetailComponent: FocusBorderProbe,
-          })} />
-        </DialogProvider>
-      </AppContext>,
-      { width: 40, height: 12 },
-    );
-
-    await testSetup.renderOnce();
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("│Read Probe");
-    expect(frame).toContain("Right│");
-    expect(frame).not.toContain("│ead Probe");
-    expect(frame).not.toContain("Righ│");
   });
 
   test("shows the gridlock tip after snapping a pane to a half screen", () => {

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,9 +1,9 @@
 import { Box, Text } from "../../ui";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNativeRenderer, useUiCapabilities } from "../../ui";
 import { useShortcut, useViewport } from "../../react/input";
 import { useDialogState } from "../../ui/dialog";
-import { saveConfig } from "../../data/config-store";
+import { scheduleConfigSave } from "../../state/config-save-scheduler";
 import {
   MIN_FLOAT_HEIGHT,
   MIN_FLOAT_WIDTH,
@@ -30,17 +30,26 @@ import {
 } from "../../plugins/pane-manager";
 import type { PluginRegistry } from "../../plugins/registry";
 import { removePaneInstances, type LayoutConfig } from "../../types/config";
+import type { PaneDef } from "../../types/plugin";
 import {
   PaneInstanceProvider,
   resolveCollectionForPane,
   resolveTickerForPane,
-  useAppState,
+  useAppDispatch,
+  useAppSelector,
 } from "../../state/app-context";
+import {
+  selectCommandBarOpen,
+  selectFocusedPaneId,
+  selectLayout,
+  selectStatusBarVisible,
+} from "../../state/selectors-ui";
 import { colors } from "../../theme/colors";
 import { PANE_HEADER_ACTION, PANE_HEADER_CLOSE } from "./pane-header";
 import { getNativeSurfaceManager, type NativeOccluder, type NativePaneLayer } from "../chart/native/surface-manager";
 import { FloatingPaneWrapper } from "./floating-pane";
 import { PaneWrapper } from "./pane";
+import { PaneFooterProvider } from "./pane-footer";
 import { getPaneBodyHeight, getPaneBodyWidth } from "./pane-sizing";
 
 interface ShellProps {
@@ -509,21 +518,67 @@ function menuForPane(
   return baseActions;
 }
 
+interface PaneContentProps {
+  component: PaneDef["component"];
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+  onClose?: (paneId: string) => void;
+}
+
+const PaneContent = memo(function PaneContent({
+  component: Component,
+  paneId,
+  paneType,
+  focused,
+  width,
+  height,
+  onClose,
+}: PaneContentProps) {
+  const close = useCallback(() => {
+    onClose?.(paneId);
+  }, [onClose, paneId]);
+
+  return (
+    <PaneInstanceProvider paneId={paneId}>
+      <Component
+        paneId={paneId}
+        paneType={paneType}
+        focused={focused}
+        width={width}
+        height={height}
+        close={onClose ? close : undefined}
+      />
+    </PaneInstanceProvider>
+  );
+});
+
 export function Shell({ pluginRegistry }: ShellProps) {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config);
+  const paneState = useAppSelector((state) => state.paneState);
+  const focusedPaneId = useAppSelector(selectFocusedPaneId);
+  const commandBarOpen = useAppSelector(selectCommandBarOpen);
+  const inputCaptured = useAppSelector((state) => state.inputCaptured);
+  const statusBarVisible = useAppSelector(selectStatusBarVisible);
   const renderer = useNativeRenderer();
   const { nativePaneChrome, precisePointer } = useUiCapabilities();
   const { width, height } = useViewport();
   const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);
 
-  const contentHeight = Math.max(1, height - (state.statusBarVisible ? 2 : 1));
+  const contentHeight = Math.max(1, height - (statusBarVisible ? 2 : 1));
   pluginRegistry.getTermSizeFn = () => ({ width, height: contentHeight });
 
-  const layout = state.config.layout;
+  const layout = useAppSelector(selectLayout);
   const dialogOpen = useDialogState((dialog) => dialog.isOpen);
   const [hoveredPaneId, setHoveredPaneId] = useState<string | null>(null);
+  const setHoveredPaneIfChanged = useCallback((paneId: string | null) => {
+    setHoveredPaneId((current) => (current === paneId ? current : paneId));
+  }, []);
   const [menuState, setMenuState] = useState<ActionMenuState | null>(null);
-  const overlayOpen = state.commandBarOpen || dialogOpen || !!menuState;
+  const overlayOpen = commandBarOpen || dialogOpen || !!menuState;
 
   const dragRef = useRef<DragMode | null>(null);
   const [dragFloatingRect, setDragFloatingRect] = useState<{ paneId: string; rect: FloatingRect } | null>(null);
@@ -564,12 +619,12 @@ export function Shell({ pluginRegistry }: ShellProps) {
       return;
     }
     if (event.name !== "w" || !event.ctrl) return;
-    if (dragRef.current || overlayOpen || state.inputCaptured) return;
+    if (dragRef.current || overlayOpen || inputCaptured) return;
     closeFocusedPane();
   });
 
   const disabledPaneIds = useMemo(() => {
-    const disabledPlugins = new Set(state.config.disabledPlugins);
+    const disabledPlugins = new Set(config.disabledPlugins);
     const ids = new Set<string>();
     for (const pluginId of disabledPlugins) {
       for (const paneId of pluginRegistry.getPluginPaneIds(pluginId)) {
@@ -577,7 +632,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
       }
     }
     return ids;
-  }, [pluginRegistry, state.config.disabledPlugins]);
+  }, [config.disabledPlugins, pluginRegistry]);
 
   const hiddenInstanceIds = useMemo(() => (
     layout.instances
@@ -591,20 +646,20 @@ export function Shell({ pluginRegistry }: ShellProps) {
   );
 
   const persistLayout = useCallback((nextLayout: LayoutConfig, options?: { pushHistory?: boolean }) => {
-    const layouts = state.config.layouts.map((savedLayout, index) => (
-      index === state.config.activeLayoutIndex ? { ...savedLayout, layout: nextLayout } : savedLayout
+    const layouts = config.layouts.map((savedLayout, index) => (
+      index === config.activeLayoutIndex ? { ...savedLayout, layout: nextLayout } : savedLayout
     ));
     if (options?.pushHistory !== false) {
       dispatch({ type: "PUSH_LAYOUT_HISTORY" });
     }
     dispatch({ type: "UPDATE_LAYOUT", layout: nextLayout });
-    saveConfig({ ...state.config, layout: nextLayout, layouts }).catch(() => {});
-  }, [dispatch, state.config]);
+    scheduleConfigSave({ ...config, layout: nextLayout, layouts });
+  }, [config, dispatch]);
 
   const closeFocusedPane = useCallback(() => {
-    if (!state.focusedPaneId || !isPaneInLayout(visibleLayout, state.focusedPaneId)) return;
-    persistLayout(removePane(visibleLayout, state.focusedPaneId));
-  }, [persistLayout, state.focusedPaneId, visibleLayout]);
+    if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) return;
+    persistLayout(removePane(visibleLayout, focusedPaneId));
+  }, [focusedPaneId, persistLayout, visibleLayout]);
 
   const focusPane = useCallback((paneId: string) => {
     dispatch({ type: "FOCUS_PANE", paneId });
@@ -695,26 +750,30 @@ export function Shell({ pluginRegistry }: ShellProps) {
     nativeSurfaceManager.setWindowState(nativeWindowState);
   }, [nativeSurfaceManager, nativeWindowState]);
 
+  const titleState = useMemo(
+    () => ({ config, paneState }) as Parameters<typeof resolveTickerForPane>[0],
+    [config, paneState],
+  );
   const getPaneTitle = useCallback((pane: ResolvedPane): string => {
     if (pane.instance.paneId === "ticker-detail") {
-      const ticker = resolveTickerForPane(state, pane.instance.instanceId);
+      const ticker = resolveTickerForPane(titleState, pane.instance.instanceId);
       if (ticker) return ticker;
-      const collectionId = resolveCollectionForPane(state, pane.instance.instanceId);
-      return state.config.portfolios.find((portfolio) => portfolio.id === collectionId)?.name
-        ?? state.config.watchlists.find((watchlist) => watchlist.id === collectionId)?.name
+      const collectionId = resolveCollectionForPane(titleState, pane.instance.instanceId);
+      return config.portfolios.find((portfolio) => portfolio.id === collectionId)?.name
+        ?? config.watchlists.find((watchlist) => watchlist.id === collectionId)?.name
         ?? pane.instance.title
         ?? pane.def.name;
     }
     if (pane.instance.title) return pane.instance.title;
     if (pane.instance.paneId === "portfolio-list") {
-      const collectionId = resolveCollectionForPane(state, pane.instance.instanceId);
-      return state.config.portfolios.find((portfolio) => portfolio.id === collectionId)?.name
-        ?? state.config.watchlists.find((watchlist) => watchlist.id === collectionId)?.name
+      const collectionId = resolveCollectionForPane(titleState, pane.instance.instanceId);
+      return config.portfolios.find((portfolio) => portfolio.id === collectionId)?.name
+        ?? config.watchlists.find((watchlist) => watchlist.id === collectionId)?.name
         ?? pane.def.name;
     }
-    const ticker = resolveTickerForPane(state, pane.instance.instanceId);
+    const ticker = resolveTickerForPane(titleState, pane.instance.instanceId);
     return ticker ? `${pane.def.name}: ${ticker}` : pane.def.name;
-  }, [state]);
+  }, [config.portfolios, config.watchlists, titleState]);
 
   const openPaneMenu = useCallback((paneId: string, rect: LayoutBounds) => {
     const pane = paneMap.get(paneId);
@@ -912,7 +971,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
         if (!pointInRect({ x: rect.x, y: rect.y, width: rect.width, height: rect.height }, event.x, shellY)) continue;
         const relativeX = event.x - rect.x;
         const relativeY = shellY - rect.y;
-        const isFocused = state.focusedPaneId === pane.instance.instanceId;
+        const isFocused = focusedPaneId === pane.instance.instanceId;
         const headerAreas = resolveHeaderHitAreas(rect.width, {
           floating: true,
           focused: isFocused,
@@ -993,7 +1052,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
         if (!pane) continue;
         const relativeX = event.x - leaf.rect.x;
         const relativeY = shellY - leaf.rect.y;
-        const isFocused = state.focusedPaneId === leaf.instanceId;
+        const isFocused = focusedPaneId === leaf.instanceId;
         const headerAreas = resolveHeaderHitAreas(leaf.rect.width, {
           floating: false,
           focused: isFocused,
@@ -1039,6 +1098,7 @@ export function Shell({ pluginRegistry }: ShellProps) {
     dockPreview,
     dragFloatingRect,
     floatingPanes,
+    focusedPaneId,
     focusPane,
     handleActiveDrag,
     handleFloatingClose,
@@ -1161,10 +1221,10 @@ export function Shell({ pluginRegistry }: ShellProps) {
       {dockLeafLayouts.map((leaf) => {
         const pane = paneMap.get(leaf.instanceId);
         if (!pane) return null;
-        const focused = state.focusedPaneId === leaf.instanceId && (!overlayOpen || menuState?.paneId === leaf.instanceId);
+        const focused = focusedPaneId === leaf.instanceId && (!overlayOpen || menuState?.paneId === leaf.instanceId);
         const showActions = focused || hoveredPaneId === leaf.instanceId || menuState?.paneId === leaf.instanceId;
-        const bodyHeight = nativePaneChrome ? Math.max(1, Math.floor(leaf.rect.height - 1)) : getPaneBodyHeight(leaf.rect.height);
-        const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(leaf.rect.width)) : getPaneBodyWidth(leaf.rect.width, focused);
+        const bodyHeight = getPaneBodyHeight(leaf.rect.height);
+        const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(leaf.rect.width)) : getPaneBodyWidth(leaf.rect.width);
         return (
           <Box
             key={`dock:${leaf.instanceId}`}
@@ -1174,72 +1234,79 @@ export function Shell({ pluginRegistry }: ShellProps) {
             width={leaf.rect.width}
             height={leaf.rect.height}
           >
-            <PaneWrapper
-              title={getPaneTitle(pane)}
-              focused={focused}
-              width={leaf.rect.width}
-              height={leaf.rect.height}
-              showActions={showActions}
-              onMouseDown={nativePaneChrome ? () => focusNativePane(leaf.instanceId) : undefined}
-              onMouseMove={() => setHoveredPaneId(leaf.instanceId)}
-              onHeaderMouseDown={nativePaneChrome ? (event) => startNativeDockedDrag(leaf.instanceId, leaf.rect, event) : undefined}
-              onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
-              onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
-              onActionMouseDown={nativePaneChrome ? (event) => handleNativePaneAction(leaf.instanceId, leaf.rect, event) : undefined}
-            >
-              <PaneInstanceProvider paneId={leaf.instanceId}>
-                <pane.def.component
-                  paneId={pane.instance.instanceId}
-                  paneType={pane.instance.paneId}
+            <PaneFooterProvider>
+              {(footer) => (
+                <PaneWrapper
+                  title={getPaneTitle(pane)}
                   focused={focused}
-                  width={bodyWidth}
-                  height={bodyHeight}
-                />
-              </PaneInstanceProvider>
-            </PaneWrapper>
+                  width={leaf.rect.width}
+                  height={leaf.rect.height}
+                  showActions={showActions}
+                  footer={footer}
+                  onMouseDown={nativePaneChrome ? () => focusNativePane(leaf.instanceId) : undefined}
+                  onMouseMove={() => setHoveredPaneIfChanged(leaf.instanceId)}
+                  onHeaderMouseDown={nativePaneChrome ? (event) => startNativeDockedDrag(leaf.instanceId, leaf.rect, event) : undefined}
+                  onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
+                  onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
+                  onActionMouseDown={nativePaneChrome ? (event) => handleNativePaneAction(leaf.instanceId, leaf.rect, event) : undefined}
+                >
+                  <PaneContent
+                    component={pane.def.component}
+                    paneId={pane.instance.instanceId}
+                    paneType={pane.instance.paneId}
+                    focused={focused}
+                    width={bodyWidth}
+                    height={bodyHeight}
+                  />
+                </PaneWrapper>
+              )}
+            </PaneFooterProvider>
           </Box>
         );
       })}
 
       {floatingPanes.map((pane) => {
         const preview = dragFloatingRect?.paneId === pane.instance.instanceId ? dragFloatingRect.rect : pane.floating!;
-        const focused = state.focusedPaneId === pane.instance.instanceId && (!overlayOpen || menuState?.paneId === pane.instance.instanceId);
+        const focused = focusedPaneId === pane.instance.instanceId && (!overlayOpen || menuState?.paneId === pane.instance.instanceId);
         const showActions = focused || hoveredPaneId === pane.instance.instanceId || menuState?.paneId === pane.instance.instanceId;
-        const bodyHeight = nativePaneChrome ? Math.max(1, Math.floor(preview.height - 1)) : getPaneBodyHeight(preview.height);
-        const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(preview.width)) : getPaneBodyWidth(preview.width, focused);
+        const bodyHeight = getPaneBodyHeight(preview.height);
+        const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(preview.width)) : getPaneBodyWidth(preview.width);
         return (
-          <FloatingPaneWrapper
-            key={`float:${pane.instance.instanceId}`}
-            title={getPaneTitle(pane)}
-            x={preview.x}
-            y={preview.y}
-            width={preview.width}
-            height={preview.height}
-            zIndex={pane.floating?.zIndex ?? 50}
-            focused={focused}
-            showActions={showActions}
-            onMouseDown={nativePaneChrome ? () => focusNativePane(pane.instance.instanceId) : undefined}
-            onMouseMove={() => setHoveredPaneId(pane.instance.instanceId)}
-            onHeaderMouseDown={nativePaneChrome ? (event) => startNativeFloatingDrag(pane.instance.instanceId, preview, event) : undefined}
-            onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
-            onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
-            onActionMouseDown={nativePaneChrome ? (event) => handleNativePaneAction(pane.instance.instanceId, preview, event) : undefined}
-            onCloseMouseDown={nativePaneChrome ? (event) => handleNativeFloatingClose(pane.instance.instanceId, event) : undefined}
-            onResizeMouseDown={nativePaneChrome ? (event) => startNativeFloatResize(pane.instance.instanceId, preview, event) : undefined}
-            onResizeMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
-            onResizeMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
-          >
-            <PaneInstanceProvider paneId={pane.instance.instanceId}>
-              <pane.def.component
-                paneId={pane.instance.instanceId}
-                paneType={pane.instance.paneId}
+          <PaneFooterProvider key={`float:${pane.instance.instanceId}`}>
+            {(footer) => (
+              <FloatingPaneWrapper
+                title={getPaneTitle(pane)}
+                x={preview.x}
+                y={preview.y}
+                width={preview.width}
+                height={preview.height}
+                zIndex={pane.floating?.zIndex ?? 50}
                 focused={focused}
-                width={bodyWidth}
-                height={bodyHeight}
-                close={() => handleFloatingClose(pane.instance.instanceId)}
-              />
-            </PaneInstanceProvider>
-          </FloatingPaneWrapper>
+                showActions={showActions}
+                footer={footer}
+                onMouseDown={nativePaneChrome ? () => focusNativePane(pane.instance.instanceId) : undefined}
+                onMouseMove={() => setHoveredPaneIfChanged(pane.instance.instanceId)}
+                onHeaderMouseDown={nativePaneChrome ? (event) => startNativeFloatingDrag(pane.instance.instanceId, preview, event) : undefined}
+                onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
+                onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
+                onActionMouseDown={nativePaneChrome ? (event) => handleNativePaneAction(pane.instance.instanceId, preview, event) : undefined}
+                onCloseMouseDown={nativePaneChrome ? (event) => handleNativeFloatingClose(pane.instance.instanceId, event) : undefined}
+                onResizeMouseDown={nativePaneChrome ? (event) => startNativeFloatResize(pane.instance.instanceId, preview, event) : undefined}
+                onResizeMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
+                onResizeMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
+              >
+                <PaneContent
+                  component={pane.def.component}
+                  paneId={pane.instance.instanceId}
+                  paneType={pane.instance.paneId}
+                  focused={focused}
+                  width={bodyWidth}
+                  height={bodyHeight}
+                  onClose={handleFloatingClose}
+                />
+              </FloatingPaneWrapper>
+            )}
+          </PaneFooterProvider>
         );
       })}
 
@@ -1277,14 +1344,14 @@ export function Shell({ pluginRegistry }: ShellProps) {
 
       {/* Focus border overlay — rendered on top of the focused pane */}
       {(() => {
-        if (!state.focusedPaneId) return null;
+        if (!focusedPaneId) return null;
         if (nativePaneChrome) return null;
         // Hide border when command bar or dialog is open, but keep it when just the pane menu is open
         if (overlayOpen && !menuState) return null;
         let rect: { x: number; y: number; width: number; height: number } | null = null;
         let z = 3;
         // Check floating panes first (they render on top of docked panes)
-        const floatingPane = floatingPanes.find((p) => p.instance.instanceId === state.focusedPaneId);
+        const floatingPane = floatingPanes.find((p) => p.instance.instanceId === focusedPaneId);
         if (floatingPane) {
           rect = dragFloatingRect?.paneId === floatingPane.instance.instanceId
             ? dragFloatingRect.rect
@@ -1292,16 +1359,15 @@ export function Shell({ pluginRegistry }: ShellProps) {
           z = (floatingPane.floating?.zIndex ?? 50) + 1;
         } else {
           // Check docked panes
-          const dockedLeaf = dockLeafLayouts.find((l) => l.instanceId === state.focusedPaneId);
+          const dockedLeaf = dockLeafLayouts.find((l) => l.instanceId === focusedPaneId);
           if (dockedLeaf) {
             rect = dockedLeaf.rect;
           }
         }
         if (!rect || rect.height < 2) return null;
         const bc = colors.borderFocused;
-        const isFloating = !!floatingPane;
         const bodyTop = rect.y + 1; // below header (header renders its own border edges)
-        const bodyH = rect.height - 2; // rows between header and bottom edge
+        const bodyH = rect.height - 2; // rows between header and footer
         return (
           <>
             {/* Left edge — body only */}
@@ -1316,13 +1382,6 @@ export function Shell({ pluginRegistry }: ShellProps) {
                 <Text fg={bc} selectable={false}>{"│".repeat(bodyH)}</Text>
               </Box>
             )}
-            {/* Bottom edge — for floating, leave last 2 chars for resize handle (rendered by FloatingPaneWrapper) */}
-            <Box key="focus-b" position="absolute" left={rect.x} top={rect.y + rect.height - 1} width={isFloating ? Math.max(0, rect.width - 2) : rect.width} height={1} zIndex={z}>
-              <Text fg={bc} selectable={false}>{isFloating
-                ? `└${"─".repeat(Math.max(0, rect.width - 4))}─`
-                : `└${"─".repeat(Math.max(0, rect.width - 2))}┘`
-              }</Text>
-            </Box>
           </>
         );
       })()}

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,7 +1,14 @@
 import { Box, Span, Text } from "../../ui";
 import { useEffect, useState } from "react";
 import { colors, hoverBg } from "../../theme/colors";
-import { useAppState, useFocusedTicker } from "../../state/app-context";
+import { useAppDispatch, useAppSelector, useFocusedTicker } from "../../state/app-context";
+import {
+  selectActiveLayoutIndex,
+  selectGridlockTipSequence,
+  selectGridlockTipVisible,
+  selectSavedLayouts,
+  selectStatusBarVisible,
+} from "../../state/selectors-ui";
 import {
   marketStateLabel,
   marketStateColor,
@@ -25,7 +32,12 @@ function truncate(text: string, width: number): string {
 
 export function StatusBar() {
   const registry = getSharedRegistry();
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const layouts = useAppSelector(selectSavedLayouts);
+  const activeLayoutIdx = useAppSelector(selectActiveLayoutIndex);
+  const statusBarVisible = useAppSelector(selectStatusBarVisible);
+  const gridlockTipVisible = useAppSelector(selectGridlockTipVisible);
+  const gridlockTipSequence = useAppSelector(selectGridlockTipSequence);
   const { symbol, financials: focusedFinancials } = useFocusedTicker();
   const [hoveredTab, setHoveredTab] = useState<number | null>(null);
   const [hoveredControl, setHoveredControl] = useState<string | null>(null);
@@ -44,18 +56,16 @@ export function StatusBar() {
   const extText = extInfo?.text ?? "";
   const extColor = extInfo?.color ?? colors.textDim;
 
-  const layouts = state.config.layouts ?? [];
-  const activeLayoutIdx = state.config.activeLayoutIndex ?? 0;
   const hasMultipleLayouts = layouts.length > 1;
-  const showGridlockTip = state.gridlockTipVisible && !!registry;
+  const showGridlockTip = gridlockTipVisible && !!registry;
 
   useEffect(() => {
-    if (!state.gridlockTipVisible) return;
+    if (!gridlockTipVisible) return;
     const timer = setTimeout(() => {
       dispatch({ type: "DISMISS_GRIDLOCK_TIP" });
     }, GRIDLOCK_TIP_DURATION_MS);
     return () => clearTimeout(timer);
-  }, [dispatch, state.gridlockTipSequence, state.gridlockTipVisible]);
+  }, [dispatch, gridlockTipSequence, gridlockTipVisible]);
 
   const handleGridlockTip = (event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
     event?.preventDefault?.();
@@ -75,7 +85,7 @@ export function StatusBar() {
     dispatch({ type: "DISMISS_GRIDLOCK_TIP" });
   };
 
-  if (!state.statusBarVisible) return null;
+  if (!statusBarVisible) return null;
 
   return (
     <Box
@@ -99,7 +109,7 @@ export function StatusBar() {
                 key={i}
                 fg={fg}
                 bg={bg}
-                onMouseMove={() => setHoveredTab(i)}
+                onMouseMove={() => setHoveredTab((current) => (current === i ? current : i))}
                 onMouseDown={(event: any) => {
                   event.preventDefault();
                   event.stopPropagation();
@@ -122,14 +132,14 @@ export function StatusBar() {
           <Box width={1} />
           <Box
             backgroundColor={hoveredControl === "gridlock-tip" ? hoverBg() : colors.header}
-            onMouseMove={() => setHoveredControl("gridlock-tip")}
+            onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip" ? current : "gridlock-tip"))}
             onMouseDown={handleGridlockTip}
           >
             <Text fg={colors.headerText}> Gridlock All </Text>
           </Box>
           <Text
             fg={hoveredControl === "gridlock-tip-dismiss" ? colors.text : colors.textDim}
-            onMouseMove={() => setHoveredControl("gridlock-tip-dismiss")}
+            onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip-dismiss" ? current : "gridlock-tip-dismiss"))}
             onMouseDown={dismissGridlockTip}
           >
             {" x"}

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -7,7 +7,7 @@ import type {
   PaneSettingTextField,
 } from "../types/plugin";
 import type { PluginRegistry } from "../plugins/registry";
-import { useAppState } from "../state/app-context";
+import { useAppSelector } from "../state/app-context";
 import { colors } from "../theme/colors";
 import { Button, DialogFrame, ListView, MultiSelectDialogContent, TextField } from "./ui";
 
@@ -203,7 +203,7 @@ export function PaneSettingsDialogContent({
   pluginRegistry,
   applyFieldValue,
 }: PaneSettingsDialogContentProps) {
-  const { state } = useAppState();
+  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
   const dialog = useDialog();
   const descriptor = pluginRegistry.resolvePaneSettings(paneId);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -320,7 +320,7 @@ export function PaneSettingsDialogContent({
           </Box>
         )}
       />
-      {fields.length === 0 && state.focusedPaneId === paneId && (
+      {fields.length === 0 && focusedPaneId === paneId && (
         <Box height={1}>
           <Text fg={colors.textDim}>No settings available.</Text>
         </Box>

--- a/src/components/ticker-list-table.test.tsx
+++ b/src/components/ticker-list-table.test.tsx
@@ -19,6 +19,19 @@ const tickers: TickerRecord[] = [
   { metadata: { ticker: "MSFT", exchange: "NASDAQ", currency: "USD", name: "Microsoft", portfolios: [], watchlists: [], positions: [], custom: {}, tags: [] } },
   { metadata: { ticker: "NVDA", exchange: "NASDAQ", currency: "USD", name: "NVIDIA", portfolios: [], watchlists: [], positions: [], custom: {}, tags: [] } },
 ];
+const manyTickers: TickerRecord[] = Array.from({ length: 1000 }, (_, index) => ({
+  metadata: {
+    ticker: `T${index}`,
+    exchange: "NASDAQ",
+    currency: "USD",
+    name: `Ticker ${index}`,
+    portfolios: [],
+    watchlists: [],
+    positions: [],
+    custom: {},
+    tags: [],
+  },
+}));
 
 function noop(_index: number | null): void {}
 
@@ -35,6 +48,23 @@ function TickerListTableHarness() {
     <TickerListTable
       columns={columns}
       tickers={tickers}
+      cursorSymbol={cursorSymbol}
+      hoveredIdx={null}
+      setHoveredIdx={noop}
+      setCursorSymbol={setCursorSymbol}
+      resolveCell={resolveCell}
+      financialsMap={financialsMap}
+    />
+  );
+}
+
+function LargeTickerListTableHarness() {
+  const [cursorSymbol, setCursorSymbol] = useState("T0");
+
+  return (
+    <TickerListTable
+      columns={columns}
+      tickers={manyTickers}
       cursorSymbol={cursorSymbol}
       hoveredIdx={null}
       setHoveredIdx={noop}
@@ -79,5 +109,21 @@ describe("TickerListTable", () => {
 
     expect(initialCallCount).toBeGreaterThan(0);
     expect(resolveCellCallCount - initialCallCount).toBe(2);
+  });
+
+  test("renders a bounded window for large ticker lists", async () => {
+    testSetup = await testRender(
+      <LargeTickerListTableHarness />,
+      { width: 20, height: 6 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("T0");
+    expect(frame).not.toContain("T999");
+    expect(resolveCellCallCount).toBeLessThan(40);
   });
 });

--- a/src/components/ticker-list-table.tsx
+++ b/src/components/ticker-list-table.tsx
@@ -1,5 +1,5 @@
 import { Box, ScrollBox, Text } from "../ui";
-import { memo, useMemo, useRef, type RefObject } from "react";
+import { memo, useCallback, useMemo, useRef, useState, type RefObject } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../ui";
 import { EmptyState } from "./ui";
 import { colors, hoverBg } from "../theme/colors";
@@ -10,6 +10,9 @@ import { padTo } from "../utils/format";
 import { renderChart, resolveChartPalette, type StyledContent } from "./chart/chart-renderer";
 import type { ProjectedChartPoint } from "./chart/chart-data";
 import { tableContentWidthProps, useMeasuredTableContentWidth } from "./ui/table-layout";
+import { useViewport } from "../react/input";
+import { useRafCallback } from "../react/use-raf-callback";
+import { measurePerf } from "../utils/perf-marks";
 
 export interface TickerTableCell {
   text: string;
@@ -69,7 +72,11 @@ interface TickerListTableProps {
   emptyTitle?: string;
   emptyHint?: string;
   showSparklines?: boolean;
+  virtualize?: boolean;
+  overscan?: number;
 }
+
+const EMPTY_FLASH_SYMBOLS = new Map<string, QuoteFlashDirection>();
 
 const TickerListHeader = memo(function TickerListHeader({
   columns,
@@ -287,12 +294,18 @@ export function TickerListTable({
   emptyTitle = "No tickers.",
   emptyHint = "Press Ctrl+P to add one.",
   showSparklines,
+  virtualize = true,
+  overscan = 4,
 }: TickerListTableProps) {
   const internalHeaderScrollRef = useRef<ScrollBoxRenderable>(null);
   const internalScrollRef = useRef<ScrollBoxRenderable>(null);
   const effectiveHeaderScrollRef = headerScrollRef ?? internalHeaderScrollRef;
   const effectiveScrollRef = scrollRef ?? internalScrollRef;
-  const safeFlashSymbols = flashSymbols ?? new Map<string, QuoteFlashDirection>();
+  const hoveredIdxRef = useRef(hoveredIdx);
+  const appViewport = useViewport();
+  const [scrollVersion, setScrollVersion] = useState(0);
+  hoveredIdxRef.current = hoveredIdx;
+  const safeFlashSymbols = flashSymbols ?? EMPTY_FLASH_SYMBOLS;
   const tableWidth = useMemo(
     () => columns.reduce((sum, column) => sum + column.width + 1, 2) + (showSparklines ? 12 : 0),
     [columns, showSparklines],
@@ -302,13 +315,70 @@ export function TickerListTable({
     effectiveHeaderScrollRef,
     effectiveScrollRef,
   );
+  const scrollTop = virtualize ? (effectiveScrollRef.current?.scrollTop ?? 0) : 0;
+  const measuredViewportHeight = effectiveScrollRef.current?.viewport?.height;
+  const viewportHeight = virtualize
+    ? Math.max(
+        1,
+        Math.min(
+          measuredViewportHeight ?? Math.min(tickers.length, 16),
+          Math.max(1, Math.ceil(appViewport.height)),
+        ),
+      )
+    : tickers.length;
+  const startIndex = virtualize ? Math.max(scrollTop - overscan, 0) : 0;
+  const endIndex = virtualize
+    ? Math.min(startIndex + viewportHeight + overscan * 2, tickers.length)
+    : tickers.length;
+  const visibleTickers = useMemo(
+    () => measurePerf(
+      "ticker-list-table.visible-rows",
+      () => tickers.slice(startIndex, endIndex),
+      {
+        itemCount: tickers.length,
+        measuredViewportHeight,
+        startIndex,
+        endIndex,
+        viewportHeight,
+        virtualize,
+      },
+    ),
+    [
+      appViewport.height,
+      endIndex,
+      measuredViewportHeight,
+      scrollVersion,
+      startIndex,
+      tickers,
+      tickers.length,
+      viewportHeight,
+      virtualize,
+    ],
+  );
+  const handleBodyScrollActivity = useCallback(() => {
+    if (virtualize) {
+      setScrollVersion((current) => current + 1);
+    }
+    onBodyScrollActivity?.();
+  }, [onBodyScrollActivity, virtualize]);
+  const syncHeader = useCallback(() => {
+    syncHeaderScroll?.();
+  }, [syncHeaderScroll]);
+  const scheduleBodyScrollActivity = useRafCallback(handleBodyScrollActivity);
+  const scheduleHeaderScrollSync = useRafCallback(syncHeader);
+  const setHoveredIdxIfChanged = useCallback((index: number | null) => {
+    if (hoveredIdxRef.current === index) return;
+    setHoveredIdx(index);
+  }, [setHoveredIdx]);
 
   return (
     <Box
       flexDirection="column"
       flexGrow={1}
+      flexBasis={0}
       width="100%"
       backgroundColor={colors.bg}
+      overflow="hidden"
     >
       <TickerListHeader
         columns={columns}
@@ -324,14 +394,15 @@ export function TickerListTable({
         ref={effectiveScrollRef}
         width="100%"
         flexGrow={1}
+        flexBasis={0}
         backgroundColor={colors.bg}
         scrollX
         scrollY
         focusable={false}
-        onMouseDown={syncHeaderScroll ? () => queueMicrotask(syncHeaderScroll) : undefined}
-        onMouseUp={onBodyScrollActivity ? () => queueMicrotask(onBodyScrollActivity) : undefined}
-        onMouseDrag={onBodyScrollActivity ? () => queueMicrotask(onBodyScrollActivity) : undefined}
-        onMouseScroll={onBodyScrollActivity ? () => queueMicrotask(onBodyScrollActivity) : undefined}
+        onMouseDown={scheduleHeaderScrollSync}
+        onMouseUp={scheduleBodyScrollActivity}
+        onMouseDrag={scheduleBodyScrollActivity}
+        onMouseScroll={scheduleBodyScrollActivity}
         onSizeChange={measureContentWidth}
       >
         {tickers.length === 0 ? (
@@ -339,7 +410,10 @@ export function TickerListTable({
             <EmptyState title={emptyTitle} hint={emptyHint} />
           </Box>
         ) : (
-          tickers.map((ticker, index) => {
+          <>
+            {virtualize && startIndex > 0 && <Box height={startIndex} />}
+            {visibleTickers.map((ticker, visibleIndex) => {
+              const index = startIndex + visibleIndex;
             return (
               <TickerListRow
                 key={ticker.metadata.ticker}
@@ -350,7 +424,7 @@ export function TickerListTable({
                 isHovered={index === hoveredIdx && ticker.metadata.ticker !== cursorSymbol}
                 financials={financialsMap.get(ticker.metadata.ticker)}
                 flashDirection={safeFlashSymbols.get(ticker.metadata.ticker)}
-                setHoveredIdx={setHoveredIdx}
+                setHoveredIdx={setHoveredIdxIfChanged}
                 setCursorSymbol={setCursorSymbol}
                 resolveCell={resolveCell}
                 onRowActivate={onRowActivate}
@@ -359,7 +433,11 @@ export function TickerListTable({
                 contentWidth={contentWidth}
               />
             );
-          })
+            })}
+            {virtualize && endIndex < tickers.length && (
+              <Box height={Math.max(tickers.length - endIndex, 0)} />
+            )}
+          </>
         )}
       </ScrollBox>
     </Box>

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,10 +1,13 @@
-import { Box, ScrollBox, Text } from "../../ui";
-import { useCallback, useEffect, useMemo, useState, type RefObject } from "react";
+import { Box, ScrollBox, Text, useUiHost } from "../../ui";
+import { useCallback, useEffect, useMemo, useState, type ComponentType, type RefObject } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
 import type { ColumnConfig } from "../../types/config";
 import { useAppDispatch, usePaneInstance } from "../../state/app-context";
+import { useViewport } from "../../react/input";
 import { padTo } from "../../utils/format";
+import { useRafCallback } from "../../react/use-raf-callback";
+import { measurePerf } from "../../utils/perf-marks";
 import { useDoubleClickActivation } from "../use-double-click-activation";
 import { EmptyState } from "./status";
 import { tableContentWidthProps, useMeasuredTableContentWidth } from "./table-layout";
@@ -69,7 +72,19 @@ interface DataTableRowPointerTarget<T> {
   index: number;
 }
 
-export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
+export function DataTable<T, C extends DataTableColumn = DataTableColumn>(
+  props: DataTableProps<T, C>,
+) {
+  const HostDataTable = useUiHost().DataTable as
+    | ComponentType<DataTableProps<T, C>>
+    | undefined;
+  if (HostDataTable) {
+    return <HostDataTable {...props} />;
+  }
+  return <OpenTuiDataTable {...props} />;
+}
+
+function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
   columns,
   items,
   sortColumnId,
@@ -89,24 +104,53 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
   renderSectionHeader,
   emptyStateTitle,
   emptyStateHint,
-  virtualize = false,
+  virtualize = true,
   overscan = 3,
   showHorizontalScrollbar = true,
 }: DataTableProps<T, C>) {
   const dispatch = useAppDispatch();
   const paneInstanceId = usePaneInstance()?.instanceId ?? null;
+  const appViewport = useViewport();
   const [scrollVersion, setScrollVersion] = useState(0);
   const scrollTop = virtualize ? (scrollRef.current?.scrollTop ?? 0) : 0;
+  const measuredViewportHeight = scrollRef.current?.viewport?.height;
   const viewportHeight = virtualize
-    ? (scrollRef.current?.viewport?.height ?? Math.min(items.length, 16))
+    ? Math.max(
+        1,
+        Math.min(
+          measuredViewportHeight ?? Math.min(items.length, 16),
+          Math.max(1, Math.ceil(appViewport.height)),
+        ),
+      )
     : items.length;
   const startIndex = virtualize ? Math.max(scrollTop - overscan, 0) : 0;
   const endIndex = virtualize
     ? Math.min(startIndex + viewportHeight + overscan * 2, items.length)
     : items.length;
   const visibleItems = useMemo(
-    () => items.slice(startIndex, endIndex),
-    [endIndex, items, scrollVersion, startIndex],
+    () => measurePerf(
+      "data-table.visible-rows",
+      () => items.slice(startIndex, endIndex),
+      {
+        itemCount: items.length,
+        measuredViewportHeight,
+        startIndex,
+        endIndex,
+        viewportHeight,
+        virtualize,
+      },
+    ),
+    [
+      appViewport.height,
+      endIndex,
+      items,
+      items.length,
+      measuredViewportHeight,
+      scrollVersion,
+      startIndex,
+      viewportHeight,
+      virtualize,
+    ],
   );
   const tableWidth = useMemo(
     () => columns.reduce((sum, column) => sum + column.width + 1, 2),
@@ -125,12 +169,14 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
         : undefined,
     });
 
-  const handleBodyScrollActivity = () => {
+  const handleBodyScrollActivity = useCallback(() => {
     if (virtualize) {
       setScrollVersion((current) => current + 1);
     }
     onBodyScrollActivity();
-  };
+  }, [onBodyScrollActivity, virtualize]);
+  const scheduleBodyScrollActivity = useRafCallback(handleBodyScrollActivity);
+  const scheduleHeaderScrollSync = useRafCallback(syncHeaderScroll);
   const focusPane = useCallback(() => {
     if (!paneInstanceId) return;
     dispatch({ type: "FOCUS_PANE", paneId: paneInstanceId });
@@ -155,8 +201,10 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
     <Box
       flexDirection="column"
       flexGrow={1}
+      flexBasis={0}
       width="100%"
       backgroundColor={colors.bg}
+      overflow="hidden"
     >
       <ScrollBox
         ref={headerScrollRef}
@@ -213,17 +261,18 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
         ref={scrollRef}
         width="100%"
         flexGrow={1}
+        flexBasis={0}
         backgroundColor={colors.bg}
         scrollX={showHorizontalScrollbar}
         scrollY
         focusable={false}
         onMouseDown={() => {
           focusPane();
-          queueMicrotask(syncHeaderScroll);
+          scheduleHeaderScrollSync();
         }}
-        onMouseUp={() => queueMicrotask(handleBodyScrollActivity)}
-        onMouseDrag={() => queueMicrotask(handleBodyScrollActivity)}
-        onMouseScroll={() => queueMicrotask(handleBodyScrollActivity)}
+        onMouseUp={scheduleBodyScrollActivity}
+        onMouseDrag={scheduleBodyScrollActivity}
+        onMouseScroll={scheduleBodyScrollActivity}
         onSizeChange={measureContentWidth}
       >
         {items.length === 0 ? (
@@ -233,11 +282,44 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
         ) : (
           <>
             {virtualize && startIndex > 0 && <Box height={startIndex} />}
-            {visibleItems.map((item, visibleIndex) => {
-              const index = startIndex + visibleIndex;
-              const sectionHeader = renderSectionHeader?.(item, index) ?? null;
+            {measurePerf(
+              "data-table.render-visible-rows",
+              () => visibleItems.map((item, visibleIndex) => {
+                const index = startIndex + visibleIndex;
+                const sectionHeader = renderSectionHeader?.(item, index) ?? null;
 
-              if (sectionHeader) {
+                if (sectionHeader) {
+                  return (
+                    <Box
+                      key={getItemKey(item, index)}
+                      flexDirection="row"
+                      height={1}
+                      {...tableContentWidthProps(contentWidth)}
+                      paddingX={1}
+                      backgroundColor={sectionHeader.backgroundColor ?? colors.bg}
+                      onMouseDown={(event) => {
+                        focusPane();
+                        event.preventDefault();
+                      }}
+                    >
+                      <Text
+                        attributes={sectionHeader.attributes ?? TextAttributes.BOLD}
+                        fg={sectionHeader.color ?? colors.textBright}
+                      >
+                        {sectionHeader.text}
+                      </Text>
+                    </Box>
+                  );
+                }
+
+                const selected = isSelected(item, index);
+                const hovered = hoveredIdx === index && !selected;
+                const rowBg = selected
+                  ? colors.selected
+                  : hovered
+                    ? hoverBg()
+                    : colors.bg;
+
                 return (
                   <Box
                     key={getItemKey(item, index)}
@@ -245,86 +327,69 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>({
                     height={1}
                     {...tableContentWidthProps(contentWidth)}
                     paddingX={1}
-                    backgroundColor={sectionHeader.backgroundColor ?? colors.bg}
+                    backgroundColor={rowBg}
+                    onMouseMove={() => {
+                      if (hoveredIdx !== index) setHoveredIdx(index);
+                    }}
                     onMouseDown={(event) => {
                       focusPane();
                       event.preventDefault();
+                      handleRowMouseDown(getItemKey(item, index), {
+                        item,
+                        index,
+                      }, event);
                     }}
                   >
-                    <Text
-                      attributes={sectionHeader.attributes ?? TextAttributes.BOLD}
-                      fg={sectionHeader.color ?? colors.textBright}
-                    >
-                      {sectionHeader.text}
-                    </Text>
+                    {columns.map((column) => {
+                      const cell = renderCell(item, column, index, {
+                        selected,
+                        hovered,
+                      });
+                      return (
+                        <Box
+                          key={column.id}
+                          width={column.width + 1}
+                          onMouseDown={(event) => {
+                            focusPane();
+                            if (cell.onMouseDown) {
+                              cell.onMouseDown(event);
+                              return;
+                            }
+                            event.preventDefault();
+                            event.stopPropagation?.();
+                            handleRowMouseDown(getItemKey(item, index), {
+                              item,
+                              index,
+                            }, event);
+                          }}
+                        >
+                          <Text
+                            attributes={cell.attributes ?? TextAttributes.NONE}
+                            fg={
+                              cell.color ??
+                              (selected ? colors.selectedText : colors.text)
+                            }
+                          >
+                            {padTo(cell.text, column.width, column.align)}
+                          </Text>
+                        </Box>
+                      );
+                    })}
                   </Box>
                 );
-              }
-
-              const selected = isSelected(item, index);
-              const hovered = hoveredIdx === index && !selected;
-              const rowBg = selected
-                ? colors.selected
-                : hovered
-                  ? hoverBg()
-                  : colors.bg;
-
-              return (
-                <Box
-                  key={getItemKey(item, index)}
-                  flexDirection="row"
-                  height={1}
-                  {...tableContentWidthProps(contentWidth)}
-                  paddingX={1}
-                  backgroundColor={rowBg}
-                  onMouseMove={() => setHoveredIdx(index)}
-                  onMouseDown={(event) => {
-                    focusPane();
-                    event.preventDefault();
-                    handleRowMouseDown(getItemKey(item, index), {
-                      item,
-                      index,
-                    }, event);
-                  }}
-                >
-                  {columns.map((column) => {
-                    const cell = renderCell(item, column, index, {
-                      selected,
-                      hovered,
-                    });
-                    return (
-                      <Box
-                        key={column.id}
-                        width={column.width + 1}
-                        onMouseDown={(event) => {
-                          focusPane();
-                          if (cell.onMouseDown) {
-                            cell.onMouseDown(event);
-                            return;
-                          }
-                          event.preventDefault();
-                          event.stopPropagation?.();
-                          handleRowMouseDown(getItemKey(item, index), {
-                            item,
-                            index,
-                          }, event);
-                        }}
-                      >
-                        <Text
-                          attributes={cell.attributes ?? TextAttributes.NONE}
-                          fg={
-                            cell.color ??
-                            (selected ? colors.selectedText : colors.text)
-                          }
-                        >
-                          {padTo(cell.text, column.width, column.align)}
-                        </Text>
-                      </Box>
-                    );
-                  })}
-                </Box>
-              );
-            })}
+              }),
+              {
+                columnCount: columns.length,
+                endIndex,
+                itemCount: items.length,
+                measuredViewportHeight,
+                paneId: paneInstanceId,
+                startIndex,
+                viewportHeight,
+                visibleCount: visibleItems.length,
+                virtualize,
+              },
+            )}
             {virtualize && endIndex < items.length && (
               <Box height={Math.max(items.length - endIndex, 0)} />
             )}

--- a/src/components/ui/list-view.tsx
+++ b/src/components/ui/list-view.tsx
@@ -131,7 +131,9 @@ export function ListView({
         height={1}
         backgroundColor={rowBg}
         onMouseMove={() => {
-          if (!disabled) setHoveredIndex(index);
+          if (!disabled) {
+            setHoveredIndex((current) => (current === index ? current : index));
+          }
         }}
         onMouseDown={() => {
           if (disabled) return;

--- a/src/components/ui/page-stack-view.tsx
+++ b/src/components/ui/page-stack-view.tsx
@@ -32,14 +32,14 @@ export function PageStackView({
 
   if (!detailOpen) {
     return (
-      <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="column" flexGrow={1} overflow="hidden">
         {rootContent}
       </Box>
     );
   }
 
   return (
-    <Box flexDirection="column" flexGrow={1}>
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
       <Box height={1} flexDirection="row">
         <Box
           onMouseDown={(event) => {
@@ -53,7 +53,7 @@ export function PageStackView({
         <Box flexGrow={1} />
         {backHint ? <Text fg={colors.textMuted}>{backHint}</Text> : null}
       </Box>
-      <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="column" flexGrow={1} overflow="hidden">
         {detailContent}
       </Box>
     </Box>

--- a/src/components/ui/row-value-cache.test.ts
+++ b/src/components/ui/row-value-cache.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { createRowValueCache } from "./row-value-cache";
+
+describe("createRowValueCache", () => {
+  test("reuses values for unchanged versions", () => {
+    const cache = createRowValueCache<string, number>();
+    let calls = 0;
+
+    const first = cache.get("AAPL", "v1", () => ++calls);
+    const second = cache.get("AAPL", "v1", () => ++calls);
+
+    expect(first).toBe(1);
+    expect(second).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  test("invalidates by version", () => {
+    const cache = createRowValueCache<string, number>();
+    let calls = 0;
+
+    cache.get("AAPL", "v1", () => ++calls);
+    const next = cache.get("AAPL", "v2", () => ++calls);
+
+    expect(next).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  test("evicts least recently used entries", () => {
+    const cache = createRowValueCache<string, number>(2);
+    let calls = 0;
+
+    cache.get("AAPL", "v1", () => ++calls);
+    cache.get("MSFT", "v1", () => ++calls);
+    cache.get("AAPL", "v1", () => ++calls);
+    cache.get("NVDA", "v1", () => ++calls);
+    const recomputed = cache.get("MSFT", "v1", () => ++calls);
+
+    expect(recomputed).toBe(4);
+  });
+});

--- a/src/components/ui/row-value-cache.ts
+++ b/src/components/ui/row-value-cache.ts
@@ -1,0 +1,41 @@
+export interface RowValueCache<K, V> {
+  get(key: K, version: string, compute: () => V): V;
+  clear(): void;
+}
+
+interface CacheEntry<V> {
+  version: string;
+  value: V;
+}
+
+export function createRowValueCache<K, V>(maxEntries = 1000): RowValueCache<K, V> {
+  const entries = new Map<K, CacheEntry<V>>();
+  const safeMaxEntries = Math.max(1, maxEntries);
+
+  const touch = (key: K, entry: CacheEntry<V>) => {
+    entries.delete(key);
+    entries.set(key, entry);
+  };
+
+  return {
+    get(key: K, version: string, compute: () => V): V {
+      const cached = entries.get(key);
+      if (cached && cached.version === version) {
+        touch(key, cached);
+        return cached.value;
+      }
+
+      const entry = { version, value: compute() };
+      touch(key, entry);
+      while (entries.size > safeMaxEntries) {
+        const firstKey = entries.keys().next().value as K | undefined;
+        if (firstKey === undefined) break;
+        entries.delete(firstKey);
+      }
+      return entry.value;
+    },
+    clear(): void {
+      entries.clear();
+    },
+  };
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,6 +1,7 @@
-import { Box, Text } from "../../ui";
-import { TextAttributes } from "../../ui";
-import { colors } from "../../theme/colors";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Box, ScrollBox, Text, useUiHost } from "../../ui";
+import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
+import { colors, hoverBg } from "../../theme/colors";
 
 export interface TabItem {
   label: string;
@@ -15,34 +16,174 @@ export interface TabsProps {
   compact?: boolean;
 }
 
-export function Tabs({ tabs, activeValue, onSelect, compact = false }: TabsProps) {
-  return (
-    <Box flexDirection="row" height={compact ? 1 : 2}>
-      {tabs.map((tab) => {
-        const active = tab.value === activeValue;
-        const tabWidth = tab.label.length + 2;
+const WHEEL_DELTA_PER_CELL = 8;
 
-        return (
-          <Box
-            key={tab.value}
-            width={tabWidth + 2}
-            flexDirection="column"
-            alignItems="center"
-            onMouseDown={(event) => {
-              event.preventDefault();
-              if (!tab.disabled) onSelect(tab.value);
-            }}
-          >
-            <Text
-              fg={tab.disabled ? colors.textMuted : active ? colors.text : colors.textDim}
-              attributes={active ? TextAttributes.BOLD : 0}
+export function Tabs({ tabs, activeValue, onSelect, compact = false }: TabsProps) {
+  const ui = useUiHost();
+  const NativeTabs = ui.Tabs;
+  const palette = {
+    activeFg: colors.text,
+    inactiveFg: colors.textDim,
+    disabledFg: colors.textMuted,
+    hoverFg: colors.text,
+    activeUnderline: colors.borderFocused,
+    inactiveUnderline: colors.bg,
+    hoverUnderline: colors.border,
+    hoverBg: hoverBg(),
+  };
+
+  if (NativeTabs) {
+    return (
+      <NativeTabs
+        tabs={tabs}
+        activeValue={activeValue}
+        onSelect={onSelect}
+        compact={compact}
+        palette={palette}
+      />
+    );
+  }
+
+  return (
+    <OpenTuiTabs
+      tabs={tabs}
+      activeValue={activeValue}
+      onSelect={onSelect}
+      compact={compact}
+      palette={palette}
+    />
+  );
+}
+
+function OpenTuiTabs({
+  tabs,
+  activeValue,
+  onSelect,
+  compact = false,
+  palette,
+}: TabsProps & {
+  palette: {
+    activeFg: string;
+    inactiveFg: string;
+    disabledFg: string;
+    hoverFg: string;
+    activeUnderline: string;
+    inactiveUnderline: string;
+    hoverUnderline: string;
+    hoverBg: string;
+  };
+}) {
+  const [hoveredValue, setHoveredValue] = useState<string | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const tabWidths = useMemo(
+    () => tabs.map((tab) => tab.label.length + 2),
+    [tabs],
+  );
+  const totalWidth = tabWidths.reduce((sum, width) => sum + width, 0);
+
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    const activeIndex = tabs.findIndex((tab) => tab.value === activeValue);
+    const viewportWidth = scrollBox?.viewport?.width ?? 0;
+    if (!scrollBox || activeIndex < 0 || viewportWidth <= 0) return;
+
+    const activeLeft = tabWidths.slice(0, activeIndex).reduce((sum, width) => sum + width, 0);
+    const activeRight = activeLeft + tabWidths[activeIndex]!;
+    const currentLeft = scrollBox.scrollLeft ?? 0;
+    const currentRight = currentLeft + viewportWidth;
+    const maxScrollLeft = Math.max(0, totalWidth - viewportWidth);
+
+    if (activeLeft < currentLeft) {
+      scrollBox.scrollTo({ x: activeLeft, y: scrollBox.scrollTop });
+    } else if (activeRight > currentRight) {
+      scrollBox.scrollTo({
+        x: Math.min(activeRight - viewportWidth, maxScrollLeft),
+        y: scrollBox.scrollTop,
+      });
+    }
+  }, [activeValue, tabWidths, tabs, totalWidth]);
+
+  const handleMouseScroll = (event?: {
+    preventDefault?: () => void;
+    stopPropagation?: () => void;
+    scroll?: { direction?: string; delta?: number };
+  }) => {
+    const direction = event?.scroll?.direction;
+    if (!direction) return;
+    const scrollBox = scrollRef.current;
+    const viewportWidth = scrollBox?.viewport?.width ?? 0;
+    if (!scrollBox || viewportWidth <= 0 || totalWidth <= viewportWidth) return;
+
+    event.preventDefault?.();
+    event.stopPropagation?.();
+
+    const rawDelta = Math.abs(event.scroll?.delta ?? 1);
+    const deltaCells = Math.max(1, Math.round(rawDelta / WHEEL_DELTA_PER_CELL));
+    const directionSign = direction === "right" || direction === "down" ? 1 : -1;
+    const maxScrollLeft = Math.max(0, totalWidth - viewportWidth);
+    const nextLeft = Math.max(
+      0,
+      Math.min(maxScrollLeft, (scrollBox.scrollLeft ?? 0) + directionSign * deltaCells),
+    );
+    scrollBox.scrollTo({ x: nextLeft, y: scrollBox.scrollTop });
+  };
+
+  return (
+    <ScrollBox
+      ref={scrollRef}
+      width="100%"
+      height={compact ? 1 : 2}
+      scrollX
+      focusable={false}
+      horizontalScrollbarOptions={{ visible: false }}
+      onMouseScroll={handleMouseScroll}
+    >
+      <Box flexDirection="row" width={totalWidth} height={compact ? 1 : 2}>
+        {tabs.map((tab, index) => {
+          const active = tab.value === activeValue;
+          const hovered = hoveredValue === tab.value && !tab.disabled;
+          const tabWidth = tabWidths[index] ?? tab.label.length + 2;
+          const tabLabel = ` ${tab.label} `;
+          const startHover = tab.disabled
+            ? undefined
+            : () => {
+                setHoveredValue((current) => (current === tab.value ? current : tab.value));
+              };
+          const endHover = tab.disabled
+            ? undefined
+            : () => {
+                setHoveredValue((current) => (current === tab.value ? null : current));
+              };
+
+          return (
+            <Box
+              key={tab.value}
+              width={tabWidth}
+              flexDirection="column"
+              backgroundColor={hovered ? palette.hoverBg : undefined}
+              onMouseOver={startHover}
+              onMouseMove={startHover}
+              onMouseOut={endHover}
+              onMouseDown={tab.disabled ? undefined : (event) => {
+                event.preventDefault();
+                onSelect(tab.value);
+              }}
             >
-              {tab.label}
-            </Text>
-            {!compact && <Text fg={active ? colors.borderFocused : colors.bg}>{"▔".repeat(tabWidth)}</Text>}
-          </Box>
-        );
-      })}
-    </Box>
+              <Text
+                fg={tab.disabled ? palette.disabledFg : active ? palette.activeFg : hovered ? palette.hoverFg : palette.inactiveFg}
+                attributes={active ? TextAttributes.BOLD : 0}
+              >
+                {tabLabel}
+              </Text>
+              {!compact && (
+                <Text fg={active ? palette.activeUnderline : hovered ? palette.hoverUnderline : palette.inactiveUnderline}>
+                  {"▔".repeat(tabWidth)}
+                </Text>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </ScrollBox>
   );
 }

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -150,6 +150,37 @@ function DataTableNoHorizontalScrollHarness() {
   );
 }
 
+function DataTableVirtualizationHarness() {
+  const headerScrollRef = useRef<ScrollBoxRenderable>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const rows = Array.from({ length: 100 }, (_, index) => ({
+    id: `row-${index}`,
+    name: `Row ${index}`,
+  }));
+
+  return (
+    <DataTable
+      columns={[{ id: "name", label: "NAME", width: 12, align: "left" }]}
+      items={rows}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      headerScrollRef={headerScrollRef}
+      scrollRef={scrollRef}
+      syncHeaderScroll={() => {}}
+      onBodyScrollActivity={() => {}}
+      hoveredIdx={hoveredIdx}
+      setHoveredIdx={setHoveredIdx}
+      getItemKey={(row) => row.id}
+      isSelected={() => false}
+      onSelect={() => {}}
+      renderCell={(row) => ({ text: row.name })}
+      emptyStateTitle="No rows."
+    />
+  );
+}
+
 function MultiSelectChipsHarness() {
   const [values, setValues] = useState(["sma"]);
   selectedChips = values;
@@ -229,6 +260,42 @@ describe("shared UI kit", () => {
     expect(frame).toContain("Save");
     expect(frame).toContain("Syncing");
     expect(frame).toContain("Connected");
+  });
+
+  test("scrolls overflowing tabs horizontally with the mouse wheel", async () => {
+    testSetup = await testRender(
+      <Tabs
+        tabs={[
+          { label: "Overview", value: "overview" },
+          { label: "Financials", value: "financials" },
+          { label: "Chart", value: "chart" },
+          { label: "Options", value: "options" },
+          { label: "Insider", value: "insider" },
+        ]}
+        activeValue="overview"
+        onSelect={() => {}}
+      />,
+      { width: 24, height: 4 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Overview");
+    expect(frame).not.toContain("Insider");
+
+    await act(async () => {
+      for (let i = 0; i < 40; i++) {
+        await testSetup!.mockMouse.scroll(1, 0, "down");
+      }
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Options");
+    expect(frame).toContain("Insider");
   });
 
   test("renders toggle lists with selection and descriptions", async () => {
@@ -472,5 +539,25 @@ describe("shared UI kit", () => {
     });
 
     expect(tableHorizontalScrollbarVisible).toBe(false);
+  });
+
+  test("virtualizes data table rows by default", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="portfolio-list:main">
+          <DataTableVirtualizationHarness />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 32, height: 6 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Row 0");
+    expect(frame).not.toContain("Row 99");
   });
 });

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -10,6 +10,10 @@ import { PluginRegistry } from "../plugins/registry";
 import { ProviderRouter } from "../sources/provider-router";
 import type { AppConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
+import { debugLog } from "../utils/debug-log";
+import { measurePerf } from "../utils/perf-marks";
+
+const servicesLog = debugLog.createLogger("services");
 
 export interface AppServices {
   persistence: AppPersistence;
@@ -29,10 +33,14 @@ export function createAppServices({
   config: AppConfig;
   externalPlugins: LoadedExternalPlugin[];
 }): AppServices {
+  servicesLog.info("create services start", {
+    externalPluginCount: externalPlugins.length,
+    brokerInstanceCount: config.brokerInstances.length,
+  });
   const dbPath = join(config.dataDir, ".gloomberb-cache.db");
-  const persistence = new AppPersistence(dbPath);
-  const tickerRepository = new TickerRepository(persistence.tickers);
-  const providerRouter = new ProviderRouter(null, [], persistence.resources);
+  const persistence = measurePerf("startup.services.persistence", () => new AppPersistence(dbPath));
+  const tickerRepository = measurePerf("startup.services.ticker-repository", () => new TickerRepository(persistence.tickers));
+  const providerRouter = measurePerf("startup.services.provider-router", () => new ProviderRouter(null, [], persistence.resources));
   const dataProvider: DataProvider = providerRouter;
   const marketData = new MarketDataCoordinator(dataProvider);
   const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence);
@@ -46,10 +54,16 @@ export function createAppServices({
   setSharedNewsService(newsService);
   setSharedMarketDataCoordinator(marketData);
 
-  for (const plugin of getLoadablePlugins(externalPlugins)) {
-    pluginRegistry.register(plugin);
+  const plugins = getLoadablePlugins(externalPlugins);
+  for (const plugin of plugins) {
+    measurePerf("startup.services.register-plugin", () => {
+      void pluginRegistry.register(plugin);
+    }, { pluginId: plugin.id });
   }
-  newsService.start();
+  measurePerf("startup.services.news-start", () => {
+    newsService.start();
+  });
+  servicesLog.info("create services complete", { pluginCount: plugins.length });
 
   return {
     persistence,

--- a/src/core/state/app-state.ts
+++ b/src/core/state/app-state.ts
@@ -272,7 +272,14 @@ function clearTickerBindings(layout: LayoutConfig, symbol: string): LayoutConfig
 
 function nextRecentTickers(current: string[], symbol: string | null): string[] {
   if (!symbol) return current;
-  return [symbol, ...current.filter((entry) => entry !== symbol)].slice(0, 50);
+  if (current[0] === symbol && !current.slice(1).includes(symbol)) {
+    return current;
+  }
+  const next = [symbol, ...current.filter((entry) => entry !== symbol)].slice(0, 50);
+  if (next.length === current.length && next.every((entry, index) => entry === current[index])) {
+    return current;
+  }
+  return next;
 }
 
 function syncLayouts(layouts: SavedLayout[], activeLayoutIndex: number, layout: LayoutConfig): SavedLayout[] {
@@ -385,6 +392,30 @@ function bringFloatingToFront(layout: LayoutConfig, paneId: string): LayoutConfi
     floating: layout.floating.map((e) =>
       e.instanceId === paneId ? { ...e, zIndex: maxZ + 1 } : e,
     ),
+  };
+}
+
+function focusPaneState(state: AppState, paneId: string): AppState {
+  const layout = bringFloatingToFront(state.config.layout, paneId);
+  const config = layout !== state.config.layout
+    ? { ...state.config, layout, layouts: syncLayouts(state.config.layouts, state.config.activeLayoutIndex, layout) }
+    : state.config;
+  const recentTickers = nextRecentTickers(
+    state.recentTickers,
+    resolveTickerForPane(state, paneId),
+  );
+  if (
+    config === state.config &&
+    state.focusedPaneId === paneId &&
+    recentTickers === state.recentTickers
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    config,
+    focusedPaneId: paneId,
+    recentTickers,
   };
 }
 
@@ -712,48 +743,21 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     }
 
     case "FOCUS_PANE": {
-      const layout = bringFloatingToFront(state.config.layout, action.paneId);
-      const config = layout !== state.config.layout
-        ? { ...state.config, layout, layouts: syncLayouts(state.config.layouts, state.config.activeLayoutIndex, layout) }
-        : state.config;
-      return {
-        ...state,
-        config,
-        focusedPaneId: action.paneId,
-        recentTickers: nextRecentTickers(state.recentTickers, resolveTickerForPane(state, action.paneId)),
-      };
+      return focusPaneState(state, action.paneId);
     }
 
     case "FOCUS_NEXT": {
       if (action.paneOrder.length === 0) return state;
       const currentIndex = state.focusedPaneId ? action.paneOrder.indexOf(state.focusedPaneId) : -1;
       const nextPaneId = action.paneOrder[(currentIndex + 1) % action.paneOrder.length]!;
-      const layout = bringFloatingToFront(state.config.layout, nextPaneId);
-      const config = layout !== state.config.layout
-        ? { ...state.config, layout, layouts: syncLayouts(state.config.layouts, state.config.activeLayoutIndex, layout) }
-        : state.config;
-      return {
-        ...state,
-        config,
-        focusedPaneId: nextPaneId,
-        recentTickers: nextRecentTickers(state.recentTickers, resolveTickerForPane(state, nextPaneId)),
-      };
+      return focusPaneState(state, nextPaneId);
     }
 
     case "FOCUS_PREV": {
       if (action.paneOrder.length === 0) return state;
       const currentIndex = state.focusedPaneId ? action.paneOrder.indexOf(state.focusedPaneId) : 0;
       const nextPaneId = action.paneOrder[(currentIndex - 1 + action.paneOrder.length) % action.paneOrder.length]!;
-      const layout = bringFloatingToFront(state.config.layout, nextPaneId);
-      const config = layout !== state.config.layout
-        ? { ...state.config, layout, layouts: syncLayouts(state.config.layouts, state.config.activeLayoutIndex, layout) }
-        : state.config;
-      return {
-        ...state,
-        config,
-        focusedPaneId: nextPaneId,
-        recentTickers: nextRecentTickers(state.recentTickers, resolveTickerForPane(state, nextPaneId)),
-      };
+      return focusPaneState(state, nextPaneId);
     }
 
     case "UPDATE_PANE_STATE": {

--- a/src/market-data/coordinator-subscriptions.test.ts
+++ b/src/market-data/coordinator-subscriptions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { MarketDataCoordinator } from "./coordinator";
+import { buildQuoteKey } from "./selectors";
+import { createTestDataProvider } from "../test-support/data-provider";
+import type { Quote } from "../types/financials";
+import type { DataProvider, QuoteSubscriptionTarget } from "../types/data-provider";
+
+function createProvider(): {
+  provider: DataProvider;
+  emitQuote: (target: QuoteSubscriptionTarget, quote: Quote) => void;
+} {
+  let onQuote: ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null = null;
+  const provider = createTestDataProvider({
+    id: "test-provider",
+    subscribeQuotes: (_targets, handler) => {
+      onQuote = handler;
+      return () => {};
+    },
+  });
+  return {
+    provider,
+    emitQuote(target, quote) {
+      if (!onQuote) throw new Error("subscription was not registered");
+      onQuote(target, quote);
+    },
+  };
+}
+
+function quote(symbol: string, price: number): Quote {
+  return {
+    symbol,
+    price,
+    currency: "USD",
+    change: 0,
+    changePercent: 0,
+    lastUpdated: Date.now(),
+  };
+}
+
+async function flushCoordinator(): Promise<void> {
+  await Promise.resolve();
+}
+
+describe("MarketDataCoordinator key subscriptions", () => {
+  test("notifies listeners for changed keys only", async () => {
+    const { provider, emitQuote } = createProvider();
+    const coordinator = new MarketDataCoordinator(provider);
+    const aapl = { symbol: "AAPL", exchange: "NASDAQ" };
+    const msft = { symbol: "MSFT", exchange: "NASDAQ" };
+    let aaplCalls = 0;
+    let msftCalls = 0;
+
+    coordinator.subscribeKeys([buildQuoteKey(aapl)], () => { aaplCalls += 1; });
+    coordinator.subscribeKeys([buildQuoteKey(msft)], () => { msftCalls += 1; });
+    coordinator.subscribeQuotes([{ instrument: aapl }, { instrument: msft }]);
+
+    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100));
+    await flushCoordinator();
+
+    expect(aaplCalls).toBe(1);
+    expect(msftCalls).toBe(0);
+  });
+
+  test("dedupes listeners subscribed to multiple changed keys", async () => {
+    const { provider, emitQuote } = createProvider();
+    const coordinator = new MarketDataCoordinator(provider);
+    const aapl = { symbol: "AAPL", exchange: "NASDAQ" };
+    const msft = { symbol: "MSFT", exchange: "NASDAQ" };
+    let calls = 0;
+
+    coordinator.subscribeKeys([buildQuoteKey(aapl), buildQuoteKey(msft)], () => { calls += 1; });
+    coordinator.subscribeQuotes([{ instrument: aapl }, { instrument: msft }]);
+
+    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100));
+    emitQuote({ symbol: "MSFT", exchange: "NASDAQ" }, quote("MSFT", 200));
+    await flushCoordinator();
+
+    expect(calls).toBe(1);
+  });
+
+  test("coalesces global notifications per microtask", async () => {
+    const { provider, emitQuote } = createProvider();
+    const coordinator = new MarketDataCoordinator(provider);
+    const aapl = { symbol: "AAPL", exchange: "NASDAQ" };
+    const msft = { symbol: "MSFT", exchange: "NASDAQ" };
+    let calls = 0;
+
+    coordinator.subscribe(() => { calls += 1; });
+    coordinator.subscribeQuotes([{ instrument: aapl }, { instrument: msft }]);
+
+    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100));
+    emitQuote({ symbol: "MSFT", exchange: "NASDAQ" }, quote("MSFT", 200));
+    await flushCoordinator();
+
+    expect(calls).toBe(1);
+    expect(coordinator.getVersion()).toBe(1);
+  });
+});

--- a/src/market-data/coordinator.test.ts
+++ b/src/market-data/coordinator.test.ts
@@ -87,9 +87,78 @@ describe("MarketDataCoordinator", () => {
     const first = await coordinator.loadChart(request);
     expect(first.data?.length).toBe(2);
 
-    const second = await coordinator.loadChart(request);
+    const second = await coordinator.loadChart(request, { forceRefresh: true });
     expect(second.data).toBeNull();
     expect(second.lastGoodData?.length).toBe(2);
+  });
+
+  it("reuses fresh snapshots instead of refetching on every pane rerender", async () => {
+    let calls = 0;
+    const provider = createProvider({
+      getTickerFinancials: async () => {
+        calls += 1;
+        return {
+          quote: {
+            symbol: "AAPL",
+            price: 100 + calls,
+            currency: "USD",
+            change: 1,
+            changePercent: 1,
+            lastUpdated: Date.now(),
+          },
+          fundamentals: { marketCap: calls },
+          profile: null,
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+        };
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+
+    const first = await coordinator.loadSnapshot(instrument);
+    const second = await coordinator.loadSnapshot(instrument);
+    const refreshed = await coordinator.loadSnapshot(instrument, { forceRefresh: true });
+
+    expect(first.data?.quote?.price).toBe(101);
+    expect(second.data?.quote?.price).toBe(101);
+    expect(refreshed.data?.quote?.price).toBe(102);
+    expect(calls).toBe(2);
+  });
+
+  it("reuses fresh empty tab query results instead of refetching on reopen", async () => {
+    let newsCalls = 0;
+    let optionsCalls = 0;
+    const provider = createProvider({
+      getNews: async () => {
+        newsCalls += 1;
+        return [];
+      },
+      getOptionsChain: async () => {
+        optionsCalls += 1;
+        return {
+          underlyingSymbol: "AAPL",
+          expirationDates: [],
+          calls: [],
+          puts: [],
+        };
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+
+    const firstNews = await coordinator.loadNews({ instrument, count: 20 });
+    const secondNews = await coordinator.loadNews({ instrument, count: 20 });
+    const firstOptions = await coordinator.loadOptions({ instrument });
+    const secondOptions = await coordinator.loadOptions({ instrument });
+
+    expect(firstNews.error?.reasonCode).toBe("NO_DATA");
+    expect(secondNews.error?.reasonCode).toBe("NO_DATA");
+    expect(firstOptions.error?.reasonCode).toBe("NO_DATA");
+    expect(secondOptions.error?.reasonCode).toBe("NO_DATA");
+    expect(newsCalls).toBe(1);
+    expect(optionsCalls).toBe(1);
   });
 
   it("uses cached chart data while a wider range request is loading", async () => {

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -26,10 +26,19 @@ import { traceMarketData } from "./trace";
 import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../utils/price-history";
 import { hasFreshQuoteForCurrentSession, isQuoteStaleForCurrentSession } from "../utils/quote-freshness";
 import { TIME_RANGE_ORDER } from "../components/chart/chart-resolution";
+import { measurePerf } from "../utils/perf-marks";
 
 const EMPTY_MESSAGE = "No data available";
 const EXPECTED_EMPTY = /no data|not found|delisted|unavailable|unsupported/i;
 const TIME_RANGE_INDEX = new Map(TIME_RANGE_ORDER.map((range, index) => [range, index]));
+const SNAPSHOT_CACHE_TTL_MS = 5 * 60_000;
+const CHART_CACHE_TTL_MS = 10 * 60_000;
+const NEWS_CACHE_TTL_MS = 2 * 60_000;
+const OPTIONS_CACHE_TTL_MS = 10 * 60_000;
+const SEC_FILINGS_CACHE_TTL_MS = 10 * 60_000;
+const SEC_CONTENT_CACHE_TTL_MS = 24 * 60 * 60_000;
+const ARTICLE_SUMMARY_CACHE_TTL_MS = 24 * 60 * 60_000;
+const FX_CACHE_TTL_MS = 30 * 60_000;
 
 function createBaselineChartRequest(instrument: InstrumentRef): ChartRequest {
   return {
@@ -67,6 +76,15 @@ function classifyError(error: unknown): { reasonCode: ProviderReasonCode; messag
   if (/mapping|symbol/i.test(message)) return { reasonCode: "BAD_MAPPING", message };
   if (/not found|no data|unavailable|delisted/i.test(message)) return { reasonCode: "NOT_FOUND", message };
   return { reasonCode: "UPSTREAM_ERROR", message };
+}
+
+function hasFreshEntryData<T>(entry: QueryEntry<T>, ttlMs: number, now = Date.now()): boolean {
+  if (resolveEntryData(entry) == null) return false;
+  return entry.fetchedAt != null && now - entry.fetchedAt < ttlMs;
+}
+
+function hasFreshReadyEntry<T>(entry: QueryEntry<T>, ttlMs: number, now = Date.now()): boolean {
+  return entry.phase === "ready" && entry.fetchedAt != null && now - entry.fetchedAt < ttlMs;
 }
 
 function createAttempt(
@@ -147,28 +165,55 @@ function errorEntry<T>(current: QueryEntry<T>, attempt: ProviderAttempt): QueryE
 
 export class MarketDataCoordinator {
   private version = 0;
+  private pendingVersionBump = false;
+  private pendingChangedKeys = new Set<string>();
   private readonly listeners = new Set<() => void>();
+  private readonly keyListeners = new Map<string, Set<() => void>>();
+  private readonly keyVersions = new Map<string, number>();
   private readonly inFlight = new Map<string, Promise<unknown>>();
   private readonly chartRequests = new Map<string, ChartRequest>();
 
-  private readonly quoteStore = new QueryStore<Quote>(() => this.bump());
-  private readonly snapshotStore = new QueryStore<TickerFinancials>(() => this.bump());
-  private readonly profileStore = new QueryStore<TickerFinancials["profile"]>(() => this.bump());
-  private readonly fundamentalsStore = new QueryStore<TickerFinancials["fundamentals"]>(() => this.bump());
-  private readonly statementsStore = new QueryStore<Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">>(() => this.bump());
-  private readonly chartStore = new QueryStore<PricePoint[]>(() => this.bump());
-  private readonly newsStore = new QueryStore<NewsItem[]>(() => this.bump());
-  private readonly optionsStore = new QueryStore<OptionsChain>(() => this.bump());
-  private readonly secFilingsStore = new QueryStore<SecFilingItem[]>(() => this.bump());
-  private readonly secContentStore = new QueryStore<string | null>(() => this.bump());
-  private readonly articleSummaryStore = new QueryStore<string | null>(() => this.bump());
-  private readonly fxStore = new QueryStore<number>(() => this.bump());
+  private readonly quoteStore = new QueryStore<Quote>((key) => this.bump(key));
+  private readonly snapshotStore = new QueryStore<TickerFinancials>((key) => this.bump(key));
+  private readonly profileStore = new QueryStore<TickerFinancials["profile"]>((key) => this.bump(key));
+  private readonly fundamentalsStore = new QueryStore<TickerFinancials["fundamentals"]>((key) => this.bump(key));
+  private readonly statementsStore = new QueryStore<Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">>((key) => this.bump(key));
+  private readonly chartStore = new QueryStore<PricePoint[]>((key) => this.bump(key));
+  private readonly newsStore = new QueryStore<NewsItem[]>((key) => this.bump(key));
+  private readonly optionsStore = new QueryStore<OptionsChain>((key) => this.bump(key));
+  private readonly secFilingsStore = new QueryStore<SecFilingItem[]>((key) => this.bump(key));
+  private readonly secContentStore = new QueryStore<string | null>((key) => this.bump(key));
+  private readonly articleSummaryStore = new QueryStore<string | null>((key) => this.bump(key));
+  private readonly fxStore = new QueryStore<number>((key) => this.bump(key));
 
   constructor(private readonly dataProvider: DataProvider) {}
 
-  private bump(): void {
-    this.version += 1;
-    for (const listener of this.listeners) listener();
+  private bump(changeKey?: string): void {
+    if (changeKey) this.pendingChangedKeys.add(changeKey);
+    if (this.pendingVersionBump) return;
+    this.pendingVersionBump = true;
+    queueMicrotask(() => this.flushBump());
+  }
+
+  private flushBump(): void {
+    this.pendingVersionBump = false;
+    const changedKeys = this.pendingChangedKeys;
+    this.pendingChangedKeys = new Set();
+    measurePerf("market-data.bump", () => {
+      this.version += 1;
+      for (const key of changedKeys) {
+        this.keyVersions.set(key, (this.keyVersions.get(key) ?? 0) + 1);
+      }
+      const keyListeners = new Set<() => void>();
+      for (const key of changedKeys) {
+        for (const listener of this.keyListeners.get(key) ?? []) {
+          keyListeners.add(listener);
+        }
+      }
+
+      for (const listener of this.listeners) listener();
+      for (const listener of keyListeners) listener();
+    }, { changedKeyCount: changedKeys.size });
   }
 
   subscribe(listener: () => void): () => void {
@@ -178,8 +223,33 @@ export class MarketDataCoordinator {
     };
   }
 
+  subscribeKeys(keys: readonly string[], listener: () => void): () => void {
+    const uniqueKeys = [...new Set(keys)];
+    for (const key of uniqueKeys) {
+      if (!this.keyListeners.has(key)) this.keyListeners.set(key, new Set());
+      this.keyListeners.get(key)!.add(listener);
+    }
+    return () => {
+      for (const key of uniqueKeys) {
+        const listeners = this.keyListeners.get(key);
+        listeners?.delete(listener);
+        if (listeners?.size === 0) {
+          this.keyListeners.delete(key);
+        }
+      }
+    };
+  }
+
   getVersion(): number {
     return this.version;
+  }
+
+  getKeysVersion(keys: readonly string[]): number {
+    let version = 0;
+    for (const key of new Set(keys)) {
+      version += this.keyVersions.get(key) ?? 0;
+    }
+    return version;
   }
 
   getQuoteEntry(instrument: InstrumentRef): QueryEntry<Quote> {
@@ -354,6 +424,10 @@ export class MarketDataCoordinator {
     options: { forceRefresh?: boolean } = {},
   ): Promise<QueryEntry<TickerFinancials>> {
     const key = buildSnapshotKey(instrument);
+    const current = this.snapshotStore.get(key);
+    if (!options.forceRefresh && hasFreshEntryData(current, SNAPSHOT_CACHE_TTL_MS)) {
+      return current;
+    }
     const flightKey = options.forceRefresh ? `${key}|refresh` : key;
     return this.runSingleFlight(flightKey, async () => {
       this.snapshotStore.update(key, loadingEntry);
@@ -448,6 +522,10 @@ export class MarketDataCoordinator {
   ): Promise<QueryEntry<PricePoint[]>> {
     const key = buildChartKey(request);
     this.chartRequests.set(key, request);
+    const current = this.chartStore.get(key);
+    if (!options.forceRefresh && hasFreshEntryData(current, CHART_CACHE_TTL_MS)) {
+      return current;
+    }
     const flightKey = options.forceRefresh ? `${key}|refresh` : key;
     return this.runSingleFlight(flightKey, async () => {
       this.chartStore.update(key, (current) => this.createChartLoadingEntry(key, request, current));
@@ -500,6 +578,10 @@ export class MarketDataCoordinator {
 
   async loadNews(request: NewsRequest): Promise<QueryEntry<NewsItem[]>> {
     const key = buildNewsKey(request);
+    const current = this.newsStore.get(key);
+    if (hasFreshReadyEntry(current, NEWS_CACHE_TTL_MS)) {
+      return current;
+    }
     return this.runSingleFlight(key, async () => {
       this.newsStore.update(key, loadingEntry);
       const startedAt = Date.now();
@@ -522,6 +604,10 @@ export class MarketDataCoordinator {
 
   async loadOptions(request: OptionsRequest): Promise<QueryEntry<OptionsChain>> {
     const key = buildOptionsKey(request);
+    const current = this.optionsStore.get(key);
+    if (hasFreshReadyEntry(current, OPTIONS_CACHE_TTL_MS)) {
+      return current;
+    }
     return this.runSingleFlight(key, async () => {
       this.optionsStore.update(key, loadingEntry);
       const startedAt = Date.now();
@@ -548,6 +634,10 @@ export class MarketDataCoordinator {
 
   async loadSecFilings(request: SecFilingsRequest): Promise<QueryEntry<SecFilingItem[]>> {
     const key = buildSecFilingsKey(request);
+    const current = this.secFilingsStore.get(key);
+    if (hasFreshReadyEntry(current, SEC_FILINGS_CACHE_TTL_MS)) {
+      return current;
+    }
     return this.runSingleFlight(key, async () => {
       this.secFilingsStore.update(key, loadingEntry);
       const startedAt = Date.now();
@@ -574,6 +664,10 @@ export class MarketDataCoordinator {
 
   async loadSecFilingContent(filing: SecFilingItem): Promise<QueryEntry<string | null>> {
     const key = buildSecContentKey(filing.accessionNumber);
+    const current = this.secContentStore.get(key);
+    if (hasFreshReadyEntry(current, SEC_CONTENT_CACHE_TTL_MS)) {
+      return current;
+    }
     return this.runSingleFlight(key, async () => {
       this.secContentStore.update(key, loadingEntry);
       const startedAt = Date.now();
@@ -596,6 +690,10 @@ export class MarketDataCoordinator {
 
   async loadArticleSummary(url: string): Promise<QueryEntry<string | null>> {
     const key = buildArticleSummaryKey(url);
+    const current = this.articleSummaryStore.get(key);
+    if (hasFreshReadyEntry(current, ARTICLE_SUMMARY_CACHE_TTL_MS)) {
+      return current;
+    }
     return this.runSingleFlight(key, async () => {
       this.articleSummaryStore.update(key, loadingEntry);
       const startedAt = Date.now();
@@ -614,6 +712,10 @@ export class MarketDataCoordinator {
 
   async loadFxRate(currency: string): Promise<QueryEntry<number>> {
     const key = buildFxKey(currency);
+    const current = this.fxStore.get(key);
+    if (hasFreshEntryData(current, FX_CACHE_TTL_MS)) {
+      return current;
+    }
     return this.runSingleFlight(key, async () => {
       this.fxStore.update(key, loadingEntry);
       const startedAt = Date.now();

--- a/src/market-data/hooks.tsx
+++ b/src/market-data/hooks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import type { NewsItem, SecFilingItem } from "../types/data-provider";
 import type { OptionsChain, PricePoint, Quote, TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
@@ -9,7 +9,19 @@ import {
   resolveEntryValue,
 } from "./coordinator";
 import type { QueryEntry } from "./result-types";
-import { buildChartKey } from "./selectors";
+import {
+  buildArticleSummaryKey,
+  buildChartKey,
+  buildFxKey,
+  buildNewsKey,
+  buildOptionsKey,
+  buildQuoteKey,
+  buildSecContentKey,
+  buildSecFilingsKey,
+  buildSnapshotKey,
+} from "./selectors";
+
+const TICKER_FINANCIALS_LOAD_DELAY_MS = 250;
 
 function useCoordinatorVersion(): number {
   const coordinator = getSharedMarketDataCoordinator();
@@ -18,6 +30,30 @@ function useCoordinatorVersion(): number {
     () => coordinator?.getVersion() ?? 0,
     () => 0,
   );
+}
+
+function useCoordinatorKeysVersion(keys: readonly string[]): number {
+  const coordinator = getSharedMarketDataCoordinator();
+  const keyString = keys.join("\u001f");
+  const stableKeys = useMemo(
+    () => (keyString ? keyString.split("\u001f") : []),
+    [keyString],
+  );
+  const subscribe = useCallback((listener: () => void) => {
+    if (!coordinator) return () => {};
+    if (typeof coordinator.subscribeKeys === "function") {
+      return coordinator.subscribeKeys(stableKeys, listener);
+    }
+    return coordinator.subscribe(listener);
+  }, [coordinator, stableKeys]);
+  const getSnapshot = useCallback(() => {
+    if (!coordinator) return 0;
+    if (typeof coordinator.getKeysVersion === "function") {
+      return coordinator.getKeysVersion(stableKeys);
+    }
+    return coordinator.getVersion();
+  }, [coordinator, stableKeys]);
+  return useSyncExternalStore(subscribe, getSnapshot, () => 0);
 }
 
 function useCoordinatorSelector<T>(selector: (coordinator: NonNullable<ReturnType<typeof getSharedMarketDataCoordinator>>) => T, fallback: T): T {
@@ -55,24 +91,52 @@ export function useTickerInstrument(symbol: string | null | undefined, ticker: T
 
 export function useTickerFinancials(symbol: string | null | undefined, ticker: TickerRecord | null | undefined): TickerFinancials | null {
   const instrument = useTickerInstrument(symbol, ticker);
-  const financials = useCoordinatorSelector(
-    (coordinator) => (instrument ? coordinator.getTickerFinancialsSync(instrument) : null),
-    null,
-  );
+  const keys = useMemo(() => (
+    instrument
+      ? [
+        buildSnapshotKey(instrument),
+        buildQuoteKey(instrument),
+        buildChartKey({ instrument, bufferRange: "5Y", granularity: "range" }),
+      ]
+      : []
+  ), [instrument?.brokerId, instrument?.brokerInstanceId, instrument?.exchange, instrument?.instrument?.conId, instrument?.symbol]);
+  useCoordinatorKeysVersion(keys);
+  const coordinator = getSharedMarketDataCoordinator();
+  const financials = coordinator && instrument
+    ? coordinator.getTickerFinancialsSync(instrument)
+    : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !instrument) return;
-    void coordinator.loadSnapshot(instrument);
+    const timeoutId = setTimeout(() => {
+      void coordinator.loadSnapshot(instrument);
+    }, TICKER_FINANCIALS_LOAD_DELAY_MS);
+    return () => clearTimeout(timeoutId);
   }, [instrument?.brokerId, instrument?.brokerInstanceId, instrument?.exchange, instrument?.instrument?.conId, instrument?.symbol]);
 
   return financials;
 }
 
+function buildTickerFinancialsKeys(tickers: TickerRecord[]): string[] {
+  const keys: string[] = [];
+  for (const ticker of tickers) {
+    const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+    if (!instrument) continue;
+    keys.push(
+      buildSnapshotKey(instrument),
+      buildQuoteKey(instrument),
+      buildChartKey({ instrument, bufferRange: "5Y", granularity: "range" }),
+    );
+  }
+  return keys;
+}
+
 export function useTickerFinancialsMap(tickers: TickerRecord[]): Map<string, TickerFinancials> {
   const coordinator = getSharedMarketDataCoordinator();
-  const version = useCoordinatorVersion();
   const tickerKey = buildTickerFinancialsMapKey(tickers);
+  const subscriptionKeys = useMemo(() => buildTickerFinancialsKeys(tickers), [tickerKey]);
+  const keysVersion = useCoordinatorKeysVersion(subscriptionKeys);
 
   return useMemo(() => {
     if (!coordinator) return new Map<string, TickerFinancials>();
@@ -86,15 +150,18 @@ export function useTickerFinancialsMap(tickers: TickerRecord[]): Map<string, Tic
       }
     }
     return result;
-  }, [coordinator, tickerKey, version]);
+  }, [coordinator, keysVersion, tickerKey, subscriptionKeys]);
 }
 
 export function useQuoteEntry(symbol: string | null | undefined, ticker: TickerRecord | null | undefined): QueryEntry<Quote> | null {
   const instrument = useTickerInstrument(symbol, ticker);
-  const entry = useCoordinatorSelector(
-    (coordinator) => (instrument ? coordinator.getQuoteEntry(instrument) : null),
-    null,
+  const keys = useMemo(
+    () => (instrument ? [buildQuoteKey(instrument)] : []),
+    [instrument?.brokerId, instrument?.brokerInstanceId, instrument?.exchange, instrument?.instrument?.conId, instrument?.symbol],
   );
+  useCoordinatorKeysVersion(keys);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && instrument ? coordinator.getQuoteEntry(instrument) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
@@ -107,10 +174,9 @@ export function useQuoteEntry(symbol: string | null | undefined, ticker: TickerR
 
 export function useChartQuery(request: ChartRequest | null | undefined): QueryEntry<PricePoint[]> | null {
   const key = request ? buildChartKey(request) : null;
-  const entry = useCoordinatorSelector(
-    (coordinator) => (request ? coordinator.getChartEntry(request) : null),
-    null,
-  );
+  useCoordinatorKeysVersion(key ? [key] : []);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && request ? coordinator.getChartEntry(request) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
@@ -127,9 +193,14 @@ export function useChartQueries(
 ): Map<string, QueryEntry<PricePoint[]>> {
   const requestKey = requests.map((request) => buildChartKey(request)).join(",");
   const debounceMs = Math.max(0, options.debounceMs ?? 0);
-  const entries = useCoordinatorSelector((coordinator) => (
-    requests.map((request) => [buildChartKey(request), coordinator.getChartEntry(request)] as const)
-  ), [] as Array<readonly [string, QueryEntry<PricePoint[]>]>);
+  const keys = useMemo(() => requests.map((request) => buildChartKey(request)), [requestKey]);
+  const keysVersion = useCoordinatorKeysVersion(keys);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entries = useMemo(() => (
+    coordinator
+      ? requests.map((request) => [buildChartKey(request), coordinator.getChartEntry(request)] as const)
+      : [] as Array<readonly [string, QueryEntry<PricePoint[]>]>
+  ), [coordinator, keys, keysVersion, requestKey]);
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
@@ -151,59 +222,55 @@ export function useChartQueries(
 }
 
 export function useNewsQuery(request: NewsRequest | null | undefined): QueryEntry<NewsItem[]> | null {
-  const key = request ? `${request.instrument.symbol}|${request.instrument.exchange ?? ""}|${request.count ?? 50}` : null;
-  const entry = useCoordinatorSelector(
-    (coordinator) => (request ? coordinator.getNewsEntry(request) : null),
-    null,
-  );
+  const requestKey = request ? buildNewsKey(request) : null;
+  useCoordinatorKeysVersion(requestKey ? [requestKey] : []);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && request ? coordinator.getNewsEntry(request) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !request) return;
     void coordinator.loadNews(request);
-  }, [key]);
+  }, [requestKey]);
 
   return entry;
 }
 
 export function useOptionsQuery(request: OptionsRequest | null | undefined): QueryEntry<OptionsChain> | null {
-  const key = request ? `${request.instrument.symbol}|${request.instrument.exchange ?? ""}|${request.expirationDate ?? "default"}` : null;
-  const entry = useCoordinatorSelector(
-    (coordinator) => (request ? coordinator.getOptionsEntry(request) : null),
-    null,
-  );
+  const requestKey = request ? buildOptionsKey(request) : null;
+  useCoordinatorKeysVersion(requestKey ? [requestKey] : []);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && request ? coordinator.getOptionsEntry(request) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !request) return;
     void coordinator.loadOptions(request);
-  }, [key]);
+  }, [requestKey]);
 
   return entry;
 }
 
 export function useSecFilingsQuery(request: SecFilingsRequest | null | undefined): QueryEntry<SecFilingItem[]> | null {
-  const key = request ? `${request.instrument.symbol}|${request.instrument.exchange ?? ""}|${request.count ?? 50}` : null;
-  const entry = useCoordinatorSelector(
-    (coordinator) => (request ? coordinator.getSecFilingsEntry(request) : null),
-    null,
-  );
+  const requestKey = request ? buildSecFilingsKey(request) : null;
+  useCoordinatorKeysVersion(requestKey ? [requestKey] : []);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && request ? coordinator.getSecFilingsEntry(request) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !request) return;
     void coordinator.loadSecFilings(request);
-  }, [key]);
+  }, [requestKey]);
 
   return entry;
 }
 
 export function useSecFilingContent(filing: SecFilingItem | null | undefined): QueryEntry<string | null> | null {
-  const key = filing?.accessionNumber ?? null;
-  const entry = useCoordinatorSelector(
-    (coordinator) => (filing ? coordinator.getSecContentEntry(filing.accessionNumber) : null),
-    null,
-  );
+  const key = filing ? buildSecContentKey(filing.accessionNumber) : null;
+  useCoordinatorKeysVersion(key ? [key] : []);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && filing ? coordinator.getSecContentEntry(filing.accessionNumber) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
@@ -215,10 +282,10 @@ export function useSecFilingContent(filing: SecFilingItem | null | undefined): Q
 }
 
 export function useArticleSummary(url: string | null | undefined): QueryEntry<string | null> | null {
-  const entry = useCoordinatorSelector(
-    (coordinator) => (url ? coordinator.getArticleSummaryEntry(url) : null),
-    null,
-  );
+  const key = url ? buildArticleSummaryKey(url) : null;
+  useCoordinatorKeysVersion(key ? [key] : []);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && url ? coordinator.getArticleSummaryEntry(url) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
@@ -230,10 +297,10 @@ export function useArticleSummary(url: string | null | undefined): QueryEntry<st
 }
 
 export function useFxRate(currency: string | null | undefined): QueryEntry<number> | null {
-  const entry = useCoordinatorSelector(
-    (coordinator) => (currency ? coordinator.getFxEntry(currency) : null),
-    null,
-  );
+  const key = currency ? buildFxKey(currency) : null;
+  useCoordinatorKeysVersion(key ? [key] : []);
+  const coordinator = getSharedMarketDataCoordinator();
+  const entry = coordinator && currency ? coordinator.getFxEntry(currency) : null;
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
@@ -246,16 +313,17 @@ export function useFxRate(currency: string | null | undefined): QueryEntry<numbe
 
 export function useFxRatesMap(currencies: Array<string | null | undefined>): Map<string, number> {
   const coordinator = getSharedMarketDataCoordinator();
-  const version = useCoordinatorVersion();
   const normalizedCurrencyKey = stableCurrencyList(currencies).join("|");
   const normalizedCurrencies = useMemo(
     () => (normalizedCurrencyKey ? normalizedCurrencyKey.split("|") : []),
     [normalizedCurrencyKey],
   );
+  const keys = useMemo(() => normalizedCurrencies.map(buildFxKey), [normalizedCurrencies]);
+  const keysVersion = useCoordinatorKeysVersion(keys);
   const entries = useMemo(() => {
     if (!coordinator) return [] as Array<readonly [string, QueryEntry<number>]>;
     return normalizedCurrencies.map((currency) => [currency, coordinator.getFxEntry(currency)] as const);
-  }, [coordinator, normalizedCurrencies, version]);
+  }, [coordinator, keys, keysVersion, normalizedCurrencies]);
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();

--- a/src/market-data/query-store.ts
+++ b/src/market-data/query-store.ts
@@ -4,7 +4,7 @@ import { createIdleEntry } from "./result-types";
 export class QueryStore<T> {
   private readonly entries = new Map<string, QueryEntry<T>>();
 
-  constructor(private readonly onChange: () => void) {}
+  constructor(private readonly onChange: (key: string) => void) {}
 
   get(key: string): QueryEntry<T> {
     return this.entries.get(key) ?? createIdleEntry<T>();
@@ -12,13 +12,13 @@ export class QueryStore<T> {
 
   set(key: string, entry: QueryEntry<T>): void {
     this.entries.set(key, entry);
-    this.onChange();
+    this.onChange(key);
   }
 
   update(key: string, updater: (current: QueryEntry<T>) => QueryEntry<T>): QueryEntry<T> {
     const next = updater(this.get(key));
     this.entries.set(key, next);
-    this.onChange();
+    this.onChange(key);
     return next;
   }
 

--- a/src/news/aggregator.ts
+++ b/src/news/aggregator.ts
@@ -175,7 +175,7 @@ export class NewsService {
     this.sources.set(source.id, source);
     this.seedCachedSource(source);
     if (this.pollTimer !== null) {
-      void this.poll();
+      void this.pollActiveQueries();
     }
     return () => this.unregister(source.id);
   }
@@ -186,7 +186,6 @@ export class NewsService {
 
   start(): void {
     if (this.pollTimer !== null) return;
-    void this.poll();
     this.pollTimer = setInterval(() => void this.pollActiveQueries(), this.pollIntervalMs);
   }
 
@@ -230,9 +229,7 @@ export class NewsService {
 
   private async pollActiveQueries(): Promise<void> {
     const queries = [...this.queryByKey.values()];
-    if (queries.length === 0) {
-      queries.push(DEFAULT_GLOBAL_QUERY);
-    }
+    if (queries.length === 0) return;
     await Promise.allSettled(queries.map((query) => this.refreshQuery(query, false)));
   }
 

--- a/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
+++ b/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
@@ -1,20 +1,20 @@
-import { Box, Input, ScrollBox, Span, Text } from "../../../ui";
+import { Box, Input, ScrollBox, Text } from "../../../ui";
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useShortcut } from "../../../react/input";
 import { TextAttributes } from "../../../ui";
 import { type InputRenderable, type ScrollBoxRenderable } from "../../../ui";
 import type { DetailTabProps } from "../../../types/plugin";
-import { useAppState, usePaneTicker } from "../../../state/app-context";
+import { useAppSelector, usePaneTicker } from "../../../state/app-context";
 import { useFxRatesMap } from "../../../market-data/hooks";
 import { usePluginState } from "../../../plugins/plugin-runtime";
 import { useInlineTickers } from "../../../state/use-inline-tickers";
 import { MarkdownText } from "../../../components/markdown-text";
+import { usePaneFooter } from "../../../components";
 import { colors } from "../../../theme/colors";
 import { Spinner } from "../../../components/spinner";
 import { buildTickerAiContext } from "./ticker-context";
 import { detectProviders, getAvailableProviders, resolveDefaultAiProviderId, __setDetectedProvidersForTests, type AiProvider } from "./providers";
 import { runAiPrompt } from "./runner";
-import { truncateWithEllipsis } from "./utils";
 
 interface ChatMessage {
   role: "user" | "assistant";
@@ -42,38 +42,19 @@ export function __resetAskAiHistoryForTests(): void {
   chatHistories.clear();
 }
 
-function getProviderHeaderParts(providerName: string, canSwitch: boolean, width: number): { prefix: string; label: string } {
-  if (width <= 0) return { prefix: "", label: "" };
-
-  const variants = [
-    { prefix: "Provider: ", label: canSwitch ? `${providerName} (t to switch)` : providerName },
-    { prefix: "Provider: ", label: canSwitch ? `${providerName} (t)` : providerName },
-    { prefix: "", label: canSwitch ? `${providerName} (t to switch)` : providerName },
-    { prefix: "", label: canSwitch ? `${providerName} (t)` : providerName },
-    { prefix: "", label: providerName },
-  ];
-
-  for (const variant of variants) {
-    if (variant.prefix.length + variant.label.length <= width) {
-      return variant;
-    }
-  }
-
-  return { prefix: "", label: truncateWithEllipsis(providerName, width) };
-}
-
 export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabProps) {
-  const { state } = useAppState();
+  const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
+  const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
   const { ticker, financials } = usePaneTicker();
   const exchangeRates = useFxRatesMap([
-    state.config.baseCurrency,
+    baseCurrency,
     ticker?.metadata.currency,
     financials?.quote?.currency,
     ...(ticker?.metadata.positions.map((position) => position.currency) ?? []),
   ]);
-  const effectiveExchangeRates = exchangeRates.size > 1 || state.exchangeRates.size === 0
+  const effectiveExchangeRates = exchangeRates.size > 1 || cachedExchangeRates.size === 0
     ? exchangeRates
-    : state.exchangeRates;
+    : cachedExchangeRates;
   const [providers] = useState(() => detectProviders());
   const defaultProviderId = resolveDefaultAiProviderId(providers);
   const [providerId, setProviderId] = usePluginState<string>("providerId", defaultProviderId);
@@ -171,7 +152,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
     const context = buildTickerAiContext(
       ticker,
       financials,
-      state.config.baseCurrency,
+      baseCurrency,
       effectiveExchangeRates,
     );
     const fullPrompt = `You are a financial analyst assistant. Here is the current financial data for the company being discussed:\n\n${context}\n\nUser question: ${text}`;
@@ -212,7 +193,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
     } finally {
       runRef.current = null;
     }
-  }, [currentProvider, effectiveExchangeRates, financials, state.config.baseCurrency, ticker]);
+  }, [baseCurrency, currentProvider, effectiveExchangeRates, financials, ticker]);
 
   useShortcut((event) => {
     if (!focused) return;
@@ -239,6 +220,24 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
   }, []);
 
   const { catalog, openTicker } = useInlineTickers(messages.map((message) => message.content));
+  const thinking = messages.some((message) => message.loading);
+
+  usePaneFooter("ask-ai", () => ({
+    info: [
+      ...(currentProvider ? [{
+        id: "provider",
+        parts: [
+          { text: "Provider", tone: "label" as const },
+          { text: currentProvider.name, tone: currentProvider.available ? "value" as const : "warning" as const, bold: true },
+        ],
+      }] : []),
+      { id: "messages", parts: [{ text: `${messages.length} messages`, tone: "muted" }] },
+      ...(thinking ? [{ id: "thinking", parts: [{ text: "thinking", tone: "muted" as const }] }] : []),
+    ],
+    hints: availableProviders.length > 1
+      ? [{ id: "provider", key: "t", label: "provider", onPress: cycleProvider }]
+      : [],
+  }), [availableProviders.length, currentProvider?.available, currentProvider?.name, cycleProvider, messages.length, thinking]);
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to ask AI.</Text>;
 
@@ -261,23 +260,11 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
   const contentWidth = Math.max(width - 2, 0);
   const dividerWidth = Math.max(contentWidth, 0);
   const chatHeight = Math.max(height - 7, 4);
-  const providerHeader = getProviderHeaderParts(
-    currentProvider?.name || "None",
-    availableProviders.length > 1,
-    Math.max(contentWidth - "Ask AI".length - 1, 0),
-  );
 
   return (
     <Box flexDirection="column" paddingX={1} paddingTop={1} height={height - 2}>
       <Box flexDirection="row" height={1}>
         <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>Ask AI</Text>
-        <Box flexGrow={1} />
-        <Box onMouseDown={cycleProvider}>
-          <Text fg={colors.textMuted}>
-            {providerHeader.prefix}
-            <Span fg={colors.textBright}>{providerHeader.label}</Span>
-          </Text>
-        </Box>
       </Box>
 
       <ScrollBox ref={scrollRef} height={chatHeight} scrollY>
@@ -330,7 +317,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
         <Box flexGrow={1}>
           <Input
             ref={inputRef}
-            placeholder={inputFocused ? "Ask a question..." : "Enter to start typing"}
+            placeholder="Ask a question..."
             focused={inputFocused && focused}
             textColor={colors.text}
             placeholderColor={colors.textDim}

--- a/src/plugins/builtin/ai/screener-pane.test.tsx
+++ b/src/plugins/builtin/ai/screener-pane.test.tsx
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useReducer, useState } from "react";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import { DialogProvider } from "@opentui-ui/dialog/react";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane-footer";
 import { AppContext, PaneInstanceProvider, appReducer, createInitialState } from "../../../state/app-context";
 import { createDefaultConfig } from "../../../types/config";
 import type { Quote, TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { createTestDataProvider } from "../../../test-support/data-provider";
+import { Box } from "../../../ui";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../../plugin-runtime";
 import { setSharedDataProviderForTests, setSharedRegistryForTests } from "../../registry";
 import { AiScreenerPane } from "./screener-pane";
@@ -152,7 +154,14 @@ function ScreenerHarness({
       <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
         <PaneInstanceProvider paneId={PANE_ID}>
           <PluginRenderProvider pluginId="ai" runtime={runtime}>
-            <AiScreenerPane paneId={PANE_ID} paneType="ai-screener" focused width={96} height={18} />
+            <PaneFooterProvider>
+              {(footer) => (
+                <Box flexDirection="column" width={96} height={18}>
+                  <AiScreenerPane paneId={PANE_ID} paneType="ai-screener" focused width={96} height={17} />
+                  <PaneFooterBar footer={footer} focused width={96} />
+                </Box>
+              )}
+            </PaneFooterProvider>
           </PluginRenderProvider>
         </PaneInstanceProvider>
       </DialogProvider>
@@ -210,7 +219,8 @@ describe("AiScreenerPane", () => {
       height: 18,
     });
 
-    const frame = await waitForFrameToContain("AAPL");
+    await waitForFrameToContain("AAPL");
+    const frame = await waitForFrameToContain("1 tickers");
     expect(frame).toContain("Compounders");
     expect(frame).toContain("Initial pass");
     expect(frame).toContain("1 tickers");
@@ -248,7 +258,8 @@ describe("AiScreenerPane", () => {
       await testSetup!.renderOnce();
     });
 
-    const frame = await waitForFrameToContain("MSFT");
+    await waitForFrameToContain("MSFT");
+    const frame = await waitForFrameToContain("2 tickers");
     expect(frame).toContain("AAPL");
     expect(frame).toContain("2 tickers");
   });
@@ -323,7 +334,8 @@ describe("AiScreenerPane", () => {
       await testSetup!.renderOnce();
     });
 
-    const frame = await waitForFrameToContain("MSFT");
+    await waitForFrameToContain("MSFT");
+    const frame = await waitForFrameToContain("1 tickers");
     expect(frame).not.toContain("AAPL");
     expect(frame).toContain("1 tickers");
   });

--- a/src/plugins/builtin/ai/screener-pane.tsx
+++ b/src/plugins/builtin/ai/screener-pane.tsx
@@ -8,14 +8,19 @@ import type { ColumnConfig } from "../../../types/config";
 import type { InstrumentSearchResult } from "../../../types/instrument";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
-import { useAppState, usePaneInstance, usePaneInstanceId } from "../../../state/app-context";
+import {
+  useAppDispatch,
+  useAppSelector,
+  usePaneInstance,
+  usePaneInstanceId,
+} from "../../../state/app-context";
 import { usePluginPaneState, usePluginState } from "../../../plugins/plugin-runtime";
 import { useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
 import { getSharedMarketDataCoordinator } from "../../../market-data/coordinator";
 import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../../market-data/request-types";
 import { useQuoteStreaming } from "../../../state/use-quote-streaming";
 import { TickerListTable } from "../../../components/ticker-list-table";
-import { Button, EmptyState, Spinner } from "../../../components";
+import { Button, EmptyState, Spinner, usePaneFooter } from "../../../components";
 import { colors } from "../../../theme/colors";
 import { canonicalExchange } from "../../../utils/exchanges";
 import { formatTimeAgo } from "../../../utils/format";
@@ -345,7 +350,10 @@ function ActionChip({
 export function AiScreenerPane({ focused, width, height }: PaneProps) {
   const paneId = usePaneInstanceId();
   const paneInstance = usePaneInstance();
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const tickers = useAppSelector((state) => state.tickers);
+  const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
+  const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
   const [providers] = useState(() => detectProviders());
   const availableProviders = providers.filter((provider) => provider.available);
   const selectableProviders = availableProviders.length > 0 ? availableProviders : providers;
@@ -423,25 +431,25 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
 
   const screenerTickers = useMemo(() => (
     (activeTab?.results ?? [])
-      .map((result) => state.tickers.get(result.symbol) ?? null)
+      .map((result) => tickers.get(result.symbol) ?? null)
       .filter((ticker): ticker is TickerRecord => ticker != null)
-  ), [activeTab?.results, state.tickers]);
+  ), [activeTab?.results, tickers]);
   const financialsMap = useTickerFinancialsMap(screenerTickers);
 
   const trackedCurrencies = useMemo(() => [
-    state.config.baseCurrency,
+    baseCurrency,
     ...screenerTickers.map((ticker) => ticker.metadata.currency),
     ...screenerTickers.map((ticker) => financialsMap.get(ticker.metadata.ticker)?.quote?.currency ?? null),
-  ], [financialsMap, screenerTickers, state.config.baseCurrency]);
+  ], [baseCurrency, financialsMap, screenerTickers]);
   const exchangeRates = useFxRatesMap(trackedCurrencies);
-  const effectiveExchangeRates = exchangeRates.size > 1 || state.exchangeRates.size === 0
+  const effectiveExchangeRates = exchangeRates.size > 1 || cachedExchangeRates.size === 0
     ? exchangeRates
-    : state.exchangeRates;
+    : cachedExchangeRates;
   const columnContext: ColumnContext = useMemo(() => ({
-    baseCurrency: state.config.baseCurrency,
+    baseCurrency,
     exchangeRates: effectiveExchangeRates,
     now,
-  }), [effectiveExchangeRates, now, state.config.baseCurrency]);
+  }), [baseCurrency, effectiveExchangeRates, now]);
 
   const sortedTickers = useMemo(
     () => sortScreenerRows(screenerTickers, resultMap, financialsMap, activeSort, columnContext, columns),
@@ -670,7 +678,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
       rawOutput = await run.done;
 
       const parsed = parseScreenerResponse(rawOutput);
-      const validated = await validateScreenerResults(parsed.tickers, state.tickers, dispatch);
+      const validated = await validateScreenerResults(parsed.tickers, tickers, dispatch);
       const nextResults = !samePrompt || mode === "force"
         ? validated.results
         : mergeScreenerResults(tab.results, validated.results);
@@ -699,7 +707,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
       }
       setRunState((current) => (current?.tabId === tab.id ? null : current));
     }
-  }, [dispatch, providers, setForceConfirmTabId, state.tickers, tabs, upsertTab]);
+  }, [dispatch, providers, setForceConfirmTabId, tabs, tickers, upsertTab]);
 
   useEffect(() => {
     if (!pendingInitialRunRef.current) return;
@@ -890,11 +898,70 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
       ]
       : activeTab
         ? ["No validated results yet."]
-        : ["Press t to create an AI screener tab."];
+        : ["Create an AI screener tab to begin."];
   const paddedDetailLines = [...detailLines];
   while (paddedDetailLines.length < DETAIL_FOOTER_LINES) {
     paddedDetailLines.push("");
   }
+  const activeProvider = activeTab ? getAiProvider(activeTab.providerId, providers) : null;
+  const refreshActiveTab = useCallback(() => {
+    if (!activeTab || isRunningActiveTab) return;
+    void runTab(activeTab.id, "refresh");
+  }, [activeTab, isRunningActiveTab, runTab]);
+  const forceRefreshActiveTab = useCallback(() => {
+    if (!activeTab || isRunningActiveTab) return;
+    if (forceRunArmed) {
+      setForceConfirmTabId(null);
+      void runTab(activeTab.id, "force");
+      return;
+    }
+    setForceConfirmTabId(activeTab.id);
+  }, [activeTab, forceRunArmed, isRunningActiveTab, runTab, setForceConfirmTabId]);
+
+  usePaneFooter("ai-screener", () => ({
+    info: [
+      ...(editorState ? [{
+        id: "provider",
+        parts: [{ text: editorProvider?.name ?? editorState.providerId, tone: editorProvider?.available === false ? "warning" as const : "value" as const, bold: true }],
+      }] : activeTab ? [{
+        id: "provider",
+        parts: [{ text: activeProvider?.name ?? activeTab.providerId, tone: activeProvider?.available === false ? "warning" as const : "value" as const, bold: true }],
+      }] : []),
+      { id: "status", parts: [{ text: statusText, tone: isRunningActiveTab ? "muted" : "value" }] },
+      ...(activeTab ? [{ id: "count", parts: [{ text: `${activeTab.results.length} tickers`, tone: "muted" as const }] }] : []),
+      ...(forceRunArmed ? [{ id: "force", parts: [{ text: "force refresh armed", tone: "warning" as const }] }] : []),
+    ],
+    hints: editorState
+      ? [
+          { id: "save", key: "Ctrl+S", label: "save", onPress: saveEditor },
+          { id: "provider", key: "Ctrl+P", label: "provider", onPress: () => cycleEditorProvider(1), disabled: selectableProviders.length <= 1 },
+        ]
+      : [
+          { id: "new", key: "t", label: "new", onPress: addTab },
+          { id: "close", key: "w", label: "close", onPress: activeTab ? () => removeTab(activeTab.id) : undefined, disabled: !activeTab },
+          { id: "refresh", key: "r", label: "efresh", onPress: refreshActiveTab, disabled: !activeTab || isRunningActiveTab },
+          { id: "force-refresh", key: "Shift+R", label: "force refresh", onPress: forceRefreshActiveTab, disabled: !activeTab || isRunningActiveTab },
+          { id: "edit", key: "e", label: "edit", onPress: editActiveTab, disabled: !activeTab },
+        ],
+  }), [
+    activeProvider?.available,
+    activeProvider?.name,
+    activeTab,
+    addTab,
+    cycleEditorProvider,
+    editActiveTab,
+    editorProvider?.available,
+    editorProvider?.name,
+    editorState,
+    forceRefreshActiveTab,
+    forceRunArmed,
+    isRunningActiveTab,
+    refreshActiveTab,
+    removeTab,
+    saveEditor,
+    selectableProviders.length,
+    statusText,
+  ]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -937,50 +1004,33 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
           );
         })}
         <Text fg={colors.textMuted} onMouseDown={() => { if (!editorState) addTab(); }}>{` + `}</Text>
-        <Box flexGrow={1} />
-        <Text fg={colors.textMuted}>
-          {editorState
-            ? editorState.mode === "create" ? "creating new screener" : "editing prompt"
-            : activeTab
-            ? `${activeTab.results.length} tickers`
-            : "t new"}
-        </Text>
       </Box>
 
       <Box flexDirection="row" height={1} gap={1}>
         {editorState ? (
           <>
-            <Button label="Save" variant="primary" shortcut="Ctrl+S" onPress={saveEditor} />
-            <Button label="Cancel" variant="ghost" shortcut="Esc" onPress={closeEditor} />
+            <Button label="Save" variant="primary" onPress={saveEditor} />
+            <Button label="Cancel" variant="ghost" onPress={closeEditor} />
           </>
         ) : (
           <>
             {isRunningActiveTab ? (
               <>
                 <Button label={runState?.mode === "force" ? "Force Refreshing..." : "Refreshing..."} variant="secondary" disabled />
-                <Button label="Stop" variant="ghost" shortcut="Esc" onPress={cancelRun} />
+                <Button label="Stop" variant="ghost" onPress={cancelRun} />
               </>
             ) : (
               <>
                 <Button
                   label={primaryRunLabel}
                   variant="primary"
-                  shortcut="r"
-                  onPress={activeTab ? () => { void runTab(activeTab.id, "refresh"); } : undefined}
+                  onPress={refreshActiveTab}
                   disabled={!activeTab}
                 />
                 <Button
                   label={forceRunArmed ? "Confirm Force Refresh" : "Force Refresh"}
                   variant={forceRunArmed ? "danger" : "ghost"}
-                  shortcut="Shift+R"
-                  onPress={activeTab ? () => {
-                    if (forceRunArmed) {
-                      setForceConfirmTabId(null);
-                      void runTab(activeTab.id, "force");
-                      return;
-                    }
-                    setForceConfirmTabId(activeTab.id);
-                  } : undefined}
+                  onPress={forceRefreshActiveTab}
                   disabled={!activeTab}
                 />
               </>
@@ -988,20 +1038,11 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
             <Button
               label="Edit Prompt"
               variant={promptDirty ? "primary" : "secondary"}
-              shortcut="e"
               onPress={editActiveTab}
               disabled={!activeTab}
             />
           </>
         )}
-        <Box flexGrow={1} />
-        <Text fg={colors.textMuted}>
-          {editorState
-            ? `${editorProvider?.name ?? editorState.providerId} · Ctrl+S save · Esc cancel`
-            : activeTab
-              ? `${getAiProvider(activeTab.providerId, providers)?.name ?? activeTab.providerId} · ${forceRunArmed ? "Force refresh armed. Click again to confirm." : statusText}`
-              : statusText}
-        </Text>
       </Box>
 
       {availableProviders.length === 0 && (
@@ -1036,7 +1077,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
               <Text fg={colors.negative}>{editorState.error}</Text>
             ) : (
               <Text fg={colors.textDim}>
-                The AI will return validated ticker ideas with a short reason for each one. Ctrl+P cycles providers.
+                The AI will return validated ticker ideas with a short reason for each one.
               </Text>
             )}
           </Box>
@@ -1058,7 +1099,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
             <Text fg={colors.textDim}>
               {editorProvider?.available === false
                 ? `${editorProvider.name} is not currently installed. Save and switch later.`
-                : "Click a provider chip or press Ctrl+P to switch. Save to keep the draft."}
+                : "Click a provider chip to switch. Save to keep the draft."}
             </Text>
           </Box>
         </>
@@ -1097,7 +1138,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
           <Box flexGrow={1} minHeight={contentHeight}>
             {!activeTab ? (
               <Box padding={1} flexGrow={1}>
-                <EmptyState title="No AI screeners yet." hint="Press t or click + to create one." />
+                <EmptyState title="No AI screeners yet." hint="Click + to create one." />
               </Box>
             ) : isRunningActiveTab && activeTab.results.length === 0 ? (
               <Box padding={1} flexGrow={1}>
@@ -1136,7 +1177,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
                   getSharedRegistry()?.pinTickerFn(ticker.metadata.ticker, { floating: true, paneType: "ticker-detail" });
                 }}
                 emptyTitle="No matches yet."
-                emptyHint={promptDirty ? "Prompt changed. Refresh to rerun." : "Press r to run this screener. Use PS to customize columns."}
+                emptyHint={promptDirty ? "Prompt changed. Refresh to rerun." : "Run this screener. Use PS to customize columns."}
               />
             )}
           </Box>

--- a/src/plugins/builtin/alerts/index.test.tsx
+++ b/src/plugins/builtin/alerts/index.test.tsx
@@ -10,6 +10,8 @@ import {
 } from "../../../state/app-context";
 import { cloneLayout, createDefaultConfig, type AppConfig } from "../../../types/config";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../../plugin-runtime";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane-footer";
+import { Box } from "../../../ui";
 import { setSharedRegistryForTests } from "../../registry";
 import { deserializeAlerts, serializeAlerts } from "./alert-engine";
 import { AlertsPane, alertsPlugin } from "./index";
@@ -150,7 +152,14 @@ function AlertsHarness({
     <AppContext value={{ state, dispatch }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
         <PluginRenderProvider pluginId="alerts" runtime={makeRuntime()}>
-          <AlertsPane focused width={width} height={height} />
+          <PaneFooterProvider>
+            {(footer) => (
+              <Box flexDirection="column" width={width} height={height}>
+                <AlertsPane focused width={width} height={Math.max(1, height - 1)} />
+                <PaneFooterBar footer={footer} focused width={width} />
+              </Box>
+            )}
+          </PaneFooterProvider>
         </PluginRenderProvider>
       </PaneInstanceProvider>
     </AppContext>

--- a/src/plugins/builtin/alerts/index.tsx
+++ b/src/plugins/builtin/alerts/index.tsx
@@ -1,8 +1,8 @@
-import { Box, Text } from "../../../ui";
+import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { DataTable, type DataTableCell, type DataTableColumn } from "../../../components";
+import { DataTable, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, GloomPluginContext, PaneProps } from "../../../types/plugin";
 import type { AlertCondition, AlertRule } from "./types";
 import { colors } from "../../../theme/colors";
@@ -194,6 +194,29 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     syncHeaderScroll();
   }, [syncHeaderScroll]);
 
+  usePaneFooter("alerts", () => ({
+    info: [
+      {
+        id: "active",
+        parts: [
+          { text: String(activeCount), tone: "value", bold: true },
+          { text: "active", tone: "label" },
+        ],
+      },
+      ...(triggeredCount > 0 ? [{
+        id: "triggered",
+        parts: [
+          { text: String(triggeredCount), tone: "warning" as const, bold: true },
+          { text: "triggered", tone: "label" as const },
+        ],
+      }] : []),
+    ],
+    hints: [
+      { id: "add", key: "a", label: "dd alert", onPress: openSetAlertCommand },
+      { id: "delete", key: "d", label: "elete", onPress: deleteSelectedAlert, disabled: rows.length === 0 },
+    ],
+  }), [activeCount, deleteSelectedAlert, openSetAlertCommand, rows.length, triggeredCount]);
+
   useEffect(() => {
     setSelectedIdx((prev) => (rows.length === 0 ? 0 : Math.min(prev, rows.length - 1)));
   }, [rows.length]);
@@ -300,20 +323,6 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
       height={height}
       backgroundColor={colors.bg}
     >
-      <Box
-        flexDirection="row"
-        height={1}
-        paddingX={1}
-        backgroundColor={colors.bg}
-      >
-        <Text fg={colors.textDim}>{activeCount} active</Text>
-        {triggeredCount > 0 && (
-          <Box marginLeft={1}>
-            <Text fg={colors.textMuted}>{triggeredCount} triggered</Text>
-          </Box>
-        )}
-      </Box>
-
       <DataTable<AlertRule, AlertColumn>
         columns={ALERT_COLUMNS}
         items={rows}
@@ -338,32 +347,6 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
         showHorizontalScrollbar={showHorizontalScrollbar}
       />
 
-      <Box
-        flexDirection="row"
-        height={1}
-        paddingX={1}
-        backgroundColor={colors.panel}
-      >
-        <Box
-          onMouseDown={(event: any) => {
-            event.preventDefault?.();
-            event.stopPropagation?.();
-            openSetAlertCommand();
-          }}
-        >
-          <Text fg={colors.textDim}>[a]dd alert</Text>
-        </Box>
-        <Box width={2} />
-        <Box
-          onMouseDown={(event: any) => {
-            event.preventDefault?.();
-            event.stopPropagation?.();
-            deleteSelectedAlert();
-          }}
-        >
-          <Text fg={rows.length > 0 ? colors.textDim : colors.textMuted}>[d]elete</Text>
-        </Box>
-      </Box>
     </Box>
   );
 }

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -15,7 +15,6 @@ import {
   usePaneInstance,
   usePaneStateValue,
 } from "../../../state/app-context";
-import { getCollectionTickers } from "../../../state/selectors";
 import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
 import { instrumentFromTicker, type ChartRequest } from "../../../market-data/request-types";
 import { buildChartKey } from "../../../market-data/selectors";
@@ -251,10 +250,15 @@ function nextSectorSortPreference(current: SectorSortPreference, columnId: strin
 }
 
 export function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
-  const state = useAppSelector((s) => s);
+  const focusedCollectionId = useAppSelector((state) => getFocusedCollectionId(state));
+  const portfolios = useAppSelector((state) => state.config.portfolios);
+  const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
+  const tickersBySymbol = useAppSelector((state) => state.tickers);
+  const cachedFinancials = useAppSelector((state) => state.financials);
+  const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
+  const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
+  const config = useAppSelector((state) => state.config);
   const paneInstance = usePaneInstance();
-  const focusedCollectionId = getFocusedCollectionId(state);
-  const portfolios = state.config.portfolios;
   const requestedPortfolioId = paneInstance?.params?.portfolioId ?? paneInstance?.params?.collectionId;
   const fallbackPortfolioId = useMemo(
     () => (
@@ -293,9 +297,10 @@ export function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
 
   const portfolioTickers = useMemo(() => {
     if (!activePortfolioId) return [];
-    return getCollectionTickers(state, activePortfolioId)
+    return [...tickersBySymbol.values()]
+      .filter((ticker) => ticker.metadata.portfolios.includes(activePortfolioId))
       .filter((ticker) => hasPortfolioPosition(ticker, activePortfolioId));
-  }, [activePortfolioId, state]);
+  }, [activePortfolioId, tickersBySymbol]);
 
   const chartTargets = useMemo<PortfolioChartTarget[]>(
     () => portfolioTickers.flatMap((ticker) => {
@@ -331,36 +336,37 @@ export function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
 
   const marketFinancials = useTickerFinancialsMap(portfolioTickers);
   const financials = useMemo(() => {
-    const merged = new Map(state.financials);
+    const merged = new Map(cachedFinancials);
     for (const [symbol, data] of marketFinancials) {
       merged.set(symbol, data);
     }
     return merged;
-  }, [marketFinancials, state.financials]);
-  const accountState = usePortfolioAccountState(activePortfolio, state);
+  }, [cachedFinancials, marketFinancials]);
+  const accountStateInput = useMemo(() => ({ brokerAccounts, config }), [brokerAccounts, config]);
+  const accountState = usePortfolioAccountState(activePortfolio, accountStateInput);
   const trackedCurrencies = useMemo(
-    () => buildTrackedCurrencies(portfolioTickers, financials, state.config.baseCurrency),
-    [financials, portfolioTickers, state.config.baseCurrency],
+    () => buildTrackedCurrencies(portfolioTickers, financials, baseCurrency),
+    [baseCurrency, financials, portfolioTickers],
   );
   const fetchedExchangeRates = useFxRatesMap(trackedCurrencies);
-  const effectiveExchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, state.exchangeRates);
+  const effectiveExchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, cachedExchangeRates);
   const columnContext = useMemo<ColumnContext>(() => ({
     activeTab: activePortfolioId || undefined,
-    baseCurrency: state.config.baseCurrency,
+    baseCurrency,
     exchangeRates: effectiveExchangeRates,
     now: Date.now(),
-  }), [activePortfolioId, effectiveExchangeRates, state.config.baseCurrency]);
+  }), [activePortfolioId, baseCurrency, effectiveExchangeRates]);
 
   const portfolioStats = useMemo(
     () => calculatePortfolioSummaryTotals(
       portfolioTickers,
       financials,
-      state.config.baseCurrency,
+      baseCurrency,
       effectiveExchangeRates,
       true,
       activePortfolioId || null,
     ),
-    [activePortfolioId, effectiveExchangeRates, financials, portfolioTickers, state.config.baseCurrency],
+    [activePortfolioId, baseCurrency, effectiveExchangeRates, financials, portfolioTickers],
   );
 
   const portfolioReturnSeries = useMemo(() => {

--- a/src/plugins/builtin/ask-ai.test.tsx
+++ b/src/plugins/builtin/ask-ai.test.tsx
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act } from "react";
+import { PaneFooterBar, PaneFooterProvider } from "../../components/layout/pane-footer";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { AppContext, PaneInstanceProvider, createInitialState } from "../../state/app-context";
 import { createDefaultConfig } from "../../types/config";
+import { Box } from "../../ui";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
 import { setSharedDataProviderForTests, setSharedRegistryForTests } from "../registry";
 import { AskAiTab, __resetAskAiHistoryForTests, __setAskAiHistoryForTests, __setDetectedProvidersForTests, type AiProvider } from "./ask-ai";
@@ -98,7 +100,14 @@ function createAskAiHarness(
     <AppContext value={{ state, dispatch: () => {} }}>
       <PaneInstanceProvider paneId={PANE_ID}>
         <PluginRenderProvider pluginId="ai" runtime={makeRuntime()}>
-          <AskAiTab width={width} height={height} focused onCapture={onCapture} />
+          <PaneFooterProvider>
+            {(footer) => (
+              <Box flexDirection="column" width={width} height={height}>
+                <AskAiTab width={width} height={Math.max(1, height - 1)} focused onCapture={onCapture} />
+                <PaneFooterBar footer={footer} focused width={width} />
+              </Box>
+            )}
+          </PaneFooterProvider>
         </PluginRenderProvider>
       </PaneInstanceProvider>
     </AppContext>
@@ -155,8 +164,8 @@ describe("AskAiTab", () => {
 
     await act(async () => {
       testSetup = await testRender(
-        createAskAiHarness(24, 12),
-        { width: 24, height: 12 },
+        createAskAiHarness(46, 12),
+        { width: 46, height: 12 },
       );
     });
 
@@ -164,8 +173,10 @@ describe("AskAiTab", () => {
 
     const headerLine = testSetup.captureCharFrame().split("\n").find((line) => line.includes("Ask AI")) ?? "";
     expect(headerLine).toContain("Ask AI");
-    expect(headerLine).toContain("Claude (t)");
     expect(headerLine).not.toContain("t to switch");
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Provider Claude");
+    expect(frame).toContain("[t]provider");
   });
 
   test("focuses the input when the prompt row is clicked", async () => {
@@ -183,8 +194,8 @@ describe("AskAiTab", () => {
     await flushFrame();
 
     const frameBeforeClick = testSetup.captureCharFrame().split("\n");
-    const inputRow = frameBeforeClick.findIndex((line) => line.includes("Enter to start typing"));
-    const inputCol = frameBeforeClick[inputRow]?.indexOf("Enter to start typing") ?? -1;
+    const inputRow = frameBeforeClick.findIndex((line) => line.includes("Ask a question..."));
+    const inputCol = frameBeforeClick[inputRow]?.indexOf("Ask a question...") ?? -1;
 
     expect(inputRow).toBeGreaterThanOrEqual(0);
     expect(inputCol).toBeGreaterThanOrEqual(0);

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, useState } from "react";
+import { PaneFooterBar, PaneFooterProvider } from "../../components/layout/pane-footer";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { AppContext, createInitialState } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import { createDefaultConfig } from "../../types/config";
 import type { PersistedResourceValue } from "../../types/persistence";
 import type { PluginPersistence } from "../../types/plugin";
+import { Box } from "../../ui";
 import { apiClient, type ChatMessage } from "../../utils/api-client";
 import { setSharedDataProviderForTests, setSharedRegistryForTests } from "../registry";
 import { ChatContent, ChatStatusWidget, getSelectedMessageScrollTop, gloomberbCloudPlugin } from "./chat";
@@ -141,6 +143,7 @@ function createHarness(
     height?: number;
     configureState?: (state: ReturnType<typeof createInitialState>) => void;
     close?: () => void;
+    withFooter?: boolean;
   },
 ) {
   const width = options?.width ?? 60;
@@ -148,15 +151,34 @@ function createHarness(
   const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
   options?.configureState?.(state);
 
+  const content = options?.withFooter ? (
+    <PaneFooterProvider>
+      {(footer) => (
+        <Box flexDirection="column" width={width} height={height}>
+          <ChatContent
+            controller={controller}
+            width={width}
+            height={Math.max(1, height - 1)}
+            focused
+            close={options?.close}
+          />
+          <PaneFooterBar footer={footer} focused width={width} />
+        </Box>
+      )}
+    </PaneFooterProvider>
+  ) : (
+    <ChatContent
+      controller={controller}
+      width={width}
+      height={height}
+      focused
+      close={options?.close}
+    />
+  );
+
   return (
     <AppContext value={{ state, dispatch: () => {} }}>
-      <ChatContent
-        controller={controller}
-        width={width}
-        height={height}
-        focused
-        close={options?.close}
-      />
+      {content}
     </AppContext>
   );
 }
@@ -880,9 +902,9 @@ describe("ChatContent", () => {
     });
 
     await act(async () => {
-      testSetup = await testRender(createHarness(controller, { width: 60, height: 12 }), {
+      testSetup = await testRender(createHarness(controller, { width: 60, height: 13, withFooter: true }), {
         width: 60,
-        height: 12,
+        height: 13,
       });
     });
 

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -3,9 +3,10 @@ import { Fragment, useState, useEffect, useRef, useCallback } from "react";
 import { useShortcut } from "../../react/input";
 import { TextAttributes, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
-import { useAppState } from "../../state/app-context";
+import { useAppDispatch, useAppSelector } from "../../state/app-context";
 import { useInlineTickers } from "../../state/use-inline-tickers";
 import { TickerBadgeText } from "../../components/ticker-badge-text";
+import { usePaneFooter } from "../../components";
 import { colors, hoverBg } from "../../theme/colors";
 import { apiClient, type ChatMessage } from "../../utils/api-client";
 import { formatTimeAgo } from "../../utils/format";
@@ -144,7 +145,7 @@ function InlineAuthActions({ showSignup = true }: { showSignup?: boolean }) {
     <Box flexDirection="row">
       <Box
         backgroundColor={hoveredAction === "login" ? hoverBg() : undefined}
-        onMouseMove={() => setHoveredAction("login")}
+        onMouseMove={() => setHoveredAction((current) => (current === "login" ? current : "login"))}
         onMouseOut={() => setHoveredAction((current) => (current === "login" ? null : current))}
         onMouseDown={(event: any) => openAuthCommand("Login", event)}
       >
@@ -155,7 +156,7 @@ function InlineAuthActions({ showSignup = true }: { showSignup?: boolean }) {
           <Text fg={colors.textDim}>/</Text>
           <Box
             backgroundColor={hoveredAction === "signup" ? hoverBg() : undefined}
-            onMouseMove={() => setHoveredAction("signup")}
+            onMouseMove={() => setHoveredAction((current) => (current === "signup" ? current : "signup"))}
             onMouseOut={() => setHoveredAction((current) => (current === "signup" ? null : current))}
             onMouseDown={(event: any) => openAuthCommand("Sign Up", event)}
           >
@@ -211,7 +212,7 @@ export function ChatContent({
   close,
   controller = chatController,
 }: ChatContentProps) {
-  const { dispatch } = useAppState();
+  const dispatch = useAppDispatch();
   const initialSnapshot = controller.getSnapshot();
   const [messages, setMessages] = useState<ChatMessage[]>(initialSnapshot.messages);
   const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
@@ -503,6 +504,21 @@ export function ChatContent({
   const separatorHeight = 1;
   const footerSeparatorHeight = 1;
   const messageAreaHeight = Math.max(1, height - headerHeight - separatorHeight - footerSeparatorHeight - inputAreaHeight);
+  const chatStatus = canSend
+    ? user?.username ? `@${user.username}` : "signed in"
+    : !user && !hasSavedSession
+      ? "read-only"
+      : !user
+        ? "login needed"
+        : "verify email";
+
+  usePaneFooter("chat", () => ({
+    info: [
+      { id: "channel", parts: [{ text: "#everyone", tone: "value", bold: true }] },
+      { id: "messages", parts: [{ text: `${messages.length} messages`, tone: "muted" }] },
+      { id: "status", parts: [{ text: chatStatus, tone: canSend ? "positive" : "warning" }] },
+    ],
+  }), [canSend, chatStatus, messages.length]);
 
   useEffect(() => {
     if (selectedIdx < messages.length) return;
@@ -551,8 +567,6 @@ export function ChatContent({
     <Box flexDirection="column" width={width} height={height}>
       <Box height={1} width={contentWidth} flexDirection="row">
         <Text fg={colors.positive} attributes={TextAttributes.BOLD}> #everyone</Text>
-        <Box flexGrow={1} />
-        <Text fg={colors.textDim}>{messages.length} messages</Text>
       </Box>
 
       <Box height={1} width={contentWidth}>
@@ -595,7 +609,7 @@ export function ChatContent({
           const authorAttributes = (isSending ? TextAttributes.DIM : 0) | TextAttributes.BOLD;
           const bodyColor = isSelected ? selectedTextColor : hasFailed ? colors.negative : isSending ? colors.textDim : colors.text;
           const bodyLines = getMessageBodyLines(msg, contentWidth);
-          const setHovered = () => setHoveredIdx(index);
+          const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));
           const clearHovered = () => setHoveredIdx((current) => (current === index ? null : current));
           const messageRowProps = {
             width: contentWidth,
@@ -758,7 +772,7 @@ export function ChatPane({ focused, width, height, close }: PaneProps) {
 }
 
 export function ChatStatusWidget({ controller = chatController }: ChatStatusWidgetProps) {
-  const { state } = useAppState();
+  const cloudPluginDisabled = useAppSelector((state) => state.config.disabledPlugins.includes("gloomberb-cloud"));
   const initialSnapshot = controller.getSnapshot();
   const [username, setUsername] = useState<string | null>(initialSnapshot.user?.username ?? null);
   const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
@@ -781,7 +795,7 @@ export function ChatStatusWidget({ controller = chatController }: ChatStatusWidg
     return unsubscribe;
   }, [controller]);
 
-  if (state.config.disabledPlugins.includes("gloomberb-cloud")) return null;
+  if (cloudPluginDisabled) return null;
 
   return (
     <Box flexDirection="row" paddingRight={1}>
@@ -794,8 +808,8 @@ export function ChatStatusWidget({ controller = chatController }: ChatStatusWidg
         <Box
           flexDirection="row"
           backgroundColor={hovered ? hoverBg() : undefined}
-          onMouseMove={() => setHovered(true)}
-          onMouseOut={() => setHovered(false)}
+          onMouseMove={() => setHovered((current) => (current ? current : true))}
+          onMouseOut={() => setHovered((current) => (current ? false : current))}
           onMouseDown={openChat}
         >
           <Text fg={unreadMentionCount > 0 ? colors.text : colors.textDim}>

--- a/src/plugins/builtin/comparison-chart.test.tsx
+++ b/src/plugins/builtin/comparison-chart.test.tsx
@@ -3,11 +3,13 @@ import { act, type ReactElement } from "react";
 import { createTestRenderer } from "@opentui/core/testing";
 import { createOpenTuiTestRoot as createRoot } from "../../renderers/opentui/test-utils";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
+import { PaneFooterBar, PaneFooterProvider } from "../../components/layout/pane-footer";
 import {
   AppContext,
   createInitialState,
   PaneInstanceProvider,
 } from "../../state/app-context";
+import { Box } from "../../ui";
 import { cloneLayout, createDefaultConfig } from "../../types/config";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerFinancials } from "../../types/financials";
@@ -148,13 +150,20 @@ function createComparisonHarness(
   return (
     <AppContext value={{ state, dispatch: () => {} }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
-        <ComparisonPane
-          paneId={TEST_PANE_ID}
-          paneType="comparison-chart"
-          focused
-          width={120}
-          height={20}
-        />
+        <PaneFooterProvider>
+          {(footer) => (
+            <Box flexDirection="column" width={120} height={20}>
+              <ComparisonPane
+                paneId={TEST_PANE_ID}
+                paneType="comparison-chart"
+                focused
+                width={120}
+                height={19}
+              />
+              <PaneFooterBar footer={footer} focused width={120} />
+            </Box>
+          )}
+        </PaneFooterProvider>
       </PaneInstanceProvider>
     </AppContext>
   );
@@ -291,7 +300,7 @@ describe("comparisonChartPlugin", () => {
     expect(frame).toContain("view:");
     expect(frame).toContain("[m]ode");
     expect(frame).toContain("[r]es");
-    expect(frame).toContain("[up/down]legend");
+    expect(frame).not.toContain("[up/down]legend");
     expect(frame).not.toContain("arrows legend");
     expect(frame).not.toContain("wheel pan");
     expect(frame).not.toContain("wheel zoom");

--- a/src/plugins/builtin/comparison-chart.tsx
+++ b/src/plugins/builtin/comparison-chart.tsx
@@ -9,7 +9,7 @@ import {
   normalizeChartResolution,
 } from "../../components/chart/chart-resolution";
 import { getSharedRegistry } from "../../plugins/registry";
-import { useAppState } from "../../state/app-context";
+import { usePaneInstance } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import type { GloomPlugin, PaneProps, PaneSettingsDef } from "../../types/plugin";
 import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } from "../../utils/ticker-list";
@@ -102,8 +102,7 @@ export function buildComparisonChartPaneTitle(symbols: string[]): string {
 }
 function ComparisonChartPane({ paneId, focused, width, height }: PaneProps) {
   const registry = getSharedRegistry();
-  const { state } = useAppState();
-  const pane = state.config.layout.instances.find((instance) => instance.instanceId === paneId);
+  const pane = usePaneInstance();
   const settings = useMemo(() => getComparisonChartPaneSettings(pane?.settings), [pane?.settings]);
 
   const openTicker = useCallback((symbol: string) => {

--- a/src/plugins/builtin/correlation/index.tsx
+++ b/src/plugins/builtin/correlation/index.tsx
@@ -1,10 +1,11 @@
 import { Box, ScrollBox, Text } from "../../../ui";
 import { useMemo } from "react";
 import { TextAttributes } from "../../../ui";
+import { usePaneFooter } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import { getSharedRegistry } from "../../registry";
-import { useAppSelector } from "../../../state/app-context";
+import { useAppSelector, usePaneInstance } from "../../../state/app-context";
 import { useChartQueries } from "../../../market-data/hooks";
 import { buildChartKey } from "../../../market-data/selectors";
 import type { PricePoint } from "../../../types/financials";
@@ -146,21 +147,21 @@ function buildCorrelationPaneTitle(symbols: string[], rangePreset: CorrelationRa
   return `${symbols.slice(0, 2).join(" · ")} +${symbols.length - 2} ${rangePreset}`;
 }
 
-export function CorrelationMatrixPane({ paneId, width, height }: PaneProps) {
-  const state = useAppSelector((s) => s);
-  const pane = state.config.layout.instances.find((instance) => instance.instanceId === paneId);
+export function CorrelationMatrixPane({ width, height }: PaneProps) {
+  const pane = usePaneInstance();
+  const tickers = useAppSelector((state) => state.tickers);
   const settings = useMemo(() => getCorrelationPaneSettings(pane?.settings), [pane?.settings]);
 
   const instruments = useMemo(() => {
     if (settings.symbolsError) return [];
     return settings.symbols.map((symbol) => {
-      const ticker = state.tickers.get(symbol);
+      const ticker = tickers.get(symbol);
       return {
         symbol,
         exchange: ticker?.metadata.exchange ?? "",
       };
     });
-  }, [state.tickers, settings.symbols.join(","), settings.symbolsError]);
+  }, [settings.symbols.join(","), settings.symbolsError, tickers]);
 
   const instrumentKey = instruments.map((instrument) => `${instrument.symbol}|${instrument.exchange}`).join(",");
 
@@ -227,6 +228,16 @@ export function CorrelationMatrixPane({ paneId, width, height }: PaneProps) {
     [symbolsKey, seriesBySymbol, matrix.sampleMin, matrix.sampleMax],
   );
 
+  usePaneFooter("correlation", () => ({
+    info: [
+      { id: "tickers", parts: [{ text: `${symbols.length} tickers`, tone: symbols.length >= 2 ? "value" : "warning", bold: symbols.length >= 2 }] },
+      { id: "range", parts: [{ text: settings.rangePreset, tone: "muted" }] },
+      ...(settings.symbolsError
+        ? [{ id: "error", parts: [{ text: settings.symbolsError, tone: "warning" as const }] }]
+        : [{ id: "status", parts: [{ text: statusSummary, tone: "muted" as const }] }]),
+    ],
+  }), [settings.rangePreset, settings.symbolsError, statusSummary, symbols.length]);
+
   if (settings.symbolsError) {
     return (
       <Box flexDirection="column" width={width} height={height} paddingX={2} paddingY={1}>
@@ -254,14 +265,6 @@ export function CorrelationMatrixPane({ paneId, width, height }: PaneProps) {
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {/* Title */}
-      <Box flexDirection="row" height={1} paddingX={1}>
-        <Text fg={colors.textMuted}>{symbols.length} tickers · {settings.rangePreset} daily returns</Text>
-      </Box>
-      <Box flexDirection="row" height={1} paddingX={1}>
-        <Text fg={colors.textDim}>{statusSummary}</Text>
-      </Box>
-
       {/* Column header row */}
       <Box flexDirection="row" paddingX={1} height={1} backgroundColor={headerBg}>
         <Box width={rowHeaderWidth} flexShrink={0} />

--- a/src/plugins/builtin/debug.tsx
+++ b/src/plugins/builtin/debug.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useShortcut } from "../../react/input";
 import { TextAttributes } from "../../ui";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
+import { usePaneFooter } from "../../components";
 import { colors, hoverBg } from "../../theme/colors";
 import { debugLog, type LogEntry, type LogLevel } from "../../utils/debug-log";
 import { writeFileSync } from "fs";
@@ -92,25 +93,39 @@ function DebugPane({ focused, width, height }: PaneProps) {
     debugLog.clear();
     setEntries([]);
   }, []);
+  const cycleLevelFilter = useCallback(() => {
+    const currentIdx = filterLevel ? ALL_LEVELS.indexOf(filterLevel) : -1;
+    const nextIdx = currentIdx + 1;
+    setFilterLevel(nextIdx >= ALL_LEVELS.length ? null : ALL_LEVELS[nextIdx] ?? null);
+  }, [filterLevel]);
+  const cycleSourceFilter = useCallback(() => {
+    const sources = sourcesRef.current;
+    if (sources.length === 0) return;
+    const currentIdx = filterSource ? sources.indexOf(filterSource) : -1;
+    const nextIdx = currentIdx + 1;
+    setFilterSource(nextIdx >= sources.length ? null : sources[nextIdx] ?? null);
+  }, [filterSource]);
+  const jumpTop = useCallback(() => {
+    setSelectedIdx(0);
+    setAutoScroll(false);
+  }, []);
+  const jumpBottom = useCallback(() => {
+    setSelectedIdx(entries.length - 1);
+    setAutoScroll(true);
+  }, [entries.length]);
 
   useShortcut((event) => {
     if (!focused) return;
 
     // Level filter cycling
     if (event.name === "l") {
-      const currentIdx = filterLevel ? ALL_LEVELS.indexOf(filterLevel) : -1;
-      const nextIdx = currentIdx + 1;
-      setFilterLevel(nextIdx >= ALL_LEVELS.length ? null : ALL_LEVELS[nextIdx] ?? null);
+      cycleLevelFilter();
       return;
     }
 
     // Source filter cycling
     if (event.name === "s") {
-      const sources = sourcesRef.current;
-      if (sources.length === 0) return;
-      const currentIdx = filterSource ? sources.indexOf(filterSource) : -1;
-      const nextIdx = currentIdx + 1;
-      setFilterSource(nextIdx >= sources.length ? null : sources[nextIdx] ?? null);
+      cycleSourceFilter();
       return;
     }
 
@@ -151,13 +166,11 @@ function DebugPane({ focused, width, height }: PaneProps) {
     }
 
     if (event.name === "g" && !event.shift) {
-      setSelectedIdx(0);
-      setAutoScroll(false);
+      jumpTop();
       return;
     }
     if (event.name === "g" && event.shift) {
-      setSelectedIdx(entries.length - 1);
-      setAutoScroll(true);
+      jumpBottom();
       return;
     }
 
@@ -167,9 +180,8 @@ function DebugPane({ focused, width, height }: PaneProps) {
     }
   });
 
-  const headerHeight = 2;
   const contentWidth = Math.max(1, width - 2);
-  const messageAreaHeight = Math.max(1, height - headerHeight);
+  const messageAreaHeight = Math.max(1, height);
 
   // Compute visible window
   const visibleCount = showDetail ? Math.max(1, messageAreaHeight - 4) : messageAreaHeight;
@@ -191,29 +203,25 @@ function DebugPane({ focused, width, height }: PaneProps) {
 
   const selectedEntry = selectedIdx >= 0 && selectedIdx < entries.length ? entries[selectedIdx] : null;
 
+  usePaneFooter("debug-log", () => ({
+    info: [
+      { id: "count", parts: [{ text: `${totalEntries} entries`, tone: "value", bold: true }] },
+      ...(filterLevel ? [{ id: "level", parts: [{ text: filterLevel.toUpperCase(), tone: "value" as const, color: levelColor(filterLevel), bold: true }] }] : []),
+      ...(filterSource ? [{ id: "source", parts: [{ text: filterSource, tone: "positive" as const }] }] : []),
+      ...(autoScroll ? [{ id: "auto", parts: [{ text: "AUTO", tone: "muted" as const }] }] : []),
+    ],
+    hints: [
+      { id: "level", key: "l", label: "evel", onPress: cycleLevelFilter },
+      { id: "source", key: "s", label: "ource", onPress: cycleSourceFilter },
+      { id: "export", key: "e", label: "xport", onPress: exportLogs },
+      { id: "clear", key: "x", label: "clear", onPress: clearLogs },
+      { id: "auto", key: "a", label: "uto", onPress: () => setAutoScroll((prev) => !prev) },
+      { id: "jump", key: "g/G", label: "jump", onPress: jumpBottom },
+    ],
+  }), [autoScroll, clearLogs, cycleLevelFilter, cycleSourceFilter, exportLogs, filterLevel, filterSource, jumpBottom, totalEntries]);
+
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {/* Header */}
-      <Box height={1} width={contentWidth} flexDirection="row" paddingLeft={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Debug Log</Text>
-        <Text fg={colors.textDim}> ({totalEntries})</Text>
-        <Box flexGrow={1} />
-        {filterLevel && (
-          <Text fg={levelColor(filterLevel)} attributes={TextAttributes.BOLD}>
-            {" "}{filterLevel.toUpperCase()}{" "}
-          </Text>
-        )}
-        {filterSource && (
-          <Text fg={colors.positive}>
-            {" "}{filterSource}{" "}
-          </Text>
-        )}
-        {autoScroll && <Text fg={colors.textDim}> AUTO </Text>}
-      </Box>
-      <Box height={1} width={contentWidth}>
-        <Text fg={colors.border}>{"-".repeat(contentWidth)}</Text>
-      </Box>
-
       {/* Log entries */}
       <Box
         height={visibleCount}
@@ -255,7 +263,7 @@ function DebugPane({ focused, width, height }: PaneProps) {
               width={contentWidth}
               flexDirection="row"
               backgroundColor={bgColor}
-              onMouseMove={() => setHoveredIdx(globalIdx)}
+              onMouseMove={() => setHoveredIdx((current) => (current === globalIdx ? current : globalIdx))}
               onMouseDown={() => { setSelectedIdx(globalIdx); setAutoScroll(false); }}
             >
               <Text fg={colors.textMuted}> {ts} </Text>

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -1,8 +1,8 @@
-import { Box, Text } from "../../../ui";
+import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { DataTable, type DataTableCell, type DataTableColumn } from "../../../components";
+import { DataTable, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import type { EarningsEvent } from "../../../types/data-provider";
 import { colors } from "../../../theme/colors";
@@ -256,20 +256,16 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
     }
   }, []);
 
+  usePaneFooter("earnings-calendar", () => ({
+    info: [
+      { id: "count", parts: [{ text: loading ? "loading" : `${eventCount} upcoming`, tone: loading ? "muted" : "value", bold: !loading }] },
+      ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+    ],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => reload(true) }],
+  }), [error, eventCount, loading, reload]);
+
   return (
     <Box flexDirection="column" width={width} height={height}>
-      <Box height={1} paddingX={1} flexDirection="row">
-        <Text fg={colors.textDim}>
-          {loading ? "loading..." : `${eventCount} upcoming`}
-        </Text>
-      </Box>
-
-      {error ? (
-        <Box paddingX={1}>
-          <Text fg={colors.negative}>{error}</Text>
-        </Box>
-      ) : null}
-
       <DataTable<DisplayRow, EarningsColumn>
         columns={columns}
         items={rows}
@@ -290,10 +286,6 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
         emptyStateTitle={loading ? "Loading earnings..." : "No upcoming earnings found"}
         showHorizontalScrollbar={false}
       />
-
-      <Box height={1} paddingX={1}>
-        <Text fg={colors.textMuted}>[r]efresh</Text>
-      </Box>
     </Box>
   );
 }

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -2,7 +2,7 @@ import { Box, ScrollBox, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyledText, TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { DataTableStackView, type DataTableCell, type DataTableColumn } from "../../../components";
+import { DataTableStackView, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors, blendHex } from "../../../theme/colors";
 import {
@@ -517,7 +517,7 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
 
   const [fredApiKey] = usePluginConfigState<string>(FRED_API_KEY_CONFIG_KEY, "");
 
-  const load = async (force = false) => {
+  const load = useCallback(async (force = false) => {
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
     setLoading(true);
@@ -534,7 +534,7 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
     } finally {
       if (fetchGenRef.current === gen) setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (sharedCache && Date.now() - sharedCache.fetchedAt < CACHE_TTL_MS) {
@@ -542,7 +542,7 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
       return;
     }
     load();
-  }, []);
+  }, [load]);
 
   // Tick every 30s to update staleness + countdown
   useEffect(() => {
@@ -694,6 +694,20 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
   // Next upcoming event for countdown
   const nextEvent = nextUpcomingEventIdx >= 0 ? filtered[nextUpcomingEventIdx] : undefined;
   const nextCountdown = nextEvent ? formatCountdown(nextEvent.date.getTime() - now) : null;
+  const cycleImpactFilter = useCallback(() => {
+    setImpactFilter((prev) => {
+      const idx = FILTER_CYCLE.indexOf(prev);
+      return FILTER_CYCLE[(idx + 1) % FILTER_CYCLE.length]!;
+    });
+    setSelectedIdx(0);
+  }, []);
+  const cycleCountryFilter = useCallback(() => {
+    setCountryFilter((prev) => {
+      const idx = COUNTRY_CYCLE.indexOf(prev);
+      return COUNTRY_CYCLE[(idx + 1) % COUNTRY_CYCLE.length]!;
+    });
+    setSelectedIdx(0);
+  }, []);
 
   const handleRootKeyDown = useCallback((event: {
     name?: string;
@@ -708,24 +722,16 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
     } else if (event.name === "f") {
       event.stopPropagation?.();
       event.preventDefault?.();
-      setImpactFilter((prev) => {
-        const idx = FILTER_CYCLE.indexOf(prev);
-        return FILTER_CYCLE[(idx + 1) % FILTER_CYCLE.length]!;
-      });
-      setSelectedIdx(0);
+      cycleImpactFilter();
       return true;
     } else if (event.name === "c") {
       event.stopPropagation?.();
       event.preventDefault?.();
-      setCountryFilter((prev) => {
-        const idx = COUNTRY_CYCLE.indexOf(prev);
-        return COUNTRY_CYCLE[(idx + 1) % COUNTRY_CYCLE.length]!;
-      });
-      setSelectedIdx(0);
+      cycleCountryFilter();
       return true;
     }
     return false;
-  }, [load]);
+  }, [cycleCountryFilter, cycleImpactFilter, load]);
 
   const columns = useMemo<EconCalendarColumn[]>(() => {
     const timeWidth = 6;
@@ -757,6 +763,26 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
         countryFilter !== "all" ? `country: ${countryFilter}` : null,
       ].filter(Boolean).join(" · ") || undefined
     : undefined;
+
+  usePaneFooter("econ-calendar", () => ({
+    info: [
+      { id: "impact", parts: [{ text: `impact: ${impactFilter}`, tone: impactFilter === "all" ? "muted" : "value" }] },
+      { id: "country", parts: [{ text: `country: ${countryFilter}`, tone: countryFilter === "all" ? "muted" : "value" }] },
+      { id: "count", parts: [{ text: `${filtered.length} events`, tone: "muted" }] },
+      ...(nextEvent && nextCountdown ? [{
+        id: "next",
+        parts: [{ text: `Next: ${nextEvent.event.length > 18 ? nextEvent.event.slice(0, 18).trimEnd() : nextEvent.event} ${nextCountdown}`, tone: "muted" as const }],
+      }] : []),
+      ...(staleness ? [{ id: "stale", parts: [{ text: staleness, tone: "muted" as const }] }] : []),
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+    ],
+    hints: [
+      { id: "impact", key: "f", label: "impact", onPress: cycleImpactFilter },
+      { id: "country", key: "c", label: "country", onPress: cycleCountryFilter },
+      { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
+    ],
+  }), [countryFilter, cycleCountryFilter, cycleImpactFilter, error, filtered.length, impactFilter, load, loading, nextCountdown, nextEvent?.event, staleness]);
 
   const handleHeaderClick = useCallback(() => {}, []);
   const selectDisplayRow = useCallback((row: DisplayRow) => {
@@ -824,53 +850,6 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
     }
   }, []);
 
-  const calendarHeader = (
-    <>
-      {/* Header */}
-      <Box flexDirection="row" height={1} paddingX={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          Economic Calendar
-        </Text>
-        <Box marginLeft={1}>
-          <Text fg={colors.textDim}>[{impactFilter}]</Text>
-        </Box>
-        <Box marginLeft={0}>
-          <Text fg={colors.textDim}>[{countryFilter}]</Text>
-        </Box>
-        <Box marginLeft={1}>
-          <Text fg={colors.textMuted}>{filtered.length} events</Text>
-        </Box>
-        {nextEvent && nextCountdown && (
-          <Box marginLeft={1}>
-            <Text fg={colors.textMuted}>
-              Next: {nextEvent.event.length > 16 ? nextEvent.event.slice(0, 16).trimEnd() : nextEvent.event} {nextCountdown}
-            </Text>
-          </Box>
-        )}
-        {loading && (
-          <Box marginLeft={1}>
-            <Text fg={colors.textMuted}>loading…</Text>
-          </Box>
-        )}
-        <Box flexGrow={1} />
-        {staleness ? <Text fg={colors.textMuted}>{staleness}</Text> : null}
-      </Box>
-
-      {/* Error state */}
-      {error && (
-        <Box paddingX={1} paddingY={1}>
-          <Text fg={colors.negative}>Error: {error}</Text>
-        </Box>
-      )}
-    </>
-  );
-
-  const calendarFooter = (
-      <Box height={1} paddingX={1}>
-        <Text fg={colors.textMuted}>[r]efresh</Text>
-      </Box>
-  );
-
   const detailContent = detailEvent ? (
     <EconDetailView
       event={detailEvent}
@@ -888,8 +867,6 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
       detailOpen={!!detailEvent}
       onBack={() => setDetailEvent(null)}
       detailContent={detailContent}
-      rootBefore={calendarHeader}
-      rootAfter={calendarFooter}
       rootWidth={width}
       rootHeight={height}
       onRootKeyDown={handleRootKeyDown}

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -1,7 +1,8 @@
 import { Box, ScrollBox, Text } from "../../../ui";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { TextAttributes } from "../../../ui";
 import { useShortcut } from "../../../react/input";
+import { usePaneFooter } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors, blendHex } from "../../../theme/colors";
 import { getSharedDataProvider } from "../../registry";
@@ -24,7 +25,7 @@ export function FxMatrixPane({ focused, width, height }: PaneProps) {
   const [now, setNow] = useState(Date.now());
   const fetchGenRef = useRef(0);
 
-  const fetchRates = async () => {
+  const fetchRates = useCallback(async () => {
     const provider = getSharedDataProvider();
     if (!provider) return;
 
@@ -54,13 +55,13 @@ export function FxMatrixPane({ focused, width, height }: PaneProps) {
     } finally {
       if (fetchGenRef.current === gen) setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchRates();
     const interval = setInterval(fetchRates, REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, []);
+  }, [fetchRates]);
 
   useEffect(() => {
     const interval = setInterval(() => setNow(Date.now()), 5_000);
@@ -86,16 +87,16 @@ export function FxMatrixPane({ focused, width, height }: PaneProps) {
 
   const ageText = lastRefreshed ? `updated ${formatAge(now - lastRefreshed)}` : loading ? "loading…" : "";
 
+  usePaneFooter("fx-matrix", () => ({
+    info: ageText ? [{ id: "updated", parts: [{ text: ageText, tone: loading ? "muted" : "value" }] }] : [],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: fetchRates }],
+  }), [ageText, fetchRates, loading]);
+
   // Row header: just the 3-letter code, no emoji (keeps width predictable)
   // Rates use flexGrow so they fill available space dynamically
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {/* Header */}
-      <Box flexDirection="row" height={1} paddingX={1}>
-        <Text fg={colors.textMuted}>{ageText}</Text>
-      </Box>
-
       {/* Column header row */}
       <Box flexDirection="row" paddingX={1} height={1} backgroundColor={headerBg}>
         <Box width={5} flexShrink={0} />
@@ -139,10 +140,6 @@ export function FxMatrixPane({ focused, width, height }: PaneProps) {
           )}
         </Box>
       </ScrollBox>
-
-      <Box height={1} paddingX={1}>
-        <Text fg={colors.textMuted}>[r]efresh</Text>
-      </Box>
     </Box>
   );
 }

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -11,7 +11,7 @@ import { instrumentFromTicker } from "../../../market-data/request-types";
 import { usePaneTicker } from "../../../state/app-context";
 import { colors } from "../../../theme/colors";
 import { Spinner } from "../../../components/spinner";
-import { FeedDataTableStackView, type FeedDataTableItem } from "../../../components";
+import { FeedDataTableStackView, usePaneFooter, type FeedDataTableItem } from "../../../components";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { formatCompact, formatCurrency } from "../../../utils/format";
@@ -264,6 +264,27 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
     return true;
   }, [selectedTransaction, toggleNameFilter]);
 
+  const selectedFilterName = selectedTransaction?.reportedName ?? null;
+  const pendingLabel = pendingCount > 0 ? `loading ${pendingCount}...` : "";
+  usePaneFooter("insider", () => ({
+    info: [
+      { id: "summary", parts: [{ text: truncateText(summary, Math.max(24, width - 20)), tone: "muted" }] },
+      ...(nameFilter ? [{ id: "filter", parts: [{ text: `filter: ${truncateText(nameFilter, 24)}`, tone: "warning" as const }] }] : []),
+      ...(pendingLabel ? [{ id: "pending", parts: [{ text: pendingLabel, tone: "muted" as const }] }] : []),
+    ],
+    hints: selectedFilterName || nameFilter
+      ? [{
+          id: "filter",
+          key: "f",
+          label: "ilter",
+          onPress: () => {
+            if (nameFilter) clearNameFilter();
+            else if (selectedFilterName) toggleNameFilter(selectedFilterName);
+          },
+        }]
+      : [],
+  }), [clearNameFilter, nameFilter, pendingLabel, selectedFilterName, summary, toggleNameFilter, width]);
+
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view insider activity.</Text>;
   if (!eligibleTicker) return renderNotice("Insider transactions are only shown for US equities.", width);
   if (loading && allFilings.length === 0) return <Spinner label="Loading insider filings..." />;
@@ -271,45 +292,6 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
   if (!loading && form4Filings.length === 0) {
     return renderNotice(`No Form 4 filings found for ${ticker.metadata.ticker}.`, width);
   }
-
-  const selectedFilterName = selectedTransaction?.reportedName ?? null;
-  const filterLabel = nameFilter
-    ? `[clear filter: ${truncateText(nameFilter, 24)}]`
-    : selectedFilterName
-      ? `[f]ilter ${truncateText(selectedFilterName, 24)}`
-      : "";
-  const pendingLabel = pendingCount > 0 ? `loading ${pendingCount}...` : "";
-  const summaryWidth = Math.max(
-    12,
-    width - filterLabel.length - pendingLabel.length - 6,
-  );
-  const rootBefore = (
-    <Box height={1} width={width} paddingX={1} flexDirection="row">
-      <Text fg={colors.textDim}>{truncateText(summary, summaryWidth)}</Text>
-      {filterLabel ? (
-        <Box
-          marginLeft={1}
-          onMouseDown={(event: any) => {
-            event.preventDefault?.();
-            event.stopPropagation?.();
-            if (nameFilter) {
-              clearNameFilter();
-            } else if (selectedFilterName) {
-              toggleNameFilter(selectedFilterName);
-            }
-          }}
-        >
-          <Text fg={nameFilter ? colors.warning : colors.textMuted}>{filterLabel}</Text>
-        </Box>
-      ) : null}
-      {pendingLabel ? (
-        <>
-          <Box flexGrow={1} />
-          <Text fg={colors.textMuted}>{pendingLabel}</Text>
-        </>
-      ) : null}
-    </Box>
-  );
 
   return (
     <FeedDataTableStackView
@@ -319,7 +301,6 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
       items={feedItems}
       selectedIdx={selectedIdx}
       onSelect={setSelectedIdx}
-      rootBefore={rootBefore}
       onRootKeyDown={handleRootKeyDown}
       sourceLabel="Insider"
       titleLabel="Transaction"

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -2,9 +2,9 @@ import { Box, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { DataTable, type DataTableCell, type DataTableColumn } from "../../../components";
+import { DataTable, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
-import { colors, priceColor, blendHex } from "../../../theme/colors";
+import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatCompact, formatPercentRaw } from "../../../utils/format";
 import { usePluginTickerActions } from "../../plugin-runtime";
 import { getSharedDataProvider } from "../../registry";
@@ -284,7 +284,7 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
     return () => clearInterval(interval);
   }, []);
 
-  const loadTab = async (tab: TabId) => {
+  const loadTab = useCallback(async (tab: TabId) => {
     const cached = cacheRef.current.get(tab);
     if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
       setQuotes(cached.data);
@@ -354,9 +354,9 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
     finally {
       if (fetchGenRef.current === gen) setLoading(false);
     }
-  };
+  }, [resetTableScroll]);
 
-  useEffect(() => { loadTab(activeTab); }, [activeTab]);
+  useEffect(() => { loadTab(activeTab); }, [activeTab, loadTab]);
 
   const openSymbol = useCallback((symbol: string) => {
     pinTicker(symbol, { floating: true, paneType: "ticker-detail" });
@@ -468,28 +468,31 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
     }
   }, []);
 
-  const summaryBg = blendHex(colors.bg, colors.border, 0.2);
+  const refreshActiveTab = useCallback(() => {
+    cacheRef.current.delete(activeTab);
+    void loadTab(activeTab);
+  }, [activeTab, loadTab]);
+
+  usePaneFooter("market-movers", () => ({
+    info: [
+      ...summaryQuotes.map((idx) => {
+        const short = INDEX_SHORT[idx.symbol] ?? idx.symbol;
+        return {
+          id: `summary:${idx.symbol}`,
+          parts: [
+            { text: short, tone: "label" as const },
+            { text: formatPercentRaw(idx.changePercent), tone: "value" as const, color: priceColor(idx.changePercent), bold: true },
+          ],
+        };
+      }),
+      { id: "count", parts: [{ text: `${quotes.length} stocks`, tone: "muted" }] },
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+    ],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refreshActiveTab }],
+  }), [loading, quotes.length, refreshActiveTab, summaryQuotes]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {/* Market Summary Bar */}
-      {summaryQuotes.length > 0 ? (
-        <Box flexDirection="row" height={1} backgroundColor={summaryBg} paddingX={1} gap={2}>
-          {summaryQuotes.map((idx) => {
-            const short = INDEX_SHORT[idx.symbol] ?? idx.symbol;
-            const chgColor = priceColor(idx.changePercent);
-            return (
-              <Box key={idx.symbol} flexDirection="row" gap={1}>
-                <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{short}</Text>
-                <Text fg={colors.text}>{formatCurrency(idx.price, "USD")}</Text>
-                <Text fg={chgColor}>{formatPercentRaw(idx.changePercent)}</Text>
-              </Box>
-            );
-          })}
-          {loading && <Text fg={colors.textMuted}> loading…</Text>}
-        </Box>
-      ) : null}
-
       {/* Tab bar */}
       <Box flexDirection="row" height={1} paddingX={1}>
         {TABS.map((tab) => {
@@ -515,8 +518,6 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
             </Box>
           );
         })}
-        <Box flexGrow={1} />
-        <Text fg={colors.textMuted}>{quotes.length} stocks</Text>
       </Box>
 
       <DataTable<MarketMoverRow, MarketMoverColumn>

--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -1,8 +1,7 @@
-import { Box, Text } from "../../../ui";
+import { Box } from "../../../ui";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { TextAttributes } from "../../../ui";
 import type { PaneProps } from "../../../types/plugin";
-import { colors } from "../../../theme/colors";
+import { usePaneFooter } from "../../../components";
 import { useNewsArticles } from "../../../news/hooks";
 import { usePluginPaneState } from "../../plugin-runtime";
 import type { MarketNewsItem } from "../../../types/news-source";
@@ -99,29 +98,15 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
     getDigest(article.id) ?? article.title
   ), [digestVersion]);
 
-  const rootBefore = (
-      <Box height={1} flexDirection="row" paddingX={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Breaking News</Text>
-        <Box marginLeft={1}>
-          <Text fg={colors.textMuted}>{articles.length} stories</Text>
-        </Box>
-        {aiAvailable && (
-          <Box marginLeft={1}>
-            <Text fg={colors.textDim}>AI digest</Text>
-          </Box>
-        )}
-        {aiRunning && (
-          <Box marginLeft={1}>
-            <Text fg={colors.positive}>{BRAILLE_FRAMES[spinFrame]}</Text>
-          </Box>
-        )}
-        {aiError && (
-          <Box marginLeft={1}>
-            <Text fg={colors.warning}>AI paused</Text>
-          </Box>
-        )}
-      </Box>
-  );
+  usePaneFooter("news-wire:breaking", () => ({
+    info: [
+      { id: "title", parts: [{ text: "Breaking News", tone: "value", bold: true }] },
+      { id: "count", parts: [{ text: `${articles.length} stories`, tone: "muted" }] },
+      ...(aiAvailable ? [{ id: "digest", parts: [{ text: "AI digest", tone: "muted" as const }] }] : []),
+      ...(aiRunning ? [{ id: "running", parts: [{ text: BRAILLE_FRAMES[spinFrame] ?? "running", tone: "positive" as const }] }] : []),
+      ...(aiError ? [{ id: "paused", parts: [{ text: "AI paused", tone: "warning" as const }] }] : []),
+    ],
+  }), [aiAvailable, aiError, aiRunning, articles.length, spinFrame]);
 
   const detailContent = detailArticle ? (
     <NewsDetailView item={detailArticle} focused={focused} width={width} height={Math.max(height - 1, 1)} />
@@ -143,7 +128,6 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
       detailOpen={!!detailArticle}
       onBack={closeDetail}
       detailContent={detailContent}
-      rootBefore={rootBefore}
       columns={["time", "source", "title", "tickers", "importance"]}
       emptyStateTitle="No breaking news"
       emptyStateHint="Breaking stories appear when high-priority headlines arrive."

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -1,11 +1,9 @@
-import { Box, Text } from "../../../ui";
+import { Box } from "../../../ui";
 import { useEffect, useMemo } from "react";
-import { TextAttributes } from "../../../ui";
 import type { PaneProps } from "../../../types/plugin";
 import type { MarketNewsItem } from "../../../types/news-source";
-import { colors } from "../../../theme/colors";
 import { useNewsArticles } from "../../../news/hooks";
-import { TabBar } from "../../../components";
+import { TabBar, usePaneFooter } from "../../../components";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
@@ -71,23 +69,23 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     return true;
   };
 
+  usePaneFooter("news-wire:industry", () => ({
+    info: [
+      { id: "title", parts: [{ text: "Sector News", tone: "value", bold: true }] },
+      { id: "category", parts: [{ text: sectorNewsLabel(category), tone: category === "all" ? "muted" : "value" }] },
+      { id: "count", parts: [{ text: `${articles.length} stories`, tone: "muted" }] },
+    ],
+  }), [articles.length, category]);
+
   const rootBefore = (
-    <>
-      <Box height={1} flexDirection="row" paddingX={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Sector News</Text>
-        <Box marginLeft={1}>
-          <Text fg={colors.textMuted}>{articles.length} stories</Text>
-        </Box>
-      </Box>
-      <Box height={1} flexShrink={0} overflow="hidden">
-        <TabBar
-          tabs={tabs}
-          activeValue={category}
-          onSelect={(value) => setCategory(value as SectorNewsSelection)}
-          compact
-        />
-      </Box>
-    </>
+    <Box height={1} flexShrink={0} overflow="hidden">
+      <TabBar
+        tabs={tabs}
+        activeValue={category}
+        onSelect={(value) => setCategory(value as SectorNewsSelection)}
+        compact
+      />
+    </Box>
   );
 
   const detailContent = detailArticle ? (

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -1,8 +1,8 @@
-import { Box, Text, TextAttributes } from "../../../ui";
+import { Box } from "../../../ui";
 import type { NewsQuery } from "../../../news/types";
 import { useNewsArticles } from "../../../news/hooks";
 import type { PaneProps } from "../../../types/plugin";
-import { colors } from "../../../theme/colors";
+import { usePaneFooter } from "../../../components";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import {
@@ -42,14 +42,12 @@ export function NewsPresetPane({
   );
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
 
-  const rootBefore = (
-    <Box height={1} flexDirection="row" paddingX={1}>
-      <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{title}</Text>
-      <Box marginLeft={1}>
-        <Text fg={colors.textMuted}>{articles.length} stories</Text>
-      </Box>
-    </Box>
-  );
+  usePaneFooter(`news-wire:${paneKey}`, () => ({
+    info: [
+      { id: "title", parts: [{ text: title, tone: "value", bold: true }] },
+      { id: "count", parts: [{ text: `${articles.length} stories`, tone: "muted" }] },
+    ],
+  }), [articles.length, paneKey, title]);
 
   const detailContent = detailArticle ? (
     <NewsDetailView item={detailArticle} focused={focused} width={width} height={Math.max(height - 1, 1)} />
@@ -71,7 +69,6 @@ export function NewsPresetPane({
       detailOpen={!!detailArticle}
       onBack={closeDetail}
       detailContent={detailContent}
-      rootBefore={rootBefore}
       columns={columns}
       emptyStateTitle={emptyStateTitle}
       emptyStateHint={emptyStateHint}

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -8,7 +8,7 @@ import { useArticleSummary, useResolvedEntryValue } from "../../market-data/hook
 import { instrumentFromTicker } from "../../market-data/request-types";
 import { usePluginPaneState } from "../../plugins/plugin-runtime";
 import { Spinner } from "../../components/spinner";
-import { FeedDataTableStackView, type FeedDataTableItem } from "../../components";
+import { FeedDataTableStackView, usePaneFooter, type FeedDataTableItem } from "../../components";
 import { useNewsArticles } from "../../news/hooks";
 import { registerNewsWireFeatures } from "./news-wire";
 
@@ -99,6 +99,16 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
       setSelectedIdx(Math.max(0, news.length - 1));
     }
   }, [news.length, selectedIdx, setSelectedIdx]);
+
+  usePaneFooter("news", () => ({
+    info: [
+      ...(ticker ? [{ id: "ticker", parts: [{ text: ticker.metadata.ticker, tone: "value" as const, bold: true }] }] : []),
+      { id: "count", parts: [{ text: `${news.length} headlines`, tone: "muted" }] },
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
+      ...(loadingSummary ? [{ id: "summary", parts: [{ text: "summary loading", tone: "muted" as const }] }] : []),
+    ],
+  }), [error, loading, loadingSummary, news.length, ticker?.metadata.ticker]);
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view news.</Text>;
   if (loading && news.length === 0) return <Spinner label="Loading news..." />;

--- a/src/plugins/builtin/notes.tsx
+++ b/src/plugins/builtin/notes.tsx
@@ -7,6 +7,7 @@ import type { GloomPlugin, DetailTabProps, PaneProps } from "../../types/plugin"
 import { usePaneTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import { MarkdownEditor } from "../../components/markdown-editor";
+import { usePaneFooter } from "../../components";
 import { NotesFiles, type QuickNoteEntry } from "./notes-files";
 
 function createNotesTab(notesFiles: NotesFiles) {
@@ -71,16 +72,18 @@ function createNotesTab(notesFiles: NotesFiles) {
       }
     });
 
+    usePaneFooter("ticker-notes", () => ({
+      info: [
+        { id: "mode", parts: [{ text: notesFocused ? "editing" : "viewing", tone: "muted" }] },
+      ],
+    }), [notesFocused]);
+
     if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view notes.</Text>;
 
     return (
       <Box flexDirection="column" padding={1} flexGrow={1}>
         <Box flexDirection="row" height={1}>
           <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>Notes</Text>
-          <Box flexGrow={1} />
-          <Text fg={colors.textMuted}>
-            {notesFocused ? "editing (Esc to stop)" : "Enter to edit"}
-          </Text>
         </Box>
         <Box height={1} />
         <Box flexGrow={1} onMouseDown={() => { if (!notesFocused) setNotesFocusedAndCapture(true); }}>
@@ -270,6 +273,23 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
       }
     });
 
+    usePaneFooter("quick-notes", () => ({
+      info: [
+        ...(activeTabId ? [{
+          id: "active",
+          parts: [{ text: tabs.find((tab) => tab.id === activeTabId)?.title ?? "Note", tone: "value" as const, bold: true }],
+        }] : []),
+        { id: "mode", parts: [{ text: renaming ? "renaming" : editing ? "editing" : `${tabs.length} notes`, tone: "muted" }] },
+      ],
+      hints: renaming
+        ? []
+        : [
+            { id: "new", key: "t", label: "new", onPress: addTab },
+            { id: "close", key: "w", label: "close", onPress: () => { if (activeTabId) removeTab(activeTabId); }, disabled: !activeTabId },
+            { id: "rename", key: "r", label: "rename", onPress: startRename, disabled: !activeTabId },
+          ],
+    }), [activeTabId, addTab, editing, removeTab, renaming, startRename, tabs]);
+
     return (
       <Box flexDirection="column" flexGrow={1}>
         {/* Tab bar */}
@@ -312,14 +332,6 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
             onMouseDown={addTab}
           >
             {` + `}
-          </Text>
-          <Box flexGrow={1} />
-          <Text fg={colors.textMuted}>
-            {renaming
-              ? "type name, Enter to confirm"
-              : editing
-                ? "editing (Esc to stop)"
-                : "Enter edit | t new | w close | r rename"}
           </Text>
         </Box>
         {/* Rename input */}

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -187,8 +187,8 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
           return (
             <Box
               key={ts}
-              onMouseMove={() => setHoveredExpIdx(realIdx)}
-              onMouseOut={() => setHoveredExpIdx(null)}
+              onMouseMove={() => setHoveredExpIdx((current) => (current === realIdx ? current : realIdx))}
+              onMouseOut={() => setHoveredExpIdx((current) => (current === realIdx ? null : current))}
               onMouseDown={() => { enterInteractive(); setExpIdx(realIdx); }}
             >
               <Text
@@ -302,15 +302,6 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
           </Text>
         </Box>
       )}
-
-      {/* Help */}
-      <Box height={1}>
-        <Text fg={colors.textMuted}>
-          {interactive
-            ? "j/k/\u2191\u2193 strike  h/l/\u2190\u2192 expiration  Esc exit"
-            : "Enter to interact"}
-        </Text>
-      </Box>
     </Box>
   );
 }

--- a/src/plugins/builtin/portfolio-list.test.ts
+++ b/src/plugins/builtin/portfolio-list.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, test } from "bun:test";
 import type { BrokerAccount } from "../../types/trading";
+import type { TickerRecord } from "../../types/ticker";
 import type { PortfolioSummaryTotals } from "./portfolio-list/metrics";
 import { buildPortfolioSummarySegments } from "./portfolio-list/summary";
 import { shouldToggleCashMarginDrawer } from "./portfolio-list";
+import { selectStreamTickers } from "./portfolio-list/pane";
+
+function ticker(symbol: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
 
 describe("buildPortfolioSummarySegments", () => {
   const totals: PortfolioSummaryTotals = {
@@ -70,5 +88,22 @@ describe("buildPortfolioSummarySegments", () => {
     expect(shouldToggleCashMarginDrawer("c", true)).toBe(true);
     expect(shouldToggleCashMarginDrawer("c", false)).toBe(false);
     expect(shouldToggleCashMarginDrawer("j", true)).toBe(false);
+  });
+});
+
+describe("selectStreamTickers", () => {
+  test("includes visible rows with overscan and clamps boundaries", () => {
+    const tickers = Array.from({ length: 20 }, (_, index) => ticker(`T${index}`));
+    expect(selectStreamTickers(tickers, { start: 3, end: 7 }).map((entry) => entry.metadata.ticker)).toEqual(
+      tickers.slice(0, 13).map((entry) => entry.metadata.ticker),
+    );
+    expect(selectStreamTickers(tickers, { start: 18, end: 20 }).map((entry) => entry.metadata.ticker)).toEqual(
+      tickers.slice(12, 20).map((entry) => entry.metadata.ticker),
+    );
+  });
+
+  test("includes selected ticker outside the visible streaming window", () => {
+    const tickers = Array.from({ length: 20 }, (_, index) => ticker(`T${index}`));
+    expect(selectStreamTickers(tickers, { start: 3, end: 7 }, "T19").map((entry) => entry.metadata.ticker)).toContain("T19");
   });
 });

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -229,6 +229,9 @@ function PortfolioHarness({
 
 async function flushFrame() {
   await act(async () => {
+    await Promise.resolve();
+    await testSetup!.renderOnce();
+    await Promise.resolve();
     await testSetup!.renderOnce();
   });
 }
@@ -272,15 +275,17 @@ describe("PortfolioListPane cash and margin UI", () => {
     );
 
     await flushFrame();
+    const rowY = testSetup.captureCharFrame().split("\n").findIndex((line) => line.includes("AAPL"));
+    expect(rowY).toBeGreaterThanOrEqual(0);
 
     await act(async () => {
-      await testSetup!.mockMouse.click(2, 3);
+      await testSetup!.mockMouse.click(2, rowY);
       await testSetup!.renderOnce();
     });
     expect(navigated).toEqual([]);
 
     await act(async () => {
-      await testSetup!.mockMouse.click(2, 3);
+      await testSetup!.mockMouse.click(2, rowY);
       await testSetup!.renderOnce();
     });
     expect(navigated).toEqual(["AAPL"]);
@@ -314,7 +319,11 @@ describe("PortfolioListPane cash and margin UI", () => {
 
   test("keeps native price and avg cost while converting market value and pnl to base currency", async () => {
     const portfolioId = "broker:ibkr-flex:DU12345";
-    const config = createPortfolioConfig(portfolioId, [createBrokerInstance("flex")]);
+    const config = createPortfolioConfigWithColumns(
+      portfolioId,
+      ["ticker", "price", "change_pct", "shares", "avg_cost", "cost_basis", "mkt_value", "pnl"],
+      [createBrokerInstance("flex")],
+    );
 
     testSetup = await testRender(
       <PortfolioHarness
@@ -398,7 +407,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     await flushFrame();
 
     const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("Val 1.3k");
+    expect(frame).toContain("1.3k");
     expect(frame).toContain("125");
     expect(frame).toContain("+250");
     expect(frame).toContain("25.00%");
@@ -623,7 +632,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(harnessState?.paneState[TEST_PANE_ID]?.cashDrawerExpanded).toBe(true);
   });
 
-  test("renders the summary on its own row below the tabs", async () => {
+  test("renders the table directly below tabs when the footer owns the summary", async () => {
     const config = {
       ...createPortfolioConfig("broker:ibkr-flex:DU12345", [createBrokerInstance("flex")]),
       watchlists: [
@@ -659,11 +668,10 @@ describe("PortfolioListPane cash and margin UI", () => {
 
     const lines = testSetup.captureCharFrame().split("\n");
     const tabsRow = lines.findIndex((line) => line.includes("Main Portfolio"));
-    const summaryRow = lines.findIndex((line) => line.includes("Net Liq 125k  Val 1.3k  Cash -50k"));
+    const tableHeaderRow = lines.findIndex((line) => line.includes("TICKER"));
 
     expect(tabsRow).toBeGreaterThanOrEqual(0);
-    expect(summaryRow).toBeGreaterThan(tabsRow);
-    expect(lines[summaryRow + 1]).toContain("TICKER");
+    expect(tableHeaderRow).toBe(tabsRow + 1);
   });
 
   test("renders bid ask and spread when those columns are enabled", async () => {
@@ -750,6 +758,9 @@ describe("PortfolioListPane cash and margin UI", () => {
     );
 
     await flushFrame();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 380));
+    });
     await act(async () => {
       resolveFinancials({
         annualStatements: [],

--- a/src/plugins/builtin/portfolio-list/pane.tsx
+++ b/src/plugins/builtin/portfolio-list/pane.tsx
@@ -2,36 +2,34 @@ import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShortcut } from "../../../react/input";
 import { type ScrollBoxRenderable } from "../../../ui";
-import { TabBar } from "../../../components/tab-bar";
+import { TabBar, usePaneFooter, type PaneFooterSegment } from "../../../components";
+import { createRowValueCache } from "../../../components/ui/row-value-cache";
 import { getSharedRegistry } from "../../registry";
 import { getSharedMarketDataCoordinator } from "../../../market-data/coordinator";
 import { useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
 import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../../market-data/request-types";
 import { useAppActive } from "../../../state/app-activity";
 import {
-  useAppState,
+  useAppSelector,
   usePaneCollection,
   usePaneInstance,
-  usePaneInstanceId,
   usePaneStateValue,
   type CollectionSortPreference,
 } from "../../../state/app-context";
-import { getCollectionTickers, getCollectionType } from "../../../state/selectors";
 import { useQuoteStreaming } from "../../../state/use-quote-streaming";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { getActiveQuoteDisplay } from "../../../utils/market-status";
-import type { ColumnConfig } from "../../../types/config";
+import type { AppConfig, ColumnConfig } from "../../../types/config";
 import type { TickerRecord } from "../../../types/ticker";
 import type { PaneProps } from "../../../types/plugin";
 import type { TickerFinancials } from "../../../types/financials";
-import { getSortValue, resolveCollectionSortPreference, type ColumnContext } from "./metrics";
+import { calculatePortfolioSummaryTotals, getSortValue, resolveCollectionSortPreference, type ColumnContext } from "./metrics";
 import {
   PortfolioCashMarginDrawer,
-  PortfolioSummaryBar,
   shouldToggleCashMarginDrawer,
   usePortfolioAccountState,
 } from "./header";
-import type { ResolvedPortfolioAccountState } from "./summary";
+import { buildPortfolioSummarySegments, type ResolvedPortfolioAccountState } from "./summary";
 import {
   getCollectionEntries,
   getPortfolioPaneSettings,
@@ -39,10 +37,16 @@ import {
   resolveScopedCollectionEntries,
   resolveVisibleColumns,
 } from "./settings";
+import { formatPercentRaw } from "../../../utils/format";
+import { getMostRecentQuoteUpdate } from "../../../utils/quote-time";
+import { priceColor } from "../../../theme/colors";
 import { PortfolioTickerTable, type QuoteFlashDirection } from "./table";
 import { useThrottledCursorSymbol } from "./use-throttled-cursor-symbol";
 
 const VISIBLE_FINANCIAL_REFRESH_COOLDOWN_MS = 5 * 60_000;
+const VISIBLE_FINANCIAL_WARMUP_DELAY_MS = 350;
+const STREAM_OVERSCAN_ROWS = 6;
+const sortValueCache = createRowValueCache<string, ReturnType<typeof getSortValue>>(5000);
 
 function needsVisibleFinancialWarmup(ticker: TickerRecord, financials: TickerFinancials | undefined): boolean {
   if (ticker.metadata.assetCategory === "OPT") return false;
@@ -51,11 +55,19 @@ function needsVisibleFinancialWarmup(ticker: TickerRecord, financials: TickerFin
   return financials.priceHistory.length === 0;
 }
 
-function selectStreamTickers(
+export function selectStreamTickers(
   tickers: TickerRecord[],
-  _visibleRange: { start: number; end: number },
+  visibleRange: { start: number; end: number },
+  selectedSymbol?: string | null,
 ) {
-  return tickers;
+  const start = Math.max(0, visibleRange.start - STREAM_OVERSCAN_ROWS);
+  const end = Math.min(tickers.length, visibleRange.end + STREAM_OVERSCAN_ROWS);
+  const visible = tickers.slice(start, end);
+  if (!selectedSymbol || visible.some((ticker) => ticker.metadata.ticker === selectedSymbol)) {
+    return visible;
+  }
+  const selectedTicker = tickers.find((ticker) => ticker.metadata.ticker === selectedSymbol);
+  return selectedTicker ? [...visible, selectedTicker] : visible;
 }
 
 function buildTrackedCurrencies(
@@ -93,6 +105,31 @@ function buildTrackedCurrencies(
   return [...currencies];
 }
 
+function getCollectionTypeFromConfig(config: AppConfig, collectionId: string | null): "portfolio" | "watchlist" | null {
+  if (!collectionId) return null;
+  if (config.portfolios.some((portfolio) => portfolio.id === collectionId)) return "portfolio";
+  if (config.watchlists.some((watchlist) => watchlist.id === collectionId)) return "watchlist";
+  return null;
+}
+
+function getCollectionTickersFromConfig(
+  config: AppConfig,
+  tickersBySymbol: Map<string, TickerRecord>,
+  collectionId: string | null,
+): TickerRecord[] {
+  if (!collectionId) return [];
+  const isPortfolio = config.portfolios.some((portfolio) => portfolio.id === collectionId);
+  const isWatchlist = !isPortfolio && config.watchlists.some((watchlist) => watchlist.id === collectionId);
+  if (!isPortfolio && !isWatchlist) return [];
+  return [...tickersBySymbol.values()]
+    .filter((ticker) => (
+      isPortfolio
+        ? ticker.metadata.portfolios.includes(collectionId)
+        : ticker.metadata.watchlists.includes(collectionId)
+    ))
+    .sort((left, right) => left.metadata.ticker.localeCompare(right.metadata.ticker));
+}
+
 function sortTickers(
   tickers: TickerRecord[],
   financialsMap: Map<string, TickerFinancials>,
@@ -104,10 +141,37 @@ function sortTickers(
 
   const sortColumn = columns.find((column) => column.id === sortPreference.columnId);
   if (!sortColumn) return tickers;
+  const exchangeRatesVersion = [...columnContext.exchangeRates]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([currency, rate]) => `${currency}:${rate}`)
+    .join(",");
+  const sortContextVersion = [
+    sortColumn.id,
+    columnContext.activeTab ?? "",
+    columnContext.baseCurrency,
+    exchangeRatesVersion,
+    sortColumn.id === "latency" ? columnContext.now : 0,
+  ].join("|");
+  const sortValues = new Map<string, ReturnType<typeof getSortValue>>();
+  for (const ticker of tickers) {
+    const financials = financialsMap.get(ticker.metadata.ticker);
+    const financialsVersion = [
+      financials?.quote?.lastUpdated ?? 0,
+      Object.keys(financials?.fundamentals ?? {}).length,
+      financials?.priceHistory.length ?? 0,
+    ].join(":");
+    const positionsVersion = JSON.stringify(ticker.metadata.positions);
+    const version = `${sortContextVersion}|${financialsVersion}|${positionsVersion}`;
+    sortValues.set(ticker.metadata.ticker, sortValueCache.get(
+      `${ticker.metadata.ticker}:${sortColumn.id}`,
+      version,
+      () => getSortValue(sortColumn, ticker, financials, columnContext),
+    ));
+  }
 
   return [...tickers].sort((leftTicker, rightTicker) => {
-    const leftValue = getSortValue(sortColumn, leftTicker, financialsMap.get(leftTicker.metadata.ticker), columnContext);
-    const rightValue = getSortValue(sortColumn, rightTicker, financialsMap.get(rightTicker.metadata.ticker), columnContext);
+    const leftValue = sortValues.get(leftTicker.metadata.ticker) ?? null;
+    const rightValue = sortValues.get(rightTicker.metadata.ticker) ?? null;
 
     if (leftValue == null && rightValue == null) return 0;
     if (leftValue == null) return 1;
@@ -123,10 +187,14 @@ function sortTickers(
 
 export function PortfolioListPane({ focused, width, height }: PaneProps) {
   const registry = getSharedRegistry();
-  const paneId = usePaneInstanceId();
   const paneInstance = usePaneInstance();
   const appActive = useAppActive();
-  const { state } = useAppState();
+  const config = useAppSelector((state) => state.config);
+  const tickersBySymbol = useAppSelector((state) => state.tickers);
+  const cachedFinancials = useAppSelector((state) => state.financials);
+  const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
+  const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
+  const refreshingSize = useAppSelector((state) => state.refreshing.size);
   const paneCollection = usePaneCollection();
 
   const [currentCollectionId, setCurrentCollectionId] = usePaneStateValue<string>("collectionId", paneCollection.collectionId ?? "");
@@ -157,54 +225,55 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     [paneInstance?.settings],
   );
   const collectionEntries = useMemo(
-    () => getCollectionEntries(state.config),
-    [state.config],
+    () => getCollectionEntries(config),
+    [config],
   );
   const visibleCollections = useMemo(
     () => resolveScopedCollectionEntries(collectionEntries, paneSettings),
     [collectionEntries, paneSettings],
   );
   const activeCollectionId = resolveActiveCollectionId(currentCollectionId, visibleCollections, paneSettings);
-  const isPortfolioTab = getCollectionType(state, activeCollectionId) === "portfolio";
+  const isPortfolioTab = getCollectionTypeFromConfig(config, activeCollectionId) === "portfolio";
   const currentPortfolio = useMemo(() => (
     isPortfolioTab
-      ? state.config.portfolios.find((portfolio) => portfolio.id === activeCollectionId) ?? null
+      ? config.portfolios.find((portfolio) => portfolio.id === activeCollectionId) ?? null
       : null
-  ), [activeCollectionId, isPortfolioTab, state.config.portfolios]);
+  ), [activeCollectionId, config.portfolios, isPortfolioTab]);
 
   const tickers = useMemo(
-    () => getCollectionTickers(state, activeCollectionId),
-    [activeCollectionId, state.config.portfolios, state.config.watchlists, state.tickers],
+    () => getCollectionTickersFromConfig(config, tickersBySymbol, activeCollectionId),
+    [activeCollectionId, config, tickersBySymbol],
   );
   const marketFinancialsMap = useTickerFinancialsMap(tickers);
   const sharedCoordinator = getSharedMarketDataCoordinator();
   const financialsMap = useMemo(() => {
-    const merged = sharedCoordinator ? new Map<string, TickerFinancials>() : new Map(state.financials);
+    const merged = sharedCoordinator ? new Map<string, TickerFinancials>() : new Map(cachedFinancials);
     for (const [symbol, financials] of marketFinancialsMap) {
       merged.set(symbol, financials);
     }
     return merged;
-  }, [marketFinancialsMap, sharedCoordinator, state.financials]);
+  }, [cachedFinancials, marketFinancialsMap, sharedCoordinator]);
 
-  const accountState = usePortfolioAccountState(currentPortfolio, state);
+  const accountStateInput = useMemo(() => ({ brokerAccounts, config }), [brokerAccounts, config]);
+  const accountState = usePortfolioAccountState(currentPortfolio, accountStateInput);
   const columns = useMemo(
     () => resolveVisibleColumns(paneSettings.columnIds, isPortfolioTab),
     [isPortfolioTab, paneSettings.columnIds],
   );
 
   const trackedCurrencies = useMemo(
-    () => buildTrackedCurrencies(tickers, financialsMap, accountState, state.config.baseCurrency),
-    [tickers, financialsMap, accountState, state.config.baseCurrency],
+    () => buildTrackedCurrencies(tickers, financialsMap, accountState, config.baseCurrency),
+    [accountState, config.baseCurrency, financialsMap, tickers],
   );
   const fetchedExchangeRates = useFxRatesMap(trackedCurrencies);
-  const effectiveExchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, state.exchangeRates);
+  const effectiveExchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, cachedExchangeRates);
 
   const columnContext: ColumnContext = useMemo(() => ({
     activeTab: isPortfolioTab ? activeCollectionId : undefined,
-    baseCurrency: state.config.baseCurrency,
+    baseCurrency: config.baseCurrency,
     exchangeRates: effectiveExchangeRates,
     now,
-  }), [activeCollectionId, effectiveExchangeRates, isPortfolioTab, now, state.config.baseCurrency]);
+  }), [activeCollectionId, config.baseCurrency, effectiveExchangeRates, isPortfolioTab, now]);
 
   const activeSort = resolveCollectionSortPreference(activeCollectionId, isPortfolioTab, collectionSorts);
   const sortedTickers = useMemo(
@@ -220,9 +289,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   const requestedDrawerHeight = showCashDrawer
     ? (cashDrawerExpanded ? Math.min(6, Math.max(3, 2 + accountState.visibleCashBalances.length)) : 1)
     : 0;
-  const headerHeight = paneSettings.hideHeader
-    ? (paneSettings.hideTabs ? 0 : 1)
-    : paneSettings.hideTabs ? 1 : 2;
+  const headerHeight = paneSettings.hideTabs ? 0 : 1;
   const drawerHeight = showCashDrawer
     ? Math.min(requestedDrawerHeight, Math.max(1, height - (headerHeight + 2)))
     : 0;
@@ -337,7 +404,6 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     cashDrawerExpanded,
     currentTabIdx,
     focused,
-    paneId,
     paneSettings.hideTabs,
     registry,
     safeSelectedIdx,
@@ -347,7 +413,6 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     handleCollectionSelect,
     showCashDrawer,
     sortedTickers,
-    state.config.layout.instances,
     visibleCollections,
   ]);
 
@@ -433,8 +498,8 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   }, [cursorSymbol, setCursorSymbol, sortedTickers]);
 
   const streamTickers = useMemo(
-    () => selectStreamTickers(sortedTickers, streamWindow),
-    [sortedTickers, streamWindow],
+    () => selectStreamTickers(sortedTickers, streamWindow, cursorSymbol),
+    [cursorSymbol, sortedTickers, streamWindow],
   );
   const streamTargets = useMemo(() => (
     streamTickers
@@ -448,6 +513,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
 
   useEffect(() => {
     if (!appActive) return;
+    if (!focused) return;
     if (!sharedCoordinator) return;
 
     const nowTimestamp = Date.now();
@@ -459,7 +525,9 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     });
     if (queue.length === 0) return;
 
+    let cancelled = false;
     const runNext = async (): Promise<void> => {
+      if (cancelled) return;
       const nextTicker = queue.shift();
       if (!nextTicker) return;
 
@@ -477,16 +545,94 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
         warmupInFlightRef.current.delete(key);
       }
 
-      if (mountedRef.current) {
+      if (mountedRef.current && !cancelled) {
         await runNext();
       }
     };
 
-    const workers = Array.from({ length: Math.min(3, queue.length) }, () => runNext());
-    void Promise.all(workers);
-  }, [appActive, financialsMap, sharedCoordinator, visibleFinancialTickers]);
+    const timeoutId = setTimeout(() => {
+      void runNext();
+    }, VISIBLE_FINANCIAL_WARMUP_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
+  }, [appActive, financialsMap, focused, sharedCoordinator, visibleFinancialTickers]);
 
   useQuoteStreaming(streamTargets);
+
+  const summaryFooterInfo = useMemo<PaneFooterSegment[]>(() => {
+    if (paneSettings.hideHeader) return [];
+
+    const lastRefreshTimestamp = getMostRecentQuoteUpdate(
+      sortedTickers.map((ticker) => financialsMap.get(ticker.metadata.ticker)?.quote),
+    );
+    const refreshText = refreshingSize > 0
+      ? "Refreshing..."
+      : lastRefreshTimestamp != null
+        ? new Date(lastRefreshTimestamp).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
+        : "-";
+    const totals = calculatePortfolioSummaryTotals(
+      sortedTickers,
+      financialsMap,
+      config.baseCurrency,
+      effectiveExchangeRates,
+      isPortfolioTab,
+      activeCollectionId,
+    );
+
+    if (!isPortfolioTab) {
+      if (totals.watchlistCount === 0) return [];
+      return [
+        {
+          id: "avg-day",
+          parts: [
+            { text: "Avg Day", tone: "label" },
+            { text: formatPercentRaw(totals.avgWatchlistChange), tone: "value", color: priceColor(totals.avgWatchlistChange), bold: true },
+          ],
+        },
+        {
+          id: "refresh",
+          parts: [{ text: refreshText, tone: "muted" }],
+        },
+      ];
+    }
+
+    if (!totals.hasPositions && !accountState) return [];
+    return buildPortfolioSummarySegments({
+      totals,
+      accountState: accountState ? { account: accountState.account, sourceLabel: accountState.sourceLabel } : null,
+      widthBudget: Math.max(16, width - 14),
+      refreshText,
+    }).map((segment) => ({
+      id: segment.id,
+      parts: segment.parts,
+    }));
+  }, [
+    accountState,
+    activeCollectionId,
+    effectiveExchangeRates,
+    financialsMap,
+    isPortfolioTab,
+    paneSettings.hideHeader,
+    config.baseCurrency,
+    refreshingSize,
+    sortedTickers,
+    width,
+  ]);
+
+  usePaneFooter("portfolio-list", () => ({
+    info: summaryFooterInfo,
+    hints: showCashDrawer
+      ? [{
+          id: "cash",
+          key: "c",
+          label: "ash",
+          onPress: () => setCashDrawerExpanded(!cashDrawerExpanded),
+        }]
+      : [],
+  }), [cashDrawerExpanded, setCashDrawerExpanded, showCashDrawer, summaryFooterInfo]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -501,21 +647,6 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
                 compact
               />
             </Box>
-          </Box>
-        )}
-        {!paneSettings.hideHeader && (
-          <Box height={1}>
-            <PortfolioSummaryBar
-              tickers={sortedTickers}
-              financialsMap={financialsMap}
-              baseCurrency={state.config.baseCurrency}
-              exchangeRates={effectiveExchangeRates}
-              refreshingCount={state.refreshing.size}
-              isPortfolio={isPortfolioTab}
-              collectionId={activeCollectionId}
-              width={Math.max(0, width)}
-              accountState={accountState}
-            />
           </Box>
         )}
       </Box>

--- a/src/plugins/builtin/portfolio-list/table.tsx
+++ b/src/plugins/builtin/portfolio-list/table.tsx
@@ -1,12 +1,44 @@
-import { useCallback, type RefObject } from "react";
+import { useCallback, useRef, type RefObject } from "react";
 import { type ScrollBoxRenderable } from "../../../ui";
 import { TickerListTable, type QuoteFlashDirection } from "../../../components/ticker-list-table";
+import { createRowValueCache } from "../../../components/ui/row-value-cache";
 import type { ColumnConfig } from "../../../types/config";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { getColumnValue, type ColumnContext } from "./metrics";
 
 export type { QuoteFlashDirection };
+
+const objectVersions = new WeakMap<object, number>();
+let nextObjectVersion = 1;
+
+function objectVersion(value: object | undefined): number {
+  if (!value) return 0;
+  const existing = objectVersions.get(value);
+  if (existing != null) return existing;
+  const next = nextObjectVersion;
+  nextObjectVersion += 1;
+  objectVersions.set(value, next);
+  return next;
+}
+
+function buildCellVersion(
+  column: ColumnConfig,
+  ticker: TickerRecord,
+  financials: TickerFinancials | undefined,
+  context: ColumnContext,
+): string {
+  const latencyNow = column.id === "latency" ? context.now : 0;
+  return [
+    column.id,
+    objectVersion(ticker),
+    objectVersion(financials),
+    objectVersion(context.exchangeRates),
+    context.activeTab ?? "",
+    context.baseCurrency,
+    latencyNow,
+  ].join("|");
+}
 
 export function PortfolioTickerTable({
   columns,
@@ -47,10 +79,15 @@ export function PortfolioTickerTable({
   showSparklines?: boolean;
   onRowActivate?: (ticker: TickerRecord) => void;
 }) {
+  const cellCacheRef = useRef(createRowValueCache<string, ReturnType<typeof getColumnValue>>(5000));
   const resolveCell = useCallback(
-    (column: ColumnConfig, ticker: TickerRecord, financials: TickerFinancials | undefined) => (
-      getColumnValue(column, ticker, financials, columnContext)
-    ),
+    (column: ColumnConfig, ticker: TickerRecord, financials: TickerFinancials | undefined) => {
+      const key = `${ticker.metadata.ticker}:${column.id}`;
+      const version = buildCellVersion(column, ticker, financials, columnContext);
+      return cellCacheRef.current.get(key, version, () => (
+        getColumnValue(column, ticker, financials, columnContext)
+      ));
+    },
     [columnContext],
   );
 

--- a/src/plugins/builtin/portfolio-list/use-throttled-cursor-symbol.ts
+++ b/src/plugins/builtin/portfolio-list/use-throttled-cursor-symbol.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-export const FOLLOW_CURSOR_THROTTLE_MS = 80;
+export const FOLLOW_CURSOR_THROTTLE_MS = 300;
 
 export function useThrottledCursorSymbol(
   committedCursorSymbol: string | null,

--- a/src/plugins/builtin/sec.tsx
+++ b/src/plugins/builtin/sec.tsx
@@ -8,7 +8,7 @@ import { usePluginPaneState } from "../../plugins/plugin-runtime";
 import { usePaneTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import { Spinner } from "../../components/spinner";
-import { FeedDataTableStackView, type FeedDataTableItem } from "../../components";
+import { FeedDataTableStackView, usePaneFooter, type FeedDataTableItem } from "../../components";
 import { isUsEquityTicker } from "../../utils/sec";
 import { getSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { parseForm4Xml, transactionTypeLabel } from "./insider/insider-data";
@@ -305,6 +305,15 @@ function SecTab({ width, height, focused }: DetailTabProps) {
       }
     })();
   }, [filings]);
+
+  usePaneFooter("sec", () => ({
+    info: [
+      ...(ticker ? [{ id: "ticker", parts: [{ text: ticker.metadata.ticker, tone: "value" as const, bold: true }] }] : []),
+      { id: "count", parts: [{ text: `${filings.length} filings`, tone: "muted" }] },
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
+    ],
+  }), [error, filings.length, loading, ticker?.metadata.ticker]);
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view SEC filings.</Text>;
   if (!eligibleTicker) return renderNotice("SEC filings are only shown for US equities.", width);

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -1,8 +1,8 @@
-import { Box, Text } from "../../../ui";
+import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { DataTable, type DataTableCell, type DataTableColumn } from "../../../components";
+import { DataTable, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
@@ -291,16 +291,18 @@ export function SectorPerformancePane({ focused, width, height }: PaneProps) {
     }
   }, []);
 
+  usePaneFooter("sectors", () => ({
+    info: [
+      {
+        id: "updated",
+        parts: [{ text: lastRefresh ? formatTime(lastRefresh) : "loading", tone: lastRefresh ? "value" : "muted" }],
+      },
+    ],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: fetchAll }],
+  }), [fetchAll, lastRefresh]);
+
   return (
     <Box flexDirection="column" width={width} height={height}>
-      <Box flexDirection="row" height={1} paddingX={1}>
-        {lastRefresh ? (
-          <Text fg={colors.textMuted}>{formatTime(lastRefresh)}</Text>
-        ) : (
-          <Text fg={colors.textMuted}>loading…</Text>
-        )}
-      </Box>
-
       <DataTable<SectorRow, SectorColumn>
         columns={columns}
         items={sortedRows}
@@ -320,10 +322,6 @@ export function SectorPerformancePane({ focused, width, height }: PaneProps) {
         emptyStateTitle="No sector data available"
         showHorizontalScrollbar={false}
       />
-
-      <Box height={1} paddingX={1}>
-        <Text fg={colors.textMuted}>[r]efresh</Text>
-      </Box>
     </Box>
   );
 }

--- a/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
+++ b/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
@@ -179,7 +179,6 @@ describe("Ticker detail chart tab switching", () => {
     await flushFrames();
     const chartTabFrame = testSetup.captureCharFrame();
     expect(chartTabFrame).toContain("AAPL");
-    expect(chartTabFrame).toContain("[i]ndicators");
     expect(manager.surfaces.has("chart-surface:ticker-detail:test:full:base")).toBe(true);
 
     act(() => {

--- a/src/plugins/builtin/ticker-detail.test.tsx
+++ b/src/plugins/builtin/ticker-detail.test.tsx
@@ -349,7 +349,7 @@ describe("TickerDetailPane", () => {
     expect(paneDef?.defaultMode).toBe("floating");
   });
 
-  test("shows only applicable tabs when no gateway, statements, or options are available", async () => {
+  test("shows core and lightweight plugin tabs without waiting on options preflight", async () => {
     setSharedRegistryForTests(makeRegistry());
     setOptionsProvider(createProvider(false));
 
@@ -368,10 +368,10 @@ describe("TickerDetailPane", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Overview");
     expect(frame).toContain("Chart");
+    expect(frame).toContain("Options");
     expect(frame).toContain("Ask AI");
     expect(frame).not.toContain("Financials");
     expect(frame).not.toContain("Trade");
-    expect(frame).not.toContain("Options");
   });
 
   test("shows Financials when statement data exists", async () => {
@@ -412,7 +412,7 @@ describe("TickerDetailPane", () => {
     expect(frame).toContain("Trade");
   });
 
-  test("shows Options after the preflight confirms a chain exists", async () => {
+  test("shows Options for option-capable tickers without a preflight round trip", async () => {
     setSharedRegistryForTests(makeRegistry());
     setOptionsProvider(createProvider(true));
 
@@ -448,6 +448,36 @@ describe("TickerDetailPane", () => {
     await flushFrame();
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("SEC");
+  });
+
+  test("passes visible tab content height to plugin tabs", async () => {
+    let receivedHeight: number | null = null;
+    const probeTab: DetailTabDef["component"] = ({ height }) => {
+      receivedHeight = height;
+      return <text>{`height:${height}`}</text>;
+    };
+    setSharedRegistryForTests({
+      detailTabs: new Map<string, DetailTabDef>([
+        ["sec", { id: "sec", name: "SEC", order: 45, component: probeTab, isVisible: ({ ticker }) => isUsEquityTicker(ticker) }],
+      ]),
+    } as unknown as PluginRegistry);
+    setOptionsProvider(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={null}
+        activeTabId="sec"
+        height={18}
+      />,
+      { width: 90, height: 18 },
+    );
+
+    await flushFrame();
+    const frame = testSetup.captureCharFrame();
+    expect(receivedHeight).toBe(16);
+    expect(frame).toContain("height:16");
   });
 
   test("hides SEC for non-US equities", async () => {

--- a/src/plugins/builtin/ticker-detail/chart-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/chart-tab.tsx
@@ -1,7 +1,6 @@
 import { Box } from "../../../ui";
 import { useViewport } from "../../../react/input";
 import { useCallback, useMemo } from "react";
-import { saveConfig } from "../../../data/config-store";
 import { ChartIndicatorSelector } from "../../../components/chart/chart-indicator-selector";
 import {
   buildIndicatorConfigFromSelection,
@@ -14,7 +13,8 @@ import {
 } from "../../../components/chart/indicators/options";
 import type { ChartAxisMode } from "../../../components/chart/chart-types";
 import { ResolvedStockChart } from "../../../components/chart/stock-chart";
-import { useAppState } from "../../../state/app-context";
+import { useAppDispatch, useAppSelector } from "../../../state/app-context";
+import { scheduleConfigSave } from "../../../state/config-save-scheduler";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { getSharedRegistry } from "../../registry";
@@ -43,12 +43,13 @@ export function ChartTab({
   financials: TickerFinancials | null;
 }) {
   const { width: termWidth, height: termHeight } = useViewport();
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config);
 
   const chartWidth = Math.max((width || Math.floor(termWidth * 0.55)) - 2, 30);
   const chartHeight = Math.max((height || termHeight - 8) - 2, 10);
-  const rawIndicatorSelection = state.config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_KEY];
-  const indicatorSelectionVersion = state.config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY];
+  const rawIndicatorSelection = config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_KEY];
+  const indicatorSelectionVersion = config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY];
   const hasStoredIndicatorSelection = Array.isArray(rawIndicatorSelection);
   const selectedIndicatorIds = useMemo(
     () => resolveChartIndicatorSelection(rawIndicatorSelection, indicatorSelectionVersion),
@@ -62,20 +63,20 @@ export function ChartTab({
   const persistIndicatorSelection = useCallback((nextSelection: ChartIndicatorId[]) => {
     const normalized = normalizeChartIndicatorSelection(nextSelection);
     const nextConfig = {
-      ...state.config,
+      ...config,
       pluginConfig: {
-        ...state.config.pluginConfig,
+        ...config.pluginConfig,
         [TICKER_DETAIL_PLUGIN_ID]: {
-          ...(state.config.pluginConfig[TICKER_DETAIL_PLUGIN_ID] ?? {}),
+          ...(config.pluginConfig[TICKER_DETAIL_PLUGIN_ID] ?? {}),
           [CHART_INDICATORS_PLUGIN_CONFIG_KEY]: normalized,
           [CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY]: CURRENT_CHART_INDICATORS_CONFIG_VERSION,
         },
       },
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    saveConfig(nextConfig).catch(() => {});
+    scheduleConfigSave(nextConfig);
     getSharedRegistry()?.events.emit("config:changed", { config: nextConfig });
-  }, [dispatch, state.config]);
+  }, [config, dispatch]);
 
   return (
     <Box
@@ -90,6 +91,13 @@ export function ChartTab({
           if (!interactive) onActivate?.();
         }}
       >
+        <ChartIndicatorSelector
+          width={chartWidth}
+          selectedIds={selectedIndicatorIds}
+          onChange={persistIndicatorSelection}
+          variant="pane-hint"
+          shortcutActive={focused}
+        />
         <ResolvedStockChart
           width={chartWidth}
           height={chartHeight}
@@ -101,15 +109,6 @@ export function ChartTab({
           financials={financials}
           indicatorConfig={hasStoredIndicatorSelection ? selectedIndicatorConfig : undefined}
           showVolume={showVolume}
-          footerControls={(
-            <ChartIndicatorSelector
-              width={chartWidth}
-              selectedIds={selectedIndicatorIds}
-              onChange={persistIndicatorSelection}
-              variant="hint"
-              shortcutActive={focused}
-            />
-          )}
         />
       </Box>
     </Box>

--- a/src/plugins/builtin/ticker-detail/financials-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/financials-tab.tsx
@@ -3,6 +3,7 @@ import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePaneTicker } from "../../../state/app-context";
+import { usePaneFooter } from "../../../components";
 import { colors, priceColor } from "../../../theme/colors";
 import type { FinancialStatement } from "../../../types/financials";
 import {
@@ -247,6 +248,33 @@ export function ResolvedFinancialsTab({
   const [subTabIdx, setSubTabIdx] = useState(0);
   const bodyScrollRef = useRef<ScrollBoxRenderable>(null);
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
+  const resolvedPeriodForFooter = resolveFinancialPeriod(period, hasAnnualStatements, hasQuarterlyStatements);
+
+  usePaneFooter("financials", () => ({
+    info: financials ? [
+      { id: "section", parts: [{ text: FINANCIAL_SUB_TABS[subTabIdx]?.name ?? "Financials", tone: "value", bold: true }] },
+      { id: "period", parts: [{ text: resolvedPeriodForFooter === "annual" ? "Annual" : "Quarterly", tone: "muted" }] },
+    ] : [],
+    hints: [
+      {
+        id: "section",
+        key: "1-3",
+        label: "section",
+        disabled: !financials,
+        onPress: () => setSubTabIdx((current) => (current + 1) % FINANCIAL_SUB_TABS.length),
+      },
+      {
+        id: "period",
+        key: "a/q",
+        label: "period",
+        disabled: !hasAnnualStatements && !hasQuarterlyStatements,
+        onPress: () => {
+          if (resolvedPeriodForFooter === "annual" && hasQuarterlyStatements) setPeriod("quarterly");
+          else if (hasAnnualStatements) setPeriod("annual");
+        },
+      },
+    ],
+  }), [financials, hasAnnualStatements, hasQuarterlyStatements, resolvedPeriodForFooter, subTabIdx]);
 
   const syncHeaderScroll = useCallback(() => {
     const body = bodyScrollRef.current;
@@ -319,18 +347,18 @@ export function ResolvedFinancialsTab({
               fg={index === subTabIdx ? colors.textBright : colors.textDim}
               attributes={index === subTabIdx ? TextAttributes.BOLD : 0}
             >
-              {`${index + 1}:${tab.name}`}
+              {tab.name}
             </Text>
             {index < FINANCIAL_SUB_TABS.length - 1 && <Text fg={colors.textMuted}>{" │ "}</Text>}
           </Box>
         ))}
         <Box flexGrow={1} />
         <Box onMouseDown={() => setPeriod("annual")}>
-          <Text fg={isAnnual ? colors.textBright : colors.textDim} attributes={isAnnual ? TextAttributes.BOLD : 0}>a</Text>
+          <Text fg={isAnnual ? colors.textBright : colors.textDim} attributes={isAnnual ? TextAttributes.BOLD : 0}>Annual</Text>
         </Box>
-        <Text fg={colors.textMuted}>/</Text>
+        <Text fg={colors.textMuted}>{" / "}</Text>
         <Box onMouseDown={() => setPeriod("quarterly")}>
-          <Text fg={!isAnnual ? colors.textBright : colors.textDim} attributes={!isAnnual ? TextAttributes.BOLD : 0}>q</Text>
+          <Text fg={!isAnnual ? colors.textBright : colors.textDim} attributes={!isAnnual ? TextAttributes.BOLD : 0}>Quarterly</Text>
         </Box>
       </Box>
       <Box height={1} />

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -17,7 +17,7 @@ import { getSharedRegistry } from "../../registry";
 import { EmptyState } from "../../../components";
 import { TabBar } from "../../../components/tab-bar";
 import { getConfiguredIbkrGatewayInstances } from "../../ibkr/instance-selection";
-import { useOptionsAvailability } from "../options-availability";
+import { resolveOptionsTarget } from "../../../utils/options";
 import { ChartTab } from "./chart-tab";
 import { ResolvedFinancialsTab } from "./financials-tab";
 import { OverviewTab } from "./overview-tab";
@@ -41,7 +41,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
   const [chartInteractive, setChartInteractive] = useState(false);
   const [pluginCaptured, setPluginCaptured] = useState(false);
   const paneSettings = getTickerDetailPaneSettings(paneInstance?.settings);
-  const hasOptionsChain = useOptionsAvailability(ticker);
+  const hasOptionsChain = !!resolveOptionsTarget(ticker)?.effectiveTicker;
   const collectionTickerCount = useAppSelector((state) => getCollectionTickerCount(state, collectionId));
   const collectionName = useAppSelector((state) => getCollectionName(state, collectionId));
 
@@ -64,6 +64,8 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
     ? resolveLockedTabId(paneSettings, allTabs)
     : (allTabs.some((tab) => tab.id === activeTabId) ? activeTabId : (allTabs[0]?.id ?? "overview"));
   const activePluginTab = pluginTabs.find((tab) => tab.id === resolvedTabId && allTabs.some((visibleTab) => visibleTab.id === tab.id)) ?? null;
+  const tabBarHeight = paneSettings.hideTabs ? 0 : 2;
+  const contentHeight = Math.max(1, height - tabBarHeight);
 
   const allTabsRef = useRef(allTabs);
   allTabsRef.current = allTabs;
@@ -178,7 +180,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
       {resolvedTabId === "chart" && (
         <ChartTab
           width={width}
-          height={height}
+          height={contentHeight}
           focused={focused}
           interactive={chartInteractive}
           axisMode={paneSettings.chartAxisMode}
@@ -192,7 +194,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
       {activePluginTab && (
         <activePluginTab.component
           width={width}
-          height={height}
+          height={contentHeight}
           focused={focused}
           onCapture={handlePluginCapture}
         />

--- a/src/plugins/builtin/ticker-detail/quote-monitor.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor.tsx
@@ -9,7 +9,7 @@ import { colors, priceColor } from "../../../theme/colors";
 import { formatPercentRaw } from "../../../utils/format";
 import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../../utils/market-format";
 import { getActiveQuoteDisplay } from "../../../utils/market-status";
-import { EmptyState } from "../../../components";
+import { EmptyState, usePaneFooter } from "../../../components";
 
 function getQuoteMonitorDisplay(quote: Quote | null | undefined) {
   return getActiveQuoteDisplay(quote);
@@ -19,6 +19,21 @@ export function QuoteMonitorPane({ focused, width }: PaneProps) {
   const { ticker, financials } = usePaneTicker();
   const streamingTarget = quoteSubscriptionTargetFromTicker(ticker, ticker?.metadata.ticker, "provider");
   useQuoteStreaming(streamingTarget ? [streamingTarget] : []);
+  const quote = financials?.quote;
+
+  usePaneFooter("quote-monitor", () => ({
+    info: [
+      ...(ticker ? [{ id: "ticker", parts: [{ text: ticker.metadata.ticker, tone: "value" as const, bold: true }] }] : []),
+      ...(quote?.lastUpdated ? [{
+        id: "updated",
+        parts: [{ text: `quote ${new Date(quote.lastUpdated).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`, tone: "muted" as const }],
+      }] : []),
+      ...(quote?.providerId || quote?.dataSource ? [{
+        id: "source",
+        parts: [{ text: quote.providerId ?? quote.dataSource ?? "", tone: "muted" as const }],
+      }] : []),
+    ],
+  }), [quote?.dataSource, quote?.lastUpdated, quote?.providerId, ticker?.metadata.ticker]);
 
   if (!ticker) {
     return (

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -2,7 +2,7 @@ import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { DataTable, type DataTableCell, type DataTableColumn } from "../../../components";
+import { DataTable, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import type { Quote } from "../../../types/financials";
 import type { MarketState } from "../../../types/financials";
@@ -182,7 +182,7 @@ export function WorldIndicesPane({ focused, width, height }: PaneProps) {
     }
   }, [flatRows, selectedFlatIdx, selectedSymbol]);
 
-  const fetchAll = () => {
+  const fetchAll = useCallback(() => {
     const provider = getSharedDataProvider();
     if (!provider) return;
 
@@ -214,13 +214,13 @@ export function WorldIndicesPane({ focused, width, height }: PaneProps) {
         });
       });
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchAll();
     const interval = setInterval(fetchAll, REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, []);
+  }, [fetchAll]);
 
   const syncHeaderScroll = useCallback(() => {
     const bodyScrollBox = scrollRef.current;
@@ -350,6 +350,21 @@ export function WorldIndicesPane({ focused, width, height }: PaneProps) {
         };
     }
   }, [quotes]);
+
+  const loadedCount = Array.from(quotes.values()).filter((state) => !!state.quote).length;
+  const loadingCount = Array.from(quotes.values()).filter((state) => state.loading).length;
+  const latestQuoteTs = Math.max(
+    0,
+    ...Array.from(quotes.values()).map((state) => state.quote?.lastUpdated ?? 0),
+  );
+  usePaneFooter("world-indices", () => ({
+    info: [
+      { id: "rows", parts: [{ text: `${navigableIndices.length} indices`, tone: "muted" }] },
+      { id: "quotes", parts: [{ text: `${loadedCount} quotes`, tone: loadedCount > 0 ? "value" : "muted" }] },
+      ...(loadingCount > 0 ? [{ id: "loading", parts: [{ text: `${loadingCount} loading`, tone: "muted" as const }] }] : []),
+      ...(latestQuoteTs > 0 ? [{ id: "fresh", parts: [{ text: new Date(latestQuoteTs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }), tone: "muted" as const }] }] : []),
+    ],
+  }), [latestQuoteTs, loadedCount, loadingCount, navigableIndices.length]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -1,7 +1,7 @@
 import { Box, ScrollBox, Text } from "../../../ui";
-import { useEffect, useRef, useState } from "react";
-import { TextAttributes } from "../../../ui";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useShortcut } from "../../../react/input";
+import { usePaneFooter } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import { useAppSelector } from "../../../state/app-context";
@@ -40,7 +40,7 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
 
   const fetchGenRef = useRef(0);
 
-  const load = async (force = false) => {
+  const load = useCallback(async (force = false) => {
     if (!apiKey) return;
 
     fetchGenRef.current += 1;
@@ -58,11 +58,11 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
     } finally {
       if (fetchGenRef.current === gen) setLoading(false);
     }
-  };
+  }, [apiKey]);
 
   useEffect(() => {
     load();
-  }, [apiKey]);
+  }, [load]);
 
   useShortcut((ev) => {
     if (!focused) return;
@@ -71,14 +71,24 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
     }
   });
 
+  const inverted = isInverted(points);
+  const bp = spreadBp(points);
+
+  usePaneFooter("yield-curve", () => ({
+    info: [
+      ...(inverted ? [{ id: "inverted", parts: [{ text: "INVERTED", tone: "warning" as const, bold: true }] }] : []),
+      ...(bp != null ? [{ id: "spread", parts: [{ text: `2Y-10Y ${bp >= 0 ? "+" : ""}${bp}bp`, tone: bp < 0 ? "warning" as const : "muted" as const }] }] : []),
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+    ],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => load(true) }],
+  }), [bp, error, inverted, load, loading]);
+
   if (!apiKey) {
     return (
       <Box flexDirection="column" width={width} height={height}>
         <Box flexGrow={1} justifyContent="center" alignItems="center">
           <Text fg={colors.textMuted}>{`Configure FRED API key: type '${FRED_API_KEY_COMMAND_LABEL}' in command bar`}</Text>
-        </Box>
-        <Box height={1} paddingX={1}>
-          <Text fg={colors.textMuted}>[r]efresh</Text>
         </Box>
       </Box>
     );
@@ -90,9 +100,6 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
         <Box flexGrow={1} justifyContent="center" alignItems="center">
           <Text fg={colors.textMuted}>Loading...</Text>
         </Box>
-        <Box height={1} paddingX={1}>
-          <Text fg={colors.textMuted}>[r]efresh</Text>
-        </Box>
       </Box>
     );
   }
@@ -103,17 +110,11 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
         <Box flexGrow={1} justifyContent="center" alignItems="center">
           <Text fg={colors.negative}>{error}</Text>
         </Box>
-        <Box height={1} paddingX={1}>
-          <Text fg={colors.textMuted}>[r]efresh</Text>
-        </Box>
       </Box>
     );
   }
 
   const validPoints = parseYieldPoints(points);
-  const inverted = isInverted(points);
-  const bp = spreadBp(points);
-  const spreadStr = bp != null ? `  2Y-10Y: ${bp >= 0 ? "+" : ""}${bp}bp` : "";
 
   const chartWidth = Math.max(10, width - 2);
   const chartHeight = Math.min(12, Math.max(6, Math.floor(height * 0.3)));
@@ -155,18 +156,6 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {/* Header */}
-      <Box height={1} paddingX={1} flexDirection="row">
-        {inverted ? (
-          <Text fg={colors.warning} attributes={TextAttributes.BOLD}>⚠ INVERTED</Text>
-        ) : null}
-        {spreadStr ? (
-          <Text fg={colors.textDim}>{inverted ? spreadStr : spreadStr.trimStart()}</Text>
-        ) : null}
-        <Box flexGrow={1} />
-        {loading ? <Text fg={colors.textDim}>updating…</Text> : null}
-      </Box>
-
       {/* Scrollable chart + table */}
       <ScrollBox flexGrow={1} scrollY focusable={false}>
         <Box flexDirection="column">
@@ -194,11 +183,6 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
           </Box>
         </Box>
       </ScrollBox>
-
-      {/* Footer */}
-      <Box height={1} paddingX={1}>
-        <Text fg={colors.textMuted}>[r]efresh</Text>
-      </Box>
     </Box>
   );
 }

--- a/src/plugins/ibkr/__snapshots__/trade-tab.test.tsx.snap
+++ b/src/plugins/ibkr/__snapshots__/trade-tab.test.tsx.snap
@@ -5,17 +5,17 @@ exports[`renders the compact trade tab layout 1`] = `
  $199.8  -3.97 · Bid 199.7 · Ask 199.9 · Spd 0.2  Paper Gateway    DU123456    —        
                                                                                         
                                                                                         
-  Next Submit order   Ticket Standby   Refresh  r                                       
+  Next Submit order   Ticket Standby   Refresh                                          
                                                                                         
   Refreshed Paper.                                                                      
                                                                                         
  ╭────────────────────────────────────────────────────────────────────────────────────╮ 
- │ Ticket                                                         Click field / Enter │ 
- │ Click a field or press Enter to edit. Shortcuts are shown inline.                  │ 
+ │ Ticket                                                                       Ready │ 
+ │ Click a field to edit. Shortcuts are in the pane footer.                           │ 
  │                                                                                    │ 
  │  Profile Paper              Ticker AMD STK             Account DU123456            │ 
  │                                                                                    │ 
- │  Side [b/v] BUY      Type [t] MKT        Qty [q] 1           TIF DAY               │ 
+ │  Side BUY            Type MKT            Qty 1               TIF DAY               │ 
  │                                                                                    │ 
  │ Advanced Micro Devices, Inc.                                                       │ 
  ╰────────────────────────────────────────────────────────────────────────────────────╯ 
@@ -25,7 +25,7 @@ exports[`renders the compact trade tab layout 1`] = `
  │ What-if: init 12.4k → 13.2k · commission $1.25                                     │ 
  │  Fee $1.25                              Init 12.4k → 13.2k                         │ 
  │  Maint 10.1k → 10.7k                    Equity 58.4k → 57.1k                       │ 
- │  Preview  p  Submit Order  Enter                                                   │ 
+ │  Preview   Submit Order                                                            │ 
  ╰────────────────────────────────────────────────────────────────────────────────────╯ 
                                                                                         
                                                                                         

--- a/src/plugins/ibkr/trade-tab.test.tsx
+++ b/src/plugins/ibkr/trade-tab.test.tsx
@@ -176,7 +176,7 @@ test("renders the compact trade tab layout", async () => {
   const frame = testSetup.captureCharFrame();
   expect(frame).toContain("Next Submit order");
   expect(frame).toContain("Ticket Standby");
-  expect(frame).toContain("Side [b/v]");
+  expect(frame).toContain("Shortcuts are in the pane footer.");
   expect(frame).toContain("What-if: init");
   expect(frame).not.toContain("1 Profile");
   expect(frame).not.toContain("Activate Ticket");

--- a/src/plugins/ibkr/trade-tab.tsx
+++ b/src/plugins/ibkr/trade-tab.tsx
@@ -3,9 +3,14 @@ import { TextAttributes } from "../../ui";
 import { useShortcut } from "../../react/input";
 import { useDialog } from "../../ui/dialog";
 import { useCallback, useEffect, useState } from "react";
-import { PriceSelectorDialog } from "../../components";
+import { PriceSelectorDialog, usePaneFooter } from "../../components";
 import { Button } from "../../components/ui/button";
-import { useAppState, usePaneCollection, usePaneInstanceId, usePaneTicker } from "../../state/app-context";
+import {
+  useAppSelector,
+  usePaneCollection,
+  usePaneInstanceId,
+  usePaneTicker,
+} from "../../state/app-context";
 import { colors, hoverBg } from "../../theme/colors";
 import type { DetailTabProps } from "../../types/plugin";
 import type { BrokerOrderRequest, BrokerOrderType } from "../../types/trading";
@@ -44,7 +49,8 @@ import {
 } from "./trade-utils";
 
 export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
-  const { state } = useAppState();
+  const config = useAppSelector((state) => state.config);
+  const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
   const paneId = usePaneInstanceId();
   const { collectionId } = usePaneCollection(paneId);
   const { ticker, financials } = usePaneTicker(paneId);
@@ -69,14 +75,14 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     availableAccounts,
     gatewayRequiredMessage,
   } = useIbkrGatewaySelection(
-    state.config,
-    state.brokerAccounts,
+    config,
+    brokerAccounts,
     collectionId,
     preferredInstanceId,
   );
   const inferredAccountId = selectedInstance
     ? inferDraftAccountId(
-      state.config,
+      config,
       collectionId,
       availableAccounts,
       selectedInstance.id,
@@ -139,7 +145,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
   useEffect(() => {
     if (!symbol || !ticker || !isGatewayMode || availableAccounts.length === 0 || ticketState.draft.accountId || !selectedInstance) return;
     const inferred = inferDraftAccountId(
-      state.config,
+      config,
       collectionId,
       availableAccounts,
       selectedInstance.id,
@@ -155,7 +161,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     availableAccounts,
     ticketState.draft.accountId,
     selectedInstance,
-    state.config,
+    config,
     collectionId,
     tradeState.accountId,
   ]);
@@ -171,7 +177,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
       setTradeTicketBusy(symbol, true, ticker);
       await refreshGatewayData(selectedInstance);
       const inferred = inferDraftAccountId(
-        state.config,
+        config,
         collectionId,
         availableAccounts,
         selectedInstance.id,
@@ -193,7 +199,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     normalizedConfig,
     isGatewayMode,
     gatewayRequiredMessage,
-    state.config,
+    config,
     collectionId,
     availableAccounts,
     tradeState.accountId,
@@ -230,7 +236,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     });
     if (!selected) return;
 
-    const instance = getBrokerInstance(state.config.brokerInstances, selected);
+    const instance = getBrokerInstance(config.brokerInstances, selected);
     if (!instance) return;
     updateTradingPaneState({
       brokerInstanceId: instance.id,
@@ -254,7 +260,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
       lastError: undefined,
       lastInfo: undefined,
     }));
-  }, [symbol, ticker, lockedBrokerInstanceId, gatewayInstances, dialog, state.config.brokerInstances]);
+  }, [symbol, ticker, lockedBrokerInstanceId, gatewayInstances, dialog, config.brokerInstances]);
 
   const chooseInstrument = useCallback(async () => {
     if (!symbol || !ticker) return;
@@ -323,7 +329,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     }
 
     const nextAccounts = getKnownIbkrAccounts(
-      state.brokerAccounts,
+      brokerAccounts,
       selectedInstance.id,
       gatewayService.getSnapshot().accounts,
     );
@@ -356,6 +362,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     gatewayService,
     isGatewayMode,
     availableAccounts,
+    brokerAccounts,
     refresh,
     dialog,
   ]);
@@ -496,7 +503,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
       updateTradingPaneState({ accountId: request.accountId });
       setTradeTicketDraft(symbol, { brokerInstanceId: selectedInstance.id, accountId: request.accountId }, ticker);
       setTradeTicketPreview(symbol, preview, ticker);
-      setTradeTicketMessage(symbol, "Review the what-if preview, then press Enter again to submit.", undefined, ticker);
+      setTradeTicketMessage(symbol, "Review the what-if preview, then submit when ready.", undefined, ticker);
     } catch (error: any) {
       const message = error?.message || "Failed to preview order.";
       setTradeTicketMessage(symbol, undefined, message.replace("Timeout has occurred", "Preview timed out — try again."), ticker);
@@ -606,14 +613,6 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     }
   });
 
-  if (!ticker || !symbol) {
-    return (
-      <Box flexGrow={1} alignItems="center" justifyContent="center">
-        <Text fg={colors.textDim}>Select a ticker to draft an IBKR trade.</Text>
-      </Box>
-    );
-  }
-
   const showLimit = isLimitOrder(ticketState.draft.orderType);
   const showStop = isStopOrder(ticketState.draft.orderType);
   const hasProfile = Boolean(selectedInstance);
@@ -629,14 +628,16 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
     ? Math.max(16, Math.floor((ticketPanelWidth - 5) / 4))
     : fieldWidth;
   const fieldTextWidth = Math.max(8, fieldWidth - 3);
-  const activeContract = ticketState.draft.contract.symbol ? ticketState.draft.contract : normalizeContract(ticker);
+  const activeContract = ticketState.draft.contract.symbol
+    ? ticketState.draft.contract
+    : ticker ? normalizeContract(ticker) : ticketState.draft.contract;
   const hasContract = Boolean(activeContract.symbol);
   const hasAccount = Boolean(currentAccountId);
   const hasPreview = Boolean(ticketState.preview);
   const previewTextWidth = Math.max(18, (previewPanelWidth ?? Math.max(34, width - 6)) - 4);
   const contractValue = truncateText(formatContractLabel(activeContract), fieldTextWidth);
   const contractMeta = truncateText(
-    ticketState.contractName || ticker.metadata.name || "Using current ticker",
+    ticketState.contractName || ticker?.metadata.name || "Using current ticker",
     Math.max(fieldTextWidth * Math.max(2, fieldsPerRow), 18),
   );
   const connectionTone: TradeTone = gatewaySnapshot.status.state === "connected"
@@ -655,7 +656,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
       || ticketState.lastInfo
       || gatewaySnapshot.status.message
       || gatewaySnapshot.lastError
-      || "Click a workflow step or field to activate the ticket, then preview before submit.";
+      || "Choose a workflow step or field, then preview before submit.";
   const previewTone: TradeTone = !ticketState.preview
     ? "neutral"
     : ticketState.preview.warningText
@@ -684,8 +685,56 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
       ? "accent"
       : "neutral";
   const ticketHint = interactive
-    ? "Esc releases the ticket. Field shortcuts stay active while captured."
-    : "Click a field or press Enter to edit. Shortcuts are shown inline.";
+    ? "Field shortcuts stay active while captured."
+    : "Click a field to edit. Shortcuts are in the pane footer.";
+
+  usePaneFooter("ibkr-trade", () => ({
+    info: [
+      { id: "next", parts: [{ text: nextStep, tone: workflowTone === "positive" ? "positive" : workflowTone === "accent" ? "value" : "muted", bold: workflowTone !== "neutral" }] },
+      { id: "ticket", parts: [{ text: interactive ? "captured" : "standby", tone: interactive ? "positive" : "muted" }] },
+      ...(statusText ? [{ id: "status", parts: [{ text: statusText, tone: statusTone === "negative" ? "negative" as const : statusTone === "positive" ? "positive" as const : "muted" as const }] }] : []),
+    ],
+    hints: [
+      { id: "refresh", key: "r", label: "efresh", onPress: () => refresh().catch(() => {}), disabled: ticketState.busy },
+      { id: "profile", key: "i", label: "profile", onPress: () => chooseBrokerInstance().catch(() => {}), disabled: ticketState.busy },
+      { id: "instrument", key: "s", label: "symbol", onPress: () => chooseInstrument().catch(() => {}), disabled: ticketState.busy },
+      { id: "account", key: "a", label: "account", onPress: () => chooseAccount().catch(() => {}), disabled: ticketState.busy },
+      { id: "side", key: "b/v", label: "side", onPress: symbol && ticker ? () => setTradeTicketDraft(symbol, { action: ticketState.draft.action === "BUY" ? "SELL" : "BUY" }, ticker) : undefined, disabled: ticketState.busy || !symbol || !ticker },
+      { id: "quantity", key: "q", label: "qty", onPress: () => editNumericField("Quantity", ticketState.draft.quantity, (value) => { if (value != null && symbol && ticker) setTradeTicketDraft(symbol, { quantity: value }, ticker); }).catch(() => {}), disabled: ticketState.busy || !symbol || !ticker },
+      { id: "type", key: "t", label: "type", onPress: () => editOrderType().catch(() => {}), disabled: ticketState.busy },
+      { id: "limit", key: "l", label: "limit", onPress: () => editPriceField("Limit Price", ticketState.draft.limitPrice, (value) => { if (symbol && ticker) setTradeTicketDraft(symbol, { limitPrice: value }, ticker); }).catch(() => {}), disabled: ticketState.busy || !showLimit || !symbol || !ticker },
+      { id: "stop", key: "x", label: "stop", onPress: () => editPriceField("Stop Price", ticketState.draft.stopPrice, (value) => { if (symbol && ticker) setTradeTicketDraft(symbol, { stopPrice: value }, ticker); }).catch(() => {}), disabled: ticketState.busy || !showStop || !symbol || !ticker },
+      { id: "preview", key: "p", label: "preview", onPress: () => previewOrder().catch(() => {}), disabled: ticketState.busy || !symbol || !ticker },
+    ],
+  }), [
+    chooseAccount,
+    chooseBrokerInstance,
+    chooseInstrument,
+    editNumericField,
+    editOrderType,
+    editPriceField,
+    interactive,
+    nextStep,
+    previewOrder,
+    refresh,
+    showLimit,
+    showStop,
+    statusText,
+    statusTone,
+    symbol,
+    ticketState.busy,
+    ticketState.draft,
+    ticker,
+    workflowTone,
+  ]);
+
+  if (!ticker || !symbol) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Text fg={colors.textDim}>Select a ticker to draft an IBKR trade.</Text>
+      </Box>
+    );
+  }
 
   const renderFieldPill = ({
     id,
@@ -742,7 +791,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
         paddingX={1}
         marginRight={1}
         onMouseMove={() => {
-          if (!disabled) setHoveredField(id);
+          if (!disabled) setHoveredField((current) => (current === id ? current : id));
         }}
         onMouseDown={disabled ? undefined : () => {
           enterInteractive();
@@ -867,7 +916,6 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
           })}
           <Button
             label="Refresh"
-            shortcut="r"
             variant="ghost"
             disabled={ticketState.busy}
             onPress={() => refresh().catch(() => {})}
@@ -894,7 +942,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Ticket</Text>
               <Box flexGrow={1} />
               <Text fg={interactive ? colors.positive : colors.textMuted}>
-                {interactive ? "Captured" : "Click field / Enter"}
+                {interactive ? "Captured" : "Ready"}
               </Text>
             </Box>
             <Text fg={colors.textMuted}>{truncateText(ticketHint, Math.max(ticketPanelWidth - 4, 24))}</Text>
@@ -930,7 +978,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
             <Box flexDirection="row" flexWrap="wrap">
               {renderFieldPill({
                 id: "action",
-                label: "Side [b/v]",
+                label: "Side",
                 value: ticketState.draft.action,
                 valueColor: ticketState.draft.action === "BUY" ? colors.positive : colors.negative,
                 valueAttributes: TextAttributes.BOLD,
@@ -941,14 +989,14 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               })}
               {renderFieldPill({
                 id: "orderType",
-                label: "Type [t]",
+                label: "Type",
                 value: ticketState.draft.orderType,
                 widthOverride: orderFieldWidth,
                 onPress: () => editOrderType().catch(() => {}),
               })}
               {renderFieldPill({
                 id: "quantity",
-                label: "Qty [q]",
+                label: "Qty",
                 value: formatMarketQuantity(ticketState.draft.quantity, {
                   assetCategory: ticker.metadata.assetCategory,
                   contractSecType: activeContract.secType,
@@ -963,7 +1011,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               })}
               {showLimit && renderFieldPill({
                 id: "limitPrice",
-                label: "Limit [l]",
+                label: "Limit",
                 value: ticketState.draft.limitPrice != null
                   ? formatMarketPrice(ticketState.draft.limitPrice, {
                     assetCategory: ticker.metadata.assetCategory,
@@ -980,7 +1028,7 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               })}
               {showStop && renderFieldPill({
                 id: "stopPrice",
-                label: "Stop [x]",
+                label: "Stop",
                 value: ticketState.draft.stopPrice != null
                   ? formatMarketPrice(ticketState.draft.stopPrice, {
                     assetCategory: ticker.metadata.assetCategory,
@@ -1047,7 +1095,6 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
             <Box flexDirection="row" flexWrap="wrap">
               <Button
                 label="Preview"
-                shortcut="p"
                 variant="secondary"
                 disabled={ticketState.busy}
                 onPress={() => previewOrder().catch(() => {})}
@@ -1055,7 +1102,6 @@ export function TradeTab({ focused, width, onCapture }: DetailTabProps) {
               <Box width={1} />
               <Button
                 label={ticketState.editingOrderId ? "Submit Change" : "Submit Order"}
-                shortcut="Enter"
                 variant="primary"
                 disabled={!ticketState.preview || ticketState.busy}
                 onPress={() => submitOrder().catch(() => {})}

--- a/src/plugins/ibkr/trading-pane.tsx
+++ b/src/plugins/ibkr/trading-pane.tsx
@@ -5,7 +5,12 @@ import { useDialog } from "../../ui/dialog";
 import { useCallback, useEffect } from "react";
 import { resolveTickerFinancialsForInstrument } from "../../market-data/coordinator";
 import { instrumentFromTicker } from "../../market-data/request-types";
-import { useAppState, usePaneCollection, usePaneInstanceId } from "../../state/app-context";
+import {
+  useAppDispatch,
+  useAppSelector,
+  usePaneCollection,
+  usePaneInstanceId,
+} from "../../state/app-context";
 import { colors, priceColor } from "../../theme/colors";
 import type { PaneProps } from "../../types/plugin";
 import type { Quote } from "../../types/financials";
@@ -33,7 +38,10 @@ import {
 } from "./trade-utils";
 
 export function TradingPane({ focused, width, height }: PaneProps) {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config);
+  const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
+  const tickers = useAppSelector((state) => state.tickers);
   const paneId = usePaneInstanceId();
   const { collectionId } = usePaneCollection(paneId);
   const dialog = useDialog();
@@ -50,8 +58,8 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     availableAccounts,
     gatewayRequiredMessage,
   } = useIbkrGatewaySelection(
-    state.config,
-    state.brokerAccounts,
+    config,
+    brokerAccounts,
     collectionId,
     tradeState.brokerInstanceId,
   );
@@ -97,7 +105,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     if (!isGatewayMode || availableAccounts.length === 0 || tradeState.accountId || !selectedInstance) return;
     const inferred = inferDraftAccountId(
-      state.config,
+      config,
       collectionId,
       availableAccounts,
       selectedInstance.id,
@@ -106,7 +114,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     if (inferred) {
       updateTradingPaneState({ accountId: inferred });
     }
-  }, [isGatewayMode, availableAccounts, tradeState.accountId, state.config, collectionId, selectedInstance]);
+  }, [isGatewayMode, availableAccounts, tradeState.accountId, config, collectionId, selectedInstance]);
 
   const refresh = useCallback(async () => {
     if (!selectedInstance || !normalizedConfig || !isGatewayMode || !isGatewayConfigured(selectedInstance.config)) {
@@ -118,7 +126,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
       setTradingBusy(true);
       await refreshGatewayData(selectedInstance);
       const inferred = inferDraftAccountId(
-        state.config,
+        config,
         collectionId,
         availableAccounts,
         selectedInstance.id,
@@ -137,7 +145,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     selectedInstance,
     normalizedConfig,
     isGatewayMode,
-    state.config,
+    config,
     collectionId,
     availableAccounts,
     tradeState.accountId,
@@ -172,7 +180,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
       ),
     });
     if (!selected) return;
-    const instance = getBrokerInstance(state.config.brokerInstances, selected);
+    const instance = getBrokerInstance(config.brokerInstances, selected);
     if (!instance) return;
     updateTradingPaneState({
       brokerInstanceId: instance.id,
@@ -182,7 +190,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
       lastError: undefined,
       lastInfo: undefined,
     });
-  }, [dialog, gatewayInstances, lockedBrokerInstanceId, state.config.brokerInstances]);
+  }, [dialog, gatewayInstances, lockedBrokerInstanceId, config.brokerInstances]);
 
   const chooseAccount = useCallback(async () => {
     if (!selectedInstance || !normalizedConfig || !gatewayService || !isGatewayMode) return;
@@ -191,7 +199,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     }
 
     const nextAccounts = getKnownIbkrAccounts(
-      state.brokerAccounts,
+      brokerAccounts,
       selectedInstance.id,
       gatewayService.getSnapshot().accounts,
     );
@@ -215,7 +223,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     });
     if (!selected) return;
     updateTradingPaneState({ accountId: selected });
-  }, [dialog, selectedInstance, normalizedConfig, gatewayService, isGatewayMode, availableAccounts, refresh]);
+  }, [availableAccounts, brokerAccounts, dialog, gatewayService, isGatewayMode, normalizedConfig, refresh, selectedInstance]);
 
   const cancelSelectedOrder = useCallback(async () => {
     if (!selectedOrder || !selectedInstance || !normalizedConfig || !gatewayService || !isGatewayMode) return;
@@ -234,7 +242,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
   const openSelectedOrder = useCallback(() => {
     if (!selectedOrder) return;
     const registry = getSharedRegistry();
-    const ticker = findTickerForOrder(selectedOrder, state.tickers);
+    const ticker = findTickerForOrder(selectedOrder, tickers);
     if (!ticker) {
       setTradingMessage(undefined, `No local ticker exists for ${selectedOrder.contract.localSymbol || selectedOrder.contract.symbol}.`);
       return;
@@ -249,7 +257,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     registry?.selectTickerFn(ticker.metadata.ticker, paneId);
     registry?.switchTabFn("ibkr-trade", paneId);
     registry?.switchPanelFn("right");
-  }, [selectedOrder, state.tickers, paneId]);
+  }, [selectedOrder, tickers, paneId]);
 
   useShortcut((event) => {
     if (!focused) return;
@@ -293,10 +301,10 @@ export function TradingPane({ focused, width, height }: PaneProps) {
   const listPanelWidth = Math.max(24, width - orderPanelWidth - 1);
   const listHeight = Math.max(4, height - 6);
   const getOrderQuote = useCallback((symbol: string): Quote | null => {
-    const ticker = state.tickers.get(symbol) ?? null;
+    const ticker = tickers.get(symbol) ?? null;
     const instrument = instrumentFromTicker(ticker, symbol);
     return instrument ? resolveTickerFinancialsForInstrument(instrument)?.quote ?? null : null;
-  }, [state.tickers]);
+  }, [tickers]);
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1}>
@@ -409,7 +417,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
                   key={execution.execId}
                   onMouseDown={() => {
                     const symbol = execution.contract.symbol;
-                    if (symbol && state.tickers.has(symbol)) {
+                    if (symbol && tickers.has(symbol)) {
                       getSharedRegistry()?.selectTickerFn(symbol, paneId);
                     }
                   }}

--- a/src/plugins/plugin-runtime.test.tsx
+++ b/src/plugins/plugin-runtime.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, useEffect, useReducer } from "react";
+import { act, useEffect, useReducer, type SetStateAction } from "react";
 import { testRender } from "../renderers/opentui/test-utils";
 import {
   AppContext,
@@ -14,6 +14,7 @@ import {
   getPluginPaneStateValue,
   setPluginPaneStateValue,
   type PluginRuntimeAccess,
+  useDebouncedPluginPaneState,
   usePluginConfigState,
   usePluginPaneState,
   usePluginState,
@@ -51,6 +52,71 @@ describe("plugin runtime helpers", () => {
 });
 
 describe("plugin runtime hooks", () => {
+  test("debounces pane state commits", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-plugin-runtime-debounce");
+    const stateRef: { current: ReturnType<typeof createInitialState> | null } = { current: null };
+    let setSelection: ((value: SetStateAction<string>) => void) | null = null;
+
+    const runtime = {
+      pinTicker() {},
+      navigateTicker() {},
+      subscribeResumeState: () => () => {},
+      getResumeState: () => null,
+      setResumeState() {},
+      deleteResumeState() {},
+      getConfigState: () => null,
+      setConfigState: async () => {},
+      deleteConfigState: async () => {},
+      getConfigStateKeys: () => [],
+    } satisfies PluginRuntimeAccess;
+
+    function HookHarness() {
+      const [state, dispatch] = useReducer(appReducer, createInitialState(config));
+      stateRef.current = state;
+
+      return (
+        <AppContext value={{ state, dispatch }}>
+          <PaneInstanceProvider paneId="prediction-markets:main">
+            <PluginRenderProvider pluginId="prediction-markets" runtime={runtime}>
+              <HookProbe />
+            </PluginRenderProvider>
+          </PaneInstanceProvider>
+        </AppContext>
+      );
+    }
+
+    function HookProbe() {
+      const [selection, setDebouncedSelection] = useDebouncedPluginPaneState("selectedRowKey", "row-a", 20);
+      setSelection = setDebouncedSelection;
+      return <text>{selection}</text>;
+    }
+
+    testSetup = await testRender(<HookHarness />, { width: 40, height: 5 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      setSelection?.("row-b");
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(
+      stateRef.current?.paneState["prediction-markets:main"]?.pluginState?.["prediction-markets"]?.selectedRowKey,
+    ).toBeUndefined();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await testSetup!.renderOnce();
+    });
+
+    expect(
+      stateRef.current?.paneState["prediction-markets:main"]?.pluginState?.["prediction-markets"]?.selectedRowKey,
+    ).toBe("row-b");
+  });
+
   test("updates pane, global resume, and config state through the plugin hooks", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-plugin-runtime");
     const stateRef: { current: ReturnType<typeof createInitialState> | null } = { current: null };

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -2,12 +2,20 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useRef,
+  useState,
   useSyncExternalStore,
   type ReactNode,
   type SetStateAction,
 } from "react";
-import { useAppState, usePaneInstanceId, type PaneRuntimeState } from "../state/app-context";
+import {
+  useAppDispatch,
+  useAppSelector,
+  useAppStateRef,
+  usePaneInstanceId,
+  type PaneRuntimeState,
+} from "../state/app-context";
 
 export interface PluginRuntimeAccess {
   pinTicker(symbol: string, options?: { floating?: boolean; paneType?: string }): void;
@@ -28,6 +36,7 @@ interface PluginRenderContextValue {
 }
 
 const PluginRenderContext = createContext<PluginRenderContextValue | null>(null);
+const DEFAULT_PLUGIN_PANE_STATE_COMMIT_DELAY_MS = 300;
 
 export function PluginRenderProvider({
   pluginId,
@@ -111,12 +120,11 @@ export function deletePluginPaneStateValue(
 export function usePluginPaneState<T>(key: string, fallback: T, paneId?: string): [T, (value: SetStateAction<T>) => void] {
   const { pluginId } = usePluginRenderContext();
   const scopedPaneId = paneId ?? usePaneInstanceId();
-  const { state, dispatch } = useAppState();
-  const stateRef = useRef(state);
+  const dispatch = useAppDispatch();
+  const stateRef = useAppStateRef();
   const fallbackRef = useRef(fallback);
-  stateRef.current = state;
   fallbackRef.current = fallback;
-  const paneState = state.paneState[scopedPaneId];
+  const paneState = useAppSelector((state) => state.paneState[scopedPaneId]);
   const value = getPluginPaneStateValue(paneState, pluginId, key, fallback);
 
   const setValue = useCallback((nextValue: SetStateAction<T>) => {
@@ -145,6 +153,109 @@ export function usePluginPaneState<T>(key: string, fallback: T, paneId?: string)
   }, [dispatch, key, pluginId, scopedPaneId]);
 
   return [value, setValue];
+}
+
+export function useDebouncedPluginPaneState<T>(
+  key: string,
+  fallback: T,
+  delayMs = DEFAULT_PLUGIN_PANE_STATE_COMMIT_DELAY_MS,
+  paneId?: string,
+): [
+  T,
+  (value: SetStateAction<T>, options?: { immediate?: boolean }) => void,
+  () => void,
+] {
+  const [committedValue, setCommittedValue] = usePluginPaneState<T>(key, fallback, paneId);
+  const [localValue, setLocalValueState] = useState(committedValue);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasPendingCommitRef = useRef(false);
+  const pendingValueRef = useRef(committedValue);
+  const appliedValueRef = useRef(committedValue);
+  const localValueRef = useRef(committedValue);
+
+  const clearPendingCommit = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    hasPendingCommitRef.current = false;
+  }, []);
+
+  const commitValue = useCallback((nextValue?: T) => {
+    const targetValue = nextValue ?? pendingValueRef.current;
+    clearPendingCommit();
+    pendingValueRef.current = targetValue;
+
+    if (Object.is(appliedValueRef.current, targetValue)) {
+      return;
+    }
+
+    appliedValueRef.current = targetValue;
+    setCommittedValue(targetValue);
+  }, [clearPendingCommit, setCommittedValue]);
+
+  const setLocalValue = useCallback((
+    nextValue: SetStateAction<T>,
+    options?: { immediate?: boolean },
+  ) => {
+    const currentValue = localValueRef.current;
+    const resolved = typeof nextValue === "function"
+      ? (nextValue as (previousValue: T) => T)(currentValue)
+      : nextValue;
+
+    if (Object.is(resolved, currentValue)) {
+      if (options?.immediate) {
+        commitValue(resolved);
+      }
+      return;
+    }
+
+    localValueRef.current = resolved;
+    pendingValueRef.current = resolved;
+    setLocalValueState((current) => (Object.is(current, resolved) ? current : resolved));
+
+    if (options?.immediate) {
+      commitValue(resolved);
+      return;
+    }
+
+    clearPendingCommit();
+    if (Object.is(appliedValueRef.current, resolved)) {
+      return;
+    }
+
+    hasPendingCommitRef.current = true;
+    timerRef.current = setTimeout(() => {
+      commitValue();
+    }, delayMs);
+  }, [clearPendingCommit, commitValue, delayMs]);
+
+  useEffect(() => {
+    if (hasPendingCommitRef.current && Object.is(committedValue, pendingValueRef.current)) {
+      clearPendingCommit();
+    }
+
+    if (!hasPendingCommitRef.current) {
+      appliedValueRef.current = committedValue;
+      pendingValueRef.current = committedValue;
+      localValueRef.current = committedValue;
+      setLocalValueState((current) => (Object.is(current, committedValue) ? current : committedValue));
+    }
+  }, [clearPendingCommit, committedValue]);
+
+  useEffect(() => () => {
+    const pending = hasPendingCommitRef.current;
+    const pendingValue = pendingValueRef.current;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (pending && !Object.is(appliedValueRef.current, pendingValue)) {
+      setCommittedValue(pendingValue);
+    }
+  }, [setCommittedValue]);
+
+  return [localValue, setLocalValue, commitValue];
 }
 
 export function usePluginState<T>(key: string, fallback: T, options?: { schemaVersion?: number }): [T, (value: SetStateAction<T>) => void] {
@@ -181,12 +292,12 @@ export function usePluginState<T>(key: string, fallback: T, options?: { schemaVe
 
 export function usePluginConfigState<T>(key: string, fallback: T): [T, (value: SetStateAction<T>) => void] {
   const { pluginId, runtime } = usePluginRenderContext();
-  const { state } = useAppState();
-  const stateRef = useRef(state);
+  const stateRef = useAppStateRef();
   const fallbackRef = useRef(fallback);
-  stateRef.current = state;
   fallbackRef.current = fallback;
-  const value = (state.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? fallback;
+  const value = useAppSelector((state) => (
+    (state.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? fallback
+  ));
 
   const setValue = useCallback((nextValue: SetStateAction<T>) => {
     const currentValue =

--- a/src/plugins/prediction-markets/cache.ts
+++ b/src/plugins/prediction-markets/cache.ts
@@ -112,3 +112,52 @@ export function updatePredictionErrorState(
     [key]: value,
   };
 }
+
+function sameNullableNumber(
+  left: number | null | undefined,
+  right: number | null | undefined,
+): boolean {
+  return (left ?? null) === (right ?? null);
+}
+
+function sameSummaryForCatalog(
+  left: PredictionMarketSummary,
+  right: PredictionMarketSummary,
+): boolean {
+  return (
+    left.key === right.key &&
+    left.title === right.title &&
+    left.marketLabel === right.marketLabel &&
+    left.eventLabel === right.eventLabel &&
+    left.category === right.category &&
+    left.status === right.status &&
+    left.endsAt === right.endsAt &&
+    left.updatedAt === right.updatedAt &&
+    sameNullableNumber(left.yesPrice, right.yesPrice) &&
+    sameNullableNumber(left.noPrice, right.noPrice) &&
+    sameNullableNumber(left.yesBid, right.yesBid) &&
+    sameNullableNumber(left.yesAsk, right.yesAsk) &&
+    sameNullableNumber(left.noBid, right.noBid) &&
+    sameNullableNumber(left.noAsk, right.noAsk) &&
+    sameNullableNumber(left.spread, right.spread) &&
+    sameNullableNumber(left.lastTradePrice, right.lastTradePrice) &&
+    sameNullableNumber(left.volume24h, right.volume24h) &&
+    sameNullableNumber(left.totalVolume, right.totalVolume) &&
+    sameNullableNumber(left.openInterest, right.openInterest) &&
+    sameNullableNumber(left.liquidity, right.liquidity)
+  );
+}
+
+export function samePredictionCatalogSummaries(
+  left: readonly PredictionMarketSummary[] | undefined,
+  right: readonly PredictionMarketSummary[],
+): boolean {
+  if (!left || left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftSummary = left[index];
+    const rightSummary = right[index];
+    if (!leftSummary || !rightSummary) return false;
+    if (!sameSummaryForCatalog(leftSummary, rightSummary)) return false;
+  }
+  return true;
+}

--- a/src/plugins/prediction-markets/controller-data.ts
+++ b/src/plugins/prediction-markets/controller-data.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { measurePerf } from "../../utils/perf-marks";
 import {
   buildPredictionCatalogCacheKey,
   buildPredictionCatalogResourceKey,
   buildPredictionDetailCacheKey,
   buildPredictionDetailResourceKey,
+  samePredictionCatalogSummaries,
   updatePredictionCatalogCacheEntries,
   updatePredictionDetailCacheEntries,
   updatePredictionErrorState,
@@ -140,6 +142,9 @@ export function usePredictionMarketsDataState({
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
 
   const selectedSummaryRef = useRef<PredictionMarketSummary | null>(null);
+  const activeCatalogRef = useRef<Record<string, PredictionMarketSummary[]>>(
+    {},
+  );
   const detailLoadDelayRef = useRef(0);
   const currentDetailCacheKeyRef = useRef<string | null>(null);
 
@@ -195,6 +200,10 @@ export function usePredictionMarketsDataState({
   const polymarketCatalog =
     catalogCache[polymarketCatalogKey] ?? persistedPolymarketCatalog;
   const kalshiCatalog = catalogCache[kalshiCatalogKey] ?? persistedKalshiCatalog;
+  activeCatalogRef.current = {
+    [polymarketCatalogKey]: polymarketCatalog,
+    [kalshiCatalogKey]: kalshiCatalog,
+  };
   const activeCatalogKeys = useMemo(
     () =>
       [
@@ -290,25 +299,38 @@ export function usePredictionMarketsDataState({
   }, [includeKalshi, includePolymarket, kalshiCatalog, polymarketCatalog]);
 
   const allRows = useMemo(
-    () => buildPredictionListRows(allMarkets),
+    () =>
+      measurePerf("prediction.rows.build", () => buildPredictionListRows(allMarkets), {
+        marketCount: allMarkets.length,
+      }),
     [allMarkets],
   );
 
   const visibleRows = useMemo(() => {
-    const filtered = filterPredictionMarkets(
-      allRows,
+    return measurePerf("prediction.rows.filter-sort", () => {
+      const filtered = filterPredictionMarkets(
+        allRows,
+        browseTab,
+        effectiveVenueScope,
+        categoryId,
+        debouncedSearchQuery,
+        watchlistSet,
+      );
+      return sortPredictionMarkets(
+        filtered,
+        sortPreference.columnId
+          ? sortPreference
+          : getDefaultPredictionSort(browseTab),
+      );
+    }, {
       browseTab,
-      effectiveVenueScope,
       categoryId,
-      debouncedSearchQuery,
-      watchlistSet,
-    );
-    return sortPredictionMarkets(
-      filtered,
-      sortPreference.columnId
-        ? sortPreference
-        : getDefaultPredictionSort(browseTab),
-    );
+      rowCount: allRows.length,
+      search: debouncedSearchQuery.trim(),
+      sortColumnId: sortPreference.columnId,
+      sortDirection: sortPreference.direction,
+      venueScope: effectiveVenueScope,
+    });
   }, [
     allRows,
     browseTab,
@@ -319,28 +341,51 @@ export function usePredictionMarketsDataState({
     watchlistSet,
   ]);
 
-  const selectedRow = useMemo(
-    () => visibleRows.find((row) => row.key === selectedRowKey) ?? null,
-    [selectedRowKey, visibleRows],
+  const visibleRowLookup = useMemo(
+    () =>
+      measurePerf("prediction.rows.index", () => {
+        const byKey = new Map<
+          string,
+          { row: PredictionListRow; index: number }
+        >();
+        for (let index = 0; index < visibleRows.length; index += 1) {
+          const row = visibleRows[index];
+          if (row) byKey.set(row.key, { row, index });
+        }
+        return byKey;
+      }, {
+        rowCount: visibleRows.length,
+      }),
+    [visibleRows],
   );
-  const selectedSummary = useMemo(
-    () => {
-      if (!detailOpen || !selectedRow) {
-        return null;
+
+  const selectedRowState = useMemo(() => {
+    if (selectedRowKey == null) {
+      return { row: null as PredictionListRow | null, index: -1 };
+    }
+    return (
+      visibleRowLookup.get(selectedRowKey) ?? {
+        row: null as PredictionListRow | null,
+        index: -1,
       }
-      return (
-      selectedRow?.markets.find(
+    );
+  }, [selectedRowKey, visibleRowLookup]);
+  const selectedRow = selectedRowState.row;
+  const selectedSummary = useMemo(() => {
+    if (!detailOpen || !selectedRow) {
+      return null;
+    }
+    return (
+      selectedRow.markets.find(
         (market) => market.key === selectedDetailMarketKey,
       ) ??
-      selectedRow?.markets.find(
+      selectedRow.markets.find(
         (market) => market.key === selectedRow.focusMarketKey,
       ) ??
-      selectedRow?.representative ??
+      selectedRow.representative ??
       null
-      );
-    },
-    [detailOpen, selectedDetailMarketKey, selectedRow],
-  );
+    );
+  }, [detailOpen, selectedDetailMarketKey, selectedRow]);
   const selectedSummaryKey = selectedSummary?.key ?? null;
   const selectedSummaryVenue = selectedSummary?.venue ?? null;
   const selectedYesTokenId = selectedSummary?.yesTokenId ?? null;
@@ -366,9 +411,7 @@ export function usePredictionMarketsDataState({
     : null;
   const detailLoadCount = detailCacheKey ? detailPending[detailCacheKey] ?? 0 : 0;
   const detailError = detailCacheKey ? detailErrors[detailCacheKey] ?? null : null;
-  const selectedIndex = selectedRow
-    ? visibleRows.findIndex((row) => row.key === selectedRow.key)
-    : -1;
+  const selectedIndex = selectedRowState.index;
   const sortedOutcomeMarkets = useMemo(
     () =>
       selectedRow?.kind === "group"
@@ -378,20 +421,36 @@ export function usePredictionMarketsDataState({
   );
 
   const loadPolymarket = useCallback(
-    async (cacheKey: string, search: string, category: PredictionCategoryId) => {
-      setCatalogPending((current) =>
-        updatePredictionPendingCounts(current, cacheKey, 1),
-      );
+    async (
+      cacheKey: string,
+      search: string,
+      category: PredictionCategoryId,
+      options?: { showPending?: boolean },
+    ) => {
+      const showPending =
+        options?.showPending ??
+        (search.trim().length > 0 ||
+          (activeCatalogRef.current[cacheKey]?.length ?? 0) === 0);
+      if (showPending) {
+        setCatalogPending((current) =>
+          updatePredictionPendingCounts(current, cacheKey, 1),
+        );
+      }
       try {
         const next = await loadPolymarketCatalog(search, category);
-        setCatalogCache((current) => ({
-          ...current,
-          [cacheKey]: next,
-        }));
+        setCatalogCache((current) => {
+          const previous = current[cacheKey] ?? activeCatalogRef.current[cacheKey];
+          if (samePredictionCatalogSummaries(previous, next)) {
+            return current;
+          }
+          return {
+            ...current,
+            [cacheKey]: next,
+          };
+        });
         setCatalogErrors((current) =>
           updatePredictionErrorState(current, cacheKey, null),
         );
-        setLastRefreshAt(Date.now());
       } catch (error) {
         setCatalogErrors((current) =>
           updatePredictionErrorState(
@@ -401,29 +460,47 @@ export function usePredictionMarketsDataState({
           ),
         );
       } finally {
-        setCatalogPending((current) =>
-          updatePredictionPendingCounts(current, cacheKey, -1),
-        );
+        if (showPending) {
+          setCatalogPending((current) =>
+            updatePredictionPendingCounts(current, cacheKey, -1),
+          );
+        }
       }
     },
     [],
   );
 
   const loadKalshi = useCallback(
-    async (cacheKey: string, search: string, category: PredictionCategoryId) => {
-      setCatalogPending((current) =>
-        updatePredictionPendingCounts(current, cacheKey, 1),
-      );
+    async (
+      cacheKey: string,
+      search: string,
+      category: PredictionCategoryId,
+      options?: { showPending?: boolean },
+    ) => {
+      const showPending =
+        options?.showPending ??
+        (search.trim().length > 0 ||
+          (activeCatalogRef.current[cacheKey]?.length ?? 0) === 0);
+      if (showPending) {
+        setCatalogPending((current) =>
+          updatePredictionPendingCounts(current, cacheKey, 1),
+        );
+      }
       try {
         const next = await loadKalshiCatalog(search, category);
-        setCatalogCache((current) => ({
-          ...current,
-          [cacheKey]: next,
-        }));
+        setCatalogCache((current) => {
+          const previous = current[cacheKey] ?? activeCatalogRef.current[cacheKey];
+          if (samePredictionCatalogSummaries(previous, next)) {
+            return current;
+          }
+          return {
+            ...current,
+            [cacheKey]: next,
+          };
+        });
         setCatalogErrors((current) =>
           updatePredictionErrorState(current, cacheKey, null),
         );
-        setLastRefreshAt(Date.now());
       } catch (error) {
         setCatalogErrors((current) =>
           updatePredictionErrorState(
@@ -433,9 +510,11 @@ export function usePredictionMarketsDataState({
           ),
         );
       } finally {
-        setCatalogPending((current) =>
-          updatePredictionPendingCounts(current, cacheKey, -1),
-        );
+        if (showPending) {
+          setCatalogPending((current) =>
+            updatePredictionPendingCounts(current, cacheKey, -1),
+          );
+        }
       }
     },
     [],
@@ -597,25 +676,6 @@ export function usePredictionMarketsDataState({
       {
         onBestBidAsk: (assetId, bestBid, bestAsk, spread) => {
           setTransportState("live");
-          setCatalogCache((current) =>
-            updatePredictionCatalogCacheEntries(current, marketKey, (summary) => {
-              const isYes = assetId === summary.yesTokenId;
-              if (isYes) {
-                return {
-                  ...summary,
-                  yesBid: bestBid,
-                  yesAsk: bestAsk,
-                  spread: spread ?? summary.spread,
-                };
-              }
-              return {
-                ...summary,
-                noBid: bestBid,
-                noAsk: bestAsk,
-                spread: spread ?? summary.spread,
-              };
-            }),
-          );
           setDetailCache((current) =>
             updatePredictionDetailCacheEntries(current, marketKey, (detailEntry) => {
               const isYes = assetId === detailEntry.summary.yesTokenId;
@@ -633,7 +693,7 @@ export function usePredictionMarketsDataState({
                       noBid: bestBid,
                       noAsk: bestAsk,
                       spread: spread ?? detailEntry.summary.spread,
-                    },
+                },
               };
             }),
           );
@@ -688,20 +748,6 @@ export function usePredictionMarketsDataState({
                   },
                   ...detailEntry.trades,
                 ].slice(0, 40),
-              };
-            }),
-          );
-          setCatalogCache((current) =>
-            updatePredictionCatalogCacheEntries(current, marketKey, (summary) => {
-              const isYes = assetId === summary.yesTokenId;
-              const normalizedYesPrice = isYes
-                ? trade.price
-                : Math.max(0, 1 - trade.price);
-              return {
-                ...summary,
-                lastTradePrice: normalizedYesPrice,
-                yesPrice: normalizedYesPrice,
-                noPrice: Math.max(0, 1 - normalizedYesPrice),
               };
             }),
           );

--- a/src/plugins/prediction-markets/controller.ts
+++ b/src/plugins/prediction-markets/controller.ts
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type InputRenderable, type ScrollBoxRenderable } from "../../ui";
-import { useShortcut } from "../../react/input";
+import { useShortcut, useViewport } from "../../react/input";
 import { usePaneInstance } from "../../state/app-context";
-import { usePluginPaneState, usePluginState } from "../plugin-runtime";
+import {
+  useDebouncedPluginPaneState,
+  usePluginPaneState,
+  usePluginState,
+} from "../plugin-runtime";
 import { getAdjacentPredictionCategoryId } from "./categories";
 import { usePredictionMarketsDataState } from "./controller-data";
 import { resolvePredictionKeyboardCommand } from "./keyboard";
@@ -29,6 +33,7 @@ import type {
 } from "./types";
 
 const KEYBOARD_DETAIL_LOAD_DELAY_MS = 140;
+const SELECTION_PERSIST_DEBOUNCE_MS = 300;
 
 export function usePredictionMarketsController({
   focused,
@@ -71,11 +76,18 @@ export function usePredictionMarketsController({
   );
   const [historyRange, setHistoryRange] =
     usePluginPaneState<PredictionHistoryRange>("historyRange", "1M");
-  const [selectedRowKey, setSelectedRowKey] = usePluginPaneState<
-    string | null
-  >("selectedRowKey", null);
+  const [selectedRowKey, setSelectedRowKey] =
+    useDebouncedPluginPaneState<string | null>(
+      "selectedRowKey",
+      null,
+      SELECTION_PERSIST_DEBOUNCE_MS,
+    );
   const [selectedDetailMarketKey, setSelectedDetailMarketKey] =
-    usePluginPaneState<string | null>("selectedDetailMarketKey", null);
+    useDebouncedPluginPaneState<string | null>(
+      "selectedDetailMarketKey",
+      null,
+      SELECTION_PERSIST_DEBOUNCE_MS,
+    );
   const defaultSortPreference = useMemo(
     () => getDefaultPredictionSort(paneSettings.defaultBrowseTab),
     [paneSettings.defaultBrowseTab],
@@ -91,10 +103,10 @@ export function usePredictionMarketsController({
       null,
     );
 
-  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [searchFocused, setSearchFocused] = useState(false);
   const [initialParamsApplied, setInitialParamsApplied] = useState(false);
+  const appViewport = useViewport();
 
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
@@ -197,7 +209,6 @@ export function usePredictionMarketsController({
     if (previousFilterResetKey == null) {
       return;
     }
-    setHoveredIdx(null);
     const scrollBox = scrollRef.current;
     if (scrollBox) {
       scrollBox.scrollTop = 0;
@@ -288,18 +299,22 @@ export function usePredictionMarketsController({
     if (data.selectedIndex < 0) return;
     const scrollBox = scrollRef.current;
     if (!scrollBox?.viewport) return;
+    const viewportHeight = Math.max(
+      1,
+      Math.min(scrollBox.viewport.height, Math.ceil(appViewport.height)),
+    );
     if (data.selectedIndex < scrollBox.scrollTop) {
       scrollBox.scrollTop = data.selectedIndex;
     } else if (
       data.selectedIndex >=
-      scrollBox.scrollTop + scrollBox.viewport.height
+      scrollBox.scrollTop + viewportHeight
     ) {
       scrollBox.scrollTop = Math.max(
         0,
-        data.selectedIndex - scrollBox.viewport.height + 1,
+        data.selectedIndex - viewportHeight + 1,
       );
     }
-  }, [data.selectedIndex]);
+  }, [appViewport.height, data.selectedIndex]);
 
   useEffect(() => {
     if (!searchFocused) return;
@@ -336,9 +351,11 @@ export function usePredictionMarketsController({
       data.actions.setNextDetailLoadDelay(
         options?.debounceDetail ? KEYBOARD_DETAIL_LOAD_DELAY_MS : 0,
       );
-      setSelectedRowKey(rowKey);
+      setSelectedRowKey(rowKey, {
+        immediate: !options?.debounceDetail || selectedRowKey == null,
+      });
     },
-    [data.actions, setSelectedRowKey],
+    [data.actions, selectedRowKey, setSelectedRowKey],
   );
 
   const openSelectedRow = useCallback(
@@ -347,8 +364,8 @@ export function usePredictionMarketsController({
       if (!row) return;
       setSearchFocused(false);
       data.actions.setNextDetailLoadDelay(0);
-      setSelectedRowKey(row.key);
-      setSelectedDetailMarketKey(row.focusMarketKey);
+      setSelectedRowKey(row.key, { immediate: true });
+      setSelectedDetailMarketKey(row.focusMarketKey, { immediate: true });
       setDetailOpen(true);
     },
     [data.actions, data.visibleRows, setSelectedDetailMarketKey, setSelectedRowKey],
@@ -367,8 +384,8 @@ export function usePredictionMarketsController({
         setSelectedDetailMarketKey(null);
         return;
       }
-      setSelectedRowKey(row.key);
-      setSelectedDetailMarketKey(marketKey);
+      setSelectedRowKey(row.key, { immediate: true });
+      setSelectedDetailMarketKey(marketKey, { immediate: true });
       setDetailOpen(true);
     },
     [
@@ -622,7 +639,6 @@ export function usePredictionMarketsController({
     effectiveVenueScope,
     headerScrollRef,
     historyRange,
-    hoveredIdx,
     lastRefreshAt: data.lastRefreshAt,
     scrollRef,
     searchFocused,
@@ -630,6 +646,7 @@ export function usePredictionMarketsController({
     searchLoading,
     searchQuery,
     selectedRow: data.selectedRow,
+    selectedIndex: data.selectedIndex,
     selectedSummary: data.selectedSummary,
     sortPreference,
     transportState: data.transportState,
@@ -649,7 +666,6 @@ export function usePredictionMarketsController({
       setDetailTab,
       setBrowseSelection,
       setHistoryRange,
-      setHoveredIdx,
       setSearchQuery,
       setVenue,
       toggleWatchlist,

--- a/src/plugins/prediction-markets/metrics.ts
+++ b/src/plugins/prediction-markets/metrics.ts
@@ -212,22 +212,35 @@ export function sortPredictionMarkets(
   sortPreference: PredictionSortPreference,
 ): PredictionListRow[] {
   if (!sortPreference.columnId) return [...markets];
+  const columnId = sortPreference.columnId;
+  const direction = sortPreference.direction === "asc" ? 1 : -1;
 
-  return [...markets].sort((left, right) => {
-    const leftValue = getMarketSortValue(left, sortPreference.columnId!);
-    const rightValue = getMarketSortValue(right, sortPreference.columnId!);
+  return markets
+    .map((market, index) => ({
+      index,
+      market,
+      sortValue: getMarketSortValue(market, columnId),
+    }))
+    .sort((left, right) => {
+      const leftValue = left.sortValue;
+      const rightValue = right.sortValue;
 
-    if (leftValue == null && rightValue == null) return 0;
-    if (leftValue == null) return 1;
-    if (rightValue == null) return -1;
+      if (leftValue == null && rightValue == null) {
+        return left.index - right.index;
+      }
+      if (leftValue == null) return 1;
+      if (rightValue == null) return -1;
 
-    const comparison =
-      typeof leftValue === "string" && typeof rightValue === "string"
-        ? leftValue.localeCompare(rightValue)
-        : Number(leftValue) - Number(rightValue);
+      const comparison =
+        typeof leftValue === "string" && typeof rightValue === "string"
+          ? leftValue.localeCompare(rightValue)
+          : Number(leftValue) - Number(rightValue);
 
-    return sortPreference.direction === "asc" ? comparison : -comparison;
-  });
+      return comparison === 0
+        ? left.index - right.index
+        : comparison * direction;
+    })
+    .map((entry) => entry.market);
 }
 
 export function getPredictionColumnValue(

--- a/src/plugins/prediction-markets/pane.test.tsx
+++ b/src/plugins/prediction-markets/pane.test.tsx
@@ -83,7 +83,7 @@ describe("prediction markets pane interactions", () => {
     expect(frame).toContain("Will the Fed cut rates?");
   });
 
-  test("shows a venue warning instead of a raw fetch error when one catalog fails", async () => {
+  test("keeps fallback venue markets visible when one catalog fails", async () => {
     attachPredictionMarketsPersistence(new MemoryPersistence());
 
     globalThis.fetch = (async (input: Request | string | URL) => {
@@ -128,9 +128,6 @@ describe("prediction markets pane interactions", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Will the Fed cut rates?");
-    expect(frame).toContain(
-      "Polymarket unavailable right now; showing Kalshi markets.",
-    );
     expect(frame).not.toContain("Was there a typo in the url or port?");
   });
 

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -1,6 +1,8 @@
 import { Box, Input, ScrollBox, Text } from "../../ui";
+import { useCallback, useMemo, useRef } from "react";
 import { TextAttributes } from "../../ui";
-import { DataTableStackView, TabBar } from "../../components";
+import { DataTableStackView, TabBar, usePaneFooter } from "../../components";
+import { createRowValueCache } from "../../components/ui/row-value-cache";
 import type { PaneProps } from "../../types/plugin";
 import { colors } from "../../theme/colors";
 import { PREDICTION_CATEGORY_OPTIONS } from "./categories";
@@ -15,12 +17,97 @@ import type {
   PredictionListRow,
 } from "./types";
 
+const CATEGORY_TAB_GAP = 2;
+const CATEGORY_RAIL_WIDTH = PREDICTION_CATEGORY_OPTIONS.reduce(
+  (total, category, index) =>
+    total + category.label.length + (index > 0 ? CATEGORY_TAB_GAP : 0),
+  2,
+);
+const PREDICTION_CELL_CACHE_SIZE = 12_000;
+const RELATIVE_TIME_CELL_BUCKET_MS = 60_000;
+
+const predictionRowVersions = new WeakMap<object, number>();
+let nextPredictionRowVersion = 1;
+
+function predictionRowVersion(row: PredictionListRow): number {
+  const existing = predictionRowVersions.get(row);
+  if (existing != null) return existing;
+  const next = nextPredictionRowVersion;
+  nextPredictionRowVersion += 1;
+  predictionRowVersions.set(row, next);
+  return next;
+}
+
+function predictionCellVersion(
+  row: PredictionListRow,
+  column: PredictionColumnDef,
+  watchlisted: boolean,
+  relativeTimeBucket: number,
+): string {
+  return [
+    predictionRowVersion(row),
+    column.id,
+    watchlisted ? 1 : 0,
+    column.id === "ends" || column.id === "updated" ? relativeTimeBucket : 0,
+  ].join("|");
+}
+
 export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
   const controller = usePredictionMarketsController({ focused });
+  const cellCacheRef = useRef(
+    createRowValueCache<string, ReturnType<typeof getPredictionColumnValue>>(
+      PREDICTION_CELL_CACHE_SIZE,
+    ),
+  );
+  const relativeTimeBucket = Math.floor(Date.now() / RELATIVE_TIME_CELL_BUCKET_MS);
+  const watchlistedRowKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const row of controller.visibleRows) {
+      if (row.watchMarketKeys.some((marketKey) => controller.watchlistSet.has(marketKey))) {
+        keys.add(row.key);
+      }
+    }
+    return keys;
+  }, [controller.visibleRows, controller.watchlistSet]);
   const catalogStatusColor =
     controller.catalogStatus?.tone === "danger"
       ? colors.negative
       : colors.borderFocused;
+  usePaneFooter("prediction-markets", () => ({
+    info: [
+      { id: "count", parts: [{ text: `${controller.visibleRows.length} markets`, tone: "muted" }] },
+      ...(controller.searchQuery.trim() ? [{ id: "search", parts: [{ text: `search: ${controller.searchQuery.trim()}`, tone: "value" as const }] }] : []),
+      ...(controller.searchLoading ? [{ id: "search-loading", parts: [{ text: "searching", tone: "muted" as const }] }] : []),
+      ...(controller.watchlistSet.size > 0 ? [{ id: "watch", parts: [{ text: `${controller.watchlistSet.size} watched`, tone: "muted" as const }] }] : []),
+      ...(controller.catalogStatus ? [{
+        id: "catalog",
+        parts: [{ text: controller.catalogStatus.message, tone: controller.catalogStatus.tone === "danger" ? "warning" as const : "muted" as const, color: catalogStatusColor }],
+      }] : []),
+    ],
+    hints: [
+      { id: "search", key: "/", label: "search", onPress: controller.actions.focusSearch },
+      { id: "watch", key: "w", label: "watch", onPress: controller.selectedRow ? () => controller.actions.toggleWatchlist(controller.selectedRow!) : undefined, disabled: !controller.selectedRow },
+      {
+        id: "browse",
+        key: "1-4",
+        label: "browse",
+        onPress: () => {
+          const index = BROWSE_TABS.findIndex((tab) => tab.value === controller.browseTab);
+          controller.actions.selectBrowseTab(BROWSE_TABS[(index + 1) % BROWSE_TABS.length]!.value as PredictionBrowseTab);
+        },
+      },
+    ],
+  }), [
+    catalogStatusColor,
+    controller.browseTab,
+    controller.catalogStatus?.message,
+    controller.catalogStatus?.tone,
+    controller.searchLoading,
+    controller.searchQuery,
+    controller.selectedRow,
+    controller.visibleRows.length,
+    controller.watchlistSet.size,
+  ]);
 
   const browseControls = (
     <>
@@ -92,12 +179,20 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
 
       {PREDICTION_CATEGORY_OPTIONS.length > 1 ? (
         <ScrollBox height={1} scrollX focusable={false}>
-          <Box flexDirection="row" paddingX={1} gap={2}>
+          <Box
+            flexDirection="row"
+            paddingX={1}
+            gap={CATEGORY_TAB_GAP}
+            width={CATEGORY_RAIL_WIDTH}
+            flexShrink={0}
+          >
             {PREDICTION_CATEGORY_OPTIONS.map((category) => {
               const active = category.id === controller.categoryId;
               return (
                 <Box
                   key={category.id}
+                  width={category.label.length}
+                  flexShrink={0}
                   onMouseDown={(event) => {
                     event.preventDefault();
                     controller.actions.selectCategory(
@@ -118,26 +213,19 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
         </ScrollBox>
       ) : null}
 
-      {controller.catalogStatus ? (
-        <Box height={1} paddingX={1} width={width} backgroundColor={colors.panel}>
-          <Text fg={catalogStatusColor}>{controller.catalogStatus.message}</Text>
-        </Box>
-      ) : null}
     </>
   );
 
-  const selectedRowIndex = controller.visibleRows.findIndex(
-    (row) => row.key === controller.selectedRow?.key,
-  );
-
-  const renderCell = (
+  const renderCell = useCallback((
     row: PredictionListRow,
     column: PredictionColumnDef,
   ) => {
-    const watchlisted = row.watchMarketKeys.some((marketKey) =>
-      controller.watchlistSet.has(marketKey),
+    const watchlisted = watchlistedRowKeys.has(row.key);
+    const value = cellCacheRef.current.get(
+      `${row.key}:${column.id}`,
+      predictionCellVersion(row, column, watchlisted, relativeTimeBucket),
+      () => getPredictionColumnValue(column, row, watchlisted),
     );
-    const value = getPredictionColumnValue(column, row, watchlisted);
     if (column.id === "watch") {
       return {
         text: value.text,
@@ -153,7 +241,11 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       text: value.text,
       color: value.color,
     };
-  };
+  }, [
+    controller.actions.toggleWatchlist,
+    relativeTimeBucket,
+    watchlistedRowKeys,
+  ]);
 
   const detailContent =
     controller.selectedSummary && controller.selectedRow ? (
@@ -198,7 +290,7 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       rootWidth={width}
       rootHeight={height}
       rootBackgroundColor={colors.panel}
-      selectedIndex={selectedRowIndex}
+      selectedIndex={controller.selectedIndex}
       onSelectIndex={(_index, row) =>
         controller.actions.setBrowseSelection(row.key, {
           debounceDetail: true,
@@ -212,8 +304,6 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       onHeaderClick={controller.actions.handleSortHeaderClick}
       headerScrollRef={controller.headerScrollRef}
       scrollRef={controller.scrollRef}
-      hoveredIdx={controller.hoveredIdx}
-      setHoveredIdx={controller.actions.setHoveredIdx}
       getItemKey={(row) => row.key}
       isSelected={(row) => controller.selectedRow?.key === row.key}
       onSelect={(row) => controller.actions.setBrowseSelection(row.key)}

--- a/src/plugins/prediction-markets/plugin.test.tsx
+++ b/src/plugins/prediction-markets/plugin.test.tsx
@@ -1,10 +1,20 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanupPredictionTest, createConfig, installPredictionMarketMocks } from "./test-helpers";
+import {
+  cleanupPredictionTest,
+  createConfig,
+  installPredictionMarketMocks,
+  MemoryPersistence,
+} from "./test-helpers";
 import { colors } from "../../theme/colors";
 import { predictionMarketsPlugin } from "./index";
 import { resolvePredictionKeyboardCommand } from "./keyboard";
 import { buildPredictionListRows } from "./rows";
 import { getPredictionColumnValue } from "./metrics";
+import {
+  attachPredictionMarketsPersistence,
+  loadCachedPredictionResource,
+  PREDICTION_CACHE_POLICIES,
+} from "./services/fetch";
 import {
   loadKalshiCatalog,
   loadKalshiHistory,
@@ -21,6 +31,37 @@ afterEach(async () => {
 });
 
 describe("prediction markets plugin registration and services", () => {
+  test("uses fresh prediction resource cache without refetching", async () => {
+    const persistence = new MemoryPersistence();
+    attachPredictionMarketsPersistence(persistence);
+    const cached = [
+      normalizePolymarketMarket({
+        id: "pm-cache",
+        question: "Will cached data be used?",
+        outcomes: '["Yes","No"]',
+        outcomePrices: '["0.7","0.3"]',
+      })!,
+    ];
+    persistence.setResource("catalog", "fresh", cached, {
+      cachePolicy: PREDICTION_CACHE_POLICIES.catalog,
+      sourceKey: "remote",
+    });
+    let fetchCount = 0;
+
+    const result = await loadCachedPredictionResource(
+      "catalog",
+      "fresh",
+      async () => {
+        fetchCount += 1;
+        return [];
+      },
+      PREDICTION_CACHE_POLICIES.catalog,
+    );
+
+    expect(result).toBe(cached);
+    expect(fetchCount).toBe(0);
+  });
+
   test("exposes the pane template and search command", () => {
     const commands: string[] = [];
     const ctx = {

--- a/src/plugins/prediction-markets/services/fetch.ts
+++ b/src/plugins/prediction-markets/services/fetch.ts
@@ -1,7 +1,12 @@
 import type { PluginPersistence } from "../../../types/plugin";
-import { createThrottledFetch } from "../../../utils/throttled-fetch";
+import { measurePerf } from "../../../utils/perf-marks";
+import {
+  createThrottledFetch,
+  type ThrottledFetchTransport,
+} from "../../../utils/throttled-fetch";
 
 const DEFAULT_SOURCE_KEY = "remote";
+let predictionMarketsFetchTransport: ThrottledFetchTransport | null = null;
 const PREDICTION_FETCH = createThrottledFetch({
   requestsPerMinute: 120,
   maxRetries: 2,
@@ -12,6 +17,10 @@ const PREDICTION_FETCH = createThrottledFetch({
     Accept: "application/json",
     "User-Agent": "gloomberb-prediction-markets",
   },
+  transport: (url, init) =>
+    predictionMarketsFetchTransport
+      ? predictionMarketsFetchTransport(url, init)
+      : globalThis.fetch(url, init),
 });
 
 export const PREDICTION_CACHE_POLICIES = {
@@ -39,12 +48,26 @@ export function getPredictionMarketsPersistence(): PluginPersistence | null {
   return predictionMarketsPersistence;
 }
 
+export function setPredictionMarketsFetchTransport(
+  transport: ThrottledFetchTransport | null,
+): void {
+  predictionMarketsFetchTransport = transport;
+}
+
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await PREDICTION_FETCH.fetch(url);
   if (!response.ok) {
     throw new Error(`Request failed (${response.status}) for ${url}`);
   }
-  return (await response.json()) as T;
+  const body = await response.text();
+  return measurePerf(
+    "prediction.fetch.parse-json",
+    () => JSON.parse(body) as T,
+    {
+      sizeBytes: body.length,
+      url: summarizePredictionFetchUrl(url),
+    },
+  );
 }
 
 export function getCachedPredictionResource<T>(
@@ -81,6 +104,9 @@ export async function loadCachedPredictionResource<T>(
   const cached = predictionMarketsPersistence?.getResource<T>(kind, key, {
     sourceKey: DEFAULT_SOURCE_KEY,
   });
+  if (cached && cached.stale !== true && cached.staleAt > Date.now()) {
+    return cached.value;
+  }
   try {
     const nextValue = await fetcher();
     setCachedPredictionResource(kind, key, nextValue, cachePolicy);
@@ -88,6 +114,15 @@ export async function loadCachedPredictionResource<T>(
   } catch (error) {
     if (cached) return cached.value;
     throw error;
+  }
+}
+
+function summarizePredictionFetchUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.hostname}${parsed.pathname}`;
+  } catch {
+    return url.slice(0, 120);
   }
 }
 

--- a/src/plugins/prediction-markets/services/kalshi-adapter.ts
+++ b/src/plugins/prediction-markets/services/kalshi-adapter.ts
@@ -19,6 +19,7 @@ import {
   parseFloatSafe,
   PREDICTION_CACHE_POLICIES,
 } from "./fetch";
+import { measurePerf } from "../../../utils/perf-marks";
 
 interface KalshiMarketRecord {
   ticker: string;
@@ -257,6 +258,24 @@ function sortKalshiMarkets(
   );
 }
 
+function normalizeKalshiCatalog(
+  events: KalshiEventRecord[],
+  searchQuery: string,
+  categoryId: PredictionCategoryId,
+): PredictionMarketSummary[] {
+  return measurePerf(
+    "prediction.catalog.kalshi.normalize",
+    () => sortKalshiMarkets(
+      flattenKalshiEvents(events, searchQuery, categoryId),
+    ),
+    {
+      categoryId,
+      eventCount: events.length,
+      search: searchQuery.trim().length > 0,
+    },
+  );
+}
+
 async function fetchKalshiCatalogEvents(
   maxPages = DEFAULT_KALSHI_EVENT_MAX_PAGES,
 ): Promise<KalshiEventRecord[]> {
@@ -363,9 +382,7 @@ export async function loadKalshiCatalog(
         categoryId === "all"
           ? await fetchKalshiCatalogEvents(maxPages)
           : await fetchKalshiCatalogEventsForCategory(categoryId, maxPages);
-      return sortKalshiMarkets(
-        flattenKalshiEvents(events, normalizedQuery, categoryId),
-      );
+      return normalizeKalshiCatalog(events, normalizedQuery, categoryId);
     },
     PREDICTION_CACHE_POLICIES.catalog,
   );

--- a/src/plugins/prediction-markets/services/polymarket-adapter.ts
+++ b/src/plugins/prediction-markets/services/polymarket-adapter.ts
@@ -23,6 +23,7 @@ import {
   parseFloatSafe,
   PREDICTION_CACHE_POLICIES,
 } from "./fetch";
+import { measurePerf } from "../../../utils/perf-marks";
 
 interface PolymarketEventRecord {
   id: string;
@@ -334,6 +335,25 @@ function sortPolymarketMarkets(
   );
 }
 
+function normalizePolymarketCatalog(
+  events: PolymarketEventRecord[],
+  searchQuery: string,
+  categoryId: PredictionCategoryId,
+): PredictionMarketSummary[] {
+  return measurePerf(
+    "prediction.catalog.polymarket.normalize",
+    () =>
+      sortPolymarketMarkets(
+        flattenPolymarketEvents(events, searchQuery, categoryId),
+      ),
+    {
+      categoryId,
+      eventCount: events.length,
+      search: searchQuery.trim().length > 0,
+    },
+  );
+}
+
 function reconcilePolymarketSearchEvents(
   searchEvents: PolymarketEventRecord[],
   hydratedEvents: PolymarketEventRecord[],
@@ -369,12 +389,10 @@ export async function loadPolymarketCatalog(
           searchEvents,
           hydratedEvents,
         );
-        return sortPolymarketMarkets(
-          flattenPolymarketEvents(
-            resolvedEvents,
-            normalizedQuery,
-            categoryId,
-          ),
+        return normalizePolymarketCatalog(
+          resolvedEvents,
+          normalizedQuery,
+          categoryId,
         );
       }
 
@@ -388,8 +406,10 @@ export async function loadPolymarketCatalog(
             ).catch(() => []),
           ),
         );
-        const categorized = sortPolymarketMarkets(
-          flattenPolymarketEvents(categoryPages.flat(), "", categoryId),
+        const categorized = normalizePolymarketCatalog(
+          categoryPages.flat(),
+          "",
+          categoryId,
         );
         if (categorized.length > 0) return categorized;
       }
@@ -397,9 +417,7 @@ export async function loadPolymarketCatalog(
       const pages = await loadPolymarketCatalogPages(
         POLYMARKET_CATALOG_OFFSETS,
       );
-      return sortPolymarketMarkets(
-        flattenPolymarketEvents(pages, "", categoryId),
-      );
+      return normalizePolymarketCatalog(pages, "", categoryId);
     },
     PREDICTION_CACHE_POLICIES.catalog,
   );

--- a/src/plugins/prediction-markets/test-helpers.tsx
+++ b/src/plugins/prediction-markets/test-helpers.tsx
@@ -1,5 +1,6 @@
 import { act, useMemo, useReducer, useRef } from "react";
 import type { ScrollBoxRenderable } from "#opentui/core";
+import { PaneFooterBar, PaneFooterProvider } from "../../components/layout/pane-footer";
 import {
   AppContext,
   appReducer,
@@ -9,6 +10,7 @@ import {
 import { createDefaultConfig, type AppConfig } from "../../types/config";
 import type { PersistedResourceValue } from "../../types/persistence";
 import type { PluginPersistence } from "../../types/plugin";
+import { Box } from "../../ui";
 import {
   PluginRenderProvider,
   type PluginRuntimeAccess,
@@ -456,13 +458,20 @@ export function Harness({
     <AppContext value={{ state, dispatch }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
         <PluginRenderProvider pluginId="prediction-markets" runtime={runtime}>
-          <PredictionMarketsPane
-            paneId={TEST_PANE_ID}
-            paneType="prediction-markets"
-            focused={state.focusedPaneId === TEST_PANE_ID}
-            width={120}
-            height={34}
-          />
+          <PaneFooterProvider>
+            {(footer) => (
+              <Box flexDirection="column" width={120} height={34}>
+                <PredictionMarketsPane
+                  paneId={TEST_PANE_ID}
+                  paneType="prediction-markets"
+                  focused={state.focusedPaneId === TEST_PANE_ID}
+                  width={120}
+                  height={33}
+                />
+                <PaneFooterBar footer={footer} focused={state.focusedPaneId === TEST_PANE_ID} width={120} />
+              </Box>
+            )}
+          </PaneFooterProvider>
         </PluginRenderProvider>
       </PaneInstanceProvider>
     </AppContext>

--- a/src/react/use-raf-callback.ts
+++ b/src/react/use-raf-callback.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef } from "react";
+
+type FrameCallback = (timestamp: number) => void;
+
+const animationFrameApi = globalThis as typeof globalThis & {
+  requestAnimationFrame?: (callback: FrameCallback) => number;
+  cancelAnimationFrame?: (id: number) => void;
+};
+
+function requestFrame(callback: FrameCallback): number {
+  if (typeof animationFrameApi.requestAnimationFrame === "function") {
+    return animationFrameApi.requestAnimationFrame(callback);
+  }
+  return setTimeout(() => callback(Date.now()), 16) as unknown as number;
+}
+
+function cancelFrame(id: number): void {
+  if (typeof animationFrameApi.cancelAnimationFrame === "function") {
+    animationFrameApi.cancelAnimationFrame(id);
+    return;
+  }
+  clearTimeout(id as unknown as ReturnType<typeof setTimeout>);
+}
+
+export function useRafCallback(callback: () => void): () => void {
+  const callbackRef = useRef(callback);
+  const frameRef = useRef<number | null>(null);
+  callbackRef.current = callback;
+
+  useEffect(() => () => {
+    if (frameRef.current !== null) {
+      cancelFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
+
+  return useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = requestFrame(() => {
+      frameRef.current = null;
+      callbackRef.current();
+    });
+  }, []);
+}

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -14,6 +14,8 @@ import { OpenTuiDialogHostProvider } from "./dialog-host";
 import { openTuiToastHost } from "./toast-host";
 import { ToastHostProvider } from "../../ui/toast";
 import { colors } from "../../theme/colors";
+import { startMainThreadMonitor } from "../../utils/main-thread-monitor";
+import { measurePerfAsync } from "../../utils/perf-marks";
 
 export async function startOpenTuiApp(): Promise<void> {
   setConfigStoreHost(nodeConfigStoreHost);
@@ -23,7 +25,7 @@ export async function startOpenTuiApp(): Promise<void> {
   appLog.info("Gloomberb starting");
 
   const cliArgs = process.argv.slice(2);
-  const externalPlugins = await loadExternalPlugins();
+  const externalPlugins = await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins());
   let cliLaunchRequest = null;
   if (cliArgs.length > 0) {
     const dispatchResult = await dispatchCli(cliArgs, { externalPlugins });
@@ -32,6 +34,7 @@ export async function startOpenTuiApp(): Promise<void> {
       cliLaunchRequest = dispatchResult.request;
     }
   }
+  startMainThreadMonitor("opentui");
 
   let dataDir = await getDataDir();
   if (!dataDir) {
@@ -42,8 +45,8 @@ export async function startOpenTuiApp(): Promise<void> {
     mkdirSync(dataDir, { recursive: true });
   }
 
-  const config = await initDataDir(dataDir);
-  const host = await createOpenTuiHost();
+  const config = await measurePerfAsync("startup.opentui.init-data-dir", () => initDataDir(dataDir));
+  const host = await measurePerfAsync("startup.opentui.create-host", () => createOpenTuiHost());
 
   host.render(
     <UiHostProvider ui={openTuiUiHost} renderer={host.rendererHost} nativeRenderer={host.nativeRenderer}>

--- a/src/renderers/tauri/backend/main.ts
+++ b/src/renderers/tauri/backend/main.ts
@@ -12,10 +12,12 @@ import {
   reconcileAppSessionSnapshot,
 } from "../../../core/state/session-persistence";
 import { encodeRpcValue, decodeRpcValue } from "../web/rpc-codec";
+import { startMainThreadMonitor } from "../../../utils/main-thread-monitor";
 
 console.log = (...args) => console.error(...args);
 console.info = (...args) => console.error(...args);
 console.warn = (...args) => console.error(...args);
+startMainThreadMonitor("tauri.backend", { mirrorToConsole: true });
 
 setConfigStoreHost(nodeConfigStoreHost);
 
@@ -40,6 +42,57 @@ function requireServices(): AppServices {
 function requireConfig(): AppConfig {
   if (!currentConfig) throw new Error("Backend config has not been initialized.");
   return currentConfig;
+}
+
+function normalizeHttpFetchHeaders(headers: unknown): Record<string, string> {
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(headers as Record<string, unknown>)
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+async function handleHttpFetch(payload: Record<string, unknown>) {
+  if (typeof payload.url !== "string") {
+    throw new Error("http.fetch requires a URL.");
+  }
+
+  const url = new URL(payload.url);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Unsupported http.fetch protocol: ${url.protocol}`);
+  }
+
+  const init =
+    payload.init && typeof payload.init === "object" && !Array.isArray(payload.init)
+      ? payload.init as Record<string, unknown>
+      : {};
+  const method =
+    typeof init.method === "string" && init.method.trim().length > 0
+      ? init.method.trim().toUpperCase()
+      : "GET";
+  const body =
+    typeof init.body === "string" && method !== "GET" && method !== "HEAD"
+      ? init.body
+      : undefined;
+
+  const response = await fetch(url, {
+    method,
+    headers: normalizeHttpFetchHeaders(init.headers),
+    body,
+  });
+  const responseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+    body: await response.text(),
+  };
 }
 
 function syncConfigAccessors() {
@@ -152,6 +205,8 @@ async function handleRequest(method: string, rawPayload: unknown) {
   const payload = decodeRpcValue<Record<string, unknown>>(rawPayload ?? {});
 
   if (method === "init") return initialize();
+
+  if (method === "http.fetch") return handleHttpFetch(payload);
 
   if (method.startsWith("data.")) {
     return handleDataProvider(method, payload);

--- a/src/renderers/tauri/web/app-services.ts
+++ b/src/renderers/tauri/web/app-services.ts
@@ -11,7 +11,18 @@ import type { BrokerContractRef, InstrumentSearchResult } from "../../../types/i
 import type { TickerRecord, TickerMetadata } from "../../../types/ticker";
 import type { TimeRange } from "../../../components/chart/chart-types";
 import type { ManualChartResolution } from "../../../components/chart/chart-resolution";
+import {
+  createPersistScheduler,
+  PLUGIN_STATE_SAVE_DEBOUNCE_MS,
+  SESSION_SAVE_DEBOUNCE_MS,
+} from "../../../state/persist-scheduler";
 import { backendRequest, getTauriBackendInitSnapshot } from "./backend-rpc";
+import { TauriMemoryResourceStore } from "./resource-store";
+import { debugLog } from "../../../utils/debug-log";
+import { measurePerf } from "../../../utils/perf-marks";
+
+const REMOTE_DATA_REQUEST_CACHE_LIMIT = 150;
+const servicesLog = debugLog.createLogger("services");
 
 class RemoteTickerRepository {
   async loadAllTickers(): Promise<TickerRecord[]> {
@@ -40,6 +51,23 @@ class RemoteTickerRepository {
 class RemoteDataProvider implements DataProvider {
   readonly id = "tauri-backend";
   readonly name = "Gloomberb Backend";
+  private readonly requestCache = new Map<string, Promise<unknown>>();
+
+  private cachedRequest<T>(method: string, payload: unknown): Promise<T> {
+    const key = `${method}:${JSON.stringify(payload)}`;
+    const cached = this.requestCache.get(key);
+    if (cached) return cached as Promise<T>;
+    const promise = backendRequest<T>(method, payload).catch((error) => {
+      this.requestCache.delete(key);
+      throw error;
+    });
+    this.requestCache.set(key, promise);
+    if (this.requestCache.size > REMOTE_DATA_REQUEST_CACHE_LIMIT) {
+      const oldestKey = this.requestCache.keys().next().value;
+      if (oldestKey) this.requestCache.delete(oldestKey);
+    }
+    return promise;
+  }
 
   getCachedFinancialsForTargets(): Map<string, TickerFinancials> {
     return new Map();
@@ -62,15 +90,15 @@ class RemoteDataProvider implements DataProvider {
   }
 
   getNews(ticker: string, count?: number, exchange?: string, context?: MarketDataRequestContext) {
-    return backendRequest("data.getNews", { ticker, count, exchange, context });
+    return this.cachedRequest("data.getNews", { ticker, count, exchange, context });
   }
 
   getSecFilings(ticker: string, count?: number, exchange?: string, context?: MarketDataRequestContext) {
-    return backendRequest("data.getSecFilings", { ticker, count, exchange, context });
+    return this.cachedRequest("data.getSecFilings", { ticker, count, exchange, context });
   }
 
   getSecFilingContent(filing: unknown): Promise<string | null> {
-    return backendRequest("data.getSecFilingContent", { filing });
+    return this.cachedRequest("data.getSecFilingContent", { filing });
   }
 
   getEarningsCalendar(symbols: string[], context?: MarketDataRequestContext) {
@@ -78,11 +106,11 @@ class RemoteDataProvider implements DataProvider {
   }
 
   getArticleSummary(url: string): Promise<string | null> {
-    return backendRequest("data.getArticleSummary", { url });
+    return this.cachedRequest("data.getArticleSummary", { url });
   }
 
   getPriceHistory(ticker: string, exchange: string, range: TimeRange, context?: MarketDataRequestContext) {
-    return backendRequest("data.getPriceHistory", { ticker, exchange, range, context });
+    return this.cachedRequest("data.getPriceHistory", { ticker, exchange, range, context });
   }
 
   getPriceHistoryForResolution(
@@ -92,7 +120,7 @@ class RemoteDataProvider implements DataProvider {
     resolution: ManualChartResolution,
     context?: MarketDataRequestContext,
   ) {
-    return backendRequest("data.getPriceHistoryForResolution", { ticker, exchange, bufferRange, resolution, context });
+    return this.cachedRequest("data.getPriceHistoryForResolution", { ticker, exchange, bufferRange, resolution, context });
   }
 
   getDetailedPriceHistory(
@@ -103,15 +131,15 @@ class RemoteDataProvider implements DataProvider {
     barSize: string,
     context?: MarketDataRequestContext,
   ) {
-    return backendRequest("data.getDetailedPriceHistory", { ticker, exchange, startDate, endDate, barSize, context });
+    return this.cachedRequest("data.getDetailedPriceHistory", { ticker, exchange, startDate, endDate, barSize, context });
   }
 
   getChartResolutionSupport(ticker: string, exchange?: string, context?: MarketDataRequestContext) {
-    return backendRequest("data.getChartResolutionSupport", { ticker, exchange, context });
+    return this.cachedRequest("data.getChartResolutionSupport", { ticker, exchange, context });
   }
 
   getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, context?: MarketDataRequestContext) {
-    return backendRequest("data.getOptionsChain", { ticker, exchange, expirationDate, context });
+    return this.cachedRequest("data.getOptionsChain", { ticker, exchange, expirationDate, context });
   }
 
   subscribeQuotes(
@@ -124,6 +152,14 @@ class RemoteDataProvider implements DataProvider {
 
 class RemoteSessionStore {
   private snapshot = getTauriBackendInitSnapshot()?.sessionSnapshot ?? null;
+  private readonly scheduler = createPersistScheduler<{
+    sessionId: string;
+    value: unknown;
+    schemaVersion: number;
+  }>({
+    delayMs: SESSION_SAVE_DEBOUNCE_MS,
+    save: ({ sessionId, value, schemaVersion }) => backendRequest("session.set", { sessionId, value, schemaVersion }),
+  });
 
   get<T>(sessionId = "app", schemaVersion = 1) {
     if (sessionId !== "app" || !this.snapshot) return null;
@@ -137,17 +173,28 @@ class RemoteSessionStore {
 
   set(sessionId: string, value: unknown, schemaVersion = 1): void {
     if (sessionId === "app") this.snapshot = value as typeof this.snapshot;
-    void backendRequest("session.set", { sessionId, value, schemaVersion }).catch(() => {});
+    this.scheduler.schedule({ sessionId, value, schemaVersion });
   }
 
   delete(sessionId: string): void {
     if (sessionId === "app") this.snapshot = null;
+    this.scheduler.cancel();
     void backendRequest("session.delete", { sessionId }).catch(() => {});
+  }
+
+  flush(): Promise<void> {
+    return this.scheduler.flush();
   }
 }
 
 class RemotePluginStateStore {
   private readonly state = new Map<string, Map<string, unknown>>();
+  private readonly schedulers = new Map<string, ReturnType<typeof createPersistScheduler<{
+    pluginId: string;
+    key: string;
+    value: unknown;
+    schemaVersion: number;
+  }>>>();
 
   constructor(initial: Record<string, Record<string, unknown>>) {
     for (const [pluginId, values] of Object.entries(initial)) {
@@ -164,11 +211,12 @@ class RemotePluginStateStore {
   set(pluginId: string, key: string, value: unknown, schemaVersion = 1): void {
     if (!this.state.has(pluginId)) this.state.set(pluginId, new Map());
     this.state.get(pluginId)!.set(key, value);
-    void backendRequest("pluginState.set", { pluginId, key, value, schemaVersion }).catch(() => {});
+    this.getScheduler(pluginId, key).schedule({ pluginId, key, value, schemaVersion });
   }
 
   delete(pluginId: string, key: string): void {
     this.state.get(pluginId)?.delete(key);
+    this.getScheduler(pluginId, key).cancel();
     void backendRequest("pluginState.delete", { pluginId, key }).catch(() => {});
   }
 
@@ -179,27 +227,43 @@ class RemotePluginStateStore {
   clear(pluginId: string): void {
     this.state.delete(pluginId);
   }
-}
 
-class EmptyResourceStore {
-  get(): null { return null; }
-  list(): [] { return []; }
-  set(): void {}
-  delete(): void {}
+  async flush(): Promise<void> {
+    await Promise.all([...this.schedulers.values()].map((scheduler) => scheduler.flush()));
+  }
+
+  private getScheduler(pluginId: string, key: string) {
+    const schedulerKey = `${pluginId}\u0000${key}`;
+    let scheduler = this.schedulers.get(schedulerKey);
+    if (!scheduler) {
+      scheduler = createPersistScheduler({
+        delayMs: PLUGIN_STATE_SAVE_DEBOUNCE_MS,
+        save: (entry) => backendRequest("pluginState.set", entry),
+      });
+      this.schedulers.set(schedulerKey, scheduler);
+    }
+    return scheduler;
+  }
 }
 
 class RemotePersistence {
   readonly tickers = {};
-  readonly resources = new EmptyResourceStore();
+  readonly resources = new TauriMemoryResourceStore();
   readonly pluginState = new RemotePluginStateStore(getTauriBackendInitSnapshot()?.pluginState ?? {});
   readonly sessions = new RemoteSessionStore();
-  close(): void {}
+  close(): void {
+    void this.sessions.flush();
+    void this.pluginState.flush();
+  }
 }
 
 export function createAppServices({ config }: { config: AppConfig }): AppServices {
-  const persistence = new RemotePersistence();
-  const tickerRepository = new RemoteTickerRepository();
-  const dataProvider = new RemoteDataProvider();
+  servicesLog.info("create tauri web services start", {
+    brokerInstanceCount: config.brokerInstances.length,
+  });
+  const persistence = measurePerf("startup.services.persistence", () => new RemotePersistence());
+  const tickerRepository = measurePerf("startup.services.ticker-repository", () => new RemoteTickerRepository());
+  const dataProvider = measurePerf("startup.services.data-provider", () => new RemoteDataProvider());
   const marketData = new MarketDataCoordinator(dataProvider);
   const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository as never, persistence as never);
   const newsService = new NewsService();
@@ -212,9 +276,14 @@ export function createAppServices({ config }: { config: AppConfig }): AppService
   setSharedNewsService(newsService);
 
   for (const plugin of uiBuiltinPlugins) {
-    pluginRegistry.register(plugin);
+    measurePerf("startup.services.register-plugin", () => {
+      void pluginRegistry.register(plugin);
+    }, { pluginId: plugin.id });
   }
-  newsService.start();
+  measurePerf("startup.services.news-start", () => {
+    newsService.start();
+  });
+  servicesLog.info("create tauri web services complete", { pluginCount: uiBuiltinPlugins.length });
 
   return {
     persistence: persistence as never,
@@ -229,6 +298,7 @@ export function createAppServices({ config }: { config: AppConfig }): AppService
       setSharedNewsService(null);
       newsService.stop();
       pluginRegistry.destroy();
+      persistence.close();
     },
   };
 }

--- a/src/renderers/tauri/web/backend-rpc.ts
+++ b/src/renderers/tauri/web/backend-rpc.ts
@@ -2,6 +2,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { AppConfig } from "../../../types/config";
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
+import { measurePerfAsync } from "../../../utils/perf-marks";
 import { decodeRpcValue, encodeRpcValue } from "./rpc-codec";
 
 export interface TauriBackendInit {
@@ -13,12 +14,12 @@ export interface TauriBackendInit {
 let initSnapshot: TauriBackendInit | null = null;
 
 export async function backendRequest<T = unknown>(method: string, payload: unknown = null): Promise<T> {
-  const result = await invoke<unknown>("tauri_backend_request", {
+  const result = await measurePerfAsync(`tauri.rpc.${method}`, () => invoke<unknown>("tauri_backend_request", {
     request: {
       method,
       payload: encodeRpcValue(payload),
     },
-  });
+  }), { method });
   return decodeRpcValue<T>(result);
 }
 

--- a/src/renderers/tauri/web/data-table.tsx
+++ b/src/renderers/tauri/web/data-table.tsx
@@ -1,0 +1,649 @@
+/// <reference lib="dom" />
+/** @jsxImportSource react */
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  memo,
+  type CSSProperties,
+  type MouseEvent,
+  type RefObject,
+} from "react";
+import { TextAttributes, type ScrollBoxRenderable } from "../../../ui/host";
+import { colors, hoverBg } from "../../../theme/colors";
+import { useAppDispatch, usePaneInstance } from "../../../state/app-context";
+import { useRafCallback } from "../../../react/use-raf-callback";
+import { padTo } from "../../../utils/format";
+import { measurePerf } from "../../../utils/perf-marks";
+import { useDoubleClickActivation } from "../../../components/use-double-click-activation";
+import type {
+  DataTableCell,
+  DataTableColumn,
+  DataTableProps,
+  DataTableSectionHeader,
+} from "../../../components/ui/data-table";
+import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
+
+interface DataTableRowPointerTarget<T> {
+  item: T;
+  index: number;
+}
+
+interface VirtualRow {
+  index: number;
+  key: string | number;
+  size: number;
+  start: number;
+}
+
+function px(cells: number): number {
+  return cells * WEB_CELL_WIDTH;
+}
+
+function hasAttribute(attributes: unknown, flag: number): boolean {
+  return typeof attributes === "number" && (attributes & flag) !== 0;
+}
+
+function cellTextStyle(
+  color: string,
+  attributes: number | undefined,
+): CSSProperties {
+  return {
+    color,
+    display: "inline-block",
+    lineHeight: "var(--cell-h)",
+    fontWeight: hasAttribute(attributes, TextAttributes.BOLD) ? 700 : undefined,
+    fontStyle: hasAttribute(attributes, TextAttributes.ITALIC) ? "italic" : undefined,
+    opacity: hasAttribute(attributes, TextAttributes.DIM) ? 0.65 : undefined,
+    filter: hasAttribute(attributes, TextAttributes.INVERSE) ? "invert(1)" : undefined,
+    textDecoration: [
+      hasAttribute(attributes, TextAttributes.UNDERLINE) ? "underline" : "",
+      hasAttribute(attributes, TextAttributes.STRIKETHROUGH)
+        ? "line-through"
+        : "",
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined,
+    whiteSpace: "pre",
+    overflow: "visible",
+    textOverflow: "clip",
+  };
+}
+
+function toCellY(pixels: number): number {
+  return Math.max(0, Math.round(pixels / WEB_CELL_HEIGHT));
+}
+
+function toCellX(pixels: number): number {
+  return Math.max(0, Math.round(pixels / WEB_CELL_WIDTH));
+}
+
+function useScrollbarState(initialVisible: boolean) {
+  const [visible, setVisible] = useState(initialVisible);
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
+  const bar = useMemo(
+    () => ({
+      get visible() {
+        return visibleRef.current;
+      },
+      set visible(nextVisible: boolean) {
+        const normalized = nextVisible === true;
+        visibleRef.current = normalized;
+        setVisible(normalized);
+      },
+    }),
+    [],
+  );
+
+  return { visible, bar };
+}
+
+function useScrollBoxHandle(
+  ref: RefObject<ScrollBoxRenderable | null>,
+  elementRef: RefObject<HTMLDivElement | null>,
+  horizontalScrollBar: { visible: boolean },
+  verticalScrollBar: { visible: boolean },
+  options: {
+    headerOnly?: boolean;
+    viewportTopInsetPx?: number;
+  } = {},
+) {
+  useImperativeHandle(ref, () => ({
+    get scrollTop() {
+      if (options.headerOnly) return 0;
+      return toCellY(elementRef.current?.scrollTop ?? 0);
+    },
+    set scrollTop(value: number) {
+      if (options.headerOnly) return;
+      const element = elementRef.current;
+      if (!element) return;
+      element.scrollTop = Math.max(0, value) * WEB_CELL_HEIGHT;
+    },
+    get scrollLeft() {
+      return toCellX(elementRef.current?.scrollLeft ?? 0);
+    },
+    set scrollLeft(value: number) {
+      const element = elementRef.current;
+      if (!element) return;
+      element.scrollLeft = Math.max(0, value) * WEB_CELL_WIDTH;
+    },
+    get scrollHeight() {
+      const element = elementRef.current;
+      if (!element) return 0;
+      if (options.headerOnly) return 1;
+      return toCellY(Math.max(0, element.scrollHeight - (options.viewportTopInsetPx ?? 0)));
+    },
+    get viewport() {
+      const element = elementRef.current;
+      if (options.headerOnly) {
+        return {
+          width: toCellX(element?.clientWidth ?? 0),
+          height: 1,
+        };
+      }
+      return {
+        width: toCellX(element?.clientWidth ?? 0),
+        height: Math.max(
+          1,
+          toCellY(Math.max(0, (element?.clientHeight ?? 0) - (options.viewportTopInsetPx ?? 0))),
+        ),
+      };
+    },
+    horizontalScrollBar,
+    verticalScrollBar,
+    scrollTo(target: number | { x?: number; y?: number }, y?: number) {
+      const element = elementRef.current;
+      if (!element) return;
+      if (options.headerOnly) {
+        if (typeof target === "number") {
+          if (typeof y === "number") {
+            element.scrollLeft = Math.max(0, y) * WEB_CELL_WIDTH;
+          }
+          return;
+        }
+        if (typeof target.x === "number") {
+          element.scrollLeft = Math.max(0, target.x) * WEB_CELL_WIDTH;
+        }
+        return;
+      }
+      if (typeof target === "number") {
+        element.scrollTop = Math.max(0, target) * WEB_CELL_HEIGHT;
+        if (typeof y === "number") {
+          element.scrollLeft = Math.max(0, y) * WEB_CELL_WIDTH;
+        }
+        return;
+      }
+      element.scrollTo({
+        left: Math.max(0, target.x ?? toCellX(element.scrollLeft)) * WEB_CELL_WIDTH,
+        top: Math.max(0, target.y ?? toCellY(element.scrollTop)) * WEB_CELL_HEIGHT,
+      });
+    },
+  }), [
+    elementRef,
+    horizontalScrollBar,
+    options.headerOnly,
+    options.viewportTopInsetPx,
+    ref,
+    verticalScrollBar,
+  ]);
+}
+
+function eventWithCellCoordinates(event: MouseEvent<HTMLElement>) {
+  const target = event.currentTarget;
+  const rect = target.getBoundingClientRect();
+  const preciseX = (event.clientX - rect.left) / WEB_CELL_WIDTH;
+  const preciseY = (event.clientY - rect.top) / WEB_CELL_HEIGHT;
+  return {
+    detail: event.detail,
+    button: event.button,
+    shiftKey: event.shiftKey,
+    altKey: event.altKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    preventDefault: () => event.preventDefault(),
+    stopPropagation: () => event.stopPropagation(),
+    x: Math.max(0, Math.floor(preciseX)),
+    y: Math.max(0, Math.floor(preciseY)),
+    preciseX: Math.max(0, preciseX),
+    preciseY: Math.max(0, preciseY),
+    pixelX: event.clientX,
+    pixelY: event.clientY,
+  };
+}
+
+function renderHeaderLabel<C extends DataTableColumn>(
+  column: C,
+  sortColumnId: string | null,
+  sortDirection: "asc" | "desc",
+) {
+  const isSorted = sortColumnId === column.id;
+  const indicator = isSorted ? (sortDirection === "asc" ? " ▲" : " ▼") : "";
+  return {
+    isSorted,
+    text: padTo(column.label + indicator, column.width, column.align),
+  };
+}
+
+function WebDataTableRowInner<
+  T,
+  C extends DataTableColumn,
+>({
+  columns,
+  focusPane,
+  handleRowMouseDown,
+  hovered,
+  index,
+  item,
+  itemKey,
+  minWidthPx,
+  renderCell,
+  renderSectionHeader,
+  rowSize,
+  rowStart,
+  selected,
+  setHoveredIdx,
+}: {
+  columns: C[];
+  focusPane: () => void;
+  handleRowMouseDown: (
+    targetKey: string,
+    value: DataTableRowPointerTarget<T>,
+    event?: { detail?: number },
+  ) => void;
+  hovered: boolean;
+  index: number;
+  item: T;
+  itemKey: string;
+  minWidthPx: number;
+  renderCell: DataTableProps<T, C>["renderCell"];
+  renderSectionHeader?: DataTableProps<T, C>["renderSectionHeader"];
+  rowSize: number;
+  rowStart: number;
+  selected: boolean;
+  setHoveredIdx: (index: number | null) => void;
+}) {
+  const sectionHeader: DataTableSectionHeader | null =
+    renderSectionHeader?.(item, index) ?? null;
+  const baseRowStyle: CSSProperties = {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    transform: `translateY(${rowStart}px)`,
+    display: "flex",
+    flexDirection: "row",
+    width: "100%",
+    minWidth: minWidthPx,
+    height: rowSize,
+    paddingLeft: WEB_CELL_WIDTH,
+    paddingRight: WEB_CELL_WIDTH,
+    lineHeight: "var(--cell-h)",
+  };
+
+  if (sectionHeader) {
+    return (
+      <div
+        key={itemKey}
+        data-gloom-role="data-table-section-header"
+        style={{
+          ...baseRowStyle,
+          backgroundColor: sectionHeader.backgroundColor ?? colors.bg,
+        }}
+        onMouseDown={(event) => {
+          focusPane();
+          event.preventDefault();
+        }}
+      >
+        <span
+          style={cellTextStyle(
+            sectionHeader.color ?? colors.textBright,
+            sectionHeader.attributes ?? TextAttributes.BOLD,
+          )}
+        >
+          {sectionHeader.text}
+        </span>
+      </div>
+    );
+  }
+
+  const rowBg = selected ? colors.selected : hovered ? hoverBg() : colors.bg;
+
+  return (
+    <div
+      key={itemKey}
+      data-gloom-role="data-table-row"
+      data-selected={selected ? "true" : undefined}
+      style={{
+        ...baseRowStyle,
+        backgroundColor: rowBg,
+      }}
+      onMouseMove={() => {
+        if (!hovered) setHoveredIdx(index);
+      }}
+      onMouseDown={(event) => {
+        focusPane();
+        event.preventDefault();
+        handleRowMouseDown(itemKey, { item, index }, event);
+      }}
+    >
+      {columns.map((column) => {
+        const cell: DataTableCell = renderCell(item, column, index, {
+          selected,
+          hovered,
+        });
+        return (
+          <div
+            key={column.id}
+            data-gloom-role="data-table-cell"
+            style={{
+              width: px(column.width + 1),
+              minWidth: px(column.width + 1),
+              height: WEB_CELL_HEIGHT,
+              flex: "0 0 auto",
+              overflow: "visible",
+            }}
+            onMouseDown={(event) => {
+              focusPane();
+              if (cell.onMouseDown) {
+                cell.onMouseDown(eventWithCellCoordinates(event));
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              handleRowMouseDown(itemKey, { item, index }, event);
+            }}
+          >
+            <span
+              style={cellTextStyle(
+                cell.color ?? (selected ? colors.selectedText : colors.text),
+                cell.attributes ?? TextAttributes.NONE,
+              )}
+            >
+              {padTo(cell.text, column.width, column.align)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const WebDataTableRow = memo(WebDataTableRowInner) as typeof WebDataTableRowInner;
+
+export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
+  columns,
+  items,
+  sortColumnId,
+  sortDirection,
+  onHeaderClick,
+  headerScrollRef,
+  scrollRef,
+  syncHeaderScroll: _syncHeaderScroll,
+  onBodyScrollActivity,
+  hoveredIdx,
+  setHoveredIdx,
+  getItemKey,
+  isSelected,
+  onSelect,
+  onActivate,
+  renderCell,
+  renderSectionHeader,
+  emptyStateTitle,
+  emptyStateHint,
+  virtualize = true,
+  overscan = 3,
+  showHorizontalScrollbar = true,
+}: DataTableProps<T, C>) {
+  const dispatch = useAppDispatch();
+  const paneInstanceId = usePaneInstance()?.instanceId ?? null;
+  const bodyElementRef = useRef<HTMLDivElement | null>(null);
+  const headerHorizontal = useScrollbarState(false);
+  const headerVertical = useScrollbarState(false);
+  const bodyHorizontal = useScrollbarState(showHorizontalScrollbar);
+  const bodyVertical = useScrollbarState(true);
+  const tableWidth = useMemo(
+    () => columns.reduce((sum, column) => sum + column.width + 1, 2),
+    [columns],
+  );
+  const minWidthPx = px(tableWidth);
+  const handleRowMouseDown =
+    useDoubleClickActivation<DataTableRowPointerTarget<T>>({
+      onSelect: ({ item, index }) => {
+        onSelect(item, index);
+      },
+      onActivate: onActivate
+        ? ({ item, index }) => {
+            onActivate(item, index);
+          }
+        : undefined,
+    });
+
+  const focusPane = useCallback(() => {
+    if (!paneInstanceId) return;
+    dispatch({ type: "FOCUS_PANE", paneId: paneInstanceId });
+  }, [dispatch, paneInstanceId]);
+
+  const handleBodyScrollActivity = useCallback(() => {
+    onBodyScrollActivity();
+  }, [onBodyScrollActivity]);
+  const scheduleBodyScrollActivity = useRafCallback(handleBodyScrollActivity);
+
+  const rowVirtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => bodyElementRef.current,
+    estimateSize: () => WEB_CELL_HEIGHT,
+    overscan,
+    paddingStart: WEB_CELL_HEIGHT,
+    scrollPaddingStart: WEB_CELL_HEIGHT,
+  });
+
+  const allRows = useMemo<VirtualRow[]>(
+    () => {
+      if (virtualize) return [];
+      return Array.from({ length: items.length }, (_, index) => ({
+        index,
+        key: getItemKey(items[index]!, index),
+        size: WEB_CELL_HEIGHT,
+        start: WEB_CELL_HEIGHT + index * WEB_CELL_HEIGHT,
+      }));
+    },
+    [getItemKey, items, virtualize],
+  );
+  const virtualRows = virtualize
+    ? (rowVirtualizer.getVirtualItems() as VirtualRow[])
+    : allRows;
+  const totalHeight = virtualize
+    ? rowVirtualizer.getTotalSize()
+    : WEB_CELL_HEIGHT + items.length * WEB_CELL_HEIGHT;
+
+  useScrollBoxHandle(
+    headerScrollRef,
+    bodyElementRef,
+    headerHorizontal.bar,
+    headerVertical.bar,
+    { headerOnly: true },
+  );
+  useScrollBoxHandle(
+    scrollRef,
+    bodyElementRef,
+    bodyHorizontal.bar,
+    bodyVertical.bar,
+    { viewportTopInsetPx: WEB_CELL_HEIGHT },
+  );
+
+  useEffect(() => {
+    headerHorizontal.bar.visible = false;
+    bodyHorizontal.bar.visible = showHorizontalScrollbar;
+    if (!showHorizontalScrollbar) {
+      if (bodyElementRef.current) bodyElementRef.current.scrollLeft = 0;
+    }
+  }, [bodyHorizontal.bar, headerHorizontal.bar, showHorizontalScrollbar]);
+
+  const rootStyle: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    flex: "1 1 0px",
+    width: "100%",
+    minWidth: 0,
+    minHeight: 0,
+    backgroundColor: colors.bg,
+    overflow: "hidden",
+  };
+  const bodyScrollerStyle: CSSProperties = {
+    width: "100%",
+    flex: "1 1 0px",
+    minWidth: 0,
+    minHeight: 0,
+    overflowX: showHorizontalScrollbar ? "auto" : "hidden",
+    overflowY: "auto",
+    backgroundColor: colors.bg,
+  };
+
+  return (
+    <div data-gloom-role="data-table" style={rootStyle}>
+      <div
+        ref={bodyElementRef}
+        data-gloom-role="data-table-body-scroll"
+        data-gloom-scrollbar-x={
+          showHorizontalScrollbar && bodyHorizontal.visible
+            ? "visible"
+            : "hidden"
+        }
+        data-gloom-scrollbar-y={bodyVertical.visible ? "visible" : "hidden"}
+        style={bodyScrollerStyle}
+        onMouseDown={() => {
+          focusPane();
+        }}
+        onMouseLeave={() => {
+          if (hoveredIdx !== null) setHoveredIdx(null);
+        }}
+        onScroll={() => {
+          scheduleBodyScrollActivity();
+        }}
+      >
+        <div
+          data-gloom-role="data-table-scroll-content"
+          style={{
+            position: "relative",
+            width: "100%",
+            minWidth: minWidthPx,
+            height: items.length > 0 ? totalHeight : "100%",
+            minHeight: WEB_CELL_HEIGHT,
+          }}
+        >
+          <div
+            data-gloom-role="data-table-header-row"
+            style={{
+              position: "sticky",
+              top: 0,
+              zIndex: 2,
+              display: "flex",
+              flexDirection: "row",
+              width: "100%",
+              minWidth: minWidthPx,
+              height: WEB_CELL_HEIGHT,
+              paddingLeft: WEB_CELL_WIDTH,
+              paddingRight: WEB_CELL_WIDTH,
+              backgroundColor: colors.panel,
+            }}
+          >
+            {columns.map((column) => {
+              const { isSorted, text } = renderHeaderLabel(
+                column,
+                sortColumnId,
+                sortDirection,
+              );
+              return (
+                <div
+                  key={column.id}
+                  data-gloom-role="data-table-header-cell"
+                  data-gloom-interactive="true"
+                  style={{
+                    width: px(column.width + 1),
+                    minWidth: px(column.width + 1),
+                    height: WEB_CELL_HEIGHT,
+                    flex: "0 0 auto",
+                    backgroundColor: colors.panel,
+                  }}
+                  onMouseDown={(event) => {
+                    focusPane();
+                    event.preventDefault();
+                    onHeaderClick(column.id);
+                  }}
+                >
+                  <span
+                    style={cellTextStyle(
+                      isSorted ? colors.text : colors.textDim,
+                      TextAttributes.BOLD,
+                    )}
+                  >
+                    {text}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          {items.length === 0 ? (
+            <div
+              style={{
+                width: "100%",
+                padding: `${WEB_CELL_HEIGHT}px ${WEB_CELL_WIDTH}px`,
+                color: colors.textDim,
+                lineHeight: "var(--cell-h)",
+              }}
+            >
+              <div style={cellTextStyle(colors.textBright, TextAttributes.BOLD)}>
+                {emptyStateTitle}
+              </div>
+              {emptyStateHint ? (
+                <div style={cellTextStyle(colors.textDim, TextAttributes.NONE)}>
+                  {emptyStateHint}
+                </div>
+              ) : null}
+            </div>
+          ) : measurePerf(
+            "data-table.tauri.render-virtual-rows",
+            () =>
+              virtualRows.map((row) => {
+                const item = items[row.index];
+                if (!item) return null;
+                const selected = isSelected(item, row.index);
+                const hovered = hoveredIdx === row.index && !selected;
+                const itemKey = getItemKey(item, row.index);
+                return (
+                  <WebDataTableRow<T, C>
+                    key={itemKey}
+                    rowSize={row.size}
+                    rowStart={row.start}
+                    index={row.index}
+                    item={item}
+                    itemKey={itemKey}
+                    columns={columns}
+                    focusPane={focusPane}
+                    handleRowMouseDown={handleRowMouseDown}
+                    hovered={hovered}
+                    minWidthPx={minWidthPx}
+                    renderCell={renderCell}
+                    renderSectionHeader={renderSectionHeader}
+                    selected={selected}
+                    setHoveredIdx={setHoveredIdx}
+                  />
+                );
+              }),
+            {
+              columnCount: columns.length,
+              itemCount: items.length,
+              paneId: paneInstanceId,
+              renderedCount: virtualRows.length,
+              virtualize,
+            },
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderers/tauri/web/http-fetch.ts
+++ b/src/renderers/tauri/web/http-fetch.ts
@@ -1,0 +1,79 @@
+/// <reference lib="dom" />
+import { setPredictionMarketsFetchTransport } from "../../../plugins/prediction-markets/services/fetch";
+import { backendRequest } from "./backend-rpc";
+
+interface TauriHttpFetchResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  if (!headers) return normalized;
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      normalized[key] = value;
+    });
+    return normalized;
+  }
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      normalized[key] = value;
+    }
+    return normalized;
+  }
+  return { ...headers };
+}
+
+function createAbortError(): Error {
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+async function serializeBody(body: BodyInit | null | undefined): Promise<string | undefined> {
+  if (body == null) return undefined;
+  if (typeof body === "string") return body;
+  return new Response(body).text();
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal | null | undefined): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) {
+    throw createAbortError();
+  }
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(createAbortError());
+    signal.addEventListener("abort", abort, { once: true });
+    void promise.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", abort);
+    });
+  });
+}
+
+async function tauriHttpFetch(url: string, init?: RequestInit): Promise<Response> {
+  if (init?.signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const requestPromise = backendRequest<TauriHttpFetchResponse>("http.fetch", {
+    url,
+    init: {
+      method: init?.method,
+      headers: normalizeHeaders(init?.headers),
+      body: await serializeBody(init?.body),
+    },
+  });
+
+  const response = await withAbort(requestPromise, init?.signal);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+export function installTauriPredictionMarketsFetchTransport(): void {
+  setPredictionMarketsFetchTransport(tauriHttpFetch);
+}

--- a/src/renderers/tauri/web/main.tsx
+++ b/src/renderers/tauri/web/main.tsx
@@ -1,6 +1,9 @@
 /// <reference lib="dom" />
 /** @jsxImportSource react */
 import { createRoot } from "react-dom/client";
+import { debugLog } from "../../../utils/debug-log";
+import { measurePerfAsync } from "../../../utils/perf-marks";
+import { startMainThreadMonitor } from "../../../utils/main-thread-monitor";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {
@@ -8,10 +11,26 @@ if (!rootElement) {
 }
 
 const root = createRoot(rootElement);
+const bootLog = debugLog.createLogger("tauri-web-boot");
+const TAURI_WEB_CONSOLE_LOG_SOURCES = [
+  "app",
+  "main-thread",
+  "perf",
+  "refresh-queue",
+  "services",
+  "startup",
+  "tauri-web-boot",
+];
+debugLog.mirrorToConsole({
+  sources: TAURI_WEB_CONSOLE_LOG_SOURCES,
+});
+const stopMainThreadMonitor = startMainThreadMonitor("tauri.web", { mirrorToConsole: true });
 
 root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
+bootLog.warn("diagnostic console mirror enabled", { sources: TAURI_WEB_CONSOLE_LOG_SOURCES });
 
 async function boot() {
+  bootLog.info("boot started");
   const backendModulePromise = import("./backend-rpc");
   const backendInitPromise = backendModulePromise.then(({ initTauriBackend }) => initTauriBackend());
   // Avoid a premature global unhandled-rejection render while UI chunks load.
@@ -22,37 +41,48 @@ async function boot() {
     { UiHostProvider },
     { WebDialogHostProvider },
     { installTauriConfigStoreHost },
+    { installTauriPredictionMarketsFetchTransport },
     { WebInputHostProvider },
     { webNativeRenderer },
     { WebToastHostProvider },
     { webRendererHost, webUiHost },
-  ] = await Promise.all([
+  ] = await measurePerfAsync("startup.tauri.import-ui", () => Promise.all([
     import("../../../app"),
     import("../../../ui/host"),
     import("./dialog-host"),
     import("./config-host"),
+    import("./http-fetch"),
     import("./input-host"),
     import("./native-renderer"),
     import("./toast-host"),
     import("./ui-host"),
-  ]);
+  ]));
 
   installTauriConfigStoreHost();
-  const { config } = await backendInitPromise;
-  root.render(
-    <UiHostProvider ui={webUiHost} renderer={webRendererHost} nativeRenderer={webNativeRenderer}>
-      <WebInputHostProvider>
-        <WebToastHostProvider>
-          <WebDialogHostProvider>
-            <App config={config} />
-          </WebDialogHostProvider>
-        </WebToastHostProvider>
-      </WebInputHostProvider>
-    </UiHostProvider>,
-  );
+  installTauriPredictionMarketsFetchTransport();
+  const { config } = await measurePerfAsync("startup.tauri.backend-init", () => backendInitPromise);
+  measurePerfAsync("startup.tauri.root-render", async () => {
+    root.render(
+      <UiHostProvider ui={webUiHost} renderer={webRendererHost} nativeRenderer={webNativeRenderer}>
+        <WebInputHostProvider>
+          <WebToastHostProvider>
+            <WebDialogHostProvider>
+              <App config={config} />
+            </WebDialogHostProvider>
+          </WebToastHostProvider>
+        </WebInputHostProvider>
+      </UiHostProvider>,
+    );
+  });
+  bootLog.info("root render scheduled", {
+    layoutPanes: config.layout.instances.length,
+    floatingPanes: config.layout.floating.length,
+    brokerInstances: config.brokerInstances.length,
+  });
 }
 
 boot().catch((error) => {
+  stopMainThreadMonitor();
   root.render(
     <div className="gloom-fatal">
       <h1>Gloomberb failed to start</h1>

--- a/src/renderers/tauri/web/resource-store.test.ts
+++ b/src/renderers/tauri/web/resource-store.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { TauriMemoryResourceStore } from "./resource-store";
+
+describe("TauriMemoryResourceStore", () => {
+  test("returns persisted resource records with values", () => {
+    const store = new TauriMemoryResourceStore();
+    const key = {
+      namespace: "plugins:prediction-markets",
+      kind: "catalog",
+      entityKey: "polymarket:all:all",
+      sourceKey: "remote",
+    };
+
+    const saved = store.set(key, [{ key: "polymarket:abc" }], {
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+      fetchedAt: Date.now(),
+    });
+    const loaded = store.get<typeof saved.value>(key);
+
+    expect(saved.value).toEqual([{ key: "polymarket:abc" }]);
+    expect(loaded?.value).toEqual([{ key: "polymarket:abc" }]);
+    expect(loaded?.sourceKey).toBe("remote");
+  });
+
+  test("returns expired records only when requested", () => {
+    const store = new TauriMemoryResourceStore();
+    const key = {
+      namespace: "plugins:prediction-markets",
+      kind: "catalog",
+      entityKey: "kalshi:all:all",
+      sourceKey: "remote",
+    };
+
+    store.set(key, ["expired"], {
+      cachePolicy: { staleMs: -2, expireMs: -1 },
+      fetchedAt: Date.now(),
+    });
+
+    expect(store.get(key)).toBeNull();
+    expect(store.get<string[]>(key, { allowExpired: true })?.value).toEqual([
+      "expired",
+    ]);
+  });
+});

--- a/src/renderers/tauri/web/resource-store.ts
+++ b/src/renderers/tauri/web/resource-store.ts
@@ -1,0 +1,106 @@
+import type {
+  CachedResourceRecord,
+  GetResourceOptions,
+  ListResourceOptions,
+  ResourceCacheKey,
+  SetResourceOptions,
+} from "../../../data/resource-store";
+
+const DEFAULT_RESOURCE_SCHEMA_VERSION = 1;
+
+function normalizeVariantKey(value: string | undefined): string {
+  return value ?? "";
+}
+
+function normalizeSourceKey(value: string | undefined): string {
+  return value ?? "";
+}
+
+function buildMapKey(key: ResourceCacheKey): string {
+  return [
+    key.namespace,
+    key.kind,
+    key.entityKey,
+    normalizeVariantKey(key.variantKey),
+    normalizeSourceKey(key.sourceKey),
+  ].join("\u0000");
+}
+
+function isExpired(record: CachedResourceRecord): boolean {
+  return record.expiresAt < Date.now();
+}
+
+function isStale(record: CachedResourceRecord): boolean {
+  return record.staleAt < Date.now();
+}
+
+export class TauriMemoryResourceStore {
+  private readonly records = new Map<string, CachedResourceRecord>();
+
+  get<T>(key: ResourceCacheKey, options: GetResourceOptions = {}): CachedResourceRecord<T> | null {
+    const record = this.records.get(buildMapKey(key)) as CachedResourceRecord<T> | undefined;
+    if (!record) return null;
+    if (!options.allowExpired && isExpired(record)) return null;
+    if (options.schemaVersion != null && record.schemaVersion !== options.schemaVersion) {
+      this.delete(key);
+      return null;
+    }
+    if (options.touch !== false) {
+      record.lastAccessedAt = Date.now();
+    }
+    record.stale = isStale(record);
+    record.expired = isExpired(record);
+    return record;
+  }
+
+  list<T>(
+    key: Pick<ResourceCacheKey, "namespace" | "kind" | "entityKey">,
+    options: ListResourceOptions = {},
+  ): CachedResourceRecord<T>[] {
+    const allowedVariantKeys = options.variantKeys ? new Set(options.variantKeys.map(normalizeVariantKey)) : null;
+    const allowedSourceKeys = options.sourceKeys ? new Set(options.sourceKeys.map(normalizeSourceKey)) : null;
+    const records = [...this.records.values()].filter((record) => {
+      if (record.namespace !== key.namespace || record.kind !== key.kind || record.entityKey !== key.entityKey) return false;
+      if (!options.allowExpired && isExpired(record)) return false;
+      if (allowedVariantKeys && !allowedVariantKeys.has(record.variantKey)) return false;
+      if (allowedSourceKeys && !allowedSourceKeys.has(record.sourceKey)) return false;
+      if (options.schemaVersion != null && record.schemaVersion !== options.schemaVersion) return false;
+      return true;
+    });
+    return records
+      .sort((left, right) => right.lastAccessedAt - left.lastAccessedAt)
+      .map((record) => this.get<T>(record, options))
+      .filter((record): record is CachedResourceRecord<T> => record != null);
+  }
+
+  set<T>(
+    key: ResourceCacheKey,
+    value: T,
+    options: SetResourceOptions,
+  ): CachedResourceRecord<T> {
+    const now = options.fetchedAt ?? Date.now();
+    const record: CachedResourceRecord<T> = {
+      namespace: key.namespace,
+      kind: key.kind,
+      entityKey: key.entityKey,
+      variantKey: normalizeVariantKey(key.variantKey),
+      sourceKey: normalizeSourceKey(key.sourceKey),
+      value,
+      schemaVersion: options.schemaVersion ?? DEFAULT_RESOURCE_SCHEMA_VERSION,
+      provenance: options.provenance ?? null,
+      fetchedAt: now,
+      staleAt: now + options.cachePolicy.staleMs,
+      expiresAt: now + options.cachePolicy.expireMs,
+      lastAccessedAt: now,
+      sizeBytes: 0,
+      stale: false,
+      expired: false,
+    };
+    this.records.set(buildMapKey(record), record);
+    return record;
+  }
+
+  delete(key: ResourceCacheKey): void {
+    this.records.delete(buildMapKey(key));
+  }
+}

--- a/src/renderers/tauri/web/ui-host.tsx
+++ b/src/renderers/tauri/web/ui-host.tsx
@@ -2,6 +2,7 @@
 /** @jsxImportSource react */
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -14,12 +15,14 @@ import {
   type Ref,
   type WheelEvent as ReactWheelEvent,
 } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   StyledText,
   TextAttributes,
   type BoxRenderable,
   type BitmapSurface,
   type ChartCrosshairOverlay,
+  type HostTabsProps,
   type InputRenderable,
   type RendererHost,
   type ScrollBoxRenderable,
@@ -30,6 +33,7 @@ import {
 } from "../../../ui/host";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
 import { backendRequest } from "./backend-rpc";
+import { WebDataTable } from "./data-table";
 
 function cellWidth(value: unknown): CSSProperties["width"] {
   if (typeof value === "number") return `${value * WEB_CELL_WIDTH}px`;
@@ -46,10 +50,18 @@ function cellInset(value: unknown, axis: "x" | "y"): CSSProperties["paddingLeft"
   return value as CSSProperties["paddingLeft"];
 }
 
+function allowsZeroMinSize(props: Record<string, unknown>, axis: "inline" | "block"): boolean {
+  if (props.overflow === "hidden" || props.overflow === "clip") return true;
+  if (typeof props.flexShrink === "number" && props.flexShrink > 0) return true;
+  return axis === "inline" ? props.scrollX === true : props.scrollY === true;
+}
+
 function commonStyle(props: Record<string, unknown>): CSSProperties {
   const hasFixedInlineSize = props.width != null || props.flexBasis != null;
   const hasFixedBlockSize = props.height != null;
   const gapUnit = props.flexDirection === "row" ? WEB_CELL_WIDTH : WEB_CELL_HEIGHT;
+  const zeroMinInlineSize = props.minWidth == null && allowsZeroMinSize(props, "inline");
+  const zeroMinBlockSize = props.minHeight == null && allowsZeroMinSize(props, "block");
   return {
     color: typeof props.fg === "string" ? props.fg : undefined,
     backgroundColor: typeof props.bg === "string" ? props.bg : typeof props.backgroundColor === "string" ? props.backgroundColor : undefined,
@@ -85,8 +97,8 @@ function commonStyle(props: Record<string, unknown>): CSSProperties {
     overflow: props.overflow as CSSProperties["overflow"],
     border: props.border ? `1px solid ${typeof props.borderColor === "string" ? props.borderColor : "#3a4148"}` : undefined,
     boxSizing: "border-box",
-    minInlineSize: 0,
-    minBlockSize: 0,
+    minInlineSize: zeroMinInlineSize ? 0 : undefined,
+    minBlockSize: zeroMinBlockSize ? 0 : undefined,
   };
 }
 
@@ -623,6 +635,8 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
     );
     const horizontalScrollBarVisibleRef = useRef(horizontalScrollBarVisible);
     const verticalScrollBarVisibleRef = useRef(verticalScrollBarVisible);
+    const scrollFrameRef = useRef<number | null>(null);
+    const lastWheelAtRef = useRef(0);
 
     const getElement = () => elementRef.current;
     const toCellY = (pixels: number) => Math.max(0, Math.round(pixels / WEB_CELL_HEIGHT));
@@ -659,6 +673,12 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         verticalScrollBar.visible = false;
       }
     }, [props.scrollY, verticalScrollBar]);
+
+    useEffect(() => () => {
+      if (scrollFrameRef.current != null) {
+        cancelAnimationFrame(scrollFrameRef.current);
+      }
+    }, []);
 
     useImperativeHandle(ref, () => ({
       get scrollTop() {
@@ -709,6 +729,19 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
 
     const overflowX = props.scrollX === true ? "auto" : "hidden";
     const overflowY = props.scrollY === true ? "auto" : "hidden";
+    const handleScroll = useCallback(() => {
+      if (typeof props.onMouseScroll !== "function") return;
+      if (Date.now() - lastWheelAtRef.current < 32) return;
+      if (scrollFrameRef.current != null) return;
+      scrollFrameRef.current = requestAnimationFrame(() => {
+        scrollFrameRef.current = null;
+        (props.onMouseScroll as () => void)();
+      });
+    }, [props.onMouseScroll]);
+    const handleWheel = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
+      lastWheelAtRef.current = Date.now();
+      callMouseHandler(props.onMouseScroll, event, "scroll");
+    }, [props.onMouseScroll]);
 
     return (
       <div
@@ -721,8 +754,8 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         onMouseMove={(event) => callMouseHandler(props.onMouseMove, event, "move")}
         onMouseUp={(event) => callMouseHandler(props.onMouseUp, event, "up")}
         onMouseOut={(event) => callMouseHandler(props.onMouseOut, event, "out")}
-        onScroll={typeof props.onMouseScroll === "function" ? () => (props.onMouseScroll as () => void)() : undefined}
-        onWheel={typeof props.onMouseScroll === "function" ? (event) => callMouseHandler(props.onMouseScroll, event, "scroll") : undefined}
+        onScroll={typeof props.onMouseScroll === "function" ? handleScroll : undefined}
+        onWheel={typeof props.onMouseScroll === "function" ? handleWheel : undefined}
         style={{ ...commonStyle(props), overflowX, overflowY, ...(props.style as CSSProperties | undefined) }}
       >
         {children as ReactNode}
@@ -731,10 +764,125 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
   },
 );
 
+type CssVars = CSSProperties & Record<`--${string}`, string>;
+
+function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: HostTabsProps) {
+  const activeTabRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [activeValue, tabs]);
+
+  const handleWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+    const element = event.currentTarget;
+    if (element.scrollWidth <= element.clientWidth) return;
+    if (Math.abs(event.deltaX) >= Math.abs(event.deltaY)) return;
+
+    element.scrollLeft += event.deltaY;
+    event.preventDefault();
+  };
+
+  return (
+    <div
+      data-gloom-role="tab-list"
+      role="tablist"
+      onWheel={handleWheel}
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        width: "100%",
+        height: cellHeight(compact ? 1 : 2),
+        minInlineSize: 0,
+        flexShrink: 0,
+        overflowX: "auto",
+        overflowY: "hidden",
+      }}
+    >
+      {tabs.map((tab) => {
+        const active = tab.value === activeValue;
+        const disabled = tab.disabled === true;
+        const tabWidth = tab.label.length + 2;
+        const tabStyle = {
+          "--tab-fg": disabled ? palette.disabledFg : active ? palette.activeFg : palette.inactiveFg,
+          "--tab-hover-fg": palette.hoverFg,
+          "--tab-underline": active ? palette.activeUnderline : palette.inactiveUnderline,
+          "--tab-hover-underline": palette.hoverUnderline,
+          "--tab-hover-bg": palette.hoverBg,
+          color: "var(--tab-fg)",
+          width: cellWidth(tabWidth),
+          height: cellHeight(compact ? 1 : 2),
+          flex: "0 0 auto",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "stretch",
+          justifyContent: "flex-start",
+          padding: 0,
+          margin: 0,
+          border: 0,
+          background: "transparent",
+          font: "inherit",
+          lineHeight: "var(--cell-h)",
+          textAlign: "left",
+          whiteSpace: "pre",
+          cursor: disabled ? "default" : "pointer",
+        } satisfies CssVars;
+
+        return (
+          <button
+            key={tab.value}
+            ref={active ? activeTabRef : undefined}
+            data-gloom-role="tab-button"
+            data-active={active ? "true" : undefined}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-disabled={disabled || undefined}
+            disabled={disabled}
+            style={tabStyle}
+            onClick={() => {
+              if (!disabled) onSelect(tab.value);
+            }}
+          >
+            <span
+              data-gloom-role="tab-label"
+              style={{
+                display: "block",
+                height: "var(--cell-h)",
+                lineHeight: "var(--cell-h)",
+                fontWeight: active ? 700 : undefined,
+              }}
+            >
+              {` ${tab.label} `}
+            </span>
+            {!compact && (
+              <span
+                data-gloom-role="tab-underline"
+                aria-hidden="true"
+                style={{
+                  display: "block",
+                  height: "var(--cell-h)",
+                  lineHeight: "var(--cell-h)",
+                  color: "var(--tab-underline)",
+                }}
+              >
+                {"▔".repeat(tabWidth)}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export const webUiHost: UiHost = {
   kind: "tauri-web",
   capabilities: {
     nativePaneChrome: true,
+    titleBarOverlay: true,
     precisePointer: true,
     fractionalViewport: true,
     cellWidthPx: WEB_CELL_WIDTH,
@@ -771,6 +919,8 @@ export const webUiHost: UiHost = {
   ScrollBox: WebScrollBox,
   Input: WebInput,
   Textarea: WebTextarea,
+  DataTable: WebDataTable,
+  Tabs: WebTabs,
   ChartSurface: forwardRef<BoxRenderable, Record<string, unknown> & { children?: ReactNode }>(
     function WebChartSurface({ children, ...props }, ref) {
       const bitmap = (props.bitmap ?? null) as BitmapSurface | null;
@@ -820,6 +970,9 @@ export const webUiHost: UiHost = {
 export const webRendererHost: RendererHost = {
   requestExit() {
     void backendRequest("host.exit").catch(() => window.close());
+  },
+  async startWindowDrag() {
+    await getCurrentWindow().startDragging();
   },
   async openExternal(url) {
     await backendRequest("host.openExternal", { url });

--- a/src/state/app-bootstrap.ts
+++ b/src/state/app-bootstrap.ts
@@ -8,6 +8,8 @@ import type { TickerMetadata, TickerRecord } from "../types/ticker";
 import type { AppAction, PaneRuntimeState } from "./app-context";
 import type { AppSessionSnapshot } from "../core/state/session-persistence";
 import { getDockedPaneIds } from "../plugins/pane-manager";
+import { debugLog } from "../utils/debug-log";
+import { measurePerf, measurePerfAsync } from "../utils/perf-marks";
 
 const DEFAULT_WATCHLIST_TICKERS: Array<Pick<TickerMetadata, "ticker" | "exchange" | "currency" | "name">> = [
   { ticker: "AAPL", exchange: "NASDAQ", currency: "USD", name: "Apple Inc." },
@@ -41,6 +43,7 @@ const PORTFOLIO_FINANCIAL_COLUMN_IDS = new Set([
   "forward_pe",
   "dividend_yield",
 ]);
+const startupLog = debugLog.createLogger("startup");
 
 export interface InitializeAppStateArgs {
   config: AppConfig;
@@ -252,57 +255,128 @@ export async function initializeAppState({
   autoImportBrokerPositions,
   persistedBrokerAccounts = {},
 }: InitializeAppStateArgs): Promise<void> {
-  let tickers = await tickerRepository.loadAllTickers();
+  startupLog.info("initialize start", {
+    layoutPaneCount: config.layout.instances.length,
+    dockedPaneCount: getDockedPaneIds(config.layout).length,
+    floatingPaneCount: config.layout.floating.length,
+    brokerInstanceCount: config.brokerInstances.length,
+    sessionHydrationTargetCount: sessionSnapshot?.hydrationTargets.length ?? 0,
+    recentTickerCount: config.recentTickers.length,
+  });
+
+  let tickers = await measurePerfAsync("startup.load-tickers", () => tickerRepository.loadAllTickers());
+  startupLog.info("tickers loaded", { count: tickers.length });
 
   // Seed default watchlist tickers on first run
   if (tickers.length === 0) {
     const defaultWatchlistId = config.watchlists[0]?.id ?? "watchlist";
-    for (const entry of DEFAULT_WATCHLIST_TICKERS) {
-      await tickerRepository.createTicker({
-        ...entry,
-        portfolios: [],
-        watchlists: [defaultWatchlistId],
-        positions: [],
-        broker_contracts: [],
-        custom: {},
-        tags: [],
+    await measurePerfAsync("startup.seed-default-tickers", async () => {
+      for (const entry of DEFAULT_WATCHLIST_TICKERS) {
+        await tickerRepository.createTicker({
+          ...entry,
+          portfolios: [],
+          watchlists: [defaultWatchlistId],
+          positions: [],
+          broker_contracts: [],
+          custom: {},
+          tags: [],
+        });
+      }
+    }, { count: DEFAULT_WATCHLIST_TICKERS.length });
+    tickers = await measurePerfAsync("startup.reload-default-tickers", () => tickerRepository.loadAllTickers());
+    startupLog.info("default tickers seeded", {
+      defaultWatchlistId,
+      count: tickers.length,
+    });
+  }
+
+  const tickerMap = measurePerf("startup.build-ticker-map", () => {
+    const nextTickerMap = new Map<string, TickerRecord>();
+    for (const ticker of tickers) {
+      nextTickerMap.set(ticker.metadata.ticker, ticker);
+    }
+    return nextTickerMap;
+  }, { tickerCount: tickers.length });
+  measurePerf("startup.dispatch-set-tickers", () => {
+    dispatch({ type: "SET_TICKERS", tickers: tickerMap });
+  }, { tickerCount: tickerMap.size });
+
+  measurePerf("startup.dispatch-broker-accounts", () => {
+    for (const [instanceId, accounts] of Object.entries(persistedBrokerAccounts)) {
+      dispatch({ type: "SET_BROKER_ACCOUNTS", instanceId, accounts });
+    }
+  }, {
+    instanceCount: Object.keys(persistedBrokerAccounts).length,
+    accountCount: Object.values(persistedBrokerAccounts).reduce((sum, accounts) => sum + accounts.length, 0),
+  });
+
+  const paneStateSeed = measurePerf(
+    "startup.build-pane-state-seed",
+    () => buildPaneStateSeed(config, tickers, tickerMap, sessionSnapshot),
+    { paneCount: config.layout.instances.length },
+  );
+  measurePerf("startup.dispatch-pane-state-seed", () => {
+    for (const [paneId, patch] of Object.entries(paneStateSeed) as Array<[string, PaneRuntimeState]>) {
+      dispatch({ type: "UPDATE_PANE_STATE", paneId, patch });
+    }
+  }, { paneStateSeedCount: Object.keys(paneStateSeed).length });
+
+  const refreshPlan = measurePerf(
+    "startup.build-refresh-plan",
+    () => buildRefreshPlan(config, tickerMap, paneStateSeed, sessionSnapshot),
+    {
+      tickerCount: tickerMap.size,
+      sessionHydrationTargetCount: sessionSnapshot?.hydrationTargets.length ?? 0,
+      recentTickerCount: config.recentTickers.length,
+    },
+  );
+  startupLog.info("refresh plan built", {
+    count: refreshPlan.length,
+    financials: refreshPlan.filter((entry) => entry.mode === "financials").length,
+    quotes: refreshPlan.filter((entry) => entry.mode === "quote").length,
+    priority0: refreshPlan.filter((entry) => entry.priority === 0).length,
+    priority1: refreshPlan.filter((entry) => entry.priority === 1).length,
+    priority2: refreshPlan.filter((entry) => entry.priority === 2).length,
+    symbols: refreshPlan.map((entry) => `${entry.mode}:${entry.ticker.metadata.ticker}`),
+  });
+
+  if (primeCachedFinancials) {
+    const cachedPrimeEntries = measurePerf(
+      "startup.resolve-cached-financial-prime",
+      () => resolveCachedFinancialPrimeEntries(refreshPlan, sessionSnapshot, dataProvider),
+      { financialRefreshCount: refreshPlan.filter((entry) => entry.mode === "financials").length },
+    );
+    if (cachedPrimeEntries.length > 0) {
+      measurePerf("startup.prime-cached-financials", () => {
+        primeCachedFinancials(cachedPrimeEntries);
+      }, { count: cachedPrimeEntries.length });
+      startupLog.info("cached financials primed", {
+        count: cachedPrimeEntries.length,
+        symbols: cachedPrimeEntries.map((entry) => entry.ticker.metadata.ticker),
       });
     }
-    tickers = await tickerRepository.loadAllTickers();
   }
 
-  const tickerMap = new Map<string, TickerRecord>();
-  for (const ticker of tickers) {
-    tickerMap.set(ticker.metadata.ticker, ticker);
-  }
-  dispatch({ type: "SET_TICKERS", tickers: tickerMap });
+  measurePerf("startup.dispatch-initialized", () => {
+    dispatch({ type: "SET_INITIALIZED" });
+  });
 
-  for (const [instanceId, accounts] of Object.entries(persistedBrokerAccounts)) {
-    dispatch({ type: "SET_BROKER_ACCOUNTS", instanceId, accounts });
-  }
-
-  const paneStateSeed = buildPaneStateSeed(config, tickers, tickerMap, sessionSnapshot);
-  for (const [paneId, patch] of Object.entries(paneStateSeed) as Array<[string, PaneRuntimeState]>) {
-    dispatch({ type: "UPDATE_PANE_STATE", paneId, patch });
-  }
-
-  const refreshPlan = buildRefreshPlan(config, tickerMap, paneStateSeed, sessionSnapshot);
-  if (primeCachedFinancials) {
-    const cachedPrimeEntries = resolveCachedFinancialPrimeEntries(refreshPlan, sessionSnapshot, dataProvider);
-    if (cachedPrimeEntries.length > 0) {
-      primeCachedFinancials(cachedPrimeEntries);
+  measurePerf("startup.enqueue-refresh-plan", () => {
+    for (const entry of refreshPlan) {
+      if (entry.mode === "financials") {
+        refreshTicker(entry.ticker.metadata.ticker, entry.ticker.metadata.exchange, entry.ticker, entry.priority);
+      } else {
+        refreshQuote(entry.ticker.metadata.ticker, entry.ticker.metadata.exchange, entry.ticker, entry.priority);
+      }
     }
-  }
+  }, { count: refreshPlan.length });
 
-  dispatch({ type: "SET_INITIALIZED" });
-
-  for (const entry of refreshPlan) {
-    if (entry.mode === "financials") {
-      refreshTicker(entry.ticker.metadata.ticker, entry.ticker.metadata.exchange, entry.ticker, entry.priority);
-    } else {
-      refreshQuote(entry.ticker.metadata.ticker, entry.ticker.metadata.exchange, entry.ticker, entry.priority);
-    }
-  }
-
-  void autoImportBrokerPositions(tickerMap);
+  void measurePerfAsync("startup.auto-import-broker-positions", () => autoImportBrokerPositions(tickerMap), {
+    brokerInstanceCount: config.brokerInstances.length,
+  }).catch((error) => {
+    startupLog.warn("auto import broker positions failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  });
+  startupLog.info("initialize complete");
 }

--- a/src/state/app-context-selector.test.tsx
+++ b/src/state/app-context-selector.test.tsx
@@ -77,6 +77,29 @@ describe("pane selectors", () => {
     expect(testSetup.captureCharFrame()).toContain("AAPL:1");
   });
 
+  test("does not rerender pane-scoped ticker consumers when another pane receives focus", async () => {
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")}>
+        <PaneInstanceProvider paneId={TEST_PANE_ID}>
+          <DispatchCapture />
+          <PaneTickerHarness />
+        </PaneInstanceProvider>
+      </AppProvider>,
+      { width: 24, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("AAPL:1");
+
+    await act(() => {
+      capturedDispatch?.({ type: "FOCUS_PANE", paneId: "portfolio-list:main" });
+    });
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("AAPL:1");
+  });
+
   test("rerenders selector consumers when the theme changes", async () => {
     testSetup = await testRender(
       <AppProvider config={createTickerDetailConfig("AAPL")}>

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -13,7 +13,6 @@ import {
   type ReactNode,
 } from "react";
 import type { SessionStore } from "../data/session-store";
-import { saveConfig } from "../data/config-store";
 import { syncTheme } from "../theme/colors";
 import { findPaneInstance, type AppConfig, type PaneInstanceConfig } from "../types/config";
 import { setPaneSetting } from "../pane-settings";
@@ -32,6 +31,7 @@ import {
   resolveTickerForPane,
 } from "../core/state/app-state";
 import type { AppAction, AppState } from "../core/state/app-state";
+import { scheduleConfigSave } from "./config-save-scheduler";
 
 export {
   appReducer,
@@ -80,6 +80,11 @@ function useRequiredAppContext(): AppContextValue {
   return context;
 }
 
+function sameStringList(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
 export function useAppState(): AppContextLegacyValue {
   const context = useRequiredAppContext();
   if (!isAppStoreContextValue(context)) {
@@ -88,6 +93,25 @@ export function useAppState(): AppContextLegacyValue {
 
   const state = useSyncExternalStore(context.subscribe, context.getState, context.getState);
   return useMemo(() => ({ state, dispatch: context.dispatch }), [context.dispatch, state]);
+}
+
+export function useAppStateRef() {
+  const context = useRequiredAppContext();
+  const stateRef = useRef(isAppStoreContextValue(context) ? context.getState() : context.state);
+
+  useLayoutEffect(() => {
+    if (!isAppStoreContextValue(context)) {
+      stateRef.current = context.state;
+      return;
+    }
+
+    stateRef.current = context.getState();
+    return context.subscribe(() => {
+      stateRef.current = context.getState();
+    });
+  }, [context]);
+
+  return stateRef;
 }
 
 export function useAppDispatch(): Dispatch<AppAction> {
@@ -146,7 +170,8 @@ export function usePaneInstance(): PaneInstanceConfig | null {
 
 export function usePaneTicker(paneId?: string) {
   const paneContextId = useContext(PaneContext);
-  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
+  const needsFocusedPane = paneId == null && paneContextId == null;
+  const focusedPaneId = useAppSelector((state) => (needsFocusedPane ? state.focusedPaneId : null));
   const scopedPaneId = paneId ?? paneContextId ?? focusedPaneId;
   const symbol = useAppSelector((state) => (
     scopedPaneId ? resolveTickerForPane(state, scopedPaneId) : null
@@ -189,7 +214,8 @@ export function useFocusedTicker() {
 
 export function usePaneCollection(paneId?: string) {
   const paneContextId = useContext(PaneContext);
-  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
+  const needsFocusedPane = paneId == null && paneContextId == null;
+  const focusedPaneId = useAppSelector((state) => (needsFocusedPane ? state.focusedPaneId : null));
   const scopedPaneId = paneId ?? paneContextId ?? focusedPaneId;
   const collectionId = useAppSelector((state) => (
     scopedPaneId ? resolveCollectionForPane(state, scopedPaneId) : null
@@ -222,24 +248,26 @@ export function usePaneSettingValue<T>(
   fallback: T,
   paneId?: string,
 ): [T, (value: SetStateAction<T>) => void] {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const stateRef = useAppStateRef();
   const scopedPaneId = paneId ?? usePaneInstanceId();
-  const instance = findPaneInstance(state.config.layout, scopedPaneId);
+  const instance = useAppSelector((state) => findPaneInstance(state.config.layout, scopedPaneId) ?? null);
   const value = (instance?.settings?.[key] as T | undefined) ?? fallback;
 
-  const setValue = (nextValue: SetStateAction<T>) => {
-    const currentValue = (findPaneInstance(state.config.layout, scopedPaneId)?.settings?.[key] as T | undefined) ?? fallback;
+  const setValue = useCallback((nextValue: SetStateAction<T>) => {
+    const currentState = stateRef.current;
+    const currentValue = (findPaneInstance(currentState.config.layout, scopedPaneId)?.settings?.[key] as T | undefined) ?? fallback;
     const resolved = typeof nextValue === "function"
       ? (nextValue as (previousValue: T) => T)(currentValue)
       : nextValue;
-    const layout = setPaneSetting(state.config.layout, scopedPaneId, key, resolved);
-    const layouts = state.config.layouts.map((savedLayout, index) => (
-      index === state.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
+    const layout = setPaneSetting(currentState.config.layout, scopedPaneId, key, resolved);
+    const layouts = currentState.config.layouts.map((savedLayout, index) => (
+      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
     ));
-    const nextConfig = { ...state.config, layout, layouts };
+    const nextConfig = { ...currentState.config, layout, layouts };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
-    saveConfig(nextConfig).catch(() => {});
-  };
+    scheduleConfigSave(nextConfig);
+  }, [dispatch, fallback, key, scopedPaneId, stateRef]);
 
   return [value, setValue];
 }
@@ -281,10 +309,9 @@ export function AppProvider({
   }
 
   useEffect(() => {
-    if (previousRecentTickers.current !== state.recentTickers) {
-      previousRecentTickers.current = state.recentTickers;
-      saveConfig({ ...state.config, recentTickers: state.recentTickers }).catch(() => {});
-    }
+    if (sameStringList(previousRecentTickers.current, state.recentTickers)) return;
+    previousRecentTickers.current = state.recentTickers;
+    scheduleConfigSave({ ...state.config, recentTickers: state.recentTickers });
   }, [state.config, state.recentTickers]);
 
   useLayoutEffect(() => {

--- a/src/state/config-save-scheduler.ts
+++ b/src/state/config-save-scheduler.ts
@@ -1,0 +1,35 @@
+import { saveConfig } from "../data/config-store";
+import type { AppConfig } from "../types/config";
+import { debugLog } from "../utils/debug-log";
+import { measurePerfAsync } from "../utils/perf-marks";
+import {
+  CONFIG_SAVE_DEBOUNCE_MS,
+  createPersistScheduler,
+} from "./persist-scheduler";
+
+const log = debugLog.createLogger("persist");
+
+const configSaveScheduler = createPersistScheduler<AppConfig>({
+  delayMs: CONFIG_SAVE_DEBOUNCE_MS,
+  save: (config) => measurePerfAsync("persist.config.save", () => saveConfig(config)),
+  onError: (error) => {
+    log.warn("config.save.failed", { error: error instanceof Error ? error.message : String(error) });
+  },
+});
+
+export function scheduleConfigSave(config: AppConfig): void {
+  configSaveScheduler.schedule(config);
+}
+
+export function flushScheduledConfigSave(): Promise<void> {
+  return configSaveScheduler.flush();
+}
+
+export function cancelScheduledConfigSave(): void {
+  configSaveScheduler.cancel();
+}
+
+export async function saveConfigImmediately(config: AppConfig): Promise<void> {
+  cancelScheduledConfigSave();
+  await measurePerfAsync("persist.config.save", () => saveConfig(config));
+}

--- a/src/state/persist-scheduler.test.ts
+++ b/src/state/persist-scheduler.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { createPersistScheduler } from "./persist-scheduler";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("createPersistScheduler", () => {
+  test("coalesces scheduled saves and writes the latest value", async () => {
+    const saved: number[] = [];
+    const scheduler = createPersistScheduler<number>({
+      delayMs: 5,
+      save: (value) => saved.push(value),
+    });
+
+    scheduler.schedule(1);
+    scheduler.schedule(2);
+    scheduler.schedule(3);
+    await delay(15);
+
+    expect(saved).toEqual([3]);
+  });
+
+  test("flush saves immediately", async () => {
+    const saved: string[] = [];
+    const scheduler = createPersistScheduler<string>({
+      delayMs: 1000,
+      save: (value) => saved.push(value),
+    });
+
+    scheduler.schedule("pending");
+    await scheduler.flush();
+
+    expect(saved).toEqual(["pending"]);
+  });
+
+  test("cancel drops pending value", async () => {
+    const saved: string[] = [];
+    const scheduler = createPersistScheduler<string>({
+      delayMs: 5,
+      save: (value) => saved.push(value),
+    });
+
+    scheduler.schedule("pending");
+    scheduler.cancel();
+    await delay(15);
+
+    expect(saved).toEqual([]);
+  });
+
+  test("save errors are reported without escaping timer", async () => {
+    const errors: unknown[] = [];
+    const scheduler = createPersistScheduler<string>({
+      delayMs: 5,
+      save: () => {
+        throw new Error("boom");
+      },
+      onError: (error) => errors.push(error),
+    });
+
+    scheduler.schedule("pending");
+    await delay(15);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+  });
+});

--- a/src/state/persist-scheduler.ts
+++ b/src/state/persist-scheduler.ts
@@ -1,0 +1,69 @@
+export const CONFIG_SAVE_DEBOUNCE_MS = 500;
+export const SESSION_SAVE_DEBOUNCE_MS = 1000;
+export const PLUGIN_STATE_SAVE_DEBOUNCE_MS = 500;
+
+export interface PersistSchedulerOptions<T> {
+  delayMs: number;
+  save: (value: T) => Promise<void> | void;
+  onError?: (error: unknown) => void;
+}
+
+export interface PersistScheduler<T> {
+  schedule(value: T): void;
+  flush(): Promise<void>;
+  cancel(): void;
+}
+
+export function createPersistScheduler<T>({
+  delayMs,
+  save,
+  onError,
+}: PersistSchedulerOptions<T>): PersistScheduler<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pendingValue: T | undefined;
+  let hasPendingValue = false;
+  let inFlight: Promise<void> = Promise.resolve();
+
+  const clearTimer = () => {
+    if (!timer) return;
+    clearTimeout(timer);
+    timer = null;
+  };
+
+  const runSave = async (value: T) => {
+    try {
+      await save(value);
+    } catch (error) {
+      onError?.(error);
+    }
+  };
+
+  const drain = async () => {
+    clearTimer();
+    if (!hasPendingValue) return inFlight;
+    const value = pendingValue as T;
+    pendingValue = undefined;
+    hasPendingValue = false;
+    inFlight = inFlight.then(() => runSave(value));
+    return inFlight;
+  };
+
+  return {
+    schedule(value: T): void {
+      pendingValue = value;
+      hasPendingValue = true;
+      clearTimer();
+      timer = setTimeout(() => {
+        void drain();
+      }, Math.max(0, delayMs));
+    },
+    flush(): Promise<void> {
+      return drain();
+    },
+    cancel(): void {
+      clearTimer();
+      pendingValue = undefined;
+      hasPendingValue = false;
+    },
+  };
+}

--- a/src/state/selectors-ui.ts
+++ b/src/state/selectors-ui.ts
@@ -1,0 +1,55 @@
+import type { AppState } from "../core/state/app-state";
+import type { LayoutConfig, SavedLayout } from "../types/config";
+import type { ReleaseInfo, UpdateProgress } from "../updater";
+
+export function selectLayout(state: AppState): LayoutConfig {
+  return state.config.layout;
+}
+
+export function selectFocusedPaneId(state: AppState): string | null {
+  return state.focusedPaneId;
+}
+
+export function selectCommandBarOpen(state: AppState): boolean {
+  return state.commandBarOpen;
+}
+
+export function selectStatusBarVisible(state: AppState): boolean {
+  return state.statusBarVisible;
+}
+
+export function selectBaseCurrency(state: AppState): string {
+  return state.config.baseCurrency;
+}
+
+export function selectSavedLayouts(state: AppState): SavedLayout[] {
+  return state.config.layouts;
+}
+
+export function selectActiveLayoutIndex(state: AppState): number {
+  return state.config.activeLayoutIndex;
+}
+
+export function selectGridlockTipVisible(state: AppState): boolean {
+  return state.gridlockTipVisible;
+}
+
+export function selectGridlockTipSequence(state: AppState): number {
+  return state.gridlockTipSequence;
+}
+
+export function selectUpdateAvailable(state: AppState): ReleaseInfo | null {
+  return state.updateAvailable;
+}
+
+export function selectUpdateProgress(state: AppState): UpdateProgress | null {
+  return state.updateProgress;
+}
+
+export function selectUpdateCheckInProgress(state: AppState): boolean {
+  return state.updateCheckInProgress;
+}
+
+export function selectUpdateNotice(state: AppState): string | null {
+  return state.updateNotice;
+}

--- a/src/state/ticker-refresh-queue.ts
+++ b/src/state/ticker-refresh-queue.ts
@@ -1,15 +1,26 @@
 
+import { debugLog } from "../utils/debug-log";
+import { measurePerfAsync } from "../utils/perf-marks";
+
 export interface TickerRefreshTask {
   key: string;
   priority: number;
   run: () => Promise<void>;
 }
 
+interface QueuedTickerRefreshTask extends TickerRefreshTask {
+  enqueuedAt: number;
+}
+
+const TASK_WARN_MS = 500;
+const WAIT_WARN_MS = 1000;
+const refreshQueueLog = debugLog.createLogger("refresh-queue");
+
 export class TickerRefreshQueue {
   private active = 0;
   private paused = false;
   private readonly pendingKeys = new Set<string>();
-  private readonly queue: TickerRefreshTask[] = [];
+  private readonly queue: QueuedTickerRefreshTask[] = [];
 
   constructor(private readonly concurrency = 3) {}
 
@@ -21,8 +32,15 @@ export class TickerRefreshQueue {
   enqueue(task: TickerRefreshTask): void {
     if (this.pendingKeys.has(task.key)) return;
     this.pendingKeys.add(task.key);
-    this.queue.push(task);
+    this.queue.push({ ...task, enqueuedAt: Date.now() });
     this.queue.sort((a, b) => a.priority - b.priority);
+    refreshQueueLog.info("task queued", {
+      key: task.key,
+      priority: task.priority,
+      active: this.active,
+      pending: this.queue.length,
+      paused: this.paused,
+    });
     this.pump();
   }
 
@@ -31,7 +49,37 @@ export class TickerRefreshQueue {
     while (this.active < this.concurrency && this.queue.length > 0) {
       const next = this.queue.shift()!;
       this.active += 1;
-      void next.run().finally(() => {
+      const waitMs = Date.now() - next.enqueuedAt;
+      refreshQueueLog.info("task started", {
+        key: next.key,
+        priority: next.priority,
+        waitMs,
+        active: this.active,
+        pending: this.queue.length,
+      });
+      void measurePerfAsync(
+        `refresh-queue.${next.key}`,
+        next.run,
+        {
+          key: next.key,
+          priority: next.priority,
+          waitMs,
+        },
+      ).finally(() => {
+        const durationMs = Date.now() - next.enqueuedAt - waitMs;
+        const payload = {
+          key: next.key,
+          priority: next.priority,
+          waitMs,
+          durationMs,
+          active: this.active - 1,
+          pending: this.queue.length,
+        };
+        if (durationMs >= TASK_WARN_MS || waitMs >= WAIT_WARN_MS) {
+          refreshQueueLog.warn("task finished slowly", payload);
+        } else {
+          refreshQueueLog.info("task finished", payload);
+        }
         this.active -= 1;
         this.pendingKeys.delete(next.key);
         this.pump();

--- a/src/state/use-inline-tickers.ts
+++ b/src/state/use-inline-tickers.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getSharedRegistry } from "../plugins/registry";
-import { useAppState } from "./app-context";
+import { useAppDispatch, useAppSelector } from "./app-context";
 import { resolveTickerSearch, upsertTickerFromSearchResult } from "../utils/ticker-search";
 import { collectUniqueTickerSymbols } from "../utils/ticker-tokenizer";
 import { useQuoteStreaming } from "./use-quote-streaming";
@@ -28,15 +28,17 @@ export function useInlineTickers(texts: readonly string[]): {
   catalog: Record<string, InlineTickerCatalogEntry>;
   openTicker: (symbol: string) => void;
 } {
-  const { state, dispatch } = useAppState();
+  const dispatch = useAppDispatch();
+  const tickers = useAppSelector((state) => state.tickers);
+  const financials = useAppSelector((state) => state.financials);
   const registry = getSharedRegistry();
   const [, setRefreshVersion] = useState(0);
   const textsKey = texts.join("\u0000");
   const symbols = useMemo(() => normalizeSymbols(texts), [textsKey]);
   const symbolsKey = symbols.join("|");
-  const latestRef = useRef({ state, dispatch, registry });
+  const latestRef = useRef({ tickers, financials, dispatch, registry });
 
-  latestRef.current = { state, dispatch, registry };
+  latestRef.current = { tickers, financials, dispatch, registry };
 
   useEffect(() => {
     let mounted = true;
@@ -46,9 +48,9 @@ export function useInlineTickers(texts: readonly string[]): {
     };
 
     for (const symbol of symbols) {
-      const currentState = latestRef.current.state;
-      const currentTicker = currentState.tickers.get(symbol) ?? null;
-      const currentQuote = currentState.financials.get(symbol)?.quote ?? null;
+      const current = latestRef.current;
+      const currentTicker = current.tickers.get(symbol) ?? null;
+      const currentQuote = current.financials.get(symbol)?.quote ?? null;
 
       if (currentTicker && currentQuote) {
         missingSymbols.delete(symbol);
@@ -66,7 +68,7 @@ export function useInlineTickers(texts: readonly string[]): {
             const resolved = await resolveTickerSearch({
               query: symbol,
               activeTicker: null,
-              tickers: current.state.tickers,
+              tickers: current.tickers,
               dataProvider: activeRegistry.dataProvider,
             });
 
@@ -106,7 +108,7 @@ export function useInlineTickers(texts: readonly string[]): {
           const activeRegistry = current.registry;
           if (!activeRegistry) return;
 
-          const latestTicker = current.state.tickers.get(symbol);
+          const latestTicker = current.tickers.get(symbol);
           if (!latestTicker) return;
 
           const instrument = latestTicker.metadata.broker_contracts?.[0] ?? null;
@@ -134,10 +136,10 @@ export function useInlineTickers(texts: readonly string[]): {
     return () => {
       mounted = false;
     };
-  }, [dispatch, registry, state.financials, state.tickers, symbols, symbolsKey]);
+  }, [dispatch, financials, registry, symbols, symbolsKey, tickers]);
 
   const streamingTargets = symbols
-    .map((symbol) => state.tickers.get(symbol))
+    .map((symbol) => tickers.get(symbol))
     .filter((ticker): ticker is TickerRecord => ticker != null)
     .map((ticker) => {
       const instrument = ticker.metadata.broker_contracts?.[0] ?? null;
@@ -162,8 +164,8 @@ export function useInlineTickers(texts: readonly string[]): {
 
   const catalog: Record<string, InlineTickerCatalogEntry> = {};
   for (const symbol of symbols) {
-    const ticker = state.tickers.get(symbol) ?? null;
-    const quote = state.financials.get(symbol)?.quote ?? null;
+    const ticker = tickers.get(symbol) ?? null;
+    const quote = financials.get(symbol)?.quote ?? null;
     const status: InlineTickerStatus = ticker
       ? (quote ? "ready" : "loading")
       : (missingSymbols.has(symbol) ? "missing" : "loading");

--- a/src/state/use-session-snapshot.ts
+++ b/src/state/use-session-snapshot.ts
@@ -5,6 +5,11 @@ import {
   type AppSessionSnapshot,
 } from "../core/state/session-persistence";
 import type { AppState } from "./app-context";
+import { measurePerf } from "../utils/perf-marks";
+import {
+  createPersistScheduler,
+  SESSION_SAVE_DEBOUNCE_MS,
+} from "./persist-scheduler";
 
 export function usePersistSessionSnapshot(
   sessionStore: SessionStore | undefined,
@@ -25,20 +30,33 @@ export function usePersistSessionSnapshot(
     schemaVersion,
   };
 
-  const saveSnapshotRef = useRef<() => void>(() => {});
-  saveSnapshotRef.current = () => {
+  const schedulerRef = useRef<ReturnType<typeof createPersistScheduler<AppSessionSnapshot>> | null>(null);
+  if (!schedulerRef.current) {
+    schedulerRef.current = createPersistScheduler<AppSessionSnapshot>({
+      delayMs: SESSION_SAVE_DEBOUNCE_MS,
+      save: (snapshot) => {
+        const {
+          sessionStore: currentStore,
+          sessionId: currentSessionId,
+          schemaVersion: currentSchemaVersion,
+        } = latestRef.current;
+        if (!currentStore) return;
+        measurePerf("persist.session.save", () => {
+          currentStore.set(currentSessionId, snapshot, currentSchemaVersion);
+        }, { sessionId: currentSessionId });
+      },
+    });
+  }
+
+  const buildSnapshot = (): AppSessionSnapshot | null => {
     const {
-      sessionStore: currentStore,
       state: currentState,
-      sessionId: currentSessionId,
-      schemaVersion: currentSchemaVersion,
     } = latestRef.current;
 
-    if (!currentStore) return;
-    if (!currentState.initialized && currentState.tickers.size === 0) return;
+    if (!currentState.initialized && currentState.tickers.size === 0) return null;
 
     try {
-      currentStore.set(currentSessionId, buildAppSessionSnapshot({
+      return buildAppSessionSnapshot({
         config: currentState.config,
         paneState: currentState.paneState,
         focusedPaneId: currentState.focusedPaneId,
@@ -47,21 +65,18 @@ export function usePersistSessionSnapshot(
         recentTickers: currentState.recentTickers,
         tickers: currentState.tickers,
         exchangeRates: currentState.exchangeRates,
-      }) satisfies AppSessionSnapshot, currentSchemaVersion);
+      }) satisfies AppSessionSnapshot;
     } catch {
       // Snapshot persistence is best-effort during teardown.
+      return null;
     }
   };
 
   useEffect(() => {
     if (!sessionStore) return;
     if (!state.initialized && state.tickers.size === 0) return;
-    const timer = setTimeout(() => {
-      saveSnapshotRef.current();
-    }, 250);
-    return () => {
-      clearTimeout(timer);
-    };
+    const snapshot = buildSnapshot();
+    if (snapshot) schedulerRef.current?.schedule(snapshot);
   }, [
     sessionStore,
     sessionId,
@@ -78,7 +93,7 @@ export function usePersistSessionSnapshot(
 
   useEffect(() => {
     return () => {
-      saveSnapshotRef.current();
+      void schedulerRef.current?.flush();
     };
   }, []);
 }

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -171,10 +171,36 @@ export interface SpinnerMarkProps extends BoxProps {
   color?: string;
 }
 
+export interface HostTabItem {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface HostTabsPalette {
+  activeFg: string;
+  inactiveFg: string;
+  disabledFg: string;
+  hoverFg: string;
+  activeUnderline: string;
+  inactiveUnderline: string;
+  hoverUnderline: string;
+  hoverBg: string;
+}
+
+export interface HostTabsProps {
+  tabs: HostTabItem[];
+  activeValue: string;
+  onSelect: (value: string) => void;
+  compact?: boolean;
+  palette: HostTabsPalette;
+}
+
 export interface UiHost {
   kind?: "opentui" | "tauri-web";
   capabilities?: {
     nativePaneChrome?: boolean;
+    titleBarOverlay?: boolean;
     precisePointer?: boolean;
     fractionalViewport?: boolean;
     cellWidthPx?: number;
@@ -193,12 +219,15 @@ export interface UiHost {
   ChartSurface: ComponentType<ChartSurfaceProps>;
   ImageSurface: ComponentType<ImageSurfaceProps>;
   SpinnerMark: ComponentType<SpinnerMarkProps>;
+  Tabs?: ComponentType<HostTabsProps>;
+  DataTable?: ComponentType<any>;
   createSyntaxStyle?(): SyntaxStyleLike;
   colorFromHex?(hex: string): unknown;
 }
 
 export interface RendererHost {
   requestExit(): void;
+  startWindowDrag?(): Promise<void> | void;
   openExternal(url: string): Promise<void>;
   copyText(text: string): Promise<void>;
   readText(): Promise<string>;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,10 +1,23 @@
 import { createElement, forwardRef, type ReactNode } from "react";
 import { useUiHost, useRendererHost } from "./host";
-export { RGBA, StyledText, TextAttributes, UiHostProvider, useNativeRenderer, useRendererHost, useSyntaxStyleFactory, useUiCapabilities } from "./host";
+export {
+  RGBA,
+  StyledText,
+  TextAttributes,
+  UiHostProvider,
+  useNativeRenderer,
+  useRendererHost,
+  useSyntaxStyleFactory,
+  useUiCapabilities,
+  useUiHost,
+} from "./host";
 export type {
   BoxRenderable,
   BoxProps,
   ChartSurfaceProps,
+  HostTabItem,
+  HostTabsPalette,
+  HostTabsProps,
   Highlight,
   ImageSurfaceProps,
   InputRenderable,

--- a/src/utils/debug-log.ts
+++ b/src/utils/debug-log.ts
@@ -11,12 +11,33 @@ export interface LogEntry {
 }
 
 type LogListener = (entry: LogEntry) => void;
+type ConsoleMethod = (...args: unknown[]) => void;
+
+interface ConsoleMirror {
+  sources: Set<string> | null;
+  minLevel: LogLevel;
+  methods: {
+    log: ConsoleMethod;
+    info: ConsoleMethod;
+    warn: ConsoleMethod;
+    error: ConsoleMethod;
+  };
+}
+
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
 
 class DebugLog {
   private entries: LogEntry[] = [];
   private listeners = new Set<LogListener>();
   private nextId = 1;
   private maxEntries = 5000;
+  private consoleMirror: ConsoleMirror | null = null;
+  private mirroringToConsole = false;
 
   /** Create a logger scoped to a source (plugin id, module name, etc.) */
   createLogger(source: string) {
@@ -41,8 +62,54 @@ class DebugLog {
     if (this.entries.length > this.maxEntries) {
       this.entries = this.entries.slice(-Math.floor(this.maxEntries * 0.8));
     }
+    this.mirrorEntryToConsole(entry);
     for (const listener of this.listeners) {
       try { listener(entry); } catch { /* ignore */ }
+    }
+  }
+
+  /** Mirror selected debug-log sources to the real console for DevTools diagnostics. */
+  mirrorToConsole(options: { sources?: readonly string[]; minLevel?: LogLevel } = {}): () => void {
+    const mirror: ConsoleMirror = {
+      sources: options.sources ? new Set(options.sources) : null,
+      minLevel: options.minLevel ?? "debug",
+      methods: {
+        log: console.log.bind(console),
+        info: console.info.bind(console),
+        warn: console.warn.bind(console),
+        error: console.error.bind(console),
+      },
+    };
+    this.consoleMirror = mirror;
+    return () => {
+      if (this.consoleMirror === mirror) this.consoleMirror = null;
+    };
+  }
+
+  private mirrorEntryToConsole(entry: LogEntry) {
+    const mirror = this.consoleMirror;
+    if (this.mirroringToConsole) return;
+    if (!mirror) return;
+    if (mirror.sources && !mirror.sources.has(entry.source)) return;
+    if (LOG_LEVEL_RANK[entry.level] < LOG_LEVEL_RANK[mirror.minLevel]) return;
+
+    const ts = new Date(entry.timestamp).toISOString().slice(11, 23);
+    const prefix = `[gloom:${entry.source}] ${ts} ${entry.message}`;
+    const method =
+      entry.level === "error" ? mirror.methods.error
+      : entry.level === "warn" ? mirror.methods.warn
+      : entry.level === "info" ? mirror.methods.info
+      : mirror.methods.log;
+
+    try {
+      this.mirroringToConsole = true;
+      if (entry.data === undefined) {
+        method(prefix);
+      } else {
+        method(prefix, entry.data);
+      }
+    } finally {
+      this.mirroringToConsole = false;
     }
   }
 

--- a/src/utils/main-thread-monitor.ts
+++ b/src/utils/main-thread-monitor.ts
@@ -1,0 +1,127 @@
+import { debugLog } from "./debug-log";
+
+const SAMPLE_INTERVAL_MS = 50;
+const LAG_WARN_MS = 100;
+const LAG_ERROR_MS = 300;
+const LONG_TASK_WARN_MS = 50;
+
+const mainThreadLog = debugLog.createLogger("main-thread");
+
+function now(): number {
+  const perf = (globalThis as { performance?: { now?: () => number } }).performance;
+  return typeof perf?.now === "function" ? perf.now() : Date.now();
+}
+
+function summarizeLongTask(entry: unknown): Record<string, unknown> {
+  const value = entry as {
+    name?: string;
+    duration?: number;
+    startTime?: number;
+    attribution?: Array<Record<string, unknown>>;
+  };
+  return {
+    name: value.name,
+    durationMs: Math.round((value.duration ?? 0) * 10) / 10,
+    startTimeMs: Math.round((value.startTime ?? 0) * 10) / 10,
+    attribution: value.attribution?.map((item) => ({
+      name: item.name,
+      entryType: item.entryType,
+      containerType: item.containerType,
+      containerName: item.containerName,
+      containerId: item.containerId,
+      scriptUrl: item.scriptUrl,
+      lineNumber: item.lineNumber,
+      columnNumber: item.columnNumber,
+    })).slice(0, 3),
+  };
+}
+
+export function startMainThreadMonitor(
+  scope: string,
+  options: { mirrorToConsole?: boolean } = {},
+): () => void {
+  let stopped = false;
+  let lastTick = now();
+  let maxLagMs = 0;
+  let sampleCount = 0;
+
+  mainThreadLog.info("monitor started", {
+    scope,
+    sampleIntervalMs: SAMPLE_INTERVAL_MS,
+    lagWarnMs: LAG_WARN_MS,
+    lagErrorMs: LAG_ERROR_MS,
+  });
+
+  const intervalId = setInterval(() => {
+    const current = now();
+    const elapsedMs = current - lastTick;
+    lastTick = current;
+    sampleCount += 1;
+
+    const lagMs = elapsedMs - SAMPLE_INTERVAL_MS;
+    if (lagMs <= 0) return;
+    maxLagMs = Math.max(maxLagMs, lagMs);
+    if (lagMs < LAG_WARN_MS) return;
+
+    const payload = {
+      scope,
+      lagMs: Math.round(lagMs * 10) / 10,
+      elapsedMs: Math.round(elapsedMs * 10) / 10,
+      sampleIntervalMs: SAMPLE_INTERVAL_MS,
+      sampleCount,
+      maxLagMs: Math.round(maxLagMs * 10) / 10,
+    };
+    if (lagMs >= LAG_ERROR_MS) {
+      mainThreadLog.error("event loop blocked", payload);
+    } else {
+      mainThreadLog.warn("event loop delayed", payload);
+    }
+    if (options.mirrorToConsole) {
+      console.error(
+        `perf main-thread.stall scope=${scope} lag_ms=${payload.lagMs} elapsed_ms=${payload.elapsedMs} sample_interval_ms=${SAMPLE_INTERVAL_MS}`,
+      );
+    }
+  }, SAMPLE_INTERVAL_MS);
+
+  const ObserverCtor = (globalThis as { PerformanceObserver?: unknown }).PerformanceObserver;
+  let observer: { disconnect?: () => void } | null = null;
+  if (typeof ObserverCtor === "function") {
+    try {
+      observer = new (ObserverCtor as new (callback: (list: { getEntries: () => unknown[] }) => void) => {
+        observe: (options: { entryTypes: string[] }) => void;
+        disconnect: () => void;
+      })((list) => {
+        for (const entry of list.getEntries()) {
+          const durationMs = (entry as { duration?: number }).duration ?? 0;
+          if (durationMs < LONG_TASK_WARN_MS) continue;
+          const payload = { scope, ...summarizeLongTask(entry) };
+          if (durationMs >= LAG_ERROR_MS) {
+            mainThreadLog.error("browser long task", payload);
+          } else {
+            mainThreadLog.warn("browser long task", payload);
+          }
+          if (options.mirrorToConsole) {
+            console.error(
+              `perf main-thread.longtask scope=${scope} duration_ms=${Math.round(durationMs * 10) / 10}`,
+            );
+          }
+        }
+      });
+      observer.observe({ entryTypes: ["longtask"] });
+    } catch {
+      observer = null;
+    }
+  }
+
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(intervalId);
+    observer?.disconnect?.();
+    mainThreadLog.info("monitor stopped", {
+      scope,
+      sampleCount,
+      maxLagMs: Math.round(maxLagMs * 10) / 10,
+    });
+  };
+}

--- a/src/utils/perf-marks.ts
+++ b/src/utils/perf-marks.ts
@@ -1,0 +1,98 @@
+import { debugLog } from "./debug-log";
+
+export interface PerfSample {
+  name: string;
+  startedAt: number;
+  durationMs: number;
+  metadata?: Record<string, unknown>;
+}
+
+export type PerfListener = (sample: PerfSample) => void;
+
+const PERF_SAMPLE_LIMIT = 300;
+const PERF_WARN_MS = 50;
+const PERF_ERROR_MS = 200;
+
+const perfLog = debugLog.createLogger("perf");
+const samples: PerfSample[] = [];
+const listeners = new Set<PerfListener>();
+
+function now(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+function emitSample(sample: PerfSample): void {
+  samples.push(sample);
+  if (samples.length > PERF_SAMPLE_LIMIT) {
+    samples.splice(0, samples.length - PERF_SAMPLE_LIMIT);
+  }
+
+  const payload = {
+    durationMs: Math.round(sample.durationMs * 10) / 10,
+    ...(sample.metadata ?? {}),
+  };
+  if (sample.durationMs >= PERF_ERROR_MS) {
+    perfLog.error(sample.name, payload);
+  } else if (sample.durationMs >= PERF_WARN_MS) {
+    perfLog.warn(sample.name, payload);
+  }
+
+  for (const listener of listeners) {
+    try {
+      listener(sample);
+    } catch {
+      // Perf listeners are diagnostic only.
+    }
+  }
+}
+
+export function measurePerf<T>(
+  name: string,
+  fn: () => T,
+  metadata?: Record<string, unknown>,
+): T {
+  const startedAt = Date.now();
+  const start = now();
+  try {
+    return fn();
+  } finally {
+    emitSample({
+      name,
+      startedAt,
+      durationMs: now() - start,
+      metadata,
+    });
+  }
+}
+
+export async function measurePerfAsync<T>(
+  name: string,
+  fn: () => Promise<T>,
+  metadata?: Record<string, unknown>,
+): Promise<T> {
+  const startedAt = Date.now();
+  const start = now();
+  try {
+    return await fn();
+  } finally {
+    emitSample({
+      name,
+      startedAt,
+      durationMs: now() - start,
+      metadata,
+    });
+  }
+}
+
+export function subscribePerf(listener: PerfListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getRecentPerfSamples(limit = PERF_SAMPLE_LIMIT): PerfSample[] {
+  return samples.slice(-Math.max(0, limit));
+}

--- a/src/utils/selection-clipboard.test.ts
+++ b/src/utils/selection-clipboard.test.ts
@@ -16,6 +16,10 @@ describe("selection clipboard sync", () => {
   test("ignores empty or missing selections", () => {
     expect(copyActiveSelection({
       copyToClipboardOSC52: () => true,
+    } as any)).toBe(false);
+
+    expect(copyActiveSelection({
+      copyToClipboardOSC52: () => true,
       getSelection: () => null,
     } as any)).toBe(false);
 
@@ -25,6 +29,18 @@ describe("selection clipboard sync", () => {
         getSelectedText: () => "",
       }),
     } as any)).toBe(false);
+
+    const originalSpawnSync = Bun.spawnSync;
+    try {
+      (Bun as any).spawnSync = undefined;
+      expect(copyActiveSelection({
+        getSelection: () => ({
+          getSelectedText: () => "AAPL",
+        }),
+      } as any)).toBe(false);
+    } finally {
+      (Bun as any).spawnSync = originalSpawnSync;
+    }
   });
 
   test("matches explicit copy shortcuts only", () => {

--- a/src/utils/selection-clipboard.ts
+++ b/src/utils/selection-clipboard.ts
@@ -52,13 +52,13 @@ export function copySelectionText(
     return false;
   }
 
-  return renderer.copyToClipboardOSC52(text) || copyTextToSystemClipboard(text);
+  return renderer.copyToClipboardOSC52?.(text) === true || copyTextToSystemClipboard(text);
 }
 
 export function copyActiveSelection(
   renderer: Pick<CliRenderer, "getSelection" | "copyToClipboardOSC52">,
 ): boolean {
-  const text = renderer.getSelection()?.getSelectedText() ?? "";
+  const text = renderer.getSelection?.()?.getSelectedText() ?? "";
   return copySelectionText(renderer, text);
 }
 

--- a/src/utils/throttled-fetch.test.ts
+++ b/src/utils/throttled-fetch.test.ts
@@ -137,6 +137,25 @@ describe("createThrottledFetch", () => {
     const client = createThrottledFetch({ maxRetries: 0 });
     await expect(client.fetchJson("https://api.example.com/test")).rejects.toThrow("Rate limited");
   });
+
+  test("uses a client-specific fetch transport", async () => {
+    const transportMock = mock((url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.example.com/proxied");
+      expect((init?.headers as Record<string, string>)["X-Transport"]).toBe("1");
+      return Promise.resolve(new Response("proxied", { status: 202 }));
+    });
+
+    const client = createThrottledFetch({
+      defaultHeaders: { "X-Transport": "1" },
+      transport: transportMock,
+    });
+    const resp = await client.fetch("https://api.example.com/proxied");
+
+    expect(resp.status).toBe(202);
+    expect(await resp.text()).toBe("proxied");
+    expect(transportMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 // Restore

--- a/src/utils/throttled-fetch.ts
+++ b/src/utils/throttled-fetch.ts
@@ -25,6 +25,8 @@ export interface ThrottledFetchOptions {
   defaultHeaders?: Record<string, string>;
   /** Share concurrent GET requests to the same URL. Default: true */
   dedupeGetRequests?: boolean;
+  /** Override the underlying request transport for this client */
+  transport?: ThrottledFetchTransport;
 }
 
 interface QueueEntry {
@@ -40,6 +42,11 @@ export interface ThrottledFetchClient {
   fetchJson<T = unknown>(url: string, init?: RequestInit): Promise<T>;
 }
 
+export type ThrottledFetchTransport = (
+  url: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
 export function createThrottledFetch(
   options: ThrottledFetchOptions = {},
 ): ThrottledFetchClient {
@@ -50,6 +57,8 @@ export function createThrottledFetch(
   const backoffBaseMs = options.backoffBaseMs ?? BACKOFF_BASE_MS;
   const defaultHeaders = options.defaultHeaders ?? {};
   const dedupeGetRequests = options.dedupeGetRequests ?? true;
+  const fetchTransport =
+    options.transport ?? ((url: string, init?: RequestInit) => globalThis.fetch(url, init));
 
   // Sliding window: track timestamps of recent requests per host
   const hostTimestamps = new Map<string, number[]>();
@@ -142,7 +151,7 @@ export function createThrottledFetch(
 
     let resp: Response;
     try {
-      resp = await fetch(url, mergedInit);
+      resp = await fetchTransport(url, mergedInit);
     } catch (error) {
       if (retriesLeft > 0 && isRetryableFetchError(error, !init?.signal)) {
         await new Promise((resolve) =>


### PR DESCRIPTION
Adds broad Tauri/web responsiveness work: backend RPC multiplexing, perf/main-thread instrumentation, batched key-scoped market data, coalesced persistence, and reduced broad state updates. Adds a Tauri-specific DOM DataTable backed by TanStack virtualization plus scroll/hover throttling, native web tabs/header behavior, row-value caching, and prediction-market data/cache tuning. Adds pane footer hint UI and updates plugin panes/tests to use the new shared interaction model. Verified with targeted UI/prediction-market tests and `bun run tauri:web:build` during implementation.