### PR TITLE
Fix news links and detail scrolling

### DIFF
--- a/src/components/feed-data-table-stack-view.tsx
+++ b/src/components/feed-data-table-stack-view.tsx
@@ -343,10 +343,20 @@ export function FeedDataTableStackView({
   }, [scrollDetailBy]);
 
   const detailContent = openItem ? (
-    <Box flexDirection="column" flexGrow={1} paddingX={1} paddingY={1}>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+      paddingX={1}
+      paddingY={1}
+    >
       <ScrollBox
         ref={detailScrollRef}
         flexGrow={1}
+        flexBasis={0}
+        minHeight={0}
         scrollY
         focusable={false}
       >

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,6 +24,7 @@ export type {
   PaneFooterPart,
   PaneHint,
 } from "./layout/pane-footer";
+export { useExternalLinkFooter } from "./use-external-link-footer";
 
 // Theme
 export { colors, priceColor, hoverBg } from "../theme/colors";

--- a/src/components/use-external-link-footer.ts
+++ b/src/components/use-external-link-footer.ts
@@ -1,0 +1,82 @@
+import { useCallback, useMemo } from "react";
+import { useShortcut } from "../react/input";
+import { useRendererHost } from "../ui";
+import {
+  usePaneFooter,
+  type PaneFooterSegment,
+  type PaneHint,
+} from "./layout/pane-footer";
+
+interface UseExternalLinkFooterOptions {
+  registrationId: string;
+  focused: boolean;
+  url: string | null | undefined;
+  source?: string | null;
+  info?: PaneFooterSegment[];
+  hints?: PaneHint[];
+  label?: string;
+}
+
+const EMPTY_INFO: PaneFooterSegment[] = [];
+const EMPTY_HINTS: PaneHint[] = [];
+
+function normalizeUrl(url: string | null | undefined): string | null {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function useExternalLinkFooter({
+  registrationId,
+  focused,
+  url: rawUrl,
+  source,
+  info = EMPTY_INFO,
+  hints = EMPTY_HINTS,
+  label = "link",
+}: UseExternalLinkFooterOptions) {
+  const rendererHost = useRendererHost();
+  const url = normalizeUrl(rawUrl);
+  const sourceLabel = source?.trim() || null;
+
+  const openUrl = useCallback(() => {
+    if (!url) return;
+    void rendererHost.openExternal(url);
+  }, [rendererHost, url]);
+
+  useShortcut((event) => {
+    const key = (event.name ?? event.key ?? "").toLowerCase();
+    if (!focused || !url || key !== "o") return;
+    event.stopPropagation?.();
+    event.preventDefault?.();
+    openUrl();
+  });
+
+  const footer = useMemo(() => {
+    const linkInfo: PaneFooterSegment[] = url
+      ? [{
+        id: "external-link",
+        onPress: openUrl,
+        parts: [
+          ...(sourceLabel ? [
+            { text: "source", tone: "label" as const },
+            { text: sourceLabel, tone: "value" as const },
+          ] : []),
+          { text: label, tone: "label" as const },
+          { text: url, tone: "muted" as const },
+        ],
+      }]
+      : [];
+
+    return {
+      info: [...info, ...linkInfo],
+      hints: [
+        ...hints,
+        ...(url ? [{ id: "open", key: "o", label: "pen", onPress: openUrl }] : []),
+      ],
+    };
+  }, [hints, info, label, openUrl, sourceLabel, url]);
+
+  usePaneFooter(registrationId, () => footer, [footer]);
+
+  return openUrl;
+}

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -11,7 +11,7 @@ import { instrumentFromTicker } from "../../../market-data/request-types";
 import { usePaneTicker } from "../../../state/app-context";
 import { colors } from "../../../theme/colors";
 import { Spinner } from "../../../components/spinner";
-import { FeedDataTableStackView, usePaneFooter, type FeedDataTableItem } from "../../../components";
+import { FeedDataTableStackView, useExternalLinkFooter, type FeedDataTableItem } from "../../../components";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { formatCompact, formatCurrency } from "../../../utils/format";
@@ -146,7 +146,6 @@ function toFeedItems(parsed: ParsedFiling[]): FeedDataTableItem[] {
         detailBody: isLoading
           ? "Loading filing content..."
           : "This Form 4 filing could not be parsed into a transaction summary.",
-        detailNote: filing.filingUrl || undefined,
       };
     }
 
@@ -162,7 +161,6 @@ function toFeedItems(parsed: ParsedFiling[]): FeedDataTableItem[] {
         ...filingMeta,
       ],
       detailBody: buildTransactionDetailBody(transaction),
-      detailNote: filing.filingUrl || undefined,
     };
   });
 }
