### PR TITLE
Add breaking news notifications

### DIFF
--- a/src/components/command-bar/workflow-ops.ts
+++ b/src/components/command-bar/workflow-ops.ts
@@ -356,6 +356,14 @@ export async function applyPaneSettingFieldValue(
   const state = deps.getState();
   const shouldPushHistory = options?.pushHistory !== false;
 
+  if (field.storage === "plugin") {
+    if (!descriptor.pluginId) {
+      throw new Error("This pane setting is not owned by a plugin.");
+    }
+    await deps.pluginRegistry.setConfigState(descriptor.pluginId, field.key, value);
+    return;
+  }
+
   if (descriptor.pane.paneId === "quote-monitor" && field.key === "symbol") {
     const rawQuery = typeof value === "string" ? value.trim() : "";
     const resolvedTicker = await resolveTickerSearch({

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -50,6 +50,7 @@ export function createAppServices({
   pluginRegistry.getConfigFn = () => config;
   pluginRegistry.getLayoutFn = () => config.layout;
   pluginRegistry.registerNewsSourceFn = (source) => newsService.register(source);
+  pluginRegistry.watchNewsQueryFn = (query, listener) => newsService.watchQuery(query, listener);
 
   setSharedNewsService(newsService);
   setSharedMarketDataCoordinator(marketData);

--- a/src/news/aggregator.test.ts
+++ b/src/news/aggregator.test.ts
@@ -188,6 +188,26 @@ describe("NewsService", () => {
     expect(callCount).toBe(2); // unsubscribed, no more calls
   });
 
+  it("watchQuery refreshes a query without a mounted pane", async () => {
+    const item = makeItem({ url: "https://watch.example.com/1", isBreaking: true });
+    const states: string[][] = [];
+
+    agg.register(makeSource("watch", [item]));
+    const dispose = agg.watchQuery(
+      { feed: "breaking", breaking: true, limit: 20 },
+      (state) => states.push(state.articles.map((article) => article.url)),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(states).toContainEqual([item.url]);
+
+    const callCount = states.length;
+    dispose();
+    await agg.poll({ feed: "breaking", breaking: true, limit: 20 });
+    expect(states).toHaveLength(callCount);
+  });
+
   it("seeds cached source items immediately on register", () => {
     const cached = makeItem({ url: "https://cached.example.com/1", importance: 70 });
     let callCount = 0;

--- a/src/news/aggregator.ts
+++ b/src/news/aggregator.ts
@@ -5,6 +5,8 @@ export interface NewsServiceOptions {
   pollIntervalMs?: number;
 }
 
+export type NewsQueryListener = (state: NewsQueryState) => void;
+
 const MAX_ARTICLES = 500;
 const DEFAULT_POLL_INTERVAL_MS = 2 * 60 * 1000;
 const DEFAULT_GLOBAL_QUERY: NewsQuery = { feed: "latest", limit: MAX_ARTICLES };
@@ -161,6 +163,7 @@ export class NewsService {
   private readonly listeners = new Set<() => void>();
   private readonly queryStates = new Map<string, NewsQueryState>();
   private readonly queryByKey = new Map<string, NewsQuery>();
+  private readonly watchedQueries = new Map<string, { query: NewsQuery; refs: number }>();
   private readonly inFlight = new Map<string, Promise<NewsQueryState>>();
   private articles: NewsArticle[] = [];
   private version = 0;
@@ -201,6 +204,35 @@ export class NewsService {
     return () => this.listeners.delete(listener);
   }
 
+  watchQuery(query: NewsQuery, listener: NewsQueryListener): () => void {
+    const normalized = normalizeQuery(query);
+    const key = buildNewsQueryKey(normalized);
+    const currentWatch = this.watchedQueries.get(key);
+    this.watchedQueries.set(key, {
+      query: normalized,
+      refs: (currentWatch?.refs ?? 0) + 1,
+    });
+
+    const emit = () => listener(this.queryStates.get(key) ?? createIdleState());
+    const unsubscribe = this.subscribe(emit);
+    emit();
+    void this.refreshQuery(normalized, false, { track: false });
+
+    let disposed = false;
+    return () => {
+      if (disposed) return;
+      disposed = true;
+      unsubscribe();
+      const watch = this.watchedQueries.get(key);
+      if (!watch) return;
+      if (watch.refs <= 1) {
+        this.watchedQueries.delete(key);
+      } else {
+        this.watchedQueries.set(key, { query: watch.query, refs: watch.refs - 1 });
+      }
+    };
+  }
+
   getVersion(): number {
     return this.version;
   }
@@ -228,14 +260,26 @@ export class NewsService {
   }
 
   private async pollActiveQueries(): Promise<void> {
-    const queries = [...this.queryByKey.values()];
-    if (queries.length === 0) return;
-    await Promise.allSettled(queries.map((query) => this.refreshQuery(query, false)));
+    const queries = new Map<string, NewsQuery>();
+    for (const query of this.queryByKey.values()) {
+      queries.set(buildNewsQueryKey(query), query);
+    }
+    for (const [key, watch] of this.watchedQueries) {
+      queries.set(key, watch.query);
+    }
+    if (queries.size === 0) return;
+    await Promise.allSettled([...queries.values()].map((query) => this.refreshQuery(query, false, { track: false })));
   }
 
-  private async refreshQuery(query: NewsQuery, showLoading: boolean): Promise<NewsQueryState> {
+  private async refreshQuery(
+    query: NewsQuery,
+    showLoading: boolean,
+    options: { track?: boolean } = {},
+  ): Promise<NewsQueryState> {
     const key = buildNewsQueryKey(query);
-    this.queryByKey.set(key, query);
+    if (options.track !== false) {
+      this.queryByKey.set(key, query);
+    }
     const existingFlight = this.inFlight.get(key);
     if (existingFlight) return existingFlight;
 

--- a/src/plugins/builtin/news-wire/breaking-notifications.test.ts
+++ b/src/plugins/builtin/news-wire/breaking-notifications.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { AppNotificationRequest, GloomPluginContext } from "../../../types/plugin";
+import type { MarketNewsItem, NewsQueryState } from "../../../types/news-source";
+import {
+  BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY,
+  setupBreakingNewsNotifications,
+} from "./breaking-notifications";
+
+function article(id: string, title = id): MarketNewsItem {
+  return {
+    id,
+    title,
+    url: `https://example.com/${id}`,
+    source: "Test Wire",
+    publishedAt: new Date(),
+    topic: "general",
+    topics: ["general"],
+    sectors: [],
+    categories: ["general"],
+    tickers: ["AAPL"],
+    scores: {
+      importance: 90,
+      urgency: 90,
+      marketImpact: 80,
+      novelty: 80,
+      confidence: 90,
+    },
+    importance: 90,
+    isBreaking: true,
+    isDeveloping: false,
+  };
+}
+
+function ready(articles: MarketNewsItem[]): NewsQueryState {
+  return {
+    phase: "ready",
+    articles,
+    error: null,
+    updatedAt: Date.now(),
+    sourceIds: ["test"],
+  };
+}
+
+describe("breaking news notifications", () => {
+  test("primes on the first ready batch and notifies for later unseen articles", () => {
+    let enabled = true;
+    let listener: ((state: NewsQueryState) => void) | null = null;
+    const notifications: AppNotificationRequest[] = [];
+    const shownPanes: string[] = [];
+
+    const ctx = {
+      configState: {
+        get: (key: string) => key === BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY ? enabled : null,
+      },
+      watchNewsQuery: (_query: unknown, nextListener: (state: NewsQueryState) => void) => {
+        listener = nextListener;
+        return () => {
+          listener = null;
+        };
+      },
+      on: (_event: string, _handler: unknown) => () => {},
+      notify: (notification: AppNotificationRequest) => {
+        notifications.push(notification);
+      },
+      showPane: (paneId: string) => {
+        shownPanes.push(paneId);
+      },
+      log: {
+        warn: () => {},
+      },
+    } as unknown as GloomPluginContext;
+
+    const dispose = setupBreakingNewsNotifications(ctx);
+    const oldArticle = article("old", "Old headline");
+    const newArticle = article("new", "New headline");
+
+    listener?.(ready([oldArticle]));
+    listener?.(ready([newArticle, oldArticle]));
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      title: "Breaking News",
+      body: "New headline",
+      desktop: "always",
+      persistent: true,
+    });
+
+    notifications[0]!.action?.onClick();
+    expect(shownPanes).toEqual(["news-breaking"]);
+
+    enabled = false;
+    listener?.(ready([article("newer", "Newer headline"), newArticle, oldArticle]));
+    expect(notifications).toHaveLength(1);
+
+    dispose();
+    expect(listener).toBeNull();
+  });
+});

--- a/src/plugins/builtin/news-wire/breaking-notifications.ts
+++ b/src/plugins/builtin/news-wire/breaking-notifications.ts
@@ -1,0 +1,110 @@
+import type { GloomPluginContext } from "../../../types/plugin";
+import type { MarketNewsItem, NewsQueryState } from "../../../types/news-source";
+import { NEWS_QUERY_PRESETS } from "./news-query-presets";
+
+export const BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY = "breakingNewsNotificationsEnabled";
+
+const MAX_SEEN_ARTICLE_IDS = 500;
+
+function isReadyState(state: NewsQueryState): boolean {
+  return state.phase === "ready" || state.phase === "refreshing";
+}
+
+function rememberArticleIds(current: Set<string>, articles: MarketNewsItem[]): Set<string> {
+  const next: string[] = [];
+  const included = new Set<string>();
+
+  for (const article of articles) {
+    if (included.has(article.id)) continue;
+    included.add(article.id);
+    next.push(article.id);
+  }
+
+  for (const id of current) {
+    if (included.has(id)) continue;
+    included.add(id);
+    next.push(id);
+    if (next.length >= MAX_SEEN_ARTICLE_IDS) break;
+  }
+
+  return new Set(next.slice(0, MAX_SEEN_ARTICLE_IDS));
+}
+
+function notificationSubtitle(article: MarketNewsItem): string {
+  const tickers = article.tickers.slice(0, 3).join(" ");
+  return tickers ? `${article.source} ${tickers}` : article.source;
+}
+
+function notifyNewBreakingArticles(ctx: GloomPluginContext, articles: MarketNewsItem[]): void {
+  const latest = [...articles].sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime())[0];
+  if (!latest) return;
+
+  const extraCount = articles.length - 1;
+  ctx.notify({
+    title: "Breaking News",
+    subtitle: notificationSubtitle(latest),
+    body: extraCount > 0 ? `${latest.title} (+${extraCount} more)` : latest.title,
+    type: "info",
+    desktop: "always",
+    persistent: true,
+    action: {
+      label: "Open",
+      onClick: () => ctx.showPane("news-breaking"),
+    },
+  });
+}
+
+export function setupBreakingNewsNotifications(ctx: GloomPluginContext): () => void {
+  let disposeWatch: (() => void) | null = null;
+  let primed = false;
+  let seenArticleIds = new Set<string>();
+
+  const enabled = () => ctx.configState.get<boolean>(BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY) === true;
+
+  const handleState = (state: NewsQueryState) => {
+    if (!isReadyState(state)) return;
+
+    if (!primed) {
+      seenArticleIds = rememberArticleIds(seenArticleIds, state.articles);
+      primed = true;
+      return;
+    }
+
+    const freshArticles = state.articles.filter((article) => !seenArticleIds.has(article.id));
+    if (freshArticles.length === 0) return;
+
+    seenArticleIds = rememberArticleIds(seenArticleIds, state.articles);
+    if (enabled()) {
+      notifyNewBreakingArticles(ctx, freshArticles);
+    }
+  };
+
+  const stop = () => {
+    disposeWatch?.();
+    disposeWatch = null;
+    primed = false;
+    seenArticleIds = new Set();
+  };
+
+  const start = () => {
+    if (disposeWatch) return;
+    if (!ctx.watchNewsQuery) {
+      ctx.log.warn("breaking notifications unavailable: news query watcher missing");
+      return;
+    }
+    disposeWatch = ctx.watchNewsQuery(NEWS_QUERY_PRESETS.breaking, handleState);
+  };
+
+  const sync = () => {
+    if (enabled()) start();
+    else stop();
+  };
+
+  const disposeConfigListener = ctx.on("config:changed", sync);
+  sync();
+
+  return () => {
+    disposeConfigListener();
+    stop();
+  };
+}

--- a/src/plugins/builtin/news-wire/index.tsx
+++ b/src/plugins/builtin/news-wire/index.tsx
@@ -4,6 +4,10 @@ import { TopPane } from "./top-pane";
 import { FeedPane } from "./feed-pane";
 import { IndustryPane } from "./industry-pane";
 import { BreakingPane } from "./breaking-pane";
+import {
+  BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY,
+  setupBreakingNewsNotifications,
+} from "./breaking-notifications";
 import { setDigestPersistence } from "./digest-store";
 import {
   addUserNewsFeed,
@@ -12,12 +16,30 @@ import {
   saveNewsFeedSettings,
 } from "./feed-config";
 
-export function registerNewsWireFeatures(ctx: GloomPluginContext): void {
+export function registerNewsWireFeatures(ctx: GloomPluginContext): () => void {
   setDigestPersistence(ctx.persistence);
   ctx.registerPane({ id: "news-top", name: "Top News", icon: "T", component: TopPane, defaultPosition: "right", defaultMode: "floating", defaultFloatingSize: { width: 90, height: 30 } });
   ctx.registerPane({ id: "news-feed", name: "News Feed", icon: "N", component: FeedPane, defaultPosition: "right", defaultMode: "floating", defaultFloatingSize: { width: 100, height: 35 } });
   ctx.registerPane({ id: "news-industry", name: "Sector News", icon: "S", component: IndustryPane, defaultPosition: "right", defaultMode: "floating", defaultFloatingSize: { width: 100, height: 35 } });
-  ctx.registerPane({ id: "news-breaking", name: "Breaking News", icon: "!", component: BreakingPane, defaultPosition: "right", defaultMode: "floating", defaultFloatingSize: { width: 85, height: 20 } });
+  ctx.registerPane({
+    id: "news-breaking",
+    name: "Breaking News",
+    icon: "!",
+    component: BreakingPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 85, height: 20 },
+    settings: {
+      title: "Breaking News Settings",
+      fields: [{
+        key: BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY,
+        label: "Notifications",
+        description: "Notify when new breaking stories arrive, even while this pane is closed.",
+        type: "toggle",
+        storage: "plugin",
+      }],
+    },
+  });
 
   ctx.registerPaneTemplate({ id: "news-top-pane", paneId: "news-top", label: "Top News", description: "Curated top market stories ranked by importance", keywords: ["top", "news", "headlines", "stories"], shortcut: { prefix: "TOP" } });
   ctx.registerPaneTemplate({ id: "news-feed-pane", paneId: "news-feed", label: "News Feed", description: "Chronological market news firehose", keywords: ["news", "feed", "firehose", "wire", "stream"], shortcut: { prefix: "N" } });
@@ -65,4 +87,6 @@ export function registerNewsWireFeatures(ctx: GloomPluginContext): void {
       ctx.notify({ body: `Added news feed: ${feed.name}`, type: "success" });
     },
   });
+
+  return setupBreakingNewsNotifications(ctx);
 }

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -19,6 +19,7 @@ const ARTICLE_SUMMARY_CACHE_POLICY = {
   expireMs: 90 * 24 * 60 * 60_000,
 };
 const NEWS_ITEM_LIMIT = 50;
+let disposeNewsWireFeatures: (() => void) | null = null;
 
 function getFeedItems(
   news: NewsArticle[],
@@ -158,6 +159,11 @@ export const newsPlugin: GloomPlugin = {
       order: 40,
       component: NewsTab,
     });
-    registerNewsWireFeatures(ctx);
+    disposeNewsWireFeatures = registerNewsWireFeatures(ctx);
+  },
+
+  dispose() {
+    disposeNewsWireFeatures?.();
+    disposeNewsWireFeatures = null;
   },
 };

--- a/src/plugins/registry.test.ts
+++ b/src/plugins/registry.test.ts
@@ -148,3 +148,48 @@ describe("PluginRegistry context menu providers", () => {
     expect(contextMenuLabels(registry.getContextMenuItems({ kind: "app" }))).toEqual(["Works"]);
   });
 });
+
+describe("PluginRegistry pane settings", () => {
+  test("resolves plugin-scoped pane setting values from plugin config", async () => {
+    const registry = createRegistry();
+    const config = createDefaultConfig("/tmp/gloomberb-pane-settings-test");
+    config.layout = {
+      dockRoot: { kind: "pane", instanceId: "test-pane:main" },
+      instances: [{
+        instanceId: "test-pane:main",
+        paneId: "test-pane",
+        binding: { kind: "none" },
+        settings: { breakingNewsNotificationsEnabled: false },
+      }],
+      floating: [],
+      detached: [],
+    };
+    config.pluginConfig = {
+      news: { breakingNewsNotificationsEnabled: true },
+    };
+    registry.getConfigFn = () => config;
+    registry.getLayoutFn = () => config.layout;
+
+    await registry.register(plugin("news", (ctx) => {
+      ctx.registerPane({
+        id: "test-pane",
+        name: "Test Pane",
+        defaultPosition: "right",
+        component: () => null,
+        settings: {
+          fields: [{
+            key: "breakingNewsNotificationsEnabled",
+            label: "Notifications",
+            type: "toggle",
+            storage: "plugin",
+          }],
+        },
+      });
+    }));
+
+    const descriptor = registry.resolvePaneSettings("test-pane:main");
+
+    expect(descriptor?.pluginId).toBe("news");
+    expect(descriptor?.context.settings.breakingNewsNotificationsEnabled).toBe(true);
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -74,6 +74,7 @@ interface PluginItems {
   contextMenuProviders: string[];
   eventDisposers: Array<() => void>;
   newsSourceDisposers: Array<() => void>;
+  newsQueryWatchDisposers: Array<() => void>;
 }
 
 export class PluginRegistry implements PluginRuntimeAccess {
@@ -82,6 +83,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   private unregisterFns = new Map<string, () => void>();
   private pluginItems = new Map<string, PluginItems>();
   private commandOwners = new Map<string, string>();
+  private paneOwners = new Map<string, string>();
   private paneTemplateOwners = new Map<string, string>();
   private shortcutOwners = new Map<string, string>();
   private dataProviderOwners = new Map<string, string>();
@@ -154,12 +156,18 @@ export class PluginRegistry implements PluginRuntimeAccess {
   getTermSizeFn: (() => { width: number; height: number }) = () => ({ width: 120, height: 40 });
 
   registerNewsSourceFn: ((source: import("../types/news-source").NewsSource) => () => void) = () => () => {};
+  watchNewsQueryFn: ((
+    query: import("../types/news-source").NewsQuery,
+    listener: (state: import("../types/news-source").NewsQueryState) => void,
+  ) => () => void) = () => () => {};
 
   notifyFn: ((notification: AppNotificationRequest) => void) = () => {};
   getPaneRuntimeStateFn: ((paneId: string) => PaneRuntimeState | null) = () => null;
   updatePaneRuntimeStateFn: ((paneId: string, patch: Partial<PaneRuntimeState>) => void) = () => {};
   applyPaneSettingValueFn: ((paneId: string, field: import("../types/plugin").PaneSettingField, value: unknown) => Promise<void>) = async () => {};
-  getPluginConfigValueFn: (<T = unknown>(pluginId: string, key: string) => T | null) = () => null;
+  getPluginConfigValueFn: (<T = unknown>(pluginId: string, key: string) => T | null) = (pluginId, key) => (
+    (this.getConfigFn().pluginConfig[pluginId]?.[key] as T | undefined) ?? null
+  );
   setPluginConfigValueFn: ((pluginId: string, key: string, value: unknown) => Promise<void>) = async () => {};
   setPluginConfigValuesFn: ((pluginId: string, values: Record<string, unknown>) => Promise<void>) = async () => {};
   deletePluginConfigValueFn: ((pluginId: string, key: string) => Promise<void>) = async () => {};
@@ -280,6 +288,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
       contextMenuProviders: [],
       eventDisposers: [],
       newsSourceDisposers: [],
+      newsQueryWatchDisposers: [],
     };
     this.pluginItems.set(pluginId, items);
     return items;
@@ -376,6 +385,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
 
   resolvePaneSettings(paneId: string): {
     paneId: string;
+    pluginId?: string;
     pane: PaneInstanceConfig;
     paneDef: PaneDef;
     settingsDef: PaneSettingsDef;
@@ -392,6 +402,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
     if (!paneDef?.settings) return null;
 
     const config = this.getConfigFn();
+    const pluginId = this.paneOwners.get(pane.paneId);
+    const paneSettings = getPaneSettings(pane);
     const paneStateMap = Object.fromEntries(
       layout.instances.map((instance) => [instance.instanceId, this.getPaneRuntimeStateFn(instance.instanceId) ?? {}]),
     );
@@ -406,7 +418,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
       paneId: targetPaneId,
       paneType: pane.paneId,
       pane,
-      settings: getPaneSettings(pane),
+      settings: paneSettings,
       paneState,
       activeTicker: resolveTickerForPane(stateView, targetPaneId),
       activeCollectionId: resolveCollectionForPane(stateView, targetPaneId),
@@ -416,8 +428,23 @@ export class PluginRegistry implements PluginRuntimeAccess {
       : paneDef.settings;
     if (!settingsDef) return null;
 
+    if (pluginId) {
+      const resolvedSettings = { ...paneSettings };
+      for (const field of settingsDef.fields) {
+        if (field.storage !== "plugin") continue;
+        const configValue = this.getConfigState(pluginId, field.key);
+        if (configValue === null) {
+          delete resolvedSettings[field.key];
+        } else {
+          resolvedSettings[field.key] = configValue;
+        }
+      }
+      context.settings = resolvedSettings;
+    }
+
     return {
       paneId: targetPaneId,
+      pluginId,
       pane,
       paneDef,
       settingsDef,
@@ -549,7 +576,11 @@ export class PluginRegistry implements PluginRuntimeAccess {
     };
 
     return {
-      registerPane: (pane) => { this.panesMap.set(pane.id, this.wrapPaneDef(pluginId, pane)); items.panes.push(pane.id); },
+      registerPane: (pane) => {
+        this.panesMap.set(pane.id, this.wrapPaneDef(pluginId, pane));
+        this.paneOwners.set(pane.id, pluginId);
+        items.panes.push(pane.id);
+      },
       registerPaneTemplate: (template) => {
         this.paneTemplatesMap.set(template.id, template);
         this.paneTemplateOwners.set(template.id, pluginId);
@@ -594,6 +625,11 @@ export class PluginRegistry implements PluginRuntimeAccess {
         };
         const dispose = this.registerNewsSourceFn(ownedSource);
         items.newsSourceDisposers.push(dispose);
+        return dispose;
+      },
+      watchNewsQuery: (query, listener) => {
+        const dispose = this.watchNewsQueryFn(query, listener);
+        items.newsQueryWatchDisposers.push(dispose);
         return dispose;
       },
 
@@ -653,6 +689,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
     if (plugin.panes) {
       for (const pane of plugin.panes) {
         this.panesMap.set(pane.id, this.wrapPaneDef(plugin.id, pane));
+        this.paneOwners.set(pane.id, plugin.id);
         items.panes.push(pane.id);
       }
     }
@@ -734,7 +771,10 @@ export class PluginRegistry implements PluginRuntimeAccess {
 
     const items = this.pluginItems.get(pluginId);
     if (items) {
-      for (const paneId of items.panes) this.panesMap.delete(paneId);
+      for (const paneId of items.panes) {
+        this.panesMap.delete(paneId);
+        this.paneOwners.delete(paneId);
+      }
       for (const templateId of items.paneTemplates) {
         this.paneTemplatesMap.delete(templateId);
         this.paneTemplateOwners.delete(templateId);
@@ -758,6 +798,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
       for (const providerKey of items.contextMenuProviders) this.contextMenuProvidersMap.delete(providerKey);
       for (const dispose of items.eventDisposers) dispose();
       for (const dispose of items.newsSourceDisposers) dispose();
+      for (const dispose of items.newsQueryWatchDisposers) dispose();
       this.pluginItems.delete(pluginId);
     }
 

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -299,6 +299,7 @@ export function createAppServices({ config }: { config: AppConfig }): AppService
   pluginRegistry.getConfigFn = () => config;
   pluginRegistry.getLayoutFn = () => config.layout;
   pluginRegistry.registerNewsSourceFn = (source) => newsService.register(source);
+  pluginRegistry.watchNewsQueryFn = (query, listener) => newsService.watchQuery(query, listener);
 
   setSharedMarketDataCoordinator(marketData);
   setSharedNewsService(newsService);

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -73,6 +73,7 @@ interface PaneSettingFieldBase {
   key: string;
   label: string;
   description?: string;
+  storage?: "pane" | "plugin";
 }
 
 export interface PaneSettingToggleField extends PaneSettingFieldBase {
@@ -410,6 +411,10 @@ export interface GloomPluginContext {
   registerTickerAction(action: TickerAction): void;
   registerContextMenuProvider(provider: ContextMenuProviderDef): void;
   registerNewsSource?(source: import("./news-source").NewsSource): () => void;
+  watchNewsQuery?(
+    query: import("./news-source").NewsQuery,
+    listener: (state: import("./news-source").NewsQueryState) => void,
+  ): () => void;
 
   getData(ticker: string): TickerFinancials | null;
   getTicker(ticker: string): TickerRecord | null;


### PR DESCRIPTION
## Summary
- Add a Breaking News pane Notifications setting stored in plugin config so it remains active after the pane closes.
- Add a news-service query watcher and plugin API hook so breaking news can poll in the background without a mounted pane.
- Send app/desktop notifications for newly seen breaking stories, with focused tests for the watcher, setting, and notifier behavior.

## Verification
- `bun test src/news/aggregator.test.ts src/plugins/registry.test.ts src/plugins/builtin/news-wire/breaking-notifications.test.ts src/plugins/builtin/news-wire/feed-config.test.ts src/plugins/builtin/news-wire/rss-source.test.ts src/plugins/builtin/news-wire/news-table.test.tsx src/plugins/builtin/news-wire/read-state.test.ts`
- `bun run build`
- tmux smoke opened Breaking News and confirmed the Notifications toggle in pane settings.
