### PR TITLE
Fix tweet list details

### DIFF
--- a/src/components/ticker-badge-text.test.tsx
+++ b/src/components/ticker-badge-text.test.tsx
@@ -115,6 +115,26 @@ describe("TickerBadgeText", () => {
     expect(frame).toContain("TSLA -5%");
   });
 
+  test("wraps long text chunks at word boundaries", async () => {
+    testSetup = await testRender(
+      <TickerBadgeText
+        text="Demand/supply unit economics move with ASML orders"
+        lineWidth={18}
+        catalog={{}}
+        textColor="#ffffff"
+        openTicker={() => {}}
+      />,
+      { width: 20, height: 5 },
+    );
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Demand/supply");
+    expect(frame).toContain("economics");
+    expect(frame.split("\n").filter((line) => line.trim()).length).toBeGreaterThan(1);
+  });
+
   test("opens detected links without trailing punctuation when clicked", async () => {
     const opened: string[] = [];
     testSetup = await testRender(

--- a/src/components/ticker-badge-text.tsx
+++ b/src/components/ticker-badge-text.tsx
@@ -4,6 +4,7 @@ import { TickerBadge } from "./ticker-badge";
 import { ExternalLinkText, openUrl } from "./ui";
 import { tokenizeInlineContent } from "../utils/inline-content-tokenizer";
 import type { InlineTickerCatalogEntry } from "../state/use-inline-tickers";
+import { displayWidth } from "../utils/format";
 
 export interface TickerBadgeTextProps {
   text: string;
@@ -12,6 +13,30 @@ export interface TickerBadgeTextProps {
   textColor: string;
   openTicker: (symbol: string) => void;
   openLink?: (url: string) => void;
+}
+
+function splitLongTextSegment(value: string, lineWidth: number): string[] {
+  if (displayWidth(value) <= lineWidth) return [value];
+
+  const chunks: string[] = [];
+  let current = "";
+  for (const char of Array.from(value)) {
+    const next = `${current}${char}`;
+    if (current && displayWidth(next) > lineWidth) {
+      chunks.push(current);
+      current = char;
+      continue;
+    }
+    current = next;
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+function splitTextForWrap(value: string, lineWidth: number): string[] {
+  const width = Math.max(1, lineWidth);
+  const segments = value.match(/\S+\s*|\s+/g) ?? [value];
+  return segments.flatMap((segment) => splitLongTextSegment(segment, width));
 }
 
 export function TickerBadgeText({
@@ -34,7 +59,9 @@ export function TickerBadgeText({
       {tokens.map((token, index) => {
         if (token.kind === "text") {
           if (!token.value) return null;
-          return <Text key={`text:${index}`} fg={textColor}>{token.value}</Text>;
+          return splitTextForWrap(token.value, lineWidth).map((part, partIndex) => (
+            <Text key={`text:${index}:${partIndex}`} fg={textColor}>{part}</Text>
+          ));
         }
 
         if (token.kind === "link") {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -20,6 +20,7 @@ export { EmptyState } from "./status";
 export { DialogFrame } from "./frame";
 
 export { ExternalLink, ExternalLinkText, openUrl } from "./external-link";
+export { RemoteImage } from "./remote-image";
 export { PageStackView } from "./page-stack-view";
 
 export { Spinner } from "./loading";

--- a/src/components/ui/remote-image.tsx
+++ b/src/components/ui/remote-image.tsx
@@ -1,0 +1,75 @@
+import { Box, ImageSurface, Text, useUiHost } from "../../ui";
+import { colors } from "../../theme/colors";
+import { ExternalLinkText } from "./external-link";
+import { normalizedHttpUrl } from "../../utils/url";
+
+export interface RemoteImageProps {
+  src: string;
+  alt?: string;
+  width: number;
+  height?: number;
+  label?: string;
+}
+
+function truncate(value: string, width: number): string {
+  if (width <= 0) return "";
+  if (value.length <= width) return value;
+  if (width <= 3) return value.slice(0, width);
+  return `${value.slice(0, width - 3)}...`;
+}
+
+export function RemoteImage({
+  src,
+  alt = "Image",
+  width,
+  height = 12,
+  label = "image",
+}: RemoteImageProps) {
+  const ui = useUiHost();
+  const resolvedWidth = Math.max(12, width);
+  const imageUrl = normalizedHttpUrl(src);
+  if (!imageUrl) return null;
+
+  if (ui.kind === "desktop-web") {
+    return (
+      <ImageSurface
+        src={imageUrl}
+        alt={alt}
+        width={resolvedWidth}
+        height={Math.max(4, height)}
+        border
+        borderColor={colors.border}
+        backgroundColor={colors.panel}
+        objectFit="contain"
+      >
+        <Box paddingX={1} paddingY={1} flexDirection="column" gap={1}>
+          <Text fg={colors.textDim}>{label}</Text>
+          <ExternalLinkText
+            url={imageUrl}
+            label={truncate(imageUrl, Math.max(1, resolvedWidth - 2))}
+            color={colors.textBright}
+          />
+        </Box>
+      </ImageSurface>
+    );
+  }
+
+  return (
+    <Box
+      width={resolvedWidth}
+      minHeight={2}
+      border
+      borderColor={colors.border}
+      backgroundColor={colors.panel}
+      paddingX={1}
+      flexDirection="column"
+    >
+      <Text fg={colors.textDim}>{label}</Text>
+      <ExternalLinkText
+        url={imageUrl}
+        label={truncate(imageUrl, Math.max(1, resolvedWidth - 2))}
+        color={colors.textBright}
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/cloud-tweets.tsx
+++ b/src/plugins/builtin/cloud-tweets.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
-import { Box, ScrollBox, Text, TextAttributes, Textarea, type TextareaRenderable } from "../../ui";
+import { Box, ScrollBox, Text, TextAttributes, Textarea, useRendererHost, type TextareaRenderable } from "../../ui";
 import { useShortcut } from "../../react/input";
 import {
   Button,
@@ -16,11 +16,14 @@ import type { DetailTabProps, PaneProps } from "../../types/plugin";
 import { usePaneInstance, usePaneInstanceId, usePaneTicker } from "../../state/app-context";
 import { usePluginPaneState, usePluginState } from "../plugin-runtime";
 import { TickerBadgeText } from "../../components/ticker-badge-text";
-import { ExternalLinkText, openUrl } from "../../components/ui";
+import { ExternalLinkText, RemoteImage } from "../../components/ui";
 import { useInlineTickers } from "../../state/use-inline-tickers";
 import { apiClient, type CloudTweetPayload, type CloudTweetQueryType, type CloudTweetSearchResponse } from "../../utils/api-client";
 import { collectUniqueTickerSymbols } from "../../utils/ticker-tokenizer";
 import { formatCompact, formatTimeAgo } from "../../utils/format";
+import { decodeHtmlEntities } from "../../utils/html-entities";
+import { toTimestampMillis } from "../../utils/timestamp";
+import { normalizedHttpUrl } from "../../utils/url";
 import { colors } from "../../theme/colors";
 import { CloudAuthNotice } from "./cloud-auth-actions";
 
@@ -30,6 +33,8 @@ const TWEET_SEARCH_SCHEMA_VERSION = 1;
 
 type TweetColumnId = "time" | "author" | "text" | "tickers" | "likes" | "views";
 type TweetColumn = DataTableColumn & { id: TweetColumnId };
+type TweetSortColumnId = "time" | "likes" | "views";
+type TweetSortDirection = "asc" | "desc";
 
 interface TweetLoadState {
   data: CloudTweetSearchResponse | null;
@@ -132,8 +137,108 @@ function formatMetric(value: number | null | undefined): string {
   return String(value);
 }
 
+function normalizeTweetDisplayText(value: string): string {
+  return decodeHtmlEntities(value).replace(/\s+/g, " ").trim();
+}
+
 function tweetTickers(tweet: CloudTweetPayload): string[] {
-  return collectUniqueTickerSymbols([tweet.text]);
+  return collectUniqueTickerSymbols([normalizeTweetDisplayText(tweet.text)]);
+}
+
+function tweetCreatedAtMs(tweet: CloudTweetPayload): number {
+  const ms = toTimestampMillis(tweet.createdAt);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function compareNullableNumber(
+  left: number | null | undefined,
+  right: number | null | undefined,
+  sortDirection: TweetSortDirection,
+): number {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+  const comparison = left - right;
+  return sortDirection === "asc" ? comparison : -comparison;
+}
+
+function isTweetSortColumnId(columnId: string): columnId is TweetSortColumnId {
+  return columnId === "time" || columnId === "likes" || columnId === "views";
+}
+
+function compareTweets(
+  left: CloudTweetPayload,
+  right: CloudTweetPayload,
+  sortColumnId: TweetSortColumnId,
+  sortDirection: TweetSortDirection,
+): number {
+  let comparison = 0;
+  switch (sortColumnId) {
+    case "time":
+      comparison = tweetCreatedAtMs(left) - tweetCreatedAtMs(right);
+      if (comparison !== 0) {
+        return sortDirection === "asc" ? comparison : -comparison;
+      }
+      break;
+    case "likes":
+      comparison = compareNullableNumber(left.metrics.likes, right.metrics.likes, sortDirection);
+      break;
+    case "views":
+      comparison = compareNullableNumber(left.metrics.views, right.metrics.views, sortDirection);
+      break;
+  }
+
+  if (comparison !== 0) return comparison;
+
+  return tweetCreatedAtMs(right) - tweetCreatedAtMs(left);
+}
+
+function sortedTweets(
+  tweets: CloudTweetPayload[],
+  sortColumnId: TweetSortColumnId,
+  sortDirection: TweetSortDirection,
+): CloudTweetPayload[] {
+  return [...tweets].sort((left, right) => compareTweets(left, right, sortColumnId, sortDirection));
+}
+
+function mediaImageUrl(value: unknown): string | null {
+  const directUrl = normalizedHttpUrl(value);
+  if (directUrl) return directUrl;
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  return normalizedHttpUrl(record.mediaUrl)
+    ?? normalizedHttpUrl(record.media_url_https)
+    ?? normalizedHttpUrl(record.media_url)
+    ?? normalizedHttpUrl(record.previewImageUrl)
+    ?? normalizedHttpUrl(record.preview_image_url)
+    ?? normalizedHttpUrl(record.url);
+}
+
+function nestedMedia(record: Record<string, unknown>, key: string): unknown {
+  const value = record[key];
+  return value && typeof value === "object" ? (value as Record<string, unknown>).media : undefined;
+}
+
+function tweetImageUrls(tweet: CloudTweetPayload): string[] {
+  const record = tweet as unknown as Record<string, unknown>;
+  const candidates = [
+    record.media,
+    record.photos,
+    record.images,
+    nestedMedia(record, "entities"),
+    nestedMedia(record, "extendedEntities"),
+    nestedMedia(record, "extended_entities"),
+  ];
+  const urls = new Set<string>();
+  for (const candidate of candidates) {
+    const entries = Array.isArray(candidate) ? candidate : candidate == null ? [] : [candidate];
+    for (const entry of entries) {
+      const url = mediaImageUrl(entry);
+      if (url) urls.add(url);
+    }
+  }
+  return [...urls];
 }
 
 function buildTweetColumns(width: number): TweetColumn[] {
@@ -190,7 +295,11 @@ function TweetDetail({
   width: number;
 }) {
   const lineWidth = Math.max(1, width - 2);
-  const { catalog, openTicker } = useInlineTickers([tweet.text]);
+  const tweetText = normalizeTweetDisplayText(tweet.text);
+  const imageUrls = tweetImageUrls(tweet);
+  const imageWidth = Math.min(lineWidth, 72);
+  const imageHeight = Math.max(6, Math.min(14, Math.floor(imageWidth * 0.35)));
+  const { catalog, openTicker } = useInlineTickers([tweetText]);
   const author = tweet.author.userName ? `@${tweet.author.userName}` : tweet.author.name;
 
   return (
@@ -201,12 +310,26 @@ function TweetDetail({
           <Text fg={colors.textDim}> - {formatTimeAgo(tweet.createdAt)}</Text>
         </Box>
         <TickerBadgeText
-          text={tweet.text}
+          text={tweetText}
           lineWidth={lineWidth}
           catalog={catalog}
           textColor={colors.text}
           openTicker={openTicker}
         />
+        {imageUrls.length > 0 ? (
+          <Box flexDirection="column" gap={1}>
+            {imageUrls.slice(0, 4).map((url, index) => (
+              <RemoteImage
+                key={url}
+                src={url}
+                alt={`Tweet image ${index + 1}`}
+                width={imageWidth}
+                height={imageHeight}
+                label={imageUrls.length > 1 ? `image ${index + 1}` : "image"}
+              />
+            ))}
+          </Box>
+        ) : null}
         <Box flexDirection="row" height={1}>
           <Text fg={colors.textDim}>
             {`likes ${formatMetric(tweet.metrics.likes)}  reposts ${formatMetric(tweet.metrics.retweets)}  replies ${formatMetric(tweet.metrics.replies)}  views ${formatMetric(tweet.metrics.views)}`}
@@ -283,12 +406,15 @@ function TweetSearchTable({
   onResult?: (result: CloudTweetSearchResponse) => void;
   onError?: (message: string) => void;
 }) {
+  const rendererHost = useRendererHost();
   const { data, loading, error, reload } = useTweetSearchData(requestKey, load, onResult, onError);
   const [selectedTweetId, setSelectedTweetId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
-  const rows = useMemo(() => (
-    [...(data?.tweets ?? [])].sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt))
-  ), [data?.tweets]);
+  const [sort, setSort] = useState<{ columnId: TweetSortColumnId; direction: TweetSortDirection }>({
+    columnId: "views",
+    direction: "desc",
+  });
+  const rows = useMemo(() => sortedTweets(data?.tweets ?? [], sort.columnId, sort.direction), [data?.tweets, sort]);
   const columns = useMemo(() => buildTweetColumns(width), [width]);
   const selectedIndex = rows.findIndex((tweet) => tweet.id === selectedTweetId);
   const activeIndex = selectedIndex >= 0 ? selectedIndex : rows.length > 0 ? 0 : -1;
@@ -306,8 +432,17 @@ function TweetSearchTable({
   }, [rows, selectedIndex, selectedTweetId]);
 
   const openSelectedTweet = useCallback(() => {
-    if (selectedTweet?.url) openUrl(selectedTweet.url);
-  }, [selectedTweet]);
+    if (selectedTweet?.url) void rendererHost.openExternal(selectedTweet.url);
+  }, [rendererHost, selectedTweet]);
+
+  const handleHeaderClick = useCallback((columnId: string) => {
+    if (!isTweetSortColumnId(columnId)) return;
+    setSort((current) => (
+      current.columnId === columnId
+        ? { columnId, direction: current.direction === "desc" ? "asc" : "desc" }
+        : { columnId, direction: "desc" }
+    ));
+  }, []);
 
   const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
     if (event.name !== "r") return false;
@@ -329,13 +464,12 @@ function TweetSearchTable({
     info: [
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
-      ...(data ? [{ id: "count", parts: [{ text: `${rows.length} tweets`, tone: "value" as const }] }] : []),
     ],
     hints: [
       { id: "refresh", key: "r", label: "efresh", onPress: reload },
-      ...(detailOpen ? [{ id: "open", key: "o", label: "open tweet", onPress: openSelectedTweet, disabled: !selectedTweet?.url }] : []),
+      ...(detailOpen ? [{ id: "open", key: "o", label: "pen", onPress: openSelectedTweet, disabled: !selectedTweet?.url }] : []),
     ],
-  }), [data, detailOpen, error, footerId, loading, openSelectedTweet, reload, rows.length, selectedTweet?.url]);
+  }), [detailOpen, error, footerId, loading, openSelectedTweet, reload, selectedTweet?.url]);
 
   const renderCell = useCallback((
     tweet: CloudTweetPayload,
@@ -354,7 +488,7 @@ function TweetSearchTable({
           attributes: TextAttributes.BOLD,
         };
       case "text":
-        return { text: tweet.text.replace(/\s+/g, " "), color: selectedColor ?? colors.text };
+        return { text: normalizeTweetDisplayText(tweet.text), color: selectedColor ?? colors.text };
       case "tickers":
         return { text: tweetTickers(tweet).map((ticker) => `$${ticker}`).join(" "), color: selectedColor ?? colors.positive };
       case "likes":
@@ -390,9 +524,9 @@ function TweetSearchTable({
       rootBefore={<TweetSearchHeader data={data} loading={loading} width={width} />}
       columns={columns}
       items={rows}
-      sortColumnId={null}
-      sortDirection="desc"
-      onHeaderClick={() => {}}
+      sortColumnId={sort.columnId}
+      sortDirection={sort.direction}
+      onHeaderClick={handleHeaderClick}
       getItemKey={(tweet) => tweet.id}
       isSelected={(tweet) => tweet.id === selectedTweetId}
       onSelect={(tweet) => setSelectedTweetId(tweet.id)}

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -1283,11 +1283,37 @@ export const webUiHost: UiHost = {
       );
     },
   ),
-  ImageSurface: ({ children, ...props }) => (
-    <div {...cleanDomProps(props)} style={{ ...commonStyle(props), ...(props.style as CSSProperties | undefined) }}>
-      {children as ReactNode}
-    </div>
-  ),
+  ImageSurface: ({ children, src, alt = "", objectFit = "contain", ...props }) => {
+    const imageSrc = typeof src === "string" ? src.trim() : "";
+    const [failed, setFailed] = useState(false);
+    useEffect(() => setFailed(false), [imageSrc]);
+    const baseStyle = commonStyle(props);
+    return (
+      <div
+        {...cleanDomProps(props)}
+        style={{
+          ...baseStyle,
+          overflow: baseStyle.overflow ?? "hidden",
+          ...(props.style as CSSProperties | undefined),
+        }}
+      >
+        {imageSrc && !failed ? (
+          <img
+            src={imageSrc}
+            alt={alt}
+            draggable={false}
+            onError={() => setFailed(true)}
+            style={{
+              width: "100%",
+              height: "100%",
+              display: "block",
+              objectFit,
+            }}
+          />
+        ) : children as ReactNode}
+      </div>
+    );
+  },
   SpinnerMark: ({ color, ...props }) => (
     <span
       {...cleanDomProps(props)}

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -56,7 +56,12 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
   const rendererHost: RendererHost = {
     requestExit: () => renderer.destroy(),
     async openExternal(url) {
-      const proc = Bun.spawn(["open", url], {
+      const command = process.platform === "darwin"
+        ? ["open", url]
+        : process.platform === "win32"
+          ? ["cmd", "/c", "start", "", url]
+          : ["xdg-open", url];
+      const proc = Bun.spawn(command, {
         stdout: "ignore",
         stderr: "ignore",
       });

--- a/src/renderers/opentui/ui-host.tsx
+++ b/src/renderers/opentui/ui-host.tsx
@@ -66,7 +66,7 @@ export const openTuiUiHost: UiHost = {
   Input: ({ children, ...props }) => createElement("input" as any, props, children),
   Textarea: ({ children, ...props }) => createElement("textarea" as any, props, children),
   ChartSurface: ({ children, bitmap: _bitmap, bitmaps: _bitmaps, crosshair: _crosshair, ...props }) => <box {...props}>{children}</box>,
-  ImageSurface: ({ children, ...props }) => <box {...props}>{children}</box>,
+  ImageSurface: ({ children, src: _src, alt: _alt, objectFit: _objectFit, ...props }) => <box {...props}>{children}</box>,
   SpinnerMark: ({ children, ...props }) => createElement("spinner" as any, props, children),
   AsciiText: ({ text, font = "tiny", color, fg, bg, backgroundColor, selectable = false, ...props }) => {
     const resolvedColor = color ?? fg;

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -167,7 +167,11 @@ export interface ChartSurfaceProps extends BoxProps {
   bitmaps?: readonly BitmapSurface[] | null;
   crosshair?: ChartCrosshairOverlay | null;
 }
-export interface ImageSurfaceProps extends BoxProps {}
+export interface ImageSurfaceProps extends BoxProps {
+  src?: string;
+  alt?: string;
+  objectFit?: "contain" | "cover";
+}
 export interface SpinnerMarkProps extends BoxProps {
   name?: string;
   color?: string;

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -237,6 +237,16 @@ export interface CloudTweetMetricsPayload {
   bookmarks: number | null;
 }
 
+export interface CloudTweetMediaPayload {
+  type?: string;
+  url?: string;
+  mediaUrl?: string;
+  media_url?: string;
+  media_url_https?: string;
+  previewImageUrl?: string;
+  preview_image_url?: string;
+}
+
 export interface CloudTweetPayload {
   id: string;
   url: string;
@@ -246,6 +256,9 @@ export interface CloudTweetPayload {
   isReply: boolean;
   author: CloudTweetUserPayload;
   metrics: CloudTweetMetricsPayload;
+  media?: CloudTweetMediaPayload[];
+  photos?: CloudTweetMediaPayload[];
+  images?: CloudTweetMediaPayload[];
 }
 
 export type CloudTweetQueryType = "Latest" | "Top";

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { displayWidth, formatTimeAgo, padTo } from "./format";
+import { normalizeTimestamp } from "./timestamp";
 
 describe("formatTimeAgo", () => {
   test("handles UTC ISO timestamps with explicit offsets", () => {
@@ -10,6 +11,12 @@ describe("formatTimeAgo", () => {
   test("treats space-separated chat timestamps without a timezone as UTC", () => {
     const fiveMinutesAgo = new Date(Date.now() - 5 * 60_000).toISOString().replace("T", " ").replace("Z", "");
     expect(formatTimeAgo(fiveMinutesAgo)).toBe("5m ago");
+  });
+});
+
+describe("normalizeTimestamp", () => {
+  test("parses Twitter API timestamps", () => {
+    expect(normalizeTimestamp("Wed Apr 29 03:20:20 +0000 2026")).toBe("2026-04-29T03:20:20.000Z");
   });
 });
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -224,6 +224,7 @@ export function convertCurrency(
 /** Format a date/timestamp as relative time (e.g., "5m ago", "2h ago") */
 export function formatTimeAgo(date: Date | string): string {
   const ts = toTimestampMillis(date);
+  if (Number.isNaN(ts)) return "unknown";
   const seconds = Math.floor((Date.now() - ts) / 1000);
   if (seconds < 60) return "just now";
   const minutes = Math.floor(seconds / 60);

--- a/src/utils/html-entities.test.ts
+++ b/src/utils/html-entities.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { decodeHtmlEntities } from "./html-entities";
+
+describe("decodeHtmlEntities", () => {
+  test("decodes common tweet HTML entities", () => {
+    expect(decodeHtmlEntities("demand/supply &amp; unit economics &#36;ASML")).toBe("demand/supply & unit economics $ASML");
+  });
+});

--- a/src/utils/html-entities.ts
+++ b/src/utils/html-entities.ts
@@ -1,0 +1,32 @@
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: "\"",
+};
+
+function decodeCodePoint(codePoint: number, fallback: string): string {
+  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : fallback;
+}
+
+export function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z][a-z0-9]+);?/gi, (match, entity: string) => {
+    const normalized = entity.toLowerCase();
+
+    if (normalized.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalized.slice(2), 16);
+      return decodeCodePoint(codePoint, match);
+    }
+
+    if (normalized.startsWith("#")) {
+      const codePoint = Number.parseInt(normalized.slice(1), 10);
+      return decodeCodePoint(codePoint, match);
+    }
+
+    return NAMED_ENTITIES[normalized] ?? match;
+  });
+}

--- a/src/utils/timestamp.ts
+++ b/src/utils/timestamp.ts
@@ -1,10 +1,38 @@
 
 const ISO_TIMEZONE_SUFFIX = /(Z|[+-]\d{2}:?\d{2})$/i;
 const DATE_TIME_SPACE = /^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)$/i;
+const TWITTER_TIMESTAMP = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})\s+(\d{2}:\d{2}:\d{2})\s+([+-]\d{4})\s+(\d{4})$/i;
+
+const TWITTER_MONTHS: Record<string, string> = {
+  jan: "01",
+  feb: "02",
+  mar: "03",
+  apr: "04",
+  may: "05",
+  jun: "06",
+  jul: "07",
+  aug: "08",
+  sep: "09",
+  oct: "10",
+  nov: "11",
+  dec: "12",
+};
+
+function normalizeTwitterTimestampInput(value: string): string | null {
+  const match = value.match(TWITTER_TIMESTAMP);
+  if (!match) return null;
+  const [, monthName, day, time, offset, year] = match;
+  const month = TWITTER_MONTHS[monthName!.toLowerCase()];
+  if (!month) return null;
+  const normalizedOffset = offset!.replace(/^([+-]\d{2})(\d{2})$/, "$1:$2");
+  return `${year}-${month}-${day!.padStart(2, "0")}T${time}${normalizedOffset}`;
+}
 
 function normalizeTimestampInput(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) return trimmed;
+  const twitterTimestamp = normalizeTwitterTimestampInput(trimmed);
+  if (twitterTimestamp) return twitterTimestamp;
   const withSeparator = DATE_TIME_SPACE.test(trimmed)
     ? trimmed.replace(DATE_TIME_SPACE, "$1T$2")
     : trimmed;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,11 @@
+export function normalizedHttpUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "https:" || url.protocol === "http:" ? trimmed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Fix tweet timestamp parsing and HTML entity decoding.
- Default tweet tables to views sort, with time/likes/views sorting.
- Clean detail/footer behavior and render tweet media through the shared image surface.

## Root Cause
- Cloud tweet timestamps can arrive in native Twitter date format, which the client treated as invalid ISO text.
- Tweet detail text was rendered as large unbreakable chunks and raw HTML entities.
- The footer open action bypassed the renderer host, so desktop/TUI external opens were inconsistent.

## Validation
- bun test src/utils/format.test.ts src/utils/html-entities.test.ts src/utils/api-client.test.ts src/components/ticker-badge-text.test.tsx
- bun run desktop:view:build
- git diff --check HEAD~1 HEAD
- tmux smoke: bun run start, then killed session