### PR TITLE
Polish desktop chat and controls

### DIFF
--- a/scripts/build-electrobun-view.ts
+++ b/scripts/build-electrobun-view.ts
@@ -78,6 +78,7 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
         color: #d8dde3;
         cursor: default;
         user-select: none;
+        color-scheme: dark;
         -webkit-font-smoothing: antialiased;
         text-rendering: geometricPrecision;
       }
@@ -172,6 +173,18 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
         overflow: hidden;
         text-overflow: ellipsis;
       }
+      [data-gloom-role="chat-message"]:hover [data-gloom-role="chat-message-row"][data-selected="false"] {
+        background-color: var(--chat-hover-bg);
+      }
+      [data-gloom-role="chat-message-reply-action"] {
+        opacity: 0;
+        pointer-events: none;
+      }
+      [data-gloom-role="chat-message"]:hover [data-gloom-role="chat-message-reply-action"],
+      [data-gloom-role="chat-message"][data-selected="true"] [data-gloom-role="chat-message-reply-action"] {
+        opacity: 1;
+        pointer-events: auto;
+      }
       [data-gloom-role="status-bar"] {
         min-height: var(--cell-h);
         max-height: var(--cell-h);
@@ -241,6 +254,51 @@ await writeFile(join(outdir, "index.html"), `<!doctype html>
       }
       [data-gloom-role="tab-close"]:hover {
         background: rgba(255,255,255,.1);
+      }
+      [data-gloom-scrollbar-x],
+      [data-gloom-scrollbar-y] {
+        scrollbar-color: transparent transparent;
+        scrollbar-width: thin;
+      }
+      [data-gloom-scrollbar-active="true"] {
+        scrollbar-color: rgba(216,221,227,.26) transparent;
+      }
+      [data-gloom-scrollbar-x]::-webkit-scrollbar,
+      [data-gloom-scrollbar-y]::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+        background: transparent;
+      }
+      [data-gloom-scrollbar-x]::-webkit-scrollbar-track,
+      [data-gloom-scrollbar-y]::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      [data-gloom-scrollbar-x]::-webkit-scrollbar-thumb,
+      [data-gloom-scrollbar-y]::-webkit-scrollbar-thumb {
+        min-width: 24px;
+        min-height: 24px;
+        border: 2px solid transparent;
+        border-radius: 999px;
+        background: transparent;
+        background-clip: content-box;
+      }
+      [data-gloom-scrollbar-x]::-webkit-scrollbar-thumb:hover,
+      [data-gloom-scrollbar-y]::-webkit-scrollbar-thumb:hover {
+        background: transparent;
+        background-clip: content-box;
+      }
+      [data-gloom-scrollbar-active="true"]::-webkit-scrollbar-thumb,
+      [data-gloom-scrollbar-active="true"]::-webkit-scrollbar-thumb:hover {
+        background: rgba(216,221,227,.24);
+        background-clip: content-box;
+      }
+      [data-gloom-scrollbar-x]::-webkit-scrollbar-corner,
+      [data-gloom-scrollbar-y]::-webkit-scrollbar-corner {
+        background: transparent;
+      }
+      [data-gloom-scrollbar-x="hidden"]:not([data-gloom-scrollbar-y="visible"]),
+      [data-gloom-scrollbar-y="hidden"]:not([data-gloom-scrollbar-x="visible"]) {
+        scrollbar-width: none;
       }
       [data-gloom-scrollbar-x="hidden"]::-webkit-scrollbar:horizontal {
         height: 0;

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -5,6 +5,7 @@ import { TextAttributes, type InputRenderable, type ScrollBoxRenderable, type Te
 import { useNativeRenderer } from "../../ui";
 import { useViewport } from "../../react/input";
 import { Button, NumberField, Spinner, TextField } from "../ui";
+import { NativeSelect, openNativeSelect, type NativeSelectElement } from "../ui/native-select";
 import { ToggleList } from "../toggle-list";
 import {
   colors,
@@ -376,6 +377,8 @@ export function CommandBar({
   const previousRootModeRef = useRef(rootModeInfo.kind);
   const rootThemeBaseIdRef = useRef<string | null>(null);
   const workflowInputRefs = useRef<Record<string, RefObject<InputRenderable | TextareaRenderable | null>>>({});
+  const workflowNativeSelectRefs = useRef(new Map<string, NativeSelectElement>());
+  const workflowScrollRef = useRef<ScrollBoxRenderable | null>(null);
   const nativeListScrollRef = useRef<ScrollBoxRenderable | null>(null);
   const visibleListStateRef = useRef<ListScreenState | null>(null);
   const processedLaunchSequenceRef = useRef<number | null>(null);
@@ -602,6 +605,14 @@ export function CommandBar({
     if (!activeField || !isWorkflowTextField(activeField)) return;
     const inputRef = getInputRef(workflowInputRefs.current, activeField.id);
     inputRef.current?.focus?.();
+  }, []);
+
+  const setWorkflowNativeSelectRef = useCallback((fieldId: string, element: NativeSelectElement | null) => {
+    if (element) {
+      workflowNativeSelectRefs.current.set(fieldId, element);
+    } else {
+      workflowNativeSelectRefs.current.delete(fieldId);
+    }
   }, []);
 
   const openWorkflowRoute = useCallback((route: CommandBarWorkflowRoute) => {
@@ -4766,11 +4777,19 @@ export function CommandBar({
           return;
         }
 
-        if (event.name === "return" || event.name === "enter") {
+        if (
+          event.name === "return"
+          || event.name === "enter"
+          || (nativePaneChrome && event.name === "space" && activeField?.type === "select")
+        ) {
           if (!activeField) return;
           if (activeField.type === "select" || activeField.type === "multi-select" || activeField.type === "ordered-multi-select" || activeField.type === "toggle") {
             event.stopPropagation();
             event.preventDefault();
+            if (nativePaneChrome && activeField.type === "select") {
+              openNativeSelect(workflowNativeSelectRefs.current.get(activeField.id));
+              return;
+            }
             openWorkflowFieldPicker(currentRoute, activeField);
             return;
           }
@@ -4933,6 +4952,7 @@ export function CommandBar({
     handleMultiSelectToggle,
     moveListSelection,
     moveWorkflowFocus,
+    nativePaneChrome,
     openWorkflowFieldPicker,
     popRoute,
     renderer,
@@ -4997,6 +5017,25 @@ export function CommandBar({
       scrollBox.scrollTo(nativeSelectedRowIndex - viewportHeight + 1);
     }
   }, [listBodyHeight, nativePaneChrome, nativeSelectedRowIndex, visibleListState?.kind, visibleListState?.query]);
+
+  useEffect(() => {
+    if (!nativePaneChrome || currentRoute?.kind !== "workflow") return;
+    const scrollBox = workflowScrollRef.current;
+    if (!scrollBox) return;
+    const visibleFields = getVisibleWorkflowFields(currentRoute.fields, currentRoute.values);
+    const activeIndex = visibleFields.findIndex((field) => field.id === currentRoute.activeFieldId);
+    if (activeIndex < 0) return;
+
+    const estimatedFieldHeight = 4;
+    const fieldTop = activeIndex * estimatedFieldHeight;
+    const fieldBottom = fieldTop + estimatedFieldHeight;
+    const viewportHeight = Math.max(1, scrollBox.viewport?.height ?? bodyHeight);
+    if (fieldTop < scrollBox.scrollTop) {
+      scrollBox.scrollTo(fieldTop);
+    } else if (fieldBottom > scrollBox.scrollTop + viewportHeight) {
+      scrollBox.scrollTo(fieldBottom - viewportHeight);
+    }
+  }, [bodyHeight, currentRoute, nativePaneChrome]);
 
   const renderListBody = () => {
     if (!visibleListState) return null;
@@ -5135,8 +5174,8 @@ export function CommandBar({
   const renderWorkflowBody = () => {
     if (currentRoute?.kind !== "workflow") return null;
     const visibleFields = getVisibleWorkflowFields(currentRoute.fields, currentRoute.values);
-    return (
-      <Box flexDirection="column" height={bodyHeight} paddingX={contentPadding}>
+    const workflowContent = (
+      <>
         {currentRoute.subtitle && (
           <Box height={1}>
             <Text fg={paletteSubtleText}>{truncateText(currentRoute.subtitle, queryDisplayWidth)}</Text>
@@ -5154,6 +5193,7 @@ export function CommandBar({
           const borderColor = active ? paletteSelectedBg : paletteBg;
           const fieldBg = nativePaneChrome ? "transparent" : active ? inputBg : panelBg;
           const nativeFieldRule = active ? "rgba(84, 201, 159, 0.48)" : "rgba(132, 145, 161, 0.18)";
+          const useNativeSelect = nativePaneChrome && field.type === "select";
           return (
             <Box
               key={field.id}
@@ -5166,7 +5206,7 @@ export function CommandBar({
                 updateTopRoute((route) => route.kind === "workflow"
                   ? { ...route, activeFieldId: field.id, error: null }
                   : route);
-                if (!isWorkflowTextField(field)) {
+                if (!isWorkflowTextField(field) && !useNativeSelect) {
                   openWorkflowFieldPicker(currentRoute, field);
                 }
               }}
@@ -5258,6 +5298,19 @@ export function CommandBar({
                     }}
                   />
                 )
+              ) : useNativeSelect ? (
+                <NativeSelect
+                  value={coerceFieldString(value)}
+                  options={field.options}
+                  width="100%"
+                  selectRef={(element) => setWorkflowNativeSelectRef(field.id, element)}
+                  onFocus={() => {
+                    updateTopRoute((route) => route.kind === "workflow"
+                      ? { ...route, activeFieldId: field.id, error: null }
+                      : route);
+                  }}
+                  onChange={(nextValue) => updateWorkflowValue(field.id, nextValue)}
+                />
               ) : (
                 <Box
                   height={1}
@@ -5298,10 +5351,35 @@ export function CommandBar({
             <Spinner label={currentRoute.pendingLabel} />
           </Box>
         )}
-        <Box flexGrow={1} />
+        {!nativePaneChrome && <Box flexGrow={1} />}
         <Box flexDirection="row" gap={1} justifyContent={visibleFields.some((field) => field.type === "textarea") ? "flex-end" : "flex-start"}>
           <Button label={currentRoute.submitLabel} variant="primary" onPress={() => { void submitWorkflowRoute(currentRoute); }} disabled={currentRoute.pending} />
         </Box>
+      </>
+    );
+
+    if (nativePaneChrome) {
+      return (
+        <ScrollBox
+          ref={workflowScrollRef}
+          height={bodyHeight}
+          scrollY
+          style={{ overflowX: "hidden", paddingRight: 4 }}
+        >
+          <Box
+            flexDirection="column"
+            paddingX={contentPadding}
+            style={{ paddingBottom: 8 }}
+          >
+            {workflowContent}
+          </Box>
+        </ScrollBox>
+      );
+    }
+
+    return (
+      <Box flexDirection="column" height={bodyHeight} paddingX={contentPadding}>
+        {workflowContent}
       </Box>
     );
   };

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import { getPaneBodyHeight } from "./pane-sizing";
+import { getPaneBodyHeight, shouldReservePaneFooter } from "./pane-sizing";
 
 interface FloatingPaneWrapperProps {
   title: string;
@@ -56,7 +56,7 @@ export function FloatingPaneWrapper({
   const { nativePaneChrome } = useUiCapabilities();
   const bg = floatingPaneBg(focused);
   const showFooter = hasPaneFooterContent(footer);
-  const reserveFooter = !nativePaneChrome || showFooter;
+  const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
   const bodyHeight = getPaneBodyHeight(height, reserveFooter);
 
   return (

--- a/src/components/layout/pane-sizing.ts
+++ b/src/components/layout/pane-sizing.ts
@@ -2,6 +2,10 @@
 const PANE_HEADER_ROWS = 1;
 const PANE_FOOTER_ROWS = 1;
 
+export function shouldReservePaneFooter(nativePaneChrome: boolean | undefined, showFooter: boolean): boolean {
+  return !nativePaneChrome || showFooter;
+}
+
 export function getPaneBodyHeight(height: number, reserveFooter = true): number {
   return Math.max(1, height - PANE_HEADER_ROWS - (reserveFooter ? PANE_FOOTER_ROWS : 0));
 }

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { colors, paneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import { getPaneBodyHeight } from "./pane-sizing";
+import { getPaneBodyHeight, shouldReservePaneFooter } from "./pane-sizing";
 
 interface PaneWrapperProps {
   title?: string;
@@ -43,7 +43,7 @@ export function PaneWrapper({
   const { nativePaneChrome } = useUiCapabilities();
   const bg = paneBg(focused);
   const showFooter = hasPaneFooterContent(footer);
-  const reserveFooter = !nativePaneChrome || showFooter;
+  const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
   const bodyHeight = typeof height === "number"
     ? title ? getPaneBodyHeight(height, reserveFooter) : height
     : undefined;

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -50,8 +50,8 @@ import { getNativeSurfaceManager, type NativeOccluder, type NativePaneLayer } fr
 import { FloatingPaneWrapper } from "./floating-pane";
 import { PaneContent } from "./pane-content";
 import { PaneWrapper } from "./pane";
-import { PaneFooterProvider } from "./pane-footer";
-import { getPaneBodyHeight, getPaneBodyWidth } from "./pane-sizing";
+import { hasPaneFooterContent, PaneFooterProvider } from "./pane-footer";
+import { getPaneBodyHeight, getPaneBodyWidth, shouldReservePaneFooter } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX } from "./titlebar-overlay";
 
@@ -1500,7 +1500,8 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
           >
             <PaneFooterProvider>
               {(footer) => {
-                const bodyHeight = getPaneBodyHeight(leaf.rect.height);
+                const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
+                const bodyHeight = getPaneBodyHeight(leaf.rect.height, reserveFooter);
                 return (
                   <PaneWrapper
                     title={getPaneTitle(pane)}
@@ -1543,7 +1544,8 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         return (
           <PaneFooterProvider key={`float:${pane.instance.instanceId}`}>
             {(footer) => {
-              const bodyHeight = getPaneBodyHeight(preview.height);
+              const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
+              const bodyHeight = getPaneBodyHeight(preview.height, reserveFooter);
               return (
                 <FloatingPaneWrapper
                   title={getPaneTitle(pane)}

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 import { Box, Text, useUiHost } from "../ui";
 import { TextAttributes } from "../ui";
 import { type AlertContext, useDialog, useDialogKeyboard } from "../ui/dialog";
@@ -8,7 +10,9 @@ import type {
 } from "../types/plugin";
 import type { PluginRegistry } from "../plugins/registry";
 import { colors } from "../theme/colors";
-import { Button, DialogFrame, ListView, MultiSelectDialogContent, SegmentedControl, TextField } from "./ui";
+import { Button, DialogFrame, ListView, MultiSelectDialogContent, TextField } from "./ui";
+
+type NativeSelectElement = HTMLSelectElement & { showPicker?: () => void };
 
 interface PaneSettingsDialogContentProps extends AlertContext {
   paneId: string;
@@ -191,6 +195,73 @@ function DesktopValuePill({ value }: { value: string }) {
   );
 }
 
+function DesktopSelectControl({
+  field,
+  currentValue,
+  selectRef,
+  onChange,
+}: {
+  field: SelectPaneSettingField;
+  currentValue: unknown;
+  selectRef?: (element: NativeSelectElement | null) => void;
+  onChange: (value: string) => void;
+}) {
+  const value = typeof currentValue === "string" ? currentValue : "";
+  const hasCurrentValue = field.options.some((option) => option.value === value);
+
+  return (
+    <Box
+      height="28px"
+      flexDirection="row"
+      alignItems="center"
+      onMouseDown={(event: any) => {
+        event.stopPropagation?.();
+      }}
+      onMouseUp={(event: any) => {
+        event.stopPropagation?.();
+      }}
+    >
+      <select
+        ref={selectRef}
+        value={value}
+        data-gloom-interactive="true"
+        onMouseDown={(event) => {
+          event.stopPropagation();
+        }}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+        onChange={(event) => {
+          onChange(event.currentTarget.value);
+        }}
+        style={{
+          width: 184,
+          height: 28,
+          color: colors.text,
+          backgroundColor: "rgba(255, 255, 255, 0.06)",
+          border: `1px solid ${colors.border}`,
+          borderRadius: 6,
+          padding: "0 8px",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+          cursor: "pointer",
+          font: "inherit",
+          letterSpacing: 0,
+          outline: "none",
+          appearance: "auto",
+          WebkitAppearance: "menulist",
+        }}
+      >
+        {!hasCurrentValue && <option value="">Unset</option>}
+        {field.options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </Box>
+  );
+}
+
 function DesktopSettingsRow({
   field,
   selected,
@@ -198,6 +269,7 @@ function DesktopSettingsRow({
   currentValue,
   onHover,
   onEdit,
+  onSelectRef,
   onApply,
 }: {
   field: PaneSettingField;
@@ -206,32 +278,20 @@ function DesktopSettingsRow({
   currentValue: unknown;
   onHover: () => void;
   onEdit: () => void;
+  onSelectRef: (fieldKey: string, element: NativeSelectElement | null) => void;
   onApply: (field: PaneSettingField, value: unknown) => void;
 }) {
   const isToggle = field.type === "toggle";
-  const isSelect = field.type === "select";
-  const rowInteractive = !isSelect;
   const summary = summarizeValue(field, currentValue);
   const control = field.type === "toggle" ? (
     <DesktopSwitch checked={currentValue === true} onChange={(checked) => onApply(field, checked)} />
   ) : field.type === "select" ? (
-    <Box
-      width="100%"
-      style={{
-        marginTop: 4,
-        overflowX: "auto",
-        overflowY: "hidden",
-      }}
-    >
-      <SegmentedControl
-        value={typeof currentValue === "string" ? currentValue : ""}
-        options={field.options.map((option) => ({
-          value: option.value,
-          label: option.label,
-        }))}
-        onChange={(value) => onApply(field, value)}
-      />
-    </Box>
+    <DesktopSelectControl
+      field={field}
+      currentValue={currentValue}
+      selectRef={(element) => onSelectRef(field.key, element)}
+      onChange={(value) => onApply(field, value)}
+    />
   ) : (
     <Box flexDirection="row" alignItems="center" gap={1}>
       <DesktopValuePill value={summary} />
@@ -242,37 +302,34 @@ function DesktopSettingsRow({
   return (
     <Box
       flexDirection="column"
-      minHeight={field.description || isSelect ? undefined : 2}
+      minHeight={field.description ? undefined : 2}
       backgroundColor={hovered || selected ? "rgba(255, 255, 255, 0.045)" : "transparent"}
       onMouseMove={onHover}
-      onMouseDown={rowInteractive
-        ? (event: any) => {
-          event.stopPropagation?.();
-          event.preventDefault?.();
-          if (isToggle) onApply(field, currentValue !== true);
-          else onEdit();
-        }
-        : undefined}
-      data-gloom-interactive={rowInteractive ? "true" : undefined}
+      onMouseDown={field.type === "select" ? undefined : (event: any) => {
+        event.stopPropagation?.();
+        event.preventDefault?.();
+        if (isToggle) onApply(field, currentValue !== true);
+        else onEdit();
+      }}
+      data-gloom-interactive={field.type === "select" ? undefined : "true"}
       style={{
-        borderBottom: `1px solid ${hovered || selected ? colors.borderFocused : colors.border}`,
-        cursor: rowInteractive ? "pointer" : "default",
-        padding: "6px 2px 7px",
-        transition: "background-color 100ms ease, border-color 100ms ease",
+        borderRadius: 6,
+        cursor: field.type === "select" ? "default" : "pointer",
+        padding: "7px 4px 8px",
+        transition: "background-color 100ms ease",
       }}
     >
       <Box flexDirection="row" alignItems="center" width="100%">
         <Box flexDirection="row" flexGrow={1} minWidth={0} style={{ paddingRight: 12 }}>
           <Text fg={colors.text} style={desktopText(650)}>{field.label}</Text>
         </Box>
-        {!isSelect && control}
+        {control}
       </Box>
       {field.description && (
         <Text fg={colors.textMuted} wrapText style={desktopText()}>
           {field.description}
         </Text>
       )}
-      {isSelect && control}
     </Box>
   );
 }
@@ -284,6 +341,7 @@ function DesktopSettingsList({
   settings,
   onHover,
   onEdit,
+  onSelectRef,
   onApply,
 }: {
   fields: PaneSettingField[];
@@ -292,13 +350,14 @@ function DesktopSettingsList({
   settings: Record<string, unknown>;
   onHover: (field: PaneSettingField, index: number) => void;
   onEdit: (field: PaneSettingField, index: number) => void;
+  onSelectRef: (fieldKey: string, element: NativeSelectElement | null) => void;
   onApply: (field: PaneSettingField, value: unknown, index: number) => void;
 }) {
   return (
     <Box
       flexDirection="column"
       style={{
-        borderTop: `1px solid ${colors.border}`,
+        marginTop: 2,
       }}
     >
       {fields.map((field, index) => (
@@ -310,6 +369,7 @@ function DesktopSettingsList({
           currentValue={settings[field.key]}
           onHover={() => onHover(field, index)}
           onEdit={() => onEdit(field, index)}
+          onSelectRef={onSelectRef}
           onApply={(targetField, value) => onApply(targetField, value, index)}
         />
       ))}
@@ -345,61 +405,14 @@ function useSelectFieldDialogController({
   return { selectedIndex, setSelectedIndex, applyOption };
 }
 
-function SelectFieldDialog(props: SelectFieldDialogProps) {
-  return useUiHost().kind === "desktop-web"
-    ? <DesktopSelectFieldDialog {...props} />
-    : <TuiSelectFieldDialog {...props} />;
-}
-
-function DesktopSelectFieldDialog(props: SelectFieldDialogProps) {
-  const { dismiss, field, currentValue } = props;
-  const { selectedIndex, setSelectedIndex, applyOption } = useSelectFieldDialogController(props);
-
-  return (
-    <DesktopDialogSurface
-      title={field.label}
-      subtitle={field.description}
-      dismiss={dismiss}
-    >
-      <Box flexDirection="column" style={{ borderTop: `1px solid ${colors.border}` }}>
-        {field.options.map((option, index) => {
-          const selected = option.value === currentValue;
-          const focused = index === selectedIndex;
-          return (
-            <Box
-              key={option.value}
-              minHeight={option.description ? 4 : 3}
-              flexDirection="row"
-              alignItems="center"
-              backgroundColor={selected || focused ? "rgba(255, 255, 255, 0.045)" : "transparent"}
-              onMouseMove={() => setSelectedIndex(index)}
-              onMouseDown={(event: any) => {
-                event.stopPropagation?.();
-                event.preventDefault?.();
-                applyOption(option.value);
-              }}
-              data-gloom-interactive="true"
-              style={{
-                borderBottom: `1px solid ${selected || focused ? colors.borderFocused : colors.border}`,
-                cursor: "pointer",
-                padding: "6px 2px 7px",
-              }}
-            >
-              <Box flexDirection="column" flexGrow={1} minWidth={0}>
-                <Text fg={colors.textBright} style={desktopText(650)}>{option.label}</Text>
-                {option.description && (
-                  <Text fg={colors.textMuted} wrapText style={{ ...desktopText(), marginTop: 3 }}>
-                    {option.description}
-                  </Text>
-                )}
-              </Box>
-              {selected && <DesktopValuePill value="Selected" />}
-            </Box>
-          );
-        })}
-      </Box>
-    </DesktopDialogSurface>
-  );
+function openNativeSelect(element: NativeSelectElement | null | undefined) {
+  if (!element) return;
+  element.focus();
+  try {
+    element.showPicker?.();
+  } catch {
+    element.click();
+  }
 }
 
 function TuiSelectFieldDialog(props: SelectFieldDialogProps) {
@@ -587,6 +600,7 @@ function DesktopPaneSettingsDialogBody({
   settings,
   onHover,
   onEdit,
+  onSelectRef,
   onApply,
 }: {
   title: string;
@@ -597,6 +611,7 @@ function DesktopPaneSettingsDialogBody({
   settings: Record<string, unknown>;
   onHover: (field: PaneSettingField, index: number) => void;
   onEdit: (field: PaneSettingField, index: number) => void;
+  onSelectRef: (fieldKey: string, element: NativeSelectElement | null) => void;
   onApply: (field: PaneSettingField, value: unknown, index: number) => void;
 }) {
   return (
@@ -616,6 +631,7 @@ function DesktopPaneSettingsDialogBody({
           settings={settings}
           onHover={onHover}
           onEdit={onEdit}
+          onSelectRef={onSelectRef}
           onApply={onApply}
         />
       )}
@@ -694,6 +710,7 @@ export function PaneSettingsDialogContent({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [hoveredFieldKey, setHoveredFieldKey] = useState<string | null>(null);
   const [, setSettingsRevision] = useState(0);
+  const desktopSelectRefs = useRef(new Map<string, NativeSelectElement>());
 
   const fields = descriptor?.settingsDef.fields ?? [];
 
@@ -708,6 +725,11 @@ export function PaneSettingsDialogContent({
     setSettingsRevision((revision) => revision + 1);
   };
 
+  const setDesktopSelectRef = (fieldKey: string, element: NativeSelectElement | null) => {
+    if (element) desktopSelectRefs.current.set(fieldKey, element);
+    else desktopSelectRefs.current.delete(fieldKey);
+  };
+
   const openFieldEditor = async (field: PaneSettingField | undefined) => {
     if (!field || !descriptor) return;
     const currentValue = descriptor.context.settings[field.key];
@@ -718,9 +740,13 @@ export function PaneSettingsDialogContent({
     }
 
     if (field.type === "select") {
+      if (isDesktop) {
+        openNativeSelect(desktopSelectRefs.current.get(field.key));
+        return;
+      }
       await dialog.alert({
         content: (ctx: AlertContext) => (
-          <SelectFieldDialog
+          <TuiSelectFieldDialog
             {...ctx}
             field={field}
             currentValue={currentValue}
@@ -787,6 +813,7 @@ export function PaneSettingsDialogContent({
         setSelectedIndex(index);
         setHoveredFieldKey(field.key);
       }}
+      onSelectRef={setDesktopSelectRef}
       onEdit={(field, index) => {
         setSelectedIndex(index);
         void openFieldEditor(field).catch(() => {});

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -11,8 +11,7 @@ import type {
 import type { PluginRegistry } from "../plugins/registry";
 import { colors } from "../theme/colors";
 import { Button, DialogFrame, ListView, MultiSelectDialogContent, TextField } from "./ui";
-
-type NativeSelectElement = HTMLSelectElement & { showPicker?: () => void };
+import { NativeSelect, openNativeSelect, type NativeSelectElement } from "./ui/native-select";
 
 interface PaneSettingsDialogContentProps extends AlertContext {
   paneId: string;
@@ -195,73 +194,6 @@ function DesktopValuePill({ value }: { value: string }) {
   );
 }
 
-function DesktopSelectControl({
-  field,
-  currentValue,
-  selectRef,
-  onChange,
-}: {
-  field: SelectPaneSettingField;
-  currentValue: unknown;
-  selectRef?: (element: NativeSelectElement | null) => void;
-  onChange: (value: string) => void;
-}) {
-  const value = typeof currentValue === "string" ? currentValue : "";
-  const hasCurrentValue = field.options.some((option) => option.value === value);
-
-  return (
-    <Box
-      height="28px"
-      flexDirection="row"
-      alignItems="center"
-      onMouseDown={(event: any) => {
-        event.stopPropagation?.();
-      }}
-      onMouseUp={(event: any) => {
-        event.stopPropagation?.();
-      }}
-    >
-      <select
-        ref={selectRef}
-        value={value}
-        data-gloom-interactive="true"
-        onMouseDown={(event) => {
-          event.stopPropagation();
-        }}
-        onClick={(event) => {
-          event.stopPropagation();
-        }}
-        onChange={(event) => {
-          onChange(event.currentTarget.value);
-        }}
-        style={{
-          width: 184,
-          height: 28,
-          color: colors.text,
-          backgroundColor: "rgba(255, 255, 255, 0.06)",
-          border: `1px solid ${colors.border}`,
-          borderRadius: 6,
-          padding: "0 8px",
-          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-          cursor: "pointer",
-          font: "inherit",
-          letterSpacing: 0,
-          outline: "none",
-          appearance: "auto",
-          WebkitAppearance: "menulist",
-        }}
-      >
-        {!hasCurrentValue && <option value="">Unset</option>}
-        {field.options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </Box>
-  );
-}
-
 function DesktopSettingsRow({
   field,
   selected,
@@ -286,9 +218,10 @@ function DesktopSettingsRow({
   const control = field.type === "toggle" ? (
     <DesktopSwitch checked={currentValue === true} onChange={(checked) => onApply(field, checked)} />
   ) : field.type === "select" ? (
-    <DesktopSelectControl
-      field={field}
-      currentValue={currentValue}
+    <NativeSelect
+      value={typeof currentValue === "string" ? currentValue : ""}
+      options={field.options}
+      includeUnsetOption
       selectRef={(element) => onSelectRef(field.key, element)}
       onChange={(value) => onApply(field, value)}
     />
@@ -403,16 +336,6 @@ function useSelectFieldDialogController({
   });
 
   return { selectedIndex, setSelectedIndex, applyOption };
-}
-
-function openNativeSelect(element: NativeSelectElement | null | undefined) {
-  if (!element) return;
-  element.focus();
-  try {
-    element.showPicker?.();
-  } catch {
-    element.click();
-  }
 }
 
 function TuiSelectFieldDialog(props: SelectFieldDialogProps) {

--- a/src/components/toggle-list.tsx
+++ b/src/components/toggle-list.tsx
@@ -58,14 +58,15 @@ function DesktopToggleRow({
       width="100%"
       minWidth={0}
       style={{
-        paddingInline: 8,
+        height: "100%",
+        gap: 10,
+        paddingInline: 10,
         opacity: state.disabled ? 0.55 : 1,
       }}
     >
       <Box
         alignItems="center"
         justifyContent="center"
-        marginRight={1}
         backgroundColor={enabled ? colors.borderFocused : "transparent"}
         style={{
           width: 16,
@@ -99,6 +100,7 @@ function DesktopToggleRow({
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
             fontWeight: state.selected ? 700 : 500,
+            lineHeight: "16px",
           }}
         >
           {item.label}

--- a/src/components/ui/multi-select-dialog.tsx
+++ b/src/components/ui/multi-select-dialog.tsx
@@ -4,13 +4,20 @@ import { useShortcut } from "../../react/input";
 import { type AlertContext, useDialog, useDialogKeyboard } from "../../ui/dialog";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { colors } from "../../theme/colors";
+import { isDetailBackNavigationKey } from "../../utils/back-navigation";
 import { ToggleList } from "../toggle-list";
 import { Button } from "./button";
 import { DialogFrame } from "./frame";
 import {
+  getMultiSelectDisplayValues,
+  mergeMultiSelectDisplayValues,
+  moveMultiSelectDisplayValue,
   moveMultiSelectValue,
   normalizeMultiSelectValues,
+  normalizeOrderedMultiSelectValues,
+  orderMultiSelectOptionsForDisplay,
   summarizeMultiSelectValues,
+  toggleOrderedMultiSelectValue,
   toggleMultiSelectValue,
   type MultiSelectOption,
 } from "./multi-select";
@@ -71,6 +78,16 @@ function matchesShortcut(event: { name?: string; sequence?: string }, shortcutKe
   });
 }
 
+function normalizeDialogSelectedValues(
+  options: readonly MultiSelectOption[],
+  values: readonly string[],
+  ordered: boolean,
+): string[] {
+  return ordered
+    ? normalizeOrderedMultiSelectValues(options, values)
+    : normalizeMultiSelectValues(options, values);
+}
+
 export function MultiSelectDialogContent({
   dismiss,
   dialogId,
@@ -83,11 +100,16 @@ export function MultiSelectDialogContent({
 }: MultiSelectDialogContentProps) {
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const optionByValue = useMemo(() => new Map(options.map((option) => [option.value, option])), [options]);
-  const [selectedValues, setSelectedValues] = useState(() => normalizeMultiSelectValues(options, selectedValuesProp));
+  const [selectedValues, setSelectedValues] = useState(() => normalizeDialogSelectedValues(options, selectedValuesProp, ordered));
+  const [displayValues, setDisplayValues] = useState(() => getMultiSelectDisplayValues(options, selectedValuesProp, ordered));
   const knownSelectedValues = selectedValues.filter((value) => optionByValue.has(value));
+  const displayOptions = useMemo(
+    () => orderMultiSelectOptionsForDisplay(options, displayValues),
+    [displayValues, options],
+  );
   const [selectedOptionId, setSelectedOptionId] = useState(options[0]?.value ?? "");
-  const selectedIndex = Math.max(0, options.findIndex((option) => option.value === selectedOptionId));
-  const selectedOption = options[selectedIndex];
+  const selectedIndex = Math.max(0, displayOptions.findIndex((option) => option.value === selectedOptionId));
+  const selectedOption = displayOptions[selectedIndex];
   const selectedOptionValue = selectedOption?.value ?? "";
   const selectedValueOrder = knownSelectedValues.indexOf(selectedOptionValue);
   const canMoveUp = ordered && selectedValueOrder > 0;
@@ -96,15 +118,16 @@ export function MultiSelectDialogContent({
     && selectedValueOrder < knownSelectedValues.length - 1;
 
   useEffect(() => {
-    setSelectedValues(normalizeMultiSelectValues(options, selectedValuesProp));
-  }, [options, selectedValuesProp]);
+    setSelectedValues((values) => normalizeDialogSelectedValues(options, values, ordered));
+    setDisplayValues((values) => mergeMultiSelectDisplayValues(options, values));
+  }, [options, ordered]);
 
   useEffect(() => {
-    if (options.some((option) => option.value === selectedOptionId)) return;
-    setSelectedOptionId(options[0]?.value ?? "");
-  }, [options, selectedOptionId]);
+    if (displayOptions.some((option) => option.value === selectedOptionId)) return;
+    setSelectedOptionId(displayOptions[0]?.value ?? "");
+  }, [displayOptions, selectedOptionId]);
 
-  const toggleItems = options.map((option) => {
+  const toggleItems = displayOptions.map((option) => {
     const order = knownSelectedValues.indexOf(option.value);
     const orderDescription = ordered && order >= 0
       ? `Order ${order + 1} of ${knownSelectedValues.length}.`
@@ -119,45 +142,53 @@ export function MultiSelectDialogContent({
     };
   });
   const listHeight = isDesktopWeb
-    ? Math.min(12, Math.max(5, toggleItems.length * 1.35))
+    ? Math.min(12, Math.max(5, displayOptions.length * 1.35))
     : Math.min(12, Math.max(6, toggleItems.length));
 
-  const applySelectedValues = async (nextValues: string[]) => {
+  const applySelectedValues = async (nextValues: string[], nextDisplayValues = displayValues) => {
     const previousValues = selectedValues;
+    const previousDisplayValues = displayValues;
     setSelectedValues(nextValues);
+    setDisplayValues(nextDisplayValues);
     try {
       await onChange(nextValues);
     } catch (error) {
       setSelectedValues(previousValues);
+      setDisplayValues(previousDisplayValues);
       throw error;
     }
   };
 
   const toggleOption = async (option: MultiSelectOption | undefined) => {
     if (!option || option.disabled) return;
-    await applySelectedValues(toggleMultiSelectValue(options, selectedValues, option.value));
+    await applySelectedValues(ordered
+      ? toggleOrderedMultiSelectValue(options, selectedValues, option.value)
+      : toggleMultiSelectValue(options, selectedValues, option.value));
   };
 
   const moveOption = async (direction: "up" | "down") => {
     if (!ordered || !selectedOption) return;
-    await applySelectedValues(moveMultiSelectValue(options, selectedValues, selectedOption.value, direction));
+    await applySelectedValues(
+      moveMultiSelectValue(options, selectedValues, selectedOption.value, direction),
+      moveMultiSelectDisplayValue(displayValues, knownSelectedValues, selectedOption.value, direction),
+    );
   };
 
   useDialogKeyboard((event) => {
     event.stopPropagation();
     if (event.name === "up" || event.name === "k") {
       const nextIndex = Math.max(0, selectedIndex - 1);
-      setSelectedOptionId(options[nextIndex]?.value ?? selectedOptionId);
+      setSelectedOptionId(displayOptions[nextIndex]?.value ?? selectedOptionId);
     } else if (event.name === "down" || event.name === "j") {
-      const nextIndex = Math.min(options.length - 1, selectedIndex + 1);
-      setSelectedOptionId(options[nextIndex]?.value ?? selectedOptionId);
+      const nextIndex = Math.min(displayOptions.length - 1, selectedIndex + 1);
+      setSelectedOptionId(displayOptions[nextIndex]?.value ?? selectedOptionId);
     } else if (isSpaceKey(event)) {
       void toggleOption(selectedOption).catch(() => {});
     } else if (event.name === "[" && ordered) {
       void moveOption("up").catch(() => {});
     } else if (event.name === "]" && ordered) {
       void moveOption("down").catch(() => {});
-    } else if (event.name === "enter" || event.name === "return" || event.name === "escape") {
+    } else if (event.name === "enter" || event.name === "return" || event.name === "escape" || isDetailBackNavigationKey(event)) {
       dismiss();
     }
   }, dialogId);
@@ -180,7 +211,7 @@ export function MultiSelectDialogContent({
           rowGap={isDesktopWeb ? 0 : undefined}
           rowHeight={isDesktopWeb ? 1.35 : undefined}
           surface={isDesktopWeb ? "plain" : undefined}
-          onSelect={(index) => setSelectedOptionId(options[index]?.value ?? selectedOptionId)}
+          onSelect={(index) => setSelectedOptionId(displayOptions[index]?.value ?? selectedOptionId)}
           onToggle={(id) => {
             setSelectedOptionId(id);
             void toggleOption(optionByValue.get(id)).catch(() => {});

--- a/src/components/ui/multi-select.ts
+++ b/src/components/ui/multi-select.ts
@@ -19,6 +19,29 @@ export function normalizeMultiSelectValues(
   ];
 }
 
+export function normalizeOrderedMultiSelectValues(
+  options: readonly MultiSelectOption[],
+  values: readonly string[],
+): string[] {
+  const knownValues = new Set(options.map((option) => option.value));
+  const seen = new Set<string>();
+  const nextValues: string[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    if (knownValues.has(value)) nextValues.push(value);
+  }
+
+  for (const value of values) {
+    if (!knownValues.has(value) && !nextValues.includes(value)) {
+      nextValues.push(value);
+    }
+  }
+
+  return nextValues;
+}
+
 export function toggleMultiSelectValue(
   options: readonly MultiSelectOption[],
   selectedValues: readonly string[],
@@ -32,6 +55,22 @@ export function toggleMultiSelectValue(
   }
 
   return normalizeMultiSelectValues(options, [...nextSelected]);
+}
+
+export function toggleOrderedMultiSelectValue(
+  options: readonly MultiSelectOption[],
+  selectedValues: readonly string[],
+  value: string,
+): string[] {
+  const knownValues = new Set(options.map((option) => option.value));
+  const normalized = normalizeOrderedMultiSelectValues(options, selectedValues);
+  if (normalized.includes(value)) {
+    return normalized.filter((entry) => entry !== value);
+  }
+
+  const knownSelected = normalized.filter((entry) => knownValues.has(entry));
+  const unknownSelected = normalized.filter((entry) => !knownValues.has(entry));
+  return [...knownSelected, value, ...unknownSelected];
 }
 
 export function moveMultiSelectValue(
@@ -57,6 +96,78 @@ export function moveMultiSelectValue(
   next.splice(targetIndex, 0, entry!);
   const unknownValues = selectedValues.filter((value) => !optionValueSet.has(value));
   return [...next, ...unknownValues];
+}
+
+export function getMultiSelectDisplayValues(
+  options: readonly MultiSelectOption[],
+  selectedValues: readonly string[],
+  ordered: boolean,
+): string[] {
+  const optionValues = options.map((option) => option.value);
+  if (!ordered) return optionValues;
+
+  const selectedQueue = normalizeOrderedMultiSelectValues(options, selectedValues);
+  const selectedValueSet = new Set(selectedQueue);
+  const displayValues: string[] = [];
+
+  for (const option of options) {
+    if (selectedValueSet.has(option.value)) {
+      displayValues.push(selectedQueue.shift() ?? option.value);
+    } else {
+      displayValues.push(option.value);
+    }
+  }
+
+  return displayValues;
+}
+
+export function mergeMultiSelectDisplayValues(
+  options: readonly MultiSelectOption[],
+  displayValues: readonly string[],
+): string[] {
+  const optionValues = options.map((option) => option.value);
+  const optionValueSet = new Set(optionValues);
+  const nextValues = displayValues.filter((value) => optionValueSet.has(value));
+  const nextValueSet = new Set(nextValues);
+  return [
+    ...nextValues,
+    ...optionValues.filter((value) => !nextValueSet.has(value)),
+  ];
+}
+
+export function orderMultiSelectOptionsForDisplay(
+  options: readonly MultiSelectOption[],
+  displayValues: readonly string[],
+): MultiSelectOption[] {
+  const optionByValue = new Map(options.map((option) => [option.value, option]));
+  return mergeMultiSelectDisplayValues(options, displayValues)
+    .map((value) => optionByValue.get(value))
+    .filter((option): option is MultiSelectOption => option != null);
+}
+
+export function moveMultiSelectDisplayValue(
+  displayValues: readonly string[],
+  selectedValues: readonly string[],
+  selectedOption: string,
+  direction: "up" | "down",
+): string[] {
+  const selectedIndex = selectedValues.indexOf(selectedOption);
+  if (selectedIndex < 0) return [...displayValues];
+
+  const targetIndex = direction === "up"
+    ? Math.max(0, selectedIndex - 1)
+    : Math.min(selectedValues.length - 1, selectedIndex + 1);
+  if (targetIndex === selectedIndex) return [...displayValues];
+
+  const targetOption = selectedValues[targetIndex];
+  const sourceDisplayIndex = displayValues.indexOf(selectedOption);
+  const targetDisplayIndex = targetOption ? displayValues.indexOf(targetOption) : -1;
+  if (sourceDisplayIndex < 0 || targetDisplayIndex < 0) return [...displayValues];
+
+  const nextDisplayValues = [...displayValues];
+  nextDisplayValues[sourceDisplayIndex] = targetOption!;
+  nextDisplayValues[targetDisplayIndex] = selectedOption;
+  return nextDisplayValues;
 }
 
 export function summarizeMultiSelectValues({

--- a/src/components/ui/native-select.tsx
+++ b/src/components/ui/native-select.tsx
@@ -1,0 +1,120 @@
+/// <reference lib="dom" />
+
+import { type CSSProperties } from "react";
+import { Box } from "../../ui";
+import { colors } from "../../theme/colors";
+
+export type NativeSelectElement = HTMLSelectElement & { showPicker?: () => void };
+
+export interface NativeSelectOption {
+  label: string;
+  value: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+export interface NativeSelectProps {
+  value: string;
+  options: NativeSelectOption[];
+  width?: number | string;
+  includeUnsetOption?: boolean;
+  selectRef?: (element: NativeSelectElement | null) => void;
+  onFocus?: () => void;
+  onChange: (value: string) => void;
+}
+
+export function openNativeSelect(element: NativeSelectElement | null | undefined) {
+  if (!element) return;
+  element.focus();
+  try {
+    if (element.showPicker) {
+      element.showPicker();
+    } else {
+      element.click();
+    }
+  } catch {
+    element.click();
+  }
+}
+
+export function NativeSelect({
+  value,
+  options,
+  width = 184,
+  includeUnsetOption = false,
+  selectRef,
+  onFocus,
+  onChange,
+}: NativeSelectProps) {
+  const hasCurrentValue = options.some((option) => option.value === value);
+  const style: CSSProperties = {
+    width,
+    height: 28,
+    color: colors.text,
+    backgroundColor: "rgba(255, 255, 255, 0.06)",
+    border: `1px solid ${colors.border}`,
+    borderRadius: 6,
+    padding: "0 8px",
+    boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+    cursor: "pointer",
+    font: "inherit",
+    letterSpacing: 0,
+    outline: "none",
+    appearance: "auto",
+    WebkitAppearance: "menulist",
+  };
+
+  return (
+    <Box
+      height="28px"
+      flexDirection="row"
+      alignItems="center"
+      onMouseDown={(event: any) => {
+        event.stopPropagation?.();
+      }}
+      onMouseUp={(event: any) => {
+        event.stopPropagation?.();
+      }}
+    >
+      <select
+        ref={selectRef}
+        value={value}
+        data-gloom-interactive="true"
+        onFocus={onFocus}
+        onMouseDown={(event) => {
+          event.stopPropagation();
+        }}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+        onKeyDown={(event) => {
+          if (
+            event.key === "ArrowUp"
+            || event.key === "ArrowDown"
+            || event.key === "ArrowLeft"
+            || event.key === "ArrowRight"
+            || event.key === "Enter"
+            || event.key === " "
+            || event.key === "Home"
+            || event.key === "End"
+            || event.key === "PageUp"
+            || event.key === "PageDown"
+          ) {
+            event.stopPropagation();
+          }
+        }}
+        onChange={(event) => {
+          onChange(event.currentTarget.value);
+        }}
+        style={style}
+      >
+        {includeUnsetOption && !hasCurrentValue && <option value="">Unset</option>}
+        {options.map((option) => (
+          <option key={option.value} value={option.value} disabled={option.disabled}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </Box>
+  );
+}

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -9,7 +9,14 @@ import { DataTable } from "./data-table";
 import { TextField } from "./fields";
 import { ListView } from "./list-view";
 import { MultiSelectDialogButton } from "./multi-select-dialog";
-import { toggleMultiSelectValue } from "./multi-select";
+import {
+  getMultiSelectDisplayValues,
+  moveMultiSelectDisplayValue,
+  normalizeOrderedMultiSelectValues,
+  orderMultiSelectOptionsForDisplay,
+  toggleMultiSelectValue,
+  toggleOrderedMultiSelectValue,
+} from "./multi-select";
 import { Tabs } from "./tabs";
 import { ToggleList } from "../toggle-list";
 import { AppContext, PaneInstanceProvider, createInitialState } from "../../state/app-context";
@@ -492,6 +499,24 @@ describe("shared UI kit", () => {
 
     expect(toggleMultiSelectValue(options, ["sma"], "ema")).toEqual(["sma", "ema"]);
     expect(toggleMultiSelectValue(options, ["sma", "ema"], "sma")).toEqual(["ema"]);
+  });
+
+  test("keeps ordered multi-select values in user order", () => {
+    const options = [
+      { value: "market", label: "MARKET" },
+      { value: "target", label: "TARGET" },
+      { value: "venue", label: "VENUE" },
+      { value: "odds", label: "TOP ODDS" },
+    ];
+
+    expect(normalizeOrderedMultiSelectValues(options, ["venue", "market"])).toEqual(["venue", "market"]);
+    expect(toggleOrderedMultiSelectValue(options, ["venue", "market"], "target")).toEqual(["venue", "market", "target"]);
+
+    const displayValues = getMultiSelectDisplayValues(options, ["venue", "market", "target"], true);
+    expect(orderMultiSelectOptionsForDisplay(options, displayValues).map((option) => option.value))
+      .toEqual(["venue", "market", "target", "odds"]);
+    expect(moveMultiSelectDisplayValue(displayValues, ["venue", "market", "target"], "market", "up"))
+      .toEqual(["market", "venue", "target", "odds"]);
   });
 
   test("auto-scrolls a scrollable list to keep the selected row visible", async () => {

--- a/src/plugins/builtin/ai/settings.ts
+++ b/src/plugins/builtin/ai/settings.ts
@@ -64,7 +64,6 @@ export function buildAiScreenerPaneSettingsDef(settings: AiScreenerPaneSettings)
       {
         key: "columnIds",
         label: "Columns",
-        description: "Choose which columns this screener shows and in what order.",
         type: "ordered-multi-select",
         options: AI_SCREENER_COLUMN_DEFS.map((column) => ({
           value: column.id,

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -356,6 +356,29 @@ describe("ChatContent", () => {
     expect(frame).not.toContain("click a message");
   });
 
+  test("uses the full message row width when the reply action is hidden", async () => {
+    const controller = createController({
+      messages: [{
+        ...makeMessage(1),
+        content: "small panes should use full width",
+      }],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 44,
+        height: 8,
+      }), {
+        width: 44,
+        height: 8,
+      });
+    });
+
+    await flushFrame();
+
+    expect(testSetup.captureCharFrame()).toContain("small panes should use full width");
+  });
+
   test("does not select a message when the row is clicked", async () => {
     const controller = createController({
       messages: [makeMessage(1)],
@@ -442,6 +465,34 @@ describe("ChatContent", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("replying to @user2");
     expect(frame).toContain("Reply to @user2...");
+  });
+
+  test("shows the reply action next to the selected message timestamp", async () => {
+    const controller = createController({
+      messages: [makeMessage(1), makeMessage(2)],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 72,
+        height: 12,
+      }), {
+        width: 72,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    await emitKeypress({ name: "up", sequence: "\u001b[A" });
+    await flushFrame();
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const headerLine = lines.find((line) => line.includes("user2"));
+    const bodyLine = lines.find((line) => line.includes("message 2"));
+
+    expect(headerLine).toContain("Reply");
+    expect(bodyLine).not.toContain("Reply");
   });
 
   test("down arrow from the newest selected message returns focus to the composer", async () => {
@@ -931,6 +982,73 @@ describe("ChatContent", () => {
     expect(frameAfterUpdate).not.toContain("message 1");
   });
 
+  test("repins the transcript to the latest message when a following chat pane regains focus", async () => {
+    const controller = createController({
+      messages: [
+        makeMessage(1),
+        makeMessage(2),
+        makeMessage(3),
+        makeMessage(4),
+        makeMessage(5),
+        makeMessage(6),
+        makeMessage(7),
+        makeMessage(8),
+      ],
+    });
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat-refocus"));
+    let setFocused: ((focused: boolean) => void) | undefined;
+
+    function FocusHarness() {
+      const [isFocused, updateFocused] = useState(false);
+      setFocused = updateFocused;
+
+      return (
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={60}
+              height={13}
+              focused={isFocused}
+            />
+          </PluginRenderProvider>
+        </AppContext>
+      );
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<FocusHarness />, {
+        width: 60,
+        height: 13,
+      });
+    });
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("message 8");
+
+    await act(async () => {
+      await testSetup!.mockMouse.scroll(3, 4, "up");
+      await testSetup!.mockMouse.scroll(3, 4, "up");
+      await testSetup!.mockMouse.scroll(3, 4, "up");
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const scrolledFrame = testSetup.captureCharFrame();
+    expect(scrolledFrame).toContain("message 2");
+    expect(scrolledFrame).not.toContain("message 8");
+
+    await act(async () => {
+      setFocused?.(true);
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    const refocusedFrame = testSetup.captureCharFrame();
+    expect(refocusedFrame).toContain("message 8");
+    expect(refocusedFrame).not.toContain("message 2");
+  });
+
   test("keeps the bottom reachable after narrowing the chat pane", async () => {
     const controller = createController({
       messages: [
@@ -989,7 +1107,7 @@ describe("ChatContent", () => {
     const frame = testSetup!.captureCharFrame();
     expect(frame).toContain("vince");
     expect(frame).toContain("newest message stays");
-    expect(frame).toContain("reachable after shrink");
+    expect(frame).toContain("shrink");
   });
 
   test("renders ticker badges and opens a floating detail pane on click", async () => {
@@ -1284,6 +1402,7 @@ describe("ChatContent", () => {
         deleteState: () => {},
       },
       registerPane: () => {},
+      registerPaneTemplate: () => {},
       registerShortcut: () => {},
       registerCommand: (command: { id: string; wizardLayout?: string; wizard?: Array<{ key: string }> }) => {
         registeredCommands.push(command);

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -1,5 +1,5 @@
 import { Box, ScrollBox, Span, Text, Textarea, useUiCapabilities } from "../../ui";
-import { Fragment, useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useShortcut } from "../../react/input";
 import { TextAttributes, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
@@ -86,7 +86,7 @@ function wrapTextLines(text: string, width: number) {
 }
 
 function getMessageBodyLines(message: ChatMessage, width: number) {
-  const contentLineWidth = Math.max(width - 4 - MESSAGE_ACTION_WIDTH, 1);
+  const contentLineWidth = Math.max(width - 4, 1);
   return wrapTextLines(message.content, contentLineWidth);
 }
 
@@ -271,7 +271,7 @@ export function ChatContent({
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const applyingExternalDraftRef = useRef(false);
   const canSend = !!user?.emailVerified;
-  const messageBodyWidth = Math.max(contentWidth - 4 - MESSAGE_ACTION_WIDTH, 1);
+  const messageBodyWidth = Math.max(contentWidth - 4, 1);
   const composerPrefixWidth = nativePaneChrome ? 0 : 3;
   const composerTextWidth = Math.max(contentWidth - composerPrefixWidth, 1);
   const composerRows = estimateComposerHeight(inputValue, composerTextWidth);
@@ -555,7 +555,8 @@ export function ChatContent({
   const composerBackground = nativePaneChrome ? blendHex(colors.panel, colors.bg, 0.22) : colors.bg;
   const composerBorder = inputFocused && focused
     ? blendHex(colors.borderFocused, colors.textBright, 0.24)
-    : blendHex(colors.border, colors.borderFocused, 0.18);
+    : colors.border;
+  const composerWidth = nativePaneChrome ? width : contentWidth;
 
   useEffect(() => {
     if (selectedIdx < messages.length) return;
@@ -566,6 +567,11 @@ export function ChatContent({
     if (!stickyTranscript) return;
     queueMicrotask(() => scrollToBottom(scrollRef.current));
   }, [contentWidth, height, messages, messageAreaHeight, stickyTranscript]);
+
+  useEffect(() => {
+    if (!focused || !stickyTranscript) return;
+    queueMicrotask(() => scrollToBottom(scrollRef.current));
+  }, [focused, stickyTranscript]);
 
   useEffect(() => {
     const sb = scrollRef.current;
@@ -644,16 +650,27 @@ export function ChatContent({
           const authorAttributes = (isSending ? TextAttributes.DIM : 0) | TextAttributes.BOLD;
           const bodyColor = isSelected ? selectedTextColor : hasFailed ? colors.negative : isSending ? colors.textDim : colors.text;
           const bodyLines = getMessageBodyLines(msg, contentWidth);
+          const showInlineReplyAction = !grouped && (nativePaneChrome ? canSend : showReplyAction);
+          const showGroupedReplyAction = grouped && (nativePaneChrome ? canSend : showReplyAction);
           const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));
           const clearHovered = () => setHoveredIdx((current) => (current === index ? null : current));
           const messageRowProps = {
             width: contentWidth,
             backgroundColor: bgColor,
-            onMouseMove: setHovered,
-            onMouseOut: clearHovered,
+            "data-gloom-role": nativePaneChrome ? "chat-message-row" : undefined,
+            "data-selected": nativePaneChrome ? (isSelected ? "true" : "false") : undefined,
+            onMouseMove: nativePaneChrome ? undefined : setHovered,
+            onMouseOut: nativePaneChrome ? undefined : clearHovered,
           };
           return (
-            <Fragment key={msg.id}>
+            <Box
+              key={msg.id}
+              width={contentWidth}
+              flexDirection="column"
+              data-gloom-role={nativePaneChrome ? "chat-message" : undefined}
+              data-selected={nativePaneChrome ? (isSelected ? "true" : "false") : undefined}
+              style={nativePaneChrome ? { "--chat-hover-bg": hoverBg() } : undefined}
+            >
               {msg.replyTo && (
                 <Box
                   {...messageRowProps}
@@ -682,6 +699,23 @@ export function ChatContent({
                     {msg.user.username ?? "anon"}
                   </Text>
                   <Text fg={headerStatusColor}> {headerStatus}</Text>
+                  {showInlineReplyAction && (
+                    <>
+                      <Text fg={headerStatusColor}> </Text>
+                      <Box
+                        width={MESSAGE_ACTION_WIDTH}
+                        height={1}
+                        data-gloom-role={nativePaneChrome ? "chat-message-reply-action" : undefined}
+                      >
+                        <ChatActionChip
+                          label="Reply"
+                          width={MESSAGE_ACTION_WIDTH}
+                          emphasized={isSelected}
+                          onPress={() => beginReplyTo(index)}
+                        />
+                      </Box>
+                    </>
+                  )}
                 </Box>
               )}
               {bodyLines.map((line, lineIndex) => (
@@ -691,6 +725,7 @@ export function ChatContent({
                   paddingLeft={3}
                   height={1}
                   flexDirection="row"
+                  position={grouped ? "relative" : undefined}
                 >
                   <Box width={messageBodyWidth} height={1}>
                     <TickerBadgeText
@@ -701,19 +736,26 @@ export function ChatContent({
                       openTicker={openTicker}
                     />
                   </Box>
-                  <Box width={MESSAGE_ACTION_WIDTH} height={1}>
-                    {lineIndex === 0 && showReplyAction && (
+                  {lineIndex === 0 && showGroupedReplyAction && (
+                    <Box
+                      position="absolute"
+                      top={0}
+                      right={0}
+                      width={MESSAGE_ACTION_WIDTH}
+                      height={1}
+                      data-gloom-role={nativePaneChrome ? "chat-message-reply-action" : undefined}
+                    >
                       <ChatActionChip
                         label="Reply"
                         width={MESSAGE_ACTION_WIDTH}
                         emphasized={isSelected}
                         onPress={() => beginReplyTo(index)}
                       />
-                    )}
-                  </Box>
+                    </Box>
+                  )}
                 </Box>
               ))}
-            </Fragment>
+            </Box>
           );
         })}
       </ScrollBox>
@@ -740,7 +782,16 @@ export function ChatContent({
             </Box>
           )}
 
-          <Box height={composerHeight} width={contentWidth} flexDirection="row" onMouseDown={focusInput}>
+          <Box
+            height={composerHeight}
+            width={composerWidth}
+            flexDirection="row"
+            backgroundColor={nativePaneChrome ? composerBackground : undefined}
+            style={nativePaneChrome ? {
+              borderTop: `1px solid ${composerBorder}`,
+            } : undefined}
+            onMouseDown={focusInput}
+          >
             {!nativePaneChrome && (
               <Box width={composerPrefixWidth} height={composerHeight}>
                 <Text fg={colors.textDim}> {">"} </Text>
@@ -749,15 +800,7 @@ export function ChatContent({
             <Box
               width={nativePaneChrome ? "100%" : composerTextWidth}
               height={composerHeight}
-              backgroundColor={nativePaneChrome ? composerBackground : undefined}
-              style={nativePaneChrome ? {
-                border: `1px solid ${composerBorder}`,
-                borderRadius: 6,
-                boxShadow: inputFocused && focused
-                  ? "0 0 0 1px rgba(84, 201, 159, 0.16), inset 0 1px 0 rgba(255,255,255,0.05)"
-                  : "inset 0 1px 0 rgba(255,255,255,0.04)",
-                overflow: "hidden",
-              } : undefined}
+              backgroundColor={nativePaneChrome ? "transparent" : undefined}
             >
               <Textarea
                 ref={inputRef}
@@ -768,14 +811,13 @@ export function ChatContent({
                 placeholder={inputPlaceholder}
                 placeholderColor={colors.textMuted}
                 textColor={colors.text}
-                backgroundColor={composerBackground}
-                focusedBackgroundColor={composerBackground}
+                backgroundColor={nativePaneChrome ? "transparent" : composerBackground}
+                focusedBackgroundColor={nativePaneChrome ? "transparent" : composerBackground}
                 cursorColor={colors.textBright}
                 style={nativePaneChrome ? {
-                  padding: "6px 10px",
+                  padding: "6px 12px",
                   lineHeight: "20px",
                   fontSize: "13px",
-                  borderRadius: 6,
                 } : undefined}
                 onInput={commitLocalDraft}
                 keyBindings={[

--- a/src/plugins/builtin/correlation/settings.ts
+++ b/src/plugins/builtin/correlation/settings.ts
@@ -83,7 +83,6 @@ export function buildCorrelationSettingsDef(): PaneSettingsDef {
       {
         key: "rangePreset",
         label: "Range",
-        description: "Use daily closes over this range.",
         type: "select",
         options: CORRELATION_RANGE_OPTIONS.map((range) => ({
           value: range,

--- a/src/plugins/builtin/portfolio-list/settings.ts
+++ b/src/plugins/builtin/portfolio-list/settings.ts
@@ -196,7 +196,6 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
     {
       key: "columnIds",
       label: "Columns",
-      description: "Choose which columns this pane shows and in what order.",
       type: "ordered-multi-select",
       options: PORTFOLIO_COLUMN_DEFS.map((column) => ({
         value: column.id,
@@ -209,7 +208,6 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
     {
       key: "collectionScope",
       label: "Collections",
-      description: "Control which portfolios or watchlists appear in this pane.",
       type: "select",
       options: COLLECTION_SCOPE_OPTIONS,
     },
@@ -219,7 +217,6 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
     fields.push({
       key: "visibleCollectionIds",
       label: "Visible Collections",
-      description: "Pick the exact collections that should appear in this pane.",
       type: "multi-select",
       options: allCollectionOptions,
     });
@@ -234,19 +231,16 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
   fields.push({
     key: "hideHeader",
     label: "Hide Header Bar",
-    description: "Hide the summary bar showing portfolio value, P&L, and account metrics.",
     type: "toggle",
   });
   fields.push({
     key: "hideCash",
     label: "Hide Cash Positions",
-    description: "Hide the cash & margin drawer at the bottom of the pane.",
     type: "toggle",
   });
   fields.push({
     key: "showSparklines",
     label: "Sparklines",
-    description: "Show a tiny price history chart in each row.",
     type: "toggle",
   });
 
@@ -254,7 +248,6 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
     fields.push({
       key: "lockedCollectionId",
       label: "Locked Collection",
-      description: "Choose which collection this pane should stay pinned to.",
       type: "select",
       options: lockedCollectionOptions,
     });

--- a/src/plugins/builtin/ticker-detail/settings.ts
+++ b/src/plugins/builtin/ticker-detail/settings.ts
@@ -81,7 +81,6 @@ export function buildTickerDetailSettingsDef(settings: TickerDetailPaneSettings)
         ? [{
           key: "lockedTabId",
           label: "Locked Tab",
-          description: "Choose which tab this pane should stay pinned to when tabs are hidden.",
           type: "select" as const,
           options: tabs.map((tab) => ({ value: tab.id, label: tab.name })),
         }]
@@ -107,7 +106,6 @@ export function buildQuoteMonitorSettingsDef(): PaneSettingsDef {
       {
         key: "symbol",
         label: "Ticker",
-        description: "Set the fixed ticker symbol for this quote monitor.",
         type: "text",
         placeholder: "AAPL",
       },

--- a/src/plugins/prediction-markets/settings.ts
+++ b/src/plugins/prediction-markets/settings.ts
@@ -116,8 +116,6 @@ export function buildPredictionMarketsPaneSettingsDef(
     {
       key: "columnIds",
       label: "Columns",
-      description:
-        "Choose which columns this prediction-markets pane shows and in what order.",
       type: "ordered-multi-select",
       options: PREDICTION_COLUMN_DEFS.map((column) => ({
         value: column.id,
@@ -137,7 +135,6 @@ export function buildPredictionMarketsPaneSettingsDef(
     fields.push({
       key: "lockedVenueScope",
       label: "Locked Venue Scope",
-      description: "Choose the venue scope to show when tabs are hidden.",
       type: "select",
       options: VENUE_SCOPE_OPTIONS,
     });
@@ -146,13 +143,11 @@ export function buildPredictionMarketsPaneSettingsDef(
   fields.push({
     key: "hideHeader",
     label: "Hide Header",
-    description: "Hide the compact status header above the table.",
     type: "toggle",
   });
   fields.push({
     key: "defaultBrowseTab",
     label: "Default Browse Tab",
-    description: "Choose the initial market slice for new panes.",
     type: "select",
     options: BROWSE_TAB_OPTIONS,
   });

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -26,6 +26,7 @@ import type {
   DataTableSectionHeader,
 } from "../../../components/ui/data-table";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
+import { useScrollbarActivity } from "./scrollbar-activity";
 
 interface VirtualRow {
   index: number;
@@ -419,6 +420,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const headerVertical = useScrollbarState(false);
   const bodyHorizontal = useScrollbarState(showHorizontalScrollbar);
   const bodyVertical = useScrollbarState(true);
+  const [scrollbarActive, markScrollbarActive] = useScrollbarActivity();
   const tableWidth = useMemo(
     () => columns.reduce((sum, column) => sum + column.width + 1, 2),
     [columns],
@@ -556,6 +558,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
             : "hidden"
         }
         data-gloom-scrollbar-y={bodyVertical.visible ? "visible" : "hidden"}
+        data-gloom-scrollbar-active={scrollbarActive ? "true" : undefined}
         style={bodyScrollerStyle}
         onMouseDown={() => {
           focusPane();
@@ -564,7 +567,11 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
           if (hoveredIdx !== null) setHoveredIdx(null);
         }}
         onScroll={() => {
+          markScrollbarActive();
           scheduleBodyScrollActivity();
+        }}
+        onWheel={() => {
+          markScrollbarActive();
         }}
       >
         <div

--- a/src/renderers/electrobun/view/scrollbar-activity.ts
+++ b/src/renderers/electrobun/view/scrollbar-activity.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const SCROLLBAR_ACTIVITY_TIMEOUT_MS = 700;
+
+export function useScrollbarActivity() {
+  const [active, setActive] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const markScrollbarActive = useCallback(() => {
+    setActive(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      setActive(false);
+    }, SCROLLBAR_ACTIVITY_TIMEOUT_MS);
+  }, []);
+
+  useEffect(() => () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
+
+  return [active, markScrollbarActive] as const;
+}

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -49,6 +49,7 @@ import {
   WebSegmentedControl,
   WebTextField,
 } from "./desktop-controls";
+import { useScrollbarActivity } from "./scrollbar-activity";
 
 function cellWidth(value: unknown): CSSProperties["width"] {
   if (typeof value === "number") return `${value * WEB_CELL_WIDTH}px`;
@@ -793,6 +794,7 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
     const verticalScrollBarVisibleRef = useRef(verticalScrollBarVisible);
     const scrollFrameRef = useRef<number | null>(null);
     const lastWheelAtRef = useRef(0);
+    const [scrollbarActive, markScrollbarActive] = useScrollbarActivity();
 
     const getElement = () => elementRef.current;
     const toCellY = (pixels: number) => Math.max(0, Math.round(pixels / WEB_CELL_HEIGHT));
@@ -883,9 +885,11 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
       },
     }), [horizontalScrollBar, verticalScrollBar]);
 
+    const scrollable = props.scrollX === true || props.scrollY === true;
     const overflowX = props.scrollX === true ? "auto" : "hidden";
     const overflowY = props.scrollY === true ? "auto" : "hidden";
     const handleScroll = useCallback(() => {
+      markScrollbarActive();
       if (typeof props.onMouseScroll !== "function") return;
       if (Date.now() - lastWheelAtRef.current < 32) return;
       if (scrollFrameRef.current != null) return;
@@ -893,11 +897,12 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         scrollFrameRef.current = null;
         (props.onMouseScroll as () => void)();
       });
-    }, [props.onMouseScroll]);
+    }, [markScrollbarActive, props.onMouseScroll]);
     const handleWheel = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
+      markScrollbarActive();
       lastWheelAtRef.current = Date.now();
       callMouseHandler(props.onMouseScroll, event, "scroll");
-    }, [props.onMouseScroll]);
+    }, [markScrollbarActive, props.onMouseScroll]);
 
     return (
       <div
@@ -905,13 +910,14 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         ref={elementRef}
         data-gloom-scrollbar-x={props.scrollX === true ? (horizontalScrollBarVisible ? "visible" : "hidden") : undefined}
         data-gloom-scrollbar-y={props.scrollY === true ? (verticalScrollBarVisible ? "visible" : "hidden") : undefined}
+        data-gloom-scrollbar-active={scrollbarActive ? "true" : undefined}
         data-gloom-interactive={hasDirectMouseHandler(props) ? "true" : undefined}
         onMouseDown={(event) => callMouseHandler(props.onMouseDown, event, "down")}
         onMouseMove={(event) => callMouseHandler(props.onMouseMove, event, "move")}
         onMouseUp={(event) => callMouseHandler(props.onMouseUp, event, "up")}
         onMouseOut={(event) => callMouseHandler(props.onMouseOut, event, "out")}
-        onScroll={typeof props.onMouseScroll === "function" ? handleScroll : undefined}
-        onWheel={typeof props.onMouseScroll === "function" ? handleWheel : undefined}
+        onScroll={scrollable ? handleScroll : undefined}
+        onWheel={scrollable ? handleWheel : undefined}
         style={{ ...commonStyle(props), overflowX, overflowY, ...(props.style as CSSProperties | undefined) }}
       >
         {children as ReactNode}


### PR DESCRIPTION
Polishes the desktop chat pane so the composer is integrated with the window, reply actions sit next to timestamps, hover state is CSS-driven, compact panes use the full message width, and focused chats repin to the latest message when following.
Fixes native-pane layout so panes without footer/status content do not reserve a blank bottom row.
Updates desktop settings and shared controls with native select controls, preserved ordered multi-select display order, leaner setting copy, tighter toggle rows, and transient desktop scrollbars.
Validated with `bun test src/components/ui/ui.test.tsx src/plugins/builtin/chat.test.tsx`, `bun run desktop:view:build`, `git diff --check`, and a cached diff secret scan.