### PR TITLE
Unify tab surfaces

### DIFF
--- a/scripts/build-electrobun-view.ts
+++ b/scripts/build-electrobun-view.ts
@@ -227,16 +227,15 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
         all: unset;
         box-sizing: border-box;
       }
-      [data-gloom-role="tab-button"]:not(:disabled):hover {
-        --tab-fg: var(--tab-hover-fg);
-        background: var(--tab-hover-bg);
-      }
-      [data-gloom-role="tab-button"]:not(:disabled):not([data-active="true"]):hover {
-        --tab-underline: var(--tab-hover-underline);
-      }
       [data-gloom-role="tab-button"]:focus-visible {
         outline: 1px solid var(--tab-hover-underline);
         outline-offset: -1px;
+      }
+      [data-gloom-role="tab-close"] {
+        cursor: pointer;
+      }
+      [data-gloom-role="tab-close"]:hover {
+        background: rgba(255,255,255,.1);
       }
       [data-gloom-scrollbar-x="hidden"]::-webkit-scrollbar:horizontal {
         height: 0;

--- a/src/components/data-table-stack-view.tsx
+++ b/src/components/data-table-stack-view.tsx
@@ -88,6 +88,7 @@ export function DataTableStackView<
   onActivate,
   renderCell,
   renderSectionHeader,
+  emptyContent,
   emptyStateTitle,
   emptyStateHint,
   virtualize = true,
@@ -223,6 +224,7 @@ export function DataTableStackView<
         onActivate={onActivate}
         renderCell={renderCell}
         renderSectionHeader={renderSectionHeader}
+        emptyContent={emptyContent}
         emptyStateTitle={emptyStateTitle}
         emptyStateHint={emptyStateHint}
         virtualize={virtualize}

--- a/src/components/feed-data-table-stack-view.tsx
+++ b/src/components/feed-data-table-stack-view.tsx
@@ -50,6 +50,8 @@ interface FeedDataTableStackViewProps {
   titleLabel?: string;
   emptyStateTitle?: string;
   emptyStateHint?: string;
+  isItemRead?: (item: FeedDataTableItem) => boolean;
+  onOpenItem?: (item: FeedDataTableItem, index: number) => void;
 }
 
 function truncateWithEllipsis(text: string, width: number): string {
@@ -214,6 +216,8 @@ export function FeedDataTableStackView({
   titleLabel = "Headline",
   emptyStateTitle = "No items.",
   emptyStateHint,
+  isItemRead,
+  onOpenItem,
 }: FeedDataTableStackViewProps) {
   const [sortPreference, setSortPreference] = useState<SortPreference>({
     columnId: "time",
@@ -264,8 +268,9 @@ export function FeedDataTableStackView({
 
   const openRow = useCallback((row: DetailRow | undefined) => {
     if (!row) return;
+    onOpenItem?.(row.item, row.itemIndex);
     setOpenItemId(row.item.id);
-  }, []);
+  }, [onOpenItem]);
 
   useEffect(() => {
     if (openItemId && !openItem) {
@@ -307,12 +312,16 @@ export function FeedDataTableStackView({
         return {
           text: row.item.title,
           color: selectedColor ?? colors.text,
-          attributes: rowState.selected
-            ? TextAttributes.BOLD
-            : TextAttributes.NONE,
+          attributes: isItemRead
+            ? isItemRead(row.item)
+              ? TextAttributes.NONE
+              : TextAttributes.BOLD
+            : rowState.selected
+              ? TextAttributes.BOLD
+              : TextAttributes.NONE,
         };
     }
-  }, []);
+  }, [isItemRead]);
 
   const handleDetailKeyDown = useCallback((event: {
     name?: string;

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -20,6 +20,7 @@ import { getSharedRegistry } from "../../plugins/registry";
 import { gridlockAllPanes } from "../../plugins/pane-manager";
 import { notifyGridlockComplete } from "../../plugins/gridlock-notification";
 import { PluginSlot } from "../../react/plugins/plugin-slot";
+import { TabBar } from "../tab-bar";
 
 const GRIDLOCK_TIP_DURATION_MS = 60_000;
 
@@ -40,7 +41,6 @@ export function StatusBar() {
   const gridlockTipVisible = useAppSelector(selectGridlockTipVisible);
   const gridlockTipSequence = useAppSelector(selectGridlockTipSequence);
   const { symbol, financials: focusedFinancials } = useFocusedTicker();
-  const [hoveredTab, setHoveredTab] = useState<number | null>(null);
   const [hoveredControl, setHoveredControl] = useState<string | null>(null);
 
   const q = focusedFinancials?.quote;
@@ -59,6 +59,16 @@ export function StatusBar() {
 
   const hasMultipleLayouts = layouts.length > 1;
   const showGridlockTip = gridlockTipVisible && !!registry;
+  const layoutTabs = layouts.map((layout, index) => ({
+    label: `^${index + 1} ${truncate(layout.name, 14)}`,
+    value: String(index),
+  }));
+  const layoutTabsWidth = layoutTabs.reduce((sum, tab) => sum + tab.label.length + 2, 0);
+  const handleLayoutSelect = (value: string) => {
+    const index = Number(value);
+    if (!Number.isInteger(index) || index < 0 || index >= layouts.length) return;
+    dispatch({ type: "SWITCH_LAYOUT", index });
+  };
 
   useEffect(() => {
     if (!gridlockTipVisible) return;
@@ -104,42 +114,15 @@ export function StatusBar() {
       >
         <Box paddingLeft={1} flexShrink={0} flexDirection="row" alignItems="center" gap={1}>
           {hasMultipleLayouts ? (
-            layouts.map((layout, index) => {
-              const active = index === activeLayoutIdx;
-              const hovered = hoveredTab === index && !active;
-              return (
-                <Box
-                  key={layout.name}
-                  height={1}
-                  flexDirection="row"
-                  alignItems="center"
-                  backgroundColor={active ? "rgba(84, 201, 159, 0.10)" : hovered ? "rgba(255,255,255,0.04)" : undefined}
-                  onMouseMove={() => setHoveredTab((current) => (current === index ? current : index))}
-                  onMouseDown={(event) => {
-                    event?.preventDefault?.();
-                    event?.stopPropagation?.();
-                    dispatch({ type: "SWITCH_LAYOUT", index });
-                  }}
-                  data-gloom-interactive="true"
-                  style={{
-                    borderRadius: 4,
-                    paddingInline: 4,
-                    cursor: "pointer",
-                  }}
-                >
-                  <Text fg={active ? colors.borderFocused : colors.textDim}>
-                    ^{index + 1}
-                  </Text>
-                  <Text
-                    fg={active ? colors.textBright : hovered ? colors.text : colors.textDim}
-                    attributes={active ? TextAttributes.BOLD : 0}
-                    style={{ marginLeft: 6 }}
-                  >
-                    {truncate(layout.name, 14)}
-                  </Text>
-                </Box>
-              );
-            })
+            <Box width={layoutTabsWidth} height={1}>
+              <TabBar
+                tabs={layoutTabs}
+                activeValue={String(activeLayoutIdx)}
+                onSelect={handleLayoutSelect}
+                compact
+                variant="pill"
+              />
+            </Box>
           ) : (
             <Text fg={colors.textDim}>
               <Span fg={colors.text}>Ctrl+P</Span> command bar
@@ -217,29 +200,15 @@ export function StatusBar() {
     >
       <Box paddingLeft={1} flexShrink={0} flexDirection="row">
         {hasMultipleLayouts ? (
-          layouts.map((l, i) => {
-            const isActive = i === activeLayoutIdx;
-            const isHovered = hoveredTab === i && !isActive;
-            const num = i + 1;
-            const label = truncate(l.name, 14);
-            const bg = isActive ? colors.header : isHovered ? hoverBg() : undefined;
-            const fg = isActive ? colors.headerText : isHovered ? colors.text : colors.textDim;
-            return (
-              <Text
-                key={i}
-                fg={fg}
-                bg={bg}
-                onMouseMove={() => setHoveredTab((current) => (current === i ? current : i))}
-                onMouseDown={(event: any) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  dispatch({ type: "SWITCH_LAYOUT", index: i });
-                }}
-              >
-                {` ^${num} `}<Span fg={isActive ? colors.headerText : colors.text}>{label}</Span>{" "}
-              </Text>
-            );
-          })
+          <Box width={layoutTabsWidth} height={1}>
+            <TabBar
+              tabs={layoutTabs}
+              activeValue={String(activeLayoutIdx)}
+              onSelect={handleLayoutSelect}
+              compact
+              variant="pill"
+            />
+          </Box>
         ) : (
           <Text fg={colors.textDim}>
             <Span fg={colors.text}>Ctrl+P</Span> command bar

--- a/src/components/tab-bar.tsx
+++ b/src/components/tab-bar.tsx
@@ -3,15 +3,42 @@ import { Tabs } from "./ui/tabs";
 export interface Tab {
   label: string;
   value: string;
+  disabled?: boolean;
+  onClose?: (value: string) => void;
+  onDoubleClick?: (value: string) => void;
 }
 
 export interface TabBarProps {
   tabs: Tab[];
-  activeValue: string;
+  activeValue: string | null;
   onSelect: (value: string) => void;
   compact?: boolean;
+  variant?: "underline" | "pill" | "bare";
+  closeMode?: "active" | "always";
+  addLabel?: string;
+  onAdd?: () => void;
 }
 
-export function TabBar({ tabs, activeValue, onSelect, compact }: TabBarProps) {
-  return <Tabs tabs={tabs} activeValue={activeValue} onSelect={onSelect} compact={compact} />;
+export function TabBar({
+  tabs,
+  activeValue,
+  onSelect,
+  compact,
+  variant,
+  closeMode,
+  addLabel,
+  onAdd,
+}: TabBarProps) {
+  return (
+    <Tabs
+      tabs={tabs}
+      activeValue={activeValue}
+      onSelect={onSelect}
+      compact={compact}
+      variant={variant}
+      closeMode={closeMode}
+      addLabel={addLabel}
+      onAdd={onAdd}
+    />
+  );
 }

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,5 +1,5 @@
 import { Box, ScrollBox, Text, useUiHost } from "../../ui";
-import { useCallback, useEffect, useMemo, useState, type ComponentType, type RefObject } from "react";
+import { useCallback, useEffect, useMemo, useState, type ComponentType, type ReactNode, type RefObject } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
 import type { ColumnConfig } from "../../types/config";
@@ -60,6 +60,7 @@ export interface DataTableProps<
     item: T,
     index: number,
   ) => DataTableSectionHeader | null;
+  emptyContent?: ReactNode;
   emptyStateTitle: string;
   emptyStateHint?: string;
   virtualize?: boolean;
@@ -102,6 +103,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
   onActivate,
   renderCell,
   renderSectionHeader,
+  emptyContent,
   emptyStateTitle,
   emptyStateHint,
   virtualize = true,
@@ -276,9 +278,11 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
         onSizeChange={measureContentWidth}
       >
         {items.length === 0 ? (
-          <Box width="100%" paddingX={1} paddingY={1}>
-            <EmptyState title={emptyStateTitle} hint={emptyStateHint} />
-          </Box>
+          emptyContent ?? (
+            <Box width="100%" paddingX={1} paddingY={1}>
+              <EmptyState title={emptyStateTitle} hint={emptyStateHint} />
+            </Box>
+          )
         ) : (
           <>
             {virtualize && startIndex > 0 && <Box height={startIndex} />}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -7,22 +7,37 @@ export interface TabItem {
   label: string;
   value: string;
   disabled?: boolean;
+  onClose?: (value: string) => void;
+  onDoubleClick?: (value: string) => void;
 }
 
 export interface TabsProps {
   tabs: TabItem[];
-  activeValue: string;
+  activeValue: string | null;
   onSelect: (value: string) => void;
   compact?: boolean;
+  variant?: "underline" | "pill" | "bare";
+  closeMode?: "active" | "always";
+  addLabel?: string;
+  onAdd?: () => void;
 }
 
 const WHEEL_DELTA_PER_CELL = 8;
 
-export function Tabs({ tabs, activeValue, onSelect, compact = false }: TabsProps) {
+export function Tabs({
+  tabs,
+  activeValue,
+  onSelect,
+  compact = false,
+  variant = "underline",
+  closeMode = "always",
+  addLabel = "+",
+  onAdd,
+}: TabsProps) {
   const ui = useUiHost();
   const NativeTabs = ui.Tabs;
   const palette = {
-    activeFg: colors.text,
+    activeFg: variant === "bare" ? colors.textBright : colors.text,
     inactiveFg: colors.textDim,
     disabledFg: colors.textMuted,
     hoverFg: colors.text,
@@ -30,6 +45,10 @@ export function Tabs({ tabs, activeValue, onSelect, compact = false }: TabsProps
     inactiveUnderline: colors.bg,
     hoverUnderline: colors.border,
     hoverBg: hoverBg(),
+    activeBg: colors.selected,
+    activePillFg: colors.selectedText,
+    closeFg: colors.textMuted,
+    addFg: colors.textMuted,
   };
 
   if (NativeTabs) {
@@ -39,6 +58,10 @@ export function Tabs({ tabs, activeValue, onSelect, compact = false }: TabsProps
         activeValue={activeValue}
         onSelect={onSelect}
         compact={compact}
+        variant={variant}
+        closeMode={closeMode}
+        addLabel={addLabel}
+        onAdd={onAdd}
         palette={palette}
       />
     );
@@ -50,9 +73,30 @@ export function Tabs({ tabs, activeValue, onSelect, compact = false }: TabsProps
       activeValue={activeValue}
       onSelect={onSelect}
       compact={compact}
+      variant={variant}
+      closeMode={closeMode}
+      addLabel={addLabel}
+      onAdd={onAdd}
       palette={palette}
     />
   );
+}
+
+function shouldShowUnderline(variant: TabsProps["variant"], compact: boolean): boolean {
+  return variant === "underline" && !compact;
+}
+
+function tabHeight(variant: TabsProps["variant"], compact: boolean): number {
+  return shouldShowUnderline(variant, compact) ? 2 : 1;
+}
+
+function tabWidth(
+  tab: TabItem,
+  active: boolean,
+  closeMode: TabsProps["closeMode"],
+): number {
+  const showClose = !!tab.onClose && (closeMode === "always" || active);
+  return tab.label.length + 2 + (showClose ? 2 : 0);
 }
 
 function OpenTuiTabs({
@@ -60,6 +104,10 @@ function OpenTuiTabs({
   activeValue,
   onSelect,
   compact = false,
+  variant = "underline",
+  closeMode = "always",
+  addLabel = "+",
+  onAdd,
   palette,
 }: TabsProps & {
   palette: {
@@ -71,15 +119,21 @@ function OpenTuiTabs({
     inactiveUnderline: string;
     hoverUnderline: string;
     hoverBg: string;
+    activeBg: string;
+    activePillFg: string;
+    closeFg: string;
+    addFg: string;
   };
 }) {
   const [hoveredValue, setHoveredValue] = useState<string | null>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const tabWidths = useMemo(
-    () => tabs.map((tab) => tab.label.length + 2),
-    [tabs],
+    () => tabs.map((tab) => tabWidth(tab, tab.value === activeValue, closeMode)),
+    [activeValue, closeMode, tabs],
   );
-  const totalWidth = tabWidths.reduce((sum, width) => sum + width, 0);
+  const addWidth = onAdd ? addLabel.length + 2 : 0;
+  const totalWidth = tabWidths.reduce((sum, width) => sum + width, 0) + addWidth;
+  const height = tabHeight(variant, compact);
 
   useEffect(() => {
     const scrollBox = scrollRef.current;
@@ -132,18 +186,18 @@ function OpenTuiTabs({
     <ScrollBox
       ref={scrollRef}
       width="100%"
-      height={compact ? 1 : 2}
+      height={height}
       scrollX
       focusable={false}
       horizontalScrollbarOptions={{ visible: false }}
       onMouseScroll={handleMouseScroll}
     >
-      <Box flexDirection="row" width={totalWidth} height={compact ? 1 : 2}>
+      <Box flexDirection="row" width={totalWidth} height={height}>
         {tabs.map((tab, index) => {
           const active = tab.value === activeValue;
           const hovered = hoveredValue === tab.value && !tab.disabled;
           const tabWidth = tabWidths[index] ?? tab.label.length + 2;
-          const tabLabel = ` ${tab.label} `;
+          const showClose = !!tab.onClose && (closeMode === "always" || active);
           const startHover = tab.disabled
             ? undefined
             : () => {
@@ -160,7 +214,7 @@ function OpenTuiTabs({
               key={tab.value}
               width={tabWidth}
               flexDirection="column"
-              backgroundColor={hovered ? palette.hoverBg : undefined}
+              backgroundColor={active && variant === "pill" ? palette.activeBg : hovered ? palette.hoverBg : undefined}
               onMouseOver={startHover}
               onMouseMove={startHover}
               onMouseOut={endHover}
@@ -168,14 +222,29 @@ function OpenTuiTabs({
                 event.preventDefault();
                 onSelect(tab.value);
               }}
+              onDoubleClick={tab.disabled || !tab.onDoubleClick ? undefined : () => tab.onDoubleClick?.(tab.value)}
             >
-              <Text
-                fg={tab.disabled ? palette.disabledFg : active ? palette.activeFg : hovered ? palette.hoverFg : palette.inactiveFg}
-                attributes={active ? TextAttributes.BOLD : 0}
-              >
-                {tabLabel}
-              </Text>
-              {!compact && (
+              <Box flexDirection="row" height={1}>
+                <Text
+                  fg={tab.disabled ? palette.disabledFg : active && variant === "pill" ? palette.activePillFg : active ? palette.activeFg : hovered ? palette.hoverFg : palette.inactiveFg}
+                  attributes={active ? TextAttributes.BOLD : 0}
+                >
+                  {` ${tab.label} `}
+                </Text>
+                {showClose && (
+                  <Text
+                    fg={active && variant === "pill" ? palette.activePillFg : palette.closeFg}
+                    onMouseDown={(event: any) => {
+                      event.preventDefault?.();
+                      event.stopPropagation?.();
+                      tab.onClose?.(tab.value);
+                    }}
+                  >
+                    {"x "}
+                  </Text>
+                )}
+              </Box>
+              {shouldShowUnderline(variant, compact) && (
                 <Text fg={active ? palette.activeUnderline : hovered ? palette.hoverUnderline : palette.inactiveUnderline}>
                   {"▔".repeat(tabWidth)}
                 </Text>
@@ -183,6 +252,23 @@ function OpenTuiTabs({
             </Box>
           );
         })}
+        {onAdd && (
+          <Box
+            width={addWidth}
+            height={1}
+            backgroundColor={hoveredValue === "__add__" ? palette.hoverBg : undefined}
+            onMouseMove={() => setHoveredValue((current) => (current === "__add__" ? current : "__add__"))}
+            onMouseOut={() => setHoveredValue((current) => (current === "__add__" ? null : current))}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              onAdd();
+            }}
+          >
+            <Text fg={hoveredValue === "__add__" ? palette.hoverFg : palette.addFg}>
+              {` ${addLabel} `}
+            </Text>
+          </Box>
+        )}
       </Box>
     </ScrollBox>
   );

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -23,6 +23,8 @@ let selectedTableRow: string | null = null;
 let activatedTableRow: string | null = null;
 let selectedChips: string[] = [];
 let tableHorizontalScrollbarVisible: boolean | null = null;
+let closedTab: string | null = null;
+let addedTab = false;
 
 function ScrollableListHarness() {
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -229,6 +231,8 @@ afterEach(() => {
   activatedTableRow = null;
   selectedChips = [];
   tableHorizontalScrollbarVisible = null;
+  closedTab = null;
+  addedTab = false;
 });
 
 describe("shared UI kit", () => {
@@ -296,6 +300,44 @@ describe("shared UI kit", () => {
     frame = testSetup.captureCharFrame();
     expect(frame).toContain("Options");
     expect(frame).toContain("Insider");
+  });
+
+  test("renders tab actions for editable tab sets", async () => {
+    testSetup = await testRender(
+      <Tabs
+        tabs={[
+          { label: "One", value: "one", onClose: (value) => { closedTab = value; } },
+          { label: "Two", value: "two" },
+        ]}
+        activeValue="one"
+        onSelect={() => {}}
+        compact
+        variant="pill"
+        closeMode="active"
+        onAdd={() => { addedTab = true; }}
+      />,
+      { width: 24, height: 3 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("One x");
+    expect(frame).toContain("+");
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(5, 0);
+      await testSetup!.renderOnce();
+    });
+    expect(closedTab).toBe("one");
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(14, 0);
+      await testSetup!.renderOnce();
+    });
+    expect(addedTab).toBe(true);
   });
 
   test("renders toggle lists with selection and descriptions", async () => {

--- a/src/plugins/builtin/ai/screener-pane.tsx
+++ b/src/plugins/builtin/ai/screener-pane.tsx
@@ -20,7 +20,7 @@ import { getSharedMarketDataCoordinator } from "../../../market-data/coordinator
 import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../../market-data/request-types";
 import { useQuoteStreaming } from "../../../state/use-quote-streaming";
 import { TickerListTable } from "../../../components/ticker-list-table";
-import { Button, EmptyState, Spinner, usePaneFooter } from "../../../components";
+import { Button, EmptyState, Spinner, TabBar, usePaneFooter } from "../../../components";
 import { colors } from "../../../theme/colors";
 import { canonicalExchange } from "../../../utils/exchanges";
 import { formatTimeAgo } from "../../../utils/format";
@@ -965,45 +965,37 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      <Box flexDirection="row" height={1}>
-        {displayTabs.map((tab) => {
-          const isDraft = tab.draft === true;
-          const isActive = isDraft ? editorState?.mode === "create" : tab.id === activeTab?.id;
-          return (
-            <Box key={tab.id} flexDirection="row">
-              <Box
-                onMouseDown={() => {
-                  if (editorState) return;
-                  if (isDraft) return;
-                  setActiveTabId(tab.id);
-                  setCursorSymbol(null);
-                  const now = Date.now();
-                  const last = lastTabClickRef.current;
-                  if (last?.tabId === tab.id && now - last.at <= 350) {
-                    lastTabClickRef.current = null;
-                    editTab(tab);
-                    return;
-                  }
-                  lastTabClickRef.current = { tabId: tab.id, at: now };
-                }}
-              >
-                <Text
-                  fg={isActive ? colors.textBright : colors.textDim}
-                  bg={isActive ? colors.selected : undefined}
-                  attributes={isActive ? TextAttributes.BOLD : 0}
-                >
-                  {` ${truncateWithEllipsis(tab.title, isDraft ? 20 : 18)} `}
-                </Text>
-              </Box>
-              {isActive && !isDraft ? (
-                <Text fg={colors.textMuted} onMouseDown={() => { if (!editorState) removeTab(tab.id); }}>{`x `}</Text>
-              ) : (
-                <Text>{` `}</Text>
-              )}
-            </Box>
-          );
-        })}
-        <Text fg={colors.textMuted} onMouseDown={() => { if (!editorState) addTab(); }}>{` + `}</Text>
+      <Box height={1}>
+        <TabBar
+          tabs={displayTabs.map((tab) => {
+            const isDraft = tab.draft === true;
+            return {
+              label: truncateWithEllipsis(tab.title, isDraft ? 20 : 18),
+              value: tab.id,
+              onClose: !editorState && !isDraft ? removeTab : undefined,
+            };
+          })}
+          activeValue={editorState?.mode === "create" ? "__draft__" : activeTab?.id ?? null}
+          onSelect={(tabId) => {
+            if (editorState || tabId === "__draft__") return;
+            const tab = tabs.find((entry) => entry.id === tabId);
+            if (!tab) return;
+            setActiveTabId(tab.id);
+            setCursorSymbol(null);
+            const now = Date.now();
+            const last = lastTabClickRef.current;
+            if (last?.tabId === tab.id && now - last.at <= 350) {
+              lastTabClickRef.current = null;
+              editTab(tab);
+              return;
+            }
+            lastTabClickRef.current = { tabId: tab.id, at: now };
+          }}
+          compact
+          variant="pill"
+          closeMode="active"
+          onAdd={editorState ? undefined : addTab}
+        />
       </Box>
 
       <Box flexDirection="row" height={1} gap={1}>

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -1,8 +1,8 @@
-import { Box, Text } from "../../../ui";
+import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { DataTable, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
+import { DataTable, TabBar, usePaneFooter, type DataTableCell, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatCompact, formatPercentRaw } from "../../../utils/format";
@@ -493,31 +493,18 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {/* Tab bar */}
-      <Box flexDirection="row" height={1} paddingX={1}>
-        {TABS.map((tab) => {
-          const isActive = tab.id === activeTab;
-          return (
-            <Box
-              key={tab.id}
-              paddingX={1}
-              marginRight={1}
-              onMouseDown={(event: any) => {
-                event.preventDefault?.();
-                setActiveTab(tab.id);
-                setSelectedSymbol(null);
-                resetTableScroll();
-              }}
-            >
-              <Text
-                fg={isActive ? colors.textBright : colors.textDim}
-                attributes={isActive ? TextAttributes.BOLD | TextAttributes.UNDERLINE : TextAttributes.NONE}
-              >
-                {tab.label}
-              </Text>
-            </Box>
-          );
-        })}
+      <Box height={1} paddingX={1}>
+        <TabBar
+          tabs={TABS.map((tab) => ({ label: tab.label, value: tab.id }))}
+          activeValue={activeTab}
+          onSelect={(value) => {
+            setActiveTab(value as TabId);
+            setSelectedSymbol(null);
+            resetTableScroll();
+          }}
+          compact
+          variant="bare"
+        />
       </Box>
 
       <DataTable<MarketMoverRow, MarketMoverColumn>

--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -12,6 +12,7 @@ import { getDigest, setDigest, isDigestInFlight, markDigestInFlight, clearDigest
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
 import { NEWS_QUERY_PRESETS } from "./news-query-presets";
+import { useNewsReadState } from "./read-state";
 
 const DIGEST_PROMPT = `You are a financial news wire editor. Condense this headline and summary into a single concise actionable bullet point for a professional trader. Include why it matters and potential market impact. Keep it under 120 characters. Respond with ONLY the bullet text, nothing else.
 
@@ -40,6 +41,7 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
   const [spinFrame, setSpinFrame] = useState(0);
   const processingRef = useRef(false);
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
+  const { readArticleIds, markArticleRead } = useNewsReadState();
 
   useEffect(() => {
     const providers = detectProviders();
@@ -127,11 +129,13 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
       focused={focused}
       width={width}
       rootHeight={height}
+      readArticleIds={readArticleIds}
       selectedArticleId={selectedArticleId}
       setSelectedArticleId={setSelectedArticleId}
       sortPreference={sortPreference}
       setSortPreference={setSortPreference}
       onOpenArticle={openArticle}
+      onArticleRead={markArticleRead}
       detailOpen={!!detailArticle}
       onBack={closeDetail}
       detailContent={detailContent}

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "../../../components/spinner";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
+import { useNewsReadState } from "./read-state";
 import {
   NEWS_QUERY_PRESETS,
   SECTOR_NEWS_SECTORS,
@@ -42,6 +43,7 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
   const { articles, allArticles, phase } = useIndustryArticles(category);
   const loading = phase === "loading" || (phase === "refreshing" && articles.length === 0);
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
+  const { readArticleIds, markArticleRead } = useNewsReadState();
   const counts = useMemo(() => {
     const next: Record<string, number> = { all: allArticles.length };
     for (const cat of SECTOR_TABS) {
@@ -91,6 +93,7 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
         activeValue={category}
         onSelect={(value) => setCategory(value as SectorNewsSelection)}
         compact
+        variant="bare"
       />
     </Box>
   );
@@ -101,27 +104,30 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     <Box flexGrow={1} />
   );
 
-  if (loading && articles.length === 0) {
-    return <Spinner label="Loading sector news..." />;
-  }
-
   return (
     <NewsArticleStackView
       articles={articles}
       focused={focused}
       width={width}
       rootHeight={height}
+      readArticleIds={readArticleIds}
       selectedArticleId={selectedArticleId}
       setSelectedArticleId={setSelectedArticleId}
       sortPreference={sortPreference}
       setSortPreference={setSortPreference}
       onOpenArticle={openArticle}
+      onArticleRead={markArticleRead}
       detailOpen={!!detailArticle}
       onBack={closeDetail}
       detailContent={detailContent}
       rootBefore={rootBefore}
       onRootKeyDown={handleRootKeyDown}
       columns={["time", "source", "title", "tickers", "categories"]}
+      emptyContent={loading && articles.length === 0 ? (
+        <Box width="100%" paddingX={1} paddingY={1}>
+          <Spinner label="Loading sector news..." />
+        </Box>
+      ) : undefined}
       emptyStateTitle="No news in this category"
       emptyStateHint="Try another category or wait for the next feed refresh."
     />

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -11,6 +11,7 @@ import {
   type NewsColumnId,
   type NewsSortPreference,
 } from "./news-table";
+import { useNewsReadState } from "./read-state";
 
 export function NewsPresetPane({
   focused,
@@ -44,6 +45,7 @@ export function NewsPresetPane({
     defaultSort,
   );
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
+  const { readArticleIds, markArticleRead } = useNewsReadState();
 
   usePaneFooter(`news-wire:${paneKey}`, () => ({
     info: [
@@ -68,11 +70,13 @@ export function NewsPresetPane({
       focused={focused}
       width={width}
       rootHeight={height}
+      readArticleIds={readArticleIds}
       selectedArticleId={selectedArticleId}
       setSelectedArticleId={setSelectedArticleId}
       sortPreference={sortPreference}
       setSortPreference={setSortPreference}
       onOpenArticle={openArticle}
+      onArticleRead={markArticleRead}
       detailOpen={!!detailArticle}
       onBack={closeDetail}
       detailContent={detailContent}

--- a/src/plugins/builtin/news-wire/news-table.test.tsx
+++ b/src/plugins/builtin/news-wire/news-table.test.tsx
@@ -1,0 +1,159 @@
+import { TextAttributes } from "@opentui/core";
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { Box, Text } from "../../../ui";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import {
+  AppContext,
+  PaneInstanceProvider,
+  createInitialState,
+} from "../../../state/app-context";
+import { createDefaultConfig } from "../../../types/config";
+import type { MarketNewsItem } from "../../../types/news-source";
+import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+const sortPreference: NewsSortPreference = {
+  columnId: "time",
+  direction: "desc",
+};
+
+function makeArticle(overrides: Partial<MarketNewsItem> & { id: string; title: string }): MarketNewsItem {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    url: `https://example.com/${overrides.id}`,
+    source: "Reuters",
+    publishedAt: new Date("2026-04-18T12:00:00Z"),
+    summary: "",
+    topic: "general",
+    topics: [],
+    sectors: [],
+    categories: [],
+    tickers: [],
+    scores: {
+      importance: 0,
+      urgency: 0,
+      marketImpact: 0,
+      novelty: 0,
+      confidence: 0,
+    },
+    isBreaking: false,
+    isDeveloping: false,
+    importance: 0,
+    ...overrides,
+  };
+}
+
+function Harness() {
+  const state = createInitialState(
+    createDefaultConfig("/tmp/gloomberb-news-table-test"),
+  );
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId="news-feed:main">
+        <NewsArticleStackView
+          articles={[
+            makeArticle({ id: "unread", title: "Unread story" }),
+            makeArticle({ id: "read", title: "Read story" }),
+          ]}
+          focused
+          width={90}
+          rootHeight={10}
+          readArticleIds={new Set(["read"])}
+          selectedArticleId="unread"
+          setSelectedArticleId={() => {}}
+          sortPreference={sortPreference}
+          setSortPreference={() => {}}
+          onOpenArticle={() => {}}
+          detailOpen={false}
+          onBack={() => {}}
+          detailContent={<Box />}
+          columns={["time", "source", "title"]}
+          emptyStateTitle="No stories"
+        />
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+});
+
+describe("NewsArticleStackView", () => {
+  test("renders unopened stories bold and opened stories normal weight", async () => {
+    testSetup = await testRender(<Harness />, { width: 90, height: 10 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const boldText = testSetup.captureSpans().lines
+      .flatMap((line) => line.spans)
+      .filter((span) => (span.attributes & TextAttributes.BOLD) !== 0)
+      .map((span) => span.text)
+      .join("");
+
+    expect(boldText).toContain("Unread story");
+    expect(boldText).not.toContain("Read story");
+  });
+
+  test("keeps root controls visible while rendering custom empty content", async () => {
+    const state = createInitialState(
+      createDefaultConfig("/tmp/gloomberb-news-table-empty-content-test"),
+    );
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="news-feed:main">
+          <NewsArticleStackView
+            articles={[]}
+            focused
+            width={90}
+            rootHeight={10}
+            selectedArticleId={null}
+            setSelectedArticleId={() => {}}
+            sortPreference={sortPreference}
+            setSortPreference={() => {}}
+            onOpenArticle={() => {}}
+            detailOpen={false}
+            onBack={() => {}}
+            detailContent={<Box />}
+            rootBefore={(
+              <Box height={1}>
+                <Text>Sector tabs stay</Text>
+              </Box>
+            )}
+            columns={["time", "source", "title"]}
+            emptyContent={(
+              <Box paddingX={1} paddingY={1}>
+                <Text>Loading sector content</Text>
+              </Box>
+            )}
+            emptyStateTitle="No stories"
+          />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 90, height: 10 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Sector tabs stay");
+    expect(frame).toContain("Loading sector content");
+    expect(frame).not.toContain("No stories");
+  });
+});

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -21,12 +21,15 @@ interface NewsArticleStackBaseProps {
   articles: MarketNewsItem[];
   focused: boolean;
   width: number;
+  readArticleIds?: ReadonlySet<string>;
   selectedArticleId: string | null;
   setSelectedArticleId: (articleId: string | null) => void;
   sortPreference: NewsSortPreference;
   setSortPreference: (preference: NewsSortPreference) => void;
   onOpenArticle: (article: MarketNewsItem) => void;
+  onArticleRead?: (articleId: string) => void;
   columns: NewsColumnId[];
+  emptyContent?: ReactNode;
   emptyStateTitle: string;
   emptyStateHint?: string;
   titleForArticle?: (article: MarketNewsItem) => string;
@@ -140,18 +143,21 @@ export function NewsArticleStackView({
   articles,
   focused,
   width,
+  readArticleIds,
   rootHeight,
   selectedArticleId,
   setSelectedArticleId,
   sortPreference,
   setSortPreference,
   onOpenArticle,
+  onArticleRead,
   detailOpen,
   onBack,
   detailContent,
   rootBefore,
   onRootKeyDown,
   columns: columnIds,
+  emptyContent,
   emptyStateTitle,
   emptyStateHint,
   titleForArticle,
@@ -168,10 +174,15 @@ export function NewsArticleStackView({
     setSelectedArticleId(sortedArticles[index]?.id ?? null);
   }, [setSelectedArticleId, sortedArticles]);
 
+  const openArticle = useCallback((article: MarketNewsItem) => {
+    onArticleRead?.(article.id);
+    onOpenArticle(article);
+  }, [onArticleRead, onOpenArticle]);
+
   const openIndex = useCallback((index: number) => {
     const article = sortedArticles[index];
-    if (article) onOpenArticle(article);
-  }, [onOpenArticle, sortedArticles]);
+    if (article) openArticle(article);
+  }, [openArticle, sortedArticles]);
 
   useEffect(() => {
     if (sortedArticles.length === 0) {
@@ -201,7 +212,9 @@ export function NewsArticleStackView({
         return {
           text: titleForArticle?.(item) ?? item.title,
           color: selectedColor ?? colors.text,
-          attributes: item.isBreaking ? TextAttributes.BOLD : TextAttributes.NONE,
+          attributes: readArticleIds?.has(item.id)
+            ? TextAttributes.NONE
+            : TextAttributes.BOLD,
         };
       case "tickers":
         return { text: item.tickers.join(" "), color: selectedColor ?? colors.textBright };
@@ -213,7 +226,7 @@ export function NewsArticleStackView({
           color: selectedColor ?? (item.importance >= 80 ? colors.positive : colors.textDim),
         };
     }
-  }, [titleForArticle]);
+  }, [readArticleIds, titleForArticle]);
 
   return (
     <DataTableStackView<MarketNewsItem, NewsTableColumn>
@@ -236,8 +249,9 @@ export function NewsArticleStackView({
       getItemKey={(item) => item.id}
       isSelected={(item, index) => item.id === selectedArticleId || (selectedArticleId === null && index === 0)}
       onSelect={(article) => setSelectedArticleId(article.id)}
-      onActivate={onOpenArticle}
+      onActivate={openArticle}
       renderCell={renderCell}
+      emptyContent={emptyContent}
       emptyStateTitle={emptyStateTitle}
       emptyStateHint={emptyStateHint}
       showHorizontalScrollbar={false}

--- a/src/plugins/builtin/news-wire/read-state.test.ts
+++ b/src/plugins/builtin/news-wire/read-state.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_READ_ARTICLE_IDS,
+  markNewsArticleRead,
+  normalizeNewsReadState,
+} from "./read-state";
+
+describe("news read state", () => {
+  test("marks opened articles as read with the most recent first", () => {
+    const state = markNewsArticleRead({ articleIds: ["old"] }, "new");
+
+    expect(state.articleIds).toEqual(["new", "old"]);
+  });
+
+  test("deduplicates existing read articles when reopened", () => {
+    const state = markNewsArticleRead({ articleIds: ["a", "b", "a"] }, "b");
+
+    expect(state.articleIds).toEqual(["b", "a"]);
+  });
+
+  test("keeps persisted read state bounded", () => {
+    const state = normalizeNewsReadState({
+      articleIds: Array.from({ length: MAX_READ_ARTICLE_IDS + 25 }, (_, index) => `id-${index}`),
+    });
+
+    expect(state.articleIds).toHaveLength(MAX_READ_ARTICLE_IDS);
+    expect(state.articleIds[0]).toBe("id-0");
+    expect(state.articleIds.at(-1)).toBe(`id-${MAX_READ_ARTICLE_IDS - 1}`);
+  });
+});

--- a/src/plugins/builtin/news-wire/read-state.ts
+++ b/src/plugins/builtin/news-wire/read-state.ts
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from "react";
+import { usePluginState } from "../../plugin-runtime";
+
+export interface NewsReadState {
+  articleIds: string[];
+}
+
+export const NEWS_READ_STATE_SCHEMA_VERSION = 1;
+export const MAX_READ_ARTICLE_IDS = 2_000;
+
+const READ_STATE_KEY = "read-articles";
+const EMPTY_READ_STATE: NewsReadState = { articleIds: [] };
+
+function normalizeArticleId(articleId: string): string {
+  return articleId.trim();
+}
+
+function sameStringArray(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+export function normalizeNewsReadState(state: NewsReadState): NewsReadState {
+  const seen = new Set<string>();
+  const articleIds: string[] = [];
+
+  for (const rawId of state.articleIds) {
+    if (typeof rawId !== "string") continue;
+    const articleId = normalizeArticleId(rawId);
+    if (!articleId || seen.has(articleId)) continue;
+    seen.add(articleId);
+    articleIds.push(articleId);
+    if (articleIds.length >= MAX_READ_ARTICLE_IDS) break;
+  }
+
+  return { articleIds };
+}
+
+export function markNewsArticleRead(
+  state: NewsReadState,
+  articleId: string,
+): NewsReadState {
+  const normalizedId = normalizeArticleId(articleId);
+  const current = normalizeNewsReadState(state).articleIds;
+  if (!normalizedId) {
+    return sameStringArray(current, state.articleIds) ? state : { articleIds: current };
+  }
+
+  const articleIds = [
+    normalizedId,
+    ...current.filter((currentId) => currentId !== normalizedId),
+  ].slice(0, MAX_READ_ARTICLE_IDS);
+
+  return sameStringArray(articleIds, state.articleIds) ? state : { articleIds };
+}
+
+export function useNewsReadState() {
+  const [readState, setReadState] = usePluginState<NewsReadState>(
+    READ_STATE_KEY,
+    EMPTY_READ_STATE,
+    { schemaVersion: NEWS_READ_STATE_SCHEMA_VERSION },
+  );
+  const normalizedReadState = useMemo(
+    () => normalizeNewsReadState(readState),
+    [readState],
+  );
+  const readArticleIds = useMemo(
+    () => new Set(normalizedReadState.articleIds),
+    [normalizedReadState],
+  );
+  const markArticleRead = useCallback((articleId: string) => {
+    setReadState((current) => markNewsArticleRead(current, articleId));
+  }, [setReadState]);
+
+  return { readArticleIds, markArticleRead };
+}

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -11,6 +11,7 @@ import { Spinner } from "../../components/spinner";
 import { FeedDataTableStackView, usePaneFooter, type FeedDataTableItem } from "../../components";
 import { useNewsArticles } from "../../news/hooks";
 import { registerNewsWireFeatures } from "./news-wire";
+import { useNewsReadState } from "./news-wire/read-state";
 
 const ARTICLE_SUMMARY_CACHE_POLICY = {
   staleMs: 30 * 24 * 60 * 60_000,
@@ -28,7 +29,7 @@ function getFeedItems(
     const preview = summaryCache.get(item.url) ?? item.summary ?? undefined;
     const isSelected = item.url === selectedUrl;
     return {
-      id: item.url || `${item.title}:${item.publishedAt.toISOString()}`,
+      id: item.id,
       eyebrow: item.source,
       title: item.title,
       timestamp: item.publishedAt,
@@ -67,6 +68,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
     limit: NEWS_ITEM_LIMIT,
   } : null);
   const news = newsState.articles;
+  const { readArticleIds, markArticleRead } = useNewsReadState();
   const loading = newsState.phase === "loading" || (newsState.phase === "refreshing" && news.length === 0);
   const error = newsState.phase === "error" ? newsState.error ?? "Failed to load news" : null;
 
@@ -125,6 +127,8 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
       items={items}
       selectedIdx={selectedIdx}
       onSelect={setSelectedIdx}
+      isItemRead={(item) => readArticleIds.has(item.id)}
+      onOpenItem={(item) => markArticleRead(item.id)}
       sourceLabel="Source"
       titleLabel="Headline"
       emptyStateTitle="No news."

--- a/src/plugins/builtin/notes.tsx
+++ b/src/plugins/builtin/notes.tsx
@@ -1,13 +1,12 @@
 import { Box, Input, Text } from "../../ui";
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useShortcut } from "../../react/input";
-import { TextAttributes } from "../../ui";
 import { type InputRenderable, type TextareaRenderable } from "../../ui";
 import type { GloomPlugin, DetailTabProps, PaneProps } from "../../types/plugin";
 import { usePaneTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import { MarkdownEditor } from "../../components/markdown-editor";
-import { usePaneFooter } from "../../components";
+import { TabBar, usePaneFooter } from "../../components";
 import { NotesFiles, type QuickNoteEntry } from "./notes-files";
 
 function createNotesTab(notesFiles: NotesFiles) {
@@ -204,6 +203,15 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
       setEditing(false);
     }, [tabs, activeTabId]);
 
+    const startRenameTab = useCallback((id: string) => {
+      const tab = tabs.find((entry) => entry.id === id);
+      if (!tab) return;
+      setActiveTabId(id);
+      setRenameValue(tab.title);
+      setRenaming(true);
+      setEditing(false);
+    }, [tabs]);
+
     const commitRename = useCallback(() => {
       const value = renameInputRef.current?.editBuffer.getText().trim() || renameValue.trim();
       if (!value || !activeTabId) {
@@ -288,47 +296,26 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
 
     return (
       <Box flexDirection="column" flexGrow={1}>
-        {/* Tab bar */}
-        <Box flexDirection="row" height={1}>
-          {tabs.map((tab) => {
-            const isActive = tab.id === activeTabId;
-            return (
-              <Box key={tab.id} flexDirection="row">
-                <Text
-                  fg={isActive ? colors.textBright : colors.textDim}
-                  bg={isActive ? colors.selected : undefined}
-                  attributes={isActive ? TextAttributes.BOLD : 0}
-                  onMouseDown={() => {
-                    if (tab.id !== activeTabId) {
-                      saveCurrentTab();
-                      setActiveTabId(tab.id);
-                      setEditing(false);
-                    }
-                  }}
-                  onDoubleClick={() => {
-                    setActiveTabId(tab.id);
-                    startRename();
-                  }}
-                >
-                  {` ${tab.title} `}
-                </Text>
-                {isActive && tabs.length > 1 ? (
-                  <Text
-                    fg={colors.textMuted}
-                    onMouseDown={() => removeTab(tab.id)}
-                  >
-                    {`x `}
-                  </Text>
-                ) : <Text>{` `}</Text>}
-              </Box>
-            );
-          })}
-          <Text
-            fg={colors.textMuted}
-            onMouseDown={addTab}
-          >
-            {` + `}
-          </Text>
+        <Box height={1}>
+          <TabBar
+            tabs={tabs.map((tab) => ({
+              label: tab.title,
+              value: tab.id,
+              onClose: tabs.length > 1 ? removeTab : undefined,
+              onDoubleClick: startRenameTab,
+            }))}
+            activeValue={activeTabId}
+            onSelect={(id) => {
+              if (id === activeTabId) return;
+              saveCurrentTab();
+              setActiveTabId(id);
+              setEditing(false);
+            }}
+            compact
+            variant="pill"
+            closeMode="active"
+            onAdd={addTab}
+          />
         </Box>
         {/* Rename input */}
         {renaming && (

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -12,6 +12,7 @@ import { formatMarketPrice } from "../../utils/market-format";
 import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../market-data/hooks";
 import { Spinner } from "../../components/spinner";
+import { TabBar } from "../../components/tab-bar";
 import { setOptionsAvailability } from "./options-availability";
 
 function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
@@ -19,7 +20,6 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
   const [expIdx, setExpIdx] = useState(0);
   const [strikeIdx, setStrikeIdx] = useState(0);
   const [interactive, setInteractive] = useState(false);
-  const [hoveredExpIdx, setHoveredExpIdx] = useState<number | null>(null);
   const target = resolveOptionsTarget(ticker);
   const isOpt = target?.isOptionTicker ?? false;
   const parsed = target?.parsedOption ?? null;
@@ -75,10 +75,6 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
     setExpIdx(0);
     setStrikeIdx(0);
   }, [effectiveTicker]);
-
-  useEffect(() => {
-    setHoveredExpIdx(null);
-  }, [expIdx]);
 
   useEffect(() => {
     if (!target) return;
@@ -180,26 +176,21 @@ function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
       {/* Expiration selector */}
       <Box flexDirection="row" height={1} gap={1}>
         <Text fg={colors.textDim}>Exp:</Text>
-        {visibleExps.map((ts, i) => {
-          const realIdx = expStart + i;
-          const isActive = realIdx === expIdx;
-          const isHovered = realIdx === hoveredExpIdx && !isActive;
-          return (
-            <Box
-              key={ts}
-              onMouseMove={() => setHoveredExpIdx((current) => (current === realIdx ? current : realIdx))}
-              onMouseOut={() => setHoveredExpIdx((current) => (current === realIdx ? null : current))}
-              onMouseDown={() => { enterInteractive(); setExpIdx(realIdx); }}
-            >
-              <Text
-                fg={isActive ? colors.textBright : isHovered ? colors.text : colors.textMuted}
-                attributes={isActive ? TextAttributes.BOLD : isHovered ? TextAttributes.UNDERLINE : 0}
-              >
-                {isActive ? `[${formatExpDate(ts)}]` : ` ${formatExpDate(ts)} `}
-              </Text>
-            </Box>
-          );
-        })}
+        <Box flexGrow={1} height={1}>
+          <TabBar
+            tabs={visibleExps.map((ts, i) => ({
+              label: formatExpDate(ts),
+              value: String(expStart + i),
+            }))}
+            activeValue={String(expIdx)}
+            onSelect={(value) => {
+              enterInteractive();
+              setExpIdx(Number(value));
+            }}
+            compact
+            variant="bare"
+          />
+        </Box>
         {loading && <spinner name="dots" color={colors.textDim} />}
       </Box>
 

--- a/src/plugins/builtin/ticker-detail/financials-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/financials-tab.tsx
@@ -3,7 +3,7 @@ import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePaneTicker } from "../../../state/app-context";
-import { usePaneFooter } from "../../../components";
+import { TabBar, usePaneFooter } from "../../../components";
 import { colors, priceColor } from "../../../theme/colors";
 import type { FinancialStatement } from "../../../types/financials";
 import {
@@ -79,6 +79,12 @@ const FINANCIAL_SUB_TABS: FinancialSubTab[] = [
     ],
   },
 ];
+
+const FINANCIAL_SUB_TABS_WIDTH = FINANCIAL_SUB_TABS.reduce(
+  (sum, tab) => sum + tab.name.length + 2,
+  0,
+);
+const FINANCIAL_PERIOD_TABS_WIDTH = "Annual".length + "Quarterly".length + 4;
 
 const FLOW_KEYS = new Set<string>([
   "totalRevenue",
@@ -341,24 +347,30 @@ export function ResolvedFinancialsTab({
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={2} paddingBottom={1}>
       <Box flexDirection="row" height={1}>
-        {FINANCIAL_SUB_TABS.map((tab, index) => (
-          <Box key={tab.key} flexDirection="row" onMouseDown={() => setSubTabIdx(index)}>
-            <Text
-              fg={index === subTabIdx ? colors.textBright : colors.textDim}
-              attributes={index === subTabIdx ? TextAttributes.BOLD : 0}
-            >
-              {tab.name}
-            </Text>
-            {index < FINANCIAL_SUB_TABS.length - 1 && <Text fg={colors.textMuted}>{" │ "}</Text>}
-          </Box>
-        ))}
-        <Box flexGrow={1} />
-        <Box onMouseDown={() => setPeriod("annual")}>
-          <Text fg={isAnnual ? colors.textBright : colors.textDim} attributes={isAnnual ? TextAttributes.BOLD : 0}>Annual</Text>
+        <Box width={FINANCIAL_SUB_TABS_WIDTH} height={1}>
+          <TabBar
+            tabs={FINANCIAL_SUB_TABS.map((tab, index) => ({
+              label: tab.name,
+              value: String(index),
+            }))}
+            activeValue={String(subTabIdx)}
+            onSelect={(value) => setSubTabIdx(Number(value))}
+            compact
+            variant="bare"
+          />
         </Box>
-        <Text fg={colors.textMuted}>{" / "}</Text>
-        <Box onMouseDown={() => setPeriod("quarterly")}>
-          <Text fg={!isAnnual ? colors.textBright : colors.textDim} attributes={!isAnnual ? TextAttributes.BOLD : 0}>Quarterly</Text>
+        <Box flexGrow={1} />
+        <Box width={FINANCIAL_PERIOD_TABS_WIDTH} height={1}>
+          <TabBar
+            tabs={[
+              { label: "Annual", value: "annual", disabled: !hasAnnualStatements },
+              { label: "Quarterly", value: "quarterly", disabled: !hasQuarterlyStatements },
+            ]}
+            activeValue={isAnnual ? "annual" : "quarterly"}
+            onSelect={(value) => setPeriod(value as FinancialPeriod)}
+            compact
+            variant="bare"
+          />
         </Box>
       </Box>
       <Box height={1} />

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -1,6 +1,5 @@
-import { Box, Input, ScrollBox, Text } from "../../ui";
+import { Box, Input, Text } from "../../ui";
 import { useCallback, useMemo, useRef } from "react";
-import { TextAttributes } from "../../ui";
 import { DataTableStackView, TabBar, usePaneFooter } from "../../components";
 import { createRowValueCache } from "../../components/ui/row-value-cache";
 import type { PaneProps } from "../../types/plugin";
@@ -17,12 +16,6 @@ import type {
   PredictionListRow,
 } from "./types";
 
-const CATEGORY_TAB_GAP = 2;
-const CATEGORY_RAIL_WIDTH = PREDICTION_CATEGORY_OPTIONS.reduce(
-  (total, category, index) =>
-    total + category.label.length + (index > 0 ? CATEGORY_TAB_GAP : 0),
-  2,
-);
 const PREDICTION_CELL_CACHE_SIZE = 12_000;
 const RELATIVE_TIME_CELL_BUCKET_MS = 60_000;
 
@@ -178,39 +171,20 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       </Box>
 
       {PREDICTION_CATEGORY_OPTIONS.length > 1 ? (
-        <ScrollBox height={1} scrollX focusable={false}>
-          <Box
-            flexDirection="row"
-            paddingX={1}
-            gap={CATEGORY_TAB_GAP}
-            width={CATEGORY_RAIL_WIDTH}
-            flexShrink={0}
-          >
-            {PREDICTION_CATEGORY_OPTIONS.map((category) => {
-              const active = category.id === controller.categoryId;
-              return (
-                <Box
-                  key={category.id}
-                  width={category.label.length}
-                  flexShrink={0}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    controller.actions.selectCategory(
-                      category.id as PredictionCategoryId,
-                    );
-                  }}
-                >
-                  <Text
-                    fg={active ? colors.textBright : colors.textDim}
-                    attributes={active ? TextAttributes.BOLD : 0}
-                  >
-                    {category.label}
-                  </Text>
-                </Box>
-              );
-            })}
-          </Box>
-        </ScrollBox>
+        <Box height={1} paddingX={1}>
+          <TabBar
+            tabs={PREDICTION_CATEGORY_OPTIONS.map((category) => ({
+              label: category.label,
+              value: category.id,
+            }))}
+            activeValue={controller.categoryId}
+            onSelect={(value) =>
+              controller.actions.selectCategory(value as PredictionCategoryId)
+            }
+            compact
+            variant="bare"
+          />
+        </Box>
       ) : null}
 
     </>

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -19,7 +19,6 @@ import { useAppDispatch, usePaneInstance } from "../../../state/app-context";
 import { useRafCallback } from "../../../react/use-raf-callback";
 import { padTo } from "../../../utils/format";
 import { measurePerf } from "../../../utils/perf-marks";
-import { useDoubleClickActivation } from "../../../components/use-double-click-activation";
 import type {
   DataTableCell,
   DataTableColumn,
@@ -27,11 +26,6 @@ import type {
   DataTableSectionHeader,
 } from "../../../components/ui/data-table";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
-
-interface DataTableRowPointerTarget<T> {
-  item: T;
-  index: number;
-}
 
 interface VirtualRow {
   index: number;
@@ -235,7 +229,8 @@ function WebDataTableRowInner<
 >({
   columns,
   focusPane,
-  handleRowMouseDown,
+  onActivateRow,
+  onSelectRow,
   hovered,
   index,
   item,
@@ -250,11 +245,8 @@ function WebDataTableRowInner<
 }: {
   columns: C[];
   focusPane: () => void;
-  handleRowMouseDown: (
-    targetKey: string,
-    value: DataTableRowPointerTarget<T>,
-    event?: { detail?: number },
-  ) => void;
+  onActivateRow?: (item: T, index: number) => void;
+  onSelectRow: (item: T, index: number) => void;
   hovered: boolean;
   index: number;
   item: T;
@@ -327,7 +319,13 @@ function WebDataTableRowInner<
       onMouseDown={(event) => {
         focusPane();
         event.preventDefault();
-        handleRowMouseDown(itemKey, { item, index }, event);
+        onSelectRow(item, index);
+      }}
+      onDoubleClick={(event) => {
+        focusPane();
+        event.preventDefault();
+        event.stopPropagation();
+        onActivateRow?.(item, index);
       }}
     >
       {columns.map((column) => {
@@ -354,7 +352,18 @@ function WebDataTableRowInner<
               }
               event.preventDefault();
               event.stopPropagation();
-              handleRowMouseDown(itemKey, { item, index }, event);
+              onSelectRow(item, index);
+            }}
+            onDoubleClick={(event) => {
+              if (cell.onMouseDown) {
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+              }
+              focusPane();
+              event.preventDefault();
+              event.stopPropagation();
+              onActivateRow?.(item, index);
             }}
           >
             <span
@@ -392,6 +401,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   onActivate,
   renderCell,
   renderSectionHeader,
+  emptyContent,
   emptyStateTitle,
   emptyStateHint,
   virtualize = true,
@@ -410,17 +420,12 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     [columns],
   );
   const minWidthPx = px(tableWidth);
-  const handleRowMouseDown =
-    useDoubleClickActivation<DataTableRowPointerTarget<T>>({
-      onSelect: ({ item, index }) => {
-        onSelect(item, index);
-      },
-      onActivate: onActivate
-        ? ({ item, index }) => {
-            onActivate(item, index);
-          }
-        : undefined,
-    });
+  const selectRow = useCallback((item: T, index: number) => {
+    onSelect(item, index);
+  }, [onSelect]);
+  const activateRow = useCallback((item: T, index: number) => {
+    onActivate?.(item, index);
+  }, [onActivate]);
 
   const focusPane = useCallback(() => {
     if (!paneInstanceId) return;
@@ -588,23 +593,25 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
             })}
           </div>
           {items.length === 0 ? (
-            <div
-              style={{
-                width: "100%",
-                padding: `${WEB_CELL_HEIGHT}px ${WEB_CELL_WIDTH}px`,
-                color: colors.textDim,
-                lineHeight: "var(--cell-h)",
-              }}
-            >
-              <div style={cellTextStyle(colors.textBright, TextAttributes.BOLD)}>
-                {emptyStateTitle}
-              </div>
-              {emptyStateHint ? (
-                <div style={cellTextStyle(colors.textDim, TextAttributes.NONE)}>
-                  {emptyStateHint}
+            emptyContent ?? (
+              <div
+                style={{
+                  width: "100%",
+                  padding: `${WEB_CELL_HEIGHT}px ${WEB_CELL_WIDTH}px`,
+                  color: colors.textDim,
+                  lineHeight: "var(--cell-h)",
+                }}
+              >
+                <div style={cellTextStyle(colors.textBright, TextAttributes.BOLD)}>
+                  {emptyStateTitle}
                 </div>
-              ) : null}
-            </div>
+                {emptyStateHint ? (
+                  <div style={cellTextStyle(colors.textDim, TextAttributes.NONE)}>
+                    {emptyStateHint}
+                  </div>
+                ) : null}
+              </div>
+            )
           ) : measurePerf(
             "data-table.desktop.render-virtual-rows",
             () =>
@@ -624,7 +631,8 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                     itemKey={itemKey}
                     columns={columns}
                     focusPane={focusPane}
-                    handleRowMouseDown={handleRowMouseDown}
+                    onActivateRow={onActivate ? activateRow : undefined}
+                    onSelectRow={selectRow}
                     hovered={hovered}
                     minWidthPx={minWidthPx}
                     renderCell={renderCell}

--- a/src/renderers/electrobun/view/desktop-controls.tsx
+++ b/src/renderers/electrobun/view/desktop-controls.tsx
@@ -653,8 +653,17 @@ export function WebPageStackView({
   }
 
   return (
-    <Box flexDirection="column" flexGrow={1} overflow="hidden" gap={1}>
-      <Box height={1} flexDirection="row" alignItems="center">
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      <Box
+        height={1}
+        flexDirection="row"
+        alignItems="center"
+        paddingX={1}
+        backgroundColor={colors.bg}
+        style={{
+          boxShadow: `inset 0 -1px 0 ${PANEL_BORDER}`,
+        }}
+      >
         <Box
           height={1}
           flexDirection="row"

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -794,8 +794,24 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
 
 type CssVars = CSSProperties & Record<`--${string}`, string>;
 
-function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: HostTabsProps) {
+function WebTabs({
+  tabs,
+  activeValue,
+  onSelect,
+  compact = false,
+  variant = "underline",
+  closeMode = "always",
+  addLabel = "+",
+  onAdd,
+  palette,
+}: HostTabsProps) {
   const activeTabRef = useRef<HTMLButtonElement | null>(null);
+  const [hoveredValue, setHoveredValue] = useState<string | null>(null);
+  const showUnderline = variant === "underline" && !compact;
+  const listHeight = showUnderline ? 28 : "100%";
+  const tabFontSize = compact || showUnderline ? 12 : 13;
+  const tabPaddingInline = showUnderline ? 10 : 8;
+  const tabPaddingBlock = variant === "bare" || variant === "pill" ? 2 : 0;
 
   useEffect(() => {
     activeTabRef.current?.scrollIntoView({
@@ -813,6 +829,21 @@ function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: Host
     event.preventDefault();
   };
 
+  const resolveTabBackground = (active: boolean, hovered: boolean) => {
+    if (active && variant === "pill") {
+      return hovered ? "rgba(84, 201, 159, 0.24)" : palette.activeBg;
+    }
+    return hovered ? palette.hoverBg : "transparent";
+  };
+
+  const resolveTabColor = (disabled: boolean, active: boolean, hovered: boolean) => {
+    if (disabled) return palette.disabledFg;
+    if (active && variant === "pill") return palette.activePillFg;
+    if (active) return palette.activeFg;
+    if (hovered) return palette.hoverFg;
+    return palette.inactiveFg;
+  };
+
   return (
     <div
       data-gloom-role="tab-list"
@@ -821,40 +852,56 @@ function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: Host
       style={{
         display: "flex",
         flexDirection: "row",
+        alignItems: "stretch",
+        gap: 4,
         width: "100%",
-        height: cellHeight(compact ? 1 : 2),
+        height: listHeight,
         minInlineSize: 0,
         flexShrink: 0,
         overflowX: "auto",
         overflowY: "hidden",
+        paddingInline: variant === "underline" ? 0 : 4,
+        paddingBlock: tabPaddingBlock,
+        marginBottom: showUnderline ? 4 : 0,
+        boxSizing: "border-box",
       }}
     >
       {tabs.map((tab) => {
         const active = tab.value === activeValue;
         const disabled = tab.disabled === true;
-        const tabWidth = tab.label.length + 2;
+        const hovered = hoveredValue === tab.value && !disabled;
+        const closeVisible = !!tab.onClose && (closeMode === "always" || active);
         const tabStyle = {
-          "--tab-fg": disabled ? palette.disabledFg : active ? palette.activeFg : palette.inactiveFg,
+          "--tab-fg": resolveTabColor(disabled, active, hovered),
           "--tab-hover-fg": palette.hoverFg,
           "--tab-underline": active ? palette.activeUnderline : palette.inactiveUnderline,
           "--tab-hover-underline": palette.hoverUnderline,
           "--tab-hover-bg": palette.hoverBg,
+          "--tab-close-fg": active && variant === "pill" ? palette.activePillFg : palette.closeFg,
           color: "var(--tab-fg)",
-          width: cellWidth(tabWidth),
-          height: cellHeight(compact ? 1 : 2),
           flex: "0 0 auto",
           display: "flex",
-          flexDirection: "column",
-          alignItems: "stretch",
-          justifyContent: "flex-start",
-          padding: 0,
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 6,
+          position: "relative",
+          minWidth: 0,
+          height: "100%",
+          paddingInline: tabPaddingInline,
+          paddingBlock: 0,
+          paddingBottom: showUnderline ? 2 : 0,
           margin: 0,
           border: 0,
-          background: "transparent",
+          borderRadius: variant === "underline" ? 5 : 6,
+          background: resolveTabBackground(active, hovered),
           font: "inherit",
-          lineHeight: "var(--cell-h)",
-          textAlign: "left",
-          whiteSpace: "pre",
+          fontSize: tabFontSize,
+          fontWeight: active ? 700 : 500,
+          lineHeight: 1,
+          textAlign: "center",
+          whiteSpace: "nowrap",
+          transition: "background-color 110ms ease, color 110ms ease, box-shadow 110ms ease",
           cursor: disabled ? "default" : "pointer",
         } satisfies CssVars;
 
@@ -870,38 +917,114 @@ function WebTabs({ tabs, activeValue, onSelect, compact = false, palette }: Host
             aria-disabled={disabled || undefined}
             disabled={disabled}
             style={tabStyle}
+            onMouseEnter={() => setHoveredValue(tab.value)}
+            onMouseLeave={() => setHoveredValue((current) => (current === tab.value ? null : current))}
             onClick={() => {
               if (!disabled) onSelect(tab.value);
+            }}
+            onDoubleClick={() => {
+              if (!disabled) tab.onDoubleClick?.(tab.value);
             }}
           >
             <span
               data-gloom-role="tab-label"
               style={{
                 display: "block",
-                height: "var(--cell-h)",
-                lineHeight: "var(--cell-h)",
-                fontWeight: active ? 700 : undefined,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
               }}
             >
-              {` ${tab.label} `}
+              {tab.label}
             </span>
-            {!compact && (
+            {closeVisible && (
+              <span
+                data-gloom-role="tab-close"
+                aria-label={`Close ${tab.label}`}
+                role="button"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 16,
+                  height: 16,
+                  marginRight: -4,
+                  borderRadius: 4,
+                  color: "var(--tab-close-fg)",
+                  fontSize: 12,
+                  lineHeight: 1,
+                }}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  tab.onClose?.(tab.value);
+                }}
+              >
+                {"x"}
+              </span>
+            )}
+            {showUnderline && (
               <span
                 data-gloom-role="tab-underline"
                 aria-hidden="true"
                 style={{
-                  display: "block",
-                  height: "var(--cell-h)",
-                  lineHeight: "var(--cell-h)",
-                  color: "var(--tab-underline)",
+                  position: "absolute",
+                  left: 10,
+                  right: 10,
+                  bottom: 1,
+                  height: 2,
+                  borderRadius: 999,
+                  background: "var(--tab-underline)",
+                  opacity: active ? 1 : hovered ? 0.7 : 0,
                 }}
-              >
-                {"▔".repeat(tabWidth)}
-              </span>
+              />
             )}
           </button>
         );
       })}
+      {onAdd && (
+        <button
+          data-gloom-role="tab-button"
+          type="button"
+          style={{
+            "--tab-fg": palette.addFg,
+            "--tab-hover-fg": palette.hoverFg,
+            "--tab-underline": palette.inactiveUnderline,
+            "--tab-hover-underline": palette.hoverUnderline,
+            "--tab-hover-bg": palette.hoverBg,
+            color: hoveredValue === "__add__" ? palette.hoverFg : "var(--tab-fg)",
+            flex: "0 0 auto",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            paddingInline: tabPaddingInline,
+            paddingBlock: 0,
+            margin: 0,
+            border: 0,
+            borderRadius: variant === "underline" ? 5 : 6,
+            background: hoveredValue === "__add__" ? palette.hoverBg : "transparent",
+            font: "inherit",
+            fontSize: tabFontSize,
+            fontWeight: 500,
+            lineHeight: 1,
+            whiteSpace: "nowrap",
+            transition: "background-color 110ms ease, color 110ms ease",
+            cursor: "pointer",
+          } satisfies CssVars}
+          onMouseEnter={() => setHoveredValue("__add__")}
+          onMouseLeave={() => setHoveredValue((current) => (current === "__add__" ? null : current))}
+          onClick={onAdd}
+        >
+          <span
+            data-gloom-role="tab-label"
+            style={{
+              display: "block",
+            }}
+          >
+            {addLabel}
+          </span>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -175,6 +175,8 @@ export interface HostTabItem {
   label: string;
   value: string;
   disabled?: boolean;
+  onClose?: (value: string) => void;
+  onDoubleClick?: (value: string) => void;
 }
 
 export interface HostTabsPalette {
@@ -186,13 +188,21 @@ export interface HostTabsPalette {
   inactiveUnderline: string;
   hoverUnderline: string;
   hoverBg: string;
+  activeBg: string;
+  activePillFg: string;
+  closeFg: string;
+  addFg: string;
 }
 
 export interface HostTabsProps {
   tabs: HostTabItem[];
-  activeValue: string;
+  activeValue: string | null;
   onSelect: (value: string) => void;
   compact?: boolean;
+  variant?: "underline" | "pill" | "bare";
+  closeMode?: "active" | "always";
+  addLabel?: string;
+  onAdd?: () => void;
   palette: HostTabsPalette;
 }
 


### PR DESCRIPTION
Replaces several bespoke tab-like controls with the shared tabs component, including notes, status layout tabs, market movers, AI screener tabs, prediction markets, ticker financial subtabs, options expirations, and Sector News. Adds native desktop tab rendering with desktop sizing, hover feedback, editable tab actions, variants, and tighter underline/pill spacing. Keeps Sector News mounted while switching categories and adds shared empty-content support plus persisted read-state styling for news tables. Verified with focused Bun tests, desktop view build, packaged build, secret scan, and tmux smoke.