### PR TITLE
Add pane screenshot copy action

### DIFF
--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -125,6 +125,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
             height={height}
             backgroundColor={background}
             data-gloom-role="detached-pane-window"
+            data-gloom-pane-id={desktopWindowBridge.paneId}
             data-focused={focused ? "true" : "false"}
             onMouseDown={focusPane}
           >

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -6,6 +6,7 @@ import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./
 import { getPaneBodyHeight, shouldReservePaneFooter } from "./pane-sizing";
 
 interface FloatingPaneWrapperProps {
+  paneId?: string;
   title: string;
   x: number;
   y: number;
@@ -31,6 +32,7 @@ interface FloatingPaneWrapperProps {
 
 /** Pure visual wrapper; Shell owns the interaction state and supplies handlers. */
 export function FloatingPaneWrapper({
+  paneId,
   title,
   x,
   y,
@@ -72,6 +74,7 @@ export function FloatingPaneWrapper({
       overflow="hidden"
       {...(nativePaneChrome ? {
         "data-gloom-role": "pane-window",
+        "data-gloom-pane-id": paneId,
         "data-floating": "true",
         "data-focused": focused ? "true" : "false",
         style: { "--pane-border-color": focused ? colors.borderFocused : colors.border },

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -6,6 +6,7 @@ import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./
 import { getPaneBodyHeight, shouldReservePaneFooter } from "./pane-sizing";
 
 interface PaneWrapperProps {
+  paneId?: string;
   title?: string;
   focused: boolean;
   width?: number;
@@ -24,6 +25,7 @@ interface PaneWrapperProps {
 }
 
 export function PaneWrapper({
+  paneId,
   title,
   focused,
   width = 0,
@@ -58,6 +60,7 @@ export function PaneWrapper({
       overflow="hidden"
       {...(nativePaneChrome ? {
         "data-gloom-role": "pane-window",
+        "data-gloom-pane-id": paneId,
         "data-floating": "false",
         "data-focused": focused ? "true" : "false",
         style: { "--pane-border-color": focused ? colors.borderFocused : colors.border },

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -838,6 +838,7 @@ describe("Shell", () => {
     expect(resolvePaneManagementShortcut({ ...base, name: "w", key: "w", ctrl: true, meta: false, super: false, shift: false })).toBe("close");
     expect(resolvePaneManagementShortcut({ ...base, name: "D", key: "D" })).toBe("toggle-floating");
     expect(resolvePaneManagementShortcut({ ...base, name: "o", key: "o" })).toBe("pop-out");
+    expect(resolvePaneManagementShortcut({ ...base, name: "c", key: "c" })).toBe("copy-screenshot");
     expect(resolvePaneManagementShortcut({ ...base, name: "l", key: "l" })).toBe("layout-actions");
     expect(resolvePaneManagementShortcut({ ...base, name: "g", key: "g" })).toBe("gridlock-all");
     expect(resolvePaneManagementShortcut({ ...base, name: "n", key: "n" })).toBeNull();

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,6 +1,6 @@
 import { AsciiText, Box, Text, useContextMenu } from "../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNativeRenderer, useUiCapabilities } from "../../ui";
+import { useNativeRenderer, useRendererHost, useUiCapabilities } from "../../ui";
 import { useShortcut, useViewport, type KeyEventLike } from "../../react/input";
 import { useDialogState } from "../../ui/dialog";
 import { scheduleConfigSave } from "../../state/config-save-scheduler";
@@ -54,6 +54,7 @@ import { hasPaneFooterContent, PaneFooterProvider } from "./pane-footer";
 import { getPaneBodyHeight, getPaneBodyWidth, shouldReservePaneFooter } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX } from "./titlebar-overlay";
+import { capturePaneScreenshotPngBase64 } from "../../utils/dom-screenshot";
 
 interface ShellProps {
   pluginRegistry: PluginRegistry;
@@ -178,6 +179,7 @@ const PANE_MANAGEMENT_ACCELERATORS = {
   settings: "CmdOrCtrl+,",
   toggleFloating: "CmdOrCtrl+Shift+D",
   popOut: "CmdOrCtrl+Shift+O",
+  copyScreenshot: "CmdOrCtrl+Shift+C",
   close: "CmdOrCtrl+W",
   layoutActions: "CmdOrCtrl+Shift+L",
   gridlockAll: "CmdOrCtrl+Shift+G",
@@ -187,6 +189,7 @@ type PaneManagementShortcut =
   | "settings"
   | "toggle-floating"
   | "pop-out"
+  | "copy-screenshot"
   | "close"
   | "layout-actions"
   | "gridlock-all";
@@ -199,6 +202,7 @@ export function resolvePaneManagementShortcut(
   if (name === "w") return "close";
   if (!event.shift && name === ",") return "settings";
   if (!event.shift || event.alt) return null;
+  if (name === "c") return "copy-screenshot";
   if (name === "d") return "toggle-floating";
   if (name === "o") return "pop-out";
   if (name === "l") return "layout-actions";
@@ -601,6 +605,7 @@ function menuForPane(
   focusPane: (paneId: string) => void,
   openPaneSettings: (paneId: string) => void,
   desktopWindowBridge?: DesktopWindowBridge,
+  copyPaneScreenshot?: (paneId: string) => void | Promise<void>,
 ): ContextMenuItem[] {
   const baseActions: ContextMenuItem[] = [];
   if (pluginRegistry.hasPaneSettings(pane.instance.instanceId)) {
@@ -609,6 +614,14 @@ function menuForPane(
       label: "Settings",
       accelerator: PANE_MANAGEMENT_ACCELERATORS.settings,
       onSelect: () => openPaneSettings(pane.instance.instanceId),
+    });
+  }
+  if (copyPaneScreenshot) {
+    baseActions.push({
+      id: "copy-screenshot",
+      label: "Copy Screenshot",
+      accelerator: PANE_MANAGEMENT_ACCELERATORS.copyScreenshot,
+      onSelect: () => copyPaneScreenshot(pane.instance.instanceId),
     });
   }
 
@@ -734,6 +747,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   const inputCaptured = useAppSelector((state) => state.inputCaptured);
   const statusBarVisible = useAppSelector(selectStatusBarVisible);
   const renderer = useNativeRenderer();
+  const rendererHost = useRendererHost();
   const { nativePaneChrome, nativeContextMenu, precisePointer, titleBarOverlay, cellHeightPx } = useUiCapabilities();
   const { showContextMenu } = useContextMenu();
   const { width, height } = useViewport();
@@ -836,6 +850,22 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     setMenuState(null);
   }, [pluginRegistry]);
 
+  const copyPaneScreenshot = useCallback(async (paneId: string) => {
+    setMenuState(null);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      if (!rendererHost.copyPngImage) {
+        throw new Error("Image clipboard is unavailable.");
+      }
+      const screenshot = await capturePaneScreenshotPngBase64(paneId);
+      await rendererHost.copyPngImage(screenshot.pngBase64);
+      pluginRegistry.notify({ body: "Pane screenshot copied", type: "success" });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not copy pane screenshot.";
+      pluginRegistry.notify({ body: message, type: "error" });
+    }
+  }, [pluginRegistry, rendererHost]);
+
   const bounds = useMemo<LayoutBounds>(() => ({ x: 0, y: 0, width, height: contentHeight }), [contentHeight, width]);
   const dockedPanes = useMemo(
     () => resolveDocked(visibleLayout, pluginRegistry.panes).filter((pane) => !disabledPaneIds.has(pane.def.id)),
@@ -853,6 +883,13 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     [contentHeight, floatingPanes, width],
   );
   const paneMap = useMemo(() => new Map([...dockedPanes, ...floatingPanes].map((pane) => [pane.instance.instanceId, pane])), [dockedPanes, floatingPanes]);
+
+  const copyFocusedPaneScreenshot = useCallback(() => {
+    if (!focusedPaneId || !nativePaneChrome || !rendererHost.copyPngImage) return false;
+    if (!paneMap.has(focusedPaneId)) return false;
+    void copyPaneScreenshot(focusedPaneId);
+    return true;
+  }, [copyPaneScreenshot, focusedPaneId, nativePaneChrome, paneMap, rendererHost.copyPngImage]);
 
   const openFocusedPaneSettings = useCallback(() => {
     if (!focusedPaneId || !pluginRegistry.hasPaneSettings(focusedPaneId)) return false;
@@ -907,6 +944,9 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         break;
       case "pop-out":
         handled = popOutFocusedPane();
+        break;
+      case "copy-screenshot":
+        handled = copyFocusedPaneScreenshot();
         break;
       case "layout-actions":
         openLayoutMenu();
@@ -1017,6 +1057,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
       focusPane,
       openPaneSettings,
       desktopWindowBridge,
+      nativePaneChrome && rendererHost.copyPngImage ? copyPaneScreenshot : undefined,
     );
     void showContextMenu({
       kind: "pane",
@@ -1037,7 +1078,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         items: fallbackItems,
       });
     });
-  }, [contentHeight, desktopWindowBridge, focusPane, getPaneTitle, openPaneSettings, paneMap, persistLayout, pluginRegistry, showContextMenu, visibleLayout, width]);
+  }, [contentHeight, copyPaneScreenshot, desktopWindowBridge, focusPane, getPaneTitle, nativePaneChrome, openPaneSettings, paneMap, persistLayout, pluginRegistry, rendererHost.copyPngImage, showContextMenu, visibleLayout, width]);
 
   const handleFloatingClose = useCallback((paneId: string) => {
     persistLayout(removePane(visibleLayout, paneId));
@@ -1504,6 +1545,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
                 const bodyHeight = getPaneBodyHeight(leaf.rect.height, reserveFooter);
                 return (
                   <PaneWrapper
+                    paneId={leaf.instanceId}
                     title={getPaneTitle(pane)}
                     focused={focused}
                     width={leaf.rect.width}
@@ -1548,6 +1590,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
               const bodyHeight = getPaneBodyHeight(preview.height, reserveFooter);
               return (
                 <FloatingPaneWrapper
+                  paneId={pane.instance.instanceId}
                   title={getPaneTitle(pane)}
                   x={preview.x}
                   y={preview.y}

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -12,6 +12,7 @@ import { resolveBrokerConfigFields, type BrokerAdapter, type BrokerConfigField }
 import { buildBrokerProfileConfig, validateBrokerProfileValues } from "../../brokers/profile-form";
 import { createBrokerInstanceId } from "../../utils/broker-instances";
 import { isBackNavigationKey, isPlainEscape } from "../../utils/back-navigation";
+import { detectShortcutPlatform, formatPrimaryShortcut } from "../../utils/shortcut-labels";
 import { syncBrokerInstance } from "../../brokers/sync-broker-instance";
 import { debugLog } from "../../utils/debug-log";
 import { ToggleList, type ToggleListItem } from "../toggle-list";
@@ -1199,11 +1200,13 @@ function ShortcutsStep({
   pluginRegistry: PluginRegistry;
   disabledPlugins: string[];
 }) {
+  const shortcutPlatform = detectShortcutPlatform();
+  const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform);
   const keyboardShortcuts = [
     { key: "Ctrl+P / `", desc: "Open the command bar" },
     { key: "Tab", desc: "Switch between panels" },
-    { key: "Cmd/Ctrl+W", desc: "Close the focused pane" },
-    { key: "Cmd/Ctrl+Shift+D", desc: "Dock or float the focused pane" },
+    { key: platformShortcut("W"), desc: "Close the focused pane" },
+    { key: platformShortcut(["Shift", "D"]), desc: "Dock or float the focused pane" },
     { key: "q", desc: "Quit" },
   ];
 

--- a/src/plugins/builtin/help.test.tsx
+++ b/src/plugins/builtin/help.test.tsx
@@ -111,6 +111,8 @@ describe("HelpPane", () => {
     expect(frame).toContain("Add Alert (Alerts)");
     expect(frame).toContain("Shift+C");
     expect(frame).toContain("Toggle chat (Gloomberb Cloud)");
+    expect(frame).not.toContain("Cmd/Ctrl");
+    expect(frame).not.toContain("CmdOrCtrl");
   });
 
   test("opens the debug log from the mouse action", async () => {

--- a/src/plugins/builtin/help.tsx
+++ b/src/plugins/builtin/help.tsx
@@ -7,6 +7,7 @@ import { colors, hoverBg } from "../../theme/colors";
 import { getSharedRegistry } from "../registry";
 import { usePluginAppActions } from "../plugin-runtime";
 import { commands as coreCommands } from "../../components/command-bar/command-registry";
+import { detectShortcutPlatform, formatPrimaryShortcut } from "../../utils/shortcut-labels";
 
 function ShortcutBadge({ label }: { label: string }) {
   return (
@@ -218,6 +219,8 @@ export function HelpPane({ width, height }: PaneProps) {
   const commandShortcuts = resolveCommandShortcuts(registry);
   const pluginShortcuts = resolvePluginShortcuts(registry);
   const windowTemplates = resolveWindowTemplates(registry);
+  const shortcutPlatform = detectShortcutPlatform();
+  const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform);
 
   const openDebugLog = () => {
     showWidget("debug");
@@ -382,32 +385,32 @@ export function HelpPane({ width, height }: PaneProps) {
 
           <HelpSection title="Pane Management">
             <ShortcutRow
-              badges={["Cmd/Ctrl+W"]}
+              badges={[platformShortcut("W")]}
               description="Close the focused pane, docked or floating."
               compact={compact}
             />
             <ShortcutRow
-              badges={["Cmd/Ctrl+,"]}
+              badges={[platformShortcut(",")]}
               description="Edit settings for the focused pane."
               compact={compact}
             />
             <ShortcutRow
-              badges={["Cmd/Ctrl+Shift+D"]}
+              badges={[platformShortcut(["Shift", "D"])]}
               description="Dock or float the focused pane."
               compact={compact}
             />
             <ShortcutRow
-              badges={["Cmd/Ctrl+Shift+O"]}
+              badges={[platformShortcut(["Shift", "O"])]}
               description="Pop the focused pane out to a desktop window."
               compact={compact}
             />
             <ShortcutRow
-              badges={["Cmd/Ctrl+Shift+L"]}
+              badges={[platformShortcut(["Shift", "L"])]}
               description="Open layout actions."
               compact={compact}
             />
             <ShortcutRow
-              badges={["Cmd/Ctrl+Shift+G"]}
+              badges={[platformShortcut(["Shift", "G"])]}
               description="Gridlock all windows."
               compact={compact}
             />

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from "fs";
 import { mkdir, readFile, rm, unlink, writeFile } from "fs/promises";
 import { dirname, join } from "path";
+import { Buffer } from "node:buffer";
 import Electrobun, { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu, type UpdateStatusEntry } from "electrobun/bun";
 import { getAiProviderDefinitions } from "../../../plugins/builtin/ai/providers";
 import { runAiPrompt, type AiRunController } from "../../../plugins/builtin/ai/runner";
@@ -1385,6 +1386,12 @@ async function handleBackendRequest(
     case "host.copyText":
       Utils.clipboardWriteText(normalizeText(payload.text) ?? "");
       return null;
+    case "host.copyPngImage": {
+      const pngBase64 = normalizeText(payload.pngBase64);
+      if (!pngBase64) throw new Error("host.copyPngImage requires PNG data.");
+      Utils.clipboardWriteImage(new Uint8Array(Buffer.from(pngBase64, "base64")));
+      return null;
+    }
     case "host.readText":
       return Utils.clipboardReadText() ?? "";
     case "host.notify":

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -1324,6 +1324,22 @@ export const webRendererHost: RendererHost = {
       await backendRequest("host.copyText", { text });
     }
   },
+  async copyPngImage(pngBase64) {
+    const bytes = Uint8Array.from(atob(pngBase64), (char) => char.charCodeAt(0));
+    const blob = new Blob([bytes], { type: "image/png" });
+    try {
+      const ClipboardItemCtor = (globalThis as typeof globalThis & {
+        ClipboardItem?: new (items: Record<string, Blob>) => ClipboardItem;
+      }).ClipboardItem;
+      if (navigator.clipboard?.write && ClipboardItemCtor) {
+        await navigator.clipboard.write([new ClipboardItemCtor({ "image/png": blob })]);
+        return;
+      }
+    } catch {
+      // Fall through to the native Electrobun clipboard bridge.
+    }
+    await backendRequest("host.copyPngImage", { pngBase64 });
+  },
   async readText() {
     try {
       return await navigator.clipboard.readText();

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -261,6 +261,7 @@ export interface RendererHost {
   startWindowDrag?(): Promise<void> | void;
   openExternal(url: string): Promise<void>;
   copyText(text: string): Promise<void>;
+  copyPngImage?(pngBase64: string): Promise<void>;
   readText(): Promise<string>;
   supportsNativeDesktopNotifications?: boolean;
   notify(notification: AppNotificationRequest): void;

--- a/src/utils/dom-screenshot.ts
+++ b/src/utils/dom-screenshot.ts
@@ -1,0 +1,326 @@
+/// <reference lib="dom" />
+
+export interface PngScreenshot {
+  pngBase64: string;
+  width: number;
+  height: number;
+}
+
+interface CaptureOrigin {
+  left: number;
+  top: number;
+}
+
+function escapeAttributeValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}
+
+export function findPaneScreenshotTarget(paneId?: string): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  if (paneId) {
+    const escapedPaneId = escapeAttributeValue(paneId);
+    const target = document.querySelector<HTMLElement>(`[data-gloom-pane-id="${escapedPaneId}"]`);
+    if (target) return target;
+  }
+  return document.querySelector<HTMLElement>(
+    "[data-gloom-role='pane-window'][data-focused='true'], [data-gloom-role='detached-pane-window'][data-focused='true']",
+  );
+}
+
+function isVisible(style: CSSStyleDeclaration): boolean {
+  return style.display !== "none" && style.visibility !== "hidden" && Number.parseFloat(style.opacity || "1") > 0;
+}
+
+function isPaintableColor(value: string): boolean {
+  return value !== "" && value !== "transparent" && !/^rgba?\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\)$/i.test(value);
+}
+
+function px(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function localRect(rect: DOMRect, origin: CaptureOrigin) {
+  return {
+    x: rect.left - origin.left,
+    y: rect.top - origin.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function roundedRectPath(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): void {
+  const r = Math.max(0, Math.min(radius, width / 2, height / 2));
+  context.beginPath();
+  context.moveTo(x + r, y);
+  context.lineTo(x + width - r, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + r);
+  context.lineTo(x + width, y + height - r);
+  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  context.lineTo(x + r, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - r);
+  context.lineTo(x, y + r);
+  context.quadraticCurveTo(x, y, x + r, y);
+  context.closePath();
+}
+
+function fillBackground(
+  context: CanvasRenderingContext2D,
+  style: CSSStyleDeclaration,
+  rect: ReturnType<typeof localRect>,
+): void {
+  if (!isPaintableColor(style.backgroundColor)) return;
+  context.fillStyle = style.backgroundColor;
+  roundedRectPath(context, rect.x, rect.y, rect.width, rect.height, px(style.borderTopLeftRadius));
+  context.fill();
+}
+
+function strokeBorder(
+  context: CanvasRenderingContext2D,
+  style: CSSStyleDeclaration,
+  rect: ReturnType<typeof localRect>,
+): void {
+  const widths = [
+    px(style.borderTopWidth),
+    px(style.borderRightWidth),
+    px(style.borderBottomWidth),
+    px(style.borderLeftWidth),
+  ];
+  if (widths.every((width) => width <= 0) || !isPaintableColor(style.borderTopColor)) return;
+
+  context.strokeStyle = style.borderTopColor;
+  context.lineWidth = Math.max(...widths);
+  roundedRectPath(
+    context,
+    rect.x + context.lineWidth / 2,
+    rect.y + context.lineWidth / 2,
+    Math.max(0, rect.width - context.lineWidth),
+    Math.max(0, rect.height - context.lineWidth),
+    px(style.borderTopLeftRadius),
+  );
+  context.stroke();
+}
+
+function shouldClip(style: CSSStyleDeclaration): boolean {
+  return [style.overflow, style.overflowX, style.overflowY].some((value) => (
+    value === "hidden" || value === "clip" || value === "auto" || value === "scroll"
+  ));
+}
+
+function applyClip(
+  context: CanvasRenderingContext2D,
+  style: CSSStyleDeclaration,
+  rect: ReturnType<typeof localRect>,
+): boolean {
+  if (!shouldClip(style)) return false;
+  roundedRectPath(context, rect.x, rect.y, rect.width, rect.height, px(style.borderTopLeftRadius));
+  context.clip();
+  return true;
+}
+
+function fontFor(style: CSSStyleDeclaration): string {
+  if (style.font) return style.font;
+  return [
+    style.fontStyle || "normal",
+    style.fontVariant || "normal",
+    style.fontWeight || "400",
+    `${style.fontSize || "14px"}/${style.lineHeight || "normal"}`,
+    style.fontFamily || "monospace",
+  ].join(" ");
+}
+
+function textBaselineOffset(style: CSSStyleDeclaration, rect: DOMRect): number {
+  const fontSize = px(style.fontSize) || rect.height;
+  const lineHeight = px(style.lineHeight) || rect.height || fontSize;
+  return Math.max(fontSize * 0.78, (lineHeight + fontSize * 0.58) / 2);
+}
+
+function drawTextNode(
+  context: CanvasRenderingContext2D,
+  textNode: Text,
+  origin: CaptureOrigin,
+): void {
+  const value = textNode.nodeValue ?? "";
+  if (value.length === 0 || value.trim().length === 0) return;
+  const parent = textNode.parentElement;
+  if (!parent) return;
+  const style = getComputedStyle(parent);
+  if (!isVisible(style) || !isPaintableColor(style.color)) return;
+
+  const range = document.createRange();
+  range.selectNodeContents(textNode);
+  const rects = Array.from(range.getClientRects()).filter((rect) => rect.width > 0 && rect.height > 0);
+  range.detach();
+  if (rects.length === 0) return;
+
+  context.fillStyle = style.color;
+  context.font = fontFor(style);
+  context.textAlign = "left";
+  context.textBaseline = "alphabetic";
+  context.direction = style.direction === "rtl" ? "rtl" : "ltr";
+
+  const explicitLines = value.split(/\r?\n/);
+  if (explicitLines.length === rects.length) {
+    rects.forEach((rect, index) => {
+      const line = explicitLines[index] ?? "";
+      if (line.length === 0) return;
+      context.fillText(line, rect.left - origin.left, rect.top - origin.top + textBaselineOffset(style, rect));
+    });
+    return;
+  }
+
+  context.fillText(value, rects[0]!.left - origin.left, rects[0]!.top - origin.top + textBaselineOffset(style, rects[0]!));
+}
+
+function drawCanvasElement(
+  context: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  origin: CaptureOrigin,
+): void {
+  const rect = canvas.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return;
+  try {
+    context.drawImage(canvas, rect.left - origin.left, rect.top - origin.top, rect.width, rect.height);
+  } catch {
+    // Ignore canvases the browser considers unsafe to read.
+  }
+}
+
+function drawInputElement(
+  context: CanvasRenderingContext2D,
+  element: HTMLInputElement | HTMLTextAreaElement,
+  origin: CaptureOrigin,
+): void {
+  const value = element.value;
+  if (!value) return;
+  const style = getComputedStyle(element);
+  const rect = element.getBoundingClientRect();
+  if (!isVisible(style) || !isPaintableColor(style.color) || rect.width <= 0 || rect.height <= 0) return;
+  context.fillStyle = style.color;
+  context.font = fontFor(style);
+  const left = rect.left - origin.left + px(style.paddingLeft);
+  const top = rect.top - origin.top + px(style.paddingTop) + textBaselineOffset(style, rect);
+  for (const [index, line] of value.split(/\r?\n/).entries()) {
+    context.fillText(line, left, top + index * (px(style.lineHeight) || rect.height));
+  }
+}
+
+function drawElement(
+  context: CanvasRenderingContext2D,
+  element: Element,
+  origin: CaptureOrigin,
+): void {
+  if (!(element instanceof HTMLElement || element instanceof SVGElement)) return;
+
+  const style = getComputedStyle(element);
+  if (!isVisible(style)) return;
+
+  const rect = localRect(element.getBoundingClientRect(), origin);
+  if (rect.width <= 0 || rect.height <= 0) return;
+
+  context.save();
+  const opacity = Number.parseFloat(style.opacity || "1");
+  if (Number.isFinite(opacity)) {
+    context.globalAlpha *= Math.max(0, Math.min(opacity, 1));
+  }
+
+  fillBackground(context, style, rect);
+  strokeBorder(context, style, rect);
+  const clipped = applyClip(context, style, rect);
+
+  if (element instanceof HTMLCanvasElement) {
+    drawCanvasElement(context, element, origin);
+  } else if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    drawInputElement(context, element, origin);
+  }
+
+  for (const child of Array.from(element.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      drawTextNode(context, child as Text, origin);
+    } else if (child.nodeType === Node.ELEMENT_NODE) {
+      drawElement(context, child as Element, origin);
+    }
+  }
+
+  if (clipped) {
+    context.restore();
+  } else {
+    context.restore();
+  }
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("Could not read screenshot data."));
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      resolve(result.includes(",") ? result.slice(result.indexOf(",") + 1) : result);
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    try {
+      canvas.toBlob((blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error("Could not encode pane screenshot."));
+      }, "image/png");
+    } catch {
+      reject(new Error("Could not encode pane screenshot."));
+    }
+  });
+}
+
+async function waitForFonts(): Promise<void> {
+  const fontSet = document.fonts;
+  if (!fontSet) return;
+  await Promise.race([
+    fontSet.ready,
+    new Promise((resolve) => setTimeout(resolve, 250)),
+  ]).catch(() => {});
+}
+
+export async function captureElementPngBase64(element: HTMLElement): Promise<PngScreenshot> {
+  const rect = element.getBoundingClientRect();
+  const width = Math.ceil(rect.width);
+  const height = Math.ceil(rect.height);
+  if (width <= 0 || height <= 0) {
+    throw new Error("Pane is not visible.");
+  }
+
+  await waitForFonts();
+
+  const scale = Math.max(1, Math.min(globalThis.devicePixelRatio || 1, 3));
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.ceil(width * scale);
+  canvas.height = Math.ceil(height * scale);
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("Could not create pane screenshot.");
+  context.scale(scale, scale);
+  context.clearRect(0, 0, width, height);
+  drawElement(context, element, { left: rect.left, top: rect.top });
+
+  return {
+    pngBase64: await blobToBase64(await canvasToPngBlob(canvas)),
+    width,
+    height,
+  };
+}
+
+export async function capturePaneScreenshotPngBase64(paneId?: string): Promise<PngScreenshot> {
+  const target = findPaneScreenshotTarget(paneId);
+  if (!target) throw new Error("Pane is not visible.");
+  return captureElementPngBase64(target);
+}

--- a/src/utils/shortcut-labels.test.ts
+++ b/src/utils/shortcut-labels.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { formatPlatformShortcutLabel, formatPrimaryShortcut } from "./shortcut-labels";
+
+describe("shortcut labels", () => {
+  test("renders command-or-control shortcuts for the active platform", () => {
+    expect(formatPlatformShortcutLabel("Cmd/Ctrl+Shift+D", "darwin")).toBe("Cmd+Shift+D");
+    expect(formatPlatformShortcutLabel("Cmd/Ctrl+Shift+D", "linux")).toBe("Ctrl+Shift+D");
+    expect(formatPlatformShortcutLabel("CmdOrCtrl+W", "win32")).toBe("Ctrl+W");
+    expect(formatPrimaryShortcut(["Shift", "G"], "darwin")).toBe("Cmd+Shift+G");
+    expect(formatPrimaryShortcut(",", "linux")).toBe("Ctrl+,");
+  });
+});

--- a/src/utils/shortcut-labels.ts
+++ b/src/utils/shortcut-labels.ts
@@ -1,0 +1,56 @@
+export type ShortcutPlatform = "darwin" | "win32" | "linux" | "unknown";
+
+function platformFromProcess(): ShortcutPlatform | null {
+  const platform = (globalThis as { process?: { platform?: string } }).process?.platform;
+  if (platform === "darwin" || platform === "win32" || platform === "linux") return platform;
+  return null;
+}
+
+function platformFromNavigator(): ShortcutPlatform | null {
+  const navigatorLike = (globalThis as {
+    navigator?: {
+      platform?: string;
+      userAgent?: string;
+      userAgentData?: { platform?: string };
+    };
+  }).navigator;
+  const raw = [
+    navigatorLike?.userAgentData?.platform,
+    navigatorLike?.platform,
+    navigatorLike?.userAgent,
+  ].filter(Boolean).join(" ").toLowerCase();
+
+  if (!raw) return null;
+  if (/(mac|iphone|ipad|ipod)/.test(raw)) return "darwin";
+  if (/win/.test(raw)) return "win32";
+  if (/(linux|x11)/.test(raw)) return "linux";
+  return null;
+}
+
+export function detectShortcutPlatform(): ShortcutPlatform {
+  return platformFromProcess() ?? platformFromNavigator() ?? "unknown";
+}
+
+export function isMacShortcutPlatform(platform: ShortcutPlatform = detectShortcutPlatform()): boolean {
+  return platform === "darwin";
+}
+
+export function getPrimaryShortcutModifier(platform: ShortcutPlatform = detectShortcutPlatform()): "Cmd" | "Ctrl" {
+  return isMacShortcutPlatform(platform) ? "Cmd" : "Ctrl";
+}
+
+export function formatPrimaryShortcut(
+  keys: string | readonly string[],
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): string {
+  const keyParts = typeof keys === "string" ? [keys] : keys;
+  return [getPrimaryShortcutModifier(platform), ...keyParts].join("+");
+}
+
+export function formatPlatformShortcutLabel(
+  label: string,
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): string {
+  const primaryModifier = getPrimaryShortcutModifier(platform);
+  return label.replace(/Cmd\/Ctrl|CmdOrCtrl/g, primaryModifier);
+}


### PR DESCRIPTION
## Summary
- add a desktop pane popover action and Cmd/Ctrl+Shift+C shortcut to copy the active pane screenshot
- copy PNG screenshots through the desktop clipboard bridge with a native fallback
- render Help and onboarding shortcut labels with the platform-specific primary modifier

## Validation
- bun test src/utils/shortcut-labels.test.ts src/plugins/builtin/help.test.tsx src/components/layout/shell.test.tsx
- bun run desktop:view:build
- bun test src/architecture/import-boundaries.test.ts
- tmux Help-pane smoke test