### PR TITLE
Smooth desktop chart dragging

### DIFF
--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -1740,6 +1740,15 @@ function ComparisonStockChartView({
       : null;
   }, [canvasBaseBitmapKey, canvasBaseBitmapState]);
 
+  const visibleCanvasBaseBitmap = useMemo<NativeChartBitmap | null>(() => {
+    if (canvasBaseBitmap) return canvasBaseBitmap;
+    if (!canvasBaseBitmapKey || !canvasBitmapSize || !canvasBaseBitmapState) return null;
+    return canvasBaseBitmapState.bitmap.width === canvasBitmapSize.pixelWidth
+      && canvasBaseBitmapState.bitmap.height === canvasBitmapSize.pixelHeight
+      ? canvasBaseBitmapState.bitmap
+      : null;
+  }, [canvasBaseBitmap, canvasBaseBitmapKey, canvasBaseBitmapState, canvasBitmapSize]);
+
   useEffect(() => {
     if (!canvasBitmapSize || !canvasBaseBitmapKey || !canvasBaseScene) {
       lastCanvasBaseBitmapRef.current = null;
@@ -1758,23 +1767,23 @@ function ComparisonStockChartView({
     }
 
     let cancelled = false;
-    const timer = setTimeout(() => {
+    const frame = requestAnimationFrameSafe(() => {
       const bitmap = renderNativeComparisonChartBase(canvasBaseScene, canvasBitmapSize.pixelWidth, canvasBitmapSize.pixelHeight);
       if (cancelled) return;
       lastCanvasBaseBitmapRef.current = { key: canvasBaseBitmapKey, bitmap };
       setCanvasBaseBitmapState((current) => (
         current?.key === canvasBaseBitmapKey ? current : { key: canvasBaseBitmapKey, bitmap }
       ));
-    }, 0);
+    });
 
     return () => {
       cancelled = true;
-      clearTimeout(timer);
+      cancelAnimationFrameSafe(frame);
     };
   }, [canvasBaseBitmapKey, canvasBaseScene, canvasBitmapSize]);
 
   const canvasCrosshair = useMemo(() => {
-    if (!canvasBitmapSize || !canvasBaseBitmap || !nativeCrosshair) return null;
+    if (!canvasBitmapSize || !visibleCanvasBaseBitmap || !nativeCrosshair) return null;
     const renderablePixelSize = getRenderablePixelSize(plotRef.current, renderer);
     const overlayPixelX = scaleLocalPixelCoordinate(
       nativeCrosshair.pixelX,
@@ -1792,12 +1801,12 @@ function ComparisonStockChartView({
       pixelY: overlayPixelY,
       color: nativeCrosshair.colors.crosshairColor,
     };
-  }, [canvasBaseBitmap, canvasBitmapSize, nativeCrosshair, renderer]);
+  }, [canvasBitmapSize, nativeCrosshair, renderer, visibleCanvasBaseBitmap]);
 
   const plotBitmaps = useMemo(() => {
-    if (!canvasBaseBitmap) return null;
-    return [canvasBaseBitmap];
-  }, [canvasBaseBitmap]);
+    if (!visibleCanvasBaseBitmap) return null;
+    return [visibleCanvasBaseBitmap];
+  }, [visibleCanvasBaseBitmap]);
 
   const plotLines: Array<string | StyledContent> = effectiveRenderer === "kitty"
     ? blankPlotLines

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -3865,6 +3865,15 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       : null;
   }, [canvasBaseBitmapKey, canvasBaseBitmapState]);
 