@@ -241,6 +239,7 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
   const summary = useMemo(() => buildSummary(allParsed), [allParsed]);
   const pendingCount = form4Filings.filter((f) => !contentMap.has(f.accessionNumber)).length;
   const selectedTransaction = parsed[selectedIdx]?.transaction ?? null;
+  const selectedFiling = parsed[selectedIdx]?.filing ?? null;
 
   const toggleNameFilter = useCallback((reportedName: string) => {
     setNameFilter((current) => current === reportedName ? null : reportedName);
@@ -266,13 +265,13 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
 
   const selectedFilterName = selectedTransaction?.reportedName ?? null;
   const pendingLabel = pendingCount > 0 ? `loading ${pendingCount}...` : "";
-  usePaneFooter("insider", () => ({
-    info: [
-      { id: "summary", parts: [{ text: truncateText(summary, Math.max(24, width - 20)), tone: "muted" }] },
-      ...(nameFilter ? [{ id: "filter", parts: [{ text: `filter: ${truncateText(nameFilter, 24)}`, tone: "warning" as const }] }] : []),
-      ...(pendingLabel ? [{ id: "pending", parts: [{ text: pendingLabel, tone: "muted" as const }] }] : []),
-    ],
-    hints: selectedFilterName || nameFilter
+  const footerInfo = useMemo(() => [
+    { id: "summary", parts: [{ text: truncateText(summary, Math.max(24, width - 20)), tone: "muted" as const }] },
+    ...(nameFilter ? [{ id: "filter", parts: [{ text: `filter: ${truncateText(nameFilter, 24)}`, tone: "warning" as const }] }] : []),
+    ...(pendingLabel ? [{ id: "pending", parts: [{ text: pendingLabel, tone: "muted" as const }] }] : []),
+  ], [nameFilter, pendingLabel, summary, width]);
+  const footerHints = useMemo(() => (
+    selectedFilterName || nameFilter
       ? [{
           id: "filter",
           key: "f",
@@ -282,8 +281,17 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
             else if (selectedFilterName) toggleNameFilter(selectedFilterName);
           },
         }]
-      : [],
-  }), [clearNameFilter, nameFilter, pendingLabel, selectedFilterName, summary, toggleNameFilter, width]);
+      : []
+  ), [clearNameFilter, nameFilter, selectedFilterName, toggleNameFilter]);
+  useExternalLinkFooter({
+    registrationId: "insider",
+    focused,
+    url: error ? null : selectedFiling?.filingUrl,
+    source: selectedFiling?.form ? formatFilingForm(selectedFiling.form) : null,
+    info: footerInfo,
+    hints: footerHints,
+    label: "filing",
+  });
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view insider activity.</Text>;
   if (!eligibleTicker) return renderNotice("Insider transactions are only shown for US equities.", width);

--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -1,7 +1,6 @@
 import { Box } from "../../../ui";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PaneProps } from "../../../types/plugin";
-import { usePaneFooter } from "../../../components";
 import { useNewsArticles } from "../../../news/hooks";
 import { Spinner } from "../../../components/spinner";
 import { usePluginPaneState } from "../../plugin-runtime";
