### PR TITLE
Fix idle desktop CPU churn

### DIFF
--- a/src/market-data/coordinator-subscriptions.test.ts
+++ b/src/market-data/coordinator-subscriptions.test.ts
@@ -26,7 +26,7 @@ function createProvider(): {
   };
 }
 
-function quote(symbol: string, price: number): Quote {
+function quote(symbol: string, price: number, overrides: Partial<Quote> = {}): Quote {
   return {
     symbol,
     price,
@@ -34,6 +34,7 @@ function quote(symbol: string, price: number): Quote {
     change: 0,
     changePercent: 0,
     lastUpdated: Date.now(),
+    ...overrides,
   };
 }
 
@@ -94,5 +95,31 @@ describe("MarketDataCoordinator key subscriptions", () => {
 
     expect(calls).toBe(1);
     expect(coordinator.getVersion()).toBe(1);
+  });
+
+  test("ignores repeated stream quotes that only refresh timestamp noise", async () => {
+    const { provider, emitQuote } = createProvider();
+    const coordinator = new MarketDataCoordinator(provider);
+    const aapl = { symbol: "AAPL", exchange: "NASDAQ" };
+    let calls = 0;
+
+    coordinator.subscribeKeys([buildQuoteKey(aapl)], () => { calls += 1; });
+    coordinator.subscribeQuotes([{ instrument: aapl }]);
+
+    const firstTimestamp = 1_700_000_000_000;
+    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100, { lastUpdated: firstTimestamp }));
+    await flushCoordinator();
+
+    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100, { lastUpdated: firstTimestamp + 10_000 }));
+    await flushCoordinator();
+
+    expect(calls).toBe(1);
+    expect(coordinator.getQuoteEntry(aapl).data?.lastUpdated).toBe(firstTimestamp);
+
+    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 101, { lastUpdated: firstTimestamp + 20_000 }));
+    await flushCoordinator();
+
+    expect(calls).toBe(2);
+    expect(coordinator.getQuoteEntry(aapl).data?.price).toBe(101);
   });
 });

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -151,6 +151,57 @@ function readyQuoteEntry(
   return readyEntry(current, quote, source, attempts, { keepLastGoodOnEmpty: true });
 }
 
+const STREAM_QUOTE_FIELDS: Array<keyof Quote> = [
+  "symbol",
+  "providerId",
+  "price",
+  "currency",
+  "change",
+  "changePercent",
+  "previousClose",
+  "high52w",
+  "low52w",
+  "marketCap",
+  "volume",
+  "name",
+  "exchangeName",
+  "fullExchangeName",
+  "listingExchangeName",
+  "listingExchangeFullName",
+  "routingExchangeName",
+  "routingExchangeFullName",
+  "marketState",
+  "sessionConfidence",
+  "preMarketPrice",
+  "preMarketChange",
+  "preMarketChangePercent",
+  "postMarketPrice",
+  "postMarketChange",
+  "postMarketChangePercent",
+  "bid",
+  "ask",
+  "bidSize",
+  "askSize",
+  "open",
+  "high",
+  "low",
+  "mark",
+  "dataSource",
+];
+
+function quoteTimestampMinute(quote: Quote): number | null {
+  return Number.isFinite(quote.lastUpdated) ? Math.floor(quote.lastUpdated / 60_000) : null;
+}
+
+function areStreamQuotesEquivalent(current: Quote | null | undefined, next: Quote): boolean {
+  if (!current) return false;
+  for (const field of STREAM_QUOTE_FIELDS) {
+    if (current[field] !== next[field]) return false;
+  }
+  return quoteTimestampMinute(current) === quoteTimestampMinute(next)
+    && JSON.stringify(current.provenance ?? null) === JSON.stringify(next.provenance ?? null);
+}
+
 function errorEntry<T>(current: QueryEntry<T>, attempt: ProviderAttempt): QueryEntry<T> {
   return {
     ...current,
@@ -764,6 +815,7 @@ export class MarketDataCoordinator {
       };
       const key = buildQuoteKey(instrument);
       const current = this.quoteStore.get(key);
+      if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, quote)) return;
       const attempts = [createAttempt(quote.providerId ?? this.dataProvider.id, Date.now(), "success")];
       this.quoteStore.set(key, readyQuoteEntry(current, quote, quote.providerId ?? this.dataProvider.id, attempts));
     });

