### PR TITLE
Fix table columns using available width

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -10,7 +10,12 @@ import { useRafCallback } from "../../react/use-raf-callback";
 import { measurePerf } from "../../utils/perf-marks";
 import { useDoubleClickActivation } from "../use-double-click-activation";
 import { EmptyState } from "./status";
-import { tableContentWidthProps, useMeasuredTableContentWidth } from "./table-layout";
+import {
+  expandTableColumns,
+  getTableWidth,
+  tableContentWidthProps,
+  useMeasuredTableContentWidth,
+} from "./table-layout";
 
 export type DataTableColumn = Pick<
   ColumnConfig,
@@ -18,6 +23,7 @@ export type DataTableColumn = Pick<
 > & {
   headerColor?: string;
   headerBackgroundColor?: string;
+  flexGrow?: number;
 };
 
 export interface DataTableCell {
@@ -191,11 +197,12 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
       virtualize,
     ],
   );
-  const tableWidth = useMemo(
-    () => columns.reduce((sum, column) => sum + column.width + 1, 2),
-    [columns],
-  );
+  const tableWidth = useMemo(() => getTableWidth(columns), [columns]);
   const { contentWidth, measureContentWidth } = useMeasuredTableContentWidth(tableWidth, headerScrollRef, scrollRef);
