### PR TITLE
Polish desktop window behavior

### DIFF
--- a/.agents/skills/opentui/SKILL.md
+++ b/.agents/skills/opentui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opentui
-description: Comprehensive OpenTUI skill for building terminal user interfaces. Covers the core imperative API, React reconciler, and Solid reconciler. Use for any TUI development task including components, layout, keyboard handling, animations, and testing.
+description: Comprehensive OpenTUI skill for building terminal user interfaces. Covers the core imperative API, React reconciler, and Solid reconciler. Use for terminal OpenTUI development tasks including components, layout, keyboard handling, animations, and testing. Do not use for Electrobun/desktop-web-only window chrome, CSS, or browser renderer work unless terminal OpenTUI behavior is also in scope.
 metadata:
    references: core, react, solid, testing
 ---
@@ -8,6 +8,8 @@ metadata:
 # OpenTUI Platform Skill
 
 Consolidated skill for building terminal user interfaces with OpenTUI. Use decision trees below to find the right framework and components, then load detailed references.
+
+This skill is for terminal OpenTUI surfaces. Do not load it for Electrobun desktop-web-only window chrome, CSS, or browser renderer fixes unless the task also changes terminal OpenTUI behavior.
 
 ## Critical Rules
 

--- a/.agents/skills/tui-testing/SKILL.md
+++ b/.agents/skills/tui-testing/SKILL.md
@@ -3,13 +3,17 @@ name: tui-testing
 description: >-
   Testing Gloomberb at every level: CLI commands for fast data/integration checks,
   OpenTUI's built-in test harness for component tests, and tmux for full end-to-end
-  TUI testing. Use this skill when you need to verify features, write regression
-  tests, or smoke-test the running app.
+  terminal TUI testing. Use this skill when you need to verify terminal TUI features,
+  write OpenTUI regression tests, or smoke-test the terminal app. Do not use it for
+  Electrobun/desktop-web-only visual or window chrome work unless tmux/OpenTUI
+  coverage is explicitly needed.
 ---
 
 # Testing Gloomberb
 
 Three testing approaches. **Start with the simplest level that covers your change** and escalate only when needed.
+
+This skill is for terminal TUI and OpenTUI test workflows. For Electrobun/desktop-web-only fixes, use focused desktop builds/tests instead unless the task explicitly asks for tmux or terminal rendering coverage.
 
 ## Critical Rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 Stack: Bun + OpenTUI
 
