### PR TITLE
Use validated news ticker links

### DIFF
--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -93,10 +93,10 @@ function nextSortPreference(current: NewsSortPreference, columnId: NewsColumnId)
 function buildColumns(width: number, columnIds: NewsColumnId[]): NewsTableColumn[] {
   const fixedWidths: Record<Exclude<NewsColumnId, "title">, number> = {
     rank: 4,
-    time: 5,
+    time: 4,
     source: 10,
-    tickers: 12,
-    categories: 14,
+    tickers: 10,
+    categories: 10,
     importance: 5,
   };
   const labels: Record<NewsColumnId, string> = {

--- a/src/sources/gloomberb-cloud.test.ts
+++ b/src/sources/gloomberb-cloud.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { GloomberbCloudProvider } from "./gloomberb-cloud";
+import { createGloomberbCloudNewsSource, GloomberbCloudProvider } from "./gloomberb-cloud";
 import { apiClient, type AuthUser } from "../utils/api-client";
 
 const verifiedUser: AuthUser = {
@@ -298,5 +298,105 @@ describe("GloomberbCloudProvider", () => {
       publishedAt: new Date("2026-04-01T10:05:00.000Z"),
       summary: "Apple lifted its outlook after stronger iPhone demand.",
     }]);
+  });
+
+  test("maps news ticker labels from validated story links only", async () => {
+    apiClient.getCloudNews = async () => ({
+      items: [{
+        id: "story-1",
+        headline: "Sanofi reports vaccine update",
+        summary: "Sanofi and Moderna shared new vaccine data.",
+        topic: "product_approval",
+        topics: ["product_approval"],
+        category: "product_approval",
+        sentiment: "positive",
+        sectors: ["health_care"],
+        firstPublishedAt: "2026-04-01T10:00:00.000Z",
+        lastPublishedAt: "2026-04-01T10:05:00.000Z",
+        firstSeenAt: "2026-04-01T10:00:10.000Z",
+        lastSeenAt: "2026-04-01T10:05:10.000Z",
+        primaryUrl: "https://example.com/sny-vaccine",
+        primarySource: "example-wire",
+        scores: {
+          importance: 77,
+          urgency: 66,
+          marketImpact: 82,
+          novelty: 71,
+          confidence: 93,
+        },
+        flags: {
+          breaking: false,
+          developing: false,
+          stale: false,
+        },
+        variantCount: 1,
+        sourceCount: 1,
+        sources: ["example-wire"],
+        entities: [{
+          id: "entity-1",
+          entityType: "company",
+          name: "Sanofi",
+          symbol: "SNY",
+          exchange: "NASDAQ",
+          canonicalTicker: "SNY:NASDAQ",
+          role: null,
+          confidence: 0.95,
+        }, {
+          id: "entity-2",
+          entityType: "company",
+          name: "Noise Corp",
+          symbol: "NOISE",
+          exchange: "OTC",
+          canonicalTicker: "NOISE:OTC",
+          role: null,
+          confidence: 0.6,
+        }],
+        tickerLinks: [{
+          symbol: "SNY",
+          exchange: "NASDAQ",
+          canonicalTicker: "SNY:NASDAQ",
+          relationType: "direct",
+          displayTier: "primary",
+          confidence: 0.98,
+          relevanceScore: 95,
+          impactScore: 88,
+          sentiment: "positive",
+        }, {
+          symbol: "SNY",
+          exchange: "NASDAQ",
+          canonicalTicker: "SNY:NASDAQ",
+          relationType: "direct",
+          displayTier: "primary",
+          confidence: 0.98,
+          relevanceScore: 95,
+          impactScore: 88,
+          sentiment: "positive",
+        }, {
+          symbol: "MRNA",
+          exchange: "NASDAQ",
+          canonicalTicker: "MRNA:NASDAQ",
+          relationType: "competitor",
+          displayTier: "related",
+          confidence: 0.8,
+          relevanceScore: 65,
+          impactScore: 54,
+          sentiment: "neutral",
+        }],
+      }],
+      nextCursor: null,
+    });
+
+    const source = createGloomberbCloudNewsSource();
+    const news = await source.fetchNews({ feed: "top", ticker: "SNY" });
+
+    expect(news[0]?.tickers).toEqual(["SNY:NASDAQ", "MRNA:NASDAQ"]);
+    expect(news[0]?.importance).toBe(77);
+    expect(news[0]?.scores).toEqual({
+      importance: 77,
+      urgency: 66,
+      marketImpact: 82,
+      novelty: 71,
+      confidence: 93,
+    });
   });
 });

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -12,6 +12,7 @@ import {
   type CloudCompanyProfile,
   type CloudFundamentals,
   type CloudMarketResponse,
+  type CloudNewsTickerLinkPayload,
   type CloudNewsPayload,
   type CloudPricePointPayload,
   type CloudQuotePayload,
@@ -107,6 +108,24 @@ function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
 }
 
+function normalizeTickerLabel(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toUpperCase();
+  return normalized ? normalized : null;
+}
+
+function displayTickerForLink(link: CloudNewsTickerLinkPayload): string | null {
+  return normalizeTickerLabel(link.canonicalTicker) ?? normalizeTickerLabel(link.symbol);
+}
+
+function mapCloudNewsTickers(item: CloudNewsPayload, fallbackTicker?: string): string[] {
+  const tickers = uniqueStrings(item.tickerLinks.flatMap((link) => displayTickerForLink(link) ?? []));
+  const fallback = normalizeTickerLabel(fallbackTicker);
+  if (fallback && tickers.length === 0) {
+    tickers.push(fallback);
+  }
+  return tickers;
+}
+
 function mapCloudNewsArticle(item: CloudNewsPayload, fallbackTicker?: string): NewsArticle {
   const publishedAt = new Date(item.lastPublishedAt || item.firstPublishedAt || item.lastSeenAt);
   const topic = item.topic ?? item.category ?? "general";
@@ -119,13 +138,7 @@ function mapCloudNewsArticle(item: CloudNewsPayload, fallbackTicker?: string): N
     novelty: item.scores?.novelty ?? 0,
     confidence: item.scores?.confidence ?? 0,
   };
-  const tickers = uniqueStrings([
-    ...item.tickerLinks.flatMap((link) => [link.symbol, link.canonicalTicker]),
-    ...item.entities.flatMap((entity) => [entity.symbol, entity.canonicalTicker].filter((value): value is string => typeof value === "string")),
-  ]);
-  if (fallbackTicker && !tickers.includes(fallbackTicker.trim().toUpperCase())) {
-    tickers.push(fallbackTicker.trim().toUpperCase());
-  }
+  const tickers = mapCloudNewsTickers(item, fallbackTicker);
   return {
     id: item.id,
     title: item.headline,


### PR DESCRIPTION
Maps cloud news ticker labels from validated story-level tickerLinks instead of raw entity metadata, which prevents duplicate or unrelated tickers from appearing in news panes. Adds a regression test covering duplicate ticker links, noisy entities, related tickers, and score preservation. Also trims fixed news table column widths to give headlines more room.