### PR TITLE
Fix overview description wrapping

### DIFF
--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -614,9 +614,9 @@ export function OverviewTab({
 
         {/* Description — last, collapsed */}
         {description && (
-          <Box flexDirection="column">
+          <Box flexDirection="column" width={contentWidth}>
             <SectionHeader title="Description" />
-            <Text fg={colors.text}>{description}</Text>
+            <Text fg={colors.text} width={contentWidth} wrapMode="word" wrapText>{description}</Text>
           </Box>
         )}
       </Box>

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -143,6 +143,7 @@ function hasAttribute(attributes: unknown, flag: number): boolean {
 
 function textStyle(props: TextProps): CSSProperties {
   const attributes = props.attributes;
+  const shouldWrap = props.wrapText || props.wrapMode === "word" || props.wrapMode === "char";
   return {
     color: props.fg,
     backgroundColor: props.bg,
@@ -156,11 +157,14 @@ function textStyle(props: TextProps): CSSProperties {
     ].filter(Boolean).join(" ") || undefined,
     opacity: props.dim || hasAttribute(attributes, TextAttributes.DIM) ? 0.65 : undefined,
     filter: props.inverse || hasAttribute(attributes, TextAttributes.INVERSE) ? "invert(1)" : undefined,
-    whiteSpace: props.wrapText ? "pre-wrap" : "pre",
+    whiteSpace: shouldWrap ? "pre-wrap" : "pre",
+    overflowWrap: shouldWrap ? "break-word" : undefined,
     overflow: "visible",
     textOverflow: "clip",
-    minWidth: 0,
-    flexShrink: 0,
+    width: cellWidth(props.width),
+    maxWidth: cellWidth(props.maxWidth),
+    minWidth: cellWidth(props.minWidth) ?? 0,
+    flexShrink: shouldWrap ? 1 : 0,
   };
 }
 
@@ -175,7 +179,7 @@ function cleanDomProps(props: Record<string, unknown>): Record<string, unknown> 
     "zIndex", "width", "height", "minWidth", "minHeight", "maxWidth", "maxHeight", "gap",
     "border", "borderStyle", "borderColor", "overflow", "selectable", "name", "color",
     "focused", "focusedBackgroundColor", "textColor", "focusedTextColor", "placeholderColor",
-    "cursorColor", "selectionBg", "selectionFg", "showCursor", "keyBindings", "wrapText",
+    "cursorColor", "selectionBg", "selectionFg", "showCursor", "keyBindings", "wrapText", "wrapMode",
     "initialValue", "value", "onInput", "onChange", "onSubmit", "onCursorChange", "onMouse",
     "scrollX", "scrollY", "focusable", "bitmap", "bitmaps", "crosshair", "text", "font",
   ]) {


### PR DESCRIPTION
## Summary
- Wrap ticker overview descriptions to the content width so long company profiles break instead of clipping.
- Teach the desktop-web text host to honor wrapMode/wrapText sizing props and strip wrapMode from DOM props.

## Tests
- bun test src/plugins/builtin/ticker-detail.test.tsx
- bun run desktop:view:build
- bun run build
- tmux smoke with bun run start