### PR TITLE
Fix command bar theme preview selection

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -3,7 +3,7 @@ import { act, useReducer } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { DialogProvider } from "@opentui-ui/dialog/react";
 import { CommandBar } from "./command-bar";
-import { AppContext, type AppState, appReducer, createInitialState } from "../../state/app-context";
+import { AppContext, type AppState, appReducer, createInitialState, getEffectiveThemeId } from "../../state/app-context";
 import { createTestDataProvider } from "../../test-support/data-provider";
 import { cloneLayout, createDefaultConfig, type AppConfig } from "../../types/config";
 import type { DataProvider } from "../../types/data-provider";
@@ -305,7 +305,7 @@ function CommandBarHarness({
   return (
     <AppContext value={{ state: currentState, dispatch: currentDispatch }}>
       <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
-        {live && <text>{`theme:${currentState.config.theme}`}</text>}
+        {live && <text>{`theme:${getEffectiveThemeId(currentState)}`}</text>}
         {showQueryState && <text>{`query:${currentState.commandBarQuery}`}</text>}
         {currentState.commandBarOpen && (
           <CommandBar
@@ -727,6 +727,32 @@ describe("CommandBar", () => {
     expect(frame).toContain("theme:green");
   });
 
+  test("does not preview a theme from mouse hover alone", async () => {
+    testSetup = await testRender(<CommandBarHarness query="TH " live />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    const rows = frame.split("\n");
+    const hoveredRow = rows.findIndex((line) => line.includes("Green"));
+    const hoveredCol = rows[hoveredRow]?.indexOf("Green") ?? -1;
+
+    expect(hoveredRow).toBeGreaterThanOrEqual(0);
+    expect(hoveredCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.moveTo(hoveredCol + 1, hoveredRow);
+      await testSetup!.renderOnce();
+    });
+    await testSetup.renderOnce();
+
+    const hoveredFrame = testSetup.captureCharFrame();
+    expect(hoveredFrame).toContain("theme:amber");
+    expect(hoveredFrame).not.toContain("theme:green");
+  });
+
   test("keeps the selected theme after pressing enter in root theme mode", async () => {
     testSetup = await testRender(<CommandBarHarness query="TH " live />, {
       width: 80,
@@ -751,6 +777,49 @@ describe("CommandBar", () => {
     expect(frame).toContain("theme:green");
     expect(frame).not.toContain("theme:amber");
     expect(frame).not.toContain("Commands");
+  });
+
+  test("uses pending keyboard theme selection when enter follows before a repaint", async () => {
+    testSetup = await testRender(<CommandBarHarness query="TH " live />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("down");
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("theme:green");
+    expect(frame).not.toContain("theme:amber");
+    expect(frame).not.toContain("Commands");
+  });
+
+  test("clears theme preview when leaving root theme mode", async () => {
+    testSetup = await testRender(<CommandBarHarness query="TH " live />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("down");
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame()).toContain("theme:green");
+
+    await emitKeypress(testSetup, { name: "u", ctrl: true });
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("theme:amber");
+    expect(frame).not.toContain("theme:green");
+    expect(frame).toContain("Commands");
   });
 
   test("keeps typed prefixes in the root query until a result is activated", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -20,6 +20,7 @@ import {
   commandBarText,
 } from "../../theme/colors";
 import {
+  getEffectiveThemeId,
   getFocusedCollectionId,
   useAppDispatch,
   useAppSelector,
@@ -28,7 +29,7 @@ import {
 } from "../../state/app-context";
 import { fuzzyFilter } from "../../utils/fuzzy-search";
 import { commands, getThemeOptions, matchPrefix, type Command } from "./command-registry";
-import { applyTheme } from "../../theme/colors";
+import { applyTheme, getCurrentThemeId } from "../../theme/colors";
 import { exportConfig, importConfig, resetAllData, saveConfig } from "../../data/config-store";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRepository } from "../../data/ticker-repository";
@@ -251,6 +252,10 @@ function buildNativeListRows(listState: ListScreenState, rows: CommandBarListRow
   return rows;
 }
 
+function clampListIndex(index: number, length: number): number {
+  return Math.max(0, Math.min(index, Math.max(0, length - 1)));
+}
+
 function getVisibleMultiSelectPickerOptions(
   route: Extract<CommandBarRoute, { kind: "picker" }>,
 ): CommandBarPickerOption[] {
@@ -375,21 +380,24 @@ export function CommandBar({
   const activeCollectionId = getFocusedCollectionId(state);
   const activePortfolio = state.config.portfolios.find((portfolio) => portfolio.id === activeCollectionId);
 
+  const clearThemePreview = useCallback((themeId: string | null | undefined) => {
+    if (!themeId) return;
+    if (getCurrentThemeId() !== themeId) {
+      applyTheme(themeId);
+    }
+    dispatch({ type: "PREVIEW_THEME", theme: null });
+  }, [dispatch]);
+
   const restoreThemePreview = useCallback(() => {
     const themeRoute = [...routeStack].reverse().find((route) => (
       route.kind === "mode" && route.screen === "themes"
     ));
     if (themeRoute?.kind === "mode" && themeRoute.themeBaseId) {
-      applyTheme(themeRoute.themeBaseId);
-      dispatch({ type: "SET_THEME", theme: themeRoute.themeBaseId });
+      clearThemePreview(themeRoute.themeBaseId);
       return;
     }
-    const rootThemeBaseId = rootThemeBaseIdRef.current;
-    if (rootThemeBaseId && stateRef.current.config.theme !== rootThemeBaseId) {
-      applyTheme(rootThemeBaseId);
-      dispatch({ type: "SET_THEME", theme: rootThemeBaseId });
-    }
-  }, [dispatch, routeStack]);
+    clearThemePreview(rootThemeBaseIdRef.current);
+  }, [clearThemePreview, routeStack]);
 
   const closeAll = useCallback((options?: { revertThemePreview?: boolean }) => {
     if (options?.revertThemePreview !== false) {
@@ -422,7 +430,10 @@ export function CommandBar({
     setRouteStack((current) => {
       if (current.length === 0) return current;
       const next = [...current];
-      next[next.length - 1] = updater(next[next.length - 1]!);
+      const top = next[next.length - 1]!;
+      const updated = updater(top);
+      if (updated === top) return current;
+      next[next.length - 1] = updated;
       return next;
     });
   }, []);
@@ -434,8 +445,7 @@ export function CommandBar({
     }
 
     if (currentRoute.kind === "mode" && currentRoute.screen === "themes" && currentRoute.themeBaseId) {
-      applyTheme(currentRoute.themeBaseId);
-      dispatch({ type: "SET_THEME", theme: currentRoute.themeBaseId });
+      clearThemePreview(currentRoute.themeBaseId);
     }
 
     if (routeStack.length === 1 && currentRoute.restoreMain) {
@@ -445,7 +455,7 @@ export function CommandBar({
     }
 
     setRouteStack((current) => current.slice(0, -1));
-  }, [closeAll, currentRoute, dispatch, routeStack.length, setRootQuery]);
+  }, [clearThemePreview, closeAll, currentRoute, routeStack.length, setRootQuery]);
 
   const dismissCommandBar = useCallback(() => {
     if (currentRoute) {
@@ -496,6 +506,21 @@ export function CommandBar({
   const openFixedTickerPane = useCallback((symbol: string) => {
     pluginRegistry.pinTickerFn(symbol, { floating: true, paneType: "ticker-detail" });
   }, [pluginRegistry]);
+
+  const previewThemeId = useCallback((themeId: string | undefined) => {
+    if (!themeId) return;
+    if (getCurrentThemeId() !== themeId) {
+      applyTheme(themeId);
+    }
+    const previewTheme = themeId === stateRef.current.config.theme ? null : themeId;
+    if (stateRef.current.themePreview !== previewTheme) {
+      dispatch({ type: "PREVIEW_THEME", theme: previewTheme });
+    }
+  }, [dispatch]);
+
+  const previewThemeSelection = useCallback((listState: ListScreenState, selectedIdx: number) => {
+    previewThemeId(listState.results[selectedIdx]?.themeId);
+  }, [previewThemeId]);
 
   const focusTicker = useCallback((symbol: string, options?: { forceNewPane?: boolean }) => {
     const currentState = stateRef.current;
@@ -2510,18 +2535,17 @@ export function CommandBar({
     if (currentRoute) return;
 
     const previousMode = previousRootModeRef.current;
-    if (rootModeInfo.kind === "themes" && previousMode !== "themes") {
+    if (rootModeInfo.kind === "themes" && (previousMode !== "themes" || !rootThemeBaseIdRef.current)) {
       rootThemeBaseIdRef.current = state.config.theme;
     } else if (rootModeInfo.kind !== "themes" && previousMode === "themes") {
       const rootThemeBaseId = rootThemeBaseIdRef.current;
-      if (rootThemeBaseId && state.config.theme !== rootThemeBaseId) {
-        applyTheme(rootThemeBaseId);
-        dispatch({ type: "SET_THEME", theme: rootThemeBaseId });
+      if (rootThemeBaseId && getEffectiveThemeId(state) !== rootThemeBaseId) {
+        clearThemePreview(rootThemeBaseId);
       }
       rootThemeBaseIdRef.current = null;
     }
     previousRootModeRef.current = rootModeInfo.kind;
-  }, [currentRoute, dispatch, rootModeInfo.kind, state.config.theme]);
+  }, [clearThemePreview, currentRoute, rootModeInfo.kind, state.config.theme, state.themePreview]);
 
   const tickerSearchRouteQuery = currentRoute?.kind === "mode" && currentRoute.screen === "ticker-search"
     ? currentRoute.query
@@ -4174,21 +4198,6 @@ export function CommandBar({
   visibleListStateRef.current = routeListState;
 
   useEffect(() => {
-    if (!state.commandBarOpen) return;
-    if (!routeListState) return;
-    const selected = currentRoute?.kind === "mode" && currentRoute.screen === "themes"
-      ? routeListState.results[currentRoute.selectedIdx]
-      : !currentRoute && rootModeInfo.kind === "themes"
-        ? routeListState.results[rootSelectedIdx]
-        : null;
-    if (!selected?.themeId) return;
-    if (selected?.themeId && state.config.theme !== selected.themeId) {
-      applyTheme(selected.themeId);
-      dispatch({ type: "SET_THEME", theme: selected.themeId });
-    }
-  }, [currentRoute, dispatch, rootModeInfo.kind, rootSelectedIdx, routeListState, state.commandBarOpen, state.config.theme]);
-
-  useEffect(() => {
     if (currentRoute?.kind !== "workflow") return;
     ensureRouteFieldFocus(currentRoute);
   }, [currentRoute, ensureRouteFieldFocus]);
@@ -4213,6 +4222,10 @@ export function CommandBar({
 
   const setActiveListQuery = useCallback((nextQuery: string) => {
     if (!currentRoute) {
+      if (rootModeInfo.kind === "themes" && resolveCommandBarMode(nextQuery).kind !== "themes") {
+        clearThemePreview(rootThemeBaseIdRef.current ?? stateRef.current.config.theme);
+        rootThemeBaseIdRef.current = null;
+      }
       setRootQuery(nextQuery);
       return;
     }
@@ -4225,14 +4238,18 @@ export function CommandBar({
         return route;
       });
     }
-  }, [currentRoute, setRootQuery, updateTopRoute]);
+  }, [clearThemePreview, currentRoute, rootModeInfo.kind, setRootQuery, updateTopRoute]);
 
   const moveListSelection = useCallback((delta: number) => {
     const listState = visibleListStateRef.current;
     if (!listState || listState.results.length === 0 || delta === 0) return;
-    const maxIndex = listState.results.length - 1;
+    const nextIndex = clampListIndex(listState.selectedIdx + delta, listState.results.length);
+    const nextListState = { ...listState, selectedIdx: nextIndex, hoveredIdx: null };
+    visibleListStateRef.current = nextListState;
+    previewThemeSelection(nextListState, nextIndex);
+
     if (!currentRouteRef.current) {
-      setRootSelectedIdx((current) => Math.max(0, Math.min(current + delta, maxIndex)));
+      setRootSelectedIdx(nextIndex);
       setRootHoveredIdx(null);
       return;
     }
@@ -4243,11 +4260,10 @@ export function CommandBar({
       if (!top || (top.kind !== "mode" && top.kind !== "picker" && top.kind !== "pane-settings")) {
         return current;
       }
-      const nextIndex = Math.max(0, Math.min(top.selectedIdx + delta, maxIndex));
       next[next.length - 1] = { ...top, selectedIdx: nextIndex, hoveredIdx: null };
       return next;
     });
-  }, []);
+  }, [previewThemeSelection]);
 
   const setHoveredIndex = useCallback((index: number | null) => {
     if (!currentRoute) {
@@ -4792,7 +4808,8 @@ export function CommandBar({
         if (currentRoute.pickerId === "field-multi-select" && (event.name === "space" || event.sequence === " ")) {
           event.stopPropagation();
           event.preventDefault();
-          const selected = routeListState?.results[currentRoute.selectedIdx];
+          const listState = visibleListStateRef.current;
+          const selected = listState?.results[listState.selectedIdx];
           if (!selected) return;
           handleMultiSelectToggle(selected.id);
           return;
@@ -4842,7 +4859,8 @@ export function CommandBar({
         return;
       }
 
-      if (!routeListState) return;
+      const activeListState = visibleListStateRef.current;
+      if (!activeListState) return;
 
       if (!currentRoute && event.name === "tab") {
         if (acceptRootShortcutTab()) {
@@ -4876,7 +4894,7 @@ export function CommandBar({
       if ((event.ctrl && event.name === "w") || (event.meta && (event.name === "h" || event.name === "u"))) {
         event.stopPropagation();
         event.preventDefault();
-        const trimmed = routeListState.query.replace(/\s+$/, "");
+        const trimmed = activeListState.query.replace(/\s+$/, "");
         const nextQuery = trimmed.replace(/[^\s]+$/, "").replace(/\s+$/, "");
         setActiveListQuery(nextQuery);
         return;
@@ -4887,7 +4905,7 @@ export function CommandBar({
       if (pluginToggleMode && event.name === "space") {
         event.stopPropagation();
         event.preventDefault();
-        const selected = routeListState.results[routeListState.selectedIdx];
+        const selected = activeListState.results[activeListState.selectedIdx];
         if (selected?.pluginToggle) {
           void selected.pluginToggle();
         }
@@ -4932,7 +4950,6 @@ export function CommandBar({
     popRoute,
     renderer,
     rootModeInfo.kind,
-    routeListState,
     setActiveListQuery,
     updateWorkflowValue,
   ]);

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -15,7 +15,7 @@ import type { PaneProps } from "../../types/plugin";
 import { StockChart } from "../chart/stock-chart";
 import { StatusBar } from "./status-bar";
 import { Header } from "./header";
-import { buildNativeWindowState, finalizePaneDragRelease, resolveNativeDockDividers, Shell } from "./shell";
+import { buildNativeWindowState, finalizePaneDragRelease, resolveNativeDockDividers, resolvePaneDragFloatingRect, Shell } from "./shell";
 import type { DataProvider } from "../../types/data-provider";
 import type { PricePoint, Quote, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
@@ -881,6 +881,52 @@ describe("Shell", () => {
       width: 30,
       height: 8,
     }));
+  });
+
+  test("derives a floating pane drag release rect from the release pointer", () => {
+    const rect = resolvePaneDragFloatingRect(
+      {
+        mode: "floating",
+        startX: 7,
+        startY: 3,
+        origRect: { x: 4, y: 2, width: 30, height: 8 },
+      },
+      { x: 4, y: 2, width: 30, height: 8 },
+      18,
+      6,
+      80,
+      24,
+    );
+
+    expect(rect).toEqual({
+      x: 15,
+      y: 5,
+      width: 30,
+      height: 8,
+    });
+  });
+
+  test("keeps the pointer anchored when releasing a docked pane drag without an intermediate preview", () => {
+    const rect = resolvePaneDragFloatingRect(
+      {
+        mode: "docked",
+        startX: 22,
+        startY: 4,
+        origRect: { x: 10, y: 2, width: 40, height: 12 },
+      },
+      { x: 8, y: 1, width: 32, height: 10 },
+      30,
+      8,
+      80,
+      24,
+    );
+
+    expect(rect).toEqual({
+      x: 18,
+      y: 6,
+      width: 32,
+      height: 10,
+    });
   });
 
   test("keeps the last floating pane body row visible above the border", async () => {

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -129,6 +129,13 @@ interface PaneDragReleaseResult {
   shouldShowGridlockTip: boolean;
 }
 
+export interface PaneDragRectState {
+  mode: "docked" | "floating";
+  startX: number;
+  startY: number;
+  origRect: FloatingRect;
+}
+
 type DragMode =
   | {
     type: "divider";
@@ -142,11 +149,7 @@ type DragMode =
   | {
     type: "pane-drag";
     paneId: string;
-    mode: "docked" | "floating";
-    startX: number;
-    startY: number;
-    origRect: FloatingRect;
-  }
+  } & PaneDragRectState
   | {
     type: "float-resize";
     paneId: string;
@@ -181,7 +184,7 @@ function isMeaningfulPaneDrag(startX: number, startY: number, currentX: number, 
 
 function positionFloatingRectUnderPointer(
   rect: FloatingRect,
-  drag: Extract<DragMode, { type: "pane-drag" }>,
+  drag: PaneDragRectState,
   pointerX: number,
   pointerY: number,
   totalWidth: number,
@@ -193,6 +196,41 @@ function positionFloatingRectUnderPointer(
     ...rect,
     x: Math.max(0, Math.min(totalWidth - rect.width, pointerX - pointerOffsetX)),
     y: Math.max(0, Math.min(totalHeight - rect.height, pointerY - pointerOffsetY)),
+  };
+}
+
+export function resolvePaneDragFloatingRect(
+  drag: PaneDragRectState,
+  baseRect: FloatingRect,
+  pointerX: number,
+  pointerY: number,
+  totalWidth: number,
+  totalHeight: number,
+): FloatingRect {
+  if (drag.mode === "docked") {
+    return positionFloatingRectUnderPointer(baseRect, drag, pointerX, pointerY, totalWidth, totalHeight);
+  }
+
+  return {
+    x: Math.max(0, Math.min(totalWidth - drag.origRect.width, drag.origRect.x + (pointerX - drag.startX))),
+    y: Math.max(0, Math.min(totalHeight - drag.origRect.height, drag.origRect.y + (pointerY - drag.startY))),
+    width: drag.origRect.width,
+    height: drag.origRect.height,
+  };
+}
+
+function resolveFloatResizeRect(
+  drag: Extract<DragMode, { type: "float-resize" }>,
+  pointerX: number,
+  pointerY: number,
+  totalWidth: number,
+  totalHeight: number,
+): FloatingRect {
+  return {
+    x: drag.origRect.x,
+    y: drag.origRect.y,
+    width: Math.max(MIN_FLOAT_WIDTH, Math.min(totalWidth - drag.origRect.x, drag.origRect.width + (pointerX - drag.startX))),
+    height: Math.max(MIN_FLOAT_HEIGHT, Math.min(totalHeight - drag.origRect.y, drag.origRect.height + (pointerY - drag.startY))),
   };
 }
 
@@ -644,12 +682,10 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   const [dragCursor, setDragCursor] = useState<{ x: number; y: number } | null>(null);
   const [dividerPreview, setDividerPreview] = useState<DividerPreviewState | null>(null);
   const [dockPreview, setDockPreview] = useState<DragPreview | null>(null);
-  const dragFloatingRectRef = useRef<{ paneId: string; rect: FloatingRect } | null>(null);
   const dividerPreviewRef = useRef<DividerPreviewState | null>(null);
   const dockPreviewRef = useRef<DragPreview | null>(null);
 
   const updateDragFloatingRect = useCallback((next: { paneId: string; rect: FloatingRect } | null) => {
-    dragFloatingRectRef.current = next;
     setDragFloatingRect(next);
   }, []);
 
@@ -908,21 +944,10 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         }
 
         const pane = paneMap.get(drag.paneId);
-        const nextRect = drag.mode === "docked"
-          ? positionFloatingRectUnderPointer(
-              getRememberedFloatingRect(visibleLayout, drag.paneId, width, contentHeight, pane?.def),
-              drag,
-              preciseX,
-              preciseShellY,
-              width,
-              contentHeight,
-            )
-          : {
-              x: Math.max(0, Math.min(width - drag.origRect.width, drag.origRect.x + (preciseX - drag.startX))),
-              y: Math.max(0, Math.min(contentHeight - drag.origRect.height, drag.origRect.y + (preciseShellY - drag.startY))),
-              width: drag.origRect.width,
-              height: drag.origRect.height,
-            };
+        const baseRect = drag.mode === "docked"
+          ? getRememberedFloatingRect(visibleLayout, drag.paneId, width, contentHeight, pane?.def)
+          : drag.origRect;
+        const nextRect = resolvePaneDragFloatingRect(drag, baseRect, preciseX, preciseShellY, width, contentHeight);
         updateDragFloatingRect({ paneId: drag.paneId, rect: nextRect });
         setDragCursor({ x: hitX, y: hitShellY });
 
@@ -947,12 +972,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
       } else if (drag.type === "float-resize") {
         updateDragFloatingRect({
           paneId: drag.paneId,
-          rect: {
-            x: drag.origRect.x,
-            y: drag.origRect.y,
-            width: Math.max(MIN_FLOAT_WIDTH, Math.min(width - drag.origRect.x, drag.origRect.width + (preciseX - drag.startX))),
-            height: Math.max(MIN_FLOAT_HEIGHT, Math.min(contentHeight - drag.origRect.y, drag.origRect.height + (preciseShellY - drag.startY))),
-          },
+          rect: resolveFloatResizeRect(drag, preciseX, preciseShellY, width, contentHeight),
         });
       }
       event.stopPropagation();
@@ -969,14 +989,17 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         updateDividerPreview(null);
       } else if (drag.type === "pane-drag") {
         const movedEnough = isMeaningfulPaneDrag(drag.startX, drag.startY, preciseX, preciseShellY, dragThreshold);
-        const preview = dragFloatingRectRef.current;
-        const previewRect = preview?.paneId === drag.paneId ? preview.rect : drag.origRect;
         if (!movedEnough) {
           updateDockPreview(null);
           setDragCursor(null);
           updateDragFloatingRect(null);
         } else {
-          const releaseResult = finalizePaneDragRelease(visibleLayout, drag.paneId, previewRect, dockPreviewRef.current);
+          const pane = paneMap.get(drag.paneId);
+          const baseRect = drag.mode === "docked"
+            ? getRememberedFloatingRect(visibleLayout, drag.paneId, width, contentHeight, pane?.def)
+            : drag.origRect;
+          const releaseRect = resolvePaneDragFloatingRect(drag, baseRect, preciseX, preciseShellY, width, contentHeight);
+          const releaseResult = finalizePaneDragRelease(visibleLayout, drag.paneId, releaseRect, dockPreviewRef.current);
           persistLayout(releaseResult.nextLayout);
           focusPane(drag.paneId);
           if (releaseResult.shouldShowGridlockTip) {
@@ -987,10 +1010,8 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
           updateDragFloatingRect(null);
         }
       } else if (drag.type === "float-resize") {
-        const preview = dragFloatingRectRef.current;
-        if (preview?.paneId === drag.paneId) {
-          persistLayout(floatAtRect(visibleLayout, drag.paneId, preview.rect));
-        }
+        const releaseRect = resolveFloatResizeRect(drag, preciseX, preciseShellY, width, contentHeight);
+        persistLayout(floatAtRect(visibleLayout, drag.paneId, releaseRect));
         updateDragFloatingRect(null);
         setDragCursor(null);
       }

--- a/src/core/state/app-state.ts
+++ b/src/core/state/app-state.ts
@@ -58,6 +58,7 @@ export interface AppState {
   commandBarOpen: boolean;
   commandBarQuery: string;
   commandBarLaunchRequest: CommandBarLaunchRequest | null;
+  themePreview: string | null;
   refreshing: Set<string>;
   initialized: boolean;
   statusBarVisible: boolean;
@@ -96,6 +97,7 @@ export type AppAction =
   | { type: "SHOW_GRIDLOCK_TIP" }
   | { type: "DISMISS_GRIDLOCK_TIP" }
   | { type: "SET_THEME"; theme: string }
+  | { type: "PREVIEW_THEME"; theme: string | null }
   | { type: "SET_UPDATE_AVAILABLE"; release: ReleaseInfo | null }
   | { type: "SET_UPDATE_PROGRESS"; progress: UpdateProgress | null }
   | { type: "SET_UPDATE_CHECK_IN_PROGRESS"; checking: boolean }
@@ -261,6 +263,10 @@ export function getFocusedTickerSymbol(state: AppState): string | null {
 
 export function getFocusedCollectionId(state: AppState): string | null {
   return state.focusedPaneId ? resolveCollectionForPane(state, state.focusedPaneId) : null;
+}
+
+export function getEffectiveThemeId(state: Pick<AppState, "config" | "themePreview">): string {
+  return state.themePreview ?? state.config.theme;
 }
 
 function clearTickerBindings(layout: LayoutConfig, symbol: string): LayoutConfig {
@@ -459,7 +465,7 @@ function hydrateDesktopSnapshot(state: AppState, snapshot: DesktopSharedStateSna
 export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case "SET_CONFIG":
-      return withFocusedPane({ ...state, layoutHistory: {} }, action.config);
+      return withFocusedPane({ ...state, themePreview: null, layoutHistory: {} }, action.config);
 
     case "SET_TICKERS":
       return { ...state, tickers: action.tickers };
@@ -529,7 +535,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case "TOGGLE_COMMAND_BAR":
       return state.commandBarOpen
-        ? { ...state, commandBarOpen: false, commandBarQuery: "", commandBarLaunchRequest: null }
+        ? { ...state, commandBarOpen: false, commandBarQuery: "", commandBarLaunchRequest: null, themePreview: null }
         : { ...state, commandBarOpen: true, commandBarQuery: "", commandBarLaunchRequest: null };
 
     case "SET_COMMAND_BAR": {
@@ -544,6 +550,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         commandBarOpen: action.open,
         commandBarQuery: action.open ? (action.query ?? "") : "",
         commandBarLaunchRequest: launchRequest,
+        themePreview: action.open ? state.themePreview : null,
       };
     }
 
@@ -584,7 +591,12 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, gridlockTipVisible: false };
 
     case "SET_THEME":
-      return { ...state, config: { ...state.config, theme: action.theme } };
+      if (state.config.theme === action.theme && state.themePreview == null) return state;
+      return { ...state, themePreview: null, config: { ...state.config, theme: action.theme } };
+
+    case "PREVIEW_THEME":
+      if (state.themePreview === action.theme) return state;
+      return { ...state, themePreview: action.theme };
 
     case "SET_UPDATE_AVAILABLE":
       return { ...state, updateAvailable: action.release, updateNotice: action.release ? null : state.updateNotice };
@@ -849,6 +861,7 @@ export function createInitialState(config: AppConfig, sessionSnapshot: AppSessio
     commandBarOpen: false,
     commandBarQuery: "",
     commandBarLaunchRequest: null,
+    themePreview: null,
     refreshing: new Set(),
     initialized: false,
     statusBarVisible: sessionSnapshot?.statusBarVisible !== false,

--- a/src/state/app-context-selector.test.tsx
+++ b/src/state/app-context-selector.test.tsx
@@ -121,6 +121,52 @@ describe("pane selectors", () => {
     expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
   });
 
+  test("rerenders selector consumers when the theme preview changes", async () => {
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")}>
+        <DispatchCapture />
+        <ThemeSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:amber`);
+
+    await act(() => {
+      capturedDispatch?.({ type: "PREVIEW_THEME", theme: "green" });
+    });
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
+  });
+
+  test("falls back to the committed theme when theme preview clears", async () => {
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")}>
+        <DispatchCapture />
+        <ThemeSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    await act(() => {
+      capturedDispatch?.({ type: "PREVIEW_THEME", theme: "green" });
+    });
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
+
+    await act(() => {
+      capturedDispatch?.({ type: "PREVIEW_THEME", theme: null });
+    });
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:amber`);
+  });
+
   test("uses the configured theme on the first provider render", async () => {
     const config = createTickerDetailConfig("AAPL");
     config.theme = "green";

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -32,6 +32,7 @@ import { usePersistSessionSnapshot } from "./use-session-snapshot";
 import {
   appReducer,
   createInitialState,
+  getEffectiveThemeId,
   getFocusedTickerSymbol,
   type PaneRuntimeState,
   resolveCollectionForPane,
@@ -43,6 +44,7 @@ import { scheduleConfigSave } from "./config-save-scheduler";
 export {
   appReducer,
   createInitialState,
+  getEffectiveThemeId,
   getFocusedCollectionId,
   getFocusedTickerSymbol,
   getPaneState,
@@ -151,7 +153,7 @@ export function useAppSelector<T>(selector: (state: AppState) => T): T {
     () => {
       const state = context.getState();
       const selection = selectorRef.current(state);
-      const themeId = state.config.theme;
+      const themeId = getEffectiveThemeId(state);
       const previous = lastSnapshotRef.current;
       if (previous && Object.is(previous.selection, selection) && previous.themeId === themeId) {
         return previous;
@@ -164,7 +166,7 @@ export function useAppSelector<T>(selector: (state: AppState) => T): T {
       const state = context.getState();
       return {
         selection: selectorRef.current(state),
-        themeId: state.config.theme,
+        themeId: getEffectiveThemeId(state),
       };
     },
   );
@@ -325,7 +327,7 @@ export function AppProvider({
     },
   );
   // Sync the current theme before descendants read the shared palette during this render.
-  syncTheme(state.config.theme);
+  syncTheme(getEffectiveThemeId(state));
   const previousRecentTickers = useRef(state.recentTickers);
   const stateRef = useRef(state);
   const listenersRef = useRef(new Set<() => void>());


### PR DESCRIPTION
## Summary
- Split theme preview state from the committed config theme so command-bar preview does not race Enter selection.
- Make keyboard navigation preview themes from the pending list selection while hover only updates row hover state.
- Recompute pane drag/resize release rectangles from the release pointer and add regression coverage.

## Tests
- bun test src/components/command-bar/command-bar.test.tsx src/state/app-context-selector.test.tsx src/state/app-context.test.ts src/state/app-context.test.tsx
- git diff --check