### PR TITLE
Migrate plugin data access to capabilities

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -87,7 +87,7 @@ The `setup()` function receives a context object with these capabilities:
 | `ctx.registerPane(pane)` | Add a full pane (left/right/bottom) |
 | `ctx.registerPaneTemplate(template)` | Add a reusable pane template (see [Pane templates](#pane-templates)) |
 | `ctx.registerBroker(broker)` | Add a broker integration |
-| `ctx.registerDataSource(source)` | Add a data source |
+| `ctx.registerCapability(capability)` | Add an asset-data, news, or plugin-service capability |
 | `ctx.registerShortcut(shortcut)` | Add a global keyboard shortcut |
 | `ctx.registerTickerAction(action)` | Add a per-ticker action (shown via `a` key) |
 | `ctx.registerContextMenuProvider(provider)` | Add renderer-neutral context menu items |
@@ -181,7 +181,7 @@ Available CLI context helpers:
 | Field | What it does |
 |------|---------------|
 | `ctx.initConfigData()` | Load config, persistence, and ticker storage |
-| `ctx.initMarketData()` | Load config plus the plugin-aware provider router |
+| `ctx.initMarketData()` | Load config plus the plugin-aware asset-data router |
 | `ctx.fail(...)` | Print an error and exit |
 | `ctx.closeAndFail(...)` | Close persistence, then print an error and exit |
 | `ctx.output.*` | CLI formatting helpers (`cliStyles`, `renderSection`, `renderTable`, `renderStat`, `colorBySign`) |
@@ -207,34 +207,46 @@ return {
 | `ctx.getData(ticker)` | Cached financials for a ticker |
 | `ctx.getTicker(ticker)` | Ticker metadata record |
 | `ctx.getConfig()` | Current app config |
-| `ctx.marketData` | The active market data router |
+| `ctx.marketData` | The active asset-data client |
 | `ctx.tickerRepository` | The ticker metadata persistence store |
 | `ctx.log` | Scoped logger for debug output |
 
-### Data sources
+### Capabilities
 
-Plugins may contribute data through `dataSources` or `ctx.registerDataSource(source)`. A data source can expose `market`, `news`, or both. Plugins remain feature modules; the source is the provider identity used for routing, cache policy, and provenance.
+Plugins contribute data and services through capabilities. A capability declares its domain, operation names, cache policy, renderer safety, and handlers. The built-in domains in this pass are:
+
+- `asset-data` for quotes, financials, search, FX, price history, options, filings, holders, analyst research, corporate actions, earnings calendars, article summaries, and quote streams.
+- `news` for ticker and global news feeds.
+- `plugin-service` for narrow renderer-safe service escape hatches.
 
 ```typescript
+import { assetDataProvider, newsProvider } from "gloomberb/capabilities";
 import type { GloomPlugin } from "gloomberb/types/plugin";
-import type { DataSource } from "gloomberb/types/data-source";
-
-const source: DataSource = {
-  id: "my-source",
-  name: "My Source",
-  priority: 100,
-  market: myMarketProvider,
-  news: {
-    supports: (query) => query.feed === "ticker",
-    fetchNews: async (query) => [],
-  },
-};
 
 export const myPlugin: GloomPlugin = {
   id: "my-plugin",
   name: "My Plugin",
   version: "1.0.0",
-  dataSources: [source],
+  capabilities: [
+    assetDataProvider(myMarketProvider),
+    newsProvider({
+      id: "my-source",
+      name: "My Source",
+      priority: 100,
+      provider: {
+        supports: (query) => query.feed === "ticker",
+        fetchNews: async (query) => [],
+      },
+    }),
+  ],
+
+  setup(ctx) {
+    ctx.registerCapability(newsProvider({
+      id: "my-live-news",
+      name: "My Live News",
+      provider: { fetchNews: async (query) => [] },
+    }));
+  },
 };
 ```
 
@@ -623,10 +635,11 @@ Do not register basic navigation hints. Pane hints must omit `Esc`, `Enter`, arr
 
 ### Plugin runtime hooks
 
-These hooks are available inside pane and tab components rendered by a plugin. They provide app actions, market data access, and reactive access to the plugin's storage layers:
+These hooks are available inside pane and tab components rendered by a plugin. They provide app actions, asset data access, and reactive access to the plugin's storage layers:
 
 ```typescript
 import {
+  useAssetData,
   useMarketData,
   usePluginPaneState,
   usePluginState,
@@ -636,6 +649,7 @@ import {
 } from "gloomberb/plugins/plugin-runtime";
 
 const marketData = useMarketData();
+const assetData = useAssetData();
 const { navigateTicker, pinTicker } = usePluginTickerActions();
 const { openCommandBar, showWidget, hideWidget, notify } = usePluginAppActions();
 

--- a/src/capabilities/factories.ts
+++ b/src/capabilities/factories.ts
@@ -1,0 +1,114 @@
+import type { AssetDataProvider } from "../types/data-provider";
+import type { NewsDataProvider } from "../types/capability-route-source";
+import type {
+  AssetDataCapability,
+  CapabilityOperation,
+  NewsCapability,
+  PluginCapability,
+} from "./types";
+
+function op(handler: CapabilityOperation["handler"], kind: CapabilityOperation["kind"] = "read"): CapabilityOperation {
+  return { kind, rendererSafe: true, handler };
+}
+
+function stream(subscribe: CapabilityOperation["subscribe"]): CapabilityOperation {
+  return { kind: "stream", rendererSafe: true, subscribe };
+}
+
+export function assetDataProvider(provider: AssetDataProvider): AssetDataCapability {
+  return {
+    id: `asset-data.${provider.id}`,
+    sourceId: provider.id,
+    kind: "asset-data",
+    name: provider.name,
+    priority: provider.priority,
+    cachePolicy: provider.cachePolicy,
+    provider,
+    operations: {
+      canProvide: op((input: any) => provider.canProvide?.(input.ticker, input.exchange, input.context) ?? true, "query"),
+      getCachedFinancialsForTargets: op((input: any) => provider.getCachedFinancialsForTargets?.(input.targets ?? [], input.options) ?? new Map()),
+      getTickerFinancials: op((input: any) => provider.getTickerFinancials(input.ticker, input.exchange, input.context)),
+      getQuote: op((input: any) => provider.getQuote(input.ticker, input.exchange, input.context)),
+      getExchangeRate: op((input: any) => provider.getExchangeRate(input.fromCurrency)),
+      search: op((input: any) => provider.search(input.query, input.context), "query"),
+      getSecFilings: op((input: any) => {
+        if (!provider.getSecFilings) throw new Error(`${provider.name} does not provide SEC filings.`);
+        return provider.getSecFilings(input.ticker, input.count, input.exchange, input.context);
+      }, "query"),
+      getHolders: op((input: any) => {
+        if (!provider.getHolders) throw new Error(`${provider.name} does not provide holders.`);
+        return provider.getHolders(input.ticker, input.exchange, input.context);
+      }, "query"),
+      getAnalystResearch: op((input: any) => {
+        if (!provider.getAnalystResearch) throw new Error(`${provider.name} does not provide analyst research.`);
+        return provider.getAnalystResearch(input.ticker, input.exchange, input.context);
+      }, "query"),
+      getCorporateActions: op((input: any) => {
+        if (!provider.getCorporateActions) throw new Error(`${provider.name} does not provide corporate actions.`);
+        return provider.getCorporateActions(input.ticker, input.exchange, input.context);
+      }, "query"),
+      getEarningsCalendar: op((input: any) => {
+        if (!provider.getEarningsCalendar) throw new Error(`${provider.name} does not provide earnings calendar.`);
+        return provider.getEarningsCalendar(input.symbols ?? [], input.context);
+      }, "query"),
+      getSecFilingContent: op((input: any) => {
+        if (!provider.getSecFilingContent) throw new Error(`${provider.name} does not provide SEC filing content.`);
+        return provider.getSecFilingContent(input.filing);
+      }, "query"),
+      getArticleSummary: op((input: any) => provider.getArticleSummary(input.url), "query"),
+      getPriceHistory: op((input: any) => provider.getPriceHistory(input.ticker, input.exchange, input.range, input.context), "query"),
+      getPriceHistoryForResolution: op((input: any) => {
+        if (!provider.getPriceHistoryForResolution) throw new Error(`${provider.name} does not provide resolution price history.`);
+        return provider.getPriceHistoryForResolution(input.ticker, input.exchange, input.bufferRange, input.resolution, input.context);
+      }, "query"),
+      getDetailedPriceHistory: op((input: any) => {
+        if (!provider.getDetailedPriceHistory) throw new Error(`${provider.name} does not provide detailed price history.`);
+        return provider.getDetailedPriceHistory(input.ticker, input.exchange, input.startDate, input.endDate, input.barSize, input.context);
+      }, "query"),
+      getChartResolutionSupport: op((input: any) => provider.getChartResolutionSupport?.(input.ticker, input.exchange, input.context) ?? [], "query"),
+      getChartResolutionCapabilities: op((input: any) => provider.getChartResolutionCapabilities?.(input.ticker, input.exchange, input.context) ?? [], "query"),
+      getOptionsChain: op((input: any) => {
+        if (!provider.getOptionsChain) throw new Error(`${provider.name} does not provide options.`);
+        return provider.getOptionsChain(input.ticker, input.exchange, input.expirationDate, input.context);
+      }, "query"),
+      subscribeQuotes: stream((input: any, emit) => {
+        if (!provider.subscribeQuotes) throw new Error(`${provider.name} does not provide quote streaming.`);
+        return provider.subscribeQuotes(input.targets ?? [], (target, quote) => emit({ target, quote }));
+      }),
+    },
+  };
+}
+
+export function newsProvider(options: {
+  id: string;
+  name: string;
+  priority?: number;
+  provider: NewsDataProvider;
+}): NewsCapability {
+  return {
+    id: `news.${options.id}`,
+    sourceId: options.id,
+    kind: "news",
+    name: options.name,
+    priority: options.priority,
+    provider: options.provider,
+    operations: {
+      supports: op((input: any) => options.provider.supports?.(input.query) ?? true, "query"),
+      getCachedNews: op((input: any) => options.provider.getCachedNews?.(input.query) ?? [], "query"),
+      fetchNews: op((input: any) => options.provider.fetchNews(input.query), "query"),
+    },
+  };
+}
+
+export function pluginServiceProvider(capability: PluginCapability): PluginCapability {
+  return {
+    ...capability,
+    kind: "plugin-service",
+    operations: Object.fromEntries(
+      Object.entries(capability.operations).map(([key, operation]) => [
+        key,
+        { ...operation, rendererSafe: operation.rendererSafe === true },
+      ]),
+    ),
+  };
+}

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./registry";
+export * from "./factories";

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { CapabilityRegistry } from "./registry";
+import type { CapabilitySchema, PluginCapability } from "./types";
+
+interface IncrementInput {
+  value: number;
+}
+
+const incrementSchema: CapabilitySchema<IncrementInput> = {
+  parse(value) {
+    if (!value || typeof value !== "object" || typeof (value as any).value !== "number") {
+      throw new Error("Expected numeric value.");
+    }
+    return value as IncrementInput;
+  },
+};
+
+function testCapability(overrides: Partial<PluginCapability> = {}): PluginCapability {
+  return {
+    id: "plugin-service.test",
+    kind: "plugin-service",
+    name: "Test Capability",
+    operations: {
+      increment: {
+        kind: "read",
+        rendererSafe: true,
+        input: incrementSchema,
+        handler: (input: IncrementInput) => input.value + 1,
+      },
+      privateRead: {
+        kind: "read",
+        rendererSafe: false,
+        handler: () => "private",
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("CapabilityRegistry", () => {
+  test("registers capabilities and rejects duplicate ids", () => {
+    const registry = new CapabilityRegistry();
+    const dispose = registry.register("plugin-a", testCapability());
+
+    expect(registry.list().map((entry) => entry.capability.id)).toEqual(["plugin-service.test"]);
+    expect(() => registry.register("plugin-b", testCapability())).toThrow("already registered");
+
+    dispose();
+    expect(registry.list()).toEqual([]);
+  });
+
+  test("filters disabled plugins and disabled capabilities", () => {
+    const registry = new CapabilityRegistry({
+      isPluginEnabled: (pluginId) => pluginId !== "disabled-plugin",
+      isCapabilityEnabled: (capability) => capability.sourceId !== "disabled-source",
+    });
+
+    registry.register("disabled-plugin", testCapability({ id: "plugin-service.disabled-plugin" }));
+    registry.register("enabled-plugin", testCapability({
+      id: "plugin-service.disabled-source",
+      sourceId: "disabled-source",
+    }));
+    registry.register("enabled-plugin", testCapability({ id: "plugin-service.enabled" }));
+
+    expect(registry.list().map((entry) => entry.capability.id)).toEqual(["plugin-service.enabled"]);
+  });
+
+  test("enforces renderer safety and input schemas on invoke", async () => {
+    const registry = new CapabilityRegistry();
+    registry.register("plugin-a", testCapability());
+
+    await expect(registry.invoke("plugin-service.test", "privateRead", {}, { renderer: true }))
+      .rejects.toThrow("not available to renderers");
+    await expect(registry.invoke("plugin-service.test", "increment", { value: "1" }, { renderer: true }))
+      .rejects.toThrow("Expected numeric value");
+
+    await expect(registry.invoke("plugin-service.test", "increment", { value: 1 }, { renderer: true }))
+      .resolves.toBe(2);
+  });
+
+  test("emits renderer-safe manifests only when requested", () => {
+    const registry = new CapabilityRegistry();
+    registry.register("plugin-a", testCapability());
+
+    expect(registry.manifests({ rendererOnly: true })[0]?.operations.map((operation) => operation.id))
+      .toEqual(["increment"]);
+    expect(registry.manifests()[0]?.operations.map((operation) => operation.id))
+      .toEqual(["increment", "privateRead"]);
+  });
+
+  test("subscribes, unsubscribes, and cleans up subscriptions on unregister", async () => {
+    const registry = new CapabilityRegistry();
+    const events: string[] = [];
+    let disposed = 0;
+
+    const disposeCapability = registry.register("plugin-a", testCapability({
+      id: "plugin-service.streams",
+      operations: {
+        ticks: {
+          kind: "stream",
+          rendererSafe: true,
+          subscribe: (input: any, emit) => {
+            emit(input.value);
+            return () => {
+              disposed += 1;
+            };
+          },
+        },
+      },
+    }));
+
+    const subscriptionId = await registry.subscribe<string>(
+      "plugin-service.streams",
+      "ticks",
+      { value: "first" },
+      (event) => events.push(event),
+      { renderer: true },
+    );
+
+    expect(events).toEqual(["first"]);
+    registry.unsubscribe(subscriptionId);
+    expect(disposed).toBe(1);
+
+    await registry.subscribe<string>(
+      "plugin-service.streams",
+      "ticks",
+      { value: "second" },
+      (event) => events.push(event),
+      { renderer: true, subscriptionId: "renderer:quote:1" },
+    );
+    disposeCapability();
+
+    expect(events).toEqual(["first", "second"]);
+    expect(disposed).toBe(2);
+    expect(registry.list()).toEqual([]);
+  });
+});

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -1,0 +1,131 @@
+import {
+  recordSchema,
+  type CapabilityManifest,
+  type CapabilityOperationManifest,
+  type CapabilityRegistryOptions,
+  type PluginCapability,
+  type RegisteredCapability,
+} from "./types";
+
+interface SubscriptionEntry {
+  capabilityId: string;
+  dispose: () => void;
+}
+
+export class CapabilityRegistry {
+  private readonly capabilities = new Map<string, RegisteredCapability>();
+  private readonly subscriptions = new Map<string, SubscriptionEntry>();
+  private nextSubscriptionId = 1;
+
+  constructor(private readonly options: CapabilityRegistryOptions = {}) {}
+
+  register(pluginId: string, capability: PluginCapability): () => void {
+    const existing = this.capabilities.get(capability.id);
+    if (existing) {
+      throw new Error(`Capability "${capability.id}" already registered by plugin "${existing.pluginId}".`);
+    }
+    this.capabilities.set(capability.id, { pluginId, capability });
+    return () => {
+      this.capabilities.delete(capability.id);
+      for (const [subscriptionId, entry] of this.subscriptions) {
+        if (entry.capabilityId === capability.id) {
+          entry.dispose();
+          this.subscriptions.delete(subscriptionId);
+        }
+      }
+    };
+  }
+
+  get(id: string): RegisteredCapability | undefined {
+    return this.capabilities.get(id);
+  }
+
+  list(kind?: string): RegisteredCapability[] {
+    return [...this.capabilities.values()]
+      .filter((entry) => !kind || entry.capability.kind === kind)
+      .filter((entry) => this.isEnabled(entry))
+      .sort((left, right) => (
+        (left.capability.priority ?? 1000) - (right.capability.priority ?? 1000)
+        || left.capability.id.localeCompare(right.capability.id)
+      ));
+  }
+
+  manifests({ rendererOnly = false }: { rendererOnly?: boolean } = {}): CapabilityManifest[] {
+    return this.list().map(({ capability }) => {
+      const operations: CapabilityOperationManifest[] = Object.entries(capability.operations)
+        .filter(([, operation]) => !rendererOnly || operation.rendererSafe === true)
+        .map(([id, operation]) => ({
+          id,
+          kind: operation.kind,
+          rendererSafe: operation.rendererSafe === true,
+        }));
+      return {
+        id: capability.id,
+        kind: capability.kind,
+        name: capability.name,
+        priority: capability.priority,
+        sourceId: capability.sourceId,
+        operations,
+      };
+    });
+  }
+
+  async invoke<T = unknown>(
+    capabilityId: string,
+    operationId: string,
+    payload: unknown,
+    options: { renderer?: boolean } = {},
+  ): Promise<T> {
+    const { capability, operation } = this.resolveOperation(capabilityId, operationId, options);
+    if (!operation.handler) throw new Error(`Capability operation "${capabilityId}.${operationId}" is not invokable.`);
+    const input = (operation.input ?? recordSchema).parse(payload);
+    const result = await operation.handler(input, { capability, operationId });
+    return (operation.output ? operation.output.parse(result) : result) as T;
+  }
+
+  async subscribe<T = unknown>(
+    capabilityId: string,
+    operationId: string,
+    payload: unknown,
+    emit: (event: T) => void,
+    options: { renderer?: boolean; subscriptionId?: string } = {},
+  ): Promise<string> {
+    const { capability, operation } = this.resolveOperation(capabilityId, operationId, options);
+    if (!operation.subscribe) throw new Error(`Capability operation "${capabilityId}.${operationId}" is not subscribable.`);
+    const input = (operation.input ?? recordSchema).parse(payload);
+    const subscriptionId = options.subscriptionId ?? `${capabilityId}:${operationId}:${this.nextSubscriptionId++}`;
+    this.unsubscribe(subscriptionId);
+    const dispose = await operation.subscribe(input, emit, { capability, operationId });
+    this.subscriptions.set(subscriptionId, { capabilityId, dispose });
+    return subscriptionId;
+  }
+
+  unsubscribe(subscriptionId: string): void {
+    const entry = this.subscriptions.get(subscriptionId);
+    if (!entry) return;
+    entry.dispose();
+    this.subscriptions.delete(subscriptionId);
+  }
+
+  destroy(): void {
+    for (const subscriptionId of [...this.subscriptions.keys()]) this.unsubscribe(subscriptionId);
+    this.capabilities.clear();
+  }
+
+  private resolveOperation(capabilityId: string, operationId: string, options: { renderer?: boolean }) {
+    const entry = this.capabilities.get(capabilityId);
+    if (!entry || !this.isEnabled(entry)) throw new Error(`Capability "${capabilityId}" is not available.`);
+    const operation = entry.capability.operations[operationId];
+    if (!operation) throw new Error(`Capability operation "${capabilityId}.${operationId}" is not available.`);
+    if (options.renderer && operation.rendererSafe !== true) {
+      throw new Error(`Capability operation "${capabilityId}.${operationId}" is not available to renderers.`);
+    }
+    return { ...entry, operation };
+  }
+
+  private isEnabled(entry: RegisteredCapability): boolean {
+    if (this.options.isPluginEnabled && !this.options.isPluginEnabled(entry.pluginId)) return false;
+    if (this.options.isCapabilityEnabled && !this.options.isCapabilityEnabled(entry.capability, entry.pluginId)) return false;
+    return entry.capability.isEnabled?.() ?? true;
+  }
+}

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -1,0 +1,90 @@
+import type { CachePolicyMap } from "../types/persistence";
+import type { AssetDataProvider } from "../types/data-provider";
+import type { NewsDataProvider } from "../types/capability-route-source";
+
+export type CapabilityOperationKind = "read" | "query" | "action" | "stream";
+
+export type CapabilityKind =
+  | "asset-data"
+  | "news"
+  | "plugin-service";
+
+export interface CapabilitySchema<T = unknown> {
+  parse(value: unknown): T;
+}
+
+export interface CapabilityHandlerContext {
+  capability: PluginCapability;
+  operationId: string;
+}
+
+export type CapabilityStreamEmit<T = unknown> = (event: T) => void;
+
+export interface CapabilityOperation<I = unknown, O = unknown, E = unknown> {
+  kind: CapabilityOperationKind;
+  rendererSafe?: boolean;
+  input?: CapabilitySchema<I>;
+  output?: CapabilitySchema<O>;
+  cachePolicy?: CachePolicyMap[keyof CachePolicyMap];
+  handler?: (input: I, ctx: CapabilityHandlerContext) => Promise<O> | O;
+  subscribe?: (input: I, emit: CapabilityStreamEmit<E>, ctx: CapabilityHandlerContext) => (() => void) | Promise<() => void>;
+}
+
+export interface PluginCapability {
+  readonly id: string;
+  readonly kind: CapabilityKind | string;
+  readonly name: string;
+  readonly priority?: number;
+  readonly cachePolicy?: CachePolicyMap;
+  readonly sourceId?: string;
+  readonly operations: Record<string, CapabilityOperation<any, any, any>>;
+  isEnabled?(): boolean;
+}
+
+export interface AssetDataCapability extends PluginCapability {
+  readonly kind: "asset-data";
+  readonly provider: AssetDataProvider;
+}
+
+export interface NewsCapability extends PluginCapability {
+  readonly kind: "news";
+  readonly provider: NewsDataProvider;
+}
+
+export interface CapabilityOperationManifest {
+  id: string;
+  kind: CapabilityOperationKind;
+  rendererSafe: boolean;
+}
+
+export interface CapabilityManifest {
+  id: string;
+  kind: string;
+  name: string;
+  priority?: number;
+  sourceId?: string;
+  operations: CapabilityOperationManifest[];
+}
+
+export interface CapabilityRegistryOptions {
+  isPluginEnabled?(pluginId: string): boolean;
+  isCapabilityEnabled?(capability: PluginCapability, pluginId: string): boolean;
+}
+
+export interface RegisteredCapability {
+  pluginId: string;
+  capability: PluginCapability;
+}
+
+export const unknownSchema: CapabilitySchema<unknown> = {
+  parse(value) {
+    return value;
+  },
+};
+
+export const recordSchema: CapabilitySchema<Record<string, unknown>> = {
+  parse(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+    return value as Record<string, unknown>;
+  },
+};

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -3,8 +3,8 @@ import { existsSync } from "fs";
 import { getDataDir, loadConfig } from "../data/config-store";
 import { AppPersistence } from "../data/app-persistence";
 import { TickerRepository } from "../data/ticker-repository";
-import { SourceRouter } from "../sources/provider-router";
-import type { DataSource } from "../types/data-source";
+import { AssetDataRouter } from "../sources/provider-router";
+import type { PluginCapability } from "../capabilities";
 import type { AppConfig } from "../types/config";
 import type { GloomPlugin } from "../types/plugin";
 import { getLoadablePlugins } from "../plugins/catalog";
@@ -15,13 +15,19 @@ interface CliContextOptions {
   plugins?: GloomPlugin[];
 }
 
-function resolveCliDataSources(config: AppConfig, plugins: GloomPlugin[]): DataSource[] {
+function resolveCliCapabilities(config: AppConfig, plugins: GloomPlugin[]): PluginCapability[] {
   const disabledPlugins = new Set(config.disabledPlugins ?? []);
   const disabledSources = new Set(config.disabledSources ?? []);
   return plugins
     .filter((plugin) => !disabledPlugins.has(plugin.id))
-    .flatMap((plugin) => plugin.dataSources ?? [])
-    .filter((source) => !disabledSources.has(source.id));
+    .flatMap((plugin) => (
+      (plugin.capabilities ?? [])
+        .filter((capability) => {
+          if (capability.kind !== "asset-data" && capability.kind !== "news") return false;
+          const sourceId = capability.sourceId ?? capability.id;
+          return !disabledSources.has(sourceId);
+        })
+    ));
 }
 
 export async function loadCliConfigIfAvailable(): Promise<AppConfig | null> {
@@ -47,10 +53,11 @@ export async function initConfigData(): Promise<ConfigContext> {
 export async function initMarketData(options: CliContextOptions = {}): Promise<MarketContext> {
   const context = await initConfigData();
   const plugins = options.plugins ?? getLoadablePlugins();
-  const dataProvider = new SourceRouter(
-    null,
-    resolveCliDataSources(context.config, plugins),
-    context.persistence.resources,
-  );
+  const capabilities = resolveCliCapabilities(context.config, plugins);
+  const dataProvider = new AssetDataRouter(null, [], context.persistence.resources);
+  dataProvider.attachRegistry({
+    brokers: new Map(),
+    getEnabledCapabilities: (kind?: string) => capabilities.filter((capability) => !kind || capability.kind === kind),
+  } as any);
   return { ...context, dataProvider };
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,7 +1,7 @@
 import type { AppConfig } from "../types/config";
 import { AppPersistence } from "../data/app-persistence";
 import { TickerRepository } from "../data/ticker-repository";
-import { SourceRouter } from "../sources/provider-router";
+import { AssetDataRouter } from "../sources/provider-router";
 
 export type ConfigContext = {
   config: AppConfig;
@@ -11,5 +11,5 @@ export type ConfigContext = {
 };
 
 export type MarketContext = ConfigContext & {
-  dataProvider: SourceRouter;
+  dataProvider: AssetDataRouter;
 };

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -7,7 +7,8 @@ import { setSharedNewsService } from "../news/hooks";
 import { getLoadablePlugins } from "../plugins/catalog";
 import type { LoadedExternalPlugin } from "../plugins/loader";
 import { PluginRegistry } from "../plugins/registry";
-import { SourceRouter } from "../sources/provider-router";
+import { AssetDataRouter } from "../sources/provider-router";
+import { assetDataProvider, newsProvider } from "../capabilities";
 import type { AppConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
 import { debugLog } from "../utils/debug-log";
@@ -18,7 +19,7 @@ const servicesLog = debugLog.createLogger("services");
 export interface AppServices {
   persistence: AppPersistence;
   tickerRepository: TickerRepository;
-  providerRouter: SourceRouter;
+  providerRouter: AssetDataRouter;
   dataProvider: DataProvider;
   marketData: MarketDataCoordinator;
   pluginRegistry: PluginRegistry;
@@ -40,16 +41,25 @@ export function createAppServices({
   const dbPath = join(config.dataDir, ".gloomberb-cache.db");
   const persistence = measurePerf("startup.services.persistence", () => new AppPersistence(dbPath));
   const tickerRepository = measurePerf("startup.services.ticker-repository", () => new TickerRepository(persistence.tickers));
-  const providerRouter = measurePerf("startup.services.source-router", () => new SourceRouter(null, [], persistence.resources));
+  const providerRouter = measurePerf("startup.services.asset-data-router", () => new AssetDataRouter(null, [], persistence.resources));
   const dataProvider: DataProvider = providerRouter;
   const marketData = new MarketDataCoordinator(dataProvider);
   const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence);
   const newsService = new NewsService();
+  pluginRegistry.capabilities.register("core", assetDataProvider(providerRouter));
+  pluginRegistry.capabilities.register("core", newsProvider({
+    id: "core",
+    name: "News",
+    provider: {
+      fetchNews: async (query) => (await newsService.load(query)).articles,
+      getCachedNews: (query) => newsService.getQueryState(query).articles,
+    },
+  }));
 
   providerRouter.attachRegistry(pluginRegistry);
   pluginRegistry.getConfigFn = () => config;
   pluginRegistry.getLayoutFn = () => config.layout;
-  pluginRegistry.registerDataSourceFn = (source) => newsService.register(source);
+  pluginRegistry.registerNewsCapabilityFn = (capability) => newsService.register(capability);
   pluginRegistry.watchNewsQueryFn = (query, listener) => newsService.watchQuery(query, listener);
 
   setSharedNewsService(newsService);

--- a/src/news/aggregator.test.ts
+++ b/src/news/aggregator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { NewsService } from "./aggregator";
-import type { DataSource } from "../types/data-source";
+import { newsProvider, type NewsCapability } from "../capabilities";
 import type { MarketNewsItem } from "../types/news-source";
 
 function makeItem(overrides: Partial<MarketNewsItem> & { url: string }): MarketNewsItem {
@@ -30,25 +30,25 @@ function makeItem(overrides: Partial<MarketNewsItem> & { url: string }): MarketN
   };
 }
 
-function makeSource(id: string, items: MarketNewsItem[]): DataSource {
-  return {
+function makeSource(id: string, items: MarketNewsItem[]): NewsCapability {
+  return newsProvider({
     id,
     name: id,
-    news: {
+    provider: {
       fetchNews: mock(async () => items),
     },
-  };
+  });
 }
 
-function makeCachedSource(id: string, cachedItems: MarketNewsItem[], fetchItems: MarketNewsItem[] = []): DataSource {
-  return {
+function makeCachedSource(id: string, cachedItems: MarketNewsItem[], fetchItems: MarketNewsItem[] = []): NewsCapability {
+  return newsProvider({
     id,
     name: id,
-    news: {
+    provider: {
       getCachedNews: () => cachedItems,
       fetchNews: mock(async () => fetchItems),
     },
-  };
+  });
 }
 
 describe("NewsService", () => {
@@ -244,16 +244,16 @@ describe("NewsService", () => {
     agg.register({
       ...empty,
       priority: 10,
-      news: {
-        ...empty.news!,
+      provider: {
+        ...empty.provider,
         supports: (query) => query.feed === "ticker" || query.scope === "ticker",
       },
     });
     agg.register({
       ...fallback,
       priority: 100,
-      news: {
-        ...fallback.news!,
+      provider: {
+        ...fallback.provider,
         supports: (query) => query.feed === "ticker" || query.scope === "ticker",
       },
     });

--- a/src/news/aggregator.ts
+++ b/src/news/aggregator.ts
@@ -1,6 +1,5 @@
 import { canonicalExchange, normalizeSymbol } from "../utils/exchanges";
-import type { DataSource } from "../types/data-source";
-import { sourcePriority } from "../types/data-source";
+import type { NewsCapability } from "../capabilities";
 import type { NewsArticle, NewsFeed, NewsQuery, NewsQueryState } from "./types";
 
 export interface NewsServiceOptions {
@@ -160,8 +159,16 @@ interface SourceFetchResult {
   sourceIds: string[];
 }
 
+function newsCapabilityPriority(source: NewsCapability): number {
+  return source.priority ?? 1000;
+}
+
+function newsCapabilitySourceId(source: NewsCapability): string {
+  return source.sourceId ?? source.id;
+}
+
 export class NewsService {
-  private readonly sources = new Map<string, DataSource>();
+  private readonly sources = new Map<string, NewsCapability>();
   private readonly listeners = new Set<() => void>();
   private readonly queryStates = new Map<string, NewsQueryState>();
   private readonly queryByKey = new Map<string, NewsQuery>();
@@ -176,7 +183,7 @@ export class NewsService {
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   }
 
-  register(source: DataSource): () => void {
+  register(source: NewsCapability): () => void {
     this.sources.set(source.id, source);
     this.seedCachedSource(source);
     if (this.pollTimer !== null) {
@@ -328,12 +335,11 @@ export class NewsService {
     return promise;
   }
 
-  private enabledSources(query: NewsQuery): DataSource[] {
+  private enabledSources(query: NewsQuery): NewsCapability[] {
     return [...this.sources.values()]
       .filter((source) => source.isEnabled?.() !== false)
-      .filter((source) => !!source.news)
-      .filter((source) => source.news?.supports?.(query) ?? true)
-      .sort((a, b) => sourcePriority(a) - sourcePriority(b));
+      .filter((source) => source.provider.supports?.(query) ?? true)
+      .sort((a, b) => newsCapabilityPriority(a) - newsCapabilityPriority(b));
   }
 
   private async fetchFromSources(query: NewsQuery): Promise<SourceFetchResult> {
@@ -344,12 +350,12 @@ export class NewsService {
     return this.fetchMergedNews(query, sources);
   }
 
-  private async fetchTickerNews(query: NewsQuery, sources: DataSource[]): Promise<SourceFetchResult> {
+  private async fetchTickerNews(query: NewsQuery, sources: NewsCapability[]): Promise<SourceFetchResult> {
     let firstEmpty: SourceFetchResult | null = null;
     for (const source of sources) {
       try {
-        const articles = await source.news!.fetchNews(query);
-        const result = { articles, sourceIds: [source.id] };
+        const articles = await source.provider.fetchNews(query);
+        const result = { articles, sourceIds: [newsCapabilitySourceId(source)] };
         if (articles.length > 0) return result;
         firstEmpty ??= result;
       } catch {
@@ -359,11 +365,11 @@ export class NewsService {
     return firstEmpty ?? { articles: [], sourceIds: [] };
   }
 
-  private async fetchMergedNews(query: NewsQuery, sources: DataSource[]): Promise<SourceFetchResult> {
+  private async fetchMergedNews(query: NewsQuery, sources: NewsCapability[]): Promise<SourceFetchResult> {
     const settled = await Promise.allSettled(
       sources.map(async (source) => ({
         source,
-        articles: await source.news!.fetchNews(query),
+        articles: await source.provider.fetchNews(query),
       })),
     );
     const articles: NewsArticle[] = [];
@@ -371,14 +377,13 @@ export class NewsService {
     for (const result of settled) {
       if (result.status !== "fulfilled") continue;
       articles.push(...result.value.articles);
-      sourceIds.push(result.value.source.id);
+      sourceIds.push(newsCapabilitySourceId(result.value.source));
     }
     return { articles, sourceIds };
   }
 
-  private seedCachedSource(source: DataSource): void {
-    const news = source.news;
-    if (!news) return;
+  private seedCachedSource(source: NewsCapability): void {
+    const news = source.provider;
     const queries = [...this.queryByKey.values()];
     if (queries.length === 0) queries.push(DEFAULT_GLOBAL_QUERY);
 
@@ -394,7 +399,7 @@ export class NewsService {
         articles: filterArticlesForQuery(dedupeArticles([...current.articles, ...cached]), query),
         error: null,
         updatedAt: Date.now(),
-        sourceIds: [...new Set([...current.sourceIds, source.id])],
+        sourceIds: [...new Set([...current.sourceIds, newsCapabilitySourceId(source)])],
       });
       changed = true;
     }

--- a/src/plugins/builtin/ai/screener-pane.tsx
+++ b/src/plugins/builtin/ai/screener-pane.tsx
@@ -16,7 +16,7 @@ import {
   usePaneInstanceId,
   type AppAction,
 } from "../../../state/app-context";
-import { useMarketData, usePluginPaneState, usePluginState, usePluginTickerActions } from "../../../plugins/plugin-runtime";
+import { useAssetData, usePluginPaneState, usePluginState, usePluginTickerActions } from "../../../plugins/plugin-runtime";
 import { useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
 import { getSharedMarketDataCoordinator } from "../../../market-data/coordinator";
 import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../../market-data/request-types";
@@ -323,7 +323,7 @@ function sortScreenerRows(
 }
 
 export function AiScreenerPane({ focused, width, height }: PaneProps) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { pinTicker } = usePluginTickerActions();
   const paneId = usePaneInstanceId();
   const paneInstance = usePaneInstance();

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -13,7 +13,7 @@ import { formatTimeAgo } from "../../utils/format";
 import { getSharedRegistry } from "../../plugins/registry";
 import { usePluginAppActions } from "../../plugins/plugin-runtime";
 import { chatController, type ChatController } from "./chat-controller";
-import { createGloomberbCloudProvider, createGloomberbCloudSource } from "../../sources/gloomberb-cloud";
+import { createGloomberbCloudCapabilities, createGloomberbCloudProvider } from "../../sources/gloomberb-cloud";
 import { registerEconCalendarFeature } from "./econ";
 import { registerYieldCurveFeature } from "./yield-curve";
 
@@ -1001,7 +1001,7 @@ export const gloomberbCloudPlugin: GloomPlugin = {
   description: "Free market, macro, and chat services. Chat requires signup.",
   toggleable: true,
   order: 10,
-  dataSources: [createGloomberbCloudSource(createGloomberbCloudProvider())],
+  capabilities: createGloomberbCloudCapabilities(createGloomberbCloudProvider()),
   paneTemplates: [
     {
       id: "new-chat-pane",

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -7,7 +7,7 @@ import { colors } from "../../../theme/colors";
 import { useAppSelector, getFocusedCollectionId } from "../../../state/app-context";
 import { getCollectionTickers } from "../../../state/selectors";
 import { formatCompact } from "../../../utils/format";
-import { useMarketData, usePluginPaneState, usePluginTickerActions } from "../../plugin-runtime";
+import { useAssetData, usePluginPaneState, usePluginTickerActions } from "../../plugin-runtime";
 import {
   attachEarningsCalendarPersistence,
   loadEarningsCalendar,
@@ -100,7 +100,7 @@ function buildColumns(width: number): EarningsColumn[] {
 }
 
 function EarningsCalendarPane({ focused, width, height }: PaneProps) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { navigateTicker } = usePluginTickerActions();
   const [events, setEvents] = useState<EarningsEvent[]>([]);
   const [loading, setLoading] = useState(false);

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -5,7 +5,7 @@ import { useShortcut } from "../../../react/input";
 import { usePaneFooter } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors, blendHex } from "../../../theme/colors";
-import { useMarketData } from "../../plugin-runtime";
+import { useAssetData } from "../../plugin-runtime";
 import { MAJOR_CURRENCIES, CURRENCY_FLAGS, formatRate, type MajorCurrency } from "./pairs";
 
 const REFRESH_INTERVAL_MS = 60_000;
@@ -19,7 +19,7 @@ function formatAge(ms: number): string {
 }
 
 export function FxMatrixPane({ focused, width, height }: PaneProps) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const [rates, setRates] = useState<Map<MajorCurrency, number>>(new Map());
   const [loading, setLoading] = useState(true);
   const [lastRefreshed, setLastRefreshed] = useState<number | null>(null);

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -15,7 +15,7 @@ import type { HolderData, HolderRecord } from "../../../types/financials";
 import type { DetailTabProps, GloomPlugin, PaneProps } from "../../../types/plugin";
 import { formatCompact, formatPercent, formatPercentRaw, padTo } from "../../../utils/format";
 import { normalizeTickerInput } from "../../../utils/ticker-search";
-import { useMarketData, usePluginPaneState } from "../../plugin-runtime";
+import { useAssetData, usePluginPaneState } from "../../plugin-runtime";
 
 type ViewMode = "table" | "chart";
 type HolderColumnId = "holder" | "value" | "shares" | "changeShares" | "changePercent" | "percentHeld" | "reportDate";
@@ -683,7 +683,7 @@ function HoldersTreemap({ rows, width, height, selectedId, onSelect, currency }:
 
 export function HoldersView({ focused, width, height }: Pick<PaneProps, "focused" | "width" | "height">) {
   const { symbol, ticker } = usePaneTicker();
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const [viewMode, setViewMode] = usePluginPaneState<ViewMode>("viewMode", "table");
   const [sortPreference, setSortPreference] = usePluginPaneState<SortPreference>("sortPreference", DEFAULT_SORT);
   const [data, setData] = useState<HolderData | null>(null);
@@ -706,7 +706,7 @@ export function HoldersView({ focused, width, height }: Pick<PaneProps, "focused
     if (!symbol || !dataProvider?.getHolders) {
       setData(null);
       setLoading(false);
-      setError(dataProvider?.getHolders ? null : "Holder data source unavailable");
+      setError(dataProvider?.getHolders ? null : "Holder data unavailable");
       return;
     }
 

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -5,7 +5,7 @@ import { DataTableView, Tabs, usePaneFooter, type DataTableCell, type DataTableC
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatCompact, formatPercentRaw } from "../../../utils/format";
-import { useMarketData, usePluginTickerActions } from "../../plugin-runtime";
+import { useAssetData, usePluginTickerActions } from "../../plugin-runtime";
 import {
   fetchScreener,
   fetchTrending,
@@ -192,7 +192,7 @@ const INDEX_SHORT: Record<string, string> = {
 };
 
 export function MarketMoversPane({ focused, width, height }: PaneProps) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { pinTicker } = usePluginTickerActions();
   const [activeTab, setActiveTab] = useState<TabId>("gainers");
   const [quotes, setQuotes] = useState<ScreenerQuote[]>([]);
@@ -222,7 +222,7 @@ export function MarketMoversPane({ focused, width, height }: PaneProps) {
     }
   }, [rows, selectedIdx, selectedSymbol]);
 
-  // Fetch market summary via the provider router
+  // Fetch market summary via the asset-data client.
   useEffect(() => {
     if (!dataProvider) return;
     const loadSummary = async () => {

--- a/src/plugins/builtin/news-wire/index.tsx
+++ b/src/plugins/builtin/news-wire/index.tsx
@@ -1,5 +1,5 @@
 import type { GloomPluginContext } from "../../../types/plugin";
-import { createRssDataSource } from "./rss-source";
+import { createRssNewsCapability } from "./rss-source";
 import { TopPane } from "./top-pane";
 import { FeedPane } from "./feed-pane";
 import { IndustryPane } from "./industry-pane";
@@ -51,11 +51,11 @@ export function registerNewsWireFeatures(ctx: GloomPluginContext): () => void {
     void saveNewsFeedSettings(ctx.configState, initialSettings);
   }
 
-  const source = createRssDataSource(
+  const source = createRssNewsCapability(
     () => getEnabledNewsFeeds(loadNewsFeedSettings(ctx.configState)),
     { persistence: ctx.persistence },
   );
-  ctx.registerDataSource(source);
+  ctx.registerCapability(source);
 
   ctx.registerCommand({
     id: "add-news-feed",

--- a/src/plugins/builtin/news-wire/rss-source.test.ts
+++ b/src/plugins/builtin/news-wire/rss-source.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { PluginPersistence } from "../../../types/plugin";
 import type { PersistedResourceValue } from "../../../types/persistence";
-import { createRssDataSource, RSS_FEED_CACHE_POLICY } from "./rss-source";
+import { createRssNewsCapability, RSS_FEED_CACHE_POLICY } from "./rss-source";
 import type { RssFeedConfig } from "./rss-parser";
 
 class MemoryPersistence implements PluginPersistence {
@@ -74,27 +74,27 @@ const RSS_FIXTURE = `<rss version="2.0"><channel><item>
   <description>NVIDIA shares moved higher.</description>
 </item></channel></rss>`;
 
-describe("createRssDataSource", () => {
+describe("createRssNewsCapability", () => {
   test("caches fetched feed items with feed authority scoring", async () => {
     const persistence = new MemoryPersistence();
     const fetchText = mock(async () => ({
       ok: true,
       text: async () => RSS_FIXTURE,
     }));
-    const source = createRssDataSource([FEED], { persistence, fetchText });
+    const source = createRssNewsCapability([FEED], { persistence, fetchText });
 
-    const items = await source.news!.fetchNews({ scope: "global" });
+    const items = await source.provider.fetchNews({ scope: "global" });
 
     expect(fetchText).toHaveBeenCalledTimes(1);
     expect(items).toHaveLength(1);
     expect(items[0]!.importance).toBeGreaterThanOrEqual(FEED.authority);
     expect(items[0]!.isBreaking).toBe(true);
-    expect(source.news!.getCachedNews?.({ scope: "global" })).toHaveLength(1);
+    expect(source.provider.getCachedNews?.({ scope: "global" })).toHaveLength(1);
   });
 
   test("uses fresh plugin cache without refetching", async () => {
     const persistence = new MemoryPersistence();
-    const source = createRssDataSource([FEED], {
+    const source = createRssNewsCapability([FEED], {
       persistence,
       fetchText: async () => {
         throw new Error("should not fetch");
@@ -118,7 +118,7 @@ describe("createRssDataSource", () => {
       cachePolicy: RSS_FEED_CACHE_POLICY,
     });
 
-    const items = await source.news!.fetchNews({ scope: "global" });
+    const items = await source.provider.fetchNews({ scope: "global" });
 
     expect(items).toHaveLength(1);
     expect(items[0]!.title).toBe("Cached headline");
@@ -144,14 +144,14 @@ describe("createRssDataSource", () => {
       cachePolicy: stalePolicy,
     });
 
-    const source = createRssDataSource([FEED], {
+    const source = createRssNewsCapability([FEED], {
       persistence,
       fetchText: async () => {
         throw new Error("network down");
       },
     });
 
-    const items = await source.news!.fetchNews({ scope: "global" });
+    const items = await source.provider.fetchNews({ scope: "global" });
 
     expect(items).toHaveLength(1);
     expect(items[0]!.title).toBe("Stale headline");

--- a/src/plugins/builtin/news-wire/rss-source.ts
+++ b/src/plugins/builtin/news-wire/rss-source.ts
@@ -1,5 +1,5 @@
 import { createThrottledFetch } from "../../../utils/throttled-fetch";
-import type { DataSource } from "../../../types/data-source";
+import { newsProvider, type NewsCapability } from "../../../capabilities";
 import type { NewsQuery, MarketNewsItem } from "../../../types/news-source";
 import type { PluginPersistence } from "../../../types/plugin";
 import { parseRssFeed, type RssFeedConfig } from "./rss-parser";
@@ -29,7 +29,7 @@ const rssClient = createThrottledFetch({
   },
 });
 
-export interface RssDataSourceOptions {
+export interface RssNewsCapabilityOptions {
   knownTickers?: Set<string>;
   persistence?: PluginPersistence;
   fetchText?: (url: string) => Promise<{ ok: boolean; text(): Promise<string> }>;
@@ -125,10 +125,10 @@ function writeFeedCache(
   });
 }
 
-export function createRssDataSource(
+export function createRssNewsCapability(
   feedsOrGetter: RssFeedConfig[] | (() => RssFeedConfig[]),
-  options: RssDataSourceOptions = {},
-): DataSource {
+  options: RssNewsCapabilityOptions = {},
+): NewsCapability {
   const fetchText = options.fetchText ?? ((url: string) => rssClient.fetch(url));
   const getFeeds = () => Array.isArray(feedsOrGetter) ? feedsOrGetter : feedsOrGetter();
 
@@ -149,11 +149,11 @@ export function createRssDataSource(
     }
   }
 
-  return {
+  return newsProvider({
     id: "rss",
     name: "RSS Feeds",
     priority: 2000,
-    news: {
+    provider: {
       supports: supportsQuery,
       getCachedNews(query: NewsQuery): MarketNewsItem[] {
         if (!supportsQuery(query)) return [];
@@ -177,5 +177,5 @@ export function createRssDataSource(
         return allItems;
       },
     },
-  };
+  });
 }

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -6,7 +6,7 @@ import { act, useReducer } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { AppPersistence } from "../../data/app-persistence";
 import { AppContext, appReducer, createInitialState, PaneInstanceProvider, type AppAction } from "../../state/app-context";
-import { SourceRouter } from "../../sources/provider-router";
+import { AssetDataRouter } from "../../sources/provider-router";
 import { cloneLayout, createDefaultConfig, type AppConfig, type BrokerInstanceConfig } from "../../types/config";
 import type { DataProvider } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
@@ -859,7 +859,7 @@ describe("PortfolioListPane cash and margin UI", () => {
       },
     };
 
-    const seedRouter = new SourceRouter(yahooProvider, [cloudProvider], persistence.resources);
+    const seedRouter = new AssetDataRouter(yahooProvider, [cloudProvider], persistence.resources);
     await seedRouter.getTickerFinancials("AAPL", "NASDAQ", {
       brokerId: "ibkr",
       brokerInstanceId: "ibkr-live",
@@ -867,7 +867,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     });
 
     let liveCalls = 0;
-    const cachedRouter = new SourceRouter({
+    const cachedRouter = new AssetDataRouter({
       ...yahooProvider,
       async getTickerFinancials() {
         liveCalls += 1;

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -14,7 +14,7 @@ import { colors, priceColor } from "../../../theme/colors";
 import { formatCompact, formatCurrency, formatNumber, formatPercent, formatPercentRaw } from "../../../utils/format";
 import { parseTickerListInput, formatTickerListInput } from "../../../utils/ticker-list";
 import { normalizeTickerInput } from "../../../utils/ticker-search";
-import { useMarketData, usePluginTickerActions } from "../../plugin-runtime";
+import { useAssetData, usePluginTickerActions } from "../../plugin-runtime";
 
 type LoadState<T> = {
   data: T | null;
@@ -122,7 +122,7 @@ function AnalystSummary({ data, width }: { data: AnalystResearchData | null; wid
     return (
       <Box flexDirection="column" paddingX={1} height={2}>
         <Text fg={colors.textDim}>Analyst data</Text>
-        <Text fg={colors.textDim}>Waiting for a data source.</Text>
+        <Text fg={colors.textDim}>Waiting for asset data.</Text>
       </Box>
     );
   }
@@ -182,10 +182,10 @@ const RATING_COLUMNS: RatingColumn[] = [
 ];
 
 function AnalystResearchView({ focused, width, height }: { focused: boolean; width: number; height: number }) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { symbol, exchange } = useSymbolBinding();
   const loader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
-    if (!dataProvider?.getAnalystResearch) throw new Error("Analyst data source unavailable");
+    if (!dataProvider?.getAnalystResearch) throw new Error("Analyst data unavailable");
     return dataProvider.getAnalystResearch(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
   }, [dataProvider]);
   const { data, loading, error, reload } = useTickerRequest<AnalystResearchData>(loader, symbol, exchange);
@@ -321,7 +321,7 @@ function toneColor(tone: ActionRow["tone"]): string {
 }
 
 function CorporateActionsView({ focused, width, height }: { focused: boolean; width: number; height: number }) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { symbol, exchange, currency } = useSymbolBinding();
   const loader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
     if (!dataProvider?.getCorporateActions) throw new Error("Corporate actions source unavailable");
@@ -444,7 +444,7 @@ function RelativeValuationPane({ focused, width, height }: PaneProps) {
     () => relativeSymbolsFromPane(symbol, pane?.settings),
     [pane?.settings, symbol],
   );
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { navigateTicker } = usePluginTickerActions();
   const [rows, setRows] = useState<RelativeRow[]>([]);
   const [loading, setLoading] = useState(false);

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -3,7 +3,7 @@ import { DataTableView, usePaneFooter, type DataTableCell, type DataTableColumn,
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
-import { useMarketData, usePluginPaneState, usePluginTickerActions } from "../../plugin-runtime";
+import { useAssetData, usePluginPaneState, usePluginTickerActions } from "../../plugin-runtime";
 import { SECTORS, type SectorDef } from "./sector-data";
 
 const REFRESH_INTERVAL_MS = 60_000;
@@ -110,7 +110,7 @@ function nextSortPreference(current: SectorSortPreference, columnId: string): Se
 }
 
 export function SectorPerformancePane({ focused, width, height }: PaneProps) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { navigateTicker } = usePluginTickerActions();
   const [rows, setRows] = useState<SectorRow[]>(
     SECTORS.map((sector) => ({ ...sector, price: null, changePercent: null, currency: "USD", loading: true })),

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -6,7 +6,7 @@ import type { Quote } from "../../../types/financials";
 import type { MarketState } from "../../../types/financials";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
-import { useMarketData, usePluginTickerActions } from "../../plugin-runtime";
+import { useAssetData, usePluginTickerActions } from "../../plugin-runtime";
 import { WORLD_INDICES, REGION_LABELS, REGION_ORDER, getIndicesByRegion, type IndexEntry } from "./indices";
 
 const REFRESH_INTERVAL_MS = 60_000;
@@ -149,7 +149,7 @@ function nextSortPreference(
 }
 
 export function WorldIndicesPane({ focused, width, height }: PaneProps) {
-  const dataProvider = useMarketData();
+  const dataProvider = useAssetData();
   const { pinTicker } = usePluginTickerActions();
   const [quotes, setQuotes] = useState<QuoteMap>(new Map());
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);

--- a/src/plugins/builtin/yahoo.ts
+++ b/src/plugins/builtin/yahoo.ts
@@ -1,8 +1,8 @@
 import type { GloomPlugin } from "../../types/plugin";
-import type { DataSource } from "../../types/data-source";
 import type { NewsArticle, NewsQuery } from "../../types/news-source";
 import type { NewsItem } from "../../types/data-provider";
 import { YahooFinanceClient } from "../../sources/yahoo-finance";
+import { assetDataProvider, newsProvider } from "../../capabilities";
 
 class YahooPluginProvider extends YahooFinanceClient {
   readonly priority = 1000;
@@ -42,35 +42,31 @@ function mapYahooNewsItem(item: NewsItem, ticker: string): NewsArticle {
   };
 }
 
-function createYahooSource(provider: YahooPluginProvider): DataSource {
+function createYahooNewsProvider(provider: YahooPluginProvider) {
   return {
-    id: "yahoo",
-    name: "Yahoo Finance",
-    priority: 1000,
-    market: provider,
-    news: {
-      supports(query: NewsQuery): boolean {
-        const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
-        return feed === "ticker" && !!query.ticker;
-      },
-      async fetchNews(query: NewsQuery): Promise<NewsArticle[]> {
-        const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
-        if (feed !== "ticker" || !query.ticker) return [];
-        const ticker = query.ticker.trim().toUpperCase();
-        const items = await provider.getNews(ticker, query.limit ?? 50, query.exchange ?? "");
-        return items.map((item) => mapYahooNewsItem(item, ticker));
-      },
+    supports(query: NewsQuery): boolean {
+      const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
+      return feed === "ticker" && !!query.ticker;
+    },
+    async fetchNews(query: NewsQuery): Promise<NewsArticle[]> {
+      const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
+      if (feed !== "ticker" || !query.ticker) return [];
+      const ticker = query.ticker.trim().toUpperCase();
+      const items = await provider.getNews(ticker, query.limit ?? 50, query.exchange ?? "");
+      return items.map((item) => mapYahooNewsItem(item, ticker));
     },
   };
 }
 
 const yahooProvider = createYahooProvider();
-const yahooSource = createYahooSource(yahooProvider);
 
 export const yahooPlugin: GloomPlugin = {
   id: "yahoo",
   name: "Yahoo Fallback",
   version: "1.0.0",
   description: "Built-in delayed fallback for quotes, fundamentals, charts, and unsupported cloud data.",
-  dataSources: [yahooSource],
+  capabilities: [
+    assetDataProvider(yahooProvider),
+    newsProvider({ id: "yahoo", name: "Yahoo Finance", priority: 1000, provider: createYahooNewsProvider(yahooProvider) }),
+  ],
 };

--- a/src/plugins/catalog-ui.ts
+++ b/src/plugins/catalog-ui.ts
@@ -56,9 +56,5 @@ export const uiBuiltinPlugins: GloomPlugin[] = [
 ];
 
 export function getRendererBuiltinPlugins(): GloomPlugin[] {
-  return uiBuiltinPlugins.map((plugin) => (
-    plugin.dataSources?.length
-      ? { ...plugin, dataSources: [] }
-      : plugin
-  ));
+  return uiBuiltinPlugins;
 }

--- a/src/plugins/ibkr/index.test.tsx
+++ b/src/plugins/ibkr/index.test.tsx
@@ -63,7 +63,7 @@ function setupIbkrPlugin(config: AppConfig) {
     registerCommand: (command: CommandDef) => { commands.push(command); },
     registerColumn: () => {},
     registerBroker: () => {},
-    registerDataSource: () => {},
+    registerCapability: () => {},
     registerDetailTab: () => {},
     registerShortcut: () => {},
     registerTickerAction: (action: TickerAction) => { tickerActions.push(action); },

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -17,11 +17,13 @@ import {
   type PaneRuntimeState,
 } from "../state/app-context";
 import type { BrokerAdapter } from "../types/broker";
+import type { PluginCapability } from "../capabilities";
 import type { DataProvider } from "../types/data-provider";
 import type { AppNotificationRequest, BrokerInstanceUpdateOptions } from "../types/plugin";
 
 export interface PluginRuntimeAccess {
   getMarketData(): DataProvider | null;
+  getCapability(capabilityId: string): PluginCapability | null;
   getBrokerAdapter(brokerType: string): BrokerAdapter | null;
   connectBrokerInstance(instanceId: string): Promise<void>;
   updateBrokerInstance(instanceId: string, values: Record<string, unknown>, options?: BrokerInstanceUpdateOptions): Promise<void>;
@@ -137,6 +139,19 @@ export function usePluginAppActions() {
 export function useMarketData(): DataProvider | null {
   const { runtime } = usePluginRenderContext();
   return runtime.getMarketData();
+}
+
+export function useAssetData(): DataProvider | null {
+  return useMarketData();
+}
+
+export function useCapability(capabilityId: string): PluginCapability | null {
+  const { runtime } = usePluginRenderContext();
+  return runtime.getCapability(capabilityId);
+}
+
+export function useNewsData(): PluginCapability | null {
+  return useCapability("news.core");
 }
 
 export function usePluginBrokerActions() {

--- a/src/plugins/registry.test.ts
+++ b/src/plugins/registry.test.ts
@@ -3,8 +3,8 @@ import { AppPersistence } from "../data/app-persistence";
 import { TickerRepository } from "../data/ticker-repository";
 import { createDefaultConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
-import type { DataSource } from "../types/data-source";
 import type { GloomPlugin, GloomPluginContext } from "../types/plugin";
+import { assetDataProvider } from "../capabilities";
 import { PluginRegistry } from "./registry";
 
 const dataProvider: DataProvider = {
@@ -28,12 +28,17 @@ const dataProvider: DataProvider = {
 let currentRegistry: PluginRegistry | null = null;
 let currentPersistence: AppPersistence | null = null;
 
-function createRegistry(options: { disabledPlugins?: string[]; disabledSources?: string[] } = {}): PluginRegistry {
+function createRegistry(options: {
+  disabledPlugins?: string[];
+  disabledSources?: string[];
+  enableCapabilityHandlers?: boolean;
+} = {}): PluginRegistry {
   const persistence = new AppPersistence(":memory:");
   const registry = new PluginRegistry(
     dataProvider,
     new TickerRepository(persistence.tickers),
     persistence,
+    { enableCapabilityHandlers: options.enableCapabilityHandlers },
   );
   registry.getConfigFn = () => ({
     ...createDefaultConfig("/tmp/gloomberb-context-menu-test"),
@@ -150,36 +155,50 @@ describe("PluginRegistry context menu providers", () => {
   });
 });
 
-describe("PluginRegistry data sources", () => {
-  const source = (id: string): DataSource => ({
-    id,
-    name: id,
-    market: dataProvider,
-  });
+describe("PluginRegistry capabilities", () => {
+  const source = (id: string) => assetDataProvider({ ...dataProvider, id, name: id });
 
-  test("disabled plugins disable their contributed data sources", async () => {
+  test("disabled plugins disable their contributed capabilities", async () => {
     const registry = createRegistry({ disabledPlugins: ["source-plugin"] });
     await registry.register({
       id: "source-plugin",
       name: "Source Plugin",
       version: "1.0.0",
-      dataSources: [source("source-a")],
+      capabilities: [source("source-a")],
     });
 
-    expect([...registry.dataSources.keys()]).toEqual(["source-a"]);
-    expect(registry.getEnabledDataSources()).toEqual([]);
+    expect(registry.getCapability("asset-data.source-a")?.sourceId).toBe("source-a");
+    expect(registry.getCapabilityPluginId("asset-data.source-a")).toBe("source-plugin");
+    expect(registry.getEnabledCapabilities("asset-data")).toEqual([]);
   });
 
-  test("disabledSources disables only the matching source", async () => {
+  test("disabledSources disables only the matching capability source", async () => {
     const registry = createRegistry({ disabledSources: ["source-a"] });
     await registry.register({
       id: "source-plugin",
       name: "Source Plugin",
       version: "1.0.0",
-      dataSources: [source("source-a"), source("source-b")],
+      capabilities: [source("source-a"), source("source-b")],
     });
 
-    expect(registry.getEnabledDataSources().map((entry) => entry.id)).toEqual(["source-b"]);
+    expect(registry.getEnabledCapabilities("asset-data").map((entry) => entry.sourceId)).toEqual(["source-b"]);
+  });
+
+  test("can skip plugin capability handlers in renderer registries", async () => {
+    const registry = createRegistry({ enableCapabilityHandlers: false });
+    await registry.register({
+      id: "source-plugin",
+      name: "Source Plugin",
+      version: "1.0.0",
+      capabilities: [source("source-a")],
+      setup(ctx) {
+        ctx.registerCapability(source("source-b"));
+      },
+    });
+
+    expect(registry.getCapability("asset-data.source-a")).toBeNull();
+    expect(registry.getCapability("asset-data.source-b")).toBeNull();
+    expect(registry.getEnabledCapabilities("asset-data")).toEqual([]);
   });
 });
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,9 +2,13 @@ import { Fragment, createElement, type ReactNode } from "react";
 import type { AppPersistence } from "../data/app-persistence";
 import type { TickerRepository } from "../data/ticker-repository";
 import type { BrokerAdapter } from "../types/broker";
+import {
+  CapabilityRegistry,
+  type NewsCapability,
+  type PluginCapability,
+} from "../capabilities";
 import type { BrokerInstanceConfig, LayoutConfig, PaneInstanceConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
-import type { DataSource } from "../types/data-source";
 import type { TickerFinancials } from "../types/financials";
 import type {
   AppNotificationRequest,
@@ -54,6 +58,10 @@ interface ContextMenuProviderEntry {
   provider: ContextMenuProviderDef;
 }
 
+interface PluginRegistryOptions {
+  enableCapabilityHandlers?: boolean;
+}
+
 export function getSharedMarketData(): DataProvider | undefined { return sharedMarketData; }
 export function getSharedRegistry(): PluginRegistry | undefined { return sharedRegistry; }
 export function setSharedMarketDataForTests(provider: DataProvider | undefined): void {
@@ -69,13 +77,13 @@ interface PluginItems {
   commands: string[];
   columns: string[];
   brokers: string[];
-  dataSources: string[];
+  capabilities: string[];
   detailTabs: string[];
   shortcuts: string[];
   tickerActions: string[];
   contextMenuProviders: string[];
   eventDisposers: Array<() => void>;
-  dataSourceDisposers: Array<() => void>;
+  capabilityDisposers: Array<() => void>;
   newsQueryWatchDisposers: Array<() => void>;
 }
 
@@ -88,7 +96,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   private paneOwners = new Map<string, string>();
   private paneTemplateOwners = new Map<string, string>();
   private shortcutOwners = new Map<string, string>();
-  private dataSourceOwners = new Map<string, string>();
+  private capabilityOwners = new Map<string, string>();
   private pluginResumeListeners = new Map<string, Set<() => void>>();
 
   private panesMap = new Map<string, PaneDef>();
@@ -96,16 +104,17 @@ export class PluginRegistry implements PluginRuntimeAccess {
   private commandsMap = new Map<string, CommandDef>();
   private columnsMap = new Map<string, CustomColumnDef>();
   private brokersMap = new Map<string, BrokerAdapter>();
-  private dataSourcesMap = new Map<string, DataSource>();
   private detailTabsMap = new Map<string, DetailTabDef>();
   private shortcutsMap = new Map<string, KeyboardShortcut>();
   private tickerActionsMap = new Map<string, TickerAction>();
   private contextMenuProvidersMap = new Map<string, ContextMenuProviderEntry>();
 
   readonly events: EventBus;
+  readonly capabilities: CapabilityRegistry;
   readonly marketData: DataProvider;
   readonly tickerRepository: TickerRepository;
   readonly persistence: AppPersistence;
+  private readonly enableCapabilityHandlers: boolean;
 
   getTickerFn: ((symbol: string) => TickerRecord | null) = () => null;
   getDataFn: ((symbol: string) => TickerFinancials | null) = () => null;
@@ -132,6 +141,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   pinTickerFn: ((symbol: string, options?: { floating?: boolean; paneType?: string }) => void) = () => {};
   navigateTickerFn: ((symbol: string) => void) = () => {};
   getMarketData = () => this.marketData;
+  getCapability = (capabilityId: string) => this.capabilities.get(capabilityId)?.capability ?? null;
   getBrokerAdapter = (brokerType: string) => this.brokersMap.get(brokerType) ?? null;
   connectBrokerInstance = (instanceId: string) => this.connectBrokerInstanceFn(instanceId);
   updateBrokerInstance = (instanceId: string, values: Record<string, unknown>, options?: BrokerInstanceUpdateOptions) => (
@@ -165,7 +175,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   updateLayoutFn: ((layout: LayoutConfig) => void) = () => {};
   getTermSizeFn: (() => { width: number; height: number }) = () => ({ width: 120, height: 40 });
 
-  registerDataSourceFn: ((source: DataSource) => () => void) = () => () => {};
+  registerNewsCapabilityFn: ((capability: NewsCapability) => () => void) = () => () => {};
   watchNewsQueryFn: ((
     query: import("../types/news-source").NewsQuery,
     listener: (state: import("../types/news-source").NewsQueryState) => void,
@@ -184,15 +194,28 @@ export class PluginRegistry implements PluginRuntimeAccess {
 
   readonly Slot;
 
-  constructor(marketData: DataProvider, tickerRepository: TickerRepository, persistence: AppPersistence) {
+  constructor(
+    marketData: DataProvider,
+    tickerRepository: TickerRepository,
+    persistence: AppPersistence,
+    options: PluginRegistryOptions = {},
+  ) {
     this.marketData = marketData;
     this.tickerRepository = tickerRepository;
     this.persistence = persistence;
+    this.enableCapabilityHandlers = options.enableCapabilityHandlers ?? true;
     this.events = new EventBus();
 
     sharedMarketData = marketData;
     sharedRegistry = this;
     (globalThis as any).__gloomRegistry = this;
+    this.capabilities = new CapabilityRegistry({
+      isPluginEnabled: (pluginId) => !this.getConfigFn().disabledPlugins.includes(pluginId),
+      isCapabilityEnabled: (capability, pluginId) => {
+        const disabledSources = this.getConfigFn().disabledSources ?? [];
+        return !disabledSources.includes(capability.sourceId ?? capability.id) && !this.getConfigFn().disabledPlugins.includes(pluginId);
+      },
+    });
     this.Slot = ({ name, ...props }: { name: keyof GloomSlots } & Record<string, unknown>) => (
       this.renderSlot(name, props as any)
     );
@@ -203,7 +226,6 @@ export class PluginRegistry implements PluginRuntimeAccess {
   get commands(): ReadonlyMap<string, CommandDef> { return this.commandsMap; }
   get columns(): ReadonlyMap<string, CustomColumnDef> { return this.columnsMap; }
   get brokers(): ReadonlyMap<string, BrokerAdapter> { return this.brokersMap; }
-  get dataSources(): ReadonlyMap<string, DataSource> { return this.dataSourcesMap; }
   get detailTabs(): ReadonlyMap<string, DetailTabDef> { return this.detailTabsMap; }
   get shortcuts(): ReadonlyMap<string, KeyboardShortcut> { return this.shortcutsMap; }
   get tickerActions(): ReadonlyMap<string, TickerAction> { return this.tickerActionsMap; }
@@ -237,23 +259,12 @@ export class PluginRegistry implements PluginRuntimeAccess {
     return items;
   }
 
-  getDataSourcePluginId(sourceId: string): string | undefined {
-    return this.dataSourceOwners.get(sourceId);
+  getCapabilityPluginId(capabilityId: string): string | undefined {
+    return this.capabilityOwners.get(capabilityId);
   }
 
-  getEnabledDataSources(): DataSource[] {
-    const disabledPlugins = new Set(this.getConfigFn().disabledPlugins ?? []);
-    const disabledSources = new Set(this.getConfigFn().disabledSources ?? []);
-    return [...this.dataSourcesMap.values()].filter((source) => {
-      const ownerId = this.dataSourceOwners.get(source.id);
-      return !disabledSources.has(source.id) && (!ownerId || !disabledPlugins.has(ownerId));
-    });
-  }
-
-  getActiveSource(): DataSource | undefined {
-    let active: DataSource | undefined;
-    for (const source of this.dataSourcesMap.values()) active = source;
-    return active;
+  getEnabledCapabilities(kind?: string): PluginCapability[] {
+    return this.capabilities.list(kind).map((entry) => entry.capability);
   }
 
   getPluginPaneIds(pluginId: string): string[] {
@@ -292,17 +303,38 @@ export class PluginRegistry implements PluginRuntimeAccess {
       commands: [],
       columns: [],
       brokers: [],
-      dataSources: [],
+      capabilities: [],
       detailTabs: [],
       shortcuts: [],
       tickerActions: [],
       contextMenuProviders: [],
       eventDisposers: [],
-      dataSourceDisposers: [],
+      capabilityDisposers: [],
       newsQueryWatchDisposers: [],
     };
     this.pluginItems.set(pluginId, items);
     return items;
+  }
+
+  private registerCapabilityForPlugin(pluginId: string, capability: PluginCapability, items: PluginItems): void {
+    const ownedCapability: PluginCapability = {
+      ...capability,
+      isEnabled: () => {
+        const config = this.getConfigFn();
+        const disabledPlugin = config.disabledPlugins.includes(pluginId);
+        const disabledSource = config.disabledSources?.includes(capability.sourceId ?? capability.id) ?? false;
+        return !disabledPlugin && !disabledSource && (capability.isEnabled?.() ?? true);
+      },
+    };
+    const disposeCapability = this.capabilities.register(pluginId, ownedCapability);
+    this.capabilityOwners.set(capability.id, pluginId);
+    items.capabilities.push(capability.id);
+    items.capabilityDisposers.push(disposeCapability);
+
+    if (ownedCapability.kind === "news") {
+      const dispose = this.registerNewsCapabilityFn(ownedCapability as NewsCapability);
+      items.capabilityDisposers.push(dispose);
+    }
   }
 
   private wrapPaneDef(pluginId: string, pane: PaneDef): PaneDef {
@@ -604,21 +636,10 @@ export class PluginRegistry implements PluginRuntimeAccess {
       },
       registerColumn: (column) => { this.columnsMap.set(column.id, column); items.columns.push(column.id); },
       registerBroker: (broker) => { this.brokersMap.set(broker.id, broker); items.brokers.push(broker.id); },
-      registerDataSource: (source) => {
-        const ownedSource: DataSource = {
-          ...source,
-          isEnabled: () => {
-            const config = this.getConfigFn();
-            const disabledPlugin = config.disabledPlugins.includes(pluginId);
-            const disabledSource = config.disabledSources?.includes(source.id) ?? false;
-            return !disabledPlugin && !disabledSource && (source.isEnabled?.() ?? true);
-          },
-        };
-        this.dataSourcesMap.set(source.id, ownedSource);
-        this.dataSourceOwners.set(source.id, pluginId);
-        items.dataSources.push(source.id);
-        const dispose = this.registerDataSourceFn(ownedSource);
-        items.dataSourceDisposers.push(dispose);
+      registerCapability: (capability) => {
+        if (this.enableCapabilityHandlers) {
+          this.registerCapabilityForPlugin(pluginId, capability, items);
+        }
       },
       registerDetailTab: (tab) => { this.detailTabsMap.set(tab.id, this.wrapDetailTabDef(pluginId, tab)); items.detailTabs.push(tab.id); },
       registerShortcut: (shortcut) => {
@@ -712,22 +733,9 @@ export class PluginRegistry implements PluginRuntimeAccess {
       items.brokers.push(plugin.broker.id);
     }
 
-    if (plugin.dataSources) {
-      for (const source of plugin.dataSources) {
-        const ownedSource: DataSource = {
-          ...source,
-          isEnabled: () => {
-            const config = this.getConfigFn();
-            const disabledPlugin = config.disabledPlugins.includes(plugin.id);
-            const disabledSource = config.disabledSources?.includes(source.id) ?? false;
-            return !disabledPlugin && !disabledSource && (source.isEnabled?.() ?? true);
-          },
-        };
-        this.dataSourcesMap.set(source.id, ownedSource);
-        this.dataSourceOwners.set(source.id, plugin.id);
-        items.dataSources.push(source.id);
-        const dispose = this.registerDataSourceFn(ownedSource);
-        items.dataSourceDisposers.push(dispose);
+    if (this.enableCapabilityHandlers && plugin.capabilities) {
+      for (const capability of plugin.capabilities) {
+        this.registerCapabilityForPlugin(plugin.id, capability, items);
       }
     }
 
@@ -803,9 +811,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
       }
       for (const columnId of items.columns) this.columnsMap.delete(columnId);
       for (const brokerId of items.brokers) this.brokersMap.delete(brokerId);
-      for (const sourceId of items.dataSources) {
-        this.dataSourcesMap.delete(sourceId);
-        this.dataSourceOwners.delete(sourceId);
+      for (const capabilityId of items.capabilities) {
+        this.capabilityOwners.delete(capabilityId);
       }
       for (const tabId of items.detailTabs) this.detailTabsMap.delete(tabId);
       for (const shortcutId of items.shortcuts) {
@@ -815,7 +822,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
       for (const actionId of items.tickerActions) this.tickerActionsMap.delete(actionId);
       for (const providerKey of items.contextMenuProviders) this.contextMenuProvidersMap.delete(providerKey);
       for (const dispose of items.eventDisposers) dispose();
-      for (const dispose of items.dataSourceDisposers) dispose();
+      for (const dispose of items.capabilityDisposers) dispose();
       for (const dispose of items.newsQueryWatchDisposers) dispose();
       this.pluginItems.delete(pluginId);
     }
@@ -835,6 +842,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
         });
       }
     }
+    this.capabilities.destroy();
+    this.capabilityOwners.clear();
     this.pluginResumeListeners.clear();
     if (sharedRegistry === this) {
       sharedRegistry = undefined;

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -82,7 +82,7 @@ const readyWindowRpcs = new Set<string>();
 const rpcWindowKeys = new Map<DesktopRpc, string>();
 const contextMenuRequestRpcs = new Map<string, DesktopRpc>();
 
-const dataQuoteSubscriptions = new Map<string, () => void>();
+const capabilitySubscriptions = new Map<string, () => void>();
 const ibkrSnapshotSubscriptions = new Map<string, () => void>();
 const ibkrQuoteSubscriptions = new Map<string, () => void>();
 const aiRuns = new Map<string, AiRunController>();
@@ -612,14 +612,14 @@ function disposeScopedAiRuns(windowKey: string): void {
 }
 
 function disposeWindowScopedResources(windowKey: string): void {
-  disposeScopedSubscriptionMap(dataQuoteSubscriptions, windowKey);
+  disposeScopedSubscriptionMap(capabilitySubscriptions, windowKey);
   disposeScopedSubscriptionMap(ibkrSnapshotSubscriptions, windowKey);
   disposeScopedSubscriptionMap(ibkrQuoteSubscriptions, windowKey);
   disposeScopedAiRuns(windowKey);
 }
 
 function teardownServices(): void {
-  disposeSubscriptionMap(dataQuoteSubscriptions);
+  disposeSubscriptionMap(capabilitySubscriptions);
   disposeSubscriptionMap(ibkrSnapshotSubscriptions);
   disposeSubscriptionMap(ibkrQuoteSubscriptions);
   disposeAiRuns();
@@ -852,6 +852,7 @@ async function initialize(
       sessionSnapshot: getSessionSnapshot(),
       desktopSnapshot: getDesktopSnapshot(),
       pluginState: loadPluginState(),
+      capabilityManifests: requireServices().pluginRegistry.capabilities.manifests({ rendererOnly: true }),
       windowKind: windowTarget.kind,
       paneId: windowTarget.paneId,
     };
@@ -887,94 +888,10 @@ async function initialize(
     sessionSnapshot: getSessionSnapshot(),
     desktopSnapshot: getDesktopSnapshot(),
     pluginState: loadPluginState(),
+    capabilityManifests: requireServices().pluginRegistry.capabilities.manifests({ rendererOnly: true }),
     windowKind: windowTarget.kind,
     paneId: windowTarget.paneId,
   };
-}
-
-async function handleDataProvider(
-  rpc: DesktopRpc,
-  method: string,
-  payload: Record<string, unknown>,
-) {
-  const provider = requireServices().dataProvider;
-  switch (method) {
-    case "data.getTickerFinancials":
-      return provider.getTickerFinancials(payload.ticker as string, payload.exchange as string | undefined, payload.context as never);
-    case "data.getQuote":
-      return provider.getQuote(payload.ticker as string, payload.exchange as string | undefined, payload.context as never);
-    case "data.getExchangeRate":
-      return provider.getExchangeRate(payload.fromCurrency as string);
-    case "data.search":
-      return provider.search(payload.query as string, payload.context as never);
-    case "data.getNews":
-      return (provider as typeof provider & { getNews?: (query: never) => unknown }).getNews?.(payload.query as never) ?? [];
-    case "data.getSecFilings":
-      return provider.getSecFilings?.(payload.ticker as string, payload.count as number | undefined, payload.exchange as string | undefined, payload.context as never) ?? [];
-    case "data.getHolders":
-      if (!provider.getHolders) throw new Error("Holder data source unavailable");
-      return provider.getHolders(payload.ticker as string, payload.exchange as string | undefined, payload.context as never);
-    case "data.getAnalystResearch":
-      if (!provider.getAnalystResearch) throw new Error("Analyst data source unavailable");
-      return provider.getAnalystResearch(payload.ticker as string, payload.exchange as string | undefined, payload.context as never);
-    case "data.getCorporateActions":
-      if (!provider.getCorporateActions) throw new Error("Corporate actions source unavailable");
-      return provider.getCorporateActions(payload.ticker as string, payload.exchange as string | undefined, payload.context as never);
-    case "data.getSecFilingContent":
-      return provider.getSecFilingContent?.(payload.filing as never) ?? null;
-    case "data.getEarningsCalendar":
-      return provider.getEarningsCalendar?.(payload.symbols as string[], payload.context as never) ?? [];
-    case "data.getArticleSummary":
-      return provider.getArticleSummary(payload.url as string);
-    case "data.getPriceHistory":
-      return provider.getPriceHistory(payload.ticker as string, payload.exchange as string, payload.range as never, payload.context as never);
-    case "data.getPriceHistoryForResolution":
-      return provider.getPriceHistoryForResolution?.(
-        payload.ticker as string,
-        payload.exchange as string,
-        payload.bufferRange as never,
-        payload.resolution as never,
-        payload.context as never,
-      ) ?? [];
-    case "data.getDetailedPriceHistory":
-      return provider.getDetailedPriceHistory?.(
-        payload.ticker as string,
-        payload.exchange as string,
-        payload.startDate as Date,
-        payload.endDate as Date,
-        payload.barSize as string,
-        payload.context as never,
-      ) ?? [];
-    case "data.getChartResolutionSupport":
-      return provider.getChartResolutionSupport?.(payload.ticker as string, payload.exchange as string | undefined, payload.context as never) ?? [];
-    case "data.getOptionsChain":
-      return provider.getOptionsChain?.(payload.ticker as string, payload.exchange as string | undefined, payload.expirationDate as number | undefined, payload.context as never) ?? null;
-    case "data.subscribeQuotes": {
-      const subscriptionId = payload.subscriptionId as string;
-      const scopedSubscriptionId = scopeClientId(rpc, subscriptionId);
-      dataQuoteSubscriptions.get(scopedSubscriptionId)?.();
-      const unsubscribe = provider.subscribeQuotes(
-        payload.targets as QuoteSubscriptionTarget[],
-        (target, quote) => {
-          rpc.send["quote.update"]({
-            subscriptionId,
-            target: encodeRpcValue(target),
-            quote: encodeRpcValue(quote),
-          });
-        },
-      );
-      dataQuoteSubscriptions.set(scopedSubscriptionId, unsubscribe);
-      return null;
-    }
-    case "data.unsubscribeQuotes": {
-      const scopedSubscriptionId = scopeClientId(rpc, payload.subscriptionId as string);
-      dataQuoteSubscriptions.get(scopedSubscriptionId)?.();
-      dataQuoteSubscriptions.delete(scopedSubscriptionId);
-      return null;
-    }
-    default:
-      throw new Error(`Unknown data method: ${method}`);
-  }
 }
 
 async function handleIbkr(
@@ -1285,6 +1202,50 @@ async function handleDesktop(
   }
 }
 
+async function handleCapability(
+  rpc: DesktopRpc,
+  method: string,
+  payload: Record<string, unknown>,
+) {
+  const registry = requireServices().pluginRegistry.capabilities;
+  switch (method) {
+    case "capability.invoke":
+      return registry.invoke(
+        payload.capabilityId as string,
+        payload.operationId as string,
+        payload.payload,
+        { renderer: true },
+      );
+    case "capability.subscribe": {
+      const clientSubscriptionId = payload.subscriptionId as string;
+      const scopedSubscriptionId = scopeClientId(rpc, clientSubscriptionId);
+      capabilitySubscriptions.get(scopedSubscriptionId)?.();
+      await registry.subscribe(
+        payload.capabilityId as string,
+        payload.operationId as string,
+        payload.payload,
+        (event) => {
+          rpc.send["capability.event"]({
+            subscriptionId: clientSubscriptionId,
+            event: encodeRpcValue(event),
+          });
+        },
+        { renderer: true, subscriptionId: scopedSubscriptionId },
+      );
+      capabilitySubscriptions.set(scopedSubscriptionId, () => registry.unsubscribe(scopedSubscriptionId));
+      return null;
+    }
+    case "capability.unsubscribe": {
+      const scopedSubscriptionId = scopeClientId(rpc, payload.subscriptionId as string);
+      capabilitySubscriptions.get(scopedSubscriptionId)?.();
+      capabilitySubscriptions.delete(scopedSubscriptionId);
+      return null;
+    }
+    default:
+      throw new Error(`Unknown capability method: ${method}`);
+  }
+}
+
 async function handleBackendRequest(
   rpc: DesktopRpc,
   method: string,
@@ -1294,7 +1255,7 @@ async function handleBackendRequest(
 
   if (method === "init") return initialize(rpc, payload);
   if (method === "http.fetch") return handleHttpFetch(payload);
-  if (method.startsWith("data.")) return handleDataProvider(rpc, method, payload);
+  if (method.startsWith("capability.")) return handleCapability(rpc, method, payload);
   if (method.startsWith("ibkr.")) return handleIbkr(rpc, method, payload);
   if (method.startsWith("ai.")) return handleAi(rpc, method, payload);
   if (method.startsWith("notes.")) return handleNotes(method, payload);

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -3,6 +3,7 @@ import type { DesktopDockPreviewState, DesktopSharedStateSnapshot } from "../../
 import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu";
 import type { AppConfig } from "../../../types/config";
 import type { UpdateProgress } from "../../../updater";
+import type { CapabilityManifest } from "../../../capabilities";
 
 export const ELECTROBUN_CONTEXT_MENU_ACTION = "gloom.context-menu.select";
 
@@ -11,6 +12,7 @@ export interface ElectrobunBackendInit {
   sessionSnapshot: AppSessionSnapshot | null;
   desktopSnapshot: DesktopSharedStateSnapshot | null;
   pluginState: Record<string, Record<string, unknown>>;
+  capabilityManifests: CapabilityManifest[];
   windowKind: "main" | "detached";
   paneId?: string;
 }
@@ -64,6 +66,11 @@ export interface UpdateProgressMessage {
   progress: UpdateProgress;
 }
 
+export interface CapabilityEventMessage {
+  subscriptionId: string;
+  event: unknown;
+}
+
 export interface ElectrobunDesktopRpcSchema {
   bun: {
     requests: {
@@ -77,7 +84,6 @@ export interface ElectrobunDesktopRpcSchema {
   webview: {
     requests: {};
     messages: {
-      "quote.update": QuoteUpdateMessage;
       "ibkr.snapshot": IbkrSnapshotMessage;
       "ibkr.resolved": IbkrResolvedMessage;
       "ibkr.quote.update": QuoteUpdateMessage;
@@ -87,6 +93,7 @@ export interface ElectrobunDesktopRpcSchema {
       "desktop.state": DesktopStateMessage;
       "desktop.dockPreview": DesktopDockPreviewMessage;
       "update.progress": UpdateProgressMessage;
+      "capability.event": CapabilityEventMessage;
     };
   };
 }

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -4,20 +4,17 @@ import { setSharedNewsService } from "../../../news/hooks";
 import { PluginRegistry } from "../../../plugins/registry";
 import type { AppServices } from "../../../core/app-services";
 import type { AppConfig } from "../../../types/config";
-import type { DataProvider, MarketDataRequestContext, SearchRequestContext, QuoteSubscriptionTarget } from "../../../types/data-provider";
-import type { DataSource } from "../../../types/data-source";
-import type { AnalystResearchData, CorporateActionsData, HolderData, TickerFinancials, Quote } from "../../../types/financials";
+import type { DataProvider, QuoteSubscriptionTarget } from "../../../types/data-provider";
+import type { Quote } from "../../../types/financials";
 import type { NewsArticle, NewsQuery } from "../../../news/types";
-import type { BrokerContractRef, InstrumentSearchResult } from "../../../types/instrument";
 import type { TickerRecord, TickerMetadata } from "../../../types/ticker";
-import type { TimeRange } from "../../../components/chart/chart-types";
-import type { ManualChartResolution } from "../../../components/chart/chart-resolution";
+import { newsProvider, type CapabilityManifest } from "../../../capabilities";
 import {
   createPersistScheduler,
   PLUGIN_STATE_SAVE_DEBOUNCE_MS,
   SESSION_SAVE_DEBOUNCE_MS,
 } from "../../../state/persist-scheduler";
-import { backendRequest, getElectrobunBackendInitSnapshot, onQuoteSubscription } from "./backend-rpc";
+import { backendRequest, getElectrobunBackendInitSnapshot, onCapabilityEvent } from "./backend-rpc";
 import { DesktopMemoryResourceStore } from "./resource-store";
 import { debugLog } from "../../../utils/debug-log";
 import { measurePerf } from "../../../utils/perf-marks";
@@ -25,6 +22,8 @@ import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 
 const REMOTE_DATA_REQUEST_CACHE_LIMIT = 150;
 const servicesLog = debugLog.createLogger("services");
+const ASSET_DATA_CAPABILITY_ID = "asset-data.asset-data-router";
+const NEWS_CAPABILITY_ID = "news.core";
 
 class RemoteTickerRepository {
   async loadAllTickers(): Promise<TickerRecord[]> {
@@ -50,146 +49,134 @@ class RemoteTickerRepository {
   }
 }
 
-class RemoteDataProvider implements DataProvider {
-  readonly id = "desktop-backend";
-  readonly name = "Gloomberb Backend";
-  private readonly requestCache = new Map<string, Promise<unknown>>();
-  private nextSubscriptionId = 1;
+type RemoteAssetDataClient = DataProvider & {
+  getNews(query: NewsQuery): Promise<NewsArticle[]>;
+};
 
-  private cachedRequest<T>(method: string, payload: unknown): Promise<T> {
-    const key = `${method}:${JSON.stringify(payload)}`;
-    const cached = this.requestCache.get(key);
+type PayloadBuilder = (...args: any[]) => Record<string, unknown>;
+
+const assetDataPayloads: Record<string, PayloadBuilder> = {
+  canProvide: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getTickerFinancials: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getQuote: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getExchangeRate: (fromCurrency) => ({ fromCurrency }),
+  search: (query, context) => ({ query, context }),
+  getSecFilings: (ticker, count, exchange, context) => ({ ticker, count, exchange, context }),
+  getHolders: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getAnalystResearch: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getCorporateActions: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getSecFilingContent: (filing) => ({ filing }),
+  getEarningsCalendar: (symbols, context) => ({ symbols, context }),
+  getArticleSummary: (url) => ({ url }),
+  getPriceHistory: (ticker, exchange, range, context) => ({ ticker, exchange, range, context }),
+  getPriceHistoryForResolution: (ticker, exchange, bufferRange, resolution, context) => ({ ticker, exchange, bufferRange, resolution, context }),
+  getDetailedPriceHistory: (ticker, exchange, startDate, endDate, barSize, context) => ({ ticker, exchange, startDate, endDate, barSize, context }),
+  getChartResolutionSupport: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getChartResolutionCapabilities: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getOptionsChain: (ticker, exchange, expirationDate, context) => ({ ticker, exchange, expirationDate, context }),
+};
+
+function findCapabilityManifest(capabilityId: string): CapabilityManifest | null {
+  return getElectrobunBackendInitSnapshot()?.capabilityManifests.find((manifest) => manifest.id === capabilityId) ?? null;
+}
+
+function getRendererOperationIds(capabilityId: string): Set<string> | null {
+  const manifest = findCapabilityManifest(capabilityId);
+  if (!manifest) return null;
+  return new Set(
+    manifest.operations
+      .filter((operation) => operation.rendererSafe)
+      .map((operation) => operation.id),
+  );
+}
+
+function hasRendererOperation(operations: Set<string> | null, operationId: string): boolean {
+  return operations === null || operations.has(operationId);
+}
+
+function createCapabilityInvoker() {
+  const requestCache = new Map<string, Promise<unknown>>();
+  return function invoke<T>(capabilityId: string, operationId: string, payload: unknown): Promise<T> {
+    const requestPayload = { capabilityId, operationId, payload };
+    const key = JSON.stringify(requestPayload);
+    const cached = requestCache.get(key);
     if (cached) return cached as Promise<T>;
-    const promise = backendRequest<T>(method, payload).catch((error) => {
-      this.requestCache.delete(key);
+    const promise = backendRequest<T>("capability.invoke", requestPayload).catch((error) => {
+      requestCache.delete(key);
       throw error;
     });
-    this.requestCache.set(key, promise);
-    if (this.requestCache.size > REMOTE_DATA_REQUEST_CACHE_LIMIT) {
-      const oldestKey = this.requestCache.keys().next().value;
-      if (oldestKey) this.requestCache.delete(oldestKey);
+    requestCache.set(key, promise);
+    if (requestCache.size > REMOTE_DATA_REQUEST_CACHE_LIMIT) {
+      const oldestKey = requestCache.keys().next().value;
+      if (oldestKey) requestCache.delete(oldestKey);
     }
     return promise;
-  }
+  };
+}
 
-  getCachedFinancialsForTargets(): Map<string, TickerFinancials> {
-    return new Map();
-  }
+function createRemoteAssetDataClient(): RemoteAssetDataClient {
+  const invoke = createCapabilityInvoker();
+  const assetDataOperations = getRendererOperationIds(ASSET_DATA_CAPABILITY_ID);
+  const newsOperations = getRendererOperationIds(NEWS_CAPABILITY_ID);
+  let nextSubscriptionId = 1;
+  const base = {
+    id: "desktop-backend",
+    name: "Gloomberb Backend",
+    getCachedFinancialsForTargets: () => new Map(),
+    getNews: (query: NewsQuery) => (
+      hasRendererOperation(newsOperations, "fetchNews")
+        ? invoke<NewsArticle[]>(NEWS_CAPABILITY_ID, "fetchNews", { query })
+        : Promise.resolve([])
+    ),
+    subscribeQuotes: (
+      targets: QuoteSubscriptionTarget[],
+      onQuote: (target: QuoteSubscriptionTarget, quote: Quote) => void,
+    ) => {
+      if (!hasRendererOperation(assetDataOperations, "subscribeQuotes")) return () => {};
+      const uniqueTargets = [...new Map(
+        targets.map((target) => [
+          `${target.symbol}:${target.exchange ?? ""}:${target.context?.brokerId ?? ""}:${target.context?.brokerInstanceId ?? ""}`,
+          target,
+        ] as const),
+      ).values()];
+      if (uniqueTargets.length === 0) return () => {};
 
-  getTickerFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<TickerFinancials> {
-    return backendRequest("data.getTickerFinancials", { ticker, exchange, context });
-  }
+      const subscriptionId = `quote:${nextSubscriptionId++}`;
+      const disposeMessages = onCapabilityEvent(subscriptionId, (message) => {
+        const event = message.event as { target: QuoteSubscriptionTarget; quote: Quote };
+        onQuote(event.target, event.quote);
+      });
+      let disposed = false;
 
-  getQuote(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<Quote> {
-    return backendRequest("data.getQuote", { ticker, exchange, context });
-  }
+      void backendRequest("capability.subscribe", {
+        subscriptionId,
+        capabilityId: ASSET_DATA_CAPABILITY_ID,
+        operationId: "subscribeQuotes",
+        payload: { targets: uniqueTargets },
+      }).catch((error) => {
+        disposeMessages();
+        console.error("Failed to subscribe to backend quotes", error);
+      });
 
-  getExchangeRate(fromCurrency: string): Promise<number> {
-    return backendRequest("data.getExchangeRate", { fromCurrency });
-  }
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        disposeMessages();
+        void backendRequest("capability.unsubscribe", { subscriptionId }).catch(() => {});
+      };
+    },
+  };
 
-  search(query: string, context?: SearchRequestContext): Promise<InstrumentSearchResult[]> {
-    return backendRequest("data.search", { query, context });
-  }
-
-  getNews(query: NewsQuery): Promise<NewsArticle[]> {
-    return this.cachedRequest("data.getNews", { query });
-  }
-
-  getSecFilings(ticker: string, count?: number, exchange?: string, context?: MarketDataRequestContext) {
-    return this.cachedRequest("data.getSecFilings", { ticker, count, exchange, context });
-  }
-
-  getHolders(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<HolderData> {
-    return this.cachedRequest("data.getHolders", { ticker, exchange, context });
-  }
-
-  getAnalystResearch(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<AnalystResearchData> {
-    return this.cachedRequest("data.getAnalystResearch", { ticker, exchange, context });
-  }
-
-  getCorporateActions(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<CorporateActionsData> {
-    return this.cachedRequest("data.getCorporateActions", { ticker, exchange, context });
-  }
-
-  getSecFilingContent(filing: unknown): Promise<string | null> {
-    return this.cachedRequest("data.getSecFilingContent", { filing });
-  }
-
-  getEarningsCalendar(symbols: string[], context?: MarketDataRequestContext) {
-    return backendRequest("data.getEarningsCalendar", { symbols, context });
-  }
-
-  getArticleSummary(url: string): Promise<string | null> {
-    return this.cachedRequest("data.getArticleSummary", { url });
-  }
-
-  getPriceHistory(ticker: string, exchange: string, range: TimeRange, context?: MarketDataRequestContext) {
-    return this.cachedRequest("data.getPriceHistory", { ticker, exchange, range, context });
-  }
-
-  getPriceHistoryForResolution(
-    ticker: string,
-    exchange: string,
-    bufferRange: TimeRange,
-    resolution: ManualChartResolution,
-    context?: MarketDataRequestContext,
-  ) {
-    return this.cachedRequest("data.getPriceHistoryForResolution", { ticker, exchange, bufferRange, resolution, context });
-  }
-
-  getDetailedPriceHistory(
-    ticker: string,
-    exchange: string,
-    startDate: Date,
-    endDate: Date,
-    barSize: string,
-    context?: MarketDataRequestContext,
-  ) {
-    return this.cachedRequest("data.getDetailedPriceHistory", { ticker, exchange, startDate, endDate, barSize, context });
-  }
-
-  getChartResolutionSupport(ticker: string, exchange?: string, context?: MarketDataRequestContext) {
-    return this.cachedRequest("data.getChartResolutionSupport", { ticker, exchange, context });
-  }
-
-  getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, context?: MarketDataRequestContext) {
-    return this.cachedRequest("data.getOptionsChain", { ticker, exchange, expirationDate, context });
-  }
-
-  subscribeQuotes(
-    targets: QuoteSubscriptionTarget[],
-    onQuote: (target: QuoteSubscriptionTarget, quote: Quote) => void,
-  ): () => void {
-    const uniqueTargets = [...new Map(
-      targets.map((target) => [
-        `${target.symbol}:${target.exchange ?? ""}:${target.brokerId ?? ""}:${target.brokerInstanceId ?? ""}`,
-        target,
-      ] as const),
-    ).values()];
-    if (uniqueTargets.length === 0) return () => {};
-
-    const subscriptionId = `quote:${this.nextSubscriptionId++}`;
-    const disposeMessages = onQuoteSubscription(subscriptionId, (message) => {
-      onQuote(message.target as QuoteSubscriptionTarget, message.quote as Quote);
-    });
-    let disposed = false;
-
-    void backendRequest("data.subscribeQuotes", {
-      subscriptionId,
-      targets: uniqueTargets,
-    }).catch((error) => {
-      disposeMessages();
-      console.error("Failed to subscribe to backend quotes", error);
-    });
-
-    return () => {
-      if (disposed) return;
-      disposed = true;
-      disposeMessages();
-      void backendRequest("data.unsubscribeQuotes", { subscriptionId }).catch(() => {});
-    };
-  }
+  return new Proxy(base, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string" || prop in target) {
+        return Reflect.get(target, prop, receiver);
+      }
+      const buildPayload = assetDataPayloads[prop];
+      if (!buildPayload || !hasRendererOperation(assetDataOperations, prop)) return undefined;
+      return (...args: unknown[]) => invoke(ASSET_DATA_CAPABILITY_ID, prop, buildPayload(...args));
+    },
+  }) as RemoteAssetDataClient;
 }
 
 class RemoteSessionStore {
@@ -305,29 +292,29 @@ export function createAppServices({ config }: { config: AppConfig }): AppService
   });
   const persistence = measurePerf("startup.services.persistence", () => new RemotePersistence());
   const tickerRepository = measurePerf("startup.services.ticker-repository", () => new RemoteTickerRepository());
-  const dataProvider = measurePerf("startup.services.data-provider", () => new RemoteDataProvider());
+  const dataProvider = measurePerf("startup.services.data-provider", () => createRemoteAssetDataClient());
   const marketData = new MarketDataCoordinator(dataProvider);
-  const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository as never, persistence as never);
+  const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository as never, persistence as never, {
+    enableCapabilityHandlers: false,
+  });
   const newsService = new NewsService();
 
   pluginRegistry.getConfigFn = () => config;
   pluginRegistry.getLayoutFn = () => config.layout;
-  pluginRegistry.registerDataSourceFn = () => () => {};
+  pluginRegistry.registerNewsCapabilityFn = () => () => {};
   pluginRegistry.watchNewsQueryFn = (query, listener) => newsService.watchQuery(query, listener);
 
   setSharedMarketDataCoordinator(marketData);
   setSharedNewsService(newsService);
 
-  const remoteDataSource: DataSource = {
+  newsService.register(newsProvider({
     id: dataProvider.id,
     name: dataProvider.name,
     priority: 0,
-    market: dataProvider,
-    news: {
+    provider: {
       fetchNews: (query) => dataProvider.getNews(query),
     },
-  };
-  newsService.register(remoteDataSource);
+  }));
 
   const plugins = getRendererBuiltinPlugins();
   for (const plugin of plugins) {

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -4,6 +4,7 @@ import { measurePerfAsync } from "../../../utils/perf-marks";
 import {
   type ApplicationMenuSelectMessage,
   type AiChunkMessage,
+  type CapabilityEventMessage,
   type ContextMenuSelectMessage,
   type DesktopDockPreviewMessage,
   type DesktopStateMessage,
@@ -25,9 +26,9 @@ type ApplicationMenuSelectListener = (message: ApplicationMenuSelectMessage) => 
 type DesktopStateListener = (message: DesktopStateMessage) => void;
 type DesktopDockPreviewListener = (message: DesktopDockPreviewMessage) => void;
 type UpdateProgressListener = (message: UpdateProgressMessage) => void;
+type CapabilityEventListener = (message: CapabilityEventMessage) => void;
 
 let initSnapshot: ElectrobunBackendInit | null = null;
-const quoteListeners = new Map<string, Set<QuoteListener>>();
 const ibkrQuoteListeners = new Map<string, Set<QuoteListener>>();
 const ibkrSnapshotListeners = new Map<string, Set<IbkrSnapshotListener>>();
 const ibkrResolvedListeners = new Set<IbkrResolvedListener>();
@@ -37,6 +38,7 @@ const applicationMenuSelectListeners = new Set<ApplicationMenuSelectListener>();
 const desktopStateListeners = new Set<DesktopStateListener>();
 const desktopDockPreviewListeners = new Set<DesktopDockPreviewListener>();
 const updateProgressListeners = new Set<UpdateProgressListener>();
+const capabilityEventListeners = new Map<string, Set<CapabilityEventListener>>();
 
 function dispatch<T>(
   listeners: Map<string, Set<(value: T) => void>>,
@@ -72,13 +74,6 @@ const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
   handlers: {
     requests: {},
     messages: {
-      "quote.update": (message) => {
-        dispatch(quoteListeners, message.subscriptionId, {
-          ...message,
-          target: decodeRpcValue(message.target),
-          quote: decodeRpcValue(message.quote),
-        });
-      },
       "ibkr.quote.update": (message) => {
         dispatch(ibkrQuoteListeners, message.subscriptionId, {
           ...message,
@@ -130,6 +125,12 @@ const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
           listener(decoded);
         }
       },
+      "capability.event": (message) => {
+        dispatch(capabilityEventListeners, message.subscriptionId, {
+          subscriptionId: message.subscriptionId,
+          event: decodeRpcValue(message.event),
+        });
+      },
     },
   },
 });
@@ -167,11 +168,11 @@ export function getElectrobunBackendInitSnapshot(): ElectrobunBackendInit | null
   return initSnapshot;
 }
 
-export function onQuoteSubscription(
+export function onCapabilityEvent(
   subscriptionId: string,
-  listener: (message: QuoteUpdateMessage) => void,
+  listener: (message: CapabilityEventMessage) => void,
 ): () => void {
-  return subscribe(quoteListeners, subscriptionId, listener);
+  return subscribe(capabilityEventListeners, subscriptionId, listener);
 }
 
 export function onIbkrQuoteSubscription(

--- a/src/sources/gloomberb-cloud.test.ts
+++ b/src/sources/gloomberb-cloud.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createGloomberbCloudSource, GloomberbCloudProvider } from "./gloomberb-cloud";
+import { createGloomberbCloudCapabilities, GloomberbCloudProvider } from "./gloomberb-cloud";
+import type { NewsCapability } from "../capabilities";
 import { apiClient, type AuthUser } from "../utils/api-client";
 
 const verifiedUser: AuthUser = {
@@ -482,8 +483,8 @@ describe("GloomberbCloudProvider", () => {
       nextCursor: null,
     });
 
-    const source = createGloomberbCloudSource();
-    const news = await source.news!.fetchNews({ feed: "top", ticker: "SNY" });
+    const source = createGloomberbCloudCapabilities().find((capability) => capability.kind === "news") as NewsCapability;
+    const news = await source.provider.fetchNews({ feed: "top", ticker: "SNY" });
 
     expect(news[0]?.tickers).toEqual(["SNY", "MRNA"]);
     expect(news[0]?.importance).toBe(77);

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -4,8 +4,8 @@ import {
   type ChartResolutionSupport,
   type ManualChartResolution,
 } from "../components/chart/chart-resolution";
-import type { DataProvider, MarketDataRequestContext, NewsItem, QuoteSubscriptionTarget, SearchRequestContext, SecFilingItem } from "../types/data-provider";
-import type { DataSource } from "../types/data-source";
+import { assetDataProvider, newsProvider, type PluginCapability } from "../capabilities";
+import type { AssetDataProvider, MarketDataRequestContext, NewsItem, QuoteSubscriptionTarget, SearchRequestContext, SecFilingItem } from "../types/data-provider";
 import type { AnalystResearchData, CorporateActionsData, HolderData, OptionsChain, PricePoint, Quote, TickerFinancials } from "../types/financials";
 import type { InstrumentSearchResult } from "../types/instrument";
 import {
@@ -338,7 +338,7 @@ function unwrapOptionalCloudResponse<T>(response: CloudMarketResponse<T>): T | n
   throw new Error(response.reasonCode ?? "Cloud data request failed");
 }
 
-export class GloomberbCloudProvider implements DataProvider {
+export class GloomberbCloudProvider implements AssetDataProvider {
   readonly id = providerId;
   readonly name = "Gloomberb Cloud";
   readonly priority = 100;
@@ -552,28 +552,30 @@ export class GloomberbCloudProvider implements DataProvider {
   }
 }
 
-export function createGloomberbCloudProvider(): DataProvider {
+export function createGloomberbCloudProvider(): AssetDataProvider {
   return new GloomberbCloudProvider();
 }
 
-export function createGloomberbCloudSource(provider = createGloomberbCloudProvider()): DataSource {
-  return {
-    id: providerId,
-    name: "Gloomberb Cloud",
-    priority: 10,
-    market: provider,
-    news: {
-      supports(query: NewsQuery): boolean {
-        const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
-        return feed === "ticker" ? !!query.ticker : true;
+export function createGloomberbCloudCapabilities(provider = createGloomberbCloudProvider()): PluginCapability[] {
+  return [
+    assetDataProvider(provider),
+    newsProvider({
+      id: providerId,
+      name: "Gloomberb Cloud",
+      priority: 10,
+      provider: {
+        supports(query: NewsQuery): boolean {
+          const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
+          return feed === "ticker" ? !!query.ticker : true;
+        },
+        async fetchNews(query: NewsQuery): Promise<NewsArticle[]> {
+          const response = await withCloudFallback(
+            () => apiClient.getCloudNews(cloudNewsParams(query)),
+            "Cloud news is unavailable",
+          );
+          return response.items.map((item) => mapCloudNewsArticle(item, query.ticker));
+        },
       },
-      async fetchNews(query: NewsQuery): Promise<NewsArticle[]> {
-        const response = await withCloudFallback(
-          () => apiClient.getCloudNews(cloudNewsParams(query)),
-          "Cloud news is unavailable",
-        );
-        return response.items.map((item) => mapCloudNewsArticle(item, query.ticker));
-      },
-    },
-  };
+    }),
+  ];
 }

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -3,10 +3,11 @@ import { existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { AppPersistence } from "../data/app-persistence";
-import { SourceRouter } from "./provider-router";
+import { AssetDataRouter } from "./provider-router";
+import { assetDataProvider } from "../capabilities";
 import type { BrokerAdapter } from "../types/broker";
 import type { DataProvider, QuoteSubscriptionTarget } from "../types/data-provider";
-import type { DataSource } from "../types/data-source";
+import type { CapabilityRouteSource } from "../types/capability-route-source";
 import type { NewsArticle } from "../news/types";
 import { cloneLayout, CURRENT_CONFIG_VERSION, DEFAULT_LAYOUT } from "../types/config";
 
@@ -81,9 +82,9 @@ function makeArticle(id: string): NewsArticle {
   };
 }
 
-describe("SourceRouter", () => {
+describe("AssetDataRouter", () => {
   test("routes market calls only through sources with market capability", async () => {
-    const newsOnlySource: DataSource = {
+    const newsOnlySource: CapabilityRouteSource = {
       id: "news-only",
       name: "News Only",
       priority: 1,
@@ -93,7 +94,7 @@ describe("SourceRouter", () => {
         },
       },
     };
-    const marketSource: DataSource = {
+    const marketSource: CapabilityRouteSource = {
       id: "market-source",
       name: "Market Source",
       priority: 10,
@@ -115,7 +116,7 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(fallbackProvider, [newsOnlySource, marketSource]);
+    const router = new AssetDataRouter(fallbackProvider, [newsOnlySource, marketSource]);
 
     const quote = await router.getQuote("AAPL", "NASDAQ");
 
@@ -125,7 +126,7 @@ describe("SourceRouter", () => {
 
   test("routes news calls only through sources with news capability", async () => {
     const article = makeArticle("source-news");
-    const marketOnlySource: DataSource = {
+    const marketOnlySource: CapabilityRouteSource = {
       id: "market-only",
       name: "Market Only",
       priority: 1,
@@ -135,7 +136,7 @@ describe("SourceRouter", () => {
         name: "Market Only",
       },
     };
-    const newsSource: DataSource = {
+    const newsSource: CapabilityRouteSource = {
       id: "news-source",
       name: "News Source",
       priority: 10,
@@ -143,7 +144,7 @@ describe("SourceRouter", () => {
         fetchNews: async () => [article],
       },
     };
-    const router = new SourceRouter(null, [marketOnlySource, newsSource]);
+    const router = new AssetDataRouter(null, [marketOnlySource, newsSource]);
 
     const articles = await router.getNews({ feed: "latest", limit: 10 });
 
@@ -187,7 +188,7 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(yahooProvider, [cloudProvider]);
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
     const holders = await router.getHolders("AAPL", "NASDAQ");
 
     expect(holders.providerId).toBe("yahoo");
@@ -195,7 +196,7 @@ describe("SourceRouter", () => {
   });
 
   test("prefers broker quotes over fallback quotes", async () => {
-    const router = new SourceRouter(fallbackProvider);
+    const router = new AssetDataRouter(fallbackProvider);
     const broker: BrokerAdapter = {
       id: "ibkr",
       name: "IBKR",
@@ -220,7 +221,7 @@ describe("SourceRouter", () => {
 
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -256,7 +257,7 @@ describe("SourceRouter", () => {
   });
 
   test("prefers the requested broker instance in search results", async () => {
-    const router = new SourceRouter(fallbackProvider);
+    const router = new AssetDataRouter(fallbackProvider);
     const broker: BrokerAdapter = {
       id: "ibkr",
       name: "IBKR",
@@ -285,7 +286,7 @@ describe("SourceRouter", () => {
 
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -375,11 +376,11 @@ describe("SourceRouter", () => {
         }];
       },
     };
-    const router = new SourceRouter(fallbackProvider, [provider]);
+    const router = new AssetDataRouter(fallbackProvider, [provider]);
 
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -417,46 +418,46 @@ describe("SourceRouter", () => {
   });
 
   test("ignores disabled plugin sources when the registry filters them out", async () => {
-    const disabledProvider: DataProvider = {
-      id: "gloomberb-cloud",
-      name: "Cloud",
-      priority: 10,
-      async getTickerFinancials() {
-        throw new Error("disabled provider should not be used");
-      },
-      async getQuote() {
-        throw new Error("disabled provider should not be used");
-      },
-      async getExchangeRate() {
-        throw new Error("disabled provider should not be used");
-      },
-      async search() {
-        throw new Error("disabled provider should not be used");
-      },
-      async getArticleSummary() {
-        throw new Error("disabled provider should not be used");
-      },
-      async getPriceHistory() {
-        throw new Error("disabled provider should not be used");
-      },
-    };
-
-    const router = new SourceRouter(fallbackProvider);
+    const router = new AssetDataRouter(fallbackProvider);
     router.attachRegistry({
       brokers: new Map(),
-      dataSources: new Map([["gloomberb-cloud", {
-        id: "gloomberb-cloud",
-        name: "Cloud",
-        market: disabledProvider,
-      } satisfies DataSource]]),
-      getEnabledDataSources() {
-        return [];
-      },
+      getEnabledCapabilities: () => [],
     } as any);
 
     const quote = await router.getQuote("AAPL", "NASDAQ");
     expect(quote.price).toBe(100);
     expect(quote.providerId).toBeUndefined();
+  });
+
+  test("routes through registered asset-data capabilities", async () => {
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 10,
+      async getQuote() {
+        return {
+          symbol: "AAPL",
+          providerId: "cloud",
+          price: 125,
+          currency: "USD",
+          change: 1,
+          changePercent: 0.8,
+          lastUpdated: Date.now(),
+        };
+      },
+    };
+    const router = new AssetDataRouter(fallbackProvider);
+    router.attachRegistry({
+      brokers: new Map(),
+      getEnabledCapabilities: (kind?: string) => (
+        kind === "asset-data" ? [assetDataProvider(cloudProvider)] : []
+      ),
+    } as any);
+
+    const quote = await router.getQuote("AAPL", "NASDAQ");
+    expect(quote.price).toBe(125);
+    expect(quote.providerId).toBe("cloud");
   });
 
   test("prefers provider quote streams when one is available", () => {
@@ -510,10 +511,10 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(fallbackProvider, [streamingProvider]);
+    const router = new AssetDataRouter(fallbackProvider, [streamingProvider]);
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -613,10 +614,10 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(fallbackProvider, [streamingProvider]);
+    const router = new AssetDataRouter(fallbackProvider, [streamingProvider]);
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -675,7 +676,7 @@ describe("SourceRouter", () => {
     const dbPath = createTempDbPath("cache-merge");
     const persistence = new AppPersistence(dbPath);
     const providerCalls = { broker: 0, fallback: 0 };
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         providerCalls.fallback += 1;
@@ -718,7 +719,7 @@ describe("SourceRouter", () => {
 
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -770,7 +771,7 @@ describe("SourceRouter", () => {
   });
 
   test("keeps broker price authority when a fallback quote is off by a likely 100x unit mismatch", async () => {
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         return {
@@ -823,7 +824,7 @@ describe("SourceRouter", () => {
 
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -866,7 +867,7 @@ describe("SourceRouter", () => {
   });
 
   test("preserves fallback profile data when broker already has fundamentals", async () => {
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         return {
@@ -903,7 +904,7 @@ describe("SourceRouter", () => {
 
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -994,7 +995,7 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(yahooProvider, [cloudProvider]);
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
     const merged = await router.getTickerFinancials("AAPL", "NASDAQ");
 
     expect(merged.quote?.price).toBe(125);
@@ -1061,13 +1062,13 @@ describe("SourceRouter", () => {
       },
     };
 
-    const seedRouter = new SourceRouter(yahooProvider, [cloudProvider], persistence.resources);
+    const seedRouter = new AssetDataRouter(yahooProvider, [cloudProvider], persistence.resources);
     const seeded = await seedRouter.getTickerFinancials("AAPL", "NASDAQ");
     expect(seeded.quote?.marketCap).toBe(2_000_000_000);
 
     let cloudCalls = 0;
     let yahooCalls = 0;
-    const cachedRouter = new SourceRouter({
+    const cachedRouter = new AssetDataRouter({
       ...yahooProvider,
       async getTickerFinancials() {
         yahooCalls += 1;
@@ -1148,7 +1149,7 @@ describe("SourceRouter", () => {
       recentTickers: [],
     };
 
-    const seedRouter = new SourceRouter({
+    const seedRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         return {
@@ -1160,7 +1161,7 @@ describe("SourceRouter", () => {
     }, [], persistence.resources);
     seedRouter.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     seedRouter.setConfigAccessor(() => config);
 
@@ -1170,7 +1171,7 @@ describe("SourceRouter", () => {
     });
     expect(seeded.profile).toBeUndefined();
 
-    const refreshedRouter = new SourceRouter({
+    const refreshedRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         return {
@@ -1187,7 +1188,7 @@ describe("SourceRouter", () => {
     }, [], persistence.resources);
     refreshedRouter.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     refreshedRouter.setConfigAccessor(() => config);
 
@@ -1204,7 +1205,7 @@ describe("SourceRouter", () => {
   test("does not reuse another broker instance's financials when a specific instance is requested", async () => {
     const dbPath = createTempDbPath("instance-scoped-financials");
     const persistence = new AppPersistence(dbPath);
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         return {
@@ -1258,7 +1259,7 @@ describe("SourceRouter", () => {
 
     router.attachRegistry({
       brokers: new Map([["ibkr", broker]]),
-      dataSources: new Map(),
+      getEnabledCapabilities: () => [],
     } as any);
     router.setConfigAccessor(() => ({
       dataDir: "",
@@ -1409,7 +1410,7 @@ describe("SourceRouter", () => {
         throw new Error("should not fetch cloud financials");
       },
     };
-    const router = new SourceRouter(yahooProvider, [cloudProvider], persistence.resources);
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider], persistence.resources);
 
     const financials = await router.getTickerFinancials("IQE", "LSE", {
       instrument: {
@@ -1503,7 +1504,7 @@ describe("SourceRouter", () => {
       },
     );
 
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       id: "yahoo",
       name: "Yahoo",
@@ -1604,7 +1605,7 @@ describe("SourceRouter", () => {
       },
     );
 
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       id: "yahoo",
       name: "Yahoo",
@@ -1641,7 +1642,7 @@ describe("SourceRouter", () => {
         throw new Error('[404] {"chart":{"result":null,"error":{"code":"Not Found","description":"No data found, symbol may be delisted"}}}');
       },
     };
-    const router = new SourceRouter(fallbackProvider, [noisyProvider]);
+    const router = new AssetDataRouter(fallbackProvider, [noisyProvider]);
     const logged: unknown[][] = [];
     console.error = (...args: unknown[]) => {
       logged.push(args);
@@ -1676,11 +1677,11 @@ describe("SourceRouter", () => {
       },
     };
 
-    const seedRouter = new SourceRouter(yahooProvider, [cloudProvider], persistence.resources);
+    const seedRouter = new AssetDataRouter(yahooProvider, [cloudProvider], persistence.resources);
     const seeded = await seedRouter.getPriceHistory("AAPL", "NASDAQ", "1Y");
     expect(seeded[0]?.close).toBe(101);
 
-    const cachedRouter = new SourceRouter(yahooProvider, [cloudProvider], persistence.resources);
+    const cachedRouter = new AssetDataRouter(yahooProvider, [cloudProvider], persistence.resources);
     const cached = await cachedRouter.getPriceHistory("AAPL", "NASDAQ", "1Y");
     expect(cached[0]?.close).toBe(101);
 
@@ -1688,7 +1689,7 @@ describe("SourceRouter", () => {
   });
 
   test("sorts reversed chart history into chronological order", async () => {
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       id: "cloud",
       name: "Cloud",
@@ -1728,7 +1729,7 @@ describe("SourceRouter", () => {
     );
 
     let providerCalls = 0;
-    const router = new SourceRouter({
+    const router = new AssetDataRouter({
       ...fallbackProvider,
       id: "yahoo",
       name: "Yahoo",
@@ -1753,7 +1754,7 @@ describe("SourceRouter", () => {
     const dbPath = createTempDbPath("forced-financial-refresh");
     const persistence = new AppPersistence(dbPath);
 
-    const seedRouter = new SourceRouter({
+    const seedRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         return {
@@ -1774,7 +1775,7 @@ describe("SourceRouter", () => {
     await seedRouter.getTickerFinancials("AAPL", "NASDAQ");
 
     let providerCalls = 0;
-    const refreshRouter = new SourceRouter({
+    const refreshRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
         providerCalls += 1;
@@ -1807,7 +1808,7 @@ describe("SourceRouter", () => {
     const dbPath = createTempDbPath("stale-chart-refresh");
     const persistence = new AppPersistence(dbPath);
 
-    const seedRouter = new SourceRouter({
+    const seedRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getPriceHistory() {
         return [{ date: new Date("2026-03-27T00:00:00Z"), close: 101 }];
@@ -1820,7 +1821,7 @@ describe("SourceRouter", () => {
       .run(Date.now() - 1, "market", "price-history", "AAPL");
 
     let providerCalls = 0;
-    const refreshRouter = new SourceRouter({
+    const refreshRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getPriceHistory() {
         providerCalls += 1;
@@ -1856,7 +1857,7 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(yahooProvider, [cloudProvider]);
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
     const history = await router.getPriceHistoryForResolution("AAPL", "NASDAQ", "1Y", "1d");
 
     expect(history[0]?.close).toBe(102);
@@ -1882,7 +1883,7 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(yahooProvider, [cloudProvider]);
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
     expect(await router.getChartResolutionCapabilities("AAPL", "NASDAQ")).toEqual(["1d", "1wk"]);
   });
 
@@ -1906,7 +1907,7 @@ describe("SourceRouter", () => {
       },
     };
 
-    const router = new SourceRouter(yahooProvider, [cloudProvider]);
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
     const history = await router.getDetailedPriceHistory(
       "AAPL",
       "NASDAQ",

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -1,5 +1,6 @@
 import type { CachedResourceRecord, ResourceStore } from "../data/resource-store";
 import type { PluginRegistry } from "../plugins/registry";
+import type { AssetDataCapability, NewsCapability } from "../capabilities";
 import type { BrokerAdapter } from "../types/broker";
 import type { AppConfig } from "../types/config";
 import { createDefaultConfig } from "../types/config";
@@ -11,8 +12,8 @@ import type {
   SearchRequestContext,
   SecFilingItem,
 } from "../types/data-provider";
-import type { DataSource } from "../types/data-source";
-import { sourcePriority } from "../types/data-source";
+import type { CapabilityRouteSource } from "../types/capability-route-source";
+import { routeSourcePriority } from "../types/capability-route-source";
 import type { AnalystResearchData, CorporateActionsData, HolderData, OptionsChain, PricePoint, Quote, TickerFinancials } from "../types/financials";
 import type { NewsArticle, NewsQuery } from "../news/types";
 import type { BrokerContractRef, InstrumentSearchResult } from "../types/instrument";
@@ -37,7 +38,7 @@ import {
 } from "../utils/quote-resolution";
 import { isProviderMiss } from "./provider-errors";
 
-const providerLog = debugLog.createLogger("provider-router");
+const providerLog = debugLog.createLogger("asset-data-router");
 
 const BROKER_ATTEMPT_TIMEOUT = 10_000;
 const EXPECTED_PROVIDER_MISS = /No data found|symbol may be delisted|"code":"Not Found"|No history for /i;
@@ -245,7 +246,9 @@ interface SourceResult<T> {
   value: T;
 }
 
-function dataSourceFromMarketProvider(provider: DataProvider): DataSource {
+type RouteSourceCapability = AssetDataCapability | NewsCapability;
+
+function routeSourceFromMarketProvider(provider: DataProvider): CapabilityRouteSource {
   return {
     id: provider.id,
     name: provider.name,
@@ -255,30 +258,50 @@ function dataSourceFromMarketProvider(provider: DataProvider): DataSource {
   };
 }
 
-function normalizeDataSource(source: DataSource | DataProvider): DataSource {
+function normalizeRouteSource(source: CapabilityRouteSource | DataProvider): CapabilityRouteSource {
   return "market" in source || "news" in source
-    ? source as DataSource
-    : dataSourceFromMarketProvider(source as DataProvider);
+    ? source as CapabilityRouteSource
+    : routeSourceFromMarketProvider(source as DataProvider);
 }
 
-export class SourceRouter implements DataProvider {
-  readonly id = "source-router";
-  readonly name = "Source Router";
+function capabilityRouteSourceId(capability: RouteSourceCapability): string {
+  return capability.sourceId ?? capability.id;
+}
+
+function mergeCapabilityRouteSource(current: CapabilityRouteSource | undefined, capability: RouteSourceCapability): CapabilityRouteSource {
+  const priority = Math.min(
+    current?.priority ?? Number.MAX_SAFE_INTEGER,
+    capability.priority ?? 1000,
+  );
+  return {
+    id: capabilityRouteSourceId(capability),
+    name: current?.name ?? capability.name,
+    priority,
+    cachePolicy: capability.cachePolicy ?? current?.cachePolicy,
+    isEnabled: capability.isEnabled ?? current?.isEnabled,
+    market: capability.kind === "asset-data" ? capability.provider : current?.market,
+    news: capability.kind === "news" ? capability.provider : current?.news,
+  };
+}
+
+export class AssetDataRouter implements DataProvider {
+  readonly id = "asset-data-router";
+  readonly name = "Asset Data Router";
   readonly priority = Number.MAX_SAFE_INTEGER;
 
   private registry: PluginRegistry | null = null;
   private readonly revalidationInFlight = new Map<string, Promise<unknown>>();
   private getConfigFn: () => AppConfig = () => createDefaultConfig("");
-  private readonly fallbackSource: DataSource | null;
-  private readonly extraSources: DataSource[];
+  private readonly fallbackSource: CapabilityRouteSource | null;
+  private readonly extraSources: CapabilityRouteSource[];
 
   constructor(
-    fallbackSource: DataSource | DataProvider | null = null,
-    extraSources: Array<DataSource | DataProvider> = [],
+    fallbackSource: CapabilityRouteSource | DataProvider | null = null,
+    extraSources: Array<CapabilityRouteSource | DataProvider> = [],
     private readonly resources?: ResourceStore,
   ) {
-    this.fallbackSource = fallbackSource ? normalizeDataSource(fallbackSource) : null;
-    this.extraSources = extraSources.map(normalizeDataSource);
+    this.fallbackSource = fallbackSource ? normalizeRouteSource(fallbackSource) : null;
+    this.extraSources = extraSources.map(normalizeRouteSource);
   }
 
   attachRegistry(registry: PluginRegistry): void {
@@ -1017,17 +1040,23 @@ export class SourceRouter implements DataProvider {
     }));
   }
 
-  private sortedSources(): DataSource[] {
+  private sortedSources(): CapabilityRouteSource[] {
     const sources = [...this.extraSources];
     if (this.registry) {
-      const registrySources = typeof this.registry.getEnabledDataSources === "function"
-        ? this.registry.getEnabledDataSources()
-        : [...this.registry.dataSources.values()];
-      sources.push(...registrySources);
+      const capabilitySources = new Map<string, CapabilityRouteSource>();
+      for (const capability of this.registry.getEnabledCapabilities("asset-data") as AssetDataCapability[]) {
+        const sourceId = capabilityRouteSourceId(capability);
+        capabilitySources.set(sourceId, mergeCapabilityRouteSource(capabilitySources.get(sourceId), capability));
+      }
+      for (const capability of this.registry.getEnabledCapabilities("news") as NewsCapability[]) {
+        const sourceId = capabilityRouteSourceId(capability);
+        capabilitySources.set(sourceId, mergeCapabilityRouteSource(capabilitySources.get(sourceId), capability));
+      }
+      sources.push(...capabilitySources.values());
     }
     return sources
       .filter((source) => source.id !== this.id && source.id !== this.fallbackSource?.id)
-      .sort((a, b) => sourcePriority(a) - sourcePriority(b));
+      .sort((a, b) => routeSourcePriority(a) - routeSourcePriority(b));
   }
 
   private sortedProviders(): DataProvider[] {
@@ -1045,7 +1074,7 @@ export class SourceRouter implements DataProvider {
     return providers;
   }
 
-  private newsSourcesInPriorityOrder(): DataSource[] {
+  private newsSourcesInPriorityOrder(): CapabilityRouteSource[] {
     const sources = this.sortedSources().filter((source) => !!source.news);
     if (this.fallbackSource?.news && !sources.some((source) => source.id === this.fallbackSource?.id)) {
       sources.push(this.fallbackSource);

--- a/src/test-support/plugin-runtime.ts
+++ b/src/test-support/plugin-runtime.ts
@@ -11,6 +11,7 @@ export function createTestPluginRuntime(
 ): PluginRuntimeAccess {
   return {
     getMarketData: () => null,
+    getCapability: () => null,
     getBrokerAdapter: () => null,
     connectBrokerInstance: async () => {},
     updateBrokerInstance: async () => {},

--- a/src/types/capability-route-source.ts
+++ b/src/types/capability-route-source.ts
@@ -1,23 +1,23 @@
-import type { DataProvider } from "./data-provider";
+import type { AssetDataProvider } from "./data-provider";
 import type { NewsArticle, NewsQuery } from "../news/types";
 import type { CachePolicyMap } from "./persistence";
 
-export interface DataSourceNewsCapability {
+export interface NewsDataProvider {
   supports?(query: NewsQuery): boolean;
   getCachedNews?(query: NewsQuery): NewsArticle[];
   fetchNews(query: NewsQuery): Promise<NewsArticle[]>;
 }
 
-export interface DataSource {
+export interface CapabilityRouteSource {
   readonly id: string;
   readonly name: string;
   readonly priority?: number;
   readonly cachePolicy?: CachePolicyMap;
   isEnabled?(): boolean;
-  readonly market?: DataProvider;
-  readonly news?: DataSourceNewsCapability;
+  readonly market?: AssetDataProvider;
+  readonly news?: NewsDataProvider;
 }
 
-export function sourcePriority(source: Pick<DataSource, "priority">): number {
+export function routeSourcePriority(source: Pick<CapabilityRouteSource, "priority">): number {
   return source.priority ?? 1000;
 }

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -75,7 +75,7 @@ export interface QuoteSubscriptionTarget {
   route?: "auto" | "provider" | "broker";
 }
 
-export interface DataProvider {
+export interface AssetDataProvider {
   readonly id: string;
   readonly name: string;
   readonly priority?: number;
@@ -121,3 +121,5 @@ export interface DataProvider {
     onQuote: (target: QuoteSubscriptionTarget, quote: Quote) => void,
   ): () => void;
 }
+
+export type DataProvider = AssetDataProvider;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -3,6 +3,7 @@ import type { TickerRepository } from "../data/ticker-repository";
 import type { PluginEvents } from "../plugins/event-bus";
 import type { PluginLogger } from "../utils/debug-log";
 import type { BrokerAdapter } from "./broker";
+import type { PluginCapability } from "../capabilities";
 import type { ContextMenuContext, ContextMenuItem } from "./context-menu";
 import type {
   AppConfig,
@@ -13,7 +14,6 @@ import type {
   PaneInstanceConfig,
 } from "./config";
 import type { DataProvider } from "./data-provider";
-import type { DataSource } from "./data-source";
 import type { TickerFinancials } from "./financials";
 import type { CachePolicy, PersistedResourceValue } from "./persistence";
 import type { TickerRecord } from "./ticker";
@@ -412,7 +412,7 @@ export interface GloomPluginContext {
   registerCommand(command: CommandDef): void;
   registerColumn(column: CustomColumnDef): void;
   registerBroker(broker: BrokerAdapter): void;
-  registerDataSource(source: DataSource): void;
+  registerCapability(capability: PluginCapability): void;
   registerDetailTab(tab: DetailTabDef): void;
   registerShortcut(shortcut: KeyboardShortcut): void;
   registerTickerAction(action: TickerAction): void;
@@ -475,7 +475,7 @@ export interface GloomPlugin {
   panes?: PaneDef[];
   paneTemplates?: PaneTemplateDef[];
   broker?: BrokerAdapter;
-  dataSources?: DataSource[];
+  capabilities?: PluginCapability[];
   slots?: Partial<{
     [K in keyof GloomSlots]: (props: GloomSlots[K]) => ReactNode;
   }>;


### PR DESCRIPTION
## Summary
- add a first-class capability registry for asset-data, news, and plugin-service operations
- migrate Yahoo, Gloomberb Cloud, RSS/news-wire, routers, plugin hooks, and docs onto capabilities
- replace desktop data.* RPC with generic capability.invoke / capability.subscribe transport

## Validation
- bun test src/capabilities/registry.test.ts src/plugins/registry.test.ts src/news/aggregator.test.ts src/sources/provider-router.test.ts src/sources/gloomberb-cloud.test.ts src/plugins/builtin/news-wire/rss-source.test.ts src/renderers/electrobun/view/native-stubs/ibkr-gateway-service.test.ts src/plugins/builtin/broker-manager/model.test.ts
- bun run desktop:view:build
- bun run build
- tmux TUI smoke: HDS AMD, ANR AAPL, EVT AMD, and N news feed

## Notes
- IBKR and broker APIs intentionally remain on the existing bridge for this pass.