### PR TITLE
Add signed macOS desktop artifacts to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,87 @@ jobs:
           name: ${{ matrix.asset }}
           path: dist/*
 
+  desktop-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install
+
+      - name: Configure Apple signing
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+          ELECTROBUN_APPLEAPIKEY: ${{ secrets.ELECTROBUN_APPLEAPIKEY }}
+          ELECTROBUN_APPLEAPIKEY_BASE64: ${{ secrets.ELECTROBUN_APPLEAPIKEY_BASE64 }}
+          ELECTROBUN_APPLEAPIISSUER: ${{ secrets.ELECTROBUN_APPLEAPIISSUER }}
+          ELECTROBUN_DEVELOPER_ID: ${{ secrets.ELECTROBUN_DEVELOPER_ID }}
+        run: |
+          set -euo pipefail
+
+          : "${APPLE_CERTIFICATE_BASE64:?missing APPLE_CERTIFICATE_BASE64 secret}"
+          : "${APPLE_CERTIFICATE_PASSWORD:?missing APPLE_CERTIFICATE_PASSWORD secret}"
+          : "${APPLE_KEYCHAIN_PASSWORD:?missing APPLE_KEYCHAIN_PASSWORD secret}"
+          : "${ELECTROBUN_APPLEAPIKEY:?missing ELECTROBUN_APPLEAPIKEY secret}"
+          : "${ELECTROBUN_APPLEAPIKEY_BASE64:?missing ELECTROBUN_APPLEAPIKEY_BASE64 secret}"
+          : "${ELECTROBUN_APPLEAPIISSUER:?missing ELECTROBUN_APPLEAPIISSUER secret}"
+          : "${ELECTROBUN_DEVELOPER_ID:?missing ELECTROBUN_DEVELOPER_ID secret}"
+
+          decode_base64() {
+            if base64 --help 2>&1 | grep -q -- "--decode"; then
+              base64 --decode
+            else
+              base64 -D
+            fi
+          }
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/apple-signing-certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          NOTARY_KEY_PATH="$RUNNER_TEMP/AuthKey_${ELECTROBUN_APPLEAPIKEY}.p8"
+
+          printf "%s" "$APPLE_CERTIFICATE_BASE64" | decode_base64 > "$CERTIFICATE_PATH"
+          printf "%s" "$ELECTROBUN_APPLEAPIKEY_BASE64" | decode_base64 > "$NOTARY_KEY_PATH"
+
+          security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          echo "ELECTROBUN_APPLEAPIKEYPATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Build signed desktop DMG
+        env:
+          ELECTROBUN_APPLEAPIISSUER: ${{ secrets.ELECTROBUN_APPLEAPIISSUER }}
+          ELECTROBUN_APPLEAPIKEY: ${{ secrets.ELECTROBUN_APPLEAPIKEY }}
+          ELECTROBUN_DEVELOPER_ID: ${{ secrets.ELECTROBUN_DEVELOPER_ID }}
+        run: bun run desktop:release
+
+      - name: Verify desktop artifacts
+        run: |
+          set -euo pipefail
+          test -f artifacts/stable-macos-arm64-Gloomberb.dmg
+          test -f artifacts/stable-macos-arm64-Gloomberb.app.tar.zst
+          test -f artifacts/stable-macos-arm64-update.json
+          codesign --verify --verbose=4 artifacts/stable-macos-arm64-Gloomberb.dmg
+          xcrun stapler validate -v artifacts/stable-macos-arm64-Gloomberb.dmg
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gloomberb-desktop-macos-arm64
+          path: artifacts/*
+
   release:
-    needs: build
+    needs:
+      - build
+      - desktop-macos
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 out
 dist
 build
+artifacts
 *.tgz
 
 # code coverage

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -1,6 +1,8 @@
 import type { ElectrobunConfig } from "electrobun/bun";
 import pkg from "./package.json";
 
+const RELEASE_BASE_URL = "https://github.com/vincelwt/gloomberb/releases/latest/download";
+
 const config: ElectrobunConfig = {
   app: {
     name: "Gloomberb",
@@ -31,7 +33,9 @@ const config: ElectrobunConfig = {
       "node_modules/**",
     ],
     mac: {
-      createDmg: false,
+      codesign: true,
+      createDmg: true,
+      notarize: true,
       icons: "icon.iconset",
       defaultRenderer: "native",
     },
@@ -44,6 +48,9 @@ const config: ElectrobunConfig = {
   },
   runtime: {
     exitOnLastWindowClosed: true,
+  },
+  release: {
+    baseUrl: RELEASE_BASE_URL,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "desktop:view:build": "bun run scripts/build-electrobun-view.ts",
     "desktop:dev": "electrobun dev --watch",
     "desktop:build": "electrobun build",
+    "desktop:release": "electrobun build --env=stable",
     "test": "bun test",
     "release": "./scripts/release.sh"
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -643,8 +643,9 @@ function AppInner({
 
   // Check for updates on mount
   useEffect(() => {
+    if (isDetachedWindow) return;
     void runUpdateCheck(false);
-  }, [runUpdateCheck]);
+  }, [isDetachedWindow, runUpdateCheck]);
 
   useEffect(() => {
     if (desktopWindowBridge?.kind !== "main" || !desktopApplicationMenuBridge) return;
@@ -695,10 +696,11 @@ function AppInner({
   ]);
 
   useEffect(() => {
+    if (isDetachedWindow) return;
     if (!state.updateAvailable || state.updateProgress || state.updateCheckInProgress) return;
     if (!canSelfUpdate(state.updateAvailable)) return;
     startUpdate(state.updateAvailable);
-  }, [startUpdate, state.updateAvailable, state.updateCheckInProgress, state.updateProgress]);
+  }, [isDetachedWindow, startUpdate, state.updateAvailable, state.updateCheckInProgress, state.updateProgress]);
 
   // Load tickers on mount
   useEffect(() => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -2723,9 +2723,9 @@ export function CommandBar({
         case "check-for-updates":
           if (state.updateProgress?.phase === "downloading") return `Downloading v${state.updateAvailable?.version}: ${state.updateProgress.percent ?? 0}%`;
           if (state.updateProgress?.phase === "replacing") return "Installing update";
-          if (state.updateProgress?.phase === "done") return "Update installed - restart to apply";
+          if (state.updateProgress?.phase === "done") return state.updateProgress.message ?? "Update installed - restart to apply";
           if (state.updateProgress?.phase === "error") return `Update failed: ${state.updateProgress.error}`;
-          if (state.updateCheckInProgress) return "Checking GitHub releases now";
+          if (state.updateCheckInProgress) return "Checking releases now";
           if (state.updateAvailable) return `Latest available: v${state.updateAvailable.version}`;
           if (state.updateNotice) return state.updateNotice;
           return command.description;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -82,7 +82,7 @@ function UpdateStatus() {
       );
     }
     if (updateProgress.phase === "done") {
-      return <Text fg={colors.headerText}>Update installed, restart to apply</Text>;
+      return <Text fg={colors.headerText}>{updateProgress.message ?? "Update installed, restart to apply"}</Text>;
     }
     if (updateProgress.phase === "error") {
       return <Text fg={colors.headerText}>Update failed: {updateProgress.error}</Text>;

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from "fs";
 import { mkdir, readFile, rm, unlink, writeFile } from "fs/promises";
 import { dirname, join } from "path";
-import Electrobun, { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu } from "electrobun/bun";
+import Electrobun, { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu, type UpdateStatusEntry } from "electrobun/bun";
 import { getAiProviderDefinitions } from "../../../plugins/builtin/ai/providers";
 import { runAiPrompt, type AiRunController } from "../../../plugins/builtin/ai/runner";
 import {
@@ -24,6 +24,7 @@ import type { PaneRuntimeState } from "../../../core/state/app-state";
 import type { QuoteSubscriptionTarget } from "../../../types/data-provider";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot } from "../../../types/desktop-window";
 import type { BrokerOrderRequest } from "../../../types/trading";
+import type { ReleaseInfo, UpdateCheckResult, UpdateProgress } from "../../../updater";
 import { buildSoundCommand } from "../../../notifications/app-notifier";
 import { isPaneDetached } from "../../../plugins/pane-manager";
 import { ELECTROBUN_CONTEXT_MENU_ACTION, type ElectrobunDesktopRpcSchema } from "../shared/protocol";
@@ -68,6 +69,7 @@ let services: AppServices | null = null;
 let mainWindow: BrowserWindow | null = null;
 let desktopWorkspace: DesktopWorkspace | null = null;
 let currentDockPreview: DesktopDockPreviewState = { paneId: null, edge: null };
+let desktopUpdateInProgress = false;
 
 const detachedWindows = new Map<string, BrowserWindow>();
 const detachedFrameTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -253,6 +255,166 @@ function playNotificationSound(sound: string | undefined): void {
       command: command.command,
       message: error instanceof Error ? error.message : String(error),
     });
+  }
+}
+
+function desktopReleasePlatformPrefix(channel: string): string {
+  const os = process.platform === "darwin" ? "macos" : process.platform === "win32" ? "win" : "linux";
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  return `${channel}-${os}-${arch}`;
+}
+
+async function desktopReleaseInfo(updateInfo: {
+  version?: string;
+  hash?: string;
+}, currentVersion: string): Promise<ReleaseInfo> {
+  const [channel, baseUrl] = await Promise.all([
+    Electrobun.Updater.localInfo.channel(),
+    Electrobun.Updater.localInfo.baseUrl(),
+  ]);
+  const version = updateInfo.version || currentVersion;
+  return {
+    version,
+    tagName: `v${version}`,
+    downloadUrl: `${baseUrl.replace(/\/+$/, "")}/${desktopReleasePlatformPrefix(channel)}-update.json`,
+    publishedAt: "",
+    updateAction: { kind: "desktop" },
+  };
+}
+
+function mapDesktopUpdateStatus(entry: UpdateStatusEntry): UpdateProgress | null {
+  const progress = entry.details?.progress;
+  switch (entry.status) {
+    case "downloading":
+    case "download-starting":
+    case "checking-local-tar":
+    case "local-tar-found":
+    case "local-tar-missing":
+    case "fetching-patch":
+    case "patch-found":
+    case "patch-not-found":
+    case "downloading-patch":
+    case "downloading-full-bundle":
+    case "download-progress":
+      return {
+        phase: "downloading",
+        percent: typeof progress === "number" ? progress : undefined,
+      };
+    case "applying-patch":
+    case "patch-applied":
+    case "extracting-version":
+    case "patch-chain-complete":
+    case "decompressing":
+    case "download-complete":
+    case "applying":
+    case "extracting":
+    case "replacing-app":
+    case "launching-new-version":
+      return { phase: "replacing" };
+    case "complete":
+      return { phase: "done", message: "Update installed, restarting..." };
+    case "error":
+      return {
+        phase: "error",
+        error: entry.details?.errorMessage || entry.message,
+      };
+    default:
+      return null;
+  }
+}
+
+function sendUpdateProgress(rpc: DesktopRpc, progress: UpdateProgress): void {
+  try {
+    rpc.send["update.progress"]({
+      progress: encodeRpcValue(progress),
+    });
+  } catch (error) {
+    console.warn("update progress send failed", summarizeError(error));
+  }
+}
+
+async function checkDesktopUpdate(currentVersion: string): Promise<UpdateCheckResult> {
+  try {
+    const [channel, baseUrl] = await Promise.all([
+      Electrobun.Updater.localInfo.channel(),
+      Electrobun.Updater.localInfo.baseUrl(),
+    ]);
+    if (channel === "dev" || !baseUrl) {
+      return { kind: "disabled" };
+    }
+
+    const info = await Electrobun.Updater.checkForUpdate();
+    if (info.error) {
+      return { kind: "error", error: info.error };
+    }
+    if (!info.updateAvailable) {
+      return { kind: "current" };
+    }
+
+    return {
+      kind: "available",
+      release: await desktopReleaseInfo(info, currentVersion),
+    };
+  } catch (error) {
+    return {
+      kind: "error",
+      error: error instanceof Error ? error.message : "Desktop update check failed",
+    };
+  }
+}
+
+async function runDesktopUpdate(rpc: DesktopRpc, currentVersion: string): Promise<void> {
+  if (desktopUpdateInProgress) {
+    sendUpdateProgress(rpc, {
+      phase: "error",
+      error: "A desktop update is already in progress.",
+    });
+    return;
+  }
+
+  desktopUpdateInProgress = true;
+  Electrobun.Updater.clearStatusHistory();
+  Electrobun.Updater.onStatusChange((entry) => {
+    const progress = mapDesktopUpdateStatus(entry);
+    if (progress) sendUpdateProgress(rpc, progress);
+  });
+
+  try {
+    sendUpdateProgress(rpc, { phase: "downloading", percent: 0 });
+    const result = await checkDesktopUpdate(currentVersion);
+    if (result.kind === "error") {
+      sendUpdateProgress(rpc, { phase: "error", error: result.error });
+      return;
+    }
+    if (result.kind !== "available") {
+      sendUpdateProgress(rpc, {
+        phase: "done",
+        message: result.kind === "disabled" ? "Desktop updates are unavailable in this build" : "Already on the latest version",
+      });
+      return;
+    }
+
+    await Electrobun.Updater.downloadUpdate();
+    const updateInfo = Electrobun.Updater.updateInfo();
+    if (updateInfo?.error) {
+      sendUpdateProgress(rpc, { phase: "error", error: updateInfo.error });
+      return;
+    }
+    if (!updateInfo?.updateReady) {
+      sendUpdateProgress(rpc, { phase: "error", error: "Desktop update did not finish downloading." });
+      return;
+    }
+
+    sendUpdateProgress(rpc, { phase: "replacing" });
+    await Electrobun.Updater.applyUpdate();
+  } catch (error) {
+    sendUpdateProgress(rpc, {
+      phase: "error",
+      error: error instanceof Error ? error.message : "Desktop update failed",
+    });
+  } finally {
+    desktopUpdateInProgress = false;
+    Electrobun.Updater.onStatusChange(null);
   }
 }
 
@@ -1129,6 +1291,18 @@ async function handleBackendRequest(
   if (method.startsWith("desktop.")) return handleDesktop(rpc, method, payload);
 
   switch (method) {
+    case "update.check":
+      return checkDesktopUpdate(typeof payload.currentVersion === "string" ? payload.currentVersion : "");
+    case "update.start": {
+      const release = payload.release && typeof payload.release === "object"
+        ? payload.release as Partial<ReleaseInfo>
+        : null;
+      void runDesktopUpdate(
+        rpc,
+        typeof payload.currentVersion === "string" ? payload.currentVersion : release?.version ?? "",
+      );
+      return null;
+    }
     case "ticker.loadAll":
       return requireServices().tickerRepository.loadAllTickers();
     case "ticker.load":

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -2,6 +2,7 @@ import type { AppSessionSnapshot } from "../../../core/state/session-persistence
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot } from "../../../types/desktop-window";
 import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu";
 import type { AppConfig } from "../../../types/config";
+import type { UpdateProgress } from "../../../updater";
 
 export const ELECTROBUN_CONTEXT_MENU_ACTION = "gloom.context-menu.select";
 
@@ -59,6 +60,10 @@ export interface DesktopDockPreviewMessage {
   preview: DesktopDockPreviewState;
 }
 
+export interface UpdateProgressMessage {
+  progress: UpdateProgress;
+}
+
 export interface ElectrobunDesktopRpcSchema {
   bun: {
     requests: {
@@ -81,6 +86,7 @@ export interface ElectrobunDesktopRpcSchema {
       "application-menu.select": ApplicationMenuSelectMessage;
       "desktop.state": DesktopStateMessage;
       "desktop.dockPreview": DesktopDockPreviewMessage;
+      "update.progress": UpdateProgressMessage;
     };
   };
 }

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -12,6 +12,7 @@ import {
   type IbkrResolvedMessage,
   type IbkrSnapshotMessage,
   type QuoteUpdateMessage,
+  type UpdateProgressMessage,
 } from "../shared/protocol";
 import { decodeRpcValue, encodeRpcValue } from "./rpc-codec";
 
@@ -23,6 +24,7 @@ type ContextMenuSelectListener = (message: ContextMenuSelectMessage) => void;
 type ApplicationMenuSelectListener = (message: ApplicationMenuSelectMessage) => void;
 type DesktopStateListener = (message: DesktopStateMessage) => void;
 type DesktopDockPreviewListener = (message: DesktopDockPreviewMessage) => void;
+type UpdateProgressListener = (message: UpdateProgressMessage) => void;
 
 let initSnapshot: ElectrobunBackendInit | null = null;
 const quoteListeners = new Map<string, Set<QuoteListener>>();
@@ -34,6 +36,7 @@ const contextMenuSelectListeners = new Map<string, Set<ContextMenuSelectListener
 const applicationMenuSelectListeners = new Set<ApplicationMenuSelectListener>();
 const desktopStateListeners = new Set<DesktopStateListener>();
 const desktopDockPreviewListeners = new Set<DesktopDockPreviewListener>();
+const updateProgressListeners = new Set<UpdateProgressListener>();
 
 function dispatch<T>(
   listeners: Map<string, Set<(value: T) => void>>,
@@ -119,6 +122,12 @@ const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
       "desktop.dockPreview": (message) => {
         for (const listener of desktopDockPreviewListeners) {
           listener({ preview: decodeRpcValue(message.preview) });
+        }
+      },
+      "update.progress": (message) => {
+        const decoded = { progress: decodeRpcValue<UpdateProgressMessage["progress"]>(message.progress) };
+        for (const listener of updateProgressListeners) {
+          listener(decoded);
         }
       },
     },
@@ -218,5 +227,12 @@ export function onDesktopDockPreview(listener: DesktopDockPreviewListener): () =
   desktopDockPreviewListeners.add(listener);
   return () => {
     desktopDockPreviewListeners.delete(listener);
+  };
+}
+
+export function onUpdateProgress(listener: UpdateProgressListener): () => void {
+  updateProgressListeners.add(listener);
+  return () => {
+    updateProgressListeners.delete(listener);
   };
 }

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -11,6 +11,7 @@ import { installElectrobunAiHost } from "./ai-host";
 import { installElectrobunConfigStoreHost } from "./config-host";
 import { WebDialogHostProvider } from "./dialog-host";
 import { installElectrobunCloudApiFetchTransport, installElectrobunPredictionMarketsFetchTransport } from "./http-fetch";
+import { installElectrobunUpdateHost } from "./update-host";
 import { WebInputHostProvider } from "./input-host";
 import { webNativeRenderer } from "./native-renderer";
 import { WebToastHostProvider } from "./toast-host";
@@ -52,6 +53,7 @@ async function boot() {
   installElectrobunConfigStoreHost();
   installElectrobunPredictionMarketsFetchTransport();
   installElectrobunCloudApiFetchTransport();
+  installElectrobunUpdateHost();
   await installElectrobunAiHost();
   const init = await measurePerfAsync("startup.electrobun.backend-init", () => backendInitPromise);
   const desktopSnapshot = init.windowKind === "detached" && init.paneId && init.desktopSnapshot

--- a/src/renderers/electrobun/view/update-host.ts
+++ b/src/renderers/electrobun/view/update-host.ts
@@ -1,0 +1,38 @@
+import {
+  setUpdateHost,
+  type ReleaseInfo,
+  type UpdateCheckResult,
+  type UpdateProgress,
+} from "../../../updater";
+import { backendRequest, onUpdateProgress } from "./backend-rpc";
+
+export function installElectrobunUpdateHost(): void {
+  setUpdateHost({
+    checkForUpdateDetailed(currentVersion: string): Promise<UpdateCheckResult> {
+      return backendRequest<UpdateCheckResult>("update.check", { currentVersion });
+    },
+    performUpdate(release: ReleaseInfo, onProgress: (progress: UpdateProgress) => void): Promise<void> {
+      return new Promise((resolve) => {
+        let settled = false;
+        const unsubscribe = onUpdateProgress(({ progress }) => {
+          onProgress(progress);
+          if (progress.phase === "done" || progress.phase === "error") {
+            settled = true;
+            unsubscribe();
+            resolve();
+          }
+        });
+
+        backendRequest("update.start", { release }).catch((error) => {
+          if (settled) return;
+          unsubscribe();
+          onProgress({
+            phase: "error",
+            error: error instanceof Error ? error.message : String(error),
+          });
+          resolve();
+        });
+      });
+    },
+  });
+}

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -10,6 +10,7 @@ import {
   detectUpdateAction,
   performUpdate,
   resolveSelfUpdateTargetPath,
+  setUpdateHost,
   type ReleaseInfo,
   type UpdateProgress,
 } from "./updater";
@@ -18,6 +19,7 @@ const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  setUpdateHost(null);
 });
 
 function expectedAssetName(compressed = false): string {
@@ -96,6 +98,73 @@ describe("canSelfUpdate", () => {
     expect(canSelfUpdate({
       updateAction: { kind: "self" },
     })).toBe(true);
+  });
+
+  test("returns true for desktop update releases", () => {
+    expect(canSelfUpdate({
+      updateAction: { kind: "desktop" },
+    })).toBe(true);
+  });
+});
+
+describe("update host", () => {
+  test("delegates update checks to an installed host", async () => {
+    setUpdateHost({
+      async checkForUpdateDetailed() {
+        return {
+          kind: "available",
+          release: {
+            version: "0.4.0",
+            tagName: "v0.4.0",
+            downloadUrl: "https://example.com/stable-macos-arm64-update.json",
+            publishedAt: "",
+            updateAction: { kind: "desktop" },
+          },
+        };
+      },
+      async performUpdate() {},
+    });
+
+    await expect(checkForUpdateDetailed("0.3.1")).resolves.toEqual({
+      kind: "available",
+      release: {
+        version: "0.4.0",
+        tagName: "v0.4.0",
+        downloadUrl: "https://example.com/stable-macos-arm64-update.json",
+        publishedAt: "",
+        updateAction: { kind: "desktop" },
+      },
+    });
+  });
+
+  test("delegates update installation and progress to an installed host", async () => {
+    const progress: UpdateProgress[] = [];
+    const release: ReleaseInfo = {
+      version: "0.4.0",
+      tagName: "v0.4.0",
+      downloadUrl: "https://example.com/stable-macos-arm64-update.json",
+      publishedAt: "",
+      updateAction: { kind: "desktop" },
+    };
+
+    setUpdateHost({
+      async checkForUpdateDetailed() {
+        return { kind: "current" };
+      },
+      async performUpdate(_release, onProgress) {
+        onProgress({ phase: "downloading", percent: 50 });
+        onProgress({ phase: "done", message: "Update installed, restarting..." });
+      },
+    });
+
+    await performUpdate(release, (entry) => {
+      progress.push(entry);
+    });
+
+    expect(progress).toEqual([
+      { phase: "downloading", percent: 50 },
+      { phase: "done", message: "Update installed, restarting..." },
+    ]);
   });
 });
 

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -18,10 +18,12 @@ export interface UpdateProgress {
   phase: "downloading" | "replacing" | "done" | "error";
   percent?: number;
   error?: string;
+  message?: string;
 }
 
 export type UpdateAction =
   | { kind: "self" }
+  | { kind: "desktop" }
   | { kind: "manual"; command: string };
 
 export type UpdateCheckResult =
@@ -29,6 +31,17 @@ export type UpdateCheckResult =
   | { kind: "current" }
   | { kind: "disabled" }
   | { kind: "error"; error: string };
+
+export interface UpdateHost {
+  checkForUpdateDetailed(currentVersion: string): Promise<UpdateCheckResult>;
+  performUpdate(release: ReleaseInfo, onProgress: (p: UpdateProgress) => void): Promise<void>;
+}
+
+let updateHost: UpdateHost | null = null;
+
+export function setUpdateHost(host: UpdateHost | null): void {
+  updateHost = host;
+}
 
 function compareSemver(a: string, b: string): number {
   const pa = a.split(".").map(Number);
@@ -146,12 +159,16 @@ export function detectUpdateAction(
 }
 
 export function canSelfUpdate(release: Pick<ReleaseInfo, "updateAction"> | null | undefined): boolean {
-  return release?.updateAction.kind === "self";
+  return release?.updateAction.kind === "self" || release?.updateAction.kind === "desktop";
 }
 
 export async function checkForUpdateDetailed(
   currentVersion: string,
 ): Promise<UpdateCheckResult> {
+  if (updateHost) {
+    return updateHost.checkForUpdateDetailed(currentVersion);
+  }
+
   const updateAction = detectUpdateAction();
   if (!updateAction) {
     return { kind: "disabled" };
@@ -225,10 +242,25 @@ export async function performUpdate(
   release: ReleaseInfo,
   onProgress: (p: UpdateProgress) => void,
 ): Promise<void> {
+  if (updateHost) {
+    await updateHost.performUpdate(release, onProgress);
+    return;
+  }
+
   if (!canSelfUpdate(release)) {
     onProgress({
       phase: "error",
-      error: `Run ${release.updateAction.command}`,
+      error: release.updateAction.kind === "manual"
+        ? `Run ${release.updateAction.command}`
+        : "This update type is unavailable in the current runtime.",
+    });
+    return;
+  }
+
+  if (release.updateAction.kind === "desktop") {
+    onProgress({
+      phase: "error",
+      error: "Desktop updates are unavailable outside the packaged desktop app.",
     });
     return;
   }


### PR DESCRIPTION
## Summary
- add a macOS desktop release job that imports the Apple signing materials, builds the signed and notarized DMG, verifies the output, and attaches the desktop artifacts to tagged releases
- enable Electrobun release packaging for signed DMG generation and desktop release metadata
- wire the packaged desktop renderer into Electrobun's updater so desktop builds can check for and apply release updates
- polish desktop update status handling so detached windows do not trigger update flows and the UI shows the correct install messages

## Verification
- `bun test src/updater.test.ts`
- `bun run desktop:view:build`
- GitHub Actions proof run on the updated snapshot: https://github.com/vincelwt/gloomberb/actions/runs/24664274553
