### PR TITLE
Fix pane footer chrome and tabs

### DIFF
--- a/src/components/chart/chart-scroll.test.ts
+++ b/src/components/chart/chart-scroll.test.ts
@@ -32,12 +32,13 @@ describe("chart-scroll", () => {
     expect(result.remainder).toBeCloseTo(-0.2);
   });
 
-  test("uses slower pan distances for keyboard and drag input", () => {
+  test("keeps keyboard pan small while matching drag to the visible window", () => {
     expect(getKeyboardPanCellCount(100)).toBe(2);
-    expect(getDragPanPointDelta(10, 100, 200)).toBe(4);
-    expect(getDragPanWindowRatio(10, 100)).toBeCloseTo(0.02);
-    expect(resolveDragPanOffset(20, 10, 100, 200, 40)).toBe(16);
-    expect(resolveDragPanOffset(2, 10, 100, 200, 40)).toBe(0);
+    expect(getDragPanPointDelta(10, 100, 200)).toBe(20);
+    expect(getDragPanWindowRatio(10, 100)).toBeCloseTo(0.1);
+    expect(resolveDragPanOffset(20, 10, 100, 200, 40)).toBe(40);
+    expect(resolveDragPanOffset(20, -10, 100, 200, 40)).toBe(0);
+    expect(resolveDragPanOffset(38, 10, 100, 200, 40)).toBe(40);
   });
 
   test("resolves wheel direction, cell delta, remainder, and ratio together", () => {

--- a/src/components/chart/chart-scroll.ts
+++ b/src/components/chart/chart-scroll.ts
@@ -5,7 +5,7 @@ export type ChartScrollDirection = "up" | "down" | "left" | "right";
 
 const KEYBOARD_PAN_WIDTH_RATIO = 0.02;
 const SCROLL_PAN_WIDTH_RATIO = 0.005;
-const DRAG_PAN_VISIBLE_RATIO = 0.2;
+const DRAG_PAN_VISIBLE_RATIO = 1;
 
 interface BufferExpansionViewState {
   activePreset: TimeRange | null;
@@ -45,7 +45,7 @@ export function resolveDragPanOffset(
   maxPanOffset: number,
 ): number {
   return clamp(
-    startPanOffset - getDragPanPointDelta(deltaCells, chartWidth, visibleCount),
+    startPanOffset + getDragPanPointDelta(deltaCells, chartWidth, visibleCount),
     0,
     Math.max(maxPanOffset, 0),
   );

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -1822,9 +1822,6 @@ function ComparisonStockChartView({
       onMouseDrag={hasChartData && !isBlockingBody && !bodyMessage ? handlePlotDrag : undefined}
       onMouseDragEnd={hasChartData && !isBlockingBody && !bodyMessage ? () => { dragRef.current = null; } : undefined}
       onMouseScroll={hasChartData && !isBlockingBody && !bodyMessage ? handlePlotScroll : undefined}
-      onMouseOut={hasChartData && !isBlockingBody && !bodyMessage ? () => {
-        dragRef.current = null;
-      } : undefined}
     >
       {isBlockingBody
         ? (

--- a/src/components/chart/stock-chart-renderer-switch.test.tsx
+++ b/src/components/chart/stock-chart-renderer-switch.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createTestRenderer } from "@opentui/core/testing";
 import { createOpenTuiTestRoot as createRoot } from "../../renderers/opentui/test-utils";
-import { act, useReducer } from "react";
+import { act, useReducer, useState } from "react";
 import { PaneFooterBar, PaneFooterProvider } from "../layout/pane-footer";
 import {
   AppContext,
@@ -123,10 +123,14 @@ function ChartHarness({
   config,
   ticker,
   financials,
+  interactive = false,
+  activateOnMouse = false,
 }: {
   config: AppConfig;
   ticker: TickerRecord;
   financials: TickerFinancials;
+  interactive?: boolean;
+  activateOnMouse?: boolean;
 }) {
   const initialState = createInitialState(config);
   initialState.focusedPaneId = TEST_PANE_ID;
@@ -134,7 +138,9 @@ function ChartHarness({
   initialState.financials = new Map([[ticker.metadata.ticker, financials]]);
 
   const [state, dispatch] = useReducer(appReducer, initialState);
+  const [mouseInteractive, setMouseInteractive] = useState(interactive);
   harnessDispatch = dispatch;
+  const effectiveInteractive = activateOnMouse ? mouseInteractive : interactive;
 
   return (
     <AppContext value={{ state, dispatch }}>
@@ -142,7 +148,13 @@ function ChartHarness({
         <PaneFooterProvider>
           {(footer) => (
             <Box flexDirection="column" width={84} height={16}>
-              <StockChart width={84} height={15} focused />
+              <StockChart
+                width={84}
+                height={15}
+                focused
+                interactive={effectiveInteractive}
+                onActivate={activateOnMouse ? () => setMouseInteractive(true) : undefined}
+              />
               <PaneFooterBar footer={footer} focused width={84} />
             </Box>
           )}
@@ -324,6 +336,65 @@ describe("StockChart renderer switching", () => {
     expect(footerLine).toContain("[m]ode");
     expect(footerLine).not.toContain("Dec 2019");
     expect(footerLine).not.toContain("Dec 2024");
+  });
+
+  test("pans the visible window with mouse drag", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    config.layout.instances = config.layout.instances.map((instance) => (
+      instance.instanceId === TEST_PANE_ID
+        ? {
+          ...instance,
+          settings: {
+            chartRangePreset: "1Y",
+            chartResolution: "1d",
+          },
+        }
+        : instance
+    ));
+    config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+    const ticker = makeTicker(symbol);
+    const history = makeHistory(240);
+    const provider = makeProvider({ [symbol]: history });
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedDataProviderForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: history,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 32 });
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+          activateOnMouse
+        />,
+      );
+    });
+
+    await flushFrames(3);
+    await emitKeypress({ name: "=", sequence: "=" });
+    await flushFrames(3);
+
+    const beforeLines = testSetup.captureCharFrame().split("\n");
+    const beforeAxis = beforeLines[14] ?? "";
+
+    await act(async () => {
+      await testSetup!.mockMouse.drag(20, 8, 68, 8);
+      await testSetup!.renderOnce();
+    });
+    await flushFrames(2);
+
+    const afterLines = testSetup.captureCharFrame().split("\n");
+    const afterAxis = afterLines[14] ?? "";
+    expect(afterAxis).not.toBe(beforeAxis);
   });
 
   test("switches from braille to kitty without crashing text updates", async () => {

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -158,6 +158,7 @@ interface StockChartProps {
   height: number;
   focused: boolean;
   interactive?: boolean;
+  onActivate?: () => void;
   compact?: boolean;
   axisMode?: ChartAxisMode;
   historyOverride?: PricePoint[] | null;
@@ -1478,6 +1479,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   height,
   focused,
   interactive,
+  onActivate,
   compact,
   axisMode = "price",
   historyOverride = null,
@@ -1776,7 +1778,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const axisGap = axisSectionWidthBudget > 0 ? 1 : 0;
   const minChartWidth = compact ? 12 : 20;
   const measurementChartWidth = Math.max(width - axisSectionWidthBudget - axisGap, minChartWidth);
-  const headerRows = compact ? 0 : 4;
+  const headerRows = compact ? 0 : 3;
   const helpRow = compact ? 1 : 0;
   const timeAxisRow = 1;
   const volumeHeight = showVolume && !compact ? 3 : 0;
@@ -3582,7 +3584,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   };
 
   const handlePlotDown = (event: ChartMouseEvent) => {
-    if (!interactive || compact) return;
+    if (compact) return;
+    if (!interactive) onActivate?.();
     focusPaneForMouseInteraction(event);
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (!localPointer) return;
@@ -3607,7 +3610,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   };
 
   const handlePlotDrag = (event: ChartMouseEvent) => {
-    if (!interactive || compact) return;
+    if (compact || (!interactive && !dragRef.current)) return;
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (localPointer) {
       const selectionCursor = resolveSelectionCursor(localPointer, projection.points.length, chartWidth, projection.effectiveMode);
@@ -3630,7 +3633,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       const deltaCells = getGlobalMouseX(event, renderer) - dragRef.current.startGlobalX;
       requestAutoWindow(shiftDateWindow(
         dragRef.current.startWindow,
-        -getDragPanWindowRatio(deltaCells, chartWidth),
+        getDragPanWindowRatio(deltaCells, chartWidth),
       ));
       return;
     }
@@ -3902,9 +3905,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       onMouseDrag={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : handlePlotDrag}
       onMouseDragEnd={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : () => { dragRef.current = null; }}
       onMouseScroll={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : handlePlotScroll}
-      onMouseOut={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : () => {
-        dragRef.current = null;
-      }}
     >
       {isBlockingBody
         ? (

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -2,7 +2,7 @@ import { Box, Text, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
-import { PaneFooterBar, hasPaneFooterContent, type CombinedPaneFooter } from "./pane-footer";
+import { PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
 import { getPaneBodyHeight } from "./pane-sizing";
 
 interface FloatingPaneWrapperProps {
@@ -53,8 +53,7 @@ export function FloatingPaneWrapper({
 }: FloatingPaneWrapperProps) {
   const { nativePaneChrome } = useUiCapabilities();
   const bg = floatingPaneBg(focused);
-  const showFooter = hasPaneFooterContent(footer);
-  const bodyHeight = getPaneBodyHeight(height, showFooter);
+  const bodyHeight = getPaneBodyHeight(height);
 
   return (
     <Box
@@ -94,7 +93,7 @@ export function FloatingPaneWrapper({
         {children}
       </Box>
 
-      {showFooter && <PaneFooterBar footer={footer} focused={focused} width={width} reserveRight={2} />}
+      <PaneFooterBar footer={footer} focused={focused} width={width} reserveRight={2} />
 
       {nativePaneChrome ? (
         <Box

--- a/src/components/layout/pane-footer.test.tsx
+++ b/src/components/layout/pane-footer.test.tsx
@@ -121,6 +121,17 @@ describe("PaneFooterBar", () => {
     expect(frame).toContain("[r]efresh");
   });
 
+  test("draws focused empty footer border before the resize handle", async () => {
+    testSetup = await testRender(
+      <PaneFooterBar footer={{ info: [], hints: [] }} focused width={12} reserveRight={2} />,
+      { width: 12, height: 1 },
+    );
+    await testSetup.renderOnce();
+
+    const line = testSetup.captureCharFrame().split("\n")[0] ?? "";
+    expect(line).toContain("└─────────");
+  });
+
   test("clears a registration when the component unmounts", async () => {
     testSetup = await testRender(<FooterHarness visible={false} />, { width: 64, height: 1 });
     await act(async () => {

--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -398,7 +398,9 @@ export function PaneFooterBar({
       <Box height={1} width={width} flexDirection="row" data-gloom-role="pane-footer" data-focused="true" data-empty={empty ? "true" : "false"}>
         <Text fg={borderColor} selectable={false}>└</Text>
         <Box width={contentWidth} height={1} overflow="hidden">
-          <FooterContent footer={resolvedFooter} focused width={contentWidth} />
+          {empty
+            ? <Text fg={borderColor} selectable={false}>{"─".repeat(contentWidth)}</Text>
+            : <FooterContent footer={resolvedFooter} focused width={contentWidth} />}
         </Box>
         {reservedRight === 0 && <Text fg={borderColor} selectable={false}>┘</Text>}
       </Box>

--- a/src/components/layout/pane-sizing.test.ts
+++ b/src/components/layout/pane-sizing.test.ts
@@ -2,16 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { getPaneBodyHeight } from "./pane-sizing";
 
 describe("getPaneBodyHeight", () => {
-  test("reserves header and footer rows when footer is visible", () => {
-    expect(getPaneBodyHeight(10, true)).toBe(8);
-  });
-
-  test("reserves only the header row when footer is hidden", () => {
-    expect(getPaneBodyHeight(10, false)).toBe(9);
+  test("reserves header and bottom chrome rows", () => {
+    expect(getPaneBodyHeight(10)).toBe(8);
   });
 
   test("never returns less than one row", () => {
-    expect(getPaneBodyHeight(1, true)).toBe(1);
-    expect(getPaneBodyHeight(1, false)).toBe(1);
+    expect(getPaneBodyHeight(1)).toBe(1);
   });
 });

--- a/src/components/layout/pane-sizing.ts
+++ b/src/components/layout/pane-sizing.ts
@@ -1,10 +1,9 @@
 
 const RESERVED_PANE_CHROME_ROWS = 2;
-const RESERVED_PANE_CHROME_ROWS_WITHOUT_FOOTER = 1;
 
-export function getPaneBodyHeight(height: number, hasFooter = true): number {
-  // Reserve the header row plus the shared pane footer row when footer content exists.
-  return Math.max(1, height - (hasFooter ? RESERVED_PANE_CHROME_ROWS : RESERVED_PANE_CHROME_ROWS_WITHOUT_FOOTER));
+export function getPaneBodyHeight(height: number): number {
+  // Reserve the header row plus the bottom chrome row, even when the footer is visually empty.
+  return Math.max(1, height - RESERVED_PANE_CHROME_ROWS);
 }
 
 export function getPaneBodyWidth(width: number): number {

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -2,7 +2,7 @@ import { Box, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
 import { colors, paneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
-import { PaneFooterBar, hasPaneFooterContent, type CombinedPaneFooter } from "./pane-footer";
+import { PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
 import { getPaneBodyHeight } from "./pane-sizing";
 
 interface PaneWrapperProps {
@@ -40,9 +40,8 @@ export function PaneWrapper({
 }: PaneWrapperProps) {
   const { nativePaneChrome } = useUiCapabilities();
   const bg = paneBg(focused);
-  const showFooter = hasPaneFooterContent(footer);
   const bodyHeight = typeof height === "number"
-    ? title ? getPaneBodyHeight(height, showFooter) : height
+    ? title ? getPaneBodyHeight(height) : height
     : undefined;
 
   return (
@@ -82,7 +81,7 @@ export function PaneWrapper({
       >
         {children}
       </Box>
-      {title && showFooter && (
+      {title && (
         <PaneFooterBar
           footer={footer}
           focused={focused}

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -925,6 +925,12 @@ describe("Shell", () => {
       await testSetup!.renderOnce();
     });
 
-    expect(testSetup.captureCharFrame()).toContain("Footer Probe");
+    const frame = testSetup.captureCharFrame();
+    const lines = frame.split("\n");
+
+    expect(frame).toContain("Footer Probe");
+    expect(lines[8]).toContain("Footer Probe");
+    expect(lines[9]).not.toContain("Footer Probe");
+    expect(lines[9]).toContain("└───────────────────────────");
   });
 });

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -48,7 +48,7 @@ import { getNativeSurfaceManager, type NativeOccluder, type NativePaneLayer } fr
 import { FloatingPaneWrapper } from "./floating-pane";
 import { PaneContent } from "./pane-content";
 import { PaneWrapper } from "./pane";
-import { hasPaneFooterContent, PaneFooterProvider } from "./pane-footer";
+import { PaneFooterProvider } from "./pane-footer";
 import { getPaneBodyHeight, getPaneBodyWidth } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 
@@ -1241,7 +1241,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
           >
             <PaneFooterProvider>
               {(footer) => {
-                const bodyHeight = getPaneBodyHeight(leaf.rect.height, hasPaneFooterContent(footer));
+                const bodyHeight = getPaneBodyHeight(leaf.rect.height);
                 return (
                   <PaneWrapper
                     title={getPaneTitle(pane)}
@@ -1281,7 +1281,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         return (
           <PaneFooterProvider key={`float:${pane.instance.instanceId}`}>
             {(footer) => {
-              const bodyHeight = getPaneBodyHeight(preview.height, hasPaneFooterContent(footer));
+              const bodyHeight = getPaneBodyHeight(preview.height);
               return (
                 <FloatingPaneWrapper
                   title={getPaneTitle(pane)}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -132,18 +132,20 @@ function OpenTuiTabs({
     <ScrollBox
       ref={scrollRef}
       width="100%"
-      height={compact ? 1 : 2}
+      height={1}
       scrollX
       focusable={false}
       horizontalScrollbarOptions={{ visible: false }}
       onMouseScroll={handleMouseScroll}
     >
-      <Box flexDirection="row" width={totalWidth} height={compact ? 1 : 2}>
+      <Box flexDirection="row" width={totalWidth} height={1}>
         {tabs.map((tab, index) => {
           const active = tab.value === activeValue;
           const hovered = hoveredValue === tab.value && !tab.disabled;
           const tabWidth = tabWidths[index] ?? tab.label.length + 2;
           const tabLabel = ` ${tab.label} `;
+          const attributes = (active ? TextAttributes.BOLD : 0)
+            | (!compact && (active || hovered) ? TextAttributes.UNDERLINE : 0);
           const startHover = tab.disabled
             ? undefined
             : () => {
@@ -159,7 +161,8 @@ function OpenTuiTabs({
             <Box
               key={tab.value}
               width={tabWidth}
-              flexDirection="column"
+              height={1}
+              flexDirection="row"
               backgroundColor={hovered ? palette.hoverBg : undefined}
               onMouseOver={startHover}
               onMouseMove={startHover}
@@ -171,15 +174,10 @@ function OpenTuiTabs({
             >
               <Text
                 fg={tab.disabled ? palette.disabledFg : active ? palette.activeFg : hovered ? palette.hoverFg : palette.inactiveFg}
-                attributes={active ? TextAttributes.BOLD : 0}
+                attributes={attributes}
               >
                 {tabLabel}
               </Text>
-              {!compact && (
-                <Text fg={active ? palette.activeUnderline : hovered ? palette.hoverUnderline : palette.inactiveUnderline}>
-                  {"▔".repeat(tabWidth)}
-                </Text>
-              )}
             </Box>
           );
         })}

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -298,6 +298,30 @@ describe("shared UI kit", () => {
     expect(frame).toContain("Insider");
   });
 
+  test("renders default tabs in one row", async () => {
+    testSetup = await testRender(
+      <box flexDirection="column">
+        <Tabs
+          tabs={[
+            { label: "Overview", value: "overview" },
+            { label: "Chart", value: "chart" },
+          ]}
+          activeValue="chart"
+          onSelect={() => {}}
+        />
+        <text>After tabs</text>
+      </box>,
+      { width: 32, height: 3 },
+    );
+
+    await testSetup.renderOnce();
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    expect(lines[0]).toContain("Overview");
+    expect(lines[0]).toContain("Chart");
+    expect(lines[1]).toContain("After tabs");
+  });
+
   test("renders toggle lists with selection and descriptions", async () => {
     testSetup = await testRender(
       <ToggleList

--- a/src/plugins/builtin/ai/screener-pane.tsx
+++ b/src/plugins/builtin/ai/screener-pane.tsx
@@ -928,7 +928,6 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
         parts: [{ text: activeProvider?.name ?? activeTab.providerId, tone: activeProvider?.available === false ? "warning" as const : "value" as const, bold: true }],
       }] : []),
       { id: "status", parts: [{ text: statusText, tone: isRunningActiveTab ? "muted" : "value" }] },
-      ...(activeTab ? [{ id: "count", parts: [{ text: `${activeTab.results.length} tickers`, tone: "muted" as const }] }] : []),
       ...(forceRunArmed ? [{ id: "force", parts: [{ text: "force refresh armed", tone: "warning" as const }] }] : []),
     ],
     hints: editorState

--- a/src/plugins/builtin/debug.tsx
+++ b/src/plugins/builtin/debug.tsx
@@ -205,7 +205,6 @@ function DebugPane({ focused, width, height }: PaneProps) {
 
   usePaneFooter("debug-log", () => ({
     info: [
-      { id: "count", parts: [{ text: `${totalEntries} entries`, tone: "value", bold: true }] },
       ...(filterLevel ? [{ id: "level", parts: [{ text: filterLevel.toUpperCase(), tone: "value" as const, color: levelColor(filterLevel), bold: true }] }] : []),
       ...(filterSource ? [{ id: "source", parts: [{ text: filterSource, tone: "positive" as const }] }] : []),
       ...(autoScroll ? [{ id: "auto", parts: [{ text: "AUTO", tone: "muted" as const }] }] : []),
@@ -218,7 +217,7 @@ function DebugPane({ focused, width, height }: PaneProps) {
       { id: "auto", key: "a", label: "uto", onPress: () => setAutoScroll((prev) => !prev) },
       { id: "jump", key: "g/G", label: "jump", onPress: jumpBottom },
     ],
-  }), [autoScroll, clearLogs, cycleLevelFilter, cycleSourceFilter, exportLogs, filterLevel, filterSource, jumpBottom, totalEntries]);
+  }), [autoScroll, clearLogs, cycleLevelFilter, cycleSourceFilter, exportLogs, filterLevel, filterSource, jumpBottom]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -258,11 +258,11 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
 
   usePaneFooter("earnings-calendar", () => ({
     info: [
-      { id: "count", parts: [{ text: loading ? "loading" : `${eventCount} upcoming`, tone: loading ? "muted" : "value", bold: !loading }] },
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
     hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => reload(true) }],
-  }), [error, eventCount, loading, reload]);
+  }), [error, loading, reload]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -768,7 +768,6 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
     info: [
       { id: "impact", parts: [{ text: `impact: ${impactFilter}`, tone: impactFilter === "all" ? "muted" : "value" }] },
       { id: "country", parts: [{ text: `country: ${countryFilter}`, tone: countryFilter === "all" ? "muted" : "value" }] },
-      { id: "count", parts: [{ text: `${filtered.length} events`, tone: "muted" }] },
       ...(nextEvent && nextCountdown ? [{
         id: "next",
         parts: [{ text: `Next: ${nextEvent.event.length > 18 ? nextEvent.event.slice(0, 18).trimEnd() : nextEvent.event} ${nextCountdown}`, tone: "muted" as const }],
@@ -782,7 +781,7 @@ export function EconCalendarPane({ focused, width, height }: PaneProps) {
       { id: "country", key: "c", label: "country", onPress: cycleCountryFilter },
       { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
     ],
-  }), [countryFilter, cycleCountryFilter, cycleImpactFilter, error, filtered.length, impactFilter, load, loading, nextCountdown, nextEvent?.event, staleness]);
+  }), [countryFilter, cycleCountryFilter, cycleImpactFilter, error, impactFilter, load, loading, nextCountdown, nextEvent?.event, staleness]);
 
   const handleHeaderClick = useCallback(() => {}, []);
   const selectDisplayRow = useCallback((row: DisplayRow) => {

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -485,11 +485,10 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
           ],
         };
       }),
-      { id: "count", parts: [{ text: `${quotes.length} stocks`, tone: "muted" }] },
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
     ],
     hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refreshActiveTab }],
-  }), [loading, quotes.length, refreshActiveTab, summaryQuotes]);
+  }), [loading, refreshActiveTab, summaryQuotes]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -103,13 +103,10 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
 
   usePaneFooter("news-wire:breaking", () => ({
     info: [
-      { id: "title", parts: [{ text: "Breaking News", tone: "value", bold: true }] },
-      { id: "count", parts: [{ text: `${articles.length} stories`, tone: "muted" }] },
-      ...(aiAvailable ? [{ id: "digest", parts: [{ text: "AI digest", tone: "muted" as const }] }] : []),
       ...(aiRunning ? [{ id: "running", parts: [{ text: BRAILLE_FRAMES[spinFrame] ?? "running", tone: "positive" as const }] }] : []),
       ...(aiError ? [{ id: "paused", parts: [{ text: "AI paused", tone: "warning" as const }] }] : []),
     ],
-  }), [aiAvailable, aiError, aiRunning, articles.length, spinFrame]);
+  }), [aiError, aiRunning, spinFrame]);
 
   const detailContent = detailArticle ? (
     <NewsDetailView item={detailArticle} focused={focused} width={width} height={Math.max(height - 1, 1)} />

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -76,13 +76,7 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     return true;
   };
 
-  usePaneFooter("news-wire:industry", () => ({
-    info: [
-      { id: "title", parts: [{ text: "Sector News", tone: "value", bold: true }] },
-      { id: "category", parts: [{ text: sectorNewsLabel(category), tone: category === "all" ? "muted" : "value" }] },
-      { id: "count", parts: [{ text: `${articles.length} stories`, tone: "muted" }] },
-    ],
-  }), [articles.length, category]);
+  usePaneFooter("news-wire:industry", () => null, [category]);
 
   const rootBefore = (
     <Box height={1} flexShrink={0} overflow="hidden">

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -45,12 +45,7 @@ export function NewsPresetPane({
   );
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
 
-  usePaneFooter(`news-wire:${paneKey}`, () => ({
-    info: [
-      { id: "title", parts: [{ text: title, tone: "value", bold: true }] },
-      { id: "count", parts: [{ text: `${articles.length} stories`, tone: "muted" }] },
-    ],
-  }), [articles.length, paneKey, title]);
+  usePaneFooter(`news-wire:${paneKey}`, () => null, [paneKey]);
 
   const detailContent = detailArticle ? (
     <NewsDetailView item={detailArticle} focused={focused} width={width} height={Math.max(height - 1, 1)} />

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -100,15 +100,14 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
     }
   }, [news.length, selectedIdx, setSelectedIdx]);
 
-  usePaneFooter("news", () => ({
-    info: [
-      ...(ticker ? [{ id: "ticker", parts: [{ text: ticker.metadata.ticker, tone: "value" as const, bold: true }] }] : []),
-      { id: "count", parts: [{ text: `${news.length} headlines`, tone: "muted" }] },
+  usePaneFooter("news", () => {
+    const info = [
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
       ...(loadingSummary ? [{ id: "summary", parts: [{ text: "summary loading", tone: "muted" as const }] }] : []),
-    ],
-  }), [error, loading, loadingSummary, news.length, ticker?.metadata.ticker]);
+    ];
+    return info.length > 0 ? { info } : null;
+  }, [error, loading, loadingSummary]);
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view news.</Text>;
   if (loading && news.length === 0) return <Spinner label="Loading news..." />;

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -13,6 +13,7 @@ import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../market-data/hooks";
 import { Spinner } from "../../components/spinner";
 import { setOptionsAvailability } from "./options-availability";
+import { usePaneFooter } from "../../components";
 
 function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const { ticker } = usePaneTicker();
@@ -100,6 +101,30 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
 
   // Build sorted strike list from the union of calls and puts
   const strikes = chain ? buildStrikeList(chain) : [];
+  const callsByStrike = new Map<number, OptionContract>(chain?.calls.map((c) => [c.strike, c]) ?? []);
+  const putsByStrike = new Map<number, OptionContract>(chain?.puts.map((p) => [p.strike, p]) ?? []);
+  const selectedStrike = strikes[strikeIdx];
+  const selectedCall = selectedStrike != null ? callsByStrike.get(selectedStrike) : undefined;
+  const selectedPut = selectedStrike != null ? putsByStrike.get(selectedStrike) : undefined;
+
+  usePaneFooter("options", () => {
+    const info = [
+      ...(selectedExpiration != null ? [{ id: "exp", parts: [{ text: formatExpDate(selectedExpiration), tone: "muted" as const }] }] : []),
+      ...(selectedStrike != null ? [{ id: "strike", parts: [{ text: `Strike ${formatStrikeLabel(selectedStrike)}`, tone: "value" as const, bold: true }] }] : []),
+      ...(selectedCall ? [{ id: "call-iv", parts: [{ text: "Call IV", tone: "label" as const }, { text: formatIv(selectedCall.impliedVolatility), tone: "value" as const }] }] : []),
+      ...(selectedPut ? [{ id: "put-iv", parts: [{ text: "Put IV", tone: "label" as const }, { text: formatIv(selectedPut.impliedVolatility), tone: "value" as const }] }] : []),
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
+    ];
+    return info.length > 0 ? { info } : null;
+  }, [
+    error,
+    loading,
+    selectedCall?.impliedVolatility,
+    selectedExpiration,
+    selectedPut?.impliedVolatility,
+    selectedStrike,
+  ]);
 
   // Auto-scroll to matching strike when viewing an option position
   useEffect(() => {
@@ -145,8 +170,6 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   if (!chain || chain.expirationDates.length === 0) return <Text fg={colors.textDim}>No options available for {effectiveTicker}.</Text>;
 
   const innerWidth = Math.max(width - 4, 60);
-  const callsByStrike = new Map<number, OptionContract>(chain.calls.map((c) => [c.strike, c]));
-  const putsByStrike = new Map<number, OptionContract>(chain.puts.map((p) => [p.strike, p]));
 
   // Column widths for each side
   const colW = { last: 7, bid: 7, ask: 7, vol: 6, oi: 6 };
@@ -164,10 +187,6 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const expStart = Math.max(0, Math.min(expIdx - Math.floor(maxExpVisible / 2), chain.expirationDates.length - maxExpVisible));
   const visibleExps = chain.expirationDates.slice(expStart, expStart + maxExpVisible);
 
-  // Selected row detail
-  const selectedStrike = strikes[strikeIdx];
-  const selectedCall = selectedStrike != null ? callsByStrike.get(selectedStrike) : undefined;
-  const selectedPut = selectedStrike != null ? putsByStrike.get(selectedStrike) : undefined;
   const strikeItems: ListViewItem[] = strikes.map((strike) => ({
     id: String(strike),
     label: formatStrikeLabel(strike),
@@ -292,16 +311,6 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
         scrollable
       />
 
-      {/* Detail for selected row */}
-      {interactive && (selectedCall || selectedPut) && (
-        <Box height={1}>
-          <Text fg={colors.textDim}>
-            {selectedCall ? `Call IV: ${(selectedCall.impliedVolatility * 100).toFixed(1)}%` : ""}
-            {selectedCall && selectedPut ? "  |  " : ""}
-            {selectedPut ? `Put IV: ${(selectedPut.impliedVolatility * 100).toFixed(1)}%` : ""}
-          </Text>
-        </Box>
-      )}
     </Box>
   );
 }
@@ -316,6 +325,11 @@ function buildStrikeList(chain: OptionsChain): number[] {
 function formatStrikeLabel(strike: number): string {
   const decimals = strike % 1 === 0 ? 0 : 2;
   return formatNumber(strike, decimals).replace(/(\.\d*?[1-9])0+$/, "$1").replace(/\.0+$/, "");
+}
+
+function formatIv(value: number | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${(value * 100).toFixed(1)}%`;
 }
 
 interface ColWidths {

--- a/src/plugins/builtin/sec.tsx
+++ b/src/plugins/builtin/sec.tsx
@@ -306,14 +306,13 @@ function SecTab({ width, height, focused }: DetailTabProps) {
     })();
   }, [filings]);
 
-  usePaneFooter("sec", () => ({
-    info: [
-      ...(ticker ? [{ id: "ticker", parts: [{ text: ticker.metadata.ticker, tone: "value" as const, bold: true }] }] : []),
-      { id: "count", parts: [{ text: `${filings.length} filings`, tone: "muted" }] },
+  usePaneFooter("sec", () => {
+    const info = [
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
-    ],
-  }), [error, filings.length, loading, ticker?.metadata.ticker]);
+    ];
+    return info.length > 0 ? { info } : null;
+  }, [error, loading]);
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view SEC filings.</Text>;
   if (!eligibleTicker) return renderNotice("SEC filings are only shown for US equities.", width);

--- a/src/plugins/builtin/ticker-detail.test.tsx
+++ b/src/plugins/builtin/ticker-detail.test.tsx
@@ -476,8 +476,8 @@ describe("TickerDetailPane", () => {
 
     await flushFrame();
     const frame = testSetup.captureCharFrame();
-    expect(receivedHeight).toBe(16);
-    expect(frame).toContain("height:16");
+    expect(receivedHeight).toBe(17);
+    expect(frame).toContain("height:17");
   });
 
   test("hides SEC for non-US equities", async () => {

--- a/src/plugins/builtin/ticker-detail/chart-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/chart-tab.tsx
@@ -47,7 +47,7 @@ export function ChartTab({
   const config = useAppSelector((state) => state.config);
 
   const chartWidth = Math.max((width || Math.floor(termWidth * 0.55)) - 2, 30);
-  const chartHeight = Math.max((height || termHeight - 8) - 2, 10);
+  const chartHeight = Math.max(height ?? termHeight - 8, 10);
   const rawIndicatorSelection = config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_KEY];
   const indicatorSelectionVersion = config.pluginConfig[TICKER_DETAIL_PLUGIN_ID]?.[CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY];
   const hasStoredIndicatorSelection = Array.isArray(rawIndicatorSelection);
@@ -103,6 +103,7 @@ export function ChartTab({
           height={chartHeight}
           focused={focused}
           interactive={interactive}
+          onActivate={onActivate}
           axisMode={axisMode}
           symbol={symbol}
           ticker={ticker}

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -64,7 +64,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
     ? resolveLockedTabId(paneSettings, allTabs)
     : (allTabs.some((tab) => tab.id === activeTabId) ? activeTabId : (allTabs[0]?.id ?? "overview"));
   const activePluginTab = pluginTabs.find((tab) => tab.id === resolvedTabId && allTabs.some((visibleTab) => visibleTab.id === tab.id)) ?? null;
-  const tabBarHeight = paneSettings.hideTabs ? 0 : 2;
+  const tabBarHeight = paneSettings.hideTabs ? 0 : 1;
   const contentHeight = Math.max(1, height - tabBarHeight);
 
   const allTabsRef = useRef(allTabs);

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -351,7 +351,6 @@ export function WorldIndicesPane({ focused, width, height }: PaneProps) {
     }
   }, [quotes]);
 
-  const loadedCount = Array.from(quotes.values()).filter((state) => !!state.quote).length;
   const loadingCount = Array.from(quotes.values()).filter((state) => state.loading).length;
   const latestQuoteTs = Math.max(
     0,
@@ -359,12 +358,10 @@ export function WorldIndicesPane({ focused, width, height }: PaneProps) {
   );
   usePaneFooter("world-indices", () => ({
     info: [
-      { id: "rows", parts: [{ text: `${navigableIndices.length} indices`, tone: "muted" }] },
-      { id: "quotes", parts: [{ text: `${loadedCount} quotes`, tone: loadedCount > 0 ? "value" : "muted" }] },
-      ...(loadingCount > 0 ? [{ id: "loading", parts: [{ text: `${loadingCount} loading`, tone: "muted" as const }] }] : []),
+      ...(loadingCount > 0 ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(latestQuoteTs > 0 ? [{ id: "fresh", parts: [{ text: new Date(latestQuoteTs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }), tone: "muted" as const }] }] : []),
     ],
-  }), [latestQuoteTs, loadedCount, loadingCount, navigableIndices.length]);
+  }), [latestQuoteTs, loadingCount]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -75,10 +75,8 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       : colors.borderFocused;
   usePaneFooter("prediction-markets", () => ({
     info: [
-      { id: "count", parts: [{ text: `${controller.visibleRows.length} markets`, tone: "muted" }] },
       ...(controller.searchQuery.trim() ? [{ id: "search", parts: [{ text: `search: ${controller.searchQuery.trim()}`, tone: "value" as const }] }] : []),
       ...(controller.searchLoading ? [{ id: "search-loading", parts: [{ text: "searching", tone: "muted" as const }] }] : []),
-      ...(controller.watchlistSet.size > 0 ? [{ id: "watch", parts: [{ text: `${controller.watchlistSet.size} watched`, tone: "muted" as const }] }] : []),
       ...(controller.catalogStatus ? [{
         id: "catalog",
         parts: [{ text: controller.catalogStatus.message, tone: controller.catalogStatus.tone === "danger" ? "warning" as const : "muted" as const, color: catalogStatusColor }],
@@ -105,8 +103,6 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
     controller.searchLoading,
     controller.searchQuery,
     controller.selectedRow,
-    controller.visibleRows.length,
-    controller.watchlistSet.size,
   ]);
 
   const browseControls = (

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -313,10 +313,10 @@ const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { children?:
     };
 
     const handleMouseDown = (event: MouseEvent) => {
-      callMouseHandler(propsRef.current.onMouseDown, event, "down");
-      if (event.isPropagationStopped() || event.button !== 0) return;
       const hasSyntheticDrag = typeof propsRef.current.onMouse === "function";
       const hasDirectDrag = typeof propsRef.current.onMouseDrag === "function" || typeof propsRef.current.onMouseDragEnd === "function";
+      callMouseHandler(propsRef.current.onMouseDown, event, "down");
+      if (event.button !== 0 || (event.isPropagationStopped() && !hasDirectDrag)) return;
       if (!hasSyntheticDrag && !hasDirectDrag) return;
       callMouseHandler(propsRef.current.onMouse, event, "down");
       draggingRef.current = true;
@@ -822,7 +822,7 @@ function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: Host
         display: "flex",
         flexDirection: "row",
         width: "100%",
-        height: cellHeight(compact ? 1 : 2),
+        height: cellHeight(1),
         minInlineSize: 0,
         flexShrink: 0,
         overflowX: "auto",
@@ -841,10 +841,10 @@ function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: Host
           "--tab-hover-bg": palette.hoverBg,
           color: "var(--tab-fg)",
           width: cellWidth(tabWidth),
-          height: cellHeight(compact ? 1 : 2),
+          height: cellHeight(1),
           flex: "0 0 auto",
           display: "flex",
-          flexDirection: "column",
+          flexDirection: "row",
           alignItems: "stretch",
           justifyContent: "flex-start",
           padding: 0,
@@ -856,6 +856,7 @@ function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: Host
           textAlign: "left",
           whiteSpace: "pre",
           cursor: disabled ? "default" : "pointer",
+          boxShadow: compact ? undefined : "inset 0 -2px 0 var(--tab-underline)",
         } satisfies CssVars;
 
         return (
@@ -885,20 +886,6 @@ function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: Host
             >
               {` ${tab.label} `}
             </span>
-            {!compact && (
-              <span
-                data-gloom-role="tab-underline"
-                aria-hidden="true"
-                style={{
-                  display: "block",
-                  height: "var(--cell-h)",
-                  lineHeight: "var(--cell-h)",
-                  color: "var(--tab-underline)",
-                }}
-              >
-                {"▔".repeat(tabWidth)}
-              </span>
-            )}
           </button>
         );
       })}


### PR DESCRIPTION
Reserve pane bottom chrome even when footers are empty so active floating and docked panes keep their bottom border and content stays above it.
Collapse TUI and desktop tabs to one row, keep chart drag interactions working, and pass the full chart height through ticker detail.
Trim count-only footer/status text across news, SEC, and other panes, and move selected options IV into the pane footer.
Verified with focused Bun tests, build, desktop view build, diff check, and a tmux smoke.