### PR TITLE
Fix restored floating pane focus order

### DIFF
--- a/src/core/state/app-state.ts
+++ b/src/core/state/app-state.ts
@@ -427,6 +427,17 @@ function focusPaneState(state: AppState, paneId: string): AppState {
   };
 }
 
+function bringFocusedFloatingPaneToFront(config: AppConfig, focusedPaneId: string | null): AppConfig {
+  if (!focusedPaneId) return config;
+  const layout = bringFloatingToFront(config.layout, focusedPaneId);
+  if (layout === config.layout) return config;
+  return {
+    ...config,
+    layout,
+    layouts: syncLayouts(config.layouts, config.activeLayoutIndex, layout),
+  };
+}
+
 function withFocusedPane(state: AppState, config: AppConfig): AppState {
   const normalizedLayout = normalizePaneLayout(config.layout);
   const nextConfig = normalizedLayout === config.layout
@@ -438,11 +449,12 @@ function withFocusedPane(state: AppState, config: AppConfig): AppState {
     };
   const nextPaneState = reconcilePaneState(nextConfig, state.paneState);
   const focusedPaneId = resolveFocusedPaneId(state.config.layout, nextConfig.layout, state.focusedPaneId);
+  const focusedConfig = bringFocusedFloatingPaneToFront(nextConfig, focusedPaneId);
   return {
     ...state,
-    config: nextConfig,
+    config: focusedConfig,
     paneState: nextPaneState,
-    brokerAccounts: reconcileBrokerAccounts(nextConfig, state.brokerAccounts),
+    brokerAccounts: reconcileBrokerAccounts(focusedConfig, state.brokerAccounts),
     focusedPaneId,
   };
 }
@@ -848,8 +860,9 @@ export function createInitialState(config: AppConfig, sessionSnapshot: AppSessio
     && config.layout.instances.some((instance) => instance.instanceId === sessionSnapshot.focusedPaneId)
     ? sessionSnapshot.focusedPaneId
     : defaultFocusedPaneId;
+  const focusedConfig = bringFocusedFloatingPaneToFront(config, focusedPaneId);
   return {
-    config,
+    config: focusedConfig,
     tickers: new Map(),
     financials: new Map(),
     exchangeRates: new Map([["USD", 1]]),

--- a/src/state/app-context.test.ts
+++ b/src/state/app-context.test.ts
@@ -3,6 +3,7 @@ import { appReducer, createInitialState, resolveCollectionForPane, resolveTicker
 import { cloneLayout, createDefaultConfig, createPaneInstance } from "../types/config";
 import type { AppSessionSnapshot } from "../core/state/session-persistence";
 import { buildBrokerPortfolioId } from "../utils/broker-instances";
+import type { DesktopSharedStateSnapshot } from "../types/desktop-window";
 
 describe("resolveTickerForPane", () => {
   test("uses a portfolio pane cursor for inspector follow panes", () => {
@@ -73,6 +74,72 @@ describe("resolveTickerForPane", () => {
       activeTabId: "financials",
     });
     expect(state.focusedPaneId).toBe("ticker-detail:main");
+  });
+
+  test("raises the session-focused floating pane above stale saved z-order", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    config.layout = {
+      ...config.layout,
+      dockRoot: null,
+      floating: [
+        { instanceId: "ticker-detail:main", x: 4, y: 2, width: 60, height: 22, zIndex: 5 },
+        { instanceId: "chat:main", x: 8, y: 4, width: 48, height: 18, zIndex: 20 },
+      ],
+    };
+    config.layouts = config.layouts.map((entry, index) => (
+      index === config.activeLayoutIndex ? { ...entry, layout: cloneLayout(config.layout) } : entry
+    ));
+    const sessionSnapshot: AppSessionSnapshot = {
+      paneState: {},
+      focusedPaneId: "ticker-detail:main",
+      activePanel: "right",
+      statusBarVisible: true,
+      openPaneIds: ["ticker-detail:main", "chat:main"],
+      hydrationTargets: [],
+      exchangeCurrencies: ["USD"],
+      savedAt: Date.now(),
+    };
+
+    const state = createInitialState(config, sessionSnapshot);
+    const tickerEntry = state.config.layout.floating.find((entry) => entry.instanceId === "ticker-detail:main");
+    const chatEntry = state.config.layout.floating.find((entry) => entry.instanceId === "chat:main");
+
+    expect(tickerEntry?.zIndex).toBe(21);
+    expect((tickerEntry?.zIndex ?? 0) > (chatEntry?.zIndex ?? 0)).toBe(true);
+    expect(state.config.layouts[state.config.activeLayoutIndex]?.layout.floating.find(
+      (entry) => entry.instanceId === "ticker-detail:main",
+    )?.zIndex).toBe(21);
+  });
+
+  test("raises the desktop-snapshot focused floating pane during hydration", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    config.layout = {
+      ...config.layout,
+      dockRoot: null,
+      floating: [
+        { instanceId: "ticker-detail:main", x: 4, y: 2, width: 60, height: 22, zIndex: 5 },
+        { instanceId: "chat:main", x: 8, y: 4, width: 48, height: 18, zIndex: 20 },
+      ],
+    };
+    config.layouts = config.layouts.map((entry, index) => (
+      index === config.activeLayoutIndex ? { ...entry, layout: cloneLayout(config.layout) } : entry
+    ));
+    const initial = createInitialState(config);
+    const snapshot: DesktopSharedStateSnapshot = {
+      config,
+      paneState: {},
+      focusedPaneId: "ticker-detail:main",
+      activePanel: "right",
+      statusBarVisible: true,
+    };
+
+    const state = appReducer(initial, { type: "HYDRATE_DESKTOP_SNAPSHOT", snapshot });
+    const tickerEntry = state.config.layout.floating.find((entry) => entry.instanceId === "ticker-detail:main");
+    const chatEntry = state.config.layout.floating.find((entry) => entry.instanceId === "chat:main");
+
+    expect(state.focusedPaneId).toBe("ticker-detail:main");
+    expect(tickerEntry?.zIndex).toBe(21);
+    expect((tickerEntry?.zIndex ?? 0) > (chatEntry?.zIndex ?? 0)).toBe(true);
   });
 
   test("preserves broker portfolio selection until broker portfolios are restored", () => {


### PR DESCRIPTION
## Summary
- bring the restored focused floating pane to the front during session and desktop snapshot hydration
- keep the active saved layout synchronized with the adjusted z-order
- add regression tests for stale floating z-order during session restore and desktop hydration

## Tests
- bun test src/state/app-context.test.ts
- bun run desktop:view:build
- git diff --check