### PR TITLE
Add infinite chat history paging

### DIFF
--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -730,4 +730,79 @@ describe("ChatController", () => {
       lastCursor: "m2",
     });
   });
+
+  test("loads older messages before the oldest cached message without moving the latest cursor", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const cached: ChatMessage[] = [
+      {
+        id: "m3",
+        channelId: "everyone",
+        content: "cached older",
+        replyToId: null,
+        createdAt: "2026-03-28T00:03:00.000Z",
+        user: { id: "u3", username: "cara", displayName: "Cara" },
+      },
+      {
+        id: "m4",
+        channelId: "everyone",
+        content: "cached newer",
+        replyToId: null,
+        createdAt: "2026-03-28T00:04:00.000Z",
+        user: { id: "u4", username: "drew", displayName: "Drew" },
+      },
+    ];
+    const older: ChatMessage[] = [
+      {
+        id: "m1",
+        channelId: "everyone",
+        content: "oldest",
+        replyToId: null,
+        createdAt: "2026-03-28T00:01:00.000Z",
+        user: { id: "u1", username: "alice", displayName: "Alice" },
+      },
+      {
+        id: "m2",
+        channelId: "everyone",
+        content: "older",
+        replyToId: null,
+        createdAt: "2026-03-28T00:02:00.000Z",
+        user: { id: "u2", username: "bob", displayName: "Bob" },
+      },
+    ];
+
+    persistence.setState("channel:everyone", {
+      draft: "",
+      replyToId: null,
+      lastCursor: "m4",
+      lastViewedMessageId: "m4",
+    }, { schemaVersion: 1 });
+    persistence.setResource(TRANSCRIPT_KIND, TRANSCRIPT_KEY, {
+      messages: cached,
+    }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+
+    controller.attachPersistence(persistence);
+
+    const calls: Array<{ channelId: string; opts?: { after?: string; before?: string; limit?: number } }> = [];
+    apiClient.getMessages = async (channelId, opts) => {
+      calls.push({ channelId, opts });
+      return opts?.before === "m3" ? older : [];
+    };
+
+    await controller.loadOlderMessages();
+
+    expect(calls).toEqual([{
+      channelId: "everyone",
+      opts: { limit: 50, before: "m3" },
+    }]);
+    expect(controller.getSnapshot().messages.map((entry) => entry.id)).toEqual(["m1", "m2", "m3", "m4"]);
+    expect(controller.getSnapshot().hasOlderMessages).toBe(false);
+    expect(persistence.getState<{ lastCursor: string }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
+      lastCursor: "m4",
+    });
+  });
 });

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -7,6 +7,7 @@ const SESSION_STATE_KEY = "session";
 const CHANNEL_STATE_KEY = "channel:everyone";
 const TRANSCRIPT_KIND = "channel-transcript";
 const TRANSCRIPT_SOURCE = "server";
+const MESSAGE_PAGE_SIZE = 50;
 const MAX_CACHED_MESSAGES = 50;
 const SESSION_SCHEMA_VERSION = 1;
 const CHANNEL_SCHEMA_VERSION = 1;
