### PR TITLE
Simplify portfolio pane selection

### DIFF
--- a/src/components/command-bar/workflow-ops.test.ts
+++ b/src/components/command-bar/workflow-ops.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { createDefaultConfig } from "../../types/config";
+import { cloneLayout, createDefaultConfig, findPaneInstance, type LayoutConfig } from "../../types/config";
 import { createInitialState } from "../../state/app-context";
 import { createTestDataProvider } from "../../test-support/data-provider";
-import { createPaneTemplateOrThrow } from "./workflow-ops";
+import { applyPaneSettingFieldValue, createPaneTemplateOrThrow } from "./workflow-ops";
 
 function makeDataProvider() {
   return createTestDataProvider({ id: "test" });
@@ -66,5 +66,79 @@ describe("createPaneTemplateOrThrow", () => {
 
     expect(buildCalls).toHaveLength(0);
     expect(placeCalls).toHaveLength(0);
+  });
+});
+
+describe("applyPaneSettingFieldValue", () => {
+  test("keeps portfolio panes on their displayed collection when switching back to all collections", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-workflow-ops-test");
+    const layout = cloneLayout(config.layout);
+    const portfolioPane = findPaneInstance(layout, "portfolio-list:main");
+    if (!portfolioPane) throw new Error("missing portfolio pane");
+    portfolioPane.settings = {
+      ...(portfolioPane.settings ?? {}),
+      collectionScope: "watchlists",
+      visibleCollectionIds: ["watchlist"],
+      hideTabs: true,
+      lockedCollectionId: "watchlist",
+    };
+
+    const state = createInitialState({ ...config, layout });
+    state.paneState["portfolio-list:main"] = {
+      collectionId: "main",
+      cursorSymbol: null,
+    };
+
+    const persisted: LayoutConfig[] = [];
+    const actions: unknown[] = [];
+
+    await applyPaneSettingFieldValue("portfolio-list:main", {
+      key: "collectionScope",
+      label: "Collections",
+      type: "select",
+      options: [],
+    }, "all", {
+      dataProvider: makeDataProvider() as any,
+      tickerRepository: makeTickerRepository() as any,
+      dispatch: (action) => { actions.push(action); },
+      getState: () => state,
+      persistLayout: (nextLayout) => { persisted.push(nextLayout); },
+      pluginRegistry: {
+        resolvePaneSettings: () => ({
+          paneId: "portfolio-list:main",
+          pane: portfolioPane,
+          paneDef: {
+            id: "portfolio-list",
+            name: "Portfolio",
+            component: () => null,
+            defaultPosition: "left",
+          },
+          settingsDef: { title: "Portfolio Pane Settings", fields: [] },
+          context: {
+            config: state.config,
+            layout: state.config.layout,
+            paneId: "portfolio-list:main",
+            paneType: "portfolio-list",
+            pane: portfolioPane,
+            settings: portfolioPane.settings ?? {},
+            paneState: state.paneState["portfolio-list:main"] ?? {},
+            activeTicker: null,
+            activeCollectionId: "main",
+          },
+        }),
+      } as any,
+    });
+
+    const nextPane = findPaneInstance(persisted[0]!, "portfolio-list:main");
+    expect(nextPane?.settings).toMatchObject({ collectionScope: "all" });
+    expect("visibleCollectionIds" in (nextPane?.settings ?? {})).toBe(false);
+    expect("hideTabs" in (nextPane?.settings ?? {})).toBe(false);
+    expect("lockedCollectionId" in (nextPane?.settings ?? {})).toBe(false);
+    expect(nextPane?.params?.collectionId).toBe("watchlist");
+    expect(actions).toContainEqual({
+      type: "UPDATE_PANE_STATE",
+      paneId: "portfolio-list:main",
+      patch: { collectionId: "watchlist" },
+    });
   });
 });

--- a/src/components/command-bar/workflow-ops.ts
+++ b/src/components/command-bar/workflow-ops.ts
@@ -10,6 +10,7 @@ import { resolveTickerSearch, upsertTickerFromSearchResult } from "../../utils/t
 import { formatTickerListInput, parseTickerListInput } from "../../utils/ticker-list";
 import { updatePaneInstance, setPaneSettings } from "../../pane-settings";
 import { isManualPortfolio } from "../../plugins/builtin/portfolio-list/mutations";