+  const visibleCanvasBaseBitmap = useMemo<NativeChartBitmap | null>(() => {
+    if (canvasBaseBitmap) return canvasBaseBitmap;
+    if (!canvasBaseBitmapKey || !canvasBitmapSize || !canvasBaseBitmapState) return null;
+    return canvasBaseBitmapState.bitmap.width === canvasBitmapSize.pixelWidth
+      && canvasBaseBitmapState.bitmap.height === canvasBitmapSize.pixelHeight
+      ? canvasBaseBitmapState.bitmap
+      : null;
+  }, [canvasBaseBitmap, canvasBaseBitmapKey, canvasBaseBitmapState, canvasBitmapSize]);
+
   useEffect(() => {
     if (!canvasBitmapSize || !canvasBaseBitmapKey || !canvasBaseScene) {
       lastCanvasBaseBitmapRef.current = null;
@@ -3883,23 +3892,23 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     }
 
     let cancelled = false;
-    const timer = setTimeout(() => {
+    const frame = requestAnimationFrameSafe(() => {
       const bitmap = renderNativeChartBase(canvasBaseScene, canvasBitmapSize.pixelWidth, canvasBitmapSize.pixelHeight);
       if (cancelled) return;
       lastCanvasBaseBitmapRef.current = { key: canvasBaseBitmapKey, bitmap };
       setCanvasBaseBitmapState((current) => (
         current?.key === canvasBaseBitmapKey ? current : { key: canvasBaseBitmapKey, bitmap }
       ));
-    }, 0);
+    });
 
     return () => {
       cancelled = true;
-      clearTimeout(timer);
+      cancelAnimationFrameSafe(frame);
     };
   }, [canvasBaseBitmapKey, canvasBaseScene, canvasBitmapSize]);
 
   const canvasCrosshair = useMemo(() => {
-    if (!canvasBitmapSize || !canvasBaseBitmap || !nativeCrosshair) return null;
+    if (!canvasBitmapSize || !visibleCanvasBaseBitmap || !nativeCrosshair) return null;
     const renderablePixelSize = getRenderablePixelSize(plotRef.current, renderer);
     const overlayPixelX = scaleLocalPixelCoordinate(
       nativeCrosshair.pixelX,
@@ -3917,12 +3926,12 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       pixelY: overlayPixelY,
       color: nativeCrosshair.colors.crosshairColor,
     };
-  }, [canvasBaseBitmap, canvasBitmapSize, nativeCrosshair, renderer]);
+  }, [canvasBitmapSize, nativeCrosshair, renderer, visibleCanvasBaseBitmap]);
 
   const plotBitmaps = useMemo(() => {
-    if (!canvasBaseBitmap) return null;
-    return [canvasBaseBitmap];
-  }, [canvasBaseBitmap]);
+    if (!visibleCanvasBaseBitmap) return null;
+    return [visibleCanvasBaseBitmap];
+  }, [visibleCanvasBaseBitmap]);
 
   const plotLines: Array<string | StyledContent> = effectiveRenderer === "kitty"
     ? blankPlotLines

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -189,6 +189,28 @@ function cleanDomProps(props: Record<string, unknown>): Record<string, unknown> 
 }
 
 type MouseLikeEvent = MouseEvent | ReactWheelEvent | globalThis.MouseEvent | globalThis.WheelEvent;