@@ -40,6 +41,8 @@ interface PersistedTranscript {
 
 export interface ChatControllerSnapshot {
   loading: boolean;
+  loadingOlderMessages: boolean;
+  hasOlderMessages: boolean;
   hasSavedSession: boolean;
   user: { id: string; username: string; emailVerified: boolean } | null;
   messages: ChatMessage[];
@@ -108,7 +111,10 @@ export class ChatController {
   private hydrated = false;
   private sessionChecked = false;
   private messagesLoading = false;
+  private olderMessagesLoading = false;
   private refreshMessagesPromise: Promise<void> | null = null;
+  private loadOlderMessagesPromise: Promise<void> | null = null;
+  private reachedOldestMessage = false;
   private user: { id: string; username: string; emailVerified: boolean } | null = null;
   private messages: ChatMessage[] = [];
   private pendingMessages: ChatMessage[] = [];
@@ -191,6 +197,8 @@ export class ChatController {
   getSnapshot(): ChatControllerSnapshot {
     return {
       loading: !this.sessionChecked || this.messagesLoading,
+      loadingOlderMessages: this.olderMessagesLoading,
+      hasOlderMessages: this.messages.length > 0 && !this.reachedOldestMessage,
       hasSavedSession: !!apiClient.getSessionToken(),
       user: this.user,
       messages: this.getVisibleMessages(),
@@ -276,6 +284,28 @@ export class ChatController {
     return request;
   }
 
+  async loadOlderMessages(): Promise<void> {
+    if (this.loadOlderMessagesPromise) return this.loadOlderMessagesPromise;
+    const before = this.messages[0]?.id ?? null;
+    if (!before || this.reachedOldestMessage) return;
+
+    this.olderMessagesLoading = true;
+    this.emit();
+
+    const request = this.fetchOlderMessages(before)
+      .catch(() => {
+        this.persistChannelState();
+      })
+      .finally(() => {
+        this.olderMessagesLoading = false;
+        this.loadOlderMessagesPromise = null;
+        this.emit();
+      });
+
+    this.loadOlderMessagesPromise = request;
+    return request;
+  }
+
   setDraft(draft: string): void {
     if (draft === this.draft) return;
     this.draft = draft;
@@ -332,6 +362,7 @@ export class ChatController {
     this.replyToId = null;
     this.lastCursor = null;
     this.lastViewedMessageId = null;
+    this.reachedOldestMessage = false;
     this.openViewCount = 0;
     if (clearSession) {
       this.user = null;
@@ -355,7 +386,9 @@ export class ChatController {
     this.wsConnection = null;
     this.wsConnected = false;
     this.messagesLoading = false;
+    this.olderMessagesLoading = false;
     this.refreshMessagesPromise = null;
+    this.loadOlderMessagesPromise = null;
     this.openViewCount = 0;
     this.notifyFn = () => {};
     this.listeners.clear();
@@ -442,18 +475,25 @@ export class ChatController {
 
   private async fetchMessages(): Promise<void> {
     const legacyTimestampCursor = isLegacyTimestampCursor(this.lastCursor);
+    const hasIncrementalCursor = !!this.lastCursor;
 
     try {
       const messages = await apiClient.getMessages("everyone", {
-        limit: MAX_CACHED_MESSAGES,
+        limit: MESSAGE_PAGE_SIZE,
         after: this.lastCursor ?? undefined,
       });
+      if (!hasIncrementalCursor && messages.length < MESSAGE_PAGE_SIZE) {
+        this.reachedOldestMessage = true;
+      }
       if (messages.length > 0) {
         this.mergeMessages(messages);
         return;
       }
       if (legacyTimestampCursor) {
-        const fullRefresh = await apiClient.getMessages("everyone", { limit: MAX_CACHED_MESSAGES });
+        const fullRefresh = await apiClient.getMessages("everyone", { limit: MESSAGE_PAGE_SIZE });
+        if (fullRefresh.length < MESSAGE_PAGE_SIZE) {
+          this.reachedOldestMessage = true;
+        }
         if (fullRefresh.length > 0) {
           this.mergeMessages(fullRefresh);
           return;
@@ -463,7 +503,10 @@ export class ChatController {
       this.persistChannelState();
       return;
     } catch {
-      const messages = await apiClient.getMessages("everyone", { limit: MAX_CACHED_MESSAGES });
+      const messages = await apiClient.getMessages("everyone", { limit: MESSAGE_PAGE_SIZE });
+      if (messages.length < MESSAGE_PAGE_SIZE) {
+        this.reachedOldestMessage = true;
+      }
       if (messages.length > 0) {
         this.mergeMessages(messages);
         return;
@@ -472,7 +515,22 @@ export class ChatController {
     }
   }
 
-  private mergeMessages(messages: ChatMessage[]): void {
+  private async fetchOlderMessages(before: string): Promise<void> {
+    const messages = await apiClient.getMessages("everyone", {
+      limit: MESSAGE_PAGE_SIZE,
+      before,
+    });
+    if (messages.length < MESSAGE_PAGE_SIZE) {
+      this.reachedOldestMessage = true;
+    }
+    if (messages.length === 0) {
+      this.persistChannelState();
+      return;
+    }
+    this.mergeMessages(messages, { notifyMentions: false });
+  }
+
+  private mergeMessages(messages: ChatMessage[], options?: { notifyMentions?: boolean }): void {
     this.reconcilePendingMessages(messages);
     const merged = new Map<string, ChatMessage>();
     const incoming = new Map<string, ChatMessage>();
@@ -484,13 +542,14 @@ export class ChatController {
       merged.set(message.id, message);
     }
     this.messages = [...merged.values()]
-      .sort(compareMessages)
-      .slice(-MAX_CACHED_MESSAGES);
+      .sort(compareMessages);
     this.lastCursor = this.messages[this.messages.length - 1]?.id ?? this.lastCursor;
     if (this.openViewCount > 0) {
       this.markViewedThroughLatestMessage(false);
     }
-    this.trackUnreadMentions([...incoming.values()]);
+    if (options?.notifyMentions !== false) {
+      this.trackUnreadMentions([...incoming.values()]);
+    }
     this.persistTranscript();
     this.emit();
   }
@@ -531,7 +590,7 @@ export class ChatController {
     }
 
     this.persistence?.setResource(TRANSCRIPT_KIND, "everyone", {
-      messages: this.messages,
+      messages: this.messages.slice(-MAX_CACHED_MESSAGES),
     } satisfies PersistedTranscript, {
       sourceKey: TRANSCRIPT_SOURCE,
       schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
@@ -604,8 +663,7 @@ export class ChatController {
 
   private getVisibleMessages(): ChatMessage[] {
     return [...this.messages, ...this.pendingMessages]
-      .sort(compareMessages)
-      .slice(-MAX_CACHED_MESSAGES);
+      .sort(compareMessages);
   }
 
   private createPendingMessage(content: string, replyToId?: string): ChatMessage {

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -982,6 +982,59 @@ describe("ChatContent", () => {
     expect(frameAfterUpdate).not.toContain("message 1");
   });
 
+  test("loads older messages at the top without jumping away from the current transcript", async () => {
+    const controller = createController({
+      messages: [
+        makeMessage(4),
+        makeMessage(5),
+        makeMessage(6),
+        makeMessage(7),
+        makeMessage(8),
+        makeMessage(9),
+        makeMessage(10),
+      ],
+    });
+    let loadCount = 0;
+    controller.loadOlderMessages = async () => {
+      loadCount += 1;
+      (controller as any).mergeMessages([
+        makeMessage(1),
+        makeMessage(2),
+        makeMessage(3),
+      ], { notifyMentions: false });
+    };
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, { width: 60, height: 13 }), {
+        width: 60,
+        height: 13,
+      });
+    });
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("message 10");
+
+    await emitKeypress({ name: "g", sequence: "g" });
+    await flushFrame();
+
+    expect(loadCount).toBe(1);
+    expect(controller.getSnapshot().messages.map((message) => message.id)).toEqual([
+      "m1",
+      "m2",
+      "m3",
+      "m4",
+      "m5",
+      "m6",
+      "m7",
+      "m8",
+      "m9",
+      "m10",
+    ]);
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("message 4");
+    expect(frame).not.toContain("message 1");
+  });
+
   test("repins the transcript to the latest message when a following chat pane regains focus", async () => {
     const controller = createController({
       messages: [

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -23,7 +23,15 @@ interface ChatContentProps {
   close?: () => void;
   controller?: Pick<
     ChatController,
-    "attachView" | "getSnapshot" | "refreshMessages" | "refreshSession" | "send" | "setDraft" | "setReplyToId" | "subscribe"
+    | "attachView"
+    | "getSnapshot"
+    | "loadOlderMessages"
+    | "refreshMessages"
+    | "refreshSession"
+    | "send"
+    | "setDraft"
+    | "setReplyToId"
+    | "subscribe"
   >;
 }
 
@@ -33,6 +41,7 @@ interface ChatStatusWidgetProps {
 
 const MESSAGE_GROUP_THRESHOLD_MS = 5 * 60 * 1000;
 const CHAT_COMPOSER_MAX_ROWS = 5;
+const NATIVE_CHAT_COMPOSER_TOP_GAP_PX = 12;
 const MESSAGE_ACTION_WIDTH = 9;
 const COMPOSER_ACTION_WIDTH = 10;
 const MESSAGE_SELECTION_BOTTOM_INSET = 1;
@@ -257,6 +266,8 @@ export function ChatContent({
   const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
   const [user, setUser] = useState<{ id: string; username: string; emailVerified: boolean } | null>(initialSnapshot.user);
   const [loading, setLoading] = useState(initialSnapshot.loading);
+  const [loadingOlderMessages, setLoadingOlderMessages] = useState(initialSnapshot.loadingOlderMessages);
+  const [hasOlderMessages, setHasOlderMessages] = useState(initialSnapshot.hasOlderMessages);
   const [inputFocused, setInputFocused] = useState(false);
   const [inputValue, setInputValue] = useState(initialSnapshot.draft);
   const [selectedIdx, setSelectedIdx] = useState(-1);
@@ -270,7 +281,14 @@ export function ChatContent({
   const inputRef = useRef<TextareaRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const applyingExternalDraftRef = useRef(false);
+  const prependAnchorRef = useRef<{
+    oldestMessageId: string | null;
+    scrollHeight: number;
+    scrollTop: number;
+    selectedMessageId: string | null;
+  } | null>(null);
   const canSend = !!user?.emailVerified;
+  const nativeComposerTopGap = nativePaneChrome && canSend ? NATIVE_CHAT_COMPOSER_TOP_GAP_PX : 0;
   const messageBodyWidth = Math.max(contentWidth - 4, 1);
   const composerPrefixWidth = nativePaneChrome ? 0 : 3;
   const composerTextWidth = Math.max(contentWidth - composerPrefixWidth, 1);
@@ -293,6 +311,8 @@ export function ChatContent({
       setHasSavedSession(snapshot.hasSavedSession);
       setUser(snapshot.user);
       setLoading(snapshot.loading);
+      setLoadingOlderMessages(snapshot.loadingOlderMessages);
+      setHasOlderMessages(snapshot.hasOlderMessages);
       setInputValue((current) => (current === snapshot.draft ? current : snapshot.draft));
       const textarea = inputRef.current;
       if (textarea && textarea.editBuffer.getText() !== snapshot.draft) {
@@ -393,6 +413,28 @@ export function ChatContent({
     setSelectedIdx(-1);
     setFollowMessages(true);
   }, [controller]);
+
+  const requestOlderMessages = useCallback(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox || loadingOlderMessages || !hasOlderMessages || messages.length === 0) return;
+
+    prependAnchorRef.current = {
+      oldestMessageId: messages[0]?.id ?? null,
+      scrollHeight: scrollBox.scrollHeight,
+      scrollTop: scrollBox.scrollTop,
+      selectedMessageId: selectedIdx >= 0 ? messages[selectedIdx]?.id ?? null : null,
+    };
+    setFollowMessages(false);
+    void controller.loadOlderMessages().catch(() => {
+      prependAnchorRef.current = null;
+    });
+  }, [controller, hasOlderMessages, loadingOlderMessages, messages, selectedIdx]);
+
+  const requestOlderMessagesIfNeeded = useCallback(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox || scrollBox.scrollTop > 1) return;
+    requestOlderMessages();
+  }, [requestOlderMessages]);
 
   useEffect(() => {
     if (!canSend && inputFocused) {
@@ -505,6 +547,10 @@ export function ChatContent({
     if (event.name === "k" || event.name === "up") {
       event.preventDefault?.();
       event.stopPropagation?.();
+      if (selectedIdx === 0 && hasOlderMessages && !loadingOlderMessages) {
+        requestOlderMessages();
+        return;
+      }
       moveMessageSelection("up");
       return;
     }
@@ -522,6 +568,7 @@ export function ChatContent({
       setSelectedIdx(0);
       setFollowMessages(false);
       scrollRef.current?.scrollTo(0);
+      queueMicrotask(requestOlderMessagesIfNeeded);
       return;
     }
     if (event.name === "g" && event.shift) {
@@ -539,9 +586,13 @@ export function ChatContent({
     clearReplyTarget,
     focused,
     inputFocused,
+    hasOlderMessages,
+    loadingOlderMessages,
     messages.length,
     moveMessageSelection,
     replyTo,
+    requestOlderMessages,
+    requestOlderMessagesIfNeeded,
     returnToComposer,
     selectedIdx,
     shouldLeaveComposerForSelection,
@@ -567,6 +618,32 @@ export function ChatContent({
     if (!stickyTranscript) return;
     queueMicrotask(() => scrollToBottom(scrollRef.current));
   }, [contentWidth, height, messages, messageAreaHeight, stickyTranscript]);
+
+  useEffect(() => {
+    const anchor = prependAnchorRef.current;
+    if (!anchor || loadingOlderMessages) return;
+
+    queueMicrotask(() => {
+      const currentAnchor = prependAnchorRef.current;
+      const scrollBox = scrollRef.current;
+      if (!currentAnchor || !scrollBox) return;
+
+      const previousOldestIndex = currentAnchor.oldestMessageId
+        ? messages.findIndex((message) => message.id === currentAnchor.oldestMessageId)
+        : -1;
+      const addedRows = previousOldestIndex > 0
+        ? getMessageTopOffset(messages, previousOldestIndex, contentWidth)
+        : Math.max(0, scrollBox.scrollHeight - currentAnchor.scrollHeight);
+      scrollBox.scrollTo(currentAnchor.scrollTop + addedRows);
+      if (currentAnchor.selectedMessageId) {
+        const selectedMessageIndex = messages.findIndex((message) => message.id === currentAnchor.selectedMessageId);
+        if (selectedMessageIndex >= 0) {
+          setSelectedIdx(selectedMessageIndex);
+        }
+      }
+      prependAnchorRef.current = null;
+    });
+  }, [contentWidth, loadingOlderMessages, messages]);
 
   useEffect(() => {
     if (!focused || !stickyTranscript) return;
@@ -621,7 +698,14 @@ export function ChatContent({
         focusable={false}
         stickyScroll={stickyTranscript}
         stickyStart="bottom"
+        onMouseScroll={() => queueMicrotask(requestOlderMessagesIfNeeded)}
+        style={nativeComposerTopGap > 0 ? { paddingBottom: nativeComposerTopGap } : undefined}
       >
+        {loadingOlderMessages && (
+          <Box alignItems="center" justifyContent="center" height={1} width={contentWidth}>
+            <Text fg={colors.textDim}>Loading earlier messages...</Text>
+          </Box>
+        )}
         {messages.length === 0 && (
           <Box alignItems="center" justifyContent="center" flexGrow={1}>
             <Text fg={colors.textDim}>No messages yet. Be the first to say something!</Text>

--- a/src/utils/api-client.test.ts
+++ b/src/utils/api-client.test.ts
@@ -213,6 +213,21 @@ describe("apiClient auth cookies", () => {
 });
 
 describe("apiClient chat timestamps", () => {
+  test("sends the before cursor when loading older chat messages", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = mockFetch(async (input: Request | string | URL) => {
+      requestedUrl = String(input);
+      return createResponse([]);
+    });
+
+    await apiClient.getMessages("everyone", { limit: 50, before: "m42" });
+
+    const url = new URL(requestedUrl);
+    expect(url.pathname).toBe("/chat/channels/everyone/messages");
+    expect(url.searchParams.get("limit")).toBe("50");
+    expect(url.searchParams.get("before")).toBe("m42");
+  });
+
   test("normalizes transcript and send-response timestamps to UTC ISO strings", async () => {
     const responses = [
       createResponse([{


### PR DESCRIPTION
Adds older-message paging to the chat controller and pane using the existing before cursor, while keeping the latest-message cursor and bounded persisted transcript cache intact.

The chat view now loads earlier messages when the user reaches the top, preserves scroll position, avoids stale mention notifications, and adds a small native desktop gap above the composer.

Tests cover older-page loading, UI scroll anchoring, and API-client before cursor serialization.