### PR TITLE
Fix popped-out pane repainting and Cmd+W

### DIFF
--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useRendererHost, useUiCapabilities } from "../../ui";
-import { useCallback, useEffect, useMemo } from "react";
-import { useViewport } from "../../react/input";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useShortcut, useViewport } from "../../react/input";
 import { useAppDispatch, useAppSelector } from "../../state/app-context";
 import type { DesktopWindowBridge } from "../../types/desktop-window";
 import { findPaneInstance } from "../../types/config";
@@ -28,6 +28,10 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
   const config = useAppSelector((state) => state.config);
   const paneState = useAppSelector((state) => state.paneState);
   const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
+  const inputCaptured = useAppSelector((state) => state.inputCaptured);
+  const [windowFocused, setWindowFocused] = useState(() => (
+    typeof document === "undefined" ? true : document.hasFocus()
+  ));
   const { width, height } = useViewport();
   const { cellHeightPx = 18, nativePaneChrome, titleBarOverlay } = useUiCapabilities();
   const instance = useAppSelector((state) => findPaneInstance(state.config.layout, desktopWindowBridge.paneId) ?? null);
@@ -40,18 +44,50 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
   const title = instance && paneDef
     ? getPaneDisplayTitle(titleState, instance, paneDef)
     : "Detached Pane";
-  const focused = focusedPaneId === desktopWindowBridge.paneId || focusedPaneId == null;
+  const focused = windowFocused;
   const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(width)) : getPaneBodyWidth(width);
 
-  useEffect(() => {
-    if (desktopWindowBridge.paneId && focusedPaneId !== desktopWindowBridge.paneId) {
-      dispatch({ type: "FOCUS_PANE", paneId: desktopWindowBridge.paneId });
-    }
-  }, [desktopWindowBridge.paneId, dispatch, focusedPaneId]);
-
   const focusPane = useCallback(() => {
+    setWindowFocused(true);
     dispatch({ type: "FOCUS_PANE", paneId: desktopWindowBridge.paneId });
   }, [desktopWindowBridge.paneId, dispatch]);
+
+  useEffect(() => {
+    if (windowFocused && focusedPaneId !== desktopWindowBridge.paneId) {
+      focusPane();
+    }
+  }, [desktopWindowBridge.paneId, focusPane, focusedPaneId, windowFocused]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") return;
+
+    const handleFocus = () => {
+      setWindowFocused(true);
+      focusPane();
+    };
+    const handleBlur = () => setWindowFocused(false);
+
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+    if (document.hasFocus()) {
+      handleFocus();
+    } else {
+      handleBlur();
+    }
+
+    return () => {
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, [focusPane]);
+
+  useShortcut((event) => {
+    if (event.name !== "w" || (!event.ctrl && !event.meta && !event.super)) return;
+    if (inputCaptured && event.ctrl && !event.meta && !event.super) return;
+    event.preventDefault();
+    event.stopPropagation();
+    void desktopWindowBridge.closeDetachedPane?.(desktopWindowBridge.paneId);
+  });
 
   const startWindowDrag = useCallback(() => {
     focusPane();
@@ -78,6 +114,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
         const headerHeightRows = titleBarOverlay ? TITLEBAR_OVERLAY_HEIGHT_PX / cellHeightPx : 1;
         const footerHeightRows = showFooter ? 1 : 0;
         const bodyHeight = Math.max(1, height - headerHeightRows - footerHeightRows);
+        const background = floatingPaneBg(focused);
         const titleBackground = floatingPaneTitleBg(focused);
 
         return (
@@ -86,7 +123,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
             flexGrow={1}
             width={width}
             height={height}
-            backgroundColor={floatingPaneBg(focused)}
+            backgroundColor={background}
             data-gloom-role="detached-pane-window"
             data-focused={focused ? "true" : "false"}
             onMouseDown={focusPane}
@@ -128,7 +165,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
                 )}
               </Box>
             </Box>
-            <Box height={bodyHeight} overflow="hidden" backgroundColor={colors.bg}>
+            <Box height={bodyHeight} overflow="hidden" backgroundColor={background}>
               <PaneContent
                 component={paneDef.component}
                 paneId={instance.instanceId}

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -856,6 +856,47 @@ describe("Shell", () => {
     expect(updateLayout?.layout.dockRoot).toEqual({ kind: "pane", instanceId: "portfolio-list:main" });
   });
 
+  test("closes the focused floating pane with Cmd+W", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+    if (!mainPane || !detailPane) throw new Error("missing default panes");
+
+    const mixedLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 }],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(mixedLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(mixedLayout) }],
+      }),
+      focusedPaneId: "ticker-detail:main",
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </DialogProvider>
+      </AppContext>,
+      { width: 40, height: 12 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressKey("w", { meta: true });
+      await testSetup!.renderOnce();
+    });
+
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId)).toEqual(["portfolio-list:main"]);
+    expect(updateLayout?.layout.floating).toEqual([]);
+  });
+
   test("keeps a floating pane at the preview rect after a free drag release", () => {
     const config = createDefaultConfig("/tmp/gloomberb-shell-drag-test");
     const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -677,9 +677,11 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
       cancelActiveDrag();
       return;
     }
-    if (event.name !== "w" || !event.ctrl) return;
+    if (event.name !== "w" || (!event.ctrl && !event.meta && !event.super)) return;
     if (dragRef.current || overlayOpen || inputCaptured) return;
-    closeFocusedPane();
+    if (!closeFocusedPane()) return;
+    event.preventDefault();
+    event.stopPropagation();
   });
 
   const disabledPaneIds = useMemo(() => {
@@ -716,8 +718,9 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   }, [config, dispatch]);
 
   const closeFocusedPane = useCallback(() => {
-    if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) return;
+    if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) return false;
     persistLayout(removePane(visibleLayout, focusedPaneId));
