### PR TITLE
Fix desktop footer hint layout

### DIFF
--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -353,6 +353,7 @@ export function PaneFooterBar({
   const borderColor = focused ? colors.borderFocused : colors.border;
   const topBorderColor = colors.border;
   const reservedRight = Math.max(0, reserveRight);
+  const rightPadding = reservedRight > 0 ? reservedRight : 1;
 
   if (nativePaneChrome) {
     return (
@@ -360,7 +361,7 @@ export function PaneFooterBar({
         height={1}
         flexDirection="row"
         paddingLeft={1}
-        paddingRight={reservedRight + 1}
+        paddingRight={rightPadding}
         alignItems="center"
         data-gloom-role="pane-footer"
         data-focused={focused ? "true" : "false"}
@@ -375,7 +376,7 @@ export function PaneFooterBar({
         <FooterContent
           footer={resolvedFooter}
           focused={focused}
-          width={width > 0 ? Math.max(0, Math.floor(width) - reservedRight - 2) : undefined}
+          width={width > 0 ? Math.max(0, Math.floor(width) - rightPadding - 1) : undefined}
           showBackground={false}
         />
       </Box>

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -473,18 +473,28 @@ function isStyledTextContent(value: unknown): value is { chunks: StyledTextChunk
     || (!!value && typeof value === "object" && Array.isArray((value as { chunks?: unknown }).chunks));
 }
 
+function styledTextChunkStyle(baseProps: TextProps, chunk: StyledTextChunk): CSSProperties {
+  const style = textStyle({
+    ...baseProps,
+    fg: typeof chunk.fg === "string" ? chunk.fg : baseProps.fg,
+    bg: typeof chunk.bg === "string" ? chunk.bg : baseProps.bg,
+    attributes: chunk.attributes,
+  });
+  style.display = "inline";
+  style.width = undefined;
+  style.maxWidth = undefined;
+  style.minWidth = undefined;
+  style.flexShrink = undefined;
+  return style;
+}
+
 function renderTextContent(children: ReactNode, content: TextProps["content"], baseProps: TextProps): ReactNode {
   const resolved = children ?? content;
   if (!isStyledTextContent(resolved)) return resolved;
   return resolved.chunks.map((chunk, index) => (
     <span
       key={index}
-      style={textStyle({
-        ...baseProps,
-        fg: typeof chunk.fg === "string" ? chunk.fg : baseProps.fg,
-        bg: typeof chunk.bg === "string" ? chunk.bg : baseProps.bg,
-        attributes: chunk.attributes,
-      })}
+      style={styledTextChunkStyle(baseProps, chunk)}
     >
       {chunk.text}
     </span>
@@ -877,7 +887,7 @@ function WebTabs({
   const activeTabRef = useRef<HTMLButtonElement | null>(null);
   const [hoveredValue, setHoveredValue] = useState<string | null>(null);
   const showUnderline = variant === "underline" && !compact;
-  const listHeight = showUnderline ? 28 : "100%";
+  const listHeight = showUnderline ? 28 : compact ? WEB_CELL_HEIGHT : "100%";
   const tabFontSize = compact || showUnderline ? 12 : 13;
   const tabPaddingInline = showUnderline ? 10 : 8;
   const tabPaddingBlock = variant === "bare" || variant === "pill" ? 2 : 0;


### PR DESCRIPTION
Fixes desktop styled text rendering so shortcut hint key chunks and labels stay inline instead of inheriting the parent width. Tightens native pane footer right padding when a resize-handle reserve is present so floating footer hints sit closer to the edge. Keeps compact desktop tabs at one terminal cell height. Verified with desktop:view:build and the pane-footer test file.