### PR TITLE
Add standalone equity research commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a shortcut or command n
 | `MOST` | Market Movers |
 | `TOP` | Top News |
 | `N` | News Feed |
+| `CN <ticker>` | Ticker News |
 | `NI` | Industry News |
 | `FIRST` | Breaking News |
 | `ALRT` | Alerts |
@@ -150,8 +151,12 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a shortcut or command n
 | `GC` | Yield Curve |
 | `BI` | Sector Performance |
 | `ERN` | Earnings Calendar |
+| `OMON <ticker>` | Options |
+| `HDS <ticker>` | Holders |
 | `ANR <ticker>` | Analyst Research |
 | `EVT <ticker>` | Corporate Actions |
+| `SEC <ticker>` | SEC Filings |
+| `INS <ticker>` | Insider Activity |
 | `RV <tickers>` | Relative Valuation |
 
 | Shortcut | Command |

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -14,8 +14,8 @@ import { blendHex, colors, priceColor } from "../../../theme/colors";
 import type { HolderData, HolderRecord } from "../../../types/financials";
 import type { DetailTabProps, GloomPlugin, PaneProps } from "../../../types/plugin";
 import { formatCompact, formatPercent, formatPercentRaw, padTo } from "../../../utils/format";
-import { normalizeTickerInput } from "../../../utils/ticker-search";
 import { useAssetData, usePluginPaneState } from "../../plugin-runtime";
+import { createTickerSurfacePaneTemplate } from "../ticker-surface";
 
 type ViewMode = "table" | "chart";
 type HolderColumnId = "holder" | "value" | "shares" | "changeShares" | "changePercent" | "percentHeld" | "reportDate";
@@ -937,24 +937,13 @@ export const holdersPlugin: GloomPlugin = {
   ],
 
   paneTemplates: [
-    {
+    createTickerSurfacePaneTemplate({
       id: "holders-pane",
       paneId: "holders",
       label: "Holders",
       description: "Institutional holders for the selected ticker.",
       keywords: ["holders", "ownership", "institutional", "owners", "hds"],
-      shortcut: { prefix: "HDS", argPlaceholder: "ticker", argKind: "ticker" },
-      canCreate: (context, options) => (options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg)) !== null,
-      createInstance: (context, options) => {
-        const ticker = options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg);
-        return ticker
-          ? {
-            title: ticker,
-            binding: { kind: "fixed", symbol: ticker },
-            placement: "floating",
-          }
-          : null;
-      },
-    },
+      shortcut: "HDS",
+    }),
   ],
 };

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { GloomPlugin, DetailTabProps } from "../../../types/plugin";
+import type { DetailTabProps, GloomPlugin, PaneProps } from "../../../types/plugin";
 import type { SecFilingItem } from "../../../types/data-provider";
 import {
   useResolvedEntryValue,
@@ -15,6 +15,7 @@ import { usePluginPaneState } from "../../plugin-runtime";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { formatCompact, formatCurrency } from "../../../utils/format";
 import { parseForm4Xml, transactionTypeLabel, type InsiderTransaction } from "./insider-data";
+import { createTickerSurfacePaneTemplate } from "../ticker-surface";
 
 const FORM4_LIMIT = 20;
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
@@ -164,7 +165,7 @@ function toFeedItems(parsed: ParsedFiling[]): FeedDataTableItem[] {
   });
 }
 
