### PR TITLE
Wire desktop notifications to ElectroBun

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -220,7 +220,8 @@ function AppInner({
       else if (type === "error") toastId = toast.error(notification.body, options);
       else toastId = toast.info(notification.body, options);
     },
-  }), []);
+    desktop: rendererHost.supportsNativeDesktopNotifications ? rendererHost : undefined,
+  }), [rendererHost, toast]);
   const notify = useCallback((body: string, options?: { type?: "info" | "success" | "error" }) => {
     pluginRegistry.notify({ body, ...options });
   }, [pluginRegistry]);

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -24,6 +24,7 @@ import type { PaneRuntimeState } from "../../../core/state/app-state";
 import type { QuoteSubscriptionTarget } from "../../../types/data-provider";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot } from "../../../types/desktop-window";
 import type { BrokerOrderRequest } from "../../../types/trading";
+import { buildSoundCommand } from "../../../notifications/app-notifier";
 import { isPaneDetached } from "../../../plugins/pane-manager";
 import { ELECTROBUN_CONTEXT_MENU_ACTION, type ElectrobunDesktopRpcSchema } from "../shared/protocol";
 import { decodeRpcValue, encodeRpcValue } from "../view/rpc-codec";
@@ -236,6 +237,21 @@ function normalizeHttpFetchHeaders(headers: unknown): Record<string, string> {
 
 function normalizeText(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function playNotificationSound(sound: string | undefined): void {
+  if (!sound) return;
+  const command = buildSoundCommand(sound);
+  if (!command) return;
+  try {
+    const child = Bun.spawn([command.command, ...command.args], { stdio: ["ignore", "ignore", "ignore"] });
+    child.unref();
+  } catch (error) {
+    console.warn("notification sound failed", {
+      command: command.command,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 function syncBackendCloudAuthState(pluginId: string, key: string, value: unknown): void {
@@ -1190,9 +1206,12 @@ async function handleBackendRequest(
     case "host.readText":
       return Utils.clipboardReadText() ?? "";
     case "host.notify":
+      playNotificationSound(normalizeText(payload.sound));
       Utils.showNotification({
         title: normalizeText(payload.title) ?? "Gloomberb",
         body: normalizeText(payload.body),
+        subtitle: normalizeText(payload.subtitle),
+        silent: true,
       });
       return null;
     case "host.showContextMenu": {

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -1203,6 +1203,7 @@ export const webUiHost: UiHost = {
 };
 
 export const webRendererHost: RendererHost = {
+  supportsNativeDesktopNotifications: true,
   requestExit() {
     void backendRequest("host.exit").catch(() => window.close());
   },
@@ -1230,6 +1231,8 @@ export const webRendererHost: RendererHost = {
     void backendRequest("host.notify", {
       title: notification.title,
       body: notification.body,
+      subtitle: notification.subtitle,
+      sound: notification.sound,
     }).catch(() => {});
   },
   async showContextMenu(items) {

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -264,6 +264,7 @@ export interface RendererHost {
   openExternal(url: string): Promise<void>;
   copyText(text: string): Promise<void>;
   readText(): Promise<string>;
+  supportsNativeDesktopNotifications?: boolean;
   notify(notification: AppNotificationRequest): void;
   showContextMenu?(items: ContextMenuItem[]): Promise<boolean>;
 }


### PR DESCRIPTION
Summary:
- Routes plugin desktop notifications through the Electrobun renderer host when native notifications are available.
- Forwards title, body, subtitle, and sound through the desktop RPC and calls ElectroBun Utils.showNotification on the Bun side.
- Keeps the OpenTUI notification behavior on the existing app notifier path.

Tests:
- bun test src/notifications/app-notifier.test.ts src/architecture/import-boundaries.test.ts
- bun run desktop:view:build
- bun run desktop:build