### PR TITLE
Add native Electrobun app menu

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -47,6 +47,7 @@ import type { DataProvider } from "./types/data-provider";
 import type { TickerFinancials } from "./types/financials";
 import type { BrokerAccount } from "./types/trading";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopWindowBridge } from "./types/desktop-window";
+import type { DesktopApplicationMenuBridge } from "./types/desktop-menu";
 import { resolveTickerSearch, upsertTickerFromSearchResult } from "./utils/ticker-search";
 
 // Built-in plugins
@@ -67,9 +68,11 @@ import {
   getDockLeafLayouts,
   getDockedPaneIds,
   getLeafRect,
+  gridlockAllPanes,
   isPaneInLayout,
   removePane,
 } from "./plugins/pane-manager";
+import { notifyGridlockComplete } from "./plugins/gridlock-notification";
 import {
   createBrokerInstanceId,
   getBrokerInstance,
@@ -138,6 +141,7 @@ interface AppInnerProps {
   marketData: MarketDataCoordinator;
   sessionSnapshot?: AppSessionSnapshot | null;
   desktopWindowBridge?: DesktopWindowBridge;
+  desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
 }
 
 function AppInner({
@@ -147,6 +151,7 @@ function AppInner({
   marketData,
   sessionSnapshot = null,
   desktopWindowBridge,
+  desktopApplicationMenuBridge,
 }: AppInnerProps) {
   const dispatch = useAppDispatch();
   const stateRef = useAppStateRef();
@@ -640,6 +645,54 @@ function AppInner({
   useEffect(() => {
     void runUpdateCheck(false);
   }, [runUpdateCheck]);
+
+  useEffect(() => {
+    if (desktopWindowBridge?.kind !== "main" || !desktopApplicationMenuBridge) return;
+    return desktopApplicationMenuBridge.subscribe((command) => {
+      switch (command.type) {
+        case "open-command-bar":
+          dispatch({ type: "SET_COMMAND_BAR", open: true, query: command.query });
+          break;
+        case "open-plugin-workflow":
+          pluginRegistry.openPluginCommandWorkflowFn(command.commandId);
+          break;
+        case "open-url":
+          void rendererHost.openExternal(command.url).catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            pluginRegistry.notify({ body: `Failed to open link: ${message}`, type: "error" });
+          });
+          break;
+        case "check-for-updates":
+          void runUpdateCheck(true);
+          break;
+        case "toggle-status-bar":
+          dispatch({ type: "TOGGLE_STATUS_BAR" });
+          break;
+        case "layout-undo":
+          dispatch({ type: "UNDO_LAYOUT" });
+          break;
+        case "layout-redo":
+          dispatch({ type: "REDO_LAYOUT" });
+          break;
+        case "layout-gridlock": {
+          const { width, height } = pluginRegistry.getTermSizeFn();
+          pluginRegistry.updateLayoutFn(gridlockAllPanes(stateRef.current.config.layout, { x: 0, y: 0, width, height }));
+          notifyGridlockComplete(pluginRegistry.notify.bind(pluginRegistry), () => {
+            dispatch({ type: "UNDO_LAYOUT" });
+          });
+          break;
+        }
+      }
+    });
+  }, [
+    desktopApplicationMenuBridge,
+    desktopWindowBridge?.kind,
+    dispatch,
+    pluginRegistry,
+    rendererHost,
+    runUpdateCheck,
+    stateRef,
+  ]);
 
   useEffect(() => {
     if (!state.updateAvailable || state.updateProgress || state.updateCheckInProgress) return;
@@ -1456,6 +1509,7 @@ interface AppProps {
   externalPlugins?: import("./plugins/loader").LoadedExternalPlugin[];
   cliLaunchRequest?: CliLaunchRequest | null;
   desktopWindowBridge?: DesktopWindowBridge;
+  desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
   desktopSnapshot?: DesktopSharedStateSnapshot | null;
 }
 
@@ -1464,6 +1518,7 @@ export function App({
   externalPlugins = [],
   cliLaunchRequest = null,
   desktopWindowBridge,
+  desktopApplicationMenuBridge,
   desktopSnapshot = null,
 }: AppProps) {
   const renderer = useNativeRenderer();
@@ -1579,6 +1634,7 @@ export function App({
         marketData={services.marketData}
         sessionSnapshot={sessionSnapshot}
         desktopWindowBridge={desktopWindowBridge}
+        desktopApplicationMenuBridge={desktopApplicationMenuBridge}
       />
     </AppProvider>
   );

--- a/src/renderers/electrobun/bun/application-menu-click.test.ts
+++ b/src/renderers/electrobun/bun/application-menu-click.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { ELECTROBUN_APPLICATION_MENU_ACTION } from "./application-menu";
+import { applicationMenuCommand } from "./application-menu-click";
+
+describe("applicationMenuCommand", () => {
+  test("parses a valid open command bar event", () => {
+    expect(applicationMenuCommand({
+      data: {
+        action: ELECTROBUN_APPLICATION_MENU_ACTION,
+        data: { type: "open-command-bar", query: "DES " },
+      },
+    })).toEqual({ type: "open-command-bar", query: "DES " });
+  });
+
+  test("ignores events for other actions", () => {
+    expect(applicationMenuCommand({
+      data: {
+        action: "gloom.other-action",
+        data: { type: "open-command-bar", query: "DES " },
+      },
+    })).toBeNull();
+  });
+
+  test("ignores unknown command types", () => {
+    expect(applicationMenuCommand({
+      data: {
+        action: ELECTROBUN_APPLICATION_MENU_ACTION,
+        data: { type: "unknown-command" },
+      },
+    })).toBeNull();
+  });
+
+  test("ignores plugin workflow commands without a command id", () => {
+    expect(applicationMenuCommand({
+      data: {
+        action: ELECTROBUN_APPLICATION_MENU_ACTION,
+        data: { type: "open-plugin-workflow" },
+      },
+    })).toBeNull();
+  });
+});

--- a/src/renderers/electrobun/bun/application-menu-click.ts
+++ b/src/renderers/electrobun/bun/application-menu-click.ts
@@ -1,0 +1,55 @@
+import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu";
+import { ELECTROBUN_APPLICATION_MENU_ACTION } from "./application-menu";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function applicationMenuClickPayload(event: unknown): Record<string, unknown> | null {
+  const eventRecord = record(event);
+  if (!eventRecord) return null;
+
+  const wrappedPayload = record(eventRecord.data);
+  if (typeof wrappedPayload?.action === "string") {
+    return wrappedPayload;
+  }
+
+  return typeof eventRecord.action === "string" ? eventRecord : null;
+}
+
+function normalizeApplicationMenuCommand(value: unknown): DesktopApplicationMenuCommand | null {
+  const command = record(value);
+  if (!command || typeof command.type !== "string") return null;
+
+  switch (command.type) {
+    case "open-command-bar":
+      if (command.query != null && typeof command.query !== "string") return null;
+      return command.query == null
+        ? { type: "open-command-bar" }
+        : { type: "open-command-bar", query: command.query };
+    case "open-plugin-workflow":
+      return typeof command.commandId === "string" && command.commandId.length > 0
+        ? { type: "open-plugin-workflow", commandId: command.commandId }
+        : null;
+    case "open-url":
+      return typeof command.url === "string" && command.url.length > 0
+        ? { type: "open-url", url: command.url }
+        : null;
+    case "check-for-updates":
+    case "toggle-status-bar":
+    case "layout-undo":
+    case "layout-redo":
+    case "layout-gridlock":
+      return { type: command.type };
+    default:
+      return null;
+  }
+}
+
+export function applicationMenuCommand(event: unknown): DesktopApplicationMenuCommand | null {
+  const payload = applicationMenuClickPayload(event);
+  if (payload?.action !== ELECTROBUN_APPLICATION_MENU_ACTION) return null;
+  return normalizeApplicationMenuCommand(payload.data);
+}

--- a/src/renderers/electrobun/bun/application-menu.ts
+++ b/src/renderers/electrobun/bun/application-menu.ts
@@ -1,0 +1,118 @@
+import type { ApplicationMenuItemConfig } from "electrobun/bun";
+import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu";
+
+export const ELECTROBUN_APPLICATION_MENU_ACTION = "gloom.application-menu.select";
+export const GITHUB_ISSUE_URL = "https://github.com/vincelwt/gloomberb/issues/new/choose";
+
+function commandItem(
+  label: string,
+  command: DesktopApplicationMenuCommand,
+  options: { accelerator?: string } = {},
+): ApplicationMenuItemConfig {
+  return {
+    label,
+    action: ELECTROBUN_APPLICATION_MENU_ACTION,
+    data: command,
+    ...(options.accelerator ? { accelerator: options.accelerator } : {}),
+  };
+}
+
+function openCommandBar(label: string, query: string, options?: { accelerator?: string }): ApplicationMenuItemConfig {
+  return commandItem(label, { type: "open-command-bar", query }, options);
+}
+
+export function buildApplicationMenu(): ApplicationMenuItemConfig[] {
+  return [
+    {
+      label: "Gloomberb",
+      submenu: [
+        { role: "about" },
+        { type: "divider" },
+        commandItem("Check for Updates...", { type: "check-for-updates" }),
+        { type: "divider" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "showAll" },
+        { type: "divider" },
+        { role: "quit" },
+      ],
+    },
+    {
+      label: "File",
+      submenu: [
+        openCommandBar("Search Ticker...", "DES "),
+        { type: "divider" },
+        openCommandBar("New Portfolio...", "New Portfolio"),
+        openCommandBar("New Watchlist...", "New Watchlist"),
+        openCommandBar("Set Portfolio Position...", "Set Portfolio Position"),
+        { type: "divider" },
+        openCommandBar("Add Broker Account...", "Add Broker Account"),
+        { type: "divider" },
+        openCommandBar("Import Config...", "Import Config"),
+        openCommandBar("Export Config...", "Export Config"),
+        { type: "divider" },
+        openCommandBar("Reset All Data...", "Reset All Data"),
+      ],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "divider" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "pasteAndMatchStyle" },
+        { role: "delete" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        openCommandBar("Open Command Bar", "", { accelerator: "CmdOrCtrl+K" }),
+        { type: "divider" },
+        commandItem("Toggle Status Bar", { type: "toggle-status-bar" }),
+        { type: "divider" },
+        openCommandBar("Change Theme...", "TH "),
+        openCommandBar("Manage Plugins...", "PL "),
+      ],
+    },
+    {
+      label: "Layout",
+      submenu: [
+        openCommandBar("Layout Actions...", "LAY ", { accelerator: "CmdOrCtrl+Shift+L" }),
+        { type: "divider" },
+        commandItem("Undo Layout Change", { type: "layout-undo" }),
+        commandItem("Redo Layout Change", { type: "layout-redo" }),
+        commandItem("Gridlock All Windows", { type: "layout-gridlock" }, { accelerator: "CmdOrCtrl+Shift+G" }),
+        { type: "divider" },
+        commandItem("New Layout...", { type: "open-plugin-workflow", commandId: "new-layout" }),
+        commandItem("Rename Current Layout...", { type: "open-plugin-workflow", commandId: "rename-layout" }),
+        openCommandBar("Duplicate Current Layout", "Duplicate Layout"),
+        openCommandBar("Delete Current Layout...", "Delete Layout"),
+      ],
+    },
+    {
+      label: "Window",
+      submenu: [
+        { role: "minimize" },
+        { role: "zoom" },
+        { type: "divider" },
+        { role: "toggleFullScreen" },
+        { type: "divider" },
+        { role: "close" },
+        { type: "divider" },
+        { role: "bringAllToFront" },
+      ],
+    },
+    {
+      label: "Help",
+      submenu: [
+        openCommandBar("Gloomberb Help", "HELP"),
+        commandItem("Open Issue on GitHub", { type: "open-url", url: GITHUB_ISSUE_URL }),
+      ],
+    },
+  ];
+}

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -32,6 +32,8 @@ import { startMainThreadMonitor } from "../../../utils/main-thread-monitor";
 import { contextMenuSelectionMessage } from "./context-menu-click";
 import { getContextMenuRequestId, normalizeContextMenuItems } from "./context-menu-normalize";
 import { createDesktopWorkspace, type DesktopWorkspace } from "./desktop-workspace";
+import { buildApplicationMenu } from "./application-menu";
+import { applicationMenuCommand } from "./application-menu-click";
 import { apiClient, type PersistedAuthUser } from "../../../utils/api-client";
 import {
   DEFAULT_WINDOW_FRAME,
@@ -1231,43 +1233,7 @@ async function handleBackendRequest(
 }
 
 function installApplicationMenu() {
-  ApplicationMenu.setApplicationMenu([
-    {
-      label: "Gloomberb",
-      submenu: [
-        { role: "about" },
-        { type: "divider" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "showAll" },
-        { type: "divider" },
-        { role: "quit" },
-      ],
-    },
-    {
-      label: "Edit",
-      submenu: [
-        { role: "undo" },
-        { role: "redo" },
-        { type: "divider" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectAll" },
-      ],
-    },
-    {
-      label: "Window",
-      submenu: [
-        { role: "minimize" },
-        { role: "zoom" },
-        { type: "divider" },
-        { role: "toggleFullScreen" },
-        { type: "divider" },
-        { role: "close" },
-      ],
-    },
-  ]);
+  ApplicationMenu.setApplicationMenu(buildApplicationMenu());
 }
 
 function createWindowRpc(key: string): DesktopRpc {
@@ -1296,6 +1262,12 @@ Electrobun.events.on("context-menu-clicked", (event: unknown) => {
   forEachReadyWindowRpc((windowRpc) => {
     windowRpc.send["context-menu.select"](message);
   });
+});
+
+ApplicationMenu.on("application-menu-clicked", (event: unknown) => {
+  const command = applicationMenuCommand(event);
+  if (!command || !readyWindowRpcs.has(MAIN_WINDOW_RPC_KEY)) return;
+  windowRpcs.get(MAIN_WINDOW_RPC_KEY)?.send["application-menu.select"]({ command });
 });
 
 installApplicationMenu();

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -1,5 +1,6 @@
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot } from "../../../types/desktop-window";
+import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu";
 import type { AppConfig } from "../../../types/config";
 
 export const ELECTROBUN_CONTEXT_MENU_ACTION = "gloom.context-menu.select";
@@ -46,6 +47,10 @@ export interface ContextMenuSelectMessage {
   itemId: string;
 }
 
+export interface ApplicationMenuSelectMessage {
+  command: DesktopApplicationMenuCommand;
+}
+
 export interface DesktopStateMessage {
   snapshot: DesktopSharedStateSnapshot;
 }
@@ -73,6 +78,7 @@ export interface ElectrobunDesktopRpcSchema {
       "ibkr.quote.update": QuoteUpdateMessage;
       "ai.chunk": AiChunkMessage;
       "context-menu.select": ContextMenuSelectMessage;
+      "application-menu.select": ApplicationMenuSelectMessage;
       "desktop.state": DesktopStateMessage;
       "desktop.dockPreview": DesktopDockPreviewMessage;
     };

--- a/src/renderers/electrobun/view/application-menu-bridge.ts
+++ b/src/renderers/electrobun/view/application-menu-bridge.ts
@@ -1,0 +1,12 @@
+import type { DesktopApplicationMenuBridge } from "../../../types/desktop-menu";
+import { onApplicationMenuSelect } from "./backend-rpc";
+
+export function createApplicationMenuBridge(): DesktopApplicationMenuBridge {
+  return {
+    subscribe(listener) {
+      return onApplicationMenuSelect((message) => {
+        listener(message.command);
+      });
+    },
+  };
+}

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -2,6 +2,7 @@
 import { Electroview } from "electrobun/view";
 import { measurePerfAsync } from "../../../utils/perf-marks";
 import {
+  type ApplicationMenuSelectMessage,
   type AiChunkMessage,
   type ContextMenuSelectMessage,
   type DesktopDockPreviewMessage,
@@ -19,6 +20,7 @@ type IbkrSnapshotListener = (message: IbkrSnapshotMessage) => void;
 type IbkrResolvedListener = (message: IbkrResolvedMessage) => void;
 type AiChunkListener = (message: AiChunkMessage) => void;
 type ContextMenuSelectListener = (message: ContextMenuSelectMessage) => void;
+type ApplicationMenuSelectListener = (message: ApplicationMenuSelectMessage) => void;
 type DesktopStateListener = (message: DesktopStateMessage) => void;
 type DesktopDockPreviewListener = (message: DesktopDockPreviewMessage) => void;
 
@@ -29,6 +31,7 @@ const ibkrSnapshotListeners = new Map<string, Set<IbkrSnapshotListener>>();
 const ibkrResolvedListeners = new Set<IbkrResolvedListener>();
 const aiChunkListeners = new Map<string, Set<AiChunkListener>>();
 const contextMenuSelectListeners = new Map<string, Set<ContextMenuSelectListener>>();
+const applicationMenuSelectListeners = new Set<ApplicationMenuSelectListener>();
 const desktopStateListeners = new Set<DesktopStateListener>();
 const desktopDockPreviewListeners = new Set<DesktopDockPreviewListener>();
 
@@ -101,6 +104,12 @@ const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
       },
       "context-menu.select": (message) => {
         dispatch(contextMenuSelectListeners, message.requestId, message);
+      },
+      "application-menu.select": (message) => {
+        const decoded = { command: decodeRpcValue<ApplicationMenuSelectMessage["command"]>(message.command) };
+        for (const listener of applicationMenuSelectListeners) {
+          listener(decoded);
+        }
       },
       "desktop.state": (message) => {
         for (const listener of desktopStateListeners) {
@@ -189,6 +198,13 @@ export function onContextMenuSelect(
   listener: (message: ContextMenuSelectMessage) => void,
 ): () => void {
   return subscribe(contextMenuSelectListeners, requestId, listener);
+}
+
+export function onApplicationMenuSelect(listener: ApplicationMenuSelectListener): () => void {
+  applicationMenuSelectListeners.add(listener);
+  return () => {
+    applicationMenuSelectListeners.delete(listener);
+  };
 }
 
 export function onDesktopState(listener: DesktopStateListener): () => void {

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -15,6 +15,7 @@ import { WebInputHostProvider } from "./input-host";
 import { webNativeRenderer } from "./native-renderer";
 import { WebToastHostProvider } from "./toast-host";
 import { webRendererHost, webUiHost } from "./ui-host";
+import { createApplicationMenuBridge } from "./application-menu-bridge";
 import { createDesktopWindowBridge } from "./desktop-window-bridge";
 import { prepareDetachedSnapshot } from "./desktop-window-snapshot";
 
@@ -58,6 +59,7 @@ async function boot() {
     : init.desktopSnapshot;
   const config = desktopSnapshot?.config ?? init.config;
   const desktopWindowBridge = createDesktopWindowBridge(init.windowKind, init.paneId);
+  const desktopApplicationMenuBridge = createApplicationMenuBridge();
   measurePerfAsync("startup.electrobun.root-render", async () => {
     root.render(
       <UiHostProvider ui={webUiHost} renderer={webRendererHost} nativeRenderer={webNativeRenderer}>
@@ -67,6 +69,7 @@ async function boot() {
               <App
                 config={config}
                 desktopWindowBridge={desktopWindowBridge}
+                desktopApplicationMenuBridge={desktopApplicationMenuBridge}
                 desktopSnapshot={desktopSnapshot}
               />
             </WebDialogHostProvider>

--- a/src/types/desktop-menu.ts
+++ b/src/types/desktop-menu.ts
@@ -1,0 +1,13 @@
+export type DesktopApplicationMenuCommand =
+  | { type: "open-command-bar"; query?: string }
+  | { type: "open-plugin-workflow"; commandId: string }
+  | { type: "open-url"; url: string }
+  | { type: "check-for-updates" }
+  | { type: "toggle-status-bar" }
+  | { type: "layout-undo" }
+  | { type: "layout-redo" }
+  | { type: "layout-gridlock" };
+
+export interface DesktopApplicationMenuBridge {
+  subscribe(listener: (command: DesktopApplicationMenuCommand) => void): () => void;
+}


### PR DESCRIPTION
Adds a richer native Electrobun application menu with File, View, Layout, Window, and Help menus, including a GitHub issue link. Wires custom menu selections through a typed Electrobun RPC bridge into the existing command bar, update, status bar, layout, and external-link handlers. Adds validation coverage for application menu click payloads. Verified with `bun test src/renderers/electrobun/bun/application-menu-click.test.ts`, `bun test src/architecture/import-boundaries.test.ts`, `bun run desktop:view:build`, and a Bun bundle check for the Electrobun main entry.