+  const displayColumns = useMemo(
+    () => expandTableColumns(columns, contentWidth),
+    [columns, contentWidth],
+  );
   const handleRowMouseDown =
     useDoubleClickActivation<DataTableRowPointerTarget<T>>({
       onSelect: ({ item, index }) => {
@@ -314,7 +321,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
           paddingX={1}
           backgroundColor={colors.panel}
         >
-          {columns.map((column) => {
+          {displayColumns.map((column) => {
             const isSorted = sortColumnId === column.id;
             const indicator = isSorted
               ? sortDirection === "asc"
@@ -440,7 +447,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
                       }, event);
                     }}
                   >
-                    {columns.map((column) => {
+                    {displayColumns.map((column) => {
                       const cell = renderCell(item, column, index, rowState);
                       return (
                         <Box
@@ -477,7 +484,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
                 );
               }),
               {
-                columnCount: columns.length,
+                columnCount: displayColumns.length,
                 endIndex,
                 itemCount: items.length,
                 measuredViewportHeight,

--- a/src/components/ui/table-layout.ts
+++ b/src/components/ui/table-layout.ts
@@ -1,6 +1,31 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
 import type { ScrollBoxRenderable } from "../../ui";
 
+interface TableWidthColumn {
+  width: number;
+  flexGrow?: number;
+}
+
+export function getTableWidth(columns: readonly TableWidthColumn[]): number {
+  return columns.reduce((sum, column) => sum + column.width + 1, 2);
+}
+
+export function expandTableColumns<C extends TableWidthColumn>(
+  columns: readonly C[],
+  targetWidth: number,
+): C[] {
+  const currentWidth = getTableWidth(columns);
+  const extraWidth = Math.floor(targetWidth) - currentWidth;
+  if (extraWidth <= 0) return [...columns];
+
+  const growIndex = columns.findIndex((column) => (column.flexGrow ?? 0) > 0);
+  if (growIndex < 0) return [...columns];
+
+  return columns.map((column, index) => {
+    return index === growIndex ? { ...column, width: column.width + extraWidth } : column;
+  });
+}
+
 export function useMeasuredTableContentWidth(
   tableWidth: number,
   headerScrollRef: RefObject<ScrollBoxRenderable | null> | undefined,

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -127,6 +127,7 @@ function buildColumns(width: number, columnIds: NewsColumnId[]): NewsTableColumn
     label: labels[id],
     width: id === "title" ? titleWidth : fixedWidths[id],
     align: id === "rank" || id === "importance" ? "right" : "left",
+    flexGrow: id === "title" ? 1 : undefined,
   }));
 }
 
@@ -248,7 +249,6 @@ export function NewsArticleStackView({
       onSelectIndex={selectIndex}
       onActivateIndex={openIndex}
       rootBefore={rootBefore}
-      rootWidth={width}
       rootHeight={rootHeight}
       onRootKeyDown={onRootKeyDown}
       columns={columns}

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -17,7 +17,6 @@ import { TextAttributes, type ScrollBoxRenderable } from "../../../ui/host";
 import { colors, hoverBg } from "../../../theme/colors";
 import { useAppDispatch, usePaneInstance } from "../../../state/app-context";
 import { useRafCallback } from "../../../react/use-raf-callback";
-import { padTo } from "../../../utils/format";
 import { measurePerf } from "../../../utils/perf-marks";
 import type {
   DataTableCell,
@@ -25,6 +24,7 @@ import type {
   DataTableProps,
   DataTableSectionHeader,
 } from "../../../components/ui/data-table";
+import { expandTableColumns, getTableWidth } from "../../../components/ui/table-layout";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
 import { useScrollbarActivity } from "./scrollbar-activity";
 
@@ -66,6 +66,22 @@ function cellTextStyle(
     whiteSpace: "pre",
     overflow: "visible",
     textOverflow: "clip",
+  };
+}
+
+function clippedCellTextStyle<C extends DataTableColumn>(
+  column: C,
+  color: string,
+  attributes: number | undefined,
+): CSSProperties {
+  return {
+    ...cellTextStyle(color, attributes),
+    display: "block",
+    width: px(column.width),
+    maxWidth: px(column.width),
+    overflow: "hidden",
+    whiteSpace: "pre",
+    textAlign: column.align,
   };
 }
 
@@ -220,7 +236,7 @@ function renderHeaderLabel<C extends DataTableColumn>(
   const indicator = isSorted ? (sortDirection === "asc" ? " ▲" : " ▼") : "";
   return {
     isSorted,
-    text: padTo(column.label + indicator, column.width, column.align),
+    text: column.label + indicator,
   };
 }
 
@@ -374,12 +390,13 @@ function WebDataTableRowInner<
             }}
           >
             <span
-              style={cellTextStyle(
+              style={clippedCellTextStyle(
+                column,
                 cell.color ?? (selected ? colors.selectedText : colors.text),
                 cell.attributes ?? TextAttributes.NONE,
               )}
             >
-              {padTo(cell.text, column.width, column.align)}
+              {cell.text}
             </span>
           </div>
         );
@@ -427,11 +444,21 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const bodyHorizontal = useScrollbarState(showHorizontalScrollbar);
   const bodyVertical = useScrollbarState(true);
   const [scrollbarActive, markScrollbarActive] = useScrollbarActivity();
-  const tableWidth = useMemo(
-    () => columns.reduce((sum, column) => sum + column.width + 1, 2),
-    [columns],
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const measureViewportWidth = useCallback(() => {
+    const nextWidth = Math.max(
+      0,
+      Math.floor((bodyElementRef.current?.clientWidth ?? 0) / WEB_CELL_WIDTH),
+    );
+    setViewportWidth((current) => current === nextWidth ? current : nextWidth);
+  }, []);
+  const tableWidth = useMemo(() => getTableWidth(columns), [columns]);
+  const displayColumns = useMemo(
+    () => expandTableColumns(columns, Math.max(tableWidth, viewportWidth)),
+    [columns, tableWidth, viewportWidth],
   );
-  const minWidthPx = px(tableWidth);
+  const displayTableWidth = useMemo(() => getTableWidth(displayColumns), [displayColumns]);
+  const minWidthPx = px(displayTableWidth);
   const selectRow = useCallback((item: T, index: number) => {
     onSelect(item, index);
   }, [onSelect]);
@@ -533,6 +560,22 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     }
   }, [bodyHorizontal.bar, headerHorizontal.bar, showHorizontalScrollbar]);
 
+  useEffect(() => {
+    measureViewportWidth();
+    const element = bodyElementRef.current;
+    if (!element) return;
+
+    const ResizeObserverCtor = globalThis.ResizeObserver;
+    if (ResizeObserverCtor) {
+      const observer = new ResizeObserverCtor(measureViewportWidth);
+      observer.observe(element);
+      return () => observer.disconnect();
+    }
+
+    window.addEventListener("resize", measureViewportWidth);
+    return () => window.removeEventListener("resize", measureViewportWidth);
+  }, [measureViewportWidth]);
+
   const rootStyle: CSSProperties = {
     display: "flex",
     flexDirection: "column",
@@ -606,7 +649,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
               backgroundColor: colors.panel,
             }}
           >
-            {columns.map((column) => {
+            {displayColumns.map((column) => {
               const { isSorted, text } = renderHeaderLabel(
                 column,
                 sortColumnId,
@@ -631,7 +674,8 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                   }}
                 >
                   <span
-                    style={cellTextStyle(
+                    style={clippedCellTextStyle(
+                      column,
                       isSorted ? colors.text : column.headerColor ?? colors.textDim,
                       TextAttributes.BOLD,
                     )}
@@ -679,7 +723,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                     index={row.index}
                     item={item}
                     itemKey={itemKey}
-                    columns={columns}
+                    columns={displayColumns}
                     focusPane={focusPane}
                     onActivateRow={onActivate ? activateRow : undefined}
                     onSelectRow={selectRow}
@@ -694,7 +738,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                 );
               }),
             {
-              columnCount: columns.length,
+              columnCount: displayColumns.length,
               itemCount: items.length,
               paneId: paneInstanceId,
               renderedCount: virtualRows.length,


### PR DESCRIPTION
## Summary
- let shared table columns opt into using measured leftover width
- let news headlines stretch to the rendered table width
- render desktop table cell text in fixed clip boxes instead of padded-space spans

## Root Cause
Breaking News had two width mismatches: the news stack constrained the table to the prop width even when the rendered parent had more room, and the desktop renderer relied on padded spaces whose browser font advance did not match the table cell width.

## Checks
- bun test src/components/ui/ui.test.tsx src/plugins/builtin/news-wire/news-table.test.tsx
- git diff --check HEAD~1..HEAD
- bun run desktop:view:build