### PR TITLE
Fix loading/spinner behavior in news wire panes

### DIFF
--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { PaneProps } from "../../../types/plugin";
 import { usePaneFooter } from "../../../components";
 import { useNewsArticles } from "../../../news/hooks";
+import { Spinner } from "../../../components/spinner";
 import { usePluginPaneState } from "../../plugin-runtime";
 import type { MarketNewsItem } from "../../../types/news-source";
 import { detectProviders, getAiProvider, resolveDefaultAiProviderId } from "../ai/providers";
@@ -27,7 +28,9 @@ function buildDigestPrompt(item: MarketNewsItem): string {
 }
 
 export function BreakingPane({ focused, width, height }: PaneProps) {
-  const articles = useNewsArticles(NEWS_QUERY_PRESETS.breaking).articles;
+  const breakingState = useNewsArticles(NEWS_QUERY_PRESETS.breaking);
+  const articles = breakingState.articles;
+  const loading = breakingState.phase === "loading" || (breakingState.phase === "refreshing" && articles.length === 0);
   const [selectedArticleId, setSelectedArticleId] = usePluginPaneState<string | null>("breaking:selectedArticleId", null);
   const [sortPreference, setSortPreference] = usePluginPaneState<NewsSortPreference>("breaking:sort", DEFAULT_SORT);
   const [digestVersion, setDigestVersion] = useState(0);
@@ -113,6 +116,10 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
   ) : (
     <Box flexGrow={1} />
   );
+
+  if (loading && articles.length === 0) {
+    return <Spinner label="Loading breaking news..." />;
+  }
 
   return (
     <NewsArticleStackView

--- a/src/plugins/builtin/news-wire/feed-pane.tsx
+++ b/src/plugins/builtin/news-wire/feed-pane.tsx
@@ -14,8 +14,8 @@ export function FeedPane(props: PaneProps) {
       query={NEWS_QUERY_PRESETS.feed}
       columns={["time", "source", "title", "tickers", "categories"]}
       defaultSort={DEFAULT_SORT}
-      emptyStateTitle="Loading news feed..."
-      emptyStateHint="News appears after the backend responds."
+      emptyStateTitle="No feed stories yet"
+      emptyStateHint="Try refreshing later as wire stories arrive."
     />
   );
 }

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo } from "react";
 import type { PaneProps } from "../../../types/plugin";
 import type { MarketNewsItem } from "../../../types/news-source";
 import { useNewsArticles } from "../../../news/hooks";
+import type { NewsQueryPhase } from "../../../news/types";
 import { TabBar, usePaneFooter } from "../../../components";
+import { Spinner } from "../../../components/spinner";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
@@ -18,14 +20,18 @@ const SECTOR_TABS = ["all", ...SECTOR_NEWS_SECTORS] as const;
 
 const DEFAULT_SORT: NewsSortPreference = { columnId: "time", direction: "desc" };
 
