### PR TITLE
Fix desktop broker and chat renderer crashes

### DIFF
--- a/src/plugins/ibkr/gateway-service.test.ts
+++ b/src/plugins/ibkr/gateway-service.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { BarSizeSetting, ConnectionState, SecType, type ContractDetails, type TickByTickAllLast } from "@stoqey/ib";
 import { Subject, of } from "rxjs";
 import {
+  setBrokerRemoteClient,
+  type BrokerRemoteClient,
+} from "../../brokers/remote-broker-adapter";
+import type { BrokerConnectionStatus } from "../../types/broker";
+import {
+  ibkrGatewayManager,
+  setNativeIbkrGatewayModuleLoader,
+} from "./gateway-service";
+import {
   applyTickByTickAllLastToQuote,
   applyTickByTickBidAskToQuote,
   diagnoseLocalIbkrPortIssue,
@@ -160,6 +169,43 @@ describe("summarizeBrokerAccount", () => {
       cashBalances: undefined,
     });
   });
+});
+
+test("remote gateway snapshots are side-effect-free", async () => {
+  const instanceId = "ibkr-gateway-snapshot-test";
+  const status: BrokerConnectionStatus = {
+    state: "connected",
+    updatedAt: 123,
+  };
+  const client: BrokerRemoteClient = {
+    invoke: async <T,>() => null as T,
+    getStatus: () => status,
+    subscribeStatus: () => () => {},
+    subscribeQuotes: () => () => {},
+    removeInstance: async () => {},
+    destroyAll: async () => {},
+  };
+
+  setBrokerRemoteClient(client);
+  let unsubscribe: (() => void) | null = null;
+  try {
+    let notifications = 0;
+    unsubscribe = ibkrGatewayManager.subscribe(instanceId, () => {
+      notifications += 1;
+    });
+
+    const first = ibkrGatewayManager.getSnapshot(instanceId);
+    const second = ibkrGatewayManager.getSnapshot(instanceId);
+
+    expect(first).toBe(second);
+    expect(first.status).toBe(status);
+    expect(notifications).toBe(0);
+  } finally {
+    unsubscribe?.();
+    setBrokerRemoteClient(null);
+    setNativeIbkrGatewayModuleLoader(null);
+    await ibkrGatewayManager.removeInstance(instanceId);
+  }
 });
 
 describe("tick-by-tick quote updates", () => {

--- a/src/plugins/ibkr/gateway-service.ts
+++ b/src/plugins/ibkr/gateway-service.ts
@@ -44,8 +44,10 @@ const DEFAULT_SNAPSHOT: IbkrSnapshot = {
 };
 
 let resolvedGatewayListener: ResolvedGatewayListener | null = null;
+let loadedNativeGatewayModule: NativeGatewayModule | null = null;
 let nativeGatewayModulePromise: Promise<NativeGatewayModule> | null = null;
 let nativeGatewayManager: NativeGatewayManager | null = null;
+let nativeGatewayModuleLoader: () => Promise<NativeGatewayModule>;
 const importNativeGatewayModule = new Function("specifier", "return import(specifier)") as (
   specifier: string,
 ) => Promise<NativeGatewayModule>;
@@ -58,17 +60,45 @@ function getSnapshotEntry(instanceId?: string): IbkrSnapshot {
   return snapshots.get(instanceId) ?? DEFAULT_SNAPSHOT;
 }
 
-function updateSnapshot(instanceId: string, patch: Partial<IbkrSnapshot>): void {
+function defaultNativeGatewayModuleLoader(): Promise<NativeGatewayModule> {
+  return importNativeGatewayModule("./gateway-service-native");
+}
+
+nativeGatewayModuleLoader = defaultNativeGatewayModuleLoader;
+
+export function setNativeIbkrGatewayModuleLoader(loader: (() => Promise<NativeGatewayModule>) | null): void {
+  nativeGatewayModuleLoader = loader ?? defaultNativeGatewayModuleLoader;
+}
+
+function applySnapshot(instanceId: string, patch: Partial<IbkrSnapshot>, shouldNotify: boolean): IbkrSnapshot {
   const current = getSnapshotEntry(instanceId);
-  snapshots.set(instanceId, {
+  const next = {
     ...current,
     ...patch,
     status: patch.status ?? current.status,
     accounts: patch.accounts ?? current.accounts,
     openOrders: patch.openOrders ?? current.openOrders,
     executions: patch.executions ?? current.executions,
-  });
-  notify(instanceId);
+  };
+  if (
+    next.status === current.status
+    && next.accounts === current.accounts
+    && next.openOrders === current.openOrders
+    && next.executions === current.executions
+  ) {
+    return current;
+  }
+  snapshots.set(instanceId, next);
+  if (shouldNotify) notify(instanceId);
+  return next;
+}
+
+function updateSnapshot(instanceId: string, patch: Partial<IbkrSnapshot>): void {
+  applySnapshot(instanceId, patch, true);
+}
+
+function cacheSnapshot(instanceId: string, patch: Partial<IbkrSnapshot>): IbkrSnapshot {
+  return applySnapshot(instanceId, patch, false);
 }
 
 function notify(instanceId: string): void {
@@ -79,10 +109,13 @@ function notify(instanceId: string): void {
 
 async function loadNativeGatewayModule(): Promise<NativeGatewayModule> {
   if (!nativeGatewayModulePromise) {
-    const modulePath = `./gateway-service-${"native"}`;
-    nativeGatewayModulePromise = importNativeGatewayModule(modulePath);
+    nativeGatewayModulePromise = nativeGatewayModuleLoader().catch((error) => {
+      nativeGatewayModulePromise = null;
+      throw error;
+    });
   }
   const module = await nativeGatewayModulePromise;
+  loadedNativeGatewayModule = module;
   nativeGatewayManager = module.ibkrGatewayManager;
   module.setResolvedIbkrGatewayListener(resolvedGatewayListener);
   return module;
@@ -96,7 +129,14 @@ async function getNativeService(instanceId: string): Promise<NativeGatewayServic
 export function setResolvedIbkrGatewayListener(listener: ResolvedGatewayListener | null): void {
   resolvedGatewayListener = listener;
   if (getBrokerRemoteClient()) return;
-  void loadNativeGatewayModule().then((module) => {
+  if (loadedNativeGatewayModule) {
+    loadedNativeGatewayModule.setResolvedIbkrGatewayListener(listener);
+    return;
+  }
+  if (!nativeGatewayModulePromise) {
+    return;
+  }
+  void nativeGatewayModulePromise.then((module) => {
     module.setResolvedIbkrGatewayListener(listener);
   }).catch(() => {});
 }
@@ -107,8 +147,7 @@ class IbkrGatewayServiceFacade {
   getSnapshot(): IbkrSnapshot {
     const remoteStatus = getBrokerRemoteClient()?.getStatus(this.instanceId);
     if (remoteStatus) {
-      updateSnapshot(this.instanceId, { status: remoteStatus });
-      return getSnapshotEntry(this.instanceId);
+      return cacheSnapshot(this.instanceId, { status: remoteStatus });
     }
     if (nativeGatewayManager) {
       return nativeGatewayManager.getService(this.instanceId).getSnapshot();
@@ -129,8 +168,11 @@ class IbkrGatewayServiceFacade {
 
     const remoteDispose = getBrokerRemoteClient()?.subscribeStatus(this.instanceId, () => {
       const status = getBrokerRemoteClient()?.getStatus(this.instanceId);
-      if (status) updateSnapshot(this.instanceId, { status });
-      listener();
+      if (status) {
+        updateSnapshot(this.instanceId, { status });
+      } else {
+        listener();
+      }
     });
 
     if (remoteDispose) {
@@ -141,15 +183,15 @@ class IbkrGatewayServiceFacade {
     }
 
     let nativeDispose: (() => void) | null = null;
-    let disposed = false;
-    void getNativeService(this.instanceId).then((service) => {
-      if (disposed) return;
-      nativeDispose = service.subscribe(listener);
-      listener();
-    }).catch(() => {});
+    if (nativeGatewayManager) {
+      const service = nativeGatewayManager.getService(this.instanceId);
+      nativeDispose = service.subscribe(() => {
+        updateSnapshot(this.instanceId, service.getSnapshot());
+      });
+    }
+    listener();
 
     return () => {
-      disposed = true;
       nativeDispose?.();
       listeners.get(this.instanceId)?.delete(listener);
     };
@@ -161,13 +203,17 @@ class IbkrGatewayServiceFacade {
       await remote.invoke<void>(this.instanceId, "connect");
       return;
     }
-    return (await getNativeService(this.instanceId)).connect(config);
+    const service = await getNativeService(this.instanceId);
+    await service.connect(config);
+    updateSnapshot(this.instanceId, service.getSnapshot());
   }
 
   async disconnect(): Promise<void> {
     const remote = getBrokerRemoteClient();
     if (remote) return remote.invoke<void>(this.instanceId, "disconnect");
-    return (await getNativeService(this.instanceId)).disconnect();
+    const service = await getNativeService(this.instanceId);
+    await service.disconnect();
+    updateSnapshot(this.instanceId, service.getSnapshot());
   }
 
   async getAccounts(config: IbkrGatewayConfig): Promise<BrokerAccount[]> {
@@ -364,8 +410,8 @@ export class IbkrGatewayServiceManager {
     const remote = getBrokerRemoteClient();
     if (remote) {
       await remote.removeInstance(instanceId);
-    } else {
-      await (await loadNativeGatewayModule()).ibkrGatewayManager.removeInstance(instanceId);
+    } else if (nativeGatewayManager) {
+      await nativeGatewayManager.removeInstance(instanceId);
     }
     this.services.delete(instanceId);
     snapshots.delete(instanceId);
@@ -376,8 +422,8 @@ export class IbkrGatewayServiceManager {
     const remote = getBrokerRemoteClient();
     if (remote) {
       await remote.destroyAll();
-    } else {
-      await (await loadNativeGatewayModule()).ibkrGatewayManager.destroyAll();
+    } else if (nativeGatewayManager) {
+      await nativeGatewayManager.destroyAll();
     }
     this.services.clear();
     snapshots.clear();

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -26,6 +26,7 @@ import { createDesktopWorkspace, type DesktopWorkspace } from "./desktop-workspa
 import { buildApplicationMenu } from "./application-menu";
 import { applicationMenuCommand } from "./application-menu-click";
 import { registerElectrobunCoreCapabilities } from "./core-capabilities";
+import { setNativeIbkrGatewayModuleLoader } from "../../../plugins/ibkr/gateway-service";
 import { apiClient, type PersistedAuthUser } from "../../../utils/api-client";
 import {
   DEFAULT_WINDOW_FRAME,
@@ -53,6 +54,7 @@ console.warn = (...args) => console.error(...args);
 
 startMainThreadMonitor("electrobun.bun", { mirrorToConsole: true });
 setConfigStoreHost(nodeConfigStoreHost);
+setNativeIbkrGatewayModuleLoader(() => import("../../../plugins/ibkr/gateway-service-native"));
 
 let currentConfig: AppConfig | null = null;
 let services: AppServices | null = null;

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -647,6 +647,74 @@ function useEditableValue(props: Record<string, unknown>) {
   return { value, valueRef, setValue };
 }
 
+type WebVisualCursor = TextareaRenderable["visualCursor"];
+
+function textareaColumnCount(props: Record<string, unknown>, element: HTMLTextAreaElement | null): number {
+  if (typeof props.width === "number") return Math.max(1, Math.floor(props.width));
+  const width = element?.clientWidth ?? 0;
+  return Math.max(1, Math.floor(width / WEB_CELL_WIDTH));
+}
+
+function wrappedLineCount(line: string, columns: number, wrap: boolean): number {
+  if (!wrap) return 1;
+  return Math.max(1, Math.ceil(line.length / columns));
+}
+
+function textareaMetrics(
+  text: string,
+  offset: number,
+  columns: number,
+  wrap: boolean,
+): { virtualLineCount: number; visualCursor: WebVisualCursor } {
+  const lines = text.split("\n");
+  const clampedOffset = Math.max(0, Math.min(offset, text.length));
+  let consumed = 0;
+  let virtualLineCount = 0;
+  let visualCursor: WebVisualCursor = {
+    visualRow: 0,
+    visualCol: 0,
+    logicalRow: 0,
+    logicalCol: 0,
+    offset: clampedOffset,
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const lineStart = consumed;
+    const lineEnd = lineStart + line.length;
+    const lineVirtualRows = wrappedLineCount(line, columns, wrap);
+    const cursorIsOnLine = clampedOffset <= lineEnd || index === lines.length - 1;
+
+    if (cursorIsOnLine) {
+      const logicalCol = Math.max(0, Math.min(clampedOffset - lineStart, line.length));
+      const visualRowInLine = wrap
+        ? Math.min(Math.floor(logicalCol / columns), lineVirtualRows - 1)
+        : 0;
+      visualCursor = {
+        visualRow: virtualLineCount + visualRowInLine,
+        visualCol: wrap ? logicalCol % columns : logicalCol,
+        logicalRow: index,
+        logicalCol,
+        offset: clampedOffset,
+      };
+    }
+
+    virtualLineCount += lineVirtualRows;
+    consumed = lineEnd + 1;
+    if (cursorIsOnLine) {
+      for (let remaining = index + 1; remaining < lines.length; remaining += 1) {
+        virtualLineCount += wrappedLineCount(lines[remaining] ?? "", columns, wrap);
+      }
+      break;
+    }
+  }
+
+  return {
+    virtualLineCount: Math.max(1, virtualLineCount),
+    visualCursor,
+  };
+}
+
 const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(function WebInput(props, ref) {
   const elementRef = useRef<HTMLInputElement | null>(null);
   const { value, valueRef, setValue } = useEditableValue(props);
@@ -731,12 +799,33 @@ const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown>>(func
     get cursorOffset() {
       return cursorOffset;
     },
+    get virtualLineCount() {
+      const metrics = textareaMetrics(
+        valueRef.current,
+        elementRef.current?.selectionStart ?? cursorOffset,
+        textareaColumnCount(props, elementRef.current),
+        props.wrapText === true || props.wrapMode === "word" || props.wrapMode === "char",
+      );
+      return metrics.virtualLineCount;
+    },
+    get visualCursor() {
+      return textareaMetrics(
+        valueRef.current,
+        elementRef.current?.selectionStart ?? cursorOffset,
+        textareaColumnCount(props, elementRef.current),
+        props.wrapText === true || props.wrapMode === "word" || props.wrapMode === "char",
+      ).visualCursor;
+    },
     focus: () => elementRef.current?.focus(),
     setText: (nextText: string) => setValue(nextText),
+    hasSelection: () => {
+      const element = elementRef.current;
+      return !!element && element.selectionStart !== element.selectionEnd;
+    },
     syntaxStyle: null,
     addHighlight: () => {},
     clearLineHighlights: () => {},
-  }), [cursorOffset, setValue, valueRef]);
+  }), [cursorOffset, props, setValue, valueRef]);
 
   const handleValueChange = (nextValue: string) => {
     setValue(nextValue);

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -111,7 +111,16 @@ export interface InputRenderable {
 }
 
 export interface TextareaRenderable extends InputRenderable {
+  virtualLineCount: number;
+  visualCursor: {
+    visualRow: number;
+    visualCol: number;
+    logicalRow: number;
+    logicalCol: number;
+    offset: number;
+  };
   setText(text: string): void;
+  hasSelection(): boolean;
   syntaxStyle?: SyntaxStyleLike | null;
   onContentChange?: (() => void) | undefined;
   addHighlight?(lineIdx: number, highlight: Highlight): void;


### PR DESCRIPTION
Fixes two Electrobun desktop crashes: IBKR Gateway status snapshots could notify during `getSnapshot()`, causing a WebKit render loop, and the bundled native Gateway loader could resolve the wrong path. It also implements the textarea selection/cursor API in the Electrobun web host so chat ArrowUp/ArrowDown handling no longer crashes when the composer is focused.

Validated with `bun test src/plugins/ibkr/gateway-service.test.ts src/plugins/builtin/chat.test.tsx -t "remote gateway snapshots|up arrow|down arrow"`, `bun scripts/build-electrobun-view.ts`, and `git diff --check`.