@@ -10,7 +9,8 @@ import { detectProviders, getAiProvider, resolveDefaultAiProviderId } from "../a
 import { runAiPrompt } from "../ai/runner";
 import { getDigest, setDigest, isDigestInFlight, markDigestInFlight, clearDigestInFlight } from "./digest-store";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
-import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
+import { getSelectedNewsArticle, NewsArticleStackView, type NewsSortPreference } from "./news-table";
+import { useNewsArticleFooter } from "./news-footer";
 import { NEWS_QUERY_PRESETS } from "./news-query-presets";
 import { useNewsReadState } from "./read-state";
 
@@ -103,12 +103,21 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
     getDigest(article.id) ?? article.title
   ), [digestVersion]);
 
-  usePaneFooter("news-wire:breaking", () => ({
-    info: [
-      ...(aiRunning ? [{ id: "running", parts: [{ text: BRAILLE_FRAMES[spinFrame] ?? "running", tone: "positive" as const }] }] : []),
-      ...(aiError ? [{ id: "paused", parts: [{ text: "AI paused", tone: "warning" as const }] }] : []),
-    ],
-  }), [aiError, aiRunning, spinFrame]);
+  const selectedArticle = useMemo(() => {
+    if (detailArticle) return detailArticle;
+    return getSelectedNewsArticle(articles, selectedArticleId, sortPreference);
+  }, [articles, detailArticle, selectedArticleId, sortPreference]);
+  const footerInfo = useMemo(() => [
+    ...(aiRunning ? [{ id: "running", parts: [{ text: BRAILLE_FRAMES[spinFrame] ?? "running", tone: "positive" as const }] }] : []),
+    ...(aiError ? [{ id: "paused", parts: [{ text: "AI paused", tone: "warning" as const }] }] : []),
+  ], [aiError, aiRunning, spinFrame]);
+
+  useNewsArticleFooter({
+    registrationId: "news-wire:breaking",
+    focused,
+    article: selectedArticle,
+    info: footerInfo,
+  });
 
   const detailContent = detailArticle ? (
     <NewsDetailView

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -4,11 +4,12 @@ import type { PaneProps } from "../../../types/plugin";
 import type { MarketNewsItem } from "../../../types/news-source";
 import { useNewsArticles } from "../../../news/hooks";
 import type { NewsQueryPhase } from "../../../news/types";
-import { TabBar, usePaneFooter } from "../../../components";
+import { TabBar } from "../../../components";
 import { Spinner } from "../../../components/spinner";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
-import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
+import { getSelectedNewsArticle, NewsArticleStackView, type NewsSortPreference } from "./news-table";
+import { useNewsArticleFooter } from "./news-footer";
 import { useNewsReadState } from "./read-state";
 import {
   NEWS_QUERY_PRESETS,
@@ -63,6 +64,11 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     setSelectedArticleId(null);
   }, [category, setSelectedArticleId]);
 
