### PR TITLE
Polish desktop multiselect

### DIFF
--- a/src/components/toggle-list.tsx
+++ b/src/components/toggle-list.tsx
@@ -1,13 +1,14 @@
-import { Box, Text } from "../ui";
+import { Box, Text, useUiHost } from "../ui";
 import { TextAttributes } from "../ui";
 import { colors } from "../theme/colors";
-import { ListView, type ListViewItem } from "./ui/list-view";
+import { ListView, type ListRowState, type ListViewItem } from "./ui/list-view";
 
 export interface ToggleListItem {
   id: string;
   label: string;
   enabled: boolean;
   description?: string;
+  disabled?: boolean;
 }
 
 export interface ToggleListProps {
@@ -22,6 +23,89 @@ export interface ToggleListProps {
   scrollable?: boolean;
   showSelectedDescription?: boolean;
   rowIdPrefix?: string;
+  rowGap?: number;
+  rowHeight?: number;
+  surface?: "framed" | "plain";
+}
+
+function DesktopToggleRow({
+  item,
+  state,
+  rowIdPrefix,
+  enabled,
+}: {
+  item: ListViewItem;
+  state: ListRowState;
+  rowIdPrefix?: string;
+  enabled: boolean;
+}) {
+  const checkboxBorder = enabled
+    ? colors.borderFocused
+    : state.selected
+    ? colors.textMuted
+    : colors.border;
+  const textColor = state.disabled
+    ? colors.textMuted
+    : state.selected
+    ? colors.text
+    : colors.textDim;
+
+  return (
+    <Box
+      id={rowIdPrefix ? `${rowIdPrefix}:${item.id}` : undefined}
+      flexDirection="row"
+      alignItems="center"
+      width="100%"
+      minWidth={0}
+      style={{
+        paddingInline: 8,
+        opacity: state.disabled ? 0.55 : 1,
+      }}
+    >
+      <Box
+        alignItems="center"
+        justifyContent="center"
+        marginRight={1}
+        backgroundColor={enabled ? colors.borderFocused : "transparent"}
+        style={{
+          width: 16,
+          height: 16,
+          minWidth: 16,
+          alignSelf: "center",
+          border: `1px solid ${checkboxBorder}`,
+          borderRadius: 4,
+          boxShadow: enabled
+            ? "inset 0 1px 0 rgba(255,255,255,0.28)"
+            : "inset 0 1px 0 rgba(255,255,255,0.05)",
+        }}
+      >
+        {enabled && (
+          <Text
+            fg={colors.bg}
+            attributes={TextAttributes.BOLD}
+            style={{ fontSize: 12, lineHeight: "14px", fontWeight: 800 }}
+          >
+            {"✓"}
+          </Text>
+        )}
+      </Box>
+      <Box minWidth={0} flexShrink={1}>
+        <Text
+          fg={textColor}
+          attributes={state.selected ? TextAttributes.BOLD : 0}
+          style={{
+            display: "block",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            fontWeight: state.selected ? 700 : 500,
+          }}
+        >
+          {item.label}
+        </Text>
+      </Box>
+    </Box>
+  );
 }
 
 export function ToggleList({
@@ -35,11 +119,16 @@ export function ToggleList({
   scrollable,
   showSelectedDescription = true,
   rowIdPrefix,
+  rowGap,
+  rowHeight,
+  surface,
 }: ToggleListProps) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
   const listItems: ListViewItem[] = items.map((item) => ({
     id: item.id,
     label: item.label,
     description: item.description,
+    disabled: item.disabled,
   }));
 
   return (
@@ -51,12 +140,26 @@ export function ToggleList({
       height={height}
       flexGrow={flexGrow}
       scrollable={scrollable}
+      rowGap={rowGap ?? (isDesktopWeb ? 0 : undefined)}
+      rowHeight={rowHeight}
+      surface={surface}
       onSelect={onSelect}
       onActivate={(item) => {
         onToggle?.(item.id);
       }}
       renderRow={(item, state, index) => {
         const toggleItem = items.find((entry) => entry.id === item.id);
+        if (isDesktopWeb) {
+          return (
+            <DesktopToggleRow
+              item={item}
+              state={state}
+              rowIdPrefix={rowIdPrefix}
+              enabled={toggleItem?.enabled === true}
+            />
+          );
+        }
+
         const checked = toggleItem?.enabled ? "\u2713" : " ";
         const activate = (event: any) => {
           event.stopPropagation?.();

--- a/src/components/ui/frame.tsx
+++ b/src/components/ui/frame.tsx
@@ -7,13 +7,14 @@ export interface DialogFrameProps {
   title: string;
   children: ReactNode;
   footer?: string;
+  showTitleDivider?: boolean;
 }
 
-export function DialogFrame({ title, children, footer }: DialogFrameProps) {
+export function DialogFrame({ title, children, footer, showTitleDivider = true }: DialogFrameProps) {
   const HostDialogFrame = useUiHost().DialogFrame as ComponentType<DialogFrameProps> | undefined;
   if (HostDialogFrame) {
     return (
-      <HostDialogFrame title={title} footer={footer}>
+      <HostDialogFrame title={title} footer={footer} showTitleDivider={showTitleDivider}>
         {children}
       </HostDialogFrame>
     );

--- a/src/components/ui/list-view.tsx
+++ b/src/components/ui/list-view.tsx
@@ -30,6 +30,9 @@ export interface ListViewProps {
   bgColor?: string;
   selectedBgColor?: string;
   hoverBgColor?: string;
+  rowGap?: number;
+  rowHeight?: number;
+  surface?: "framed" | "plain";
   height?: number;
   flexGrow?: number;
   scrollable?: boolean;
@@ -77,6 +80,9 @@ export function ListView({
   bgColor,
   selectedBgColor,
   hoverBgColor,
+  rowGap,
+  rowHeight,
+  surface,
   height,
   flexGrow,
   scrollable = false,
@@ -99,6 +105,9 @@ export function ListView({
         bgColor={bgColor}
         selectedBgColor={selectedBgColor}
         hoverBgColor={hoverBgColor}
+        rowGap={rowGap}
+        rowHeight={rowHeight}
+        surface={surface}
         height={height}
         flexGrow={flexGrow}
         scrollable={scrollable}

--- a/src/components/ui/multi-select-dialog.tsx
+++ b/src/components/ui/multi-select-dialog.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "../../ui";
+import { Box, Text, useUiHost } from "../../ui";
 import { TextAttributes } from "../../ui";
 import { useShortcut } from "../../react/input";
 import { type AlertContext, useDialog, useDialogKeyboard } from "../../ui/dialog";
@@ -81,6 +81,7 @@ export function MultiSelectDialogContent({
   ordered = false,
   idPrefix,
 }: MultiSelectDialogContentProps) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
   const optionByValue = useMemo(() => new Map(options.map((option) => [option.value, option])), [options]);
   const [selectedValues, setSelectedValues] = useState(() => normalizeMultiSelectValues(options, selectedValuesProp));
   const knownSelectedValues = selectedValues.filter((value) => optionByValue.has(value));
@@ -112,11 +113,14 @@ export function MultiSelectDialogContent({
     return {
       id: option.value,
       label: option.label,
+      disabled: option.disabled,
       enabled: selectedValues.includes(option.value),
       description: [option.description, orderDescription].filter((entry): entry is string => !!entry).join(" "),
     };
   });
-  const listHeight = Math.min(12, Math.max(6, toggleItems.length));
+  const listHeight = isDesktopWeb
+    ? Math.min(12, Math.max(5, toggleItems.length * 1.35))
+    : Math.min(12, Math.max(6, toggleItems.length));
 
   const applySelectedValues = async (nextValues: string[]) => {
     const previousValues = selectedValues;
@@ -159,23 +163,35 @@ export function MultiSelectDialogContent({
   }, dialogId);
 
   return (
-    <DialogFrame title={title}>
-      <Box flexDirection="column" gap={1}>
+    <DialogFrame title={title} showTitleDivider={!isDesktopWeb}>
+      <Box
+        flexDirection="column"
+        gap={1}
+        style={isDesktopWeb ? { minWidth: 520 } : undefined}
+      >
         <ToggleList
           items={toggleItems}
           selectedIdx={selectedIndex}
-          bgColor={colors.commandBg}
+          bgColor={isDesktopWeb ? "transparent" : colors.commandBg}
           height={listHeight}
           scrollable
           showSelectedDescription={false}
           rowIdPrefix={idPrefix ? `${idPrefix}:option` : undefined}
+          rowGap={isDesktopWeb ? 0 : undefined}
+          rowHeight={isDesktopWeb ? 1.35 : undefined}
+          surface={isDesktopWeb ? "plain" : undefined}
           onSelect={(index) => setSelectedOptionId(options[index]?.value ?? selectedOptionId)}
           onToggle={(id) => {
             setSelectedOptionId(id);
             void toggleOption(optionByValue.get(id)).catch(() => {});
           }}
         />
-        <Box flexDirection="row" gap={1}>
+        <Box
+          flexDirection="row"
+          gap={1}
+          justifyContent={isDesktopWeb ? "flex-end" : undefined}
+          style={isDesktopWeb ? { paddingTop: 6 } : undefined}
+        >
           {ordered && (
             <>
               <Button label="Move Up" variant="ghost" disabled={!canMoveUp} onPress={() => { void moveOption("up").catch(() => {}); }} />
@@ -203,6 +219,7 @@ export function MultiSelectDialogButton({
   shortcutKey,
   shortcutActive = false,
 }: MultiSelectDialogButtonProps) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
   const dialog = useDialog();
   const summary = summarizeMultiSelectValues({ options, selectedValues, emptyLabel });
   const buttonLabel = `${label}: ${summary}`;
@@ -241,6 +258,25 @@ export function MultiSelectDialogButton({
       openDialog,
       stopMouseEvent,
     });
+  }
+
+  if (isDesktopWeb) {
+    return (
+      <Box
+        id={idPrefix ? `${idPrefix}:button` : undefined}
+        height={1}
+        flexDirection="row"
+        onMouseDown={stopMouseEvent}
+        onMouseUp={stopMouseEvent}
+      >
+        <Button
+          label={buttonLabel}
+          variant="secondary"
+          disabled={disabled}
+          onPress={() => openDialog()}
+        />
+      </Box>
+    );
   }
 
   return (

--- a/src/renderers/electrobun/view/desktop-controls.tsx
+++ b/src/renderers/electrobun/view/desktop-controls.tsx
@@ -272,6 +272,9 @@ export function WebListView({
   bgColor,
   selectedBgColor,
   hoverBgColor,
+  rowGap = 1,
+  rowHeight = 1,
+  surface = "framed",
   height,
   flexGrow,
   scrollable = false,
@@ -291,19 +294,21 @@ export function WebListView({
     if (!scrollBox) return;
     const safeIndex = Math.min(activeScrollIndex, items.length - 1);
     const viewportHeight = Math.max(scrollBox.viewport.height, 1);
-    if (safeIndex < scrollBox.scrollTop) {
-      scrollBox.scrollTo(safeIndex);
-    } else if (safeIndex >= scrollBox.scrollTop + viewportHeight) {
-      scrollBox.scrollTo(safeIndex - viewportHeight + 1);
+    const rowTop = safeIndex * rowHeight;
+    const rowBottom = rowTop + rowHeight;
+    if (rowTop < scrollBox.scrollTop) {
+      scrollBox.scrollTo(rowTop);
+    } else if (rowBottom > scrollBox.scrollTop + viewportHeight) {
+      scrollBox.scrollTo(rowBottom - viewportHeight);
     }
-  }, [activeScrollIndex, autoScrollToIndex, items.length, scrollable]);
+  }, [activeScrollIndex, autoScrollToIndex, items.length, rowHeight, scrollable]);
 
   useEffect(() => {
     if (!scrollable) return;
     const scrollBox = scrollRef.current;
     if (!scrollBox) return;
-    scrollBox.verticalScrollBar.visible = items.length > scrollBox.viewport.height;
-  }, [items.length, height, flexGrow, scrollable]);
+    scrollBox.verticalScrollBar.visible = items.length * rowHeight > scrollBox.viewport.height;
+  }, [items.length, height, flexGrow, rowHeight, scrollable]);
 
   const rows = items.length === 0
     ? (
@@ -322,7 +327,7 @@ export function WebListView({
       return (
         <Box
           key={item.id}
-          height={1}
+          height={rowHeight}
           width="100%"
           backgroundColor={rowBg}
           alignItems="center"
@@ -355,19 +360,26 @@ export function WebListView({
           flexGrow={flexGrow}
           scrollY
           focusable={false}
-          style={{
-            border: `1px solid ${PANEL_BORDER}`,
-            borderRadius: CONTROL_RADIUS,
-            padding: 4,
-            backgroundColor: "rgba(9, 12, 15, 0.22)",
-          }}
+          style={surface === "plain"
+            ? {
+              border: "none",
+              borderRadius: 0,
+              padding: 0,
+              backgroundColor: "transparent",
+            }
+            : {
+              border: `1px solid ${PANEL_BORDER}`,
+              borderRadius: CONTROL_RADIUS,
+              padding: 4,
+              backgroundColor: "rgba(9, 12, 15, 0.22)",
+            }}
         >
-          <Box flexDirection="column" gap={1}>
+          <Box flexDirection="column" gap={rowGap}>
             {rows}
           </Box>
         </ScrollBox>
       ) : (
-        <Box flexDirection="column" gap={1}>
+        <Box flexDirection="column" gap={rowGap}>
           {rows}
         </Box>
       )}
@@ -439,7 +451,12 @@ export function WebSegmentedControl({
   );
 }
 
-export function WebDialogFrame({ title, children, footer }: DialogFrameProps) {
+export function WebDialogFrame({
+  title,
+  children,
+  footer,
+  showTitleDivider = true,
+}: DialogFrameProps) {
   return (
     <Box flexDirection="column" style={{ padding: 14 }}>
       <Box
@@ -447,9 +464,9 @@ export function WebDialogFrame({ title, children, footer }: DialogFrameProps) {
         flexDirection="row"
         alignItems="center"
         style={{
-          borderBottom: `1px solid ${PANEL_BORDER}`,
-          paddingBottom: 8,
-          marginBottom: 10,
+          borderBottom: showTitleDivider ? `1px solid ${PANEL_BORDER}` : "none",
+          paddingBottom: showTitleDivider ? 8 : 0,
+          marginBottom: showTitleDivider ? 10 : 14,
         }}
       >
         <Text fg={colors.text} attributes={TextAttributes.BOLD} style={{ fontWeight: 700 }}>


### PR DESCRIPTION
This PR polishes the desktop multiselect used by chart indicators: desktop rows use checkbox-style controls and the trigger uses the shared desktop button styling while terminal rendering remains unchanged.
It adds small shared options for plain list surfaces, taller rows, and optional dialog title dividers so the multiselect can drop the nested card/divider and render larger without one-off DOM overrides.
Verified with bun run desktop:view:build, bun test src/components/ui/ui.test.tsx, git diff --check, and a credential-pattern scan.