--- a/src/plugins/ibkr/gateway-helpers.ts
+++ b/src/plugins/ibkr/gateway-helpers.ts
@@ -1,13 +1,18 @@
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import type { BrokerInstanceConfig } from "../../types/config";
 import { getGatewayConfig } from "./config";
 import { ibkrGatewayManager } from "./gateway-service";
 
 export function useGatewaySnapshot(instanceId?: string) {
-  return useSyncExternalStore(
-    (listener) => ibkrGatewayManager.subscribe(instanceId, listener),
-    () => ibkrGatewayManager.getSnapshot(instanceId),
+  const subscribe = useCallback(
+    (listener: () => void) => ibkrGatewayManager.subscribe(instanceId, listener),
+    [instanceId],
   );
+  const getSnapshot = useCallback(
+    () => ibkrGatewayManager.getSnapshot(instanceId),
+    [instanceId],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
 }
 
 export function getGatewayRequiredMessage(instanceCount: number) {

--- a/src/renderers/electrobun/view/broker-remote-client.ts
+++ b/src/renderers/electrobun/view/broker-remote-client.ts
@@ -12,7 +12,16 @@ import type { BrokerConnectionStatus } from "../../../types/broker";
 import { backendRequest, onCapabilityEvent } from "./backend-rpc";
 
 const statuses = new Map<string, BrokerConnectionStatus>();
+const statusSubscriptions = new Map<string, StatusSubscription>();
+const STATUS_SUBSCRIPTION_TEARDOWN_DELAY_MS = 250;
 let nextSubscriptionId = 1;
+
+type StatusSubscription = {
+  subscriptionId: string;
+  listeners: Set<() => void>;
+  disposeEvents: () => void;
+  teardownTimer: ReturnType<typeof setTimeout> | null;
+};
 
 function isBrokerStatusEvent(event: BrokerRemoteEvent): event is BrokerStatusEvent {
   return event.kind === "status";
@@ -43,6 +52,43 @@ function subscribeBrokerCapability(
   });
 }
 
+function disposeStatusSubscription(instanceId: string, entry: StatusSubscription): void {
+  if (statusSubscriptions.get(instanceId) !== entry) return;
+  entry.disposeEvents();
+  if (entry.teardownTimer) clearTimeout(entry.teardownTimer);
+  statusSubscriptions.delete(instanceId);
+  void backendRequest("capability.unsubscribe", { subscriptionId: entry.subscriptionId }).catch(() => {});
+}
+
+function getStatusSubscription(instanceId: string): StatusSubscription {
+  const current = statusSubscriptions.get(instanceId);
+  if (current) return current;
+
+  const subscriptionId = `broker-status:${instanceId}:${nextSubscriptionId++}`;
+  const entry: StatusSubscription = {
+    subscriptionId,
+    listeners: new Set(),
+    disposeEvents: () => {},
+    teardownTimer: null,
+  };
+  entry.disposeEvents = onCapabilityEvent(subscriptionId, (message) => {
+    const event = message.event as BrokerRemoteEvent;
+    if (!isBrokerStatusEvent(event)) return;
+    statuses.set(event.instanceId, event.status);
+    for (const listener of entry.listeners) {
+      listener();
+    }
+  });
+  statusSubscriptions.set(instanceId, entry);
+
+  void subscribeBrokerCapability(subscriptionId, "status", { instanceId }).catch((error) => {
+    disposeStatusSubscription(instanceId, entry);
+    console.error("Failed to subscribe to broker status", error);
+  });
+
+  return entry;
+}
+
 const client: BrokerRemoteClient = {
   invoke(operationInstanceId, operation, args = []) {
     return invokeBrokerCapability("invoke", {
@@ -57,20 +103,21 @@ const client: BrokerRemoteClient = {
   },
 
   subscribeStatus(instanceId, listener) {
-    const subscriptionId = `broker-status:${instanceId}:${nextSubscriptionId++}`;
-    const disposeEvents = onCapabilityEvent(subscriptionId, (message) => {
-      const event = message.event as BrokerRemoteEvent;
-      if (!isBrokerStatusEvent(event)) return;
-      statuses.set(event.instanceId, event.status);
-      listener();
-    });
-    void subscribeBrokerCapability(subscriptionId, "status", { instanceId }).catch((error) => {
-      disposeEvents();
-      console.error("Failed to subscribe to broker status", error);
-    });
+    const entry = getStatusSubscription(instanceId);
+    if (entry.teardownTimer) {
+      clearTimeout(entry.teardownTimer);
+      entry.teardownTimer = null;
+    }
+    entry.listeners.add(listener);
     return () => {
-      disposeEvents();
-      void backendRequest("capability.unsubscribe", { subscriptionId }).catch(() => {});
+      entry.listeners.delete(listener);
+      if (entry.listeners.size > 0 || entry.teardownTimer) return;
+      entry.teardownTimer = setTimeout(() => {
+        entry.teardownTimer = null;
+        if (entry.listeners.size === 0) {
+          disposeStatusSubscription(instanceId, entry);
+        }
+      }, STATUS_SUBSCRIPTION_TEARDOWN_DELAY_MS);
     };
   },
 

--- a/src/utils/quote-freshness.ts
+++ b/src/utils/quote-freshness.ts
@@ -2,6 +2,14 @@ import type { MarketState, Quote } from "../types/financials";
 import { canonicalExchange, EXCHANGE_TIME_ZONES } from "./exchanges";
 
 const US_EXTENDED_HOURS_EXCHANGES = new Set(["NASDAQ", "NYSE", "AMEX", "ARCA", "BATS"]);
+const exchangeLocalDateFormatters = new Map<string, Intl.DateTimeFormat>();
+const usSessionFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: "America/New_York",
+  weekday: "short",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+});
 
 type UsSessionState = Exclude<MarketState, never>;
 
@@ -9,16 +17,25 @@ function isUsExtendedHoursExchange(exchange?: string): boolean {
   return US_EXTENDED_HOURS_EXCHANGES.has(canonicalExchange(exchange));
 }
 
+function getExchangeLocalDateFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = exchangeLocalDateFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    exchangeLocalDateFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
 function exchangeLocalDate(exchange: string, timestampMs: number): string | null {
   const timeZone = EXCHANGE_TIME_ZONES[canonicalExchange(exchange)];
   if (!timeZone) return null;
 
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).formatToParts(new Date(timestampMs));
+  const parts = getExchangeLocalDateFormatter(timeZone).formatToParts(new Date(timestampMs));
   const year = parts.find((part) => part.type === "year")?.value;
   const month = parts.find((part) => part.type === "month")?.value;
   const day = parts.find((part) => part.type === "day")?.value;
@@ -27,13 +44,7 @@ function exchangeLocalDate(exchange: string, timestampMs: number): string | null
 }
 
 function usSessionState(timestampMs: number): UsSessionState {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: "America/New_York",
-    weekday: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-  }).formatToParts(new Date(timestampMs));
+  const parts = usSessionFormatter.formatToParts(new Date(timestampMs));
 
   const weekday = parts.find((part) => part.type === "weekday")?.value ?? "";
   if (weekday === "Sat" || weekday === "Sun") return "CLOSED";


### PR DESCRIPTION
Fixes idle desktop CPU churn in the Electrobun app by stabilizing IBKR gateway snapshot subscriptions and sharing broker status streams per instance.
It also caches quote freshness date formatters and filters no-op quote stream updates that only move timestamps within the same minute.
The root cause was a subscribe/unsubscribe loop that made the internal Electrobun WebSocket emit thousands of broker status events per second while idle.
Verified with focused market-data and IBKR tests, desktop:view:build, git diff --check, and a diff secret scan.