+  const selectedArticle = useMemo(() => {
+    if (detailArticle) return detailArticle;
+    return getSelectedNewsArticle(articles, selectedArticleId, sortPreference);
+  }, [articles, detailArticle, selectedArticleId, sortPreference]);
+
   const handleRootKeyDown = (event: {
     name?: string;
     preventDefault?: () => void;
@@ -78,7 +84,11 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     return true;
   };
 
-  usePaneFooter("news-wire:industry", () => null, [category]);
+  useNewsArticleFooter({
+    registrationId: "news-wire:industry",
+    focused,
+    article: selectedArticle,
+  });
 
   const rootBefore = (
     <Box height={1} flexShrink={0} overflow="hidden">

--- a/src/plugins/builtin/news-wire/news-detail-view.tsx
+++ b/src/plugins/builtin/news-wire/news-detail-view.tsx
@@ -109,8 +109,8 @@ export function NewsDetailView({ item, focused, width, showTitle = true }: {
   });
 
   return (
-    <Box flexDirection="column" width={width} flexGrow={1} minHeight={0}>
-      <ScrollBox ref={scrollRef} flexGrow={1} scrollY focusable={false}>
+    <Box flexDirection="column" width={width} flexGrow={1} flexBasis={0} minHeight={0} overflow="hidden">
+      <ScrollBox ref={scrollRef} flexGrow={1} flexBasis={0} minHeight={0} scrollY focusable={false}>
         <Box flexDirection="column" paddingX={1} paddingY={1} gap={1}>
           {showTitle && (
             <Box flexDirection="column">

--- a/src/plugins/builtin/news-wire/news-footer.ts
+++ b/src/plugins/builtin/news-wire/news-footer.ts
@@ -1,0 +1,28 @@
+import { useExternalLinkFooter, type PaneFooterSegment } from "../../../components";
+
+export interface NewsFooterArticle {
+  source?: string | null;
+  url?: string | null;
+}
+
+interface UseNewsArticleFooterOptions {
+  registrationId: string;
+  focused: boolean;
+  article: NewsFooterArticle | null | undefined;
+  info?: PaneFooterSegment[];
+}
+
+export function useNewsArticleFooter({
+  registrationId,
+  focused,
+  article,
+  info,
+}: UseNewsArticleFooterOptions) {
+  useExternalLinkFooter({
+    registrationId,
+    focused,
+    url: article?.url,
+    source: article?.source,
+    info,
+  });
+}

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -1,16 +1,18 @@
 import { Box } from "../../../ui";
+import { useMemo } from "react";
 import type { NewsQuery } from "../../../news/types";
 import { useNewsArticles } from "../../../news/hooks";
 import type { PaneProps } from "../../../types/plugin";
-import { usePaneFooter } from "../../../components";
 import { Spinner } from "../../../components/spinner";
 import { usePluginPaneState } from "../../plugin-runtime";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import {
+  getSelectedNewsArticle,
   NewsArticleStackView,
   type NewsColumnId,
   type NewsSortPreference,
 } from "./news-table";
+import { useNewsArticleFooter } from "./news-footer";
 import { useNewsReadState } from "./read-state";
 
 export function NewsPresetPane({
@@ -46,8 +48,16 @@ export function NewsPresetPane({
   );
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
   const { readArticleIds, markArticleRead } = useNewsReadState();
+  const selectedArticle = useMemo(() => {
+    if (detailArticle) return detailArticle;
+    return getSelectedNewsArticle(articles, selectedArticleId, sortPreference);
+  }, [articles, detailArticle, selectedArticleId, sortPreference]);
 
-  usePaneFooter(`news-wire:${paneKey}`, () => null, [paneKey]);
+  useNewsArticleFooter({
+    registrationId: `news-wire:${paneKey}`,
+    focused,
+    article: selectedArticle,
+  });
 
   const detailContent = detailArticle ? (
     <NewsDetailView

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -84,6 +84,17 @@ export function sortNewsArticles(
   });
 }
 
+export function getSelectedNewsArticle(
+  articles: MarketNewsItem[],
+  selectedArticleId: string | null,
+  preference: NewsSortPreference,
+): MarketNewsItem | null {
+  const selectedArticle = selectedArticleId
+    ? articles.find((article) => article.id === selectedArticleId) ?? null
+    : null;
+  return selectedArticle ?? sortNewsArticles(articles, preference)[0] ?? null;
+}
+
 function nextSortPreference(current: NewsSortPreference, columnId: NewsColumnId): NewsSortPreference {
   if (current.columnId === columnId) {
     return {

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -1,5 +1,5 @@
 import { Text } from "../../ui";
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useMemo, useState } from "react";
 import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
 import { usePaneTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
@@ -8,9 +8,10 @@ import { useArticleSummary, useResolvedEntryValue } from "../../market-data/hook
 import { instrumentFromTicker } from "../../market-data/request-types";
 import { usePluginPaneState } from "../../plugins/plugin-runtime";
 import { Spinner } from "../../components/spinner";
-import { FeedDataTableStackView, usePaneFooter, type FeedDataTableItem } from "../../components";
+import { FeedDataTableStackView, type FeedDataTableItem } from "../../components";
 import { useNewsArticles } from "../../news/hooks";
 import { registerNewsWireFeatures } from "./news-wire";
+import { useNewsArticleFooter } from "./news-wire/news-footer";
 import { useNewsReadState } from "./news-wire/read-state";
 
 const ARTICLE_SUMMARY_CACHE_POLICY = {
@@ -102,14 +103,18 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
     }
   }, [news.length, selectedIdx, setSelectedIdx]);
 
-  usePaneFooter("news", () => {
-    const info = [
-      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
-      ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
-      ...(loadingSummary ? [{ id: "summary", parts: [{ text: "summary loading", tone: "muted" as const }] }] : []),
-    ];
-    return info.length > 0 ? { info } : null;
-  }, [error, loading, loadingSummary]);
+  const footerInfo = useMemo(() => [
+    ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+    ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
+    ...(loadingSummary ? [{ id: "summary", parts: [{ text: "summary loading", tone: "muted" as const }] }] : []),
+  ], [error, loading, loadingSummary]);
+
+  useNewsArticleFooter({
+    registrationId: "news",
+    focused,
+    article: selected,
+    info: footerInfo,
+  });
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view news.</Text>;
   if (loading && news.length === 0) return <Spinner label="Loading news..." />;

--- a/src/plugins/builtin/sec.tsx
+++ b/src/plugins/builtin/sec.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "../../ui";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
 import type { SecFilingItem } from "../../types/data-provider";
 import { useResolvedEntryValue, useSecFilingContent, useSecFilingsQuery } from "../../market-data/hooks";
@@ -8,7 +8,7 @@ import { usePluginPaneState } from "../../plugins/plugin-runtime";
 import { usePaneTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import { Spinner } from "../../components/spinner";
-import { FeedDataTableStackView, usePaneFooter, type FeedDataTableItem } from "../../components";
+import { FeedDataTableStackView, useExternalLinkFooter, type FeedDataTableItem } from "../../components";
 import { isUsEquityTicker } from "../../utils/sec";
 import { getSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { parseForm4Xml, transactionTypeLabel } from "./insider/insider-data";
@@ -222,7 +222,6 @@ function toFeedItems(
               : form4Detail ?? fetchedContent ?? fallbackBody
           )
         : form4Detail ?? fallbackBody,
-      detailNote: filing.filingUrl || undefined,
     };
   });
 }
@@ -306,13 +305,18 @@ function SecTab({ width, height, focused }: DetailTabProps) {
     })();
   }, [filings]);
 
-  usePaneFooter("sec", () => {
-    const info = [
-      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
-      ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
-    ];
-    return info.length > 0 ? { info } : null;
-  }, [error, loading]);
+  const footerInfo = useMemo(() => [
+    ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+    ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
+  ], [error, loading]);
+  useExternalLinkFooter({
+    registrationId: "sec",
+    focused,
+    url: error ? null : selected?.filingUrl,
+    source: selected?.form,
+    info: footerInfo,
+    label: "filing",
+  });
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view SEC filings.</Text>;
   if (!eligibleTicker) return renderNotice("SEC filings are only shown for US equities.", width);


### PR DESCRIPTION
Summary:
- Keep feed-style detail panes scrollable on desktop by constraining detail scroll containers.
- Move News, SEC, and Insider article or filing URLs into footer link segments with a shared [o]pen action.
- Reuse selected article lookup so News footer links follow the highlighted item across latest, breaking, and sector feeds.

Verified with `bun test src/components/feed-data-table-stack-view.test.tsx src/components/data-table-stack-view.test.tsx src/components/layout/pane-footer.test.tsx`, `bun run desktop:view:build`, `bun run build`, and tmux News/SEC smoke tests.
