### PR TITLE
Refine breaking news story views

### DIFF
--- a/src/news/types.ts
+++ b/src/news/types.ts
@@ -10,6 +10,17 @@ export interface NewsScores {
   confidence: number;
 }
 
+export interface NewsStoryItem {
+  id: string;
+  sourceKey: string;
+  sourceName: string;
+  title: string;
+  summary?: string;
+  url: string;
+  publishedAt: Date;
+  hasArticleText?: boolean;
+}
+
 export interface NewsArticle {
   id: string;
   title: string;
@@ -27,6 +38,7 @@ export interface NewsArticle {
   scores: NewsScores;
   isBreaking: boolean;
   isDeveloping: boolean;
+  items?: NewsStoryItem[];
 
   // Compatibility aliases for RSS/Yahoo panes and existing table columns.
   importance: number;

--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -20,7 +20,7 @@ const DIGEST_PROMPT = `You are a financial news wire editor. Condense this headl
 Headline: {title}
 Summary: {summary}`;
 
-const DEFAULT_SORT: NewsSortPreference = { columnId: "time", direction: "desc" };
+const DEFAULT_SORT: NewsSortPreference = { columnId: "importance", direction: "desc" };
 const BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 function buildDigestPrompt(item: MarketNewsItem): string {
@@ -148,7 +148,7 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
       onBack={closeDetail}
       detailContent={detailContent}
       detailTitle={detailArticle?.title}
-      columns={["time", "source", "title", "tickers", "importance"]}
+      columns={["time", "title", "tickers", "importance"]}
       emptyStateTitle="No breaking news"
       emptyStateHint="Breaking stories appear when high-priority headlines arrive."
       titleForArticle={titleForArticle}

--- a/src/plugins/builtin/news-wire/default-feeds.ts
+++ b/src/plugins/builtin/news-wire/default-feeds.ts
@@ -1,24 +1,3 @@
 import type { RssFeedConfig } from "./rss-parser";
 
-export const DEFAULT_FEEDS: RssFeedConfig[] = [
-  // Tier 1 — Primary market news (authority 70-80)
-  { id: "cnbc-top", url: "https://www.cnbc.com/id/100003114/device/rss/rss.html", name: "CNBC", category: "general", authority: 80, enabled: true },
-  { id: "cnbc-markets", url: "https://www.cnbc.com/id/15839069/device/rss/rss.html", name: "CNBC Markets", category: "finance", authority: 75, enabled: true },
-  { id: "marketwatch-top", url: "https://feeds.marketwatch.com/marketwatch/topstories", name: "MarketWatch", category: "general", authority: 75, enabled: true },
-  { id: "marketwatch-pulse", url: "https://feeds.marketwatch.com/marketwatch/marketpulse", name: "MarketWatch Pulse", category: "general", authority: 70, enabled: true },
-  { id: "seeking-alpha-market-currents", url: "https://seekingalpha.com/market_currents.xml", name: "Seeking Alpha", category: "general", authority: 70, enabled: true },
-
-  // Tier 2 — Sector-specific (authority 65)
-  { id: "cnbc-tech", url: "https://www.cnbc.com/id/19854910/device/rss/rss.html", name: "CNBC Tech", category: "tech", authority: 65, enabled: true },
-  { id: "cnbc-finance", url: "https://www.cnbc.com/id/10000664/device/rss/rss.html", name: "CNBC Finance", category: "finance", authority: 65, enabled: true },
-  { id: "cnbc-energy", url: "https://www.cnbc.com/id/19836768/device/rss/rss.html", name: "CNBC Energy", category: "energy", authority: 65, enabled: true },
-  { id: "cnbc-real-estate", url: "https://www.cnbc.com/id/10000115/device/rss/rss.html", name: "CNBC Real Estate", category: "realestate", authority: 65, enabled: true },
-
-  // Tier 3 — Broad/international (authority 50-60)
-  { id: "yahoo-finance", url: "https://finance.yahoo.com/news/rssindex", name: "Yahoo Finance", category: "general", authority: 55, enabled: true },
-  { id: "seeking-alpha-analysis", url: "https://seekingalpha.com/feed.xml", name: "Seeking Alpha Analysis", category: "general", authority: 60, enabled: true },
-  { id: "investing-com", url: "https://www.investing.com/rss/news.rss", name: "Investing.com", category: "general", authority: 50, enabled: true },
-  { id: "nyt-business", url: "https://rss.nytimes.com/services/xml/rss/nyt/Business.xml", name: "NYT Business", category: "general", authority: 55, enabled: true },
-  { id: "bbc-business", url: "https://feeds.bbci.co.uk/news/business/rss.xml", name: "BBC Business", category: "general", authority: 50, enabled: true },
-  { id: "ft-home", url: "https://www.ft.com/rss/home", name: "Financial Times", category: "general", authority: 60, enabled: true },
-];
+export const DEFAULT_FEEDS: RssFeedConfig[] = [];

--- a/src/plugins/builtin/news-wire/feed-config.test.ts
+++ b/src/plugins/builtin/news-wire/feed-config.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import type { PluginConfigState } from "../../../types/plugin";
-import { DEFAULT_FEEDS } from "./default-feeds";
 import {
   addUserNewsFeed,
   createUserFeed,
@@ -32,7 +31,7 @@ class MemoryConfigState implements PluginConfigState {
 }
 
 describe("news feed config", () => {
-  test("normalizes legacy JSON feed storage and disabled default feed names", () => {
+  test("normalizes legacy JSON feed storage and ignores removed default feed names", () => {
     const config = new MemoryConfigState();
     config.values.set("feeds", JSON.stringify([
       { url: "https://example.com/rss.xml", name: "Example", authority: 120 },
@@ -45,7 +44,7 @@ describe("news feed config", () => {
     expect(settings.userFeeds).toHaveLength(1);
     expect(settings.userFeeds[0]!.id).toMatch(/^user-/);
     expect(settings.userFeeds[0]!.authority).toBe(100);
-    expect(settings.disabledDefaultFeedIds).toEqual(["cnbc-top"]);
+    expect(settings.disabledDefaultFeedIds).toEqual([]);
   });
 
   test("adds, updates, and removes user feeds through typed helpers", async () => {
@@ -70,17 +69,18 @@ describe("news feed config", () => {
     expect(loadNewsFeedSettings(config).userFeeds).toHaveLength(0);
   });
 
-  test("enables and disables default feeds by stable id", async () => {
+  test("returns only user feeds when the default feed catalog is empty", async () => {
     const config = new MemoryConfigState();
-    const defaultFeed = DEFAULT_FEEDS[0]!;
 
-    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config)).some((feed) => feed.id === defaultFeed.id)).toBe(true);
+    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config))).toEqual([]);
 
-    await setDefaultNewsFeedEnabled(config, defaultFeed.id, false);
-    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config)).some((feed) => feed.id === defaultFeed.id)).toBe(false);
+    const added = await addUserNewsFeed(config, {
+      url: "https://example.com/feed",
+      name: "Example",
+    });
 
-    await setDefaultNewsFeedEnabled(config, defaultFeed.id, true);
-    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config)).some((feed) => feed.id === defaultFeed.id)).toBe(true);
+    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config)).map((feed) => feed.id)).toEqual([added.id]);
+    expect(await setDefaultNewsFeedEnabled(config, "missing-default-feed", false)).toBe(false);
   });
 
   test("rejects invalid user feed input", () => {

--- a/src/plugins/builtin/news-wire/news-detail-view.tsx
+++ b/src/plugins/builtin/news-wire/news-detail-view.tsx
@@ -2,10 +2,10 @@ import { Box, ScrollBox, Text } from "../../../ui";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { MarketNewsItem } from "../../../types/news-source";
+import type { MarketNewsItem, NewsStoryItem } from "../../../types/news-source";
 import { colors } from "../../../theme/colors";
 import { TickerBadge } from "../../../components/ticker-badge";
-import { ExternalLink } from "../../../components/ui";
+import { ExternalLink, ExternalLinkText } from "../../../components/ui";
 import { collectNewsDisplayTickers } from "../../../news/ticker-symbols";
 import { useInlineTickers } from "../../../state/use-inline-tickers";
 
@@ -59,6 +59,75 @@ export function wrapText(text: string, width: number): string[] {
   return lines;
 }
 
+function storyItemDate(value: Date | string): Date {
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(date.getTime()) ? new Date(0) : date;
+}
+
+function formatDetailDate(date: Date): string {
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function sortStoryItems(items: readonly NewsStoryItem[] | undefined): NewsStoryItem[] {
+  return [...(items ?? [])].sort((a, b) => (
+    storyItemDate(a.publishedAt).getTime() - storyItemDate(b.publishedAt).getTime()
+  ));
+}
+
+function truncateText(text: string, maxWidth: number): string {
+  if (text.length <= maxWidth) return text;
+  if (maxWidth <= 3) return text.slice(0, Math.max(0, maxWidth));
+  return `${text.slice(0, maxWidth - 3)}...`;
+}
+
+function NewsStoryTimelineItemView({
+  item,
+  index,
+  total,
+  width,
+}: {
+  item: NewsStoryItem;
+  index: number;
+  total: number;
+  width: number;
+}) {
+  const marker = total <= 1 ? "*" : index === 0 || index === total - 1 ? "+" : "|";
+  const time = formatDetailDate(storyItemDate(item.publishedAt));
+  const sourceLabel = truncateText(item.sourceName || item.sourceKey, Math.max(4, width - time.length - 4));
+  const titleLines = wrapText(item.title, Math.max(10, width - 2));
+  const summary = item.summary && item.summary.trim() !== item.title.trim() ? item.summary : "";
+  const summaryLines = summary ? wrapText(summary, Math.max(10, width - 2)) : [];
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.textDim}>{marker} </Text>
+        <Text fg={colors.textDim}>{time}</Text>
+        <Text fg={colors.textDim}>  </Text>
+        <ExternalLinkText url={item.url} label={sourceLabel} color={colors.textBright} />
+      </Box>
+      <Box flexDirection="column" paddingLeft={2}>
+        {titleLines.map((line, lineIndex) => (
+          <Box key={`title-${lineIndex}`} height={1}>
+            <Text fg={colors.text}>{line}</Text>
+          </Box>
+        ))}
+        {summaryLines.map((line, lineIndex) => (
+          <Box key={`summary-${lineIndex}`} height={1}>
+            <Text fg={colors.textDim}>{line}</Text>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
 export function NewsDetailView({ item, focused, width, showTitle = true }: {
   item: MarketNewsItem;
   focused: boolean;
@@ -77,9 +146,8 @@ export function NewsDetailView({ item, focused, width, showTitle = true }: {
   const tickerTexts = useMemo(() => tickers.map((ticker) => `$${ticker}`), [tickers]);
   const { catalog, openTicker } = useInlineTickers(tickerTexts);
   const [hoveredTicker, setHoveredTicker] = useState<string | null>(null);
-  const dateStr = item.publishedAt.toLocaleString("en-US", {
-    month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit",
-  });
+  const dateStr = formatDetailDate(item.publishedAt);
+  const timelineItems = useMemo(() => sortStoryItems(item.items), [item.items]);
 
   const scrollBy = useCallback((delta: number) => {
     const scrollBox = scrollRef.current;
@@ -174,6 +242,19 @@ export function NewsDetailView({ item, focused, width, showTitle = true }: {
               <Text fg={colors.textMuted}>
                 {item.categories.join(" · ")}
               </Text>
+            </Box>
+          )}
+          {timelineItems.length > 0 && (
+            <Box flexDirection="column" gap={1} width={innerW}>
+              {timelineItems.map((timelineItem, index) => (
+                <NewsStoryTimelineItemView
+                  key={timelineItem.id}
+                  item={timelineItem}
+                  index={index}
+                  total={timelineItems.length}
+                  width={innerW}
+                />
+              ))}
             </Box>
           )}
           {/* URL */}

--- a/src/plugins/builtin/news-wire/persisted-articles.ts
+++ b/src/plugins/builtin/news-wire/persisted-articles.ts
@@ -1,17 +1,31 @@
 import { useEffect, useMemo } from "react";
-import type { MarketNewsItem } from "../../../types/news-source";
+import type { MarketNewsItem, NewsStoryItem } from "../../../types/news-source";
 import { usePluginPaneState } from "../../plugin-runtime";
 
 const MAX_PERSISTED_ARTICLES = 200;
 const EMPTY_PERSISTED_ARTICLES: PersistedNewsArticle[] = [];
 
-interface PersistedNewsArticle extends Omit<MarketNewsItem, "publishedAt"> {
+interface PersistedNewsStoryItem extends Omit<NewsStoryItem, "publishedAt"> {
   publishedAt: string;
 }
 
-function articleDate(value: MarketNewsItem["publishedAt"]): Date | null {
+interface PersistedNewsArticle extends Omit<MarketNewsItem, "publishedAt" | "items"> {
+  publishedAt: string;
+  items?: PersistedNewsStoryItem[];
+}
+
+function articleDate(value: Date | string): Date | null {
   const date = value instanceof Date ? value : new Date(String(value));
   return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function serializeStoryItem(item: NewsStoryItem): PersistedNewsStoryItem | null {
+  const publishedAt = articleDate(item.publishedAt);
+  if (!publishedAt) return null;
+  return {
+    ...item,
+    publishedAt: publishedAt.toISOString(),
+  };
 }
 
 function serializeArticle(article: MarketNewsItem): PersistedNewsArticle | null {
@@ -20,6 +34,18 @@ function serializeArticle(article: MarketNewsItem): PersistedNewsArticle | null 
   return {
     ...article,
     publishedAt: publishedAt.toISOString(),
+    items: article.items
+      ?.map(serializeStoryItem)
+      .filter((item): item is PersistedNewsStoryItem => !!item),
+  };
+}
+
+function restoreStoryItem(item: PersistedNewsStoryItem): NewsStoryItem | null {
+  const publishedAt = articleDate(item.publishedAt);
+  if (!publishedAt) return null;
+  return {
+    ...item,
+    publishedAt,
   };
 }
 
@@ -29,6 +55,9 @@ function restoreArticle(article: PersistedNewsArticle): MarketNewsItem | null {
   return {
     ...article,
     publishedAt,
+    items: article.items
+      ?.map(restoreStoryItem)
+      .filter((item): item is NewsStoryItem => !!item),
   };
 }
 

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -17,10 +17,11 @@ import {
   type CloudHoldersPayload,
   type CloudMarketResponse,
   type CloudNewsPayload,
+  type CloudNewsStoryItemPayload,
   type CloudPricePointPayload,
   type CloudQuotePayload,
 } from "../utils/api-client";
-import type { NewsArticle, NewsQuery } from "../types/news-source";
+import type { NewsArticle, NewsQuery, NewsStoryItem } from "../types/news-source";
 import { normalizePriceValueByDivisor, resolveCurrencyUnit } from "../utils/currency-units";
 import { canonicalTickerKey, publicExchange } from "../utils/exchanges";
 import { collectNewsDisplayTickers } from "../news/ticker-symbols";
@@ -121,6 +122,20 @@ function mapCloudNewsTickers(item: CloudNewsPayload, fallbackTicker?: string): s
   return tickers;
 }
 
+function mapCloudNewsStoryItem(item: CloudNewsStoryItemPayload): NewsStoryItem {
+  const publishedAt = new Date(item.publishedAt);
+  return {
+    id: item.id,
+    sourceKey: item.sourceKey,
+    sourceName: item.sourceName || item.sourceKey,
+    title: item.title,
+    summary: item.summary,
+    url: item.url,
+    publishedAt: Number.isNaN(publishedAt.getTime()) ? new Date(0) : publishedAt,
+    hasArticleText: item.hasArticleText,
+  };
+}
+
 function mapCloudNewsArticle(item: CloudNewsPayload, fallbackTicker?: string): NewsArticle {
   const publishedAt = new Date(item.lastPublishedAt || item.firstPublishedAt || item.lastSeenAt);
   const topic = item.topic ?? item.category ?? "general";
@@ -151,6 +166,7 @@ function mapCloudNewsArticle(item: CloudNewsPayload, fallbackTicker?: string): N
     importance: scores.importance,
     isBreaking: !!item.flags?.breaking,
     isDeveloping: !!item.flags?.developing,
+    items: item.items?.map(mapCloudNewsStoryItem) ?? [],
   };
 }
 

--- a/src/types/news-source.ts
+++ b/src/types/news-source.ts
@@ -3,6 +3,7 @@ export type {
   NewsQuery,
   NewsQueryPhase,
   NewsQueryState,
+  NewsStoryItem,
 } from "../news/types";
 
 export type { NewsArticle as MarketNewsItem } from "../news/types";

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -170,6 +170,17 @@ export interface CloudNewsTickerLinkPayload {
   sentiment?: "positive" | "neutral" | "negative" | null;
 }
 
+export interface CloudNewsStoryItemPayload {
+  id: string;
+  sourceKey: string;
+  sourceName: string;
+  title: string;
+  summary?: string;
+  url: string;
+  publishedAt: string;
+  hasArticleText?: boolean;
+}
+
 export interface CloudNewsPayload {
   id: string;
   headline: string;
@@ -203,6 +214,7 @@ export interface CloudNewsPayload {
   sources: string[];
   entities: CloudNewsEntityPayload[];
   tickerLinks: CloudNewsTickerLinkPayload[];
+  items?: CloudNewsStoryItemPayload[];
 }
 
 export interface CloudNewsListResponse {


### PR DESCRIPTION
## Summary
- rank Breaking stories by score by default and hide the source column
- map Gloomberb Cloud story items through the client and render them as a timeline in story details
- disable the built-in RSS default feed catalog while preserving user-added feeds

## Validation
- bun test src/sources/gloomberb-cloud.test.ts src/plugins/builtin/news-wire/feed-config.test.ts src/plugins/builtin/news-wire/rss-source.test.ts src/plugins/builtin/news-wire/news-table.test.tsx
- git diff --check