-Use tmux to test your changes (see the `tui-testing` skill). Always kill the tmux session when done.
+Use tmux to test terminal TUI changes (see the `tui-testing` skill). Always kill the tmux session when done.
+For Electrobun/desktop-web-only work, do not load the OpenTUI or tui-testing skills unless the change also touches terminal OpenTUI behavior or explicitly needs tmux coverage.
 Add mouse/cursor interactivity for everything interactive.
 Never fix chart issues by disabling / turning off the kitty renderer; preserve kitty support and fix the root cause.
 When adding new pane/plugin, read PLUGINS.md check how others are made first to keep UI consistent. Always prefer shared UI components and plugin APIs before rolling your own.

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -23,6 +23,8 @@ const config: ElectrobunConfig = {
       "package.json",
     ],
     watchIgnore: [
+      ".git",
+      ".git/**",
       "dist/**",
       "build/**",
       "artifacts/**",

--- a/scripts/build-electrobun-view.ts
+++ b/scripts/build-electrobun-view.ts
@@ -88,6 +88,11 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
       [data-gloom-role="pane-window"] {
         background-clip: padding-box;
       }
+      [data-gloom-role="detached-pane-window"] {
+        border: 0;
+        box-shadow: none;
+        background-clip: padding-box;
+      }
       [data-gloom-role="app-header"][data-titlebar-overlay="true"],
       .electrobun-webkit-app-region-drag {
         cursor: default;

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -6,11 +6,11 @@ import type { DesktopWindowBridge } from "../../types/desktop-window";
 import { findPaneInstance } from "../../types/config";
 import type { PluginRegistry } from "../../plugins/registry";
 import { colors, floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../../theme/colors";
-import { PaneFooterBar, PaneFooterProvider } from "./pane-footer";
+import { hasPaneFooterContent, PaneFooterBar, PaneFooterProvider } from "./pane-footer";
 import { PaneContent } from "./pane-content";
-import { getPaneBodyHeight, getPaneBodyWidth } from "./pane-sizing";
+import { getPaneBodyWidth } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
-import { TITLEBAR_TRAFFIC_LIGHT_WIDTH } from "./titlebar-overlay";
+import { TITLEBAR_OVERLAY_HEIGHT_PX, TITLEBAR_TRAFFIC_LIGHT_WIDTH } from "./titlebar-overlay";
 
 interface DetachedPaneShellProps {
   pluginRegistry: PluginRegistry;
@@ -29,7 +29,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
   const paneState = useAppSelector((state) => state.paneState);
   const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
   const { width, height } = useViewport();
-  const { nativePaneChrome, titleBarOverlay } = useUiCapabilities();
+  const { cellHeightPx = 18, nativePaneChrome, titleBarOverlay } = useUiCapabilities();
   const instance = useAppSelector((state) => findPaneInstance(state.config.layout, desktopWindowBridge.paneId) ?? null);
   const paneDef = instance ? pluginRegistry.panes.get(instance.paneId) ?? null : null;
   const hasPaneSettings = !!instance && pluginRegistry.hasPaneSettings(instance.instanceId);
@@ -41,7 +41,6 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     ? getPaneDisplayTitle(titleState, instance, paneDef)
     : "Detached Pane";
   const focused = focusedPaneId === desktopWindowBridge.paneId || focusedPaneId == null;
-  const bodyHeight = getPaneBodyHeight(height);
   const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(width)) : getPaneBodyWidth(width);
 
   useEffect(() => {
@@ -64,16 +63,6 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     pluginRegistry.openPaneSettingsFn(desktopWindowBridge.paneId);
   }, [desktopWindowBridge.paneId, pluginRegistry]);
 
-  const dockPane = useCallback((event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
-    stopMouse(event);
-    void desktopWindowBridge.dockDetachedPane?.(desktopWindowBridge.paneId);
-  }, [desktopWindowBridge]);
-
-  const closePane = useCallback((event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
-    stopMouse(event);
-    void desktopWindowBridge.closeDetachedPane?.(desktopWindowBridge.paneId);
-  }, [desktopWindowBridge]);
-
   if (!instance || !paneDef) {
     return (
       <Box flexGrow={1} alignItems="center" justifyContent="center" backgroundColor={colors.bg}>
@@ -84,88 +73,75 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
 
   return (
     <PaneFooterProvider>
-      {(footer) => (
-        <Box
-          flexDirection="column"
-          flexGrow={1}
-          width={width}
-          height={height}
-          backgroundColor={floatingPaneBg(focused)}
-          data-gloom-role="pane-window"
-          data-floating="false"
-          data-focused={focused ? "true" : "false"}
-          style={{ "--pane-border-color": focused ? colors.borderFocused : colors.border }}
-          onMouseDown={focusPane}
-        >
+      {(footer) => {
+        const showFooter = hasPaneFooterContent(footer);
+        const headerHeightRows = titleBarOverlay ? TITLEBAR_OVERLAY_HEIGHT_PX / cellHeightPx : 1;
+        const footerHeightRows = showFooter ? 1 : 0;
+        const bodyHeight = Math.max(1, height - headerHeightRows - footerHeightRows);
+        const titleBackground = floatingPaneTitleBg(focused);
+
+        return (
           <Box
-            height={1}
+            flexDirection="column"
+            flexGrow={1}
             width={width}
-            backgroundColor={floatingPaneTitleBg(focused)}
-            flexDirection="row"
-            data-gloom-role="pane-header"
-            data-titlebar-overlay={titleBarOverlay ? "true" : undefined}
-            data-floating="true"
+            height={height}
+            backgroundColor={floatingPaneBg(focused)}
+            data-gloom-role="detached-pane-window"
             data-focused={focused ? "true" : "false"}
-            onMouseDown={startWindowDrag}
+            onMouseDown={focusPane}
           >
             <Box
+              height={1}
+              width={width}
+              backgroundColor={titleBackground}
               flexDirection="row"
-              alignItems="center"
-              flexGrow={1}
-              minWidth={0}
-              paddingLeft={titleBarOverlay ? TITLEBAR_TRAFFIC_LIGHT_WIDTH : 1}
-              paddingRight={1}
+              data-gloom-role="pane-header"
+              data-titlebar-overlay={titleBarOverlay ? "true" : undefined}
+              data-floating="true"
+              data-focused={focused ? "true" : "false"}
+              style={{ boxShadow: `0 -1px 0 ${titleBackground}, inset 0 1px 0 ${titleBackground}` }}
+              onMouseDown={startWindowDrag}
             >
-              <Text fg={paneTitleText(focused, true)} selectable={false}>{":: "}</Text>
-              <Box flexGrow={1} minWidth={0} overflow="hidden">
-                <Text fg={paneTitleText(focused, true)} selectable={false} data-gloom-role="pane-title">{title}</Text>
+              <Box
+                flexDirection="row"
+                alignItems="center"
+                flexGrow={1}
+                minWidth={0}
+                paddingLeft={titleBarOverlay ? TITLEBAR_TRAFFIC_LIGHT_WIDTH : 1}
+                paddingRight={1}
+              >
+                <Box flexGrow={1} minWidth={0} overflow="hidden">
+                  <Text fg={paneTitleText(focused, true)} selectable={false} data-gloom-role="pane-title">{title}</Text>
+                </Box>
+                {hasPaneSettings && (
+                  <Text
+                    fg={paneTitleText(focused, true)}
+                    selectable={false}
+                    className="electrobun-webkit-app-region-no-drag"
+                    data-gloom-role="pane-action"
+                    data-gloom-interactive="true"
+                    onMouseDown={openSettings}
+                  >
+                    {" ... "}
+                  </Text>
+                )}
               </Box>
-              {hasPaneSettings && (
-                <Text
-                  fg={paneTitleText(focused, true)}
-                  selectable={false}
-                  className="electrobun-webkit-app-region-no-drag"
-                  data-gloom-role="pane-action"
-                  data-gloom-interactive="true"
-                  onMouseDown={openSettings}
-                >
-                  {" ... "}
-                </Text>
-              )}
-              <Text
-                fg={paneTitleText(focused, true)}
-                selectable={false}
-                className="electrobun-webkit-app-region-no-drag"
-                data-gloom-interactive="true"
-                onMouseDown={dockPane}
-              >
-                {" dock "}
-              </Text>
-              <Text
-                fg={paneTitleText(focused, true)}
-                selectable={false}
-                className="electrobun-webkit-app-region-no-drag"
-                data-gloom-role="pane-close"
-                data-gloom-interactive="true"
-                onMouseDown={closePane}
-              >
-                {" x "}
-              </Text>
             </Box>
+            <Box height={bodyHeight} overflow="hidden" backgroundColor={colors.bg}>
+              <PaneContent
+                component={paneDef.component}
+                paneId={instance.instanceId}
+                paneType={instance.paneId}
+                focused={focused}
+                width={bodyWidth}
+                height={bodyHeight}
+              />
+            </Box>
+            {showFooter && <PaneFooterBar footer={footer} focused={focused} width={width} />}
           </Box>
-          <Box height={bodyHeight} overflow="hidden">
-            <PaneContent
-              component={paneDef.component}
-              paneId={instance.instanceId}
-              paneType={instance.paneId}
-              focused={focused}
-              width={bodyWidth}
-              height={bodyHeight}
-            />
-          </Box>
-          <PaneFooterBar footer={footer} focused={focused} width={width} reserveRight={13} />
-        </Box>
-      )}
+        );
+      }}
     </PaneFooterProvider>
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -164,7 +164,7 @@ export function Header() {
         className="electrobun-webkit-app-region-drag"
         style={{
           borderBottom: `1px solid ${colors.borderFocused}`,
-          boxShadow: "inset 0 -1px 0 rgba(84, 201, 159, 0.18)",
+          boxShadow: `0 -1px 0 ${colors.header}, inset 0 1px 0 ${colors.header}, inset 0 -1px 0 rgba(84, 201, 159, 0.18)`,
           paddingInline: 8,
         }}
       >

--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -376,10 +376,10 @@ export function PaneFooterBar({
         data-focused={focused ? "true" : "false"}
         data-empty={empty ? "true" : "false"}
         style={{
-          "--pane-footer-border-color": borderColor,
-          borderTop: `1px solid ${borderColor}`,
-          backgroundColor: focused ? "rgba(84, 201, 159, 0.05)" : "rgba(20, 25, 30, 0.55)",
-          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.03)",
+          "--pane-footer-border-color": empty ? "transparent" : borderColor,
+          borderTop: `1px solid ${empty ? "transparent" : borderColor}`,
+          backgroundColor: empty ? "transparent" : focused ? "rgba(84, 201, 159, 0.05)" : "rgba(20, 25, 30, 0.55)",
+          boxShadow: empty ? "none" : "inset 0 1px 0 rgba(255,255,255,0.03)",
         }}
       >
         <FooterContent

--- a/src/renderers/electrobun/view/input-host.tsx
+++ b/src/renderers/electrobun/view/input-host.tsx
@@ -2,7 +2,7 @@
 /** @jsxImportSource react */
 import { useEffect, useMemo, useSyncExternalStore, type ReactNode } from "react";
 import { InputHostProvider, type InputHost, type KeyEventLike } from "../../../react/input";
-import { hasWebCtrlModifier, normalizeWebKeyName, webKeySequence } from "./key-event";
+import { hasWebCtrlModifier, normalizeWebKeyName, shouldConsumeWebAppKeyDown, webKeySequence } from "./key-event";
 
 export const WEB_CELL_WIDTH = 8;
 export const WEB_CELL_HEIGHT = 18;
@@ -44,7 +44,10 @@ export function WebInputHostProvider({ children }: { children: ReactNode }) {
     useShortcut(handler, options) {
       useEffect(() => {
         if (options?.enabled === false) return;
-        const onKeyDown = (event: KeyboardEvent) => handler(toKeyEventLike(event));
+        const onKeyDown = (event: KeyboardEvent) => {
+          handler(toKeyEventLike(event));
+          if (shouldConsumeWebAppKeyDown(event)) event.preventDefault();
+        };
         window.addEventListener("keydown", onKeyDown);
         return () => window.removeEventListener("keydown", onKeyDown);
       }, [handler, options?.enabled, options?.scope]);

--- a/src/renderers/electrobun/view/key-event.test.ts
+++ b/src/renderers/electrobun/view/key-event.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { shouldConsumeWebAppKeyDown } from "./key-event";
+
+function keyEvent(overrides: Record<string, unknown>) {
+  return {
+    key: "x",
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    target: null,
+    ...overrides,
+  } as never;
+}
+
+describe("shouldConsumeWebAppKeyDown", () => {
+  test("consumes non-editable app keydowns", () => {
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "+" }))).toBe(true);
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "ArrowDown", target: { tagName: "DIV" } }))).toBe(true);
+  });
+
+  test("preserves native editing and control targets", () => {
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ target: { tagName: "INPUT" } }))).toBe(false);
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ target: { tagName: "TEXTAREA" } }))).toBe(false);
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ target: { tagName: "DIV", isContentEditable: true } }))).toBe(false);
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "Enter", target: { tagName: "BUTTON" } }))).toBe(false);
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "+", target: { tagName: "BUTTON" } }))).toBe(true);
+  });
+
+  test("preserves browser modifier shortcuts unless they are terminal-style ctrl-shift shortcuts", () => {
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "c", ctrlKey: true }))).toBe(false);
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "c", metaKey: true }))).toBe(false);
+    expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "c", ctrlKey: true, shiftKey: true }))).toBe(true);
+  });
+});

