### PR TITLE
Polish desktop pane settings and context menus

### DIFF
--- a/scripts/build-electrobun-view.ts
+++ b/scripts/build-electrobun-view.ts
@@ -324,17 +324,19 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
         display: flex;
         align-items: center;
         justify-content: center;
-        background: rgba(0,0,0,.72);
+        background: rgba(0,0,0,.64);
         z-index: 9999;
       }
       .gloom-dialog {
         max-width: min(920px, calc(100vw - 48px));
         max-height: calc(100vh - 48px);
         overflow: auto;
-        border: 1px solid #54c99f;
+        border: 1px solid #3a4148;
+        border-radius: 6px;
         background: #101417;
         color: #d8dde3;
-        padding: 14px;
+        padding: 0;
+        box-shadow: 0 18px 48px rgba(0,0,0,.46), inset 0 1px 0 rgba(255,255,255,.05);
       }
     </style>
   </head>

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -1,15 +1,14 @@
-import { Box, Text } from "../ui";
+import { Box, Text, useUiHost } from "../ui";
 import { TextAttributes } from "../ui";
 import { type AlertContext, useDialog, useDialogKeyboard } from "../ui/dialog";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type {
   PaneSettingField,
   PaneSettingTextField,
 } from "../types/plugin";
 import type { PluginRegistry } from "../plugins/registry";
-import { useAppSelector } from "../state/app-context";
 import { colors } from "../theme/colors";
