### PR TITLE
Polish notes pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a shortcut or command n
 | `QQ <ticker>` | Quote Monitor |
 | `CHAT` | New Chat Pane |
 | `IBKR` | New IBKR Trading Pane |
-| `NOTE` | Quick Notes |
+| `NOTE` | Notes |
 | `AI <prompt>` | AI Screener |
 | `CMP <tickers>` | Comparison Chart |
 | `PM <query>` | Prediction Markets |

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -78,6 +78,7 @@ export interface MarkdownEditorProps {
   initialValue?: string;
   placeholder?: string;
   onRef?: (ref: TextareaRenderable | null) => void;
+  onChange?: (value: string) => void;
 }
 
 export function MarkdownEditor({
@@ -86,6 +87,7 @@ export function MarkdownEditor({
   initialValue = "",
   placeholder = "Write notes...",
   onRef,
+  onChange,
 }: MarkdownEditorProps) {
   const syntaxFactory = useSyntaxStyleFactory();
   const textareaRef = useRef<TextareaRenderable>(null);
@@ -98,10 +100,10 @@ export function MarkdownEditor({
     const lines = text.split("\n");
     const { ids } = styleRef.current;
     for (let i = 0; i < lines.length; i++) {
-      ta.clearLineHighlights(i);
+      ta.clearLineHighlights?.(i);
       const lineHls = computeLineHighlights(lines[i]!, ids);
       for (const hl of lineHls) {
-        ta.addHighlight(i, hl);
+        ta.addHighlight?.(i, hl);
       }
     }
   }, []);
@@ -114,11 +116,14 @@ export function MarkdownEditor({
     styleRef.current = created;
     ta.syntaxStyle = created.style;
     applyHighlights();
-    ta.onContentChange = () => applyHighlights();
+    ta.onContentChange = () => {
+      applyHighlights();
+      onChange?.(ta.editBuffer.getText());
+    };
     return () => {
       if (ta) ta.onContentChange = undefined;
     };
-  }, [textareaKey, applyHighlights, syntaxFactory]);
+  }, [textareaKey, applyHighlights, onChange, syntaxFactory]);
 
   useEffect(() => {
     onRef?.(textareaRef.current);
@@ -136,7 +141,10 @@ export function MarkdownEditor({
       placeholderColor={colors.textDim}
       backgroundColor={focused ? colors.panel : colors.bg}
       flexGrow={1}
+      height="100%"
+      width="100%"
       wrapText
+      onInput={onChange}
     />
   );
 }

--- a/src/components/markdown-text.tsx
+++ b/src/components/markdown-text.tsx
@@ -8,10 +8,10 @@ import { colors } from "../theme/colors";
 
 export interface MarkdownTextProps {
   text: string;
-  lineWidth: number;
-  catalog: Record<string, InlineTickerCatalogEntry>;
-  textColor: string;
-  openTicker: (symbol: string) => void;
+  lineWidth?: number;
+  catalog?: Record<string, InlineTickerCatalogEntry>;
+  textColor?: string;
+  openTicker?: (symbol: string) => void;
 }
 
 interface StyledSegment {
@@ -115,7 +115,7 @@ function MarkdownLine({
   onHover,
 }: {
   parsed: ParsedLine;
-  lineWidth: number;
+  lineWidth?: number;
   catalog: Record<string, InlineTickerCatalogEntry>;
   textColor: string;
   openTicker: (symbol: string) => void;
@@ -145,7 +145,7 @@ function MarkdownLine({
   // Complex case: need to handle tickers within styled segments
   // Render as a flex row to allow badge elements
   return (
-    <Box flexDirection="row" flexWrap="wrap" width={lineWidth}>
+    <Box flexDirection="row" flexWrap="wrap" {...(lineWidth != null ? { width: lineWidth } : {})}>
       {indentStr ? <Text fg={textColor}>{indentStr}</Text> : null}
       {parsed.segments.map((segment, segIdx) => {
         const tokens = tokenizeTickerText(segment.text);
@@ -187,15 +187,15 @@ function MarkdownLine({
 export function MarkdownText({
   text,
   lineWidth,
-  catalog,
-  textColor,
-  openTicker,
+  catalog = {},
+  textColor = colors.text,
+  openTicker = () => {},
 }: MarkdownTextProps) {
   const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
   const lines = text.split("\n");
 
   return (
-    <Box flexDirection="column" width={lineWidth}>
+    <Box flexDirection="column" {...(lineWidth != null ? { width: lineWidth } : {})}>
       {lines.map((line, index) => {
         if (line.trim() === "") {
           return <Text key={index}>{" "}</Text>;

--- a/src/plugins/builtin/help.test.tsx
+++ b/src/plugins/builtin/help.test.tsx
@@ -28,7 +28,7 @@ describe("HelpPane", () => {
         ["notes-pane", {
           id: "notes-pane",
           paneId: "notes",
-          label: "Quick Notes",
+          label: "Notes",
           description: "Open a notes window",
           shortcut: { prefix: "NOTE" },
         }],

--- a/src/plugins/builtin/notes-files.ts
+++ b/src/plugins/builtin/notes-files.ts
@@ -1,6 +1,7 @@
 export interface QuickNoteEntry {
   id: string;
   title: string;
+  updatedAt?: number;
 }
 
 const QUICK_NOTES_INDEX = "__quick-notes-index__";

--- a/src/plugins/builtin/notes.tsx
+++ b/src/plugins/builtin/notes.tsx
@@ -1,4 +1,4 @@
-import { Box, Input, Text } from "../../ui";
+import { Box, Input, ScrollBox, Text, TextAttributes } from "../../ui";
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useShortcut } from "../../react/input";
 import { type InputRenderable, type TextareaRenderable } from "../../ui";
@@ -6,20 +6,148 @@ import type { GloomPlugin, DetailTabProps, PaneProps } from "../../types/plugin"
 import { usePaneTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import { MarkdownEditor } from "../../components/markdown-editor";
-import { TabBar, usePaneFooter } from "../../components";
+import { MarkdownText } from "../../components/markdown-text";
+import { DialogFrame, TabBar, usePaneFooter } from "../../components";
+import { type PromptContext, useDialog, useDialogKeyboard } from "../../ui/dialog";
 import { NotesFiles, type QuickNoteEntry } from "./notes-files";
 
+function useSyncedText(initialValue = "") {
+  const [text, setTextState] = useState(initialValue);
+  const textRef = useRef(initialValue);
+  const setText = useCallback((nextText: string) => {
+    textRef.current = nextText;
+    setTextState(nextText);
+  }, []);
+  return { text, textRef, setText };
+}
+
+function noteContentWidth(width: number): number {
+  return Math.max(1, Math.floor(width) - 2);
+}
+
+function formatLastEdited(updatedAt: number | undefined): string {
+  if (!updatedAt) return "not edited";
+  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - updatedAt) / 1000));
+  if (!Number.isFinite(elapsedSeconds)) return "not edited";
+  if (elapsedSeconds < 60) return "now";
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `${elapsedHours}h ago`;
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays === 1) return "yday";
+  if (elapsedDays < 7) return `${elapsedDays}d ago`;
+
+  const elapsedWeeks = Math.floor(elapsedDays / 7);
+  if (elapsedWeeks < 5) return `${elapsedWeeks}w ago`;
+
+  const elapsedMonths = Math.floor(elapsedDays / 30);
+  if (elapsedMonths < 12) return `${elapsedMonths}mo ago`;
+
+  return `${Math.floor(elapsedDays / 365)}y ago`;
+}
+
+function MarkdownNotePreview({
+  text,
+  width,
+  placeholder,
+  onActivate,
+}: {
+  text: string;
+  width: number;
+  placeholder: string;
+  onActivate: () => void;
+}) {
+  const lineWidth = noteContentWidth(width);
+  const hasText = text.trim().length > 0;
+
+  return (
+    <ScrollBox
+      flexGrow={1}
+      width="100%"
+      height="100%"
+      scrollY
+      focusable={false}
+      onMouseDown={onActivate}
+    >
+      <Box flexDirection="column" flexGrow={1} width={lineWidth}>
+        {hasText
+          ? <MarkdownText text={text} lineWidth={lineWidth} />
+          : <Text fg={colors.textDim}>{placeholder}</Text>}
+      </Box>
+    </ScrollBox>
+  );
+}
+
+function ConfirmDeleteNoteDialog({
+  resolve,
+  title,
+}: PromptContext<boolean> & {
+  title: string;
+}) {
+  const confirm = useCallback(() => resolve(true), [resolve]);
+  const cancel = useCallback(() => resolve(false), [resolve]);
+  const displayTitle = title.length > 28 ? `${title.slice(0, 25)}...` : title;
+
+  useDialogKeyboard((event) => {
+    event.stopPropagation();
+    if (event.name === "enter" || event.name === "return") {
+      confirm();
+      return;
+    }
+    if (event.name === "escape") {
+      cancel();
+    }
+  });
+
+  return (
+    <DialogFrame title="Delete note?" footer="Enter delete · Esc cancel">
+      <Box flexDirection="column" width={44}>
+        <Text fg={colors.text}>{`Delete "${displayTitle}"?`}</Text>
+        <Box height={1} />
+        <Text fg={colors.textDim}>This note has content.</Text>
+        <Text fg={colors.textDim}>Deleting it cannot be undone.</Text>
+        <Box height={1} />
+        <Box flexDirection="row" gap={1}>
+          <Box
+            backgroundColor={colors.negative}
+            onMouseDown={confirm}
+            data-gloom-interactive="true"
+          >
+            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{" Delete "}</Text>
+          </Box>
+          <Box
+            backgroundColor={colors.panel}
+            onMouseDown={cancel}
+            data-gloom-interactive="true"
+          >
+            <Text fg={colors.text}>{" Cancel "}</Text>
+          </Box>
+        </Box>
+      </Box>
+    </DialogFrame>
+  );
+}
+
 function createNotesTab(notesFiles: NotesFiles) {
-  return function NotesTab({ focused, onCapture }: DetailTabProps) {
+  return function NotesTab({ focused, width, onCapture }: DetailTabProps) {
     const { ticker } = usePaneTicker();
     const textareaRef = useRef<TextareaRenderable | null>(null);
     const [notesFocused, setNotesFocused] = useState(false);
-    const [loadedNotes, setLoadedNotes] = useState("");
+    const { text: noteText, textRef: noteTextRef, setText: setNoteText } = useSyncedText("");
+    const wasNotesFocusedRef = useRef(false);
 
     const setNotesFocusedAndCapture = useCallback((value: boolean) => {
       setNotesFocused(value);
       onCapture(value);
     }, [onCapture]);
+
+    const getCurrentNoteText = useCallback(() => (
+      textareaRef.current?.editBuffer.getText() ?? noteTextRef.current
+    ), [noteTextRef]);
 
     const saveNotesFor = useCallback((symbol: string | null, text: string) => {
       if (!symbol) return;
@@ -27,11 +155,11 @@ function createNotesTab(notesFiles: NotesFiles) {
     }, [notesFiles]);
 
     useEffect(() => {
-      const textarea = textareaRef.current;
-      if (!notesFocused && textarea && ticker?.metadata.ticker) {
-        saveNotesFor(ticker.metadata.ticker, textarea.editBuffer.getText());
+      if (wasNotesFocusedRef.current && !notesFocused && ticker?.metadata.ticker) {
+        saveNotesFor(ticker.metadata.ticker, getCurrentNoteText());
       }
-    }, [notesFocused, ticker, saveNotesFor]);
+      wasNotesFocusedRef.current = notesFocused;
+    }, [getCurrentNoteText, notesFocused, ticker, saveNotesFor]);
 
     const tickerSymbol = ticker?.metadata.ticker ?? null;
     const prevSymbolRef = useRef<string | null>(null);
@@ -43,20 +171,20 @@ function createNotesTab(notesFiles: NotesFiles) {
         prevSymbolRef.current = tickerSymbol;
 
         if (!tickerSymbol) {
-          setLoadedNotes("");
+          setNoteText("");
           textareaRef.current?.setText("");
           return;
         }
 
         notesFiles.load(tickerSymbol).then((nextNotes) => {
-          setLoadedNotes(nextNotes);
+          setNoteText(nextNotes);
           textareaRef.current?.setText(nextNotes);
         }).catch(() => {
-          setLoadedNotes("");
+          setNoteText("");
           textareaRef.current?.setText("");
         });
       }
-    }, [tickerSymbol, saveNotesFor, notesFiles]);
+    }, [tickerSymbol, saveNotesFor, notesFiles, setNoteText]);
 
     useShortcut((event) => {
       if (!focused) return;
@@ -81,14 +209,24 @@ function createNotesTab(notesFiles: NotesFiles) {
 
     return (
       <Box flexDirection="column" flexGrow={1}>
-        <Box flexGrow={1} onMouseDown={() => { if (!notesFocused) setNotesFocusedAndCapture(true); }}>
-          <MarkdownEditor
-            textareaKey={tickerSymbol ?? "none"}
-            focused={notesFocused}
-            initialValue={loadedNotes}
-            placeholder="Write notes about this ticker..."
-            onRef={(ref) => { textareaRef.current = ref; }}
-          />
+        <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!notesFocused) setNotesFocusedAndCapture(true); }}>
+          {notesFocused ? (
+            <MarkdownEditor
+              textareaKey={tickerSymbol ?? "none"}
+              focused={notesFocused}
+              initialValue={noteText}
+              placeholder="Write notes about this ticker..."
+              onRef={(ref) => { textareaRef.current = ref; }}
+              onChange={setNoteText}
+            />
+          ) : (
+            <MarkdownNotePreview
+              text={noteText}
+              width={width}
+              placeholder="Write notes about this ticker..."
+              onActivate={() => setNotesFocusedAndCapture(true)}
+            />
+          )}
         </Box>
       </Box>
     );
@@ -101,16 +239,46 @@ function generateNoteId(): string {
 }
 
 function createQuickNotesPane(notesFiles: NotesFiles) {
-  return function QuickNotesPane({ focused }: PaneProps) {
+  return function QuickNotesPane({ focused, width }: PaneProps) {
+    const dialog = useDialog();
     const textareaRef = useRef<TextareaRenderable | null>(null);
     const [editing, setEditing] = useState(false);
     const [tabs, setTabs] = useState<QuickNoteEntry[]>([]);
     const [activeTabId, setActiveTabId] = useState<string | null>(null);
     const [renaming, setRenaming] = useState(false);
     const [renameValue, setRenameValue] = useState("");
+    const { text: noteText, textRef: noteTextRef, setText: setNoteText } = useSyncedText("");
     const renameInputRef = useRef<InputRenderable>(null);
     const prevTabRef = useRef<string | null>(null);
+    const lastSavedTextRef = useRef<Map<string, string>>(new Map());
     const loadedRef = useRef(false);
+    const activeTab = tabs.find((tab) => tab.id === activeTabId);
+
+    const saveQuickNotesIndex = useCallback((entries: QuickNoteEntry[]) => {
+      notesFiles.saveQuickNotesIndex(entries).catch(() => {});
+    }, [notesFiles]);
+
+    const readActiveNoteText = useCallback(() => (
+      textareaRef.current?.editBuffer.getText() ?? noteTextRef.current
+    ), [noteTextRef]);
+
+    const saveTab = useCallback((tabId: string | null) => {
+      if (!tabId) return;
+      if (!lastSavedTextRef.current.has(tabId)) return;
+      const text = tabId === activeTabId ? readActiveNoteText() : noteTextRef.current;
+      if (lastSavedTextRef.current.get(tabId) === text) return;
+
+      lastSavedTextRef.current.set(tabId, text);
+      notesFiles.save(notesFiles.quickNoteKey(tabId), text).catch(() => {});
+
+      const updatedAt = Date.now();
+      setTabs((prev) => {
+        if (!prev.some((tab) => tab.id === tabId)) return prev;
+        const next = prev.map((tab) => (tab.id === tabId ? { ...tab, updatedAt } : tab));
+        saveQuickNotesIndex(next);
+        return next;
+      });
+    }, [activeTabId, noteTextRef, notesFiles, readActiveNoteText, saveQuickNotesIndex]);
 
     // Load index on mount
     useEffect(() => {
@@ -120,97 +288,129 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
         if (entries.length === 0) {
           const id = generateNoteId();
           const initial: QuickNoteEntry[] = [{ id, title: "New" }];
+          lastSavedTextRef.current.set(id, "");
           setTabs(initial);
           setActiveTabId(id);
-          notesFiles.saveQuickNotesIndex(initial).catch(() => {});
+          saveQuickNotesIndex(initial);
         } else {
           setTabs(entries);
           setActiveTabId(entries[0]!.id);
         }
       });
-    }, []);
-
-    // Save current tab content before switching away
-    const saveCurrentTab = useCallback(() => {
-      const tabId = prevTabRef.current;
-      if (tabId && textareaRef.current) {
-        const text = textareaRef.current.editBuffer.getText();
-        notesFiles.save(notesFiles.quickNoteKey(tabId), text).catch(() => {});
-      }
-    }, []);
+    }, [notesFiles, saveQuickNotesIndex]);
 
     // Load content when active tab changes
     useEffect(() => {
-      if (!activeTabId) return;
-      if (prevTabRef.current && prevTabRef.current !== activeTabId) {
-        saveCurrentTab();
+      if (!activeTabId) {
+        setNoteText("");
+        return;
       }
       prevTabRef.current = activeTabId;
+      let cancelled = false;
       notesFiles.load(notesFiles.quickNoteKey(activeTabId)).then((text) => {
+        if (cancelled) return;
+        lastSavedTextRef.current.set(activeTabId, text);
+        setNoteText(text);
         textareaRef.current?.setText(text);
       }).catch(() => {
+        if (cancelled) return;
+        lastSavedTextRef.current.set(activeTabId, "");
+        setNoteText("");
         textareaRef.current?.setText("");
       });
-    }, [activeTabId, saveCurrentTab]);
+      return () => {
+        cancelled = true;
+      };
+    }, [activeTabId, notesFiles, setNoteText]);
 
     // Save on editing stop
     useEffect(() => {
-      if (!editing) saveCurrentTab();
-    }, [editing, saveCurrentTab]);
+      if (!editing) saveTab(activeTabId);
+    }, [activeTabId, editing, saveTab]);
 
     const addTab = useCallback(() => {
-      saveCurrentTab();
+      saveTab(activeTabId);
       const id = generateNoteId();
       const entry: QuickNoteEntry = { id, title: "New" };
+      lastSavedTextRef.current.set(id, "");
       setTabs((prev) => {
         const next = [...prev, entry];
-        notesFiles.saveQuickNotesIndex(next).catch(() => {});
+        saveQuickNotesIndex(next);
         return next;
       });
       setActiveTabId(id);
+      setNoteText("");
       setEditing(false);
-    }, [saveCurrentTab]);
+      setRenaming(false);
+    }, [activeTabId, saveQuickNotesIndex, saveTab, setNoteText]);
 
     const removeTab = useCallback((id: string) => {
+      lastSavedTextRef.current.delete(id);
       setTabs((prev) => {
         const next = prev.filter((t) => t.id !== id);
         if (next.length === 0) {
           const newId = generateNoteId();
           const fresh: QuickNoteEntry[] = [{ id: newId, title: "New" }];
-          notesFiles.saveQuickNotesIndex(fresh).catch(() => {});
+          lastSavedTextRef.current.set(newId, "");
+          saveQuickNotesIndex(fresh);
           setActiveTabId(newId);
+          setNoteText("");
           prevTabRef.current = null;
           return fresh;
         }
-        notesFiles.saveQuickNotesIndex(next).catch(() => {});
+        saveQuickNotesIndex(next);
         if (activeTabId === id) {
           const idx = prev.findIndex((t) => t.id === id);
           const newActive = next[Math.min(idx, next.length - 1)]!;
           setActiveTabId(newActive.id);
+          setNoteText("");
           prevTabRef.current = null;
         }
         return next;
       });
       notesFiles.delete(notesFiles.quickNoteKey(id)).catch(() => {});
       setEditing(false);
-    }, [activeTabId]);
+      setRenaming(false);
+    }, [activeTabId, notesFiles, saveQuickNotesIndex, setNoteText]);
+
+    const requestRemoveTab = useCallback(async (id: string) => {
+      const tab = tabs.find((entry) => entry.id === id);
+      const text = id === activeTabId
+        ? readActiveNoteText()
+        : await notesFiles.load(notesFiles.quickNoteKey(id));
+
+      if (text.trim().length > 0) {
+        const confirmed = await dialog.prompt<boolean>({
+          closeOnClickOutside: true,
+          content: (ctx: PromptContext<boolean>) => (
+            <ConfirmDeleteNoteDialog
+              {...ctx}
+              title={tab?.title ?? "Note"}
+            />
+          ),
+        }).catch(() => false);
+        if (confirmed !== true) return;
+      }
+
+      removeTab(id);
+    }, [activeTabId, dialog, notesFiles, readActiveNoteText, removeTab, tabs]);
 
     const startRename = useCallback(() => {
-      const tab = tabs.find((t) => t.id === activeTabId);
-      if (!tab) return;
-      setRenameValue(tab.title);
+      if (!activeTab) return;
+      setRenameValue(activeTab.title);
       setRenaming(true);
       setEditing(false);
-    }, [tabs, activeTabId]);
+    }, [activeTab]);
 
     const startRenameTab = useCallback((id: string) => {
       const tab = tabs.find((entry) => entry.id === id);
       if (!tab) return;
+      if (id !== activeTabId) saveTab(activeTabId);
       setActiveTabId(id);
       setRenameValue(tab.title);
       setRenaming(true);
       setEditing(false);
-    }, [tabs]);
+    }, [activeTabId, saveTab, tabs]);
 
     const commitRename = useCallback(() => {
       const value = renameInputRef.current?.editBuffer.getText().trim() || renameValue.trim();
@@ -251,12 +451,12 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
         return;
       }
       if (!editing) {
-        if (event.name === "t") {
+        if (event.name === "n" || event.name === "t") {
           addTab();
           return;
         }
         if (event.name === "w" && tabs.length > 0) {
-          if (activeTabId) removeTab(activeTabId);
+          if (activeTabId) void requestRemoveTab(activeTabId);
           return;
         }
         if (event.name === "r") {
@@ -270,7 +470,7 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
           const next = event.name === "]"
             ? (idx + 1) % tabs.length
             : (idx - 1 + tabs.length) % tabs.length;
-          saveCurrentTab();
+          saveTab(activeTabId);
           setActiveTabId(tabs[next]!.id);
           return;
         }
@@ -279,20 +479,15 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
 
     usePaneFooter("quick-notes", () => ({
       info: [
-        ...(activeTabId ? [{
-          id: "active",
-          parts: [{ text: tabs.find((tab) => tab.id === activeTabId)?.title ?? "Note", tone: "value" as const, bold: true }],
-        }] : []),
-        { id: "mode", parts: [{ text: renaming ? "renaming" : editing ? "editing" : `${tabs.length} notes`, tone: "muted" }] },
+        { id: "edited", parts: [{ text: editing || renaming ? "editing" : formatLastEdited(activeTab?.updatedAt), tone: "muted" }] },
       ],
-      hints: renaming
+      hints: editing || renaming
         ? []
         : [
-            { id: "new", key: "t", label: "new", onPress: addTab },
-            { id: "close", key: "w", label: "close", onPress: () => { if (activeTabId) removeTab(activeTabId); }, disabled: !activeTabId },
+            { id: "new", key: "n", label: "new", onPress: addTab },
             { id: "rename", key: "r", label: "rename", onPress: startRename, disabled: !activeTabId },
           ],
-    }), [activeTabId, addTab, editing, removeTab, renaming, startRename, tabs]);
+    }), [activeTab, activeTabId, addTab, editing, renaming, startRename]);
 
     return (
       <Box flexDirection="column" flexGrow={1}>
@@ -301,13 +496,13 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
             tabs={tabs.map((tab) => ({
               label: tab.title,
               value: tab.id,
-              onClose: tabs.length > 1 ? removeTab : undefined,
+              onClose: tabs.length > 1 ? (id) => { void requestRemoveTab(id); } : undefined,
               onDoubleClick: startRenameTab,
             }))}
             activeValue={activeTabId}
             onSelect={(id) => {
               if (id === activeTabId) return;
-              saveCurrentTab();
+              saveTab(activeTabId);
               setActiveTabId(id);
               setEditing(false);
             }}
@@ -332,14 +527,24 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
             />
           </Box>
         )}
-        {/* Editor */}
-        <Box flexGrow={1} padding={1} onMouseDown={() => { if (!editing && !renaming) setEditing(true); }}>
-          <MarkdownEditor
-            textareaKey={activeTabId ?? "none"}
-            focused={editing && !renaming}
-            placeholder="Write notes..."
-            onRef={(ref) => { textareaRef.current = ref; }}
-          />
+        <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!editing && !renaming) setEditing(true); }}>
+          {editing && !renaming ? (
+            <MarkdownEditor
+              textareaKey={activeTabId ?? "none"}
+              focused
+              initialValue={noteText}
+              placeholder="Write notes..."
+              onRef={(ref) => { textareaRef.current = ref; }}
+              onChange={setNoteText}
+            />
+          ) : (
+            <MarkdownNotePreview
+              text={noteText}
+              width={width}
+              placeholder="Write notes..."
+              onActivate={() => { if (!renaming) setEditing(true); }}
+            />
+          )}
         </Box>
       </Box>
     );