--- a/src/renderers/electrobun/view/key-event.ts
+++ b/src/renderers/electrobun/view/key-event.ts
@@ -1,10 +1,87 @@
 /// <reference lib="dom" />
 
+type KeyboardTargetLike = EventTarget & {
+  tagName?: string;
+  nodeName?: string;
+  isContentEditable?: boolean;
+  closest?: (selector: string) => unknown;
+  getAttribute?: (name: string) => string | null;
+};
+
+type WebKeyDefaultEvent = Pick<KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "shiftKey" | "target"> & {
+  defaultPrevented?: boolean;
+  isComposing?: boolean;
+};
+
 function controlLetterForKey(key: string): string | null {
   if (key.length !== 1) return null;
   const code = key.charCodeAt(0);
   if (code < 1 || code > 26) return null;
   return String.fromCharCode(96 + code);
+}
+
+function getKeyboardTarget(target: EventTarget | null): KeyboardTargetLike | null {
+  if (!target || typeof target !== "object") return null;
+  return target as KeyboardTargetLike;
+}
+
+function getTargetTagName(target: KeyboardTargetLike): string {
+  return (target.tagName ?? target.nodeName ?? "").toUpperCase();
+}
+
+function targetHasClosest(target: KeyboardTargetLike, selector: string): boolean {
+  if (typeof target.closest !== "function") return false;
+  try {
+    return target.closest(selector) != null;
+  } catch {
+    return false;
+  }
+}
+
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  const element = getKeyboardTarget(target);
+  if (!element) return false;
+
+  const tagName = getTargetTagName(element);
+  if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") {
+    return true;
+  }
+  if (element.isContentEditable === true) return true;
+
+  const contentEditable = element.getAttribute?.("contenteditable");
+  return contentEditable === "" || contentEditable?.toLowerCase() === "true"
+    || targetHasClosest(element, "input, textarea, select, [contenteditable=''], [contenteditable='true']");
+}
+
+function isNativeKeyboardControlTarget(target: EventTarget | null): boolean {
+  const element = getKeyboardTarget(target);
+  if (!element) return false;
+
+  const tagName = getTargetTagName(element);
+  if (tagName === "BUTTON" || tagName === "A" || tagName === "SUMMARY") return true;
+
+  return targetHasClosest(element, "button, a[href], summary");
+}
+
+function isBrowserModifierShortcut(event: WebKeyDefaultEvent): boolean {
+  if (event.metaKey) return true;
+  if (!event.ctrlKey || event.shiftKey) return false;
+
+  const key = normalizeWebKeyName(event.key);
+  return key === "c" || key === "v" || key === "x" || key === "a";
+}
+
+function isNativeControlActivationKey(event: WebKeyDefaultEvent): boolean {
+  const key = normalizeWebKeyName(event.key);
+  return key === "return" || key === "enter" || key === "space";
+}
+
+export function shouldConsumeWebAppKeyDown(event: WebKeyDefaultEvent): boolean {
+  if (event.defaultPrevented || event.isComposing) return false;
+  if (isEditableKeyboardTarget(event.target)) return false;
+  if (isBrowserModifierShortcut(event)) return false;
+  if (isNativeKeyboardControlTarget(event.target) && isNativeControlActivationKey(event)) return false;
+  return true;
 }
 
 export function normalizeWebKeyName(key: string): string {

--- a/src/renderers/electrobun/view/native-renderer.ts
+++ b/src/renderers/electrobun/view/native-renderer.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 import type { NativeRendererHost } from "../../../ui";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
-import { hasWebCtrlModifier, normalizeWebKeyName, webKeySequence } from "./key-event";
+import { hasWebCtrlModifier, normalizeWebKeyName, shouldConsumeWebAppKeyDown, webKeySequence } from "./key-event";
 
 type Listener = (...args: unknown[]) => void;
 type KeypressListener = (event: {
@@ -54,10 +54,12 @@ class WebKeyInput {
       stopPropagation: () => event.stopPropagation(),
       preventDefault: () => event.preventDefault(),
     };
-    for (const listener of this.listeners.get("keypress") ?? []) {
+    const listeners = this.listeners.get("keypress");
+    for (const listener of listeners ?? []) {
       listener(payload);
       if (event.defaultPrevented) break;
     }
+    if (listeners?.size && shouldConsumeWebAppKeyDown(event)) event.preventDefault();
   }
 }
 

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -172,7 +172,7 @@ export function useAppSelector<T>(selector: (state: AppState) => T): T {
 }
 
 export function PaneInstanceProvider({ paneId, children }: { paneId: string; children: ReactNode }) {
-  return <PaneContext value={paneId}>{children}</PaneContext>;
+  return <PaneContext.Provider value={paneId}>{children}</PaneContext.Provider>;
 }
 
 export function usePaneInstanceId(): string {
@@ -439,5 +439,5 @@ export function AppProvider({
 
   usePersistSessionSnapshot(sessionStore, state, APP_SESSION_ID, APP_SESSION_SCHEMA_VERSION);
 
-  return <AppContext value={storeRef.current}>{children}</AppContext>;
+  return <AppContext.Provider value={storeRef.current}>{children}</AppContext.Provider>;
 }


### PR DESCRIPTION
Summary:
- Refines detached desktop pane chrome by removing in-pane drag/dock/close controls, stripping active border styling, filling the hidden-inset titlebar edge, and reserving footer space only when a footer is present.
- Adds desktop web keydown consumption that preserves edit fields, native controls, and browser copy/paste/select shortcuts, with focused tests.
- Updates Electrobun watch ignores, React provider usage, and local TUI skill guidance so desktop-web fixes do not load terminal TUI workflows.

Verification:
- bun run desktop:view:build
- bun build src/renderers/electrobun/bun/index.ts --target=bun --outdir .context/verify-electrobun-bun
- bun test src/renderers/electrobun/bun/desktop-workspace.test.ts
- bun test src/components/layout/pane-footer.test.tsx
- bun test src/renderers/electrobun/view/key-event.test.ts
- git diff --check