+type CellMouseEvent = ReturnType<typeof cellMouseEvent>;
+type WebFrameCallback = (timestamp: number) => void;
+
+const webAnimationFrameApi = globalThis as typeof globalThis & {
+  requestAnimationFrame?: (callback: WebFrameCallback) => number;
+  cancelAnimationFrame?: (id: number) => void;
+};
+
+function requestWebFrame(callback: WebFrameCallback): number {
+  if (typeof webAnimationFrameApi.requestAnimationFrame === "function") {
+    return webAnimationFrameApi.requestAnimationFrame(callback);
+  }
+  return setTimeout(() => callback(Date.now()), 16) as unknown as number;
+}
+
+function cancelWebFrame(id: number): void {
+  if (typeof webAnimationFrameApi.cancelAnimationFrame === "function") {
+    webAnimationFrameApi.cancelAnimationFrame(id);
+    return;
+  }
+  clearTimeout(id as unknown as ReturnType<typeof setTimeout>);
+}
 
 function resolveScroll(event: MouseLikeEvent) {
   if (!("deltaX" in event) && !("deltaY" in event)) return undefined;
@@ -247,6 +269,11 @@ function callMouseHandler(handler: unknown, event: MouseLikeEvent, type?: string
   (handler as (event: unknown) => void)(cellMouseEvent(event, type));
 }
 
+function callCellMouseHandler(handler: unknown, event: CellMouseEvent): void {
+  if (typeof handler !== "function") return;
+  (handler as (event: unknown) => void)(event);
+}
+
 function hasDirectMouseHandler(props: Record<string, unknown>): boolean {
   return typeof props.onMouseDown === "function"
     || typeof props.onMouseUp === "function"
@@ -297,12 +324,67 @@ const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { children?:
   function WebBox({ children, ...props }, ref: Ref<HTMLDivElement>) {
     const elementRef = useRef<HTMLDivElement | null>(null);
     const draggingRef = useRef(false);
+    const frameRef = useRef<number | null>(null);
+    const pendingMoveRef = useRef<CellMouseEvent | null>(null);
+    const pendingDragRef = useRef<CellMouseEvent | null>(null);
     const propsRef = useRef(props);
     propsRef.current = props;
 
     useImperativeHandle(ref, () => cellBoundsForElement(() => elementRef.current, () => propsRef.current) as HTMLDivElement, []);
 
+    const cancelPendingFrame = () => {
+      if (frameRef.current !== null) {
+        cancelWebFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+
+    const flushPendingFrameMouseHandlers = () => {
+      const moveEvent = pendingMoveRef.current;
+      const dragEvent = pendingDragRef.current;
+      pendingMoveRef.current = null;
+      pendingDragRef.current = null;
+
+      if (moveEvent) {
+        callCellMouseHandler(propsRef.current.onMouseMove, moveEvent);
+      }
+      if (dragEvent) {
+        callCellMouseHandler(propsRef.current.onMouse, dragEvent);
+        callCellMouseHandler(propsRef.current.onMouseDrag, dragEvent);
+      }
+    };
+
+    const flushPendingFrameNow = () => {
+      cancelPendingFrame();
+      flushPendingFrameMouseHandlers();
+    };
+
+    const scheduleFrameMouseHandler = (event: MouseLikeEvent, type: "move" | "drag") => {
+      if (type === "move" && typeof propsRef.current.onMouseMove !== "function") return;
+      if (type === "drag"
+        && typeof propsRef.current.onMouse !== "function"
+        && typeof propsRef.current.onMouseDrag !== "function") {
+        return;
+      }
+
+      const nextEvent = cellMouseEvent(event, type);
+      if (type === "move") {
+        pendingMoveRef.current = nextEvent;
+      } else {
+        pendingDragRef.current = nextEvent;
+      }
+
+      if (frameRef.current !== null) return;
+      frameRef.current = requestWebFrame(() => {
+        frameRef.current = null;
+        flushPendingFrameMouseHandlers();
+      });
+    };
+
     useEffect(() => () => {
+      cancelPendingFrame();
+      pendingMoveRef.current = null;
+      pendingDragRef.current = null;
       document.body.classList.remove("gloom-dragging");
     }, []);
 
@@ -316,12 +398,12 @@ const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { children?:
 
     const handleDocumentMove = (event: globalThis.MouseEvent) => {
       if (!draggingRef.current) return;
-      callMouseHandler(propsRef.current.onMouse, event, "drag");
-      callMouseHandler(propsRef.current.onMouseDrag, event, "drag");
+      scheduleFrameMouseHandler(event, "drag");
     };
 
     const handleDocumentUp = (event: globalThis.MouseEvent) => {
       if (!draggingRef.current) return;
+      flushPendingFrameNow();
       callMouseHandler(propsRef.current.onMouse, event, "up");
       callMouseHandler(propsRef.current.onMouseUp, event, "up");
       callMouseHandler(propsRef.current.onMouseDragEnd, event, "drag-end");
@@ -331,6 +413,7 @@ const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { children?:
     const handleMouseDown = (event: MouseEvent) => {
       const hasSyntheticDrag = typeof propsRef.current.onMouse === "function";
       const hasDirectDrag = typeof propsRef.current.onMouseDrag === "function" || typeof propsRef.current.onMouseDragEnd === "function";
+      pendingMoveRef.current = null;
       callMouseHandler(propsRef.current.onMouseDown, event, "down");
       if (event.button !== 0 || (event.isPropagationStopped() && !hasDirectDrag)) return;
       if (!hasSyntheticDrag && !hasDirectDrag) return;
@@ -345,15 +428,20 @@ const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { children?:
       callMouseHandler(propsRef.current.onMouseScroll, event, "scroll");
     };
 
+    const handleMouseOut = (event: MouseEvent) => {
+      pendingMoveRef.current = null;
+      callMouseHandler(propsRef.current.onMouseOut, event, "out");
+    };
+
     return (
       <div
         {...cleanDomProps(props)}
         data-gloom-interactive={hasDirectMouseHandler(props) ? "true" : undefined}
         ref={elementRef}
         onMouseDown={handleMouseDown}
-        onMouseMove={(event) => callMouseHandler(propsRef.current.onMouseMove, event, "move")}
+        onMouseMove={(event) => scheduleFrameMouseHandler(event, "move")}
         onMouseUp={(event) => callMouseHandler(propsRef.current.onMouseUp, event, "up")}
-        onMouseOut={(event) => callMouseHandler(propsRef.current.onMouseOut, event, "out")}
+        onMouseOut={handleMouseOut}
         onWheel={typeof props.onMouseScroll === "function" ? handleWheel : undefined}
         style={{ ...commonStyle(props), ...(props.style as CSSProperties | undefined) }}
       >


### PR DESCRIPTION
## Summary
Smooths desktop chart dragging by coalescing web mouse move and drag handlers to animation frames.
Keeps the previous canvas bitmap mounted while replacement chart bitmaps render, avoiding one-frame blank flashes during pan updates.
Applies the bitmap fallback behavior to both single-stock and comparison charts.

## Verification
bun run desktop:view:build
bun test src/components/chart/stock-chart.test.ts src/components/chart/chart-scroll.test.ts src/components/chart/comparison-chart-renderer.test.ts