+    return true;
   }, [focusedPaneId, persistLayout, visibleLayout]);
 
   const focusPane = useCallback((paneId: string) => {

--- a/src/renderers/electrobun/view/desktop-window-bridge.ts
+++ b/src/renderers/electrobun/view/desktop-window-bridge.ts
@@ -4,9 +4,15 @@ import type {
   DesktopSharedStateSnapshot,
   DesktopWindowBridge,
 } from "../../../types/desktop-window";
-import { backendRequest, onDesktopDockPreview, onDesktopState } from "./backend-rpc";
+import { backendRequest, getElectrobunBackendInitSnapshot, onDesktopDockPreview, onDesktopState } from "./backend-rpc";
+import { detachedSnapshotKey, prepareDetachedSnapshot } from "./desktop-window-snapshot";
 
 export function createDesktopWindowBridge(kind: "main" | "detached", paneId?: string): DesktopWindowBridge {
+  const initialDesktopSnapshot = getElectrobunBackendInitSnapshot()?.desktopSnapshot ?? null;
+  let lastDetachedSnapshotKey = kind === "detached" && paneId && initialDesktopSnapshot
+    ? detachedSnapshotKey(initialDesktopSnapshot, paneId)
+    : null;
+
   return {
     kind,
     paneId,
@@ -34,6 +40,13 @@ export function createDesktopWindowBridge(kind: "main" | "detached", paneId?: st
     },
     subscribeState(listener: (snapshot: DesktopSharedStateSnapshot) => void) {
       return onDesktopState((message) => {
+        if (kind === "detached" && paneId) {
+          const nextKey = detachedSnapshotKey(message.snapshot, paneId);
+          if (nextKey === lastDetachedSnapshotKey) return;
+          lastDetachedSnapshotKey = nextKey;
+          listener(prepareDetachedSnapshot(message.snapshot, paneId));
+          return;
+        }
         listener(message.snapshot);
       });
     },

--- a/src/renderers/electrobun/view/desktop-window-snapshot.test.ts
+++ b/src/renderers/electrobun/view/desktop-window-snapshot.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultConfig } from "../../../types/config";
+import type { DesktopSharedStateSnapshot } from "../../../types/desktop-window";
+import { detachedSnapshotKey, prepareDetachedSnapshot } from "./desktop-window-snapshot";
+
+function createSnapshot(): DesktopSharedStateSnapshot {
+  const config = createDefaultConfig("/tmp/gloomberb-test");
+  config.layout.detached = [{ instanceId: "ticker-detail:main", x: 20, y: 20, width: 640, height: 420 }];
+  return {
+    config,
+    paneState: {
+      "portfolio-list:main": { cursorSymbol: "AAPL", collectionId: "main" },
+      "ticker-detail:main": { activeTabId: "overview" },
+    },
+    focusedPaneId: "portfolio-list:main",
+    activePanel: "left",
+    statusBarVisible: true,
+  };
+}
+
+describe("detached desktop snapshots", () => {
+  test("focuses the detached pane before hydration", () => {
+    const snapshot = createSnapshot();
+
+    expect(prepareDetachedSnapshot(snapshot, "ticker-detail:main").focusedPaneId).toBe("ticker-detail:main");
+  });
+
+  test("ignores unrelated window state", () => {
+    const snapshot = createSnapshot();
+    const key = detachedSnapshotKey(snapshot, "ticker-detail:main");
+
+    expect(detachedSnapshotKey({
+      ...snapshot,
+      activePanel: "right",
+      focusedPaneId: "chat:main",
+      paneState: {
+        ...snapshot.paneState,
+        "chat:main": { draft: "unrelated" },
+      },
+    }, "ticker-detail:main")).toBe(key);
+  });
+
+  test("tracks the detached pane and its follow source", () => {
+    const snapshot = createSnapshot();
+    const key = detachedSnapshotKey(snapshot, "ticker-detail:main");
+
+    expect(detachedSnapshotKey({
+      ...snapshot,
+      paneState: {
+        ...snapshot.paneState,
+        "ticker-detail:main": { activeTabId: "financials" },
+      },
+    }, "ticker-detail:main")).not.toBe(key);
+
+    expect(detachedSnapshotKey({
+      ...snapshot,
+      paneState: {
+        ...snapshot.paneState,
+        "portfolio-list:main": { cursorSymbol: "MSFT", collectionId: "main" },
+      },
+    }, "ticker-detail:main")).not.toBe(key);
+  });
+});

--- a/src/renderers/electrobun/view/desktop-window-snapshot.ts
+++ b/src/renderers/electrobun/view/desktop-window-snapshot.ts
@@ -1,0 +1,41 @@
+import { findPaneInstance } from "../../../types/config";
+import type { DesktopSharedStateSnapshot } from "../../../types/desktop-window";
+
+export function prepareDetachedSnapshot(
+  snapshot: DesktopSharedStateSnapshot,
+  paneId: string,
+): DesktopSharedStateSnapshot {
+  return snapshot.focusedPaneId === paneId ? snapshot : { ...snapshot, focusedPaneId: paneId };
+}
+
+function collectPaneStateIds(snapshot: DesktopSharedStateSnapshot, paneId: string): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let currentPaneId: string | null = paneId;
+
+  while (currentPaneId && !seen.has(currentPaneId)) {
+    seen.add(currentPaneId);
+    ids.push(currentPaneId);
+
+    const instance = findPaneInstance(snapshot.config.layout, currentPaneId);
+    currentPaneId = instance?.binding?.kind === "follow" ? instance.binding.sourceInstanceId : null;
+  }
+
+  return ids;
+}
+
+export function detachedSnapshotKey(snapshot: DesktopSharedStateSnapshot, paneId: string): string {
+  const paneStateIds = collectPaneStateIds(snapshot, paneId);
+  return JSON.stringify({
+    theme: snapshot.config.theme,
+    baseCurrency: snapshot.config.baseCurrency,
+    portfolios: snapshot.config.portfolios,
+    watchlists: snapshot.config.watchlists,
+    brokerInstances: snapshot.config.brokerInstances,
+    pluginConfig: snapshot.config.pluginConfig,
+    disabledPlugins: snapshot.config.disabledPlugins,
+    chartPreferences: snapshot.config.chartPreferences,
+    instances: paneStateIds.map((id) => findPaneInstance(snapshot.config.layout, id) ?? null),
+    paneState: Object.fromEntries(paneStateIds.map((id) => [id, snapshot.paneState[id] ?? {}])),
+  });
+}

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -16,6 +16,7 @@ import { webNativeRenderer } from "./native-renderer";
 import { WebToastHostProvider } from "./toast-host";
 import { webRendererHost, webUiHost } from "./ui-host";
 import { createDesktopWindowBridge } from "./desktop-window-bridge";
+import { prepareDetachedSnapshot } from "./desktop-window-snapshot";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {
@@ -51,7 +52,10 @@ async function boot() {
   installElectrobunPredictionMarketsFetchTransport();
   await installElectrobunAiHost();
   const init = await measurePerfAsync("startup.electrobun.backend-init", () => backendInitPromise);
-  const config = init.desktopSnapshot?.config ?? init.config;
+  const desktopSnapshot = init.windowKind === "detached" && init.paneId && init.desktopSnapshot
+    ? prepareDetachedSnapshot(init.desktopSnapshot, init.paneId)
+    : init.desktopSnapshot;
+  const config = desktopSnapshot?.config ?? init.config;
   const desktopWindowBridge = createDesktopWindowBridge(init.windowKind, init.paneId);
   measurePerfAsync("startup.electrobun.root-render", async () => {
     root.render(
@@ -62,7 +66,7 @@ async function boot() {
               <App
                 config={config}
                 desktopWindowBridge={desktopWindowBridge}
-                desktopSnapshot={init.desktopSnapshot}
+                desktopSnapshot={desktopSnapshot}
               />
             </WebDialogHostProvider>
           </WebToastHostProvider>


### PR DESCRIPTION
Fixes popped-out desktop panes flashing by filtering detached-window state broadcasts to only the pane and follow-source state that can affect that window. Keeps detached panes locally focused on initial hydration and native window focus, aligns the detached body background with its shell, and adds Cmd+W close support for both in-app focused panes and popped-out panes. Adds focused regression coverage for detached snapshot filtering and the Cmd+W pane close path.

Tests: `bun test ./src/components/layout/shell.test.tsx ./src/renderers/electrobun/view/desktop-window-snapshot.test.ts ./src/state/app-context.test.ts`; `bun run desktop:view:build`; `git diff --check`.