-function InsiderTab({ width, height, focused }: DetailTabProps) {
+export function InsiderView({ width, height, focused }: Pick<DetailTabProps, "width" | "height" | "focused">) {
   const { ticker } = usePaneTicker();
   const tickerKey = ticker?.metadata.ticker ?? "none";
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>(`insider:selectedIdx:${tickerKey}`, 0);
@@ -320,11 +321,43 @@ function InsiderTab({ width, height, focused }: DetailTabProps) {
   );
 }
 
+function InsiderTab(props: DetailTabProps) {
+  return <InsiderView {...props} />;
+}
+
+function InsiderPane({ focused, width, height }: PaneProps) {
+  return <InsiderView focused={focused} width={width} height={height} />;
+}
+
 export const insiderPlugin: GloomPlugin = {
   id: "insider",
   name: "Insider Trading",
   version: "1.0.0",
   description: "SEC Form 4 insider transaction activity",
+
+  panes: [
+    {
+      id: "insider",
+      name: "Insider",
+      icon: "I",
+      component: InsiderPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 30 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "insider-pane",
+      paneId: "insider",
+      label: "Insider",
+      description: "Insider transaction activity for the selected ticker.",
+      keywords: ["insider", "form 4", "ownership", "transactions", "ins"],
+      shortcut: "INS",
+      canCreate: (_context, options) => !options?.ticker || isUsEquityTicker(options.ticker),
+    }),
+  ],
 
   setup(ctx) {
     ctx.registerDetailTab({

--- a/src/plugins/builtin/news.tsx
+++ b/src/plugins/builtin/news.tsx
@@ -1,6 +1,6 @@
 import { Text } from "../../ui";
 import { useRef, useEffect, useMemo, useState } from "react";
-import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
+import type { DetailTabProps, GloomPlugin, PaneProps } from "../../types/plugin";
 import { usePaneTicker } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import type { NewsArticle } from "../../types/news-source";
@@ -13,6 +13,7 @@ import { registerNewsWireFeatures } from "./news-wire";
 import { useNewsArticleFooter } from "./news-wire/news-footer";
 import { usePersistedNewsArticles } from "./news-wire/persisted-articles";
 import { useNewsReadState } from "./news-wire/read-state";
+import { createTickerSurfacePaneTemplate } from "./ticker-surface";
 
 const ARTICLE_SUMMARY_CACHE_POLICY = {
   staleMs: 30 * 24 * 60 * 60_000,
@@ -55,7 +56,7 @@ function getFeedItems(
   });
 }
 
-function NewsTab({ width, height, focused }: DetailTabProps) {
+export function TickerNewsView({ width, height, focused }: Pick<DetailTabProps, "width" | "height" | "focused">) {
   const { ticker } = usePaneTicker();
   const selectionKey = `selectedIdx:${ticker?.metadata.ticker ?? "none"}`;
   const [selectedIdx, setSelectedIdx] = useDebouncedPluginPaneState<number>(selectionKey, 0);
@@ -150,12 +151,43 @@ function NewsTab({ width, height, focused }: DetailTabProps) {
   );
 }
 
+function NewsTab(props: DetailTabProps) {
+  return <TickerNewsView {...props} />;
+}
+
+function TickerNewsPane({ focused, width, height }: PaneProps) {
+  return <TickerNewsView focused={focused} width={width} height={height} />;
+}
+
 export const newsPlugin: GloomPlugin = {
   id: "news",
   name: "News",
   version: "1.0.0",
   description: "View latest news for each ticker",
   toggleable: true,
+
+  panes: [
+    {
+      id: "ticker-news",
+      name: "Ticker News",
+      icon: "C",
+      component: TickerNewsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 32 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "ticker-news-pane",
+      paneId: "ticker-news",
+      label: "Ticker News",
+      description: "Company news for the selected ticker.",
+      keywords: ["company", "ticker", "news", "headlines", "cn"],
+      shortcut: "CN",
+    }),
+  ],
 
   setup(ctx) {
     ctx.registerDetailTab({

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from "../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes } from "../../ui";
-import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
+import type { DetailTabProps, GloomPlugin, PaneProps } from "../../types/plugin";
 import type { OptionContract, OptionsChain } from "../../types/financials";
 import { usePaneTicker } from "../../state/app-context";
 import { blendHex, colors } from "../../theme/colors";
@@ -10,6 +10,7 @@ import { formatMarketPrice } from "../../utils/market-format";
 import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../market-data/hooks";
 import { DataTableView, Spinner, Tabs, usePaneFooter, type DataTableCell, type DataTableColumn, type DataTableKeyEvent } from "../../components";
+import { createTickerSurfacePaneTemplate } from "./ticker-surface";
 
 type OptionColumnId =
   | "callLast"
@@ -35,6 +36,10 @@ interface OptionTableRow {
   isPositionStrike: boolean;
 }
 
+type OptionsViewProps = Pick<DetailTabProps, "width" | "height" | "focused"> & {
+  onCapture?: DetailTabProps["onCapture"];
+};
+
 const OPTION_CALL_COLOR = "#5ed69a";
 const OPTION_PUT_COLOR = "#ff9c7a";
 const OPTION_PRICE_COLOR = "#dfc05b";
@@ -58,7 +63,7 @@ const OPTION_COLUMNS: OptionColumn[] = [
   { id: "putOpenInterest", label: "P OI", width: 6, align: "right", headerColor: OPTION_ACTIVITY_COLOR },
 ];
 
-export function OptionsTab({ width, height, focused, onCapture }: DetailTabProps) {
+export function OptionsView({ width, height, focused, onCapture = () => {} }: OptionsViewProps) {
   const { ticker, financials } = usePaneTicker();
   const [expIdx, setExpIdx] = useState(0);
   const [strikeIdx, setStrikeIdx] = useState(0);
@@ -322,6 +327,14 @@ export function OptionsTab({ width, height, focused, onCapture }: DetailTabProps
   );
 }
 
+export function OptionsTab(props: DetailTabProps) {
+  return <OptionsView {...props} />;
+}
+
+export function OptionsPane({ focused, width, height }: PaneProps) {
+  return <OptionsView focused={focused} width={width} height={height} />;
+}
+
 function buildStrikeList(chain: OptionsChain): number[] {
   const set = new Set<number>();
   for (const c of chain.calls) set.add(c.strike);
@@ -456,6 +469,29 @@ export const optionsPlugin: GloomPlugin = {
   version: "1.0.0",
   description: "View options chain for tickers",
   toggleable: true,
+
+  panes: [
+    {
+      id: "options",
+      name: "Options",
+      icon: "O",
+      component: OptionsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 112, height: 28 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "options-pane",
+      paneId: "options",
+      label: "Options",
+      description: "Options chain for the selected ticker.",
+      keywords: ["options", "chain", "calls", "puts", "omon"],
+      shortcut: "OMON",
+    }),
+  ],
 
   setup(ctx) {
     ctx.registerDetailTab({

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -13,8 +13,8 @@ import { usePaneInstance, usePaneTicker } from "../../../state/app-context";
 import { blendHex, colors, priceColor } from "../../../theme/colors";
 import { formatCompact, formatCurrency, formatNumber, formatPercent, formatPercentRaw } from "../../../utils/format";
 import { parseTickerListInput, formatTickerListInput } from "../../../utils/ticker-list";
-import { normalizeTickerInput } from "../../../utils/ticker-search";
 import { useAssetData, usePluginTickerActions } from "../../plugin-runtime";
+import { createTickerSurfacePaneTemplate } from "../ticker-surface";
 
 type LoadState<T> = {
   data: T | null;
@@ -625,17 +625,6 @@ function EventsTab({ focused, width, height }: DetailTabProps) {
   return <CorporateActionsView focused={focused} width={width} height={height} />;
 }
 
-function createTickerBoundPane(contextTicker: string | null, arg: string | undefined, titlePrefix: string) {
-  const ticker = normalizeTickerInput(contextTicker, arg);
-  return ticker
-    ? {
-        title: `${titlePrefix} ${ticker}`,
-        binding: { kind: "fixed" as const, symbol: ticker },
-        placement: "floating" as const,
-      }
-    : null;
-}
-
 export const researchPlugin: GloomPlugin = {
   id: "research",
   name: "Research",
@@ -691,26 +680,22 @@ export const researchPlugin: GloomPlugin = {
   ],
 
   paneTemplates: [
-    {
+    createTickerSurfacePaneTemplate({
       id: "analyst-research-pane",
       paneId: "analyst-research",
       label: "Analyst Research",
       description: "Price targets, recommendations, and recent analyst actions.",
       keywords: ["analyst", "research", "ratings", "target", "anr"],
-      shortcut: { prefix: "ANR", argPlaceholder: "ticker", argKind: "ticker" },
-      canCreate: (context, options) => (options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg)) !== null,
-      createInstance: (context, options) => createTickerBoundPane(options?.symbol ?? context.activeTicker, options?.arg, "Analyst"),
-    },
-    {
+      shortcut: "ANR",
+    }),
+    createTickerSurfacePaneTemplate({
       id: "corporate-actions-pane",
       paneId: "corporate-actions",
       label: "Corporate Actions",
       description: "Dividends, splits, and recent earnings.",
       keywords: ["events", "corporate", "actions", "dividend", "split", "earnings", "evt"],
-      shortcut: { prefix: "EVT", argPlaceholder: "ticker", argKind: "ticker" },
-      canCreate: (context, options) => (options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg)) !== null,
-      createInstance: (context, options) => createTickerBoundPane(options?.symbol ?? context.activeTicker, options?.arg, "Events"),
-    },
+      shortcut: "EVT",
+    }),
     {
       id: "relative-valuation-pane",
       paneId: "relative-valuation",

--- a/src/plugins/builtin/sec.tsx
+++ b/src/plugins/builtin/sec.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "../../ui";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { GloomPlugin, DetailTabProps } from "../../types/plugin";
+import type { DetailTabProps, GloomPlugin, PaneProps } from "../../types/plugin";
 import type { SecFilingItem } from "../../types/data-provider";
 import { useResolvedEntryValue, useSecFilingContent, useSecFilingsQuery } from "../../market-data/hooks";
 import { instrumentFromTicker } from "../../market-data/request-types";
@@ -12,6 +12,7 @@ import { isUsEquityTicker } from "../../utils/sec";
 import { getSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { parseForm4Xml, transactionTypeLabel } from "./insider/insider-data";
 import { formatCompact, formatCurrency } from "../../utils/format";
+import { createTickerSurfacePaneTemplate } from "./ticker-surface";
 
 const SEC_FILING_LIMIT = 50;
 const OWNERSHIP_FORMS = new Set(["3", "4", "5"]);
@@ -225,7 +226,7 @@ function toFeedItems(
   });
 }
 
-function SecTab({ width, height, focused }: DetailTabProps) {
+export function SecView({ width, height, focused }: Pick<DetailTabProps, "width" | "height" | "focused">) {
   const { ticker } = usePaneTicker();
   const selectionKey = `selectedIdx:${ticker?.metadata.ticker ?? "none"}`;
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>(selectionKey, 0);
@@ -343,12 +344,44 @@ function SecTab({ width, height, focused }: DetailTabProps) {
   );
 }
 
+function SecTab(props: DetailTabProps) {
+  return <SecView {...props} />;
+}
+
+function SecPane({ focused, width, height }: PaneProps) {
+  return <SecView focused={focused} width={width} height={height} />;
+}
+
 export const secPlugin: GloomPlugin = {
   id: "sec",
   name: "SEC",
   version: "1.0.0",
   description: "Recent SEC filings for US equities",
   toggleable: true,
+
+  panes: [
+    {
+      id: "sec",
+      name: "SEC",
+      icon: "S",
+      component: SecPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 32 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "sec-pane",
+      paneId: "sec",
+      label: "SEC",
+      description: "Recent SEC filings for the selected ticker.",
+      keywords: ["sec", "filings", "10-k", "10-q", "8-k"],
+      shortcut: "SEC",
+      canCreate: (_context, options) => !options?.ticker || isUsEquityTicker(options.ticker),
+    }),
+  ],
 
   setup(ctx) {
     ctx.registerDetailTab({

--- a/src/plugins/builtin/ticker-surface.ts
+++ b/src/plugins/builtin/ticker-surface.ts
@@ -1,0 +1,68 @@
+import type {
+  PaneTemplateContext,
+  PaneTemplateCreateOptions,
+  PaneTemplateDef,
+  PaneTemplateInstanceConfig,
+} from "../../types/plugin";
+import { normalizeTickerInput } from "../../utils/ticker-search";
+
+export interface TickerSurfacePaneTemplateOptions {
+  id: string;
+  paneId: string;
+  label: string;
+  description: string;
+  keywords: string[];
+  shortcut: string;
+  titlePrefix?: string;
+  canCreate?: (
+    context: PaneTemplateContext,
+    options: PaneTemplateCreateOptions | undefined,
+    symbol: string,
+  ) => boolean;
+}
+
+export function resolveTickerSurfaceSymbol(
+  context: Pick<PaneTemplateContext, "activeTicker">,
+  options?: Pick<PaneTemplateCreateOptions, "arg" | "symbol">,
+): string | null {
+  const explicitSymbol = options?.symbol?.trim().toUpperCase();
+  return explicitSymbol || normalizeTickerInput(context.activeTicker, options?.arg);
+}
+
+export function createTickerSurfacePaneInstance(
+  context: Pick<PaneTemplateContext, "activeTicker">,
+  options: Pick<PaneTemplateCreateOptions, "arg" | "symbol"> | undefined,
+  titlePrefix: string,
+): PaneTemplateInstanceConfig | null {
+  const ticker = resolveTickerSurfaceSymbol(context, options);
+  return ticker
+    ? {
+      title: `${titlePrefix} ${ticker}`,
+      binding: { kind: "fixed", symbol: ticker },
+      placement: "floating",
+    }
+    : null;
+}
+
+export function createTickerSurfacePaneTemplate(
+  templateOptions: TickerSurfacePaneTemplateOptions,
+): PaneTemplateDef {
+  const titlePrefix = templateOptions.titlePrefix ?? templateOptions.shortcut;
+  return {
+    id: templateOptions.id,
+    paneId: templateOptions.paneId,
+    label: templateOptions.label,
+    description: templateOptions.description,
+    keywords: templateOptions.keywords,
+    shortcut: {
+      prefix: templateOptions.shortcut,
+      argPlaceholder: "ticker",
+      argKind: "ticker",
+    },
+    canCreate: (context, createOptions) => {
+      const symbol = resolveTickerSurfaceSymbol(context, createOptions);
+      return symbol !== null && (templateOptions.canCreate?.(context, createOptions, symbol) ?? true);
+    },
+    createInstance: (context, createOptions) => createTickerSurfacePaneInstance(context, createOptions, titlePrefix),
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared ticker-bound pane template helper for equity research surfaces
- add standalone OMON, CN, SEC, and INS panes while preserving ticker-detail tabs
- normalize HDS, ANR, and EVT standalone pane titles through the shared helper
- document the new Bloomberg-style shortcuts

## Validation
- bun test src/components/command-bar/command-bar.test.tsx src/plugins/builtin/help.test.tsx src/plugins/builtin/options.test.tsx src/plugins/registry.test.ts src/plugins/catalog-ui.test.ts
- bun run build
- tmux smoke: DES AMD tab bar and HDS/ANR/EVT/OMON/CN/SEC/INS standalone panes