### PR TITLE
Show feed links only in detail views

### DIFF
--- a/src/components/feed-data-table-stack-view.tsx
+++ b/src/components/feed-data-table-stack-view.tsx
@@ -52,6 +52,7 @@ interface FeedDataTableStackViewProps {
   emptyStateHint?: string;
   isItemRead?: (item: FeedDataTableItem) => boolean;
   onOpenItem?: (item: FeedDataTableItem, index: number) => void;
+  onOpenItemIdChange?: (itemId: string | null) => void;
 }
 
 function truncateWithEllipsis(text: string, width: number): string {
@@ -218,6 +219,7 @@ export function FeedDataTableStackView({
   emptyStateHint,
   isItemRead,
   onOpenItem,
+  onOpenItemIdChange,
 }: FeedDataTableStackViewProps) {
   const [sortPreference, setSortPreference] = useState<SortPreference>({
     columnId: "time",
@@ -251,6 +253,7 @@ export function FeedDataTableStackView({
         : null,
     [items, openItemId],
   );
+  const activeOpenItemId = openItem ? openItem.id : null;
 
   const scrollDetailBy = useCallback((delta: number) => {
     const scrollBox = detailScrollRef.current;
@@ -276,6 +279,10 @@ export function FeedDataTableStackView({
       setOpenItemId(null);
     }
   }, [openItem, openItemId]);
+
+  useEffect(() => {
+    onOpenItemIdChange?.(activeOpenItemId);
+  }, [activeOpenItemId, onOpenItemIdChange]);
 
   useEffect(() => {
     if (!openItemId) return;

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -169,6 +169,7 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
   const tickerKey = ticker?.metadata.ticker ?? "none";
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>(`insider:selectedIdx:${tickerKey}`, 0);
   const [nameFilter, setNameFilter] = usePluginPaneState<string | null>(`insider:nameFilter:${tickerKey}`, null);
+  const [openItemId, setOpenItemId] = useState<string | null>(null);
   const eligibleTicker = isUsEquityTicker(ticker);
   const instrument = instrumentFromTicker(ticker, ticker?.metadata.ticker ?? null);
 
@@ -238,7 +239,9 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
   const summary = useMemo(() => buildSummary(allParsed), [allParsed]);
   const pendingCount = form4Filings.filter((f) => !contentMap.has(f.accessionNumber)).length;
   const selectedTransaction = parsed[selectedIdx]?.transaction ?? null;
-  const selectedFiling = parsed[selectedIdx]?.filing ?? null;
+  const openFiling = openItemId
+    ? parsed.find(({ filing }) => filing.accessionNumber === openItemId)?.filing ?? null
+    : null;
 
   const toggleNameFilter = useCallback((reportedName: string) => {
     setNameFilter((current) => current === reportedName ? null : reportedName);
@@ -285,8 +288,8 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
   useExternalLinkFooter({
     registrationId: "insider",
     focused,
-    url: error ? null : selectedFiling?.filingUrl,
-    source: selectedFiling?.form ? formatFilingForm(selectedFiling.form) : null,
+    url: error ? null : openFiling?.filingUrl,
+    source: openFiling?.form ? formatFilingForm(openFiling.form) : null,
     info: footerInfo,
     hints: footerHints,
     label: "filing",
@@ -308,6 +311,7 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
       items={feedItems}
       selectedIdx={selectedIdx}
       onSelect={setSelectedIdx}
+      onOpenItemIdChange={setOpenItemId}
       onRootKeyDown={handleRootKeyDown}
       sourceLabel="Insider"
       titleLabel="Transaction"

--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -9,7 +9,7 @@ import { detectProviders, getAiProvider, resolveDefaultAiProviderId } from "../a
 import { runAiPrompt } from "../ai/runner";
 import { getDigest, setDigest, isDigestInFlight, markDigestInFlight, clearDigestInFlight } from "./digest-store";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
-import { getSelectedNewsArticle, NewsArticleStackView, type NewsSortPreference } from "./news-table";
+import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
 import { useNewsArticleFooter } from "./news-footer";
 import { NEWS_QUERY_PRESETS } from "./news-query-presets";
 import { usePersistedNewsArticles } from "./persisted-articles";
@@ -104,10 +104,6 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
     getDigest(article.id) ?? article.title
   ), [digestVersion]);
 
-  const selectedArticle = useMemo(() => {
-    if (detailArticle) return detailArticle;
-    return getSelectedNewsArticle(articles, selectedArticleId, sortPreference);
-  }, [articles, detailArticle, selectedArticleId, sortPreference]);
   const footerInfo = useMemo(() => [
     ...(aiRunning ? [{ id: "running", parts: [{ text: BRAILLE_FRAMES[spinFrame] ?? "running", tone: "positive" as const }] }] : []),
     ...(aiError ? [{ id: "paused", parts: [{ text: "AI paused", tone: "warning" as const }] }] : []),
@@ -116,7 +112,7 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
   useNewsArticleFooter({
     registrationId: "news-wire:breaking",
     focused,
-    article: selectedArticle,
+    article: detailArticle,
     info: footerInfo,
   });
 

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -7,7 +7,7 @@ import type { NewsQueryPhase } from "../../../news/types";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../plugin-runtime";
 import { Spinner, Tabs } from "../../../components";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
-import { getSelectedNewsArticle, NewsArticleStackView, type NewsSortPreference } from "./news-table";
+import { NewsArticleStackView, type NewsSortPreference } from "./news-table";
 import { useNewsArticleFooter } from "./news-footer";
 import { useNewsReadState } from "./read-state";
 import { usePersistedNewsArticles } from "./persisted-articles";
@@ -64,11 +64,6 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     setSelectedArticleId(null);
   }, [category, setSelectedArticleId]);
 
-  const selectedArticle = useMemo(() => {
-    if (detailArticle) return detailArticle;
-    return getSelectedNewsArticle(articles, selectedArticleId, sortPreference);
-  }, [articles, detailArticle, selectedArticleId, sortPreference]);
-
   const handleRootKeyDown = (event: {
     name?: string;
     preventDefault?: () => void;
@@ -87,7 +82,7 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
   useNewsArticleFooter({
     registrationId: "news-wire:industry",
     focused,
-    article: selectedArticle,
+    article: detailArticle,
   });
 
   const rootBefore = (

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -1,5 +1,4 @@
 import { Box } from "../../../ui";
-import { useMemo } from "react";
 import type { NewsQuery } from "../../../news/types";
 import { useNewsArticles } from "../../../news/hooks";
 import type { PaneProps } from "../../../types/plugin";
@@ -7,7 +6,6 @@ import { useDebouncedPluginPaneState, usePluginPaneState } from "../../plugin-ru
 import { Spinner } from "../../../components";
 import { NewsDetailView, useNewsArticleDetail } from "./news-detail-view";
 import {
-  getSelectedNewsArticle,
   NewsArticleStackView,
   type NewsColumnId,
   type NewsSortPreference,
@@ -49,15 +47,11 @@ export function NewsPresetPane({
   );
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
   const { readArticleIds, markArticleRead } = useNewsReadState();
-  const selectedArticle = useMemo(() => {
-    if (detailArticle) return detailArticle;
-    return getSelectedNewsArticle(articles, selectedArticleId, sortPreference);
-  }, [articles, detailArticle, selectedArticleId, sortPreference]);
 
   useNewsArticleFooter({
     registrationId: `news-wire:${paneKey}`,
     focused,
-    article: selectedArticle,
+    article: detailArticle,
   });
 
   const detailContent = detailArticle ? (

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -84,17 +84,6 @@ export function sortNewsArticles(
   });
 }
 
-export function getSelectedNewsArticle(
-  articles: MarketNewsItem[],
-  selectedArticleId: string | null,
-  preference: NewsSortPreference,
-): MarketNewsItem | null {
-  const selectedArticle = selectedArticleId
-    ? articles.find((article) => article.id === selectedArticleId) ?? null
-    : null;
-  return selectedArticle ?? sortNewsArticles(articles, preference)[0] ?? null;
-}
-
 function nextSortPreference(current: NewsSortPreference, columnId: NewsColumnId): NewsSortPreference {
   if (current.columnId === columnId) {
     return {

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -75,6 +75,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
     liveNews,
   );
   const { readArticleIds, markArticleRead } = useNewsReadState();
+  const [openItemId, setOpenItemId] = useState<string | null>(null);
   const loading = newsState.phase === "loading" || (newsState.phase === "refreshing" && news.length === 0);
   const error = newsState.phase === "error" ? newsState.error ?? "Failed to load news" : null;
 
@@ -84,6 +85,9 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
   }, [ticker?.metadata.ticker]);
 
   const selected = news[selectedIdx];
+  const openArticle = openItemId
+    ? news.find((article) => article.id === openItemId) ?? null
+    : null;
   const cachedSelectedSummary = selected ? summaryCache.get(selected.url) : undefined;
   const articleSummaryEntry = useArticleSummary(
     selected && !selected.summary && !cachedSelectedSummary ? selected.url : null,
@@ -117,7 +121,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
   useNewsArticleFooter({
     registrationId: "news",
     focused,
-    article: selected,
+    article: openArticle,
     info: footerInfo,
   });
 
@@ -138,6 +142,7 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
       onSelect={setSelectedIdx}
       isItemRead={(item) => readArticleIds.has(item.id)}
       onOpenItem={(item) => markArticleRead(item.id)}
+      onOpenItemIdChange={setOpenItemId}
       sourceLabel="Source"
       titleLabel="Headline"
       emptyStateTitle="No news."

--- a/src/plugins/builtin/sec.tsx
+++ b/src/plugins/builtin/sec.tsx
@@ -230,6 +230,7 @@ function SecTab({ width, height, focused }: DetailTabProps) {
   const selectionKey = `selectedIdx:${ticker?.metadata.ticker ?? "none"}`;
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>(selectionKey, 0);
   const [contentCache, setContentCache] = useState<Map<string, string | null>>(new Map());
+  const [openItemId, setOpenItemId] = useState<string | null>(null);
   const contentFetchRef = useRef(0);
   const eligibleTicker = isUsEquityTicker(ticker);
   const instrument = instrumentFromTicker(ticker, ticker?.metadata.ticker ?? null);
@@ -248,6 +249,9 @@ function SecTab({ width, height, focused }: DetailTabProps) {
   }, [eligibleTicker, ticker?.metadata.exchange, ticker?.metadata.ticker]);
 
   const selected = filings[selectedIdx];
+  const openFiling = openItemId
+    ? filings.find((filing) => filing.accessionNumber === openItemId) ?? null
+    : null;
   const cachedSelectedContent = selected ? contentCache.get(selected.accessionNumber) : undefined;
   const filingContentEntry = useSecFilingContent(
     selected && cachedSelectedContent === undefined ? selected : null,
@@ -311,8 +315,8 @@ function SecTab({ width, height, focused }: DetailTabProps) {
   useExternalLinkFooter({
     registrationId: "sec",
     focused,
-    url: error ? null : selected?.filingUrl,
-    source: selected?.form,
+    url: error ? null : openFiling?.filingUrl,
+    source: openFiling?.form,
     info: footerInfo,
     label: "filing",
   });
@@ -331,6 +335,7 @@ function SecTab({ width, height, focused }: DetailTabProps) {
       items={toFeedItems(filings, selected?.accessionNumber, contentCache, loadingContent)}
       selectedIdx={selectedIdx}
       onSelect={setSelectedIdx}
+      onOpenItemIdChange={setOpenItemId}
       sourceLabel="Form"
       titleLabel="Filing"
       emptyStateTitle="No SEC filings."


### PR DESCRIPTION
## Summary
- show news, SEC, and insider link footer entries only when an item is open in detail view
- keep list/table selection and hover from publishing the selected row URL into the footer
- remove the now-unused selected-article helper from news wire tables

## Validation
- bun test src/components/feed-data-table-stack-view.test.tsx
- bun test src/plugins/builtin/news-wire/news-table.test.tsx
