### PR TITLE
Refine desktop command bar chrome

### DIFF
--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -1,4 +1,4 @@
-import { Box, Input, Text, Textarea } from "../../ui";
+import { Box, Input, Text, Textarea, useUiCapabilities } from "../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { TextAttributes, type InputRenderable, type TextareaRenderable } from "../../ui";
@@ -12,6 +12,8 @@ import {
   commandBarBg,
   commandBarHeadingText,
   commandBarHoverBg,
+  commandBarInputBg,
+  commandBarPanelBg,
   commandBarSelectedBg,
   commandBarSelectedText,
   commandBarSubtleText,
@@ -187,6 +189,8 @@ interface ListScreenState {
 type WorkflowStringValues = Record<string, string>;
 
 const commandBarLog = debugLog.createLogger("command-bar");
+const COMMAND_BAR_OVERLAY_Z_INDEX = 2_147_483_646;
+const COMMAND_BAR_PANEL_Z_INDEX = 2_147_483_647;
 
 function getDefaultConfigBackupPath(): string {
   const home = typeof process !== "undefined" ? process.env.HOME : undefined;
@@ -297,6 +301,7 @@ export function CommandBar({
   const { symbol: activeTickerSymbol, ticker: activeTickerData, financials: activeFinancials } = useFocusedTicker();
   const renderer = useNativeRenderer();
   const { width: termWidth, height: termHeight } = useViewport();
+  const { nativePaneChrome } = useUiCapabilities();
   const [rootQuery, setRootQueryValue] = useState(state.commandBarQuery);
   const rootQueryRef = useRef(rootQuery);
   rootQueryRef.current = rootQuery;
@@ -4891,12 +4896,14 @@ export function CommandBar({
     updateWorkflowValue,
   ]);
 
-  const barWidth = Math.max(42, Math.min(72, termWidth - 8, Math.floor(termWidth * 0.68)));
+  const barWidth = nativePaneChrome
+    ? Math.max(46, Math.min(78, termWidth - 10, Math.floor(termWidth * 0.64)))
+    : Math.max(42, Math.min(72, termWidth - 8, Math.floor(termWidth * 0.68)));
   const bodyHeight = Math.min(16, Math.max(9, termHeight - 9));
-  const barHeight = bodyHeight + 7;
+  const barHeight = nativePaneChrome ? bodyHeight + 4 : bodyHeight + 7;
   const barLeft = Math.max(4, Math.floor((termWidth - barWidth) / 2));
   const barTop = Math.max(1, Math.floor((termHeight - barHeight) / 2));
-  const contentPadding = 3;
+  const contentPadding = nativePaneChrome ? 2 : 3;
   const paletteBg = commandBarBg();
   const paletteHeadingText = commandBarHeadingText();
   const paletteHoverBg = commandBarHoverBg();
@@ -4904,6 +4911,8 @@ export function CommandBar({
   const paletteSelectedText = commandBarSelectedText();
   const paletteText = commandBarText();
   const paletteSubtleText = commandBarSubtleText();
+  const panelBg = nativePaneChrome ? commandBarPanelBg() : paletteBg;
+  const inputBg = nativePaneChrome ? commandBarInputBg() : paletteBg;
   const resultsInnerWidth = Math.max(12, barWidth - contentPadding * 2);
   const trailingWidth = Math.max(8, Math.min(12, Math.floor(resultsInnerWidth * 0.18)));
   const labelWidth = Math.max(10, resultsInnerWidth - trailingWidth);
@@ -5010,7 +5019,11 @@ export function CommandBar({
               flexDirection="row"
               height={1}
               paddingX={contentPadding}
-              backgroundColor={isSelected ? paletteSelectedBg : isHovered ? paletteHoverBg : paletteBg}
+              backgroundColor={isSelected
+                ? paletteSelectedBg
+                : isHovered
+                  ? paletteHoverBg
+                  : (nativePaneChrome ? panelBg : paletteBg)}
               onMouseMove={() => setHoveredIndex(row.globalIdx)}
               onMouseScroll={handleListScroll}
               onMouseDown={(event: any) => {
@@ -5028,6 +5041,7 @@ export function CommandBar({
                 }
                 activateListSelection({ item: row.item });
               }}
+              style={nativePaneChrome ? { borderRadius: 6 } : undefined}
             >
               <Box width={labelWidth}>
                 <Text fg={isSelected ? paletteSelectedText : presentation.primaryMuted ? paletteSubtleText : paletteText}>
@@ -5069,7 +5083,7 @@ export function CommandBar({
               key={field.id}
               flexDirection="column"
               marginBottom={1}
-              backgroundColor={active ? colors.panel : paletteBg}
+              backgroundColor={active ? inputBg : panelBg}
               onMouseDown={(event: any) => {
                 event.stopPropagation?.();
                 syncActiveWorkflowTextarea(currentRoute);
@@ -5080,6 +5094,12 @@ export function CommandBar({
                   openWorkflowFieldPicker(currentRoute, field);
                 }
               }}
+              style={nativePaneChrome ? {
+                border: `1px solid ${active ? "rgba(84, 201, 159, 0.28)" : "rgba(132, 145, 161, 0.16)"}`,
+                borderRadius: 6,
+                paddingInline: 8,
+                paddingBlock: 6,
+              } : undefined}
             >
               <Box height={1}>
                 <Text fg={active ? paletteText : paletteSubtleText} attributes={active ? TextAttributes.BOLD : 0}>
@@ -5093,6 +5113,7 @@ export function CommandBar({
                     value={coerceFieldString(value)}
                     placeholder={field.placeholder}
                     focused={active && !currentRoute.pending}
+                    backgroundColor={active ? inputBg : panelBg}
                     onChange={(nextValue) => updateWorkflowValue(field.id, nextValue)}
                     onSubmit={() => {
                       const index = visibleFields.findIndex((entry) => entry.id === field.id);
@@ -5108,8 +5129,9 @@ export function CommandBar({
                     minHeight={6}
                     height={6}
                     border
-                    borderColor={active ? paletteSelectedBg : paletteBg}
-                    backgroundColor={active ? colors.panel : paletteBg}
+                    borderColor={active ? (nativePaneChrome ? "rgba(84, 201, 159, 0.28)" : paletteSelectedBg) : (nativePaneChrome ? "rgba(132, 145, 161, 0.16)" : paletteBg)}
+                    backgroundColor={active ? inputBg : panelBg}
+                    style={nativePaneChrome ? { borderRadius: 6, overflow: "hidden" } : undefined}
                   >
                     {active ? (
                       <Textarea
@@ -5120,7 +5142,7 @@ export function CommandBar({
                         focused={!currentRoute.pending}
                         textColor={paletteText}
                         placeholderColor={paletteSubtleText}
-                        backgroundColor={colors.panel}
+                        backgroundColor={nativePaneChrome ? inputBg : colors.panel}
                         flexGrow={1}
                         wrapText
                       />
@@ -5148,6 +5170,7 @@ export function CommandBar({
                     value={coerceFieldString(value)}
                     placeholder={field.placeholder}
                     focused={active && !currentRoute.pending}
+                    backgroundColor={active ? inputBg : panelBg}
                     onChange={(nextValue) => updateWorkflowValue(field.id, nextValue)}
                     onSubmit={() => {
                       const index = visibleFields.findIndex((entry) => entry.id === field.id);
@@ -5162,11 +5185,12 @@ export function CommandBar({
               ) : (
                 <Box
                   height={1}
-                  backgroundColor={borderColor}
+                  backgroundColor={nativePaneChrome ? "transparent" : borderColor}
                   onMouseDown={(event: any) => {
                     event.stopPropagation?.();
                     openWorkflowFieldPicker(currentRoute, field);
                   }}
+                  style={nativePaneChrome ? { borderRadius: 4 } : undefined}
                 >
                   <Text fg={active ? paletteText : paletteSubtleText}>
                     {truncateText(summarizeWorkflowFieldValue(field, value), barWidth - contentPadding * 2)}
@@ -5266,7 +5290,7 @@ export function CommandBar({
               : route);
           }}
           onToggle={(id) => handleMultiSelectToggle(id)}
-          bgColor={paletteBg}
+          bgColor={nativePaneChrome ? panelBg : paletteBg}
         />
         <Box flexDirection="row" gap={1}>
           <Button label="Done" variant="primary" onPress={commitMultiSelectPicker} />
@@ -5282,7 +5306,7 @@ export function CommandBar({
       left={0}
       width={termWidth}
       height={termHeight}
-      zIndex={100}
+      zIndex={nativePaneChrome ? COMMAND_BAR_OVERLAY_Z_INDEX : 100}
       onMouseDown={(event: any) => {
         event.stopPropagation?.();
         event.preventDefault?.();
@@ -5296,51 +5320,87 @@ export function CommandBar({
         width={barWidth}
         height={barHeight}
         flexDirection="column"
-        backgroundColor={paletteBg}
-        zIndex={101}
+        backgroundColor={panelBg}
+        zIndex={nativePaneChrome ? COMMAND_BAR_PANEL_Z_INDEX : 101}
         onMouseDown={(event: any) => {
           event.stopPropagation?.();
         }}
+        data-gloom-role="command-bar-panel"
+        style={nativePaneChrome ? {
+          borderRadius: 8,
+          boxShadow: "0 14px 32px rgba(0,0,0,0.18)",
+          overflow: "hidden",
+        } : undefined}
       >
-        <Box height={1} />
+        {!nativePaneChrome && <Box height={1} backgroundColor={paletteBg} />}
 
-        <Box height={1} paddingX={contentPadding} flexDirection="row" alignItems="center">
-          {currentRoute && (
-            <Box marginRight={1}>
-              <Button label="Back" variant="ghost" onPress={popRoute} />
+        {!nativePaneChrome && (
+          <Box
+            height={1}
+            paddingX={contentPadding}
+            flexDirection="row"
+            alignItems="center"
+          >
+            {currentRoute && (
+              <Box marginRight={1}>
+                <Button label="Back" variant="ghost" onPress={popRoute} />
+              </Box>
+            )}
+            <Box flexGrow={1}>
+              <Text fg={paletteText} attributes={TextAttributes.BOLD}>
+                {currentRoute?.kind === "mode"
+                  ? currentRoute.screen === "themes" ? "Change Theme"
+                    : currentRoute.screen === "plugins" ? "Manage Plugins"
+                      : currentRoute.screen === "layout" ? "Layout Actions"
+                        : currentRoute.screen === "new-pane" ? "New Pane"
+                          : "Security Description"
+                  : currentRoute?.kind === "picker" ? currentRoute.title
+                    : currentRoute?.kind === "pane-settings" ? "Pane Settings"
+                      : currentRoute?.kind === "workflow" ? currentRoute.title
+                      : currentRoute?.kind === "confirm" ? currentRoute.title
+                          : "Commands"}
+              </Text>
+            </Box>
+          </Box>
+        )}
+
+        <Box key={bodySlotKey} flexDirection="column" flexGrow={1} width="100%" backgroundColor={panelBg}>
+          {nativePaneChrome && currentRoute && (
+            <Box height={1} paddingX={contentPadding}>
+              <Text
+                fg={paletteSubtleText}
+                onMouseDown={(event: any) => {
+                  event.stopPropagation?.();
+                  event.preventDefault?.();
+                  popRoute();
+                }}
+                data-gloom-interactive="true"
+              >
+                ← Back
+              </Text>
             </Box>
           )}
-          <Box flexGrow={1}>
-            <Text fg={paletteText} attributes={TextAttributes.BOLD}>
-              {currentRoute?.kind === "mode"
-                ? currentRoute.screen === "themes" ? "Change Theme"
-                  : currentRoute.screen === "plugins" ? "Manage Plugins"
-                    : currentRoute.screen === "layout" ? "Layout Actions"
-                      : currentRoute.screen === "new-pane" ? "New Pane"
-                        : "Security Description"
-                : currentRoute?.kind === "picker" ? currentRoute.title
-                  : currentRoute?.kind === "pane-settings" ? "Pane Settings"
-                    : currentRoute?.kind === "workflow" ? currentRoute.title
-                    : currentRoute?.kind === "confirm" ? currentRoute.title
-                        : "Commands"}
-            </Text>
-          </Box>
-        </Box>
-
-        <Box key={bodySlotKey} flexDirection="column" flexGrow={1} width="100%" backgroundColor={paletteBg}>
           {(visibleListState || currentRoute?.kind === "picker") && visibleListState && (
             <>
               <Box height={1} paddingX={contentPadding}>
-                <Box width={queryDisplayWidth} height={1} position="relative">
+                <Box
+                  width={queryDisplayWidth}
+                  height={1}
+                  position="relative"
+                  backgroundColor={nativePaneChrome ? undefined : inputBg}
+                  style={nativePaneChrome ? undefined : {
+                    overflow: "hidden",
+                  }}
+                >
                   <Input
                     value={visibleListState.query}
                     onInput={setActiveListQuery}
                     onChange={setActiveListQuery}
                     placeholder={visibleListState.kind === "root" ? "Search" : "Filter"}
                     focused
-                    width={queryDisplayWidth}
-                    backgroundColor={paletteBg}
-                    focusedBackgroundColor={paletteBg}
+                    width={nativePaneChrome ? "100%" : queryDisplayWidth}
+                    backgroundColor={nativePaneChrome ? "transparent" : paletteBg}
+                    focusedBackgroundColor={nativePaneChrome ? "transparent" : paletteBg}
                     textColor={paletteText}
                     focusedTextColor={paletteText}
                     placeholderColor={paletteSubtleText}
@@ -5382,7 +5442,7 @@ export function CommandBar({
           {showCustomMultiSelectPicker && renderMultiSelectBody()}
         </Box>
 
-        <Box flexGrow={1} />
+        <Box flexGrow={1} backgroundColor={nativePaneChrome ? panelBg : undefined} />
       </Box>
     </Box>
   );

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,5 +1,5 @@
 import { Box, SpinnerMark, Text, TextAttributes, useUiCapabilities } from "../../ui";
-import { useEffect } from "react";
+import { useEffect, type ReactNode } from "react";
 import { colors, priceColor } from "../../theme/colors";
 import { useAppActive } from "../../state/app-activity";
 import { useAppDispatch, useAppSelector } from "../../state/app-context";
@@ -20,6 +20,32 @@ import { VERSION } from "../../version";
 const SPY_REFRESH_MS = 5 * 60_000; // 5 min
 const UPDATE_NOTICE_DURATION_MS = 5_000;
 const TITLEBAR_TRAFFIC_LIGHT_WIDTH = 11;
+
+function DesktopHeaderPill({
+  children,
+  backgroundColor = "rgba(8, 12, 15, 0.34)",
+  borderColor = "rgba(132, 145, 161, 0.22)",
+}: {
+  children: ReactNode;
+  backgroundColor?: string;
+  borderColor?: string;
+}) {
+  return (
+    <Box
+      height={1}
+      flexDirection="row"
+      alignItems="center"
+      backgroundColor={backgroundColor}
+      style={{
+        border: `1px solid ${borderColor}`,
+        borderRadius: 5,
+        paddingInline: 6,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
 
 function UpdateStatus() {
   const dispatch = useAppDispatch();
@@ -125,6 +151,57 @@ export function Header() {
   const mktState = spyQuote?.marketState;
   const mktLabel = mktState ? marketStateLabel(mktState) : "";
   const mktColor = mktState ? marketStateColor(mktState) : colors.headerText;
+
+  if (titleBarOverlay) {
+    return (
+      <Box
+        flexDirection="row"
+        height={1}
+        alignItems="center"
+        backgroundColor={colors.header}
+        data-gloom-role="app-header"
+        data-titlebar-overlay="true"
+        className="electrobun-webkit-app-region-drag"
+        style={{
+          borderBottom: `1px solid ${colors.borderFocused}`,
+          boxShadow: "inset 0 -1px 0 rgba(84, 201, 159, 0.18)",
+          paddingInline: 8,
+        }}
+      >
+        <Box paddingLeft={TITLEBAR_TRAFFIC_LIGHT_WIDTH} flexDirection="row" alignItems="center" gap={1}>
+          <Text attributes={TextAttributes.BOLD} fg={colors.headerText}>
+            Gloomberb
+          </Text>
+          <DesktopHeaderPill
+            backgroundColor="rgba(84, 201, 159, 0.12)"
+            borderColor="rgba(84, 201, 159, 0.28)"
+          >
+            <Text fg={colors.headerText}>v{VERSION}</Text>
+          </DesktopHeaderPill>
+        </Box>
+        <Box flexGrow={1} paddingLeft={2} paddingRight={2} minWidth={0}>
+          <UpdateStatus />
+        </Box>
+        {mktLabel ? (
+          <Box paddingRight={1}>
+            <DesktopHeaderPill borderColor="rgba(132, 145, 161, 0.18)">
+              <Text fg={mktColor}>{mktLabel}</Text>
+            </DesktopHeaderPill>
+          </Box>
+        ) : null}
+        <Box paddingRight={1}>
+          <Text fg={spyColor}>{spyText}</Text>
+        </Box>
+        {extText ? (
+          <Box paddingRight={1}>
+            <Text fg={extText.color}>{extText.text}</Text>
+          </Box>
+        ) : null}
+        <Text fg={colors.headerText}>{baseCurrency}</Text>
+      </Box>
+    );
+  }
+
   return (
     <Box
       flexDirection="row"

--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -360,19 +360,29 @@ export function PaneFooterBar({
   const reservedRight = Math.max(0, reserveRight);
 
   if (nativePaneChrome) {
-    const nativeContentWidth = width > 0 ? Math.max(0, Math.floor(width) - reservedRight - 2) : undefined;
     return (
       <Box
         height={1}
         flexDirection="row"
         paddingLeft={1}
         paddingRight={reservedRight + 1}
+        alignItems="center"
         data-gloom-role="pane-footer"
         data-focused={focused ? "true" : "false"}
         data-empty={empty ? "true" : "false"}
-        style={{ "--pane-footer-border-color": borderColor }}
+        style={{
+          "--pane-footer-border-color": borderColor,
+          borderTop: `1px solid ${borderColor}`,
+          backgroundColor: focused ? "rgba(84, 201, 159, 0.05)" : "rgba(20, 25, 30, 0.55)",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.03)",
+        }}
       >
-        <FooterContent footer={resolvedFooter} focused={focused} width={nativeContentWidth} showBackground={false} />
+        <FooterContent
+          footer={resolvedFooter}
+          focused={focused}
+          width={width > 0 ? Math.max(0, Math.floor(width) - reservedRight - 2) : undefined}
+          showBackground={false}
+        />
       </Box>
     );
   }

--- a/src/components/layout/pane-header.tsx
+++ b/src/components/layout/pane-header.tsx
@@ -1,4 +1,5 @@
 import { Box, Text, useUiCapabilities } from "../../ui";
+import type { ReactNode } from "react";
 import { colors, floatingPaneTitleBg, paneTitleBg, paneTitleText } from "../../theme/colors";
 
 export const PANE_HEADER_HEIGHT = 1;
@@ -26,6 +27,44 @@ function truncateTitle(title: string, maxWidth: number): string {
   return `${title.slice(0, maxWidth - 2)}..`;
 }
 
+function DesktopPaneButton({
+  icon,
+  onMouseDown,
+}: {
+  icon: ReactNode;
+  onMouseDown?: (event: any) => void;
+}) {
+  return (
+    <Box
+      height={1}
+      alignItems="center"
+      justifyContent="center"
+      onMouseDown={onMouseDown}
+      data-gloom-interactive={onMouseDown ? "true" : undefined}
+      style={{
+        borderRadius: 4,
+        minWidth: 20,
+        paddingInline: 4,
+        backgroundColor: "rgba(255,255,255,0.04)",
+        cursor: onMouseDown ? "pointer" : "default",
+      }}
+    >
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 12,
+          height: 12,
+          color: colors.textDim,
+        }}
+      >
+        {icon}
+      </span>
+    </Box>
+  );
+}
+
 export function PaneHeader({
   title,
   width,
@@ -46,8 +85,6 @@ export function PaneHeader({
   const textColor = paneTitleText(focused, floating);
 
   if (nativePaneChrome) {
-    const reservedWidth = PANE_HEADER_GRIP.length + actionText.length + closeText.length;
-    const clippedTitle = truncateTitle(title, Math.max(0, width - reservedWidth));
     return (
       <Box
         height={PANE_HEADER_HEIGHT}
@@ -60,27 +97,60 @@ export function PaneHeader({
         onMouseDown={onHeaderMouseDown}
         onMouseDrag={onHeaderMouseDrag}
         onMouseDragEnd={onHeaderMouseDragEnd}
+        style={{
+          borderBottom: `1px solid ${focused ? colors.borderFocused : colors.border}`,
+          paddingInline: 6,
+          boxShadow: focused ? "inset 0 -1px 0 rgba(84, 201, 159, 0.18)" : "inset 0 -1px 0 rgba(255,255,255,0.04)",
+        }}
       >
-        <Text fg={textColor} selectable={false} data-gloom-role="pane-grip">{PANE_HEADER_GRIP}</Text>
-        <Text fg={textColor} selectable={false} data-gloom-role="pane-title">{clippedTitle}</Text>
-        <Box flexGrow={1} />
-        <Text
-          fg={textColor}
-          selectable={false}
-          data-gloom-role="pane-action"
-          onMouseDown={showActions ? onActionMouseDown : undefined}
-        >
-          {actionText}
+        <Text fg={focused ? colors.borderFocused : colors.textMuted} selectable={false} data-gloom-role="pane-grip">
+          {PANE_HEADER_GRIP}
         </Text>
-        {floating && (
+        <Box flexGrow={1} minWidth={0} overflow="hidden">
           <Text
             fg={textColor}
             selectable={false}
-            data-gloom-role="pane-close"
-            onMouseDown={onCloseMouseDown}
+            data-gloom-role="pane-title"
+            style={{
+              fontWeight: focused ? 700 : 600,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
           >
-            {closeText}
+            {title}
           </Text>
+        </Box>
+        <Box data-gloom-role="pane-action">
+          {showActions ? (
+            <DesktopPaneButton
+              onMouseDown={onActionMouseDown}
+              icon={(
+                <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                  <circle cx="2" cy="6" r="1.1" fill="currentColor" />
+                  <circle cx="6" cy="6" r="1.1" fill="currentColor" />
+                  <circle cx="10" cy="6" r="1.1" fill="currentColor" />
+                </svg>
+              )}
+            />
+          ) : <Box width={2} />}
+        </Box>
+        {floating && (
+          <Box data-gloom-role="pane-close" marginLeft={1}>
+            <DesktopPaneButton
+              onMouseDown={onCloseMouseDown}
+              icon={(
+                <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                  <path
+                    d="M3 3L9 9M9 3L3 9"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              )}
+            />
+          </Box>
         )}
       </Box>
     );

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,4 +1,4 @@
-import { Box, Span, Text } from "../../ui";
+import { Box, Span, Text, TextAttributes, useUiCapabilities } from "../../ui";
 import { useEffect, useState } from "react";
 import { colors, hoverBg } from "../../theme/colors";
 import { useAppDispatch, useAppSelector, useFocusedTicker } from "../../state/app-context";
@@ -31,6 +31,7 @@ function truncate(text: string, width: number): string {
 }
 
 export function StatusBar() {
+  const { nativePaneChrome } = useUiCapabilities();
   const registry = getSharedRegistry();
   const dispatch = useAppDispatch();
   const layouts = useAppSelector(selectSavedLayouts);
@@ -86,6 +87,125 @@ export function StatusBar() {
   };
 
   if (!statusBarVisible) return null;
+
+  if (nativePaneChrome) {
+    return (
+      <Box
+        flexDirection="row"
+        height={1}
+        alignItems="center"
+        backgroundColor={colors.panel}
+        data-gloom-role="status-bar"
+        style={{
+          borderTop: `1px solid ${colors.border}`,
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.03)",
+          paddingInline: 8,
+        }}
+      >
+        <Box paddingLeft={1} flexShrink={0} flexDirection="row" alignItems="center" gap={1}>
+          {hasMultipleLayouts ? (
+            layouts.map((layout, index) => {
+              const active = index === activeLayoutIdx;
+              const hovered = hoveredTab === index && !active;
+              return (
+                <Box
+                  key={layout.name}
+                  height={1}
+                  flexDirection="row"
+                  alignItems="center"
+                  backgroundColor={active ? "rgba(84, 201, 159, 0.10)" : hovered ? "rgba(255,255,255,0.04)" : undefined}
+                  onMouseMove={() => setHoveredTab((current) => (current === index ? current : index))}
+                  onMouseDown={(event) => {
+                    event?.preventDefault?.();
+                    event?.stopPropagation?.();
+                    dispatch({ type: "SWITCH_LAYOUT", index });
+                  }}
+                  data-gloom-interactive="true"
+                  style={{
+                    borderRadius: 4,
+                    paddingInline: 4,
+                    cursor: "pointer",
+                  }}
+                >
+                  <Text fg={active ? colors.borderFocused : colors.textDim}>
+                    ^{index + 1}
+                  </Text>
+                  <Text
+                    fg={active ? colors.textBright : hovered ? colors.text : colors.textDim}
+                    attributes={active ? TextAttributes.BOLD : 0}
+                    style={{ marginLeft: 6 }}
+                  >
+                    {truncate(layout.name, 14)}
+                  </Text>
+                </Box>
+              );
+            })
+          ) : (
+            <Text fg={colors.textDim}>
+              <Span fg={colors.text}>Ctrl+P</Span> command bar
+            </Text>
+          )}
+        </Box>
+        {showGridlockTip && (
+          <Box paddingLeft={2} flexShrink={0} flexDirection="row" alignItems="center" gap={1}>
+            <Text fg={colors.textDim}>Snapped a window?</Text>
+            <Text
+              fg={hoveredControl === "gridlock-tip" ? colors.textBright : colors.borderFocused}
+              attributes={TextAttributes.BOLD}
+              onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip" ? current : "gridlock-tip"))}
+              onMouseDown={handleGridlockTip}
+              data-gloom-interactive="true"
+            >
+              Gridlock All
+            </Text>
+            <Text
+              fg={hoveredControl === "gridlock-tip-dismiss" ? colors.text : colors.textDim}
+              onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip-dismiss" ? current : "gridlock-tip-dismiss"))}
+              onMouseDown={dismissGridlockTip}
+              data-gloom-interactive="true"
+            >
+              Dismiss
+            </Text>
+          </Box>
+        )}
+        <Box flexGrow={1} />
+        {extText && (
+          <Box paddingRight={1}>
+            <Text fg={extColor}>{symbol} {extText}</Text>
+          </Box>
+        )}
+        {(exchName || mktState || q?.provenance?.session) && (
+          <Box
+            paddingRight={1}
+            height={1}
+            flexDirection="row"
+            alignItems="center"
+            backgroundColor="rgba(8, 12, 15, 0.30)"
+            style={{
+              border: "1px solid rgba(132, 145, 161, 0.22)",
+              borderRadius: 5,
+              paddingInline: 6,
+            }}
+          >
+            <Text fg={mktState ? marketStateColor(mktState) : colors.textDim}>
+              {exchName ? `${exchName} ` : ""}{sessionLabel}
+            </Text>
+          </Box>
+        )}
+        {priceSourceLabel && (
+          <Box paddingRight={1}>
+            <Text fg={colors.textDim}>px {priceSourceLabel}</Text>
+          </Box>
+        )}
+        {sessionSourceLabel && sessionSourceLabel !== priceSourceLabel && (
+          <Box paddingRight={1}>
+            <Text fg={colors.textDim}>ses {sessionSourceLabel}</Text>
+          </Box>
+        )}
+        <PluginSlot name="status:widget" />
+      </Box>
+    );
+  }
 
   return (
     <Box

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,6 @@
-import { Box, Text } from "../../ui";
+import { Box, Text, useUiHost } from "../../ui";
 import { TextAttributes } from "../../ui";
+import { type ComponentType } from "react";
 import { colors } from "../../theme/colors";
 
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
@@ -44,6 +45,21 @@ export function Button({
   shortcut,
   width,
 }: ButtonProps) {
+  const HostButton = useUiHost().Button as ComponentType<ButtonProps> | undefined;
+  if (HostButton) {
+    return (
+      <HostButton
+        label={label}
+        onPress={onPress}
+        variant={variant}
+        disabled={disabled}
+        active={active}
+        shortcut={shortcut}
+        width={width}
+      />
+    );
+  }
+
   const palette = resolveButtonColors(variant, active, disabled);
 
   return (

--- a/src/components/ui/fields.tsx
+++ b/src/components/ui/fields.tsx
@@ -1,5 +1,5 @@
-import { Box, Input, Span, Text } from "../../ui";
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { Box, Input, Span, Text, useUiHost } from "../../ui";
+import { useEffect, useRef, useState, type ComponentType, type RefObject } from "react";
 import { type InputRenderable } from "../../ui";
 import { colors } from "../../theme/colors";
 
@@ -42,6 +42,28 @@ export function TextField({
   placeholderColor = colors.textDim,
   onMouseDown,
 }: TextFieldProps) {
+  const HostTextField = useUiHost().TextField as ComponentType<TextFieldProps> | undefined;
+  if (HostTextField) {
+    return (
+      <HostTextField
+        label={label}
+        value={value}
+        placeholder={placeholder}
+        focused={focused}
+        width={width}
+        inputRef={inputRef}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        hint={hint}
+        type={type}
+        backgroundColor={backgroundColor}
+        textColor={textColor}
+        placeholderColor={placeholderColor}
+        onMouseDown={onMouseDown}
+      />
+    );
+  }
+
   const localInputRef = useRef<InputRenderable>(null);
   const resolvedInputRef = inputRef ?? localInputRef;
   const currentValueRef = useRef(value ?? "");

--- a/src/components/ui/frame.tsx
+++ b/src/components/ui/frame.tsx
@@ -1,6 +1,6 @@
-import { Box, Text } from "../../ui";
+import { Box, Text, useUiHost } from "../../ui";
 import { TextAttributes } from "../../ui";
-import type { ReactNode } from "react";
+import { type ComponentType, type ReactNode } from "react";
 import { colors } from "../../theme/colors";
 
 export interface SectionProps {
@@ -54,6 +54,15 @@ export interface DialogFrameProps {
 }
 
 export function DialogFrame({ title, children, footer }: DialogFrameProps) {
+  const HostDialogFrame = useUiHost().DialogFrame as ComponentType<DialogFrameProps> | undefined;
+  if (HostDialogFrame) {
+    return (
+      <HostDialogFrame title={title} footer={footer}>
+        {children}
+      </HostDialogFrame>
+    );
+  }
+
   return (
     <Box flexDirection="column">
       <Box height={1}>

--- a/src/components/ui/list-view.tsx
+++ b/src/components/ui/list-view.tsx
@@ -1,5 +1,5 @@
-import { Box, ScrollBox, Text } from "../../ui";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Box, ScrollBox, Text, useUiHost } from "../../ui";
+import { useEffect, useRef, useState, type ComponentType, type ReactNode } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
 
@@ -81,6 +81,30 @@ export function ListView({
   scrollable = false,
   autoScrollToIndex = true,
 }: ListViewProps) {
+  const HostListView = useUiHost().ListView as ComponentType<ListViewProps> | undefined;
+  if (HostListView) {
+    return (
+      <HostListView
+        items={items}
+        selectedIndex={selectedIndex}
+        scrollIndex={scrollIndex}
+        onSelect={onSelect}
+        onActivate={onActivate}
+        renderRow={renderRow}
+        getRowBackgroundColor={getRowBackgroundColor}
+        showSelectedDescription={showSelectedDescription}
+        emptyMessage={emptyMessage}
+        bgColor={bgColor}
+        selectedBgColor={selectedBgColor}
+        hoverBgColor={hoverBgColor}
+        height={height}
+        flexGrow={flexGrow}
+        scrollable={scrollable}
+        autoScrollToIndex={autoScrollToIndex}
+      />
+    );
+  }
+
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const baseBg = bgColor ?? colors.bg;

--- a/src/components/ui/page-stack-view.tsx
+++ b/src/components/ui/page-stack-view.tsx
@@ -1,10 +1,10 @@
-import { Box, Text } from "../../ui";
+import { Box, Text, useUiHost } from "../../ui";
 import { useShortcut } from "../../react/input";
-import type { ReactNode } from "react";
+import { type ComponentType, type ReactNode } from "react";
 import { colors } from "../../theme/colors";
 import { isDetailBackNavigationKey } from "../../utils/back-navigation";
 
-interface PageStackViewProps {
+export interface PageStackViewProps {
   focused: boolean;
   detailOpen: boolean;
   onBack: () => void;
@@ -23,6 +23,21 @@ export function PageStackView({
   backLabel = "Back",
   backHint,
 }: PageStackViewProps) {
+  const HostPageStackView = useUiHost().PageStackView as ComponentType<PageStackViewProps> | undefined;
+  if (HostPageStackView) {
+    return (
+      <HostPageStackView
+        focused={focused}
+        detailOpen={detailOpen}
+        onBack={onBack}
+        rootContent={rootContent}
+        detailContent={detailContent}
+        backLabel={backLabel}
+        backHint={backHint}
+      />
+    );
+  }
+
   useShortcut((event) => {
     if (!focused || !detailOpen || !isDetailBackNavigationKey(event)) return;
     event.stopPropagation?.();
@@ -48,7 +63,7 @@ export function PageStackView({
             onBack();
           }}
         >
-          <Text fg={colors.textBright}>{`<- ${backLabel}`}</Text>
+          <Text fg={colors.textBright}>{`← ${backLabel}`}</Text>
         </Box>
         <Box flexGrow={1} />
         {backHint ? <Text fg={colors.textMuted}>{backHint}</Text> : null}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,5 +1,6 @@
-import { Box, Text } from "../../ui";
+import { Box, Text, useUiHost } from "../../ui";
 import { TextAttributes } from "../../ui";
+import { type ComponentType } from "react";
 import { colors } from "../../theme/colors";
 
 export interface CheckboxProps {
@@ -17,6 +18,19 @@ export function Checkbox({
   selected = false,
   onChange,
 }: CheckboxProps) {
+  const HostCheckbox = useUiHost().Checkbox as ComponentType<CheckboxProps> | undefined;
+  if (HostCheckbox) {
+    return (
+      <HostCheckbox
+        label={label}
+        checked={checked}
+        disabled={disabled}
+        selected={selected}
+        onChange={onChange}
+      />
+    );
+  }
+
   const fg = disabled ? colors.textMuted : selected ? colors.text : colors.textDim;
   const marker = checked ? "x" : " ";
 
@@ -50,6 +64,18 @@ export function Switch({
   disabled = false,
   onChange,
 }: SwitchProps) {
+  const HostSwitch = useUiHost().Switch as ComponentType<SwitchProps> | undefined;
+  if (HostSwitch) {
+    return (
+      <HostSwitch
+        label={label}
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+      />
+    );
+  }
+
   const fg = disabled ? colors.textMuted : colors.text;
   const stateBg = checked ? colors.positive : colors.panel;
   const stateText = checked ? " ON " : " OFF ";
@@ -89,6 +115,18 @@ export function RadioGroup({
   value,
   onChange,
 }: RadioGroupProps) {
+  const HostRadioGroup = useUiHost().RadioGroup as ComponentType<RadioGroupProps> | undefined;
+  if (HostRadioGroup) {
+    return (
+      <HostRadioGroup
+        label={label}
+        options={options}
+        value={value}
+        onChange={onChange}
+      />
+    );
+  }
+
   return (
     <Box flexDirection="column">
       {label && (
@@ -139,6 +177,17 @@ export function SegmentedControl({
   value,
   onChange,
 }: SegmentedControlProps) {
+  const HostSegmentedControl = useUiHost().SegmentedControl as ComponentType<SegmentedControlProps> | undefined;
+  if (HostSegmentedControl) {
+    return (
+      <HostSegmentedControl
+        options={options}
+        value={value}
+        onChange={onChange}
+      />
+    );
+  }
+
   return (
     <Box flexDirection="row">
       {options.map((option) => {

--- a/src/renderers/electrobun/view/desktop-controls.tsx
+++ b/src/renderers/electrobun/view/desktop-controls.tsx
@@ -1,0 +1,692 @@
+/** @jsxImportSource react */
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from "react";
+import { Box, Input, ScrollBox, Text } from "../../../ui";
+import { TextAttributes, type InputRenderable, type ScrollBoxRenderable } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { blendHex, colors, hoverBg } from "../../../theme/colors";
+import { isDetailBackNavigationKey } from "../../../utils/back-navigation";
+import type { ButtonProps } from "../../../components/ui/button";
+import type { TextFieldProps } from "../../../components/ui/fields";
+import type { DialogFrameProps } from "../../../components/ui/frame";
+import type { ListRowState, ListViewItem, ListViewProps } from "../../../components/ui/list-view";
+import type { PageStackViewProps } from "../../../components/ui/page-stack-view";
+import type {
+  CheckboxProps,
+  RadioGroupProps,
+  SegmentedControlProps,
+  SwitchProps,
+} from "../../../components/ui/toggle";
+
+const CONTROL_RADIUS = 6;
+const PANEL_BORDER = blendHex(colors.border, colors.borderFocused, 0.18);
+const PANEL_FILL = blendHex(colors.panel, colors.bg, 0.22);
+
+function controlBorderColor(focused = false, active = false): string {
+  if (active) return colors.borderFocused;
+  if (focused) return blendHex(colors.borderFocused, colors.textBright, 0.24);
+  return PANEL_BORDER;
+}
+
+function controlShadow(active = false): string {
+  return active
+    ? "0 0 0 1px rgba(84, 201, 159, 0.18), inset 0 1px 0 rgba(255,255,255,0.06)"
+    : "inset 0 1px 0 rgba(255,255,255,0.04)";
+}
+
+function buttonPalette(props: Pick<ButtonProps, "variant" | "active" | "disabled">) {
+  if (props.disabled) {
+    return {
+      fg: colors.textMuted,
+      bg: "rgba(63, 72, 82, 0.35)",
+      border: PANEL_BORDER,
+    };
+  }
+  if (props.active) {
+    return {
+      fg: colors.selectedText,
+      bg: colors.selected,
+      border: colors.borderFocused,
+    };
+  }
+
+  switch (props.variant) {
+    case "primary":
+      return {
+        fg: colors.bg,
+        bg: colors.borderFocused,
+        border: colors.borderFocused,
+      };
+    case "danger":
+      return {
+        fg: colors.bg,
+        bg: colors.negative,
+        border: colors.negative,
+      };
+    case "ghost":
+      return {
+        fg: colors.textDim,
+        bg: "rgba(0, 0, 0, 0)",
+        border: PANEL_BORDER,
+      };
+    case "secondary":
+    default:
+      return {
+        fg: colors.text,
+        bg: PANEL_FILL,
+        border: PANEL_BORDER,
+      };
+  }
+}
+
+export function WebButton({
+  label,
+  onPress,
+  variant = "secondary",
+  disabled = false,
+  active = false,
+  shortcut,
+  width,
+}: ButtonProps) {
+  const palette = buttonPalette({ variant, active, disabled });
+
+  return (
+    <Box
+      width={width}
+      height={1}
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="center"
+      backgroundColor={palette.bg}
+      onMouseDown={() => {
+        if (!disabled) onPress?.();
+      }}
+      data-gloom-role="desktop-button"
+      data-gloom-interactive={disabled ? undefined : "true"}
+      style={{
+        border: `1px solid ${palette.border}`,
+        borderRadius: CONTROL_RADIUS,
+        paddingInline: 8,
+        boxShadow: controlShadow(active),
+        cursor: disabled ? "default" : "pointer",
+      }}
+    >
+      <Text
+        fg={palette.fg}
+        attributes={active ? TextAttributes.BOLD : 0}
+        style={{ fontWeight: active || variant === "primary" ? 700 : 600 }}
+      >
+        {label}
+      </Text>
+      {shortcut && (
+        <Text
+          fg={disabled ? colors.textMuted : colors.textDim}
+          style={{ marginLeft: 8, fontSize: "0.92em" }}
+        >
+          {shortcut}
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+export function WebTextField({
+  label,
+  value,
+  placeholder,
+  focused,
+  width,
+  inputRef,
+  onChange,
+  onSubmit,
+  hint,
+  type = "text",
+  backgroundColor = colors.bg,
+  textColor = colors.text,
+  placeholderColor = colors.textDim,
+  onMouseDown,
+}: TextFieldProps) {
+  const localInputRef = useRef<InputRenderable>(null);
+  const resolvedInputRef = inputRef ?? localInputRef;
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      {label && (
+        <Box height={1}>
+          <Text
+            fg={focused ? colors.textBright : placeholderColor}
+            style={{ fontWeight: 600 }}
+          >
+            {label}
+          </Text>
+        </Box>
+      )}
+      <Box
+        height={1}
+        width={width}
+        alignItems="center"
+        backgroundColor={backgroundColor}
+        onMouseDown={() => {
+          onMouseDown?.();
+          resolvedInputRef.current?.focus?.();
+        }}
+        data-gloom-role="desktop-text-field"
+        style={{
+          border: `1px solid ${controlBorderColor(focused, false)}`,
+          borderRadius: CONTROL_RADIUS,
+          boxShadow: controlShadow(focused),
+          overflow: "hidden",
+        }}
+      >
+        <Input
+          ref={resolvedInputRef as RefObject<InputRenderable | null>}
+          width="100%"
+          value={value}
+          type={type}
+          placeholder={placeholder}
+          focused={focused}
+          textColor={textColor}
+          focusedTextColor={textColor}
+          placeholderColor={placeholderColor}
+          backgroundColor={backgroundColor}
+          focusedBackgroundColor={backgroundColor}
+          cursorColor={colors.textBright}
+          style={{
+            paddingLeft: 10,
+            paddingRight: 10,
+            borderRadius: CONTROL_RADIUS,
+          }}
+          onInput={onChange}
+          onChange={onChange}
+          onSubmit={() => onSubmit?.(value ?? resolvedInputRef.current?.editBuffer.getText() ?? "")}
+        />
+      </Box>
+      {hint && (
+        <Box height={1}>
+          <Text fg={colors.textMuted} style={{ fontSize: "0.94em" }}>
+            {hint}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function DefaultDesktopRow({
+  item,
+  selected,
+}: {
+  item: ListViewItem;
+  selected: boolean;
+}) {
+  return (
+    <Box flexDirection="row" justifyContent="space-between" width="100%" alignItems="center">
+      <Box flexDirection="row" alignItems="center" minWidth={0}>
+        <Box
+          width={1}
+          height={1}
+          marginRight={1}
+          backgroundColor={selected ? colors.borderFocused : "transparent"}
+          style={{ borderRadius: CONTROL_RADIUS }}
+        />
+        <Text
+          fg={selected ? colors.text : colors.textDim}
+          attributes={selected ? TextAttributes.BOLD : 0}
+        >
+          {item.label}
+        </Text>
+      </Box>
+      {item.detail && (
+        <Text fg={colors.textMuted}>
+          {item.detail}
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+function listRowStyle(selected: boolean): CSSProperties {
+  return {
+    borderRadius: CONTROL_RADIUS,
+    border: `1px solid ${selected ? colors.borderFocused : "transparent"}`,
+    boxShadow: selected ? "inset 0 1px 0 rgba(255,255,255,0.06)" : undefined,
+    cursor: "pointer",
+  };
+}
+
+export function WebListView({
+  items,
+  selectedIndex,
+  scrollIndex,
+  onSelect,
+  onActivate,
+  renderRow,
+  getRowBackgroundColor,
+  showSelectedDescription = false,
+  emptyMessage = "Nothing to show.",
+  bgColor,
+  selectedBgColor,
+  hoverBgColor,
+  height,
+  flexGrow,
+  scrollable = false,
+  autoScrollToIndex = true,
+}: ListViewProps) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const baseBg = bgColor ?? colors.bg;
+  const activeBg = selectedBgColor ?? "rgba(84, 201, 159, 0.12)";
+  const rowHoverBg = hoverBgColor ?? hoverBg();
+  const selectedItem = selectedIndex >= 0 ? items[selectedIndex] : undefined;
+  const activeScrollIndex = scrollIndex ?? selectedIndex;
+
+  useEffect(() => {
+    if (!scrollable || !autoScrollToIndex || activeScrollIndex < 0) return;
+    const scrollBox = scrollRef.current;
+    if (!scrollBox) return;
+    const safeIndex = Math.min(activeScrollIndex, items.length - 1);
+    const viewportHeight = Math.max(scrollBox.viewport.height, 1);
+    if (safeIndex < scrollBox.scrollTop) {
+      scrollBox.scrollTo(safeIndex);
+    } else if (safeIndex >= scrollBox.scrollTop + viewportHeight) {
+      scrollBox.scrollTo(safeIndex - viewportHeight + 1);
+    }
+  }, [activeScrollIndex, autoScrollToIndex, items.length, scrollable]);
+
+  useEffect(() => {
+    if (!scrollable) return;
+    const scrollBox = scrollRef.current;
+    if (!scrollBox) return;
+    scrollBox.verticalScrollBar.visible = items.length > scrollBox.viewport.height;
+  }, [items.length, height, flexGrow, scrollable]);
+
+  const rows = items.length === 0
+    ? (
+      <Box height={1}>
+        <Text fg={colors.textDim}>{emptyMessage}</Text>
+      </Box>
+    )
+    : items.map((item, index) => {
+      const selected = index === selectedIndex;
+      const hovered = index === hoveredIndex && !selected;
+      const disabled = item.disabled === true;
+      const state: ListRowState = { selected, hovered, disabled };
+      const rowBg = getRowBackgroundColor?.(item, state, index)
+        ?? (selected ? activeBg : hovered ? rowHoverBg : baseBg);
+
+      return (
+        <Box
+          key={item.id}
+          height={1}
+          width="100%"
+          backgroundColor={rowBg}
+          alignItems="center"
+          onMouseMove={() => {
+            if (!disabled) {
+              setHoveredIndex((current) => (current === index ? current : index));
+            }
+          }}
+          onMouseDown={() => {
+            if (disabled) return;
+            onSelect?.(index);
+            onActivate?.(item, index);
+          }}
+          data-gloom-role="desktop-list-row"
+          style={listRowStyle(selected)}
+        >
+          {renderRow
+            ? renderRow(item, state, index)
+            : <DefaultDesktopRow item={item} selected={selected} />}
+        </Box>
+      );
+    });
+
+  return (
+    <Box flexDirection="column" height={height} flexGrow={flexGrow} gap={1}>
+      {scrollable ? (
+        <ScrollBox
+          ref={scrollRef}
+          height={height}
+          flexGrow={flexGrow}
+          scrollY
+          focusable={false}
+          style={{
+            border: `1px solid ${PANEL_BORDER}`,
+            borderRadius: CONTROL_RADIUS,
+            padding: 4,
+            backgroundColor: "rgba(9, 12, 15, 0.22)",
+          }}
+        >
+          <Box flexDirection="column" gap={1}>
+            {rows}
+          </Box>
+        </ScrollBox>
+      ) : (
+        <Box flexDirection="column" gap={1}>
+          {rows}
+        </Box>
+      )}
+
+      {showSelectedDescription && selectedItem?.description && (
+        <Box
+          flexDirection="row"
+          backgroundColor="rgba(9, 12, 15, 0.22)"
+          style={{
+            border: `1px solid ${PANEL_BORDER}`,
+            borderRadius: CONTROL_RADIUS,
+            paddingInline: 10,
+          }}
+        >
+          <Text fg={colors.textDim}>
+            {selectedItem.description}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function desktopRowShell(props: {
+  disabled: boolean;
+  selected?: boolean;
+  onMouseDown?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Box
+      height={1}
+      alignItems="center"
+      flexDirection="row"
+      onMouseDown={props.disabled ? undefined : props.onMouseDown}
+      data-gloom-interactive={props.disabled ? undefined : "true"}
+      style={{
+        border: `1px solid ${controlBorderColor(false, props.selected === true)}`,
+        borderRadius: CONTROL_RADIUS,
+        paddingInline: 8,
+        backgroundColor: props.selected ? "rgba(84, 201, 159, 0.10)" : PANEL_FILL,
+        cursor: props.disabled ? "default" : "pointer",
+      }}
+    >
+      {props.children}
+    </Box>
+  );
+}
+
+export function WebCheckbox({
+  label,
+  checked,
+  disabled = false,
+  selected = false,
+  onChange,
+}: CheckboxProps) {
+  return desktopRowShell({
+    disabled,
+    selected,
+    onMouseDown: () => onChange?.(!checked),
+    children: (
+      <>
+        <Box
+          width={1}
+          height={1}
+          alignItems="center"
+          justifyContent="center"
+          backgroundColor={checked ? colors.borderFocused : "transparent"}
+          style={{
+            border: `1px solid ${checked ? colors.borderFocused : PANEL_BORDER}`,
+            borderRadius: 4,
+            marginRight: 8,
+          }}
+        >
+          <Text fg={checked ? colors.bg : "transparent"} style={{ fontWeight: 700 }}>
+            x
+          </Text>
+        </Box>
+        <Text
+          fg={disabled ? colors.textMuted : colors.text}
+          attributes={selected ? TextAttributes.BOLD : 0}
+        >
+          {label}
+        </Text>
+      </>
+    ),
+  });
+}
+
+export function WebSwitch({
+  label,
+  checked,
+  disabled = false,
+  onChange,
+}: SwitchProps) {
+  return desktopRowShell({
+    disabled,
+    onMouseDown: () => onChange?.(!checked),
+    children: (
+      <>
+        <Text fg={disabled ? colors.textMuted : colors.text} style={{ marginRight: 8 }}>
+          {label}
+        </Text>
+        <Box
+          width={4}
+          height={1}
+          alignItems="center"
+          justifyContent={checked ? "flex-end" : "flex-start"}
+          backgroundColor={checked ? colors.positive : "rgba(94, 106, 120, 0.28)"}
+          style={{
+            border: `1px solid ${checked ? colors.positive : PANEL_BORDER}`,
+            borderRadius: 999,
+            paddingInline: 3,
+          }}
+        >
+          <Box
+            width={1}
+            height={1}
+            backgroundColor={checked ? colors.bg : colors.textMuted}
+            style={{ borderRadius: 999 }}
+          />
+        </Box>
+      </>
+    ),
+  });
+}
+
+export function WebRadioGroup({
+  label,
+  options,
+  value,
+  onChange,
+}: RadioGroupProps) {
+  return (
+    <Box flexDirection="column" gap={1}>
+      {label && (
+        <Box height={1}>
+          <Text fg={colors.textDim} style={{ fontWeight: 600 }}>
+            {label}
+          </Text>
+        </Box>
+      )}
+      {options.map((option) => {
+        const checked = option.value === value;
+        return desktopRowShell({
+          disabled: option.disabled === true,
+          selected: checked,
+          onMouseDown: () => onChange?.(option.value),
+          children: (
+            <>
+              <Box
+                width={1}
+                height={1}
+                alignItems="center"
+                justifyContent="center"
+                style={{
+                  border: `1px solid ${checked ? colors.borderFocused : PANEL_BORDER}`,
+                  borderRadius: 999,
+                  marginRight: 8,
+                }}
+              >
+                <Box
+                  width={0.5}
+                  height={0.5}
+                  backgroundColor={checked ? colors.borderFocused : "transparent"}
+                  style={{ borderRadius: 999 }}
+                />
+              </Box>
+              <Text
+                fg={option.disabled ? colors.textMuted : colors.text}
+                attributes={checked ? TextAttributes.BOLD : 0}
+              >
+                {option.label}
+              </Text>
+            </>
+          ),
+        });
+      })}
+    </Box>
+  );
+}
+
+export function WebSegmentedControl({
+  options,
+  value,
+  onChange,
+}: SegmentedControlProps) {
+  return (
+    <Box
+      flexDirection="row"
+      backgroundColor="rgba(8, 11, 14, 0.32)"
+      style={{
+        border: `1px solid ${PANEL_BORDER}`,
+        borderRadius: CONTROL_RADIUS,
+        padding: 2,
+      }}
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <Box
+            key={option.value}
+            height={1}
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="center"
+            backgroundColor={active ? colors.selected : "transparent"}
+            onMouseDown={() => {
+              if (!option.disabled) onChange?.(option.value);
+            }}
+            data-gloom-interactive={option.disabled ? undefined : "true"}
+            style={{
+              borderRadius: CONTROL_RADIUS - 2,
+              paddingInline: 10,
+              cursor: option.disabled ? "default" : "pointer",
+            }}
+          >
+            <Text
+              fg={option.disabled ? colors.textMuted : active ? colors.selectedText : colors.textDim}
+              attributes={active ? TextAttributes.BOLD : 0}
+            >
+              {option.label}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function WebDialogFrame({ title, children, footer }: DialogFrameProps) {
+  return (
+    <Box flexDirection="column">
+      <Box
+        height={1}
+        flexDirection="row"
+        alignItems="center"
+        style={{
+          borderBottom: `1px solid ${PANEL_BORDER}`,
+          paddingBottom: 8,
+          marginBottom: 10,
+        }}
+      >
+        <Text fg={colors.text} attributes={TextAttributes.BOLD} style={{ fontWeight: 700 }}>
+          {title}
+        </Text>
+      </Box>
+      {children}
+      {footer && (
+        <Box
+          height={1}
+          style={{
+            borderTop: `1px solid ${PANEL_BORDER}`,
+            paddingTop: 8,
+            marginTop: 10,
+          }}
+        >
+          <Text fg={colors.textMuted}>
+            {footer}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function WebPageStackView({
+  focused,
+  detailOpen,
+  onBack,
+  rootContent,
+  detailContent,
+  backLabel = "Back",
+  backHint,
+}: PageStackViewProps) {
+  useShortcut((event) => {
+    if (!focused || !detailOpen || !isDetailBackNavigationKey(event)) return;
+    event.stopPropagation?.();
+    event.preventDefault?.();
+    onBack();
+  });
+
+  if (!detailOpen) {
+    return (
+      <Box flexDirection="column" flexGrow={1} overflow="hidden">
+        {rootContent}
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1} overflow="hidden" gap={1}>
+      <Box height={1} flexDirection="row" alignItems="center">
+        <Box
+          height={1}
+          flexDirection="row"
+          alignItems="center"
+          backgroundColor={PANEL_FILL}
+          onMouseDown={(event) => {
+            event.preventDefault?.();
+            event.stopPropagation?.();
+            onBack();
+          }}
+          data-gloom-interactive="true"
+          style={{
+            border: `1px solid ${PANEL_BORDER}`,
+            borderRadius: CONTROL_RADIUS,
+            paddingInline: 8,
+            cursor: "pointer",
+          }}
+        >
+          <Text fg={colors.textBright} style={{ fontWeight: 600 }}>
+            {`← ${backLabel}`}
+          </Text>
+        </Box>
+        <Box flexGrow={1} />
+        {backHint ? (
+          <Text fg={colors.textMuted}>
+            {backHint}
+          </Text>
+        ) : null}
+      </Box>
+      <Box flexDirection="column" flexGrow={1} overflow="hidden">
+        {detailContent}
+      </Box>
+    </Box>
+  );
+}

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -33,6 +33,17 @@ import {
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
 import { backendRequest } from "./backend-rpc";
 import { WebDataTable } from "./data-table";
+import {
+  WebButton,
+  WebCheckbox,
+  WebDialogFrame,
+  WebListView,
+  WebPageStackView,
+  WebRadioGroup,
+  WebSegmentedControl,
+  WebSwitch,
+  WebTextField,
+} from "./desktop-controls";
 
 function cellWidth(value: unknown): CSSProperties["width"] {
   if (typeof value === "number") return `${value * WEB_CELL_WIDTH}px`;
@@ -552,6 +563,10 @@ const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(function W
       {...cleanDomProps(props)}
       ref={elementRef}
       value={value}
+      autoCorrect="off"
+      autoCapitalize="off"
+      autoComplete="off"
+      spellCheck={false}
       placeholder={getStringProp(props, "placeholder")}
       onChange={(event) => handleValueChange(event.currentTarget.value)}
       onKeyDown={handleKeyDown}
@@ -610,6 +625,10 @@ const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown>>(func
       {...cleanDomProps(props)}
       ref={elementRef}
       value={value}
+      autoCorrect="off"
+      autoCapitalize="off"
+      autoComplete="off"
+      spellCheck={false}
       placeholder={getStringProp(props, "placeholder")}
       onChange={(event) => handleValueChange(event.currentTarget.value)}
       onKeyDown={handleKeyDown}
@@ -918,6 +937,15 @@ export const webUiHost: UiHost = {
   ScrollBox: WebScrollBox,
   Input: WebInput,
   Textarea: WebTextarea,
+  Button: WebButton,
+  TextField: WebTextField,
+  ListView: WebListView,
+  Checkbox: WebCheckbox,
+  Switch: WebSwitch,
+  RadioGroup: WebRadioGroup,
+  SegmentedControl: WebSegmentedControl,
+  DialogFrame: WebDialogFrame,
+  PageStackView: WebPageStackView,
   DataTable: WebDataTable,
   Tabs: WebTabs,
   ChartSurface: forwardRef<BoxRenderable, Record<string, unknown> & { children?: ReactNode }>(

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -55,6 +55,22 @@ export function commandBarBg(): string {
   return blendForContrast(base, colors.bg, accent, 1.45);
 }
 
+export function commandBarPanelBg(): string {
+  return blendHex(commandBarBg(), colors.panel, 0.28);
+}
+
+export function commandBarInputBg(): string {
+  return blendHex(commandBarPanelBg(), colors.bg, 0.22);
+}
+
+export function commandBarPanelBorder(): string {
+  return blendHex(colors.border, colors.borderFocused, 0.18);
+}
+
+export function commandBarOverlayBg(): string {
+  return blendHex(colors.bg, colors.panel, 0.18);
+}
+
 export function commandBarSelectedBg(): string {
   const base = commandBarBg();
   const accent = higherContrast(colors.selectedText, colors.textBright, colors.selected);

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -219,6 +219,15 @@ export interface UiHost {
   ChartSurface: ComponentType<ChartSurfaceProps>;
   ImageSurface: ComponentType<ImageSurfaceProps>;
   SpinnerMark: ComponentType<SpinnerMarkProps>;
+  Button?: ComponentType<any>;
+  TextField?: ComponentType<any>;
+  ListView?: ComponentType<any>;
+  Checkbox?: ComponentType<any>;
+  Switch?: ComponentType<any>;
+  RadioGroup?: ComponentType<any>;
+  SegmentedControl?: ComponentType<any>;
+  DialogFrame?: ComponentType<any>;
+  PageStackView?: ComponentType<any>;
   Tabs?: ComponentType<HostTabsProps>;
   DataTable?: ComponentType<any>;
   createSyntaxStyle?(): SyntaxStyleLike;


### PR DESCRIPTION
## Summary
- Remove the native command bar overlay, border, and root header row
- Make the command field ghost-style with only placeholder text visible
- Keep the desktop renderer and shared input hosts aligned with theme-aware surfaces

## Testing
- `bun test src/components/command-bar/command-bar.test.tsx`
- `bun run desktop:view:build`
- tmux smoke run completed and the session was killed