@@ -371,7 +576,7 @@ export const notesPlugin: GloomPlugin = {
 
     ctx.registerPane({
       id: "quick-notes",
-      name: "Quick Notes",
+      name: "Notes",
       icon: "N",
       component: QuickNotesPane,
       defaultPosition: "right",
@@ -382,7 +587,7 @@ export const notesPlugin: GloomPlugin = {
     ctx.registerPaneTemplate({
       id: "new-quick-notes-pane",
       paneId: "quick-notes",
-      label: "Quick Notes",
+      label: "Notes",
       description: "Open a general-purpose notes scratchpad",
       keywords: ["notes", "quick", "scratchpad", "memo"],
       shortcut: { prefix: "NOTE" },

--- a/src/renderers/electrobun/view/notes-files.ts
+++ b/src/renderers/electrobun/view/notes-files.ts
@@ -3,6 +3,7 @@ import { backendRequest } from "./backend-rpc";
 export interface QuickNoteEntry {
   id: string;
   title: string;
+  updatedAt?: number;
 }
 
 export class NotesFiles {


### PR DESCRIPTION
## Summary
- Rename Quick Notes surfaces to Notes and update the NOTE shortcut docs/test fixture.
- Add read-mode markdown rendering for notes, full-height editing, compact footer status, and hide footer hints while editing.
- Confirm deletion for notes with content and persist quick-note last-edited metadata for terminal and desktop notes storage.

## Verification
- bun run desktop:view:build
- bun run build
- bun test src/plugins/builtin/help.test.tsx
- filtered tsc check for touched notes/markdown files
- tmux smoke of the Notes pane footer