-function useIndustryArticles(sector: SectorNewsSelection): { articles: MarketNewsItem[]; allArticles: MarketNewsItem[] } {
-  const allArticles = useNewsArticles(NEWS_QUERY_PRESETS.feed).articles;
-  const sectorArticles = useNewsArticles(
+function useIndustryArticles(sector: SectorNewsSelection): { articles: MarketNewsItem[]; allArticles: MarketNewsItem[]; phase: NewsQueryPhase } {
+  const allState = useNewsArticles(NEWS_QUERY_PRESETS.feed);
+  const sectorState = useNewsArticles(
     sector === "all" ? null : NEWS_QUERY_PRESETS.sector(sector),
-  ).articles;
+  );
+  const allArticles = allState.articles;
+  const sectorArticles = sectorState.articles;
+  const phase = sector === "all" ? allState.phase : sectorState.phase;
   return {
     articles: sector === "all" ? allArticles : sectorArticles,
     allArticles,
+    phase,
   };
 }
 
@@ -33,7 +39,8 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
   const [category, setCategory] = usePluginPaneState<SectorNewsSelection>("industry:category", "all");
   const [selectedArticleId, setSelectedArticleId] = usePluginPaneState<string | null>("industry:selectedArticleId", null);
   const [sortPreference, setSortPreference] = usePluginPaneState<NewsSortPreference>("industry:sort", DEFAULT_SORT);
-  const { articles, allArticles } = useIndustryArticles(category);
+  const { articles, allArticles, phase } = useIndustryArticles(category);
+  const loading = phase === "loading" || (phase === "refreshing" && articles.length === 0);
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
   const counts = useMemo(() => {
     const next: Record<string, number> = { all: allArticles.length };
@@ -93,6 +100,10 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
   ) : (
     <Box flexGrow={1} />
   );
+
+  if (loading && articles.length === 0) {
+    return <Spinner label="Loading sector news..." />;
+  }
 
   return (
     <NewsArticleStackView

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -3,6 +3,7 @@ import type { NewsQuery } from "../../../news/types";
 import { useNewsArticles } from "../../../news/hooks";
 import type { PaneProps } from "../../../types/plugin";
 import { usePaneFooter } from "../../../components";
+import { Spinner } from "../../../components/spinner";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import {
@@ -31,7 +32,9 @@ export function NewsPresetPane({
   emptyStateTitle: string;
   emptyStateHint: string;
 }) {
-  const articles = useNewsArticles(query).articles;
+  const newsState = useNewsArticles(query);
+  const articles = newsState.articles;
+  const loading = newsState.phase === "loading" || (newsState.phase === "refreshing" && articles.length === 0);
   const [selectedArticleId, setSelectedArticleId] = usePluginPaneState<string | null>(
     `${paneKey}:selectedArticleId`,
     null,
@@ -54,6 +57,10 @@ export function NewsPresetPane({
   ) : (
     <Box flexGrow={1} />
   );
+
+  if (loading && articles.length === 0) {
+    return <Spinner label={`Loading ${title.toLowerCase()}...`} />;
+  }
 
   return (
     <NewsArticleStackView

--- a/src/plugins/builtin/news-wire/top-pane.tsx
+++ b/src/plugins/builtin/news-wire/top-pane.tsx
@@ -14,8 +14,8 @@ export function TopPane(props: PaneProps) {
       query={NEWS_QUERY_PRESETS.top}
       columns={["rank", "time", "source", "title", "tickers", "importance"]}
       defaultSort={DEFAULT_SORT}
-      emptyStateTitle="Loading top news..."
-      emptyStateHint="News appears after the backend ranks stories."
+      emptyStateTitle="No top stories yet"
+      emptyStateHint="Try refreshing later as new headlines are ranked."
     />
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent empty-state text from appearing while news queries are still loading so users see a spinner during initial fetches. 
- Make news pane loading behavior consistent across top/feed/industry/breaking views and surface phase-aware state to choose spinner vs empty-state.

### Description
- Updated `NewsPresetPane` to read the full result from `useNewsArticles(query)` and render a `Spinner` when `phase` is `loading` (or `refreshing` with no rows) instead of showing the empty-state UI prematurely. (`src/plugins/builtin/news-wire/news-preset-pane.tsx`)
- Made `IndustryPane` return and use the query `phase` from `useNewsArticles` and render a `Spinner` for initial loads with no articles. (`src/plugins/builtin/news-wire/industry-pane.tsx`)
- Made `BreakingPane` use the query `phase` and render a `Spinner` while breaking-news is in-flight and empty. (`src/plugins/builtin/news-wire/breaking-pane.tsx`)
- Adjusted empty-state copy for top/feed panes so the empty messages are used only when results are truly empty after load. (`src/plugins/builtin/news-wire/top-pane.tsx`, `src/plugins/builtin/news-wire/feed-pane.tsx`)
