### PR TITLE
Fix chart transparency and axis layout

### DIFF
--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -91,14 +91,15 @@ export interface ResolvedChartPalette extends ChartColors {
 
 type VolumeTrendMode = "previousClose" | "openClose";
 
-function makeChunk(text: string, fgColor: string, bgColor: string): StyledChunk {
-  return {
+function makeChunk(text: string, fgColor?: string, bgColor?: string): StyledChunk {
+  const chunk: StyledChunk = {
     __isChunk: true,
     text,
-    fg: RGBA.fromHex(fgColor),
-    bg: RGBA.fromHex(bgColor),
     attributes: 0,
   };
+  if (fgColor) chunk.fg = RGBA.fromHex(fgColor);
+  if (bgColor) chunk.bg = RGBA.fromHex(bgColor);
+  return chunk;
 }
 
 function blendHex(a: string, b: string, ratio: number): string {
@@ -506,7 +507,7 @@ export function drawGridLines(
 // Braille buffer → styled terminal output
 // ---------------------------------------------------------------------------
 
-export function bufferToBrailleLines(buf: PixelBuffer, bgColor: string): StyledContent[] {
+export function bufferToBrailleLines(buf: PixelBuffer): StyledContent[] {
   const lines: StyledContent[] = [];
   const termCols = Math.ceil(buf.width / 2);
   const termRows = Math.ceil(buf.height / 4);
@@ -514,8 +515,8 @@ export function bufferToBrailleLines(buf: PixelBuffer, bgColor: string): StyledC
   for (let row = 0; row < termRows; row++) {
     const chunks: StyledChunk[] = [];
     let runChar = "";
-    let runFg = "";
-    let runBg = "";
+    let runFg: string | undefined;
+    let runBg: string | undefined;
     let runLen = 0;
 
     const flushRun = () => {
@@ -552,13 +553,13 @@ export function bufferToBrailleLines(buf: PixelBuffer, bgColor: string): StyledC
       }
 
       let char: string;
-      let cellFg: string;
-      let cellBg: string;
+      let cellFg: string | undefined;
+      let cellBg: string | undefined;
 
       if (topLayer < 0) {
         char = " ";
-        cellFg = bgColor;
-        cellBg = bgColor;
+        cellFg = undefined;
+        cellBg = undefined;
       } else {
         // Only show dots from the highest layer — keeps lines thin in mixed
         // cells (e.g. area chart where line and fill overlap).
@@ -573,7 +574,7 @@ export function bufferToBrailleLines(buf: PixelBuffer, bgColor: string): StyledC
         }
 
         cellFg = topColor;
-        cellBg = bgColor;
+        cellBg = undefined;
       }
 
       if (char === runChar && cellFg === runFg && cellBg === runBg) {
@@ -1350,7 +1351,7 @@ export function renderChart(
   const timeAxisDates = opts.timeAxisDates ?? points.map((point) => point.date);
 
   return {
-    lines: bufferToBrailleLines(buf, palette.bgColor),
+    lines: bufferToBrailleLines(buf),
     axisLabels: [...axisLabelsByRow.entries()].map(([row, label]) => ({ row, label })),
     timeLabels: buildTimeAxis(timeAxisDates, width),
     activePoint,

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -368,6 +368,24 @@ describe("renderChart", () => {
     expect(result.axisLabels.every((entry) => Number.isInteger(entry.row))).toBe(true);
   });
 
+  test("keeps terminal chart cells transparent", () => {
+    const projection = projectChartData(chartFixture, 12, "area", false);
+    const result = renderChart(projection.points, {
+      width: 12,
+      height: 5,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: projection.effectiveMode,
+      colors: palette,
+    });
+
+    const chunks = result.lines.flatMap((line) => line.chunks);
+    expect(chunks.some((chunk) => chunk.text.trim().length > 0)).toBe(true);
+    expect(chunks.every((chunk) => chunk.bg === undefined)).toBe(true);
+  });
+
   test("keeps one decimal on zoomed equity axes even when whole-dollar ticks are distinct", () => {
     const mediumRangeFixture: PricePoint[] = [
       { date: new Date("2024-01-02T09:30:00Z"), close: 233.82, volume: 100 },

--- a/src/components/chart/comparison-chart-renderer.test.ts
+++ b/src/components/chart/comparison-chart-renderer.test.ts
@@ -40,7 +40,6 @@ describe("renderComparisonChart", () => {
     const projection = projectComparisonChartData([
       makeSeries("AAPL", "#00ff00", [18.02, 17.91, 17.84, 17.73]),
     ], 24, {
-      timeRange: "ALL",
       panOffset: 0,
       zoomLevel: 1,
       renderMode: "line",
@@ -68,7 +67,6 @@ describe("renderComparisonChart", () => {
     const projection = projectComparisonChartData([
       makeSeries("AAPL", "#00ff00", [233.82, 232.14, 230.21, 231.67, 228.94]),
     ], 24, {
-      timeRange: "ALL",
       panOffset: 0,
       zoomLevel: 1,
       renderMode: "line",
@@ -96,7 +94,6 @@ describe("renderComparisonChart", () => {
       makeSeries("AAPL", "#00ff00", [10, 12, 11, 13]),
       makeSeries("MSFT", "#ff0000", [8, 9, 10, 11]),
     ], 12, {
-      timeRange: "ALL",
       panOffset: 0,
       zoomLevel: 1,
       renderMode: "line",
@@ -122,12 +119,38 @@ describe("renderComparisonChart", () => {
     expect(result.activeDate?.toISOString()).toBe("2024-01-03T00:00:00.000Z");
   });
 
+  test("keeps terminal comparison chart cells transparent", () => {
+    const projection = projectComparisonChartData([
+      makeSeries("AAPL", "#00ff00", [10, 12, 11, 13]),
+    ], 12, {
+      panOffset: 0,
+      zoomLevel: 1,
+      renderMode: "area",
+    }, "percent");
+
+    const result = renderComparisonChart(projection, {
+      width: 12,
+      height: 6,
+      cursorX: null,
+      cursorY: null,
+      selectedSymbol: "AAPL",
+      colors: {
+        bgColor: "#000000",
+        gridColor: "#333333",
+        crosshairColor: "#ffffff",
+      },
+    });
+
+    const chunks = result.lines.flatMap((line) => line.chunks);
+    expect(chunks.some((chunk) => chunk.text.trim().length > 0)).toBe(true);
+    expect(chunks.every((chunk) => chunk.bg === undefined)).toBe(true);
+  });
+
   test("builds a scene with the selected series driving the hover readout", () => {
     const projection = projectComparisonChartData([
       makeSeries("AAPL", "#00ff00", [100, 102, 104]),
       makeSeries("NVDA", "#ff0000", [200, 210, 220]),
     ], 10, {
-      timeRange: "ALL",
       panOffset: 0,
       zoomLevel: 1,
       renderMode: "area",

--- a/src/components/chart/comparison-chart-renderer.ts
+++ b/src/components/chart/comparison-chart-renderer.ts
@@ -376,7 +376,7 @@ export function renderComparisonChart(
   }
 
   return {
-    lines: bufferToBrailleLines(buf, scene.colors.bgColor),
+    lines: bufferToBrailleLines(buf),
     axisLabels: [...axisLabelsByRow.entries()].map(([row, label]) => ({ row, label })),
     timeLabels: scene.timeLabels,
     activeDate: scene.activeDate,

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -1813,7 +1813,6 @@ function ComparisonStockChartView({
       width={chartWidth}
       height={chartHeight}
       flexDirection="column"
-      backgroundColor={chartColors.bgColor}
       bitmaps={plotBitmaps}
       crosshair={canvasCrosshair}
       onMouseMove={hasChartData && !isBlockingBody && !bodyMessage ? handlePlotMove : undefined}

--- a/src/components/chart/native/chart-rasterizer.ts
+++ b/src/components/chart/native/chart-rasterizer.ts
@@ -99,16 +99,6 @@ function blendPixel(
   data[index + 3] = Math.round(outAlpha * 255);
 }
 
-function fillBackground(data: Uint8Array, width: number, height: number, color: RgbaColor) {
-  for (let index = 0; index < width * height; index += 1) {
-    const offset = index * 4;
-    data[offset] = color.r;
-    data[offset + 1] = color.g;
-    data[offset + 2] = color.b;
-    data[offset + 3] = color.a;
-  }
-}
-
 function drawLine(
   data: Uint8Array,
   width: number,
@@ -482,7 +472,6 @@ export function renderNativeChartBase(scene: ChartScene, pixelWidth: number, pix
       return { width: Math.max(pixelWidth, 1), height: Math.max(pixelHeight, 1), pixels };
     }
 
-    fillBackground(pixels, pixelWidth, pixelHeight, parseHex(scene.colors.bgColor, 1));
     const layout = getChartPixelLayout(scene, pixelWidth, pixelHeight);
     drawPriceGrid(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
 
@@ -587,7 +576,6 @@ export function renderNativeComparisonChartBase(
     return { width: Math.max(pixelWidth, 1), height: Math.max(pixelHeight, 1), pixels };
   }
 
-  fillBackground(pixels, pixelWidth, pixelHeight, parseHex(scene.colors.bgColor, 1));
   const layout = getComparisonPixelLayout(pixelWidth, pixelHeight);
   drawPriceGrid(
     pixels,

--- a/src/components/chart/native/kitty.test.ts
+++ b/src/components/chart/native/kitty.test.ts
@@ -99,7 +99,7 @@ describe("computeNativePlacement", () => {
 });
 
 describe("renderNativeChartBase", () => {
-  test("fills the bitmap background opaquely", () => {
+  test("leaves untouched bitmap pixels transparent", () => {
     const palette = resolveChartPalette({
       bg: "#112233",
       border: "#333333",
@@ -126,9 +126,17 @@ describe("renderNativeChartBase", () => {
     expect(scene).not.toBeNull();
 
     const bitmap = renderNativeChartBase(scene!, 24, 12);
+    let transparentPixels = 0;
+    let drawnPixels = 0;
     for (let offset = 3; offset < bitmap.pixels.length; offset += 4) {
-      expect(bitmap.pixels[offset]).toBe(0xff);
+      if (bitmap.pixels[offset] === 0) {
+        transparentPixels += 1;
+      } else {
+        drawnPixels += 1;
+      }
     }
+    expect(transparentPixels).toBeGreaterThan(0);
+    expect(drawnPixels).toBeGreaterThan(0);
   });
 
   test("keeps solid candle bodies opaque over the wick", () => {
@@ -277,7 +285,7 @@ describe("renderNativeChartBase", () => {
 });
 
 describe("renderNativeComparisonChartBase", () => {
-  test("renders multi-series comparison overlays into an opaque bitmap", () => {
+  test("renders multi-series comparison overlays over transparent pixels", () => {
     const projection = projectComparisonChartData([
       {
         symbol: "AAPL",
@@ -302,7 +310,6 @@ describe("renderNativeComparisonChartBase", () => {
         ],
       },
     ], 12, {
-      timeRange: "ALL",
       panOffset: 0,
       zoomLevel: 1,
       renderMode: "line",
@@ -323,17 +330,25 @@ describe("renderNativeComparisonChartBase", () => {
     expect(scene).not.toBeNull();
 
     const bitmap = renderNativeComparisonChartBase(scene!, 120, 60);
+    let transparentPixels = 0;
+    let drawnPixels = 0;
     for (let offset = 3; offset < bitmap.pixels.length; offset += 4) {
-      expect(bitmap.pixels[offset]).toBe(0xff);
-    }
-
-    const brightPixels = [];
-    for (let offset = 0; offset < bitmap.pixels.length; offset += 4) {
-      if (bitmap.pixels[offset] !== 17 || bitmap.pixels[offset + 1] !== 34 || bitmap.pixels[offset + 2] !== 51) {
-        brightPixels.push(offset);
+      if (bitmap.pixels[offset] === 0) {
+        transparentPixels += 1;
+      } else {
+        drawnPixels += 1;
       }
     }
-    expect(brightPixels.length).toBeGreaterThan(0);
+    expect(transparentPixels).toBeGreaterThan(0);
+    expect(drawnPixels).toBeGreaterThan(0);
+
+    const visiblePixels = [];
+    for (let offset = 0; offset < bitmap.pixels.length; offset += 4) {
+      if (bitmap.pixels[offset + 3] !== 0) {
+        visiblePixels.push(offset);
+      }
+    }
+    expect(visiblePixels.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/components/chart/stock-chart-renderer-switch.test.tsx
+++ b/src/components/chart/stock-chart-renderer-switch.test.tsx
@@ -18,6 +18,7 @@ import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { Box } from "../../ui";
 import { StockChart } from "./stock-chart";
+import { getNativeSurfaceManager } from "./native/surface-manager";
 
 const TEST_PANE_ID = "ticker-detail:test";
 const CHART_DETAIL_REQUEST_DEBOUNCE_WAIT_MS = 220;
@@ -125,12 +126,14 @@ function ChartHarness({
   financials,
   interactive = false,
   activateOnMouse = false,
+  width = 84,
 }: {
   config: AppConfig;
   ticker: TickerRecord;
   financials: TickerFinancials;
   interactive?: boolean;
   activateOnMouse?: boolean;
+  width?: number;
 }) {
   const initialState = createInitialState(config);
   initialState.focusedPaneId = TEST_PANE_ID;
@@ -147,15 +150,15 @@ function ChartHarness({
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
         <PaneFooterProvider>
           {(footer) => (
-            <Box flexDirection="column" width={84} height={16}>
+            <Box flexDirection="column" width={width} height={16}>
               <StockChart
-                width={84}
+                width={width}
                 height={15}
                 focused
                 interactive={effectiveInteractive}
                 onActivate={activateOnMouse ? () => setMouseInteractive(true) : undefined}
               />
-              <PaneFooterBar footer={footer} focused width={84} />
+              <PaneFooterBar footer={footer} focused width={width} />
             </Box>
           )}
         </PaneFooterProvider>
@@ -338,6 +341,94 @@ describe("StockChart renderer switching", () => {
     expect(footerLine).not.toContain("Dec 2024");
   });
 
+  test("keeps the native chart surface clear of the time axis row", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    config.chartPreferences.renderer = "kitty";
+    const ticker = makeTicker(symbol);
+    const history = makeMonthlyHistory(72, new Date(Date.UTC(2019, 0, 1)));
+    const provider = makeProvider({ [symbol]: history });
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedDataProviderForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: history,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 32 });
+    ((testSetup.renderer as unknown) as { _capabilities: unknown })._capabilities = { kitty_graphics: true };
+    ((testSetup.renderer as unknown) as { _resolution: unknown })._resolution = { width: 1200, height: 960 };
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+        />,
+      );
+    });
+
+    await flushFrames(4);
+    const lines = testSetup.captureCharFrame().split("\n");
+    const axisLineIndex = lines.findIndex((line) => line.includes("Dec 2019"));
+    const footerLineIndex = lines.findIndex((line) => line.includes("[m]ode"));
+    expect(axisLineIndex).toBeGreaterThanOrEqual(0);
+    expect(footerLineIndex).toBeGreaterThan(axisLineIndex);
+
+    const manager = getNativeSurfaceManager(testSetup.renderer as never) as unknown as {
+      surfaces: Map<string, { snapshot: { rect: { height: number } } }>;
+    };
+    expect(manager.surfaces.get("chart-surface:ticker-detail:test:full:base")?.snapshot.rect.height).toBe(11);
+  });
+
+  test("moves candle OHLC summary into the pane footer", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    config.chartPreferences.defaultRenderMode = "candles";
+    const ticker = makeTicker(symbol);
+    const history = makeHistory(96);
+    const provider = makeProvider({ [symbol]: history });
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedDataProviderForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: history,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 140, height: 32 });
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+          width={120}
+        />,
+      );
+    });
+
+    await flushFrames(4);
+    const lines = testSetup.captureCharFrame().split("\n");
+    const chartAndFooterLines = lines.slice(0, 16);
+    const footerLine = chartAndFooterLines.at(-1) ?? "";
+
+    expect(chartAndFooterLines.join("\n")).not.toContain("AAPL -");
+    expect(footerLine).toContain("O $");
+    expect(footerLine).toContain("H $");
+    expect(footerLine).toContain("L $");
+    expect(footerLine).toContain("C $");
+    expect(footerLine).toContain("V ");
+    expect(footerLine).toContain("[m]ode");
+  });
+
   test("pans the visible window with mouse drag", async () => {
     const symbol = "AAPL";
     const config = makeChartConfig(symbol);
@@ -426,7 +517,7 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames();
-    expect(testSetup.captureCharFrame()).toContain("AAPL");
+    expect(testSetup.captureCharFrame()).toContain("AUTO 1M");
 
     const nextConfig: AppConfig = {
       ...config,
@@ -441,7 +532,7 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames();
-    expect(testSetup.captureCharFrame()).toContain("AAPL");
+    expect(testSetup.captureCharFrame()).toContain("AUTO 1M");
   });
 
   test("applies preset hotkeys without reverting to the previous stored range", async () => {
@@ -472,15 +563,14 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames(3);
-    expect(testSetup.captureCharFrame()).toContain("AAPL - AUTO");
+    expect(testSetup.captureCharFrame()).toContain("AUTO 1M");
 
     await emitKeypress({ name: "3", sequence: "3" });
     await flushFrames(3);
     await flushDebouncedChartRequests();
 
     const frame = testSetup.captureCharFrame();
-    expect(frame).not.toContain("AAPL - AUTO");
-    expect(frame).toContain("AAPL - 15M");
+    expect(frame).not.toContain("AAPL -");
     expect(frame).toContain("May 28");
     expect(frame).not.toContain("view:");
   });
@@ -543,7 +633,7 @@ describe("StockChart renderer switching", () => {
 
     await flushFrames(6);
     await flushDebouncedChartRequests();
-    expect(testSetup.captureCharFrame()).toContain("AAPL - AUTO");
+    expect(testSetup.captureCharFrame()).toContain("AUTO 1M");
     expect(detailBarSizes).toContain("15m");
 
     for (let index = 0; index < 6; index += 1) {
@@ -744,18 +834,18 @@ describe("StockChart renderer switching", () => {
 
     await flushFrames(6);
     const initialFrame = testSetup.captureCharFrame();
-    const titleRow = getFrameRowContaining(initialFrame, "AAPL - AUTO");
-    expect(titleRow).toBeGreaterThanOrEqual(0);
+    const controlsRow = getFrameRowContaining(initialFrame, "AUTO 1M");
+    expect(controlsRow).toBeGreaterThanOrEqual(0);
 
     await act(async () => {
-      await testSetup!.mockMouse.scroll(1, titleRow, "up");
+      await testSetup!.mockMouse.scroll(1, controlsRow, "up");
       await testSetup!.renderOnce();
     });
     await flushFrames(2);
 
     for (let index = 0; index < 4; index += 1) {
       await act(async () => {
-        await testSetup!.mockMouse.scroll(68, titleRow + 3, "up");
+        await testSetup!.mockMouse.scroll(68, controlsRow + 3, "up");
         await testSetup!.renderOnce();
       });
       await flushFrames(2);
@@ -763,8 +853,8 @@ describe("StockChart renderer switching", () => {
     await flushDebouncedChartRequests();
 
     const pannedFrame = testSetup.captureCharFrame();
-    const pannedHeader = getFrameLineContaining(pannedFrame, "AAPL - AUTO");
-    expect(pannedHeader).not.toContain("view:");
+    const pannedControls = getFrameLineContaining(pannedFrame, "AUTO 1M");
+    expect(pannedControls).not.toContain("view:");
     expect(detailRequests.some((request) => /(m|h)$/i.test(request))).toBe(false);
   });
 
@@ -825,14 +915,14 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames(6);
-    expect(testSetup.captureCharFrame()).toContain("AAPL - 1D");
+    expect(testSetup.captureCharFrame()).toContain("1D");
 
     await emitKeypress({ name: "a", sequence: "a" });
     await flushFrames(3);
 
     const loadingFrame = testSetup.captureCharFrame();
     expect(pendingResolvers.length).toBeGreaterThan(0);
-    expect(loadingFrame).toContain("AAPL - 1D");
+    expect(loadingFrame).toContain("1D");
     expect(loadingFrame).not.toContain("Loading chart...");
 
     await emitKeypress({ name: "a", sequence: "a" });
@@ -906,7 +996,7 @@ describe("StockChart renderer switching", () => {
     });
 
     await flushFrames(6);
-    expect(testSetup.captureCharFrame()).toContain("AAPL - 1D");
+    expect(testSetup.captureCharFrame()).toContain("1D");
 
     holdDetailRequests = true;
     for (let index = 0; index < 5; index += 1) {
@@ -917,7 +1007,7 @@ describe("StockChart renderer switching", () => {
 
     const loadingFrame = testSetup.captureCharFrame();
     expect(pendingResolvers.length).toBeGreaterThan(0);
-    expect(loadingFrame).toContain("AAPL - 1D");
+    expect(loadingFrame).toContain("1D");
     expect(loadingFrame).not.toContain("Loading chart...");
 
     await act(async () => {
@@ -999,7 +1089,6 @@ describe("StockChart renderer switching", () => {
     const firstFrame = testSetup.captureCharFrame();
     expect(pendingOneDayResolvers.length).toBeGreaterThan(0);
     expect(fallbackRequests).toBeGreaterThan(0);
-    expect(firstFrame).toContain("AAPL - 1D");
     expect(firstFrame).toContain("showing 1W");
     expect(firstFrame).toContain("updating");
     expect(firstFrame).not.toContain("Loading chart...");
@@ -1069,7 +1158,6 @@ describe("StockChart renderer switching", () => {
     const frame = testSetup.captureCharFrame();
     expect(detailRequests).toContain("1m");
     expect(detailRequests).toContain("1d");
-    expect(frame).toContain("AAPL - 1M");
     expect(frame).toContain("showing 1D");
     expect(frame).not.toContain("No price history available.");
   });

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -4,7 +4,7 @@ import { TextAttributes, type BoxRenderable, type NativeRendererHost as CliRende
 import { useNativeRenderer, useUiCapabilities } from "../../ui";
 import { useShortcut } from "../../react/input";
 import { useAppDispatch, useAppSelector, usePaneInstance, usePaneInstanceId, usePaneSettingValue, usePaneTicker } from "../../state/app-context";
-import { usePaneFooter, type PaneHint } from "../layout/pane-footer";
+import { usePaneFooter, type PaneFooterSegment, type PaneHint } from "../layout/pane-footer";
 import { saveConfig } from "../../data/config-store";
 import { getSharedDataProvider } from "../../plugins/registry";
 import { colors } from "../../theme/colors";
@@ -82,7 +82,6 @@ import {
 import {
   buildChartScene,
   formatAxisCell,
-  formatDateShort,
   formatCursorAxisValue,
   getActivePointIndex,
   getPointTerminalColumn,
@@ -1531,6 +1530,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const [lastReadyRenderView, setLastReadyRenderView] = useState<CachedRenderedView | null>(null);
   const showVolume = showVolumeOverride ?? !compact;
   const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
+  const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
+  const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;
+  const useCanvasChart = canvasCharts && effectiveRenderer !== "kitty";
   const [displayCursor, setDisplayCursor] = useState<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
   const [canvasBaseBitmapState, setCanvasBaseBitmapState] = useState<{ key: string; bitmap: NativeChartBitmap } | null>(null);
   const plotRef = useRef<BoxRenderable | null>(null);
@@ -1778,11 +1780,14 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const axisGap = axisSectionWidthBudget > 0 ? 1 : 0;
   const minChartWidth = compact ? 12 : 20;
   const measurementChartWidth = Math.max(width - axisSectionWidthBudget - axisGap, minChartWidth);
-  const headerRows = compact ? 0 : 3;
+  const headerRows = compact ? 0 : 2;
   const helpRow = compact ? 1 : 0;
   const timeAxisRow = 1;
+  // Native/canvas surfaces can cover the last physical row after pixel rounding;
+  // keep the text x-axis one row clear of the pane footer.
+  const nativeSurfaceGuardRow = !compact && (useCanvasChart || effectiveRenderer === "kitty") ? 1 : 0;
   const volumeHeight = showVolume && !compact ? 3 : 0;
-  const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow, 4);
+  const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow - nativeSurfaceGuardRow, 4);
   const chartCurrency = currencyOverride ?? financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
   const chartAssetCategory = ticker?.metadata.assetCategory;
   const boundsHistory = compact
@@ -3138,10 +3143,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     indicators,
   }), [axisMode, chartColors, chartHeight, chartWidth, compact, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
-  const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
-  const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;
-  const useCanvasChart = canvasCharts && effectiveRenderer !== "kitty";
-
   const staticResult = useMemo(() => renderChart(projection.points, {
     width: chartWidth,
     height: chartHeight,
@@ -3431,11 +3432,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const hasHistory = chartWindow.points.length > 0;
   const requestedMode = projection.requestedMode;
   const showOhlcSummary = projection.effectiveMode === "candles" || projection.effectiveMode === "ohlc";
-  const hasSelectionCursor = selectionCursorX !== null;
   const hasDisplayCursor = displayCursorX !== null && displayCursorY !== null;
-  const displayDate = hasSelectionCursor || showOhlcSummary
-    ? (selectionScene?.dateAtCursor ? formatDateShort(selectionScene.dateAtCursor) : null)
-    : null;
   const activePoint = showOhlcSummary ? (selectionScene?.activePoint ?? null) : null;
   const visiblePriceRange = selectionScene
     ? Math.max(selectionScene.max - selectionScene.min, 0)
@@ -3457,6 +3454,16 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     : null;
   const isUpdating = !compact && (renderBodyState.updating || boundsBodyState.updating);
   const timeAxisLabel = selectionScene?.timeLabels ?? staticResult.timeLabels;
+  const timeAxisBox = (
+    <Box
+      height={1}
+      width={chartWidth}
+      overflow="hidden"
+      data-gloom-role="chart-time-axis"
+    >
+      <Text fg={colors.textDim} style={{ whiteSpace: "pre" }}>{timeAxisLabel}</Text>
+    </Box>
+  );
   const chartFooterHints = useMemo<PaneHint[]>(() => {
     if (compact) return [];
 
@@ -3544,14 +3551,49 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     width,
   ]);
 
+  const chartFooterInfo = useMemo<PaneFooterSegment[]>(() => {
+    if (compact || !showOhlcSummary || !activePoint) return [];
+
+    const formatPrice = (value: number) => formatMarketPriceWithCurrency(value, chartCurrency, {
+      assetCategory: chartAssetCategory,
+      minimumFractionDigits: 2,
+      precisionOffset: 1,
+      priceRange: visiblePriceRange,
+    });
+
+    return [{
+      id: "ohlc",
+      parts: [
+        { text: "O", tone: "label" },
+        { text: formatPrice(activePoint.open), tone: "value" },
+        { text: "H", tone: "label" },
+        { text: formatPrice(activePoint.high), tone: "value" },
+        { text: "L", tone: "label" },
+        { text: formatPrice(activePoint.low), tone: "value" },
+        { text: "C", tone: "label" },
+        { text: formatPrice(activePoint.close), tone: "value" },
+        { text: "V", tone: "label" },
+        { text: formatCompact(activePoint.volume), tone: "value" },
+      ],
+    }];
+  }, [
+    activePoint,
+    chartAssetCategory,
+    chartCurrency,
+    compact,
+    showOhlcSummary,
+    visiblePriceRange,
+  ]);
+
   usePaneFooter("stock-chart", () => (
     compact
       ? null
       : {
           order: 10,
+          info: chartFooterInfo,
           hints: chartFooterHints,
         }
-  ), [chartFooterHints, compact]);
+  ), [chartFooterHints, chartFooterInfo, compact]);
 
   useEffect(() => {
     queueMicrotask(() => renderer.requestRender());
@@ -3896,7 +3938,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       width={chartWidth}
       height={chartHeight}
       flexDirection="column"
-      backgroundColor={chartColors.bgColor}
       bitmaps={plotBitmaps}
       crosshair={canvasCrosshair}
       onMouseMove={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : handlePlotMove}
@@ -3943,9 +3984,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
           {plotBox}
           {axisBox}
         </Box>
-        <Box height={1}>
-          <Text fg={colors.textDim}>{selectionScene?.timeLabels ?? staticResult.timeLabels}</Text>
-        </Box>
+        {timeAxisBox}
       </Box>
     );
   }
@@ -3956,45 +3995,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       flexGrow={1}
       onMouseScroll={compact || !hasHistory || isBlockingBody || !!bodyMessage ? undefined : handlePlotScroll}
     >
-      <Box flexDirection="row" gap={2} height={1}>
-        <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
-          {ticker?.metadata.ticker ?? ""} - {getChartResolutionLabel(selectedResolution)}
-        </Text>
-        {fallbackResolutionLabel && (
-          <Text fg={colors.textDim}>{fallbackResolutionLabel}</Text>
-        )}
-        {displayDate && <Text fg={colors.textDim}>{displayDate}</Text>}
-        {showOhlcSummary && activePoint && (
-          <>
-            <Text fg={colors.textDim}>O {formatMarketPriceWithCurrency(activePoint.open, chartCurrency, {
-              assetCategory: chartAssetCategory,
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })}</Text>
-            <Text fg={colors.textDim}>H {formatMarketPriceWithCurrency(activePoint.high, chartCurrency, {
-              assetCategory: chartAssetCategory,
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })}</Text>
-            <Text fg={colors.textDim}>L {formatMarketPriceWithCurrency(activePoint.low, chartCurrency, {
-              assetCategory: chartAssetCategory,
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })}</Text>
-            <Text fg={colors.textDim}>C {formatMarketPriceWithCurrency(activePoint.close, chartCurrency, {
-              assetCategory: chartAssetCategory,
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })}</Text>
-            <Text fg={colors.textDim}>V {formatCompact(activePoint.volume)}</Text>
-          </>
-        )}
-      </Box>
-
       <Box flexDirection="row" height={1}>
         <Box flexDirection="row" gap={1}>
           {TIME_RANGES.map((range, index) => (
@@ -4030,6 +4030,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
           ))}
           {isUpdating && (
             <Text fg={colors.textDim}>updating</Text>
+          )}
+          {fallbackResolutionLabel && (
+            <Text fg={colors.textDim}>{fallbackResolutionLabel}</Text>
           )}
         </Box>
         <Box flexGrow={1} />
@@ -4078,9 +4081,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         {axisBox}
       </Box>
 
-      <Box height={1}>
-        <Text fg={colors.textDim}>{timeAxisLabel}</Text>
-      </Box>
+      {timeAxisBox}
 
       {compact && (
         <>

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -400,7 +400,7 @@ function EconDetailView({ event, width, height, focused }: EconDetailViewProps) 
           {/* Chart */}
           {chartResult ? (
             <Box flexDirection="column" paddingX={1} marginTop={1}>
-              <Box flexDirection="column" height={chartHeight} backgroundColor={palette.bgColor}>
+              <Box flexDirection="column" height={chartHeight}>
                 {chartResult.lines.map((line, i) => (
                   <Text key={i} content={chartLineContent(line)} />
                 ))}

--- a/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
+++ b/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
@@ -178,7 +178,8 @@ describe("Ticker detail chart tab switching", () => {
 
     await flushFrames();
     const chartTabFrame = testSetup.captureCharFrame();
-    expect(chartTabFrame).toContain("AAPL");
+    expect(chartTabFrame).toContain("AUTO 1M");
+    expect(chartTabFrame).not.toContain("AAPL -");
     expect(manager.surfaces.has("chart-surface:ticker-detail:test:full:base")).toBe(true);
 
     act(() => {

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -162,7 +162,7 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
           {/* Chart */}
           {chartResult && chartResult.lines.length > 0 ? (
             <Box flexDirection="column" paddingX={1} marginTop={1}>
-              <Box flexDirection="column" height={chartHeight} backgroundColor={palette.bgColor}>
+              <Box flexDirection="column" height={chartHeight}>
                 {chartResult.lines.map((line, i) => (
                   <Text key={i} content={line} />
                 ))}


### PR DESCRIPTION
Summary:
- Make terminal and native chart renderers preserve transparent chart backgrounds across stock, comparison, econ, and yield charts.
- Remove the duplicated stock chart header, move OHLC/V into the pane footer, and keep the x-axis clear of the native chart surface.
- Add regression coverage for transparent chart cells, native bitmap transparency, footer OHLC, and ticker-detail chart tab switching.

Tests:
- bun test ./src/components/chart/chart.test.ts ./src/components/chart/comparison-chart-renderer.test.ts ./src/components/chart/native/kitty.test.ts ./src/components/chart/stock-chart-renderer-switch.test.tsx ./src/plugins/prediction-markets/chart.test.tsx ./src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
- bun run build
- tmux full chart tab smoke, session killed