-import { Button, DialogFrame, ListView, MultiSelectDialogContent, TextField } from "./ui";
+import { Button, DialogFrame, ListView, MultiSelectDialogContent, SegmentedControl, TextField } from "./ui";
 
 interface PaneSettingsDialogContentProps extends AlertContext {
   paneId: string;
@@ -54,6 +53,255 @@ function coerceSelectedValues(value: unknown): string[] {
     : [];
 }
 
+const DESKTOP_TEXT_STYLE = {
+  letterSpacing: 0,
+  lineHeight: "var(--cell-h)",
+} as const;
+
+function desktopText(weight?: number) {
+  return weight ? { ...DESKTOP_TEXT_STYLE, fontWeight: weight } : DESKTOP_TEXT_STYLE;
+}
+
+function DesktopDialogSurface({
+  title,
+  subtitle,
+  dismiss,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  dismiss: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Box
+      width={68}
+      maxWidth="calc(100vw - 72px)"
+      flexDirection="column"
+      style={{
+        padding: 12,
+      }}
+    >
+      <Box flexDirection="row" alignItems="flex-start" style={{ marginBottom: 10 }}>
+        <Box flexDirection="column" flexGrow={1} minWidth={0}>
+          <Text fg={colors.textBright} style={desktopText(700)}>{title}</Text>
+          {subtitle && (
+            <Text fg={colors.textMuted} wrapText style={{ ...desktopText(), marginTop: 3 }}>
+              {subtitle}
+            </Text>
+          )}
+        </Box>
+        <Box
+          width={3}
+          height={1}
+          alignItems="center"
+          justifyContent="center"
+          onMouseDown={(event: any) => {
+            event.stopPropagation?.();
+            event.preventDefault?.();
+            dismiss();
+          }}
+          data-gloom-interactive="true"
+          style={{
+            borderRadius: 6,
+            cursor: "pointer",
+            marginLeft: 16,
+            color: colors.textMuted,
+          }}
+        >
+          <Text fg={colors.textMuted} style={desktopText(700)}>x</Text>
+        </Box>
+      </Box>
+      {children}
+    </Box>
+  );
+}
+
+function DesktopSwitch({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <Box
+      width="42px"
+      height="18px"
+      flexDirection="row"
+      alignItems="center"
+      justifyContent={checked ? "flex-end" : "flex-start"}
+      backgroundColor={checked ? colors.selected : "rgba(255, 255, 255, 0.07)"}
+      onMouseDown={(event: any) => {
+        event.stopPropagation?.();
+        event.preventDefault?.();
+        onChange(!checked);
+      }}
+      data-gloom-interactive="true"
+      style={{
+        border: `1px solid ${checked ? colors.borderFocused : colors.border}`,
+        borderRadius: 999,
+        boxShadow: checked ? "inset 0 1px 0 rgba(255,255,255,0.10)" : "inset 0 1px 0 rgba(255,255,255,0.05)",
+        cursor: "pointer",
+        paddingInline: 2,
+      }}
+    >
+      <Box
+        width="14px"
+        height="14px"
+        backgroundColor={checked ? colors.selectedText : colors.textMuted}
+        style={{
+          borderRadius: 999,
+          boxShadow: "0 1px 2px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+    </Box>
+  );
+}
+
+function DesktopValuePill({ value }: { value: string }) {
+  return (
+    <Box
+      flexDirection="row"
+      alignItems="center"
+      backgroundColor="rgba(255, 255, 255, 0.06)"
+      style={{
+        border: `1px solid ${colors.border}`,
+        borderRadius: 6,
+        padding: "1px 7px",
+      }}
+    >
+      <Text fg={colors.textDim} style={desktopText(600)}>{value}</Text>
+    </Box>
+  );
+}
+
+function DesktopSettingsRow({
+  field,
+  selected,
+  hovered,
+  currentValue,
+  onHover,
+  onEdit,
+  onApply,
+}: {
+  field: PaneSettingField;
+  selected: boolean;
+  hovered: boolean;
+  currentValue: unknown;
+  onHover: () => void;
+  onEdit: () => void;
+  onApply: (field: PaneSettingField, value: unknown) => void;
+}) {
+  const isToggle = field.type === "toggle";
+  const isSelect = field.type === "select";
+  const rowInteractive = !isSelect;
+  const summary = summarizeValue(field, currentValue);
+  const control = field.type === "toggle" ? (
+    <DesktopSwitch checked={currentValue === true} onChange={(checked) => onApply(field, checked)} />
+  ) : field.type === "select" ? (
+    <Box
+      width="100%"
+      style={{
+        marginTop: 4,
+        overflowX: "auto",
+        overflowY: "hidden",
+      }}
+    >
+      <SegmentedControl
+        value={typeof currentValue === "string" ? currentValue : ""}
+        options={field.options.map((option) => ({
+          value: option.value,
+          label: option.label,
+        }))}
+        onChange={(value) => onApply(field, value)}
+      />
+    </Box>
+  ) : (
+    <Box flexDirection="row" alignItems="center" gap={1}>
+      <DesktopValuePill value={summary} />
+      <Text fg={colors.textMuted} style={desktopText(600)}>Edit</Text>
+    </Box>
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      minHeight={field.description || isSelect ? undefined : 2}
+      backgroundColor={hovered || selected ? "rgba(255, 255, 255, 0.045)" : "transparent"}
+      onMouseMove={onHover}
+      onMouseDown={rowInteractive
+        ? (event: any) => {
+          event.stopPropagation?.();
+          event.preventDefault?.();
+          if (isToggle) onApply(field, currentValue !== true);
+          else onEdit();
+        }
+        : undefined}
+      data-gloom-interactive={rowInteractive ? "true" : undefined}
+      style={{
+        borderBottom: `1px solid ${hovered || selected ? colors.borderFocused : colors.border}`,
+        cursor: rowInteractive ? "pointer" : "default",
+        padding: "6px 2px 7px",
+        transition: "background-color 100ms ease, border-color 100ms ease",
+      }}
+    >
+      <Box flexDirection="row" alignItems="center" width="100%">
+        <Box flexDirection="row" flexGrow={1} minWidth={0} style={{ paddingRight: 12 }}>
+          <Text fg={colors.text} style={desktopText(650)}>{field.label}</Text>
+        </Box>
+        {!isSelect && control}
+      </Box>
+      {field.description && (
+        <Text fg={colors.textMuted} wrapText style={desktopText()}>
+          {field.description}
+        </Text>
+      )}
+      {isSelect && control}
+    </Box>
+  );
+}
+
+function DesktopSettingsList({
+  fields,
+  selectedIndex,
+  hoveredFieldKey,
+  settings,
+  onHover,
+  onEdit,
+  onApply,
+}: {
+  fields: PaneSettingField[];
+  selectedIndex: number;
+  hoveredFieldKey: string | null;
+  settings: Record<string, unknown>;
+  onHover: (field: PaneSettingField, index: number) => void;
+  onEdit: (field: PaneSettingField, index: number) => void;
+  onApply: (field: PaneSettingField, value: unknown, index: number) => void;
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      style={{
+        borderTop: `1px solid ${colors.border}`,
+      }}
+    >
+      {fields.map((field, index) => (
+        <DesktopSettingsRow
+          key={field.key}
+          field={field}
+          selected={index === selectedIndex && hoveredFieldKey === null}
+          hovered={hoveredFieldKey === field.key}
+          currentValue={settings[field.key]}
+          onHover={() => onHover(field, index)}
+          onEdit={() => onEdit(field, index)}
+          onApply={(targetField, value) => onApply(targetField, value, index)}
+        />
+      ))}
+    </Box>
+  );
+}
+
 function SelectFieldDialog({
   dismiss,
   dialogId,
@@ -67,6 +315,7 @@ function SelectFieldDialog({
 }) {
   const initialIndex = Math.max(0, field.options.findIndex((option) => option.value === currentValue));
   const [selectedIndex, setSelectedIndex] = useState(initialIndex);
+  const isDesktop = useUiHost().kind === "desktop-web";
 
   useDialogKeyboard((event) => {
     event.stopPropagation();
@@ -79,6 +328,54 @@ function SelectFieldDialog({
       void onApply(option.value).then(() => dismiss()).catch(() => {});
     }
   }, dialogId);
+
+  if (isDesktop) {
+    return (
+      <DesktopDialogSurface
+        title={field.label}
+        subtitle={field.description}
+        dismiss={dismiss}
+      >
+        <Box flexDirection="column" style={{ borderTop: `1px solid ${colors.border}` }}>
+          {field.options.map((option, index) => {
+            const selected = option.value === currentValue;
+            const focused = index === selectedIndex;
+            return (
+              <Box
+                key={option.value}
+                minHeight={option.description ? 4 : 3}
+                flexDirection="row"
+                alignItems="center"
+                backgroundColor={selected || focused ? "rgba(255, 255, 255, 0.045)" : "transparent"}
+                onMouseMove={() => setSelectedIndex(index)}
+                onMouseDown={(event: any) => {
+                  event.stopPropagation?.();
+                  event.preventDefault?.();
+                  void onApply(option.value).then(() => dismiss()).catch(() => {});
+                }}
+                data-gloom-interactive="true"
+                style={{
+                  borderBottom: `1px solid ${selected || focused ? colors.borderFocused : colors.border}`,
+                  cursor: "pointer",
+                  padding: "6px 2px 7px",
+                }}
+              >
+                <Box flexDirection="column" flexGrow={1} minWidth={0}>
+                  <Text fg={colors.textBright} style={desktopText(650)}>{option.label}</Text>
+                  {option.description && (
+                    <Text fg={colors.textMuted} wrapText style={{ ...desktopText(), marginTop: 3 }}>
+                      {option.description}
+                    </Text>
+                  )}
+                </Box>
+                {selected && <DesktopValuePill value="Selected" />}
+              </Box>
+            );
+          })}
+        </Box>
+      </DesktopDialogSurface>
+    );
+  }
 
   return (
     <DialogFrame
@@ -117,6 +414,7 @@ function TextFieldDialog({
   const [value, setValue] = useState(typeof currentValue === "string" ? currentValue : "");
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<any>(null);
+  const isDesktop = useUiHost().kind === "desktop-web";
 
   useEffect(() => {
     inputRef.current?.focus?.();
@@ -138,6 +436,34 @@ function TextFieldDialog({
       setError(err instanceof Error ? err.message : "Could not save this value.");
     }
   };
+
+  if (isDesktop) {
+    return (
+      <DesktopDialogSurface
+        title={field.label}
+        subtitle={field.description}
+        dismiss={dismiss}
+      >
+        <Box flexDirection="column" gap={1}>
+          <TextField
+            inputRef={inputRef}
+            value={value}
+            placeholder={field.placeholder}
+            focused
+            width={56}
+            onChange={setValue}
+            onSubmit={() => { void submit(); }}
+          />
+          {error && (
+            <Text fg={colors.negative} wrapText style={desktopText(600)}>{error}</Text>
+          )}
+          <Box flexDirection="row" justifyContent="flex-end" style={{ marginTop: 12 }}>
+            <Button label="Save" variant="primary" onPress={() => { void submit(); }} />
+          </Box>
+        </Box>
+      </DesktopDialogSurface>
+    );
+  }
 
   return (
     <DialogFrame
@@ -203,10 +529,12 @@ export function PaneSettingsDialogContent({
   pluginRegistry,
   applyFieldValue,
 }: PaneSettingsDialogContentProps) {
-  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
   const dialog = useDialog();
+  const isDesktop = useUiHost().kind === "desktop-web";
   const descriptor = pluginRegistry.resolvePaneSettings(paneId);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [hoveredFieldKey, setHoveredFieldKey] = useState<string | null>(null);
+  const [, setSettingsRevision] = useState(0);
 
   const fields = descriptor?.settingsDef.fields ?? [];
 
@@ -216,12 +544,17 @@ export function PaneSettingsDialogContent({
     }
   }, [fields.length, selectedIndex]);
 
+  const applyAndRefresh = async (field: PaneSettingField, value: unknown) => {
+    await applyFieldValue(paneId, field, value);
+    setSettingsRevision((revision) => revision + 1);
+  };
+
   const openFieldEditor = async (field: PaneSettingField | undefined) => {
     if (!field || !descriptor) return;
     const currentValue = descriptor.context.settings[field.key];
 
     if (field.type === "toggle") {
-      await applyFieldValue(paneId, field, currentValue !== true);
+      await applyAndRefresh(field, currentValue !== true);
       return;
     }
 
@@ -232,7 +565,7 @@ export function PaneSettingsDialogContent({
             {...ctx}
             field={field}
             currentValue={currentValue}
-            onApply={(value) => applyFieldValue(paneId, field, value)}
+            onApply={(value) => applyAndRefresh(field, value)}
           />
         ),
       });
@@ -246,7 +579,7 @@ export function PaneSettingsDialogContent({
             {...ctx}
             field={field}
             currentValue={currentValue}
-            onApply={(value) => applyFieldValue(paneId, field, value)}
+            onApply={(value) => applyAndRefresh(field, value)}
           />
         ),
       });
@@ -259,7 +592,7 @@ export function PaneSettingsDialogContent({
           {...ctx}
           field={field}
           currentValue={currentValue}
-          onApply={(value) => applyFieldValue(paneId, field, value)}
+          onApply={(value) => applyAndRefresh(field, value)}
         />
       ),
     });
@@ -276,6 +609,16 @@ export function PaneSettingsDialogContent({
   }, dialogId);
 
   if (!descriptor) {
+    if (isDesktop) {
+      return (
+        <DesktopDialogSurface title="Pane Settings" dismiss={dismiss}>
+          <Text fg={colors.textDim} wrapText style={desktopText()}>
+            This pane is no longer configurable.
+          </Text>
+        </DesktopDialogSurface>
+      );
+    }
+
     return (
       <DialogFrame title="Pane Settings" footer="Press esc to cancel">
         <Text fg={colors.textDim}>This pane is no longer configurable.</Text>
@@ -284,6 +627,40 @@ export function PaneSettingsDialogContent({
   }
 
   const title = descriptor.settingsDef.title ?? `${descriptor.paneDef.name} Settings`;
+
+  if (isDesktop) {
+    return (
+      <DesktopDialogSurface
+        title={title}
+        dismiss={dismiss}
+      >
+        {fields.length === 0 ? (
+          <Text fg={colors.textDim} wrapText style={desktopText()}>
+            No settings available.
+          </Text>
+        ) : (
+          <DesktopSettingsList
+            fields={fields}
+            selectedIndex={selectedIndex}
+            hoveredFieldKey={hoveredFieldKey}
+            settings={descriptor.context.settings}
+            onHover={(field, index) => {
+              setSelectedIndex(index);
+              setHoveredFieldKey(field.key);
+            }}
+            onEdit={(field, index) => {
+              setSelectedIndex(index);
+              void openFieldEditor(field).catch(() => {});
+            }}
+            onApply={(field, value, index) => {
+              setSelectedIndex(index);
+              void applyAndRefresh(field, value).catch(() => {});
+            }}
+          />
+        )}
+      </DesktopDialogSurface>
+    );
+  }
 
   return (
     <DialogFrame title={title} footer="Use ↑↓ to choose · enter to edit · esc cancel">
@@ -320,7 +697,7 @@ export function PaneSettingsDialogContent({
           </Box>
         )}
       />
-      {fields.length === 0 && focusedPaneId === paneId && (
+      {fields.length === 0 && (
         <Box height={1}>
           <Text fg={colors.textDim}>No settings available.</Text>
         </Box>

--- a/src/renderers/electrobun/bun/context-menu-click.test.ts
+++ b/src/renderers/electrobun/bun/context-menu-click.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { ELECTROBUN_CONTEXT_MENU_ACTION } from "../shared/protocol";
+import { contextMenuSelectionMessage } from "./context-menu-click";
+
+describe("contextMenuSelectionMessage", () => {
+  test("extracts custom menu selections encoded in the native action string", () => {
+    expect(contextMenuSelectionMessage({
+      name: "context-menu-clicked",
+      data: {
+        action: `${ELECTROBUN_CONTEXT_MENU_ACTION}:ctx%3A1:pane%3Asettings`,
+      },
+    }, ELECTROBUN_CONTEXT_MENU_ACTION)).toEqual({
+      requestId: "ctx:1",
+      itemId: "pane:settings",
+    });
+  });
+
+  test("extracts custom menu selections from Electrobun event wrappers", () => {
+    expect(contextMenuSelectionMessage({
+      name: "context-menu-clicked",
+      data: {
+        action: ELECTROBUN_CONTEXT_MENU_ACTION,
+        data: {
+          requestId: "ctx:1",
+          itemId: "pane:settings",
+        },
+      },
+    }, ELECTROBUN_CONTEXT_MENU_ACTION)).toEqual({
+      requestId: "ctx:1",
+      itemId: "pane:settings",
+    });
+  });
+
+  test("also accepts a bare native menu payload", () => {
+    expect(contextMenuSelectionMessage({
+      action: ELECTROBUN_CONTEXT_MENU_ACTION,
+      data: {
+        requestId: "ctx:2",
+        itemId: "pane:close",
+      },
+    }, ELECTROBUN_CONTEXT_MENU_ACTION)).toEqual({
+      requestId: "ctx:2",
+      itemId: "pane:close",
+    });
+  });
+
+  test("ignores nonmatching and malformed native menu selections", () => {
+    expect(contextMenuSelectionMessage({
+      data: {
+        action: "other",
+        data: {
+          requestId: "ctx:3",
+          itemId: "pane:close",
+        },
+      },
+    }, ELECTROBUN_CONTEXT_MENU_ACTION)).toBeNull();
+
+    expect(contextMenuSelectionMessage({
+      data: {
+        action: ELECTROBUN_CONTEXT_MENU_ACTION,
+        data: {
+          requestId: "ctx:3",
+        },
+      },
+    }, ELECTROBUN_CONTEXT_MENU_ACTION)).toBeNull();
+  });
+});

--- a/src/renderers/electrobun/bun/context-menu-click.ts
+++ b/src/renderers/electrobun/bun/context-menu-click.ts
@@ -1,0 +1,61 @@
+export interface ContextMenuSelectionMessage {
+  requestId: string;
+  itemId: string;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function contextMenuClickPayload(event: unknown): Record<string, unknown> | null {
+  const eventRecord = record(event);
+  if (!eventRecord) return null;
+
+  const wrappedPayload = record(eventRecord.data);
+  if (typeof wrappedPayload?.action === "string") {
+    return wrappedPayload;
+  }
+
+  return typeof eventRecord.action === "string" ? eventRecord : null;
+}
+
+function decodeActionSelection(action: string, expectedAction: string): ContextMenuSelectionMessage | null {
+  const prefix = `${expectedAction}:`;
+  if (!action.startsWith(prefix)) return null;
+
+  const [requestId, itemId] = action.slice(prefix.length).split(":").map((part) => {
+    try {
+      return decodeURIComponent(part);
+    } catch {
+      return "";
+    }
+  });
+  if (!requestId || !itemId) return null;
+
+  return { requestId, itemId };
+}
+
+export function contextMenuSelectionMessage(
+  event: unknown,
+  expectedAction: string,
+): ContextMenuSelectionMessage | null {
+  const payload = contextMenuClickPayload(event);
+  if (typeof payload?.action !== "string") return null;
+
+  const actionMessage = decodeActionSelection(payload.action, expectedAction);
+  if (actionMessage) return actionMessage;
+
+  if (payload.action !== expectedAction) return null;
+
+  const data = record(payload.data);
+  if (typeof data?.requestId !== "string" || typeof data.itemId !== "string") {
+    return null;
+  }
+
+  return {
+    requestId: data.requestId,
+    itemId: data.itemId,
+  };
+}

--- a/src/renderers/electrobun/bun/context-menu-normalize.test.ts
+++ b/src/renderers/electrobun/bun/context-menu-normalize.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { ELECTROBUN_CONTEXT_MENU_ACTION } from "../shared/protocol";
+import { getContextMenuRequestId, normalizeContextMenuItems } from "./context-menu-normalize";
+
+describe("normalizeContextMenuItems", () => {
+  test("keeps encoded custom actions and discovers their request id", () => {
+    const menu = normalizeContextMenuItems([
+      {
+        label: "Settings",
+        action: `${ELECTROBUN_CONTEXT_MENU_ACTION}:ctx%3A1:settings`,
+      },
+    ]);
+
+    expect(menu).toEqual([
+      {
+        type: "normal",
+        label: "Settings",
+        tooltip: undefined,
+        enabled: true,
+        checked: false,
+        hidden: false,
+        accelerator: undefined,
+        action: `${ELECTROBUN_CONTEXT_MENU_ACTION}:ctx%3A1:settings`,
+      },
+    ]);
+    expect(getContextMenuRequestId(menu)).toBe("ctx:1");
+  });
+
+  test("keeps legacy custom actions that carry request data separately", () => {
+    const menu = normalizeContextMenuItems([
+      {
+        label: "Pop Out",
+        action: ELECTROBUN_CONTEXT_MENU_ACTION,
+        data: {
+          requestId: "ctx:2",
+          itemId: "pop-out",
+        },
+      },
+    ]);
+
+    expect(menu).toMatchObject([
+      {
+        action: ELECTROBUN_CONTEXT_MENU_ACTION,
+        data: {
+          requestId: "ctx:2",
+          itemId: "pop-out",
+        },
+      },
+    ]);
+    expect(getContextMenuRequestId(menu)).toBe("ctx:2");
+  });
+});

--- a/src/renderers/electrobun/bun/context-menu-normalize.ts
+++ b/src/renderers/electrobun/bun/context-menu-normalize.ts
@@ -1,0 +1,67 @@
+import { ELECTROBUN_CONTEXT_MENU_ACTION } from "../shared/protocol";
+import { contextMenuSelectionMessage } from "./context-menu-click";
+
+function normalizeText(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function normalizeContextMenuItems(value: unknown, depth = 0): unknown[] {
+  if (!Array.isArray(value) || depth > 4) return [];
+
+  const items: unknown[] = [];
+  for (const rawItem of value) {
+    const item = record(rawItem);
+    if (!item) continue;
+    if (item.type === "divider" || item.type === "separator") {
+      items.push({ type: "divider" });
+      continue;
+    }
+
+    const submenu = normalizeContextMenuItems(item.submenu, depth + 1);
+    const role = normalizeText(item.role);
+    const action = normalizeText(item.action);
+    const data = record(item.data);
+    const customAction = contextMenuSelectionMessage({ action, data }, ELECTROBUN_CONTEXT_MENU_ACTION) !== null;
+
+    if (!role && !customAction && submenu.length === 0 && !normalizeText(item.label)) continue;
+    items.push({
+      type: "normal",
+      label: normalizeText(item.label),
+      tooltip: normalizeText(item.tooltip),
+      enabled: item.enabled === false ? false : true,
+      checked: item.checked === true,
+      hidden: item.hidden === true,
+      accelerator: normalizeText(item.accelerator),
+      ...(role ? { role } : {}),
+      ...(customAction ? {
+        action,
+        ...(data ? { data } : {}),
+      } : {}),
+      ...(submenu.length > 0 ? { submenu } : {}),
+    });
+  }
+
+  return items;
+}
+
+export function getContextMenuRequestId(items: unknown[]): string | null {
+  for (const item of items) {
+    const recordItem = record(item);
+    if (!recordItem) continue;
+    const message = contextMenuSelectionMessage(recordItem, ELECTROBUN_CONTEXT_MENU_ACTION);
+    if (message) {
+      return message.requestId;
+    }
+    if (Array.isArray(recordItem.submenu)) {
+      const submenuRequestId = getContextMenuRequestId(recordItem.submenu);
+      if (submenuRequestId) return submenuRequestId;
+    }
+  }
+  return null;
+}

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from "fs";
 import { mkdir, readFile, rm, unlink, writeFile } from "fs/promises";
 import { dirname, join } from "path";
-import { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu } from "electrobun/bun";
+import Electrobun, { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu } from "electrobun/bun";
 import { getAiProviderDefinitions } from "../../../plugins/builtin/ai/providers";
 import { runAiPrompt, type AiRunController } from "../../../plugins/builtin/ai/runner";
 import {
@@ -28,6 +28,8 @@ import { isPaneDetached } from "../../../plugins/pane-manager";
 import { ELECTROBUN_CONTEXT_MENU_ACTION, type ElectrobunDesktopRpcSchema } from "../shared/protocol";
 import { decodeRpcValue, encodeRpcValue } from "../view/rpc-codec";
 import { startMainThreadMonitor } from "../../../utils/main-thread-monitor";
+import { contextMenuSelectionMessage } from "./context-menu-click";
+import { getContextMenuRequestId, normalizeContextMenuItems } from "./context-menu-normalize";
 import { createDesktopWorkspace, type DesktopWorkspace } from "./desktop-workspace";
 
 const DEFAULT_WINDOW_FRAME = { x: 64, y: 48, width: 1440, height: 920 };
@@ -216,70 +218,6 @@ function normalizeHttpFetchHeaders(headers: unknown): Record<string, string> {
 
 function normalizeText(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function normalizeContextMenuItems(value: unknown, depth = 0): unknown[] {
-  if (!Array.isArray(value) || depth > 4) return [];
-
-  const items: unknown[] = [];
-  for (const rawItem of value) {
-    if (!rawItem || typeof rawItem !== "object" || Array.isArray(rawItem)) continue;
-    const item = rawItem as Record<string, unknown>;
-    if (item.type === "divider" || item.type === "separator") {
-      items.push({ type: "divider" });
-      continue;
-    }
-
-    const submenu = normalizeContextMenuItems(item.submenu, depth + 1);
-    const role = normalizeText(item.role);
-    const action = normalizeText(item.action);
-    const data = item.data && typeof item.data === "object" && !Array.isArray(item.data)
-      ? item.data as Record<string, unknown>
-      : null;
-    const customAction = action === ELECTROBUN_CONTEXT_MENU_ACTION
-      && typeof data?.requestId === "string"
-      && typeof data?.itemId === "string";
-
-    if (!role && !customAction && submenu.length === 0 && !normalizeText(item.label)) continue;
-    items.push({
-      type: "normal",
-      label: normalizeText(item.label),
-      tooltip: normalizeText(item.tooltip),
-      enabled: item.enabled === false ? false : true,
-      checked: item.checked === true,
-      hidden: item.hidden === true,
-      accelerator: normalizeText(item.accelerator),
-      ...(role ? { role } : {}),
-      ...(customAction ? {
-        action: ELECTROBUN_CONTEXT_MENU_ACTION,
-        data: {
-          requestId: data!.requestId,
-          itemId: data!.itemId,
-        },
-      } : {}),
-      ...(submenu.length > 0 ? { submenu } : {}),
-    });
-  }
-
-  return items;
-}
-
-function getContextMenuRequestId(items: unknown[]): string | null {
-  for (const item of items) {
-    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
-    const record = item as Record<string, unknown>;
-    const data = record.data && typeof record.data === "object" && !Array.isArray(record.data)
-      ? record.data as Record<string, unknown>
-      : null;
-    if (record.action === ELECTROBUN_CONTEXT_MENU_ACTION && typeof data?.requestId === "string") {
-      return data.requestId;
-    }
-    if (Array.isArray(record.submenu)) {
-      const submenuRequestId = getContextMenuRequestId(record.submenu);
-      if (submenuRequestId) return submenuRequestId;
-    }
-  }
-  return null;
 }
 
 function notePath(dataDir: string, symbol: string): string {
@@ -1283,17 +1221,11 @@ function createWindowRpc(key: string): DesktopRpc {
   return rpc;
 }
 
-ContextMenu.on("context-menu-clicked", (event: unknown) => {
-  const payload = event && typeof event === "object" ? event as Record<string, unknown> : {};
-  if (payload.action !== ELECTROBUN_CONTEXT_MENU_ACTION) return;
-  const data = payload.data && typeof payload.data === "object" ? payload.data as Record<string, unknown> : {};
-  if (typeof data.requestId !== "string" || typeof data.itemId !== "string") return;
-  const targetRpc = contextMenuRequestRpcs.get(data.requestId);
-  contextMenuRequestRpcs.delete(data.requestId);
-  const message = {
-    requestId: data.requestId,
-    itemId: data.itemId,
-  };
+Electrobun.events.on("context-menu-clicked", (event: unknown) => {
+  const message = contextMenuSelectionMessage(event, ELECTROBUN_CONTEXT_MENU_ACTION);
+  if (!message) return;
+  const targetRpc = contextMenuRequestRpcs.get(message.requestId);
+  contextMenuRequestRpcs.delete(message.requestId);
   if (targetRpc) {
     targetRpc.send["context-menu.select"](message);
     return;

--- a/src/renderers/electrobun/view/context-menu.test.ts
+++ b/src/renderers/electrobun/view/context-menu.test.ts
@@ -77,7 +77,7 @@ describe("Electrobun desktop context menu serialization", () => {
 
     expect(prepared.menu[0]).toMatchObject({ role: "paste" });
     expect(prepared.menu[1]).toMatchObject({
-      action: ELECTROBUN_CONTEXT_MENU_ACTION,
+      action: `${ELECTROBUN_CONTEXT_MENU_ACTION}:request-2:open`,
       data: { requestId: "request-2", itemId: "open" },
     });
     expect(prepared.actions.get("open")).toBe(action);

--- a/src/renderers/electrobun/view/context-menu.ts
+++ b/src/renderers/electrobun/view/context-menu.ts
@@ -48,6 +48,10 @@ function actionIdFor(path: readonly number[], item: ContextMenuActionItem): stri
   return item.id || path.join(".");
 }
 
+function nativeActionFor(requestId: string, itemId: string): string {
+  return `${ELECTROBUN_CONTEXT_MENU_ACTION}:${encodeURIComponent(requestId)}:${encodeURIComponent(itemId)}`;
+}
+
 function roleItemToDesktop(item: ContextMenuRoleItem): DesktopContextMenuItem {
   return {
     type: "normal",
@@ -85,7 +89,7 @@ function prepareItems(
       checked: item.checked,
       hidden: item.hidden,
       accelerator: item.accelerator,
-      action: item.onSelect ? ELECTROBUN_CONTEXT_MENU_ACTION : undefined,
+      action: item.onSelect ? nativeActionFor(requestId, itemId) : undefined,
       data: item.onSelect ? { requestId, itemId } : undefined,
       submenu: item.submenu ? prepareItems(item.submenu, requestId, itemPath, actions) : undefined,
     };

--- a/src/renderers/electrobun/view/desktop-controls.tsx
+++ b/src/renderers/electrobun/view/desktop-controls.tsx
@@ -603,7 +603,7 @@ export function WebSegmentedControl({
 
 export function WebDialogFrame({ title, children, footer }: DialogFrameProps) {
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" style={{ padding: 14 }}>
       <Box
         height={1}
         flexDirection="row"


### PR DESCRIPTION
Summary:
- Refactors desktop pane settings into a compact flat desktop dialog with fixed switch behavior and preserved terminal fallback.
- Uses the native Electrobun context-menu path from main and fixes global item click dispatch through the documented Electrobun events API.
- Adjusts desktop dialog chrome/padding and adds focused tests for context-menu serialization, normalization, and click parsing.

Tests:
- git diff --check
- bun test ./src/renderers/electrobun/bun/context-menu-click.test.ts ./src/renderers/electrobun/bun/context-menu-normalize.test.ts ./src/renderers/electrobun/view/context-menu.test.ts ./src/ui/context-menu.test.ts ./src/components/layout/shell.test.tsx
- bun run desktop:view:build
- bun run desktop:build