+import { cleanPortfolioPaneSettings, resolvePortfolioPaneCollectionId } from "../../plugins/builtin/portfolio-list/settings";
 import {
   buildComparisonChartPaneTitle,
   COMPARISON_CHART_PANE_ID,
@@ -427,18 +428,13 @@ export async function applyPaneSettingFieldValue(
     return;
   }
 
-  const nextSettings = {
+  let nextSettings: Record<string, unknown> = {
     ...descriptor.context.settings,
     [field.key]: value,
   };
 
-  if (descriptor.pane.paneId === "portfolio-list" && field.key === "hideTabs" && value === true) {
-    const lockedCollectionId = typeof descriptor.context.paneState.collectionId === "string"
-      ? descriptor.context.paneState.collectionId
-      : descriptor.context.activeCollectionId;
-    if (lockedCollectionId) {
-      nextSettings.lockedCollectionId = lockedCollectionId;
-    }
+  if (descriptor.pane.paneId === "portfolio-list") {
+    nextSettings = cleanPortfolioPaneSettings(nextSettings);
   }
 
   if (descriptor.pane.paneId === "ticker-detail" && field.key === "hideTabs" && value === true) {
@@ -448,6 +444,33 @@ export async function applyPaneSettingFieldValue(
     nextSettings.lockedTabId = lockedTabId;
   }
 
-  const nextLayout = setPaneSettings(state.config.layout, targetId, nextSettings);
+  let nextLayout = setPaneSettings(state.config.layout, targetId, nextSettings);
+
+  if (descriptor.pane.paneId === "portfolio-list") {
+    const currentCollectionId = typeof descriptor.context.paneState.collectionId === "string"
+      ? descriptor.context.paneState.collectionId
+      : (descriptor.context.activeCollectionId ?? "");
+    const displayedCollectionId = resolvePortfolioPaneCollectionId(
+      state.config,
+      descriptor.context.settings,
+      currentCollectionId,
+    );
+    const nextCollectionId = resolvePortfolioPaneCollectionId(
+      state.config,
+      nextSettings,
+      displayedCollectionId || currentCollectionId,
+    );
+    if (nextCollectionId) {
+      nextLayout = updatePaneInstance(nextLayout, targetId, (instance) => ({
+        ...instance,
+        params: {
+          ...(instance.params ?? {}),
+          collectionId: nextCollectionId,
+        },
+      }));
+      deps.dispatch({ type: "UPDATE_PANE_STATE", paneId: targetId, patch: { collectionId: nextCollectionId } });
+    }
+  }
+
   deps.persistLayout(nextLayout, { pushHistory: shouldPushHistory });
 }

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -88,7 +88,6 @@ function focusPortfolioListCollection(config: AppConfig, collectionId: string): 
       },
       settings: {
         ...instance.settings,
-        lockedCollectionId: collectionId,
         visibleCollectionIds: [collectionId, ...visibleCollectionIds.filter((value) => value !== collectionId)],
       },
     };

--- a/src/core/state/app-state.ts
+++ b/src/core/state/app-state.ts
@@ -145,10 +145,6 @@ function shouldPreserveUnknownCollectionId(collectionId: string | undefined): bo
 function getConfiguredCollectionId(config: AppConfig, instance: PaneInstanceConfig): string {
   const candidates = [
     instance.params?.collectionId,
-    typeof instance.settings?.lockedCollectionId === "string" ? instance.settings.lockedCollectionId : undefined,
-    ...(Array.isArray(instance.settings?.visibleCollectionIds)
-      ? instance.settings.visibleCollectionIds.filter((value): value is string => typeof value === "string")
-      : []),
   ];
 
   for (const candidate of candidates) {

--- a/src/pane-settings.test.ts
+++ b/src/pane-settings.test.ts
@@ -10,8 +10,6 @@ describe("pane settings helpers", () => {
 
     expect(portfolioPane?.settings).toMatchObject({
       collectionScope: "all",
-      hideTabs: false,
-      lockedCollectionId: "main",
     });
     expect(portfolioPane?.settings?.columnIds).toEqual(DEFAULT_PORTFOLIO_COLUMN_IDS);
     expect(detailPane?.settings).toEqual({

--- a/src/plugins/builtin/portfolio-list.test.ts
+++ b/src/plugins/builtin/portfolio-list.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { createDefaultConfig } from "../../types/config";
 import type { BrokerAccount } from "../../types/trading";
 import type { TickerRecord } from "../../types/ticker";
 import type { PortfolioSummaryTotals } from "./portfolio-list/metrics";
 import { buildPortfolioSummarySegments } from "./portfolio-list/summary";
-import { shouldToggleCashMarginDrawer } from "./portfolio-list";
+import { portfolioListPlugin, shouldToggleCashMarginDrawer } from "./portfolio-list";
 import { selectStreamTickers } from "./portfolio-list/pane";
 
 function ticker(symbol: string): TickerRecord {
@@ -105,5 +106,28 @@ describe("selectStreamTickers", () => {
   test("includes selected ticker outside the visible streaming window", () => {
     const tickers = Array.from({ length: 20 }, (_, index) => ticker(`T${index}`));
     expect(selectStreamTickers(tickers, { start: 3, end: 7 }, "T19").map((entry) => entry.metadata.ticker)).toContain("T19");
+  });
+});
+
+describe("portfolio list pane templates", () => {
+  test("create panes with default all-collection settings", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-portfolio-list-template");
+    const context = {
+      config,
+      layout: config.layout,
+      focusedPaneId: "portfolio-list:main",
+      activeTicker: null,
+      activeCollectionId: "watchlist",
+    };
+
+    for (const templateId of ["new-collection-pane", "new-watchlist-pane"]) {
+      const template = portfolioListPlugin.paneTemplates?.find((entry) => entry.id === templateId);
+      const instance = await template?.createInstance?.(context);
+      expect(instance).toEqual({ params: { collectionId: "watchlist" } });
+    }
+
+    const portfolioTemplate = portfolioListPlugin.paneTemplates?.find((entry) => entry.id === "new-portfolio-pane");
+    const portfolioInstance = await portfolioTemplate?.createInstance?.(context);
+    expect(portfolioInstance).toEqual({ params: { collectionId: "main" } });
   });
 });

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -259,10 +259,13 @@ describe("PortfolioListPane cash and margin UI", () => {
   test("opens the selected ticker on a second row click", async () => {
     const portfolioId = "broker:ibkr-flex:DU12345";
     const config = createPortfolioConfig(portfolioId, [createBrokerInstance("flex")]);
-    const navigated: string[] = [];
+    const pinned: Array<{ symbol: string; options: { floating?: boolean; paneType?: string } | undefined }> = [];
     const runtime = createTestPluginRuntime({
-      navigateTicker: (symbol: string) => {
-        navigated.push(symbol);
+      navigateTicker: () => {
+        throw new Error("portfolio rows should open fixed floating panes directly");
+      },
+      pinTicker: (symbol, options) => {
+        pinned.push({ symbol, options });
       },
     });
 
@@ -279,13 +282,13 @@ describe("PortfolioListPane cash and margin UI", () => {
       await testSetup!.mockMouse.click(2, rowY);
       await testSetup!.renderOnce();
     });
-    expect(navigated).toEqual([]);
+    expect(pinned).toEqual([]);
 
     await act(async () => {
       await testSetup!.mockMouse.click(2, rowY);
       await testSetup!.renderOnce();
     });
-    expect(navigated).toEqual(["AAPL"]);
+    expect(pinned).toEqual([{ symbol: "AAPL", options: { floating: true, paneType: "ticker-detail" } }]);
   });
 
   test("keeps non-broker portfolios unchanged", async () => {
@@ -680,6 +683,30 @@ describe("PortfolioListPane cash and margin UI", () => {
 
     expect(tabsRow).toBeGreaterThanOrEqual(0);
     expect(tableHeaderRow).toBe(tabsRow + 1);
+  });
+
+  test("hides collection tabs when there is only one visible collection", async () => {
+    const config = createPortfolioConfig("main");
+    config.portfolios = [{ id: "main", name: "Main Portfolio", currency: "USD" }];
+    config.watchlists = [];
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="main"
+        ticker={makeTicker({ portfolios: ["main"], positions: [] })}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const tabsRow = lines.findIndex((line) => line.includes("Main Portfolio"));
+    const tableHeaderRow = lines.findIndex((line) => line.includes("TICKER"));
+
+    expect(tabsRow).toBe(-1);
+    expect(tableHeaderRow).toBe(0);
   });
 
   test("renders bid ask and spread when those columns are enabled", async () => {

--- a/src/plugins/builtin/portfolio-list/index.tsx
+++ b/src/plugins/builtin/portfolio-list/index.tsx
@@ -1,15 +1,35 @@
-import type { GloomPlugin } from "../../../types/plugin";
+import type { GloomPlugin, PaneTemplateContext, PaneTemplateInstanceConfig } from "../../../types/plugin";
 import { PortfolioListPane } from "./pane";
 import { shouldToggleCashMarginDrawer } from "./header";
 import {
   buildPortfolioPaneSettingsDef,
-  createPortfolioPaneSettings,
   getPortfolioPaneSettings,
   resolveCollectionPaneId,
 } from "./settings";
 import { portfolioCliCommand, watchlistCliCommand } from "./cli/commands";
 
 export { shouldToggleCashMarginDrawer };
+
+function resolveCollectionIdForKind(context: PaneTemplateContext, kind: "portfolio" | "watchlist"): string | null {
+  if (context.activeCollectionId) {
+    const matchesKind = kind === "portfolio"
+      ? context.config.portfolios.some((portfolio) => portfolio.id === context.activeCollectionId)
+      : context.config.watchlists.some((watchlist) => watchlist.id === context.activeCollectionId);
+    if (matchesKind) return context.activeCollectionId;
+  }
+
+  return kind === "portfolio"
+    ? (context.config.portfolios[0]?.id ?? null)
+    : (context.config.watchlists[0]?.id ?? null);
+}
+
+function createCollectionPaneInstance(
+  context: PaneTemplateContext,
+  kind?: "portfolio" | "watchlist",
+): PaneTemplateInstanceConfig | null {
+  const collectionId = kind ? resolveCollectionIdForKind(context, kind) : resolveCollectionPaneId(context);
+  return collectionId ? { params: { collectionId } } : null;
+}
 
 export const portfolioListPlugin: GloomPlugin = {
   id: "portfolio-list",
@@ -43,20 +63,7 @@ export const portfolioListPlugin: GloomPlugin = {
       keywords: ["portfolio", "watchlist", "collection", "pane", "list"],
       shortcut: { prefix: "PF" },
       canCreate: (context) => resolveCollectionPaneId(context) !== null,
-      createInstance: (context) => {
-        const collectionId = resolveCollectionPaneId(context);
-        return collectionId
-          ? {
-            params: { collectionId },
-            settings: createPortfolioPaneSettings({
-              collectionScope: "custom",
-              visibleCollectionIds: [collectionId],
-              hideTabs: true,
-              lockedCollectionId: collectionId,
-            }) as unknown as Record<string, unknown>,
-          }
-          : null;
-      },
+      createInstance: (context) => createCollectionPaneInstance(context),
     },
     {
       id: "new-portfolio-pane",
@@ -65,19 +72,7 @@ export const portfolioListPlugin: GloomPlugin = {
       description: "Open another portfolio list pane",
       keywords: ["new", "portfolio", "pane", "list"],
       canCreate: (context) => context.config.portfolios.length > 0,
-      createInstance: (context) => {
-        const collectionId = context.activeCollectionId && context.config.portfolios.some((portfolio) => portfolio.id === context.activeCollectionId)
-          ? context.activeCollectionId
-          : (context.config.portfolios[0]?.id ?? null);
-        if (!collectionId) return null;
-        return {
-          params: { collectionId },
-          settings: createPortfolioPaneSettings({
-            collectionScope: "portfolios",
-            lockedCollectionId: collectionId,
-          }) as unknown as Record<string, unknown>,
-        };
-      },
+      createInstance: (context) => createCollectionPaneInstance(context, "portfolio"),
     },
     {
       id: "new-watchlist-pane",
@@ -86,19 +81,7 @@ export const portfolioListPlugin: GloomPlugin = {
       description: "Open another watchlist pane",
       keywords: ["new", "watchlist", "pane", "list"],
       canCreate: (context) => context.config.watchlists.length > 0,
-      createInstance: (context) => {
-        const collectionId = context.activeCollectionId && context.config.watchlists.some((watchlist) => watchlist.id === context.activeCollectionId)
-          ? context.activeCollectionId
-          : (context.config.watchlists[0]?.id ?? null);
-        if (!collectionId) return null;
-        return {
-          params: { collectionId },
-          settings: createPortfolioPaneSettings({
-            collectionScope: "watchlists",
-            lockedCollectionId: collectionId,
-          }) as unknown as Record<string, unknown>,
-        };
-      },
+      createInstance: (context) => createCollectionPaneInstance(context, "watchlist"),
     },
   ],
 };

--- a/src/plugins/builtin/portfolio-list/pane.tsx
+++ b/src/plugins/builtin/portfolio-list/pane.tsx
@@ -190,7 +190,7 @@ function sortTickers(
 }
 
 export function PortfolioListPane({ focused, width, height }: PaneProps) {
-  const { navigateTicker, pinTicker } = usePluginTickerActions();
+  const { pinTicker } = usePluginTickerActions();
   const paneInstance = usePaneInstance();
   const appActive = useAppActive();
   const config = useAppSelector((state) => state.config);
@@ -233,7 +233,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     () => resolveScopedCollectionEntries(collectionEntries, paneSettings),
     [collectionEntries, paneSettings],
   );
-  const activeCollectionId = resolveActiveCollectionId(currentCollectionId, visibleCollections, paneSettings);
+  const activeCollectionId = resolveActiveCollectionId(currentCollectionId, visibleCollections);
   const isPortfolioTab = getCollectionTypeFromConfig(config, activeCollectionId) === "portfolio";
   const currentPortfolio = useMemo(() => (
     isPortfolioTab
@@ -290,7 +290,8 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   const requestedDrawerHeight = showCashDrawer
     ? (cashDrawerExpanded ? Math.min(6, Math.max(3, 2 + accountState.visibleCashBalances.length)) : 1)
     : 0;
-  const headerHeight = paneSettings.hideTabs ? 0 : 1;
+  const showCollectionTabs = visibleCollections.length > 1;
+  const headerHeight = showCollectionTabs ? 1 : 0;
   const drawerHeight = showCashDrawer
     ? Math.min(requestedDrawerHeight, Math.max(1, height - (headerHeight + 2)))
     : 0;
@@ -326,10 +327,14 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     setSortPreference({ columnId, direction: "asc" });
   }, [activeSort.columnId, activeSort.direction, setSortPreference]);
 
+  const openTickerFloating = useCallback((symbol: string) => {
+    pinTicker(symbol, { floating: true, paneType: "ticker-detail" });
+  }, [pinTicker]);
+
   const handleRowActivate = useCallback((ticker: TickerRecord) => {
     flushCursorSymbol(ticker.metadata.ticker);
-    navigateTicker(ticker.metadata.ticker);
-  }, [flushCursorSymbol, navigateTicker]);
+    openTickerFloating(ticker.metadata.ticker);
+  }, [flushCursorSymbol, openTickerFloating]);
 
   const handleTableKeyDown = useCallback((event: DataTableKeyEvent) => {
     if (!focused) return;
@@ -342,7 +347,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       event.stopPropagation?.();
       const ticker = sortedTickers[safeSelectedIdx];
       if (ticker) {
-        pinTicker(ticker.metadata.ticker, { floating: true, paneType: "ticker-detail" });
+        openTickerFloating(ticker.metadata.ticker);
       }
       return true;
     }
@@ -354,7 +359,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       return true;
     }
 
-    if (!paneSettings.hideTabs && (key === "h" || key === "left")) {
+    if (showCollectionTabs && (key === "h" || key === "left")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       const previousCollection = visibleCollections[Math.max(currentTabIdx - 1, 0)];
@@ -362,7 +367,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       return true;
     }
 
-    if (!paneSettings.hideTabs && (key === "l" || key === "right")) {
+    if (showCollectionTabs && (key === "l" || key === "right")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       const nextCollection = visibleCollections[Math.min(currentTabIdx + 1, visibleCollections.length - 1)];
@@ -375,12 +380,12 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     cashDrawerExpanded,
     currentTabIdx,
     focused,
-    paneSettings.hideTabs,
-    pinTicker,
+    openTickerFloating,
     safeSelectedIdx,
     setCashDrawerExpanded,
     handleCollectionSelect,
     showCashDrawer,
+    showCollectionTabs,
     sortedTickers,
     visibleCollections,
   ]);
@@ -577,7 +582,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   return (
     <Box flexDirection="column" width={width} height={height}>
       <Box flexDirection="column" height={headerHeight}>
-        {!paneSettings.hideTabs && (
+        {showCollectionTabs && (
           <Box flexDirection="row" height={1}>
             <Box flexShrink={1} overflow="hidden">
               <Tabs

--- a/src/plugins/builtin/portfolio-list/settings.ts
+++ b/src/plugins/builtin/portfolio-list/settings.ts
@@ -7,10 +7,8 @@ export interface PortfolioPaneSettings {
   columnIds: string[];
   collectionScope: CollectionScope;
   visibleCollectionIds: string[];
-  hideTabs: boolean;
   hideHeader: boolean;
   hideCash: boolean;
-  lockedCollectionId: string;
   showSparklines?: boolean;
 }
 
@@ -95,13 +93,6 @@ function resolveCollectionOptions(entries: CollectionEntry[]): PaneSettingOption
   }));
 }
 
-function resolveLockedCollectionId(settings: PortfolioPaneSettings, visibleCollections: CollectionEntry[]): string {
-  if (visibleCollections.some((entry) => entry.id === settings.lockedCollectionId)) {
-    return settings.lockedCollectionId;
-  }
-  return visibleCollections[0]?.id ?? "";
-}
-
 export function getPortfolioPaneSettings(settings: Record<string, unknown> | undefined): PortfolioPaneSettings {
   const columnIds = Array.isArray(settings?.columnIds)
     ? settings.columnIds.filter((value): value is string => typeof value === "string")
@@ -114,25 +105,20 @@ export function getPortfolioPaneSettings(settings: Record<string, unknown> | und
     columnIds: columnIds.length > 0 ? columnIds : DEFAULT_PORTFOLIO_COLUMN_IDS,
     collectionScope: isCollectionScope(settings?.collectionScope) ? settings.collectionScope : "all",
     visibleCollectionIds,
-    hideTabs: settings?.hideTabs === true,
     hideHeader: settings?.hideHeader === true,
     hideCash: settings?.hideCash === true,
-    lockedCollectionId: typeof settings?.lockedCollectionId === "string" ? settings.lockedCollectionId : "",
     showSparklines: settings?.showSparklines === true,
   };
 }
 
-export function createPortfolioPaneSettings(overrides: Partial<PortfolioPaneSettings> = {}): PortfolioPaneSettings {
-  return {
-    columnIds: [...(overrides.columnIds ?? DEFAULT_PORTFOLIO_COLUMN_IDS)],
-    collectionScope: overrides.collectionScope ?? "all",
-    visibleCollectionIds: [...(overrides.visibleCollectionIds ?? [])],
-    hideTabs: overrides.hideTabs ?? false,
-    hideHeader: overrides.hideHeader ?? false,
-    hideCash: overrides.hideCash ?? false,
-    lockedCollectionId: overrides.lockedCollectionId ?? "",
-    showSparklines: overrides.showSparklines ?? false,
-  };
+export function cleanPortfolioPaneSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const nextSettings = { ...settings };
+  delete nextSettings.hideTabs;
+  delete nextSettings.lockedCollectionId;
+  if (nextSettings.collectionScope !== "custom") {
+    delete nextSettings.visibleCollectionIds;
+  }
+  return nextSettings;
 }
 
 export function getCollectionEntries(config: AppConfig): CollectionEntry[] {
@@ -161,16 +147,22 @@ export function resolveScopedCollectionEntries(entries: CollectionEntry[], setti
 export function resolveActiveCollectionId(
   currentCollectionId: string,
   visibleCollections: CollectionEntry[],
-  settings: PortfolioPaneSettings,
 ): string {
   if (visibleCollections.length === 0) return "";
-  if (settings.hideTabs) {
-    return resolveLockedCollectionId(settings, visibleCollections);
-  }
   if (visibleCollections.some((entry) => entry.id === currentCollectionId)) {
     return currentCollectionId;
   }
-  return resolveLockedCollectionId(settings, visibleCollections);
+  return visibleCollections[0]?.id ?? "";
+}
+
+export function resolvePortfolioPaneCollectionId(
+  config: AppConfig,
+  rawSettings: Record<string, unknown> | undefined,
+  currentCollectionId: string,
+): string {
+  const settings = getPortfolioPaneSettings(rawSettings);
+  const visibleCollections = resolveScopedCollectionEntries(getCollectionEntries(config), settings);
+  return resolveActiveCollectionId(currentCollectionId, visibleCollections);
 }
 
 export function resolveVisibleColumns(columnIds: string[], isPortfolioTab: boolean): ColumnConfig[] {
@@ -188,9 +180,7 @@ export function resolveVisibleColumns(columnIds: string[], isPortfolioTab: boole
 
 export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: PortfolioPaneSettings): PaneSettingsDef {
   const collectionEntries = getCollectionEntries(config);
-  const scopedEntries = resolveScopedCollectionEntries(collectionEntries, settings);
   const allCollectionOptions = resolveCollectionOptions(collectionEntries);
-  const lockedCollectionOptions = resolveCollectionOptions(scopedEntries.length > 0 ? scopedEntries : collectionEntries);
 
   const fields: PaneSettingsDef["fields"] = [
     {
@@ -223,12 +213,6 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
   }
 
   fields.push({
-    key: "hideTabs",
-    label: "Hide Tabs",
-    description: "Hide the collection tab bar and lock this pane to one collection.",
-    type: "toggle",
-  });
-  fields.push({
     key: "hideHeader",
     label: "Hide Header Bar",
     type: "toggle",
@@ -243,15 +227,6 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
     label: "Sparklines",
     type: "toggle",
   });
-
-  if (settings.hideTabs && lockedCollectionOptions.length > 0) {
-    fields.push({
-      key: "lockedCollectionId",
-      label: "Locked Collection",
-      type: "select",
-      options: lockedCollectionOptions,
-    });
-  }
 
   return {
     title: "Portfolio Pane Settings",

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -185,8 +185,6 @@ export const DEFAULT_LAYOUT: LayoutConfig = {
         columnIds: [...DEFAULT_PORTFOLIO_COLUMN_IDS],
         collectionScope: "all",
         visibleCollectionIds: [],
-        hideTabs: false,
-        lockedCollectionId: "main",
       },
       binding: { kind: "none" },
     },


### PR DESCRIPTION
## Summary
- Open tickers from portfolio and watchlist panes in new floating ticker-detail panes instead of retargeting existing detail panes.
- Remove portfolio pane hide-tab/locked-collection settings and auto-hide collection tabs when only one collection is visible.
- Normalize portfolio pane scope changes so switching back to all collections clears stale scoped settings and keeps the displayed collection valid.

## Validation
- `bun test src/components/command-bar/workflow-ops.test.ts src/plugins/builtin/portfolio-list.test.ts src/plugins/builtin/portfolio-list.test.tsx src/pane-settings.test.ts src/state/app-context.test.ts`
- `bun run build`
- `git diff --check origin/main..HEAD`

Note: the focused portfolio-list test still prints existing React `act(...)` warnings, but the suite passes.