### PR TITLE
Show Ctrl-based shortcut hints in the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,17 +169,18 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a shortcut or command n
 | Key | Action |
 |-----|--------|
 | `Ctrl+P` or `` ` `` | Open command bar |
-| `Cmd/Ctrl+,` | Open focused pane settings |
-| `Cmd/Ctrl+W` | Close focused pane |
-| `Cmd/Ctrl+Shift+D` | Dock or float focused pane |
-| `Cmd/Ctrl+Shift+O` | Pop out focused pane |
-| `Cmd/Ctrl+Shift+L` | Layout actions |
-| `Cmd/Ctrl+Shift+G` | Gridlock all windows |
+| `Ctrl+,` | Open focused pane settings |
+| `Ctrl+W` | Close focused pane |
+| `Ctrl+Shift+D` | Dock or float focused pane |
+| `Ctrl+Shift+L` | Layout actions |
+| `Ctrl+Shift+G` | Gridlock all windows |
 | `Tab` | Switch between panels |
 | `j` / `k` | Navigate ticker list |
 | `h` / `l` | Switch tabs |
 | `m` | Cycle chart mode in the chart tab |
 | `q` | Quit |
+
+Desktop builds also accept the matching `Cmd` shortcuts on macOS, plus `Cmd/Ctrl+Shift+O` to pop out a pane.
 
 ## License
 

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1,4 +1,4 @@
-import { AsciiText, Box, Input, Span, Strong, Text, Underline } from "../../ui";
+import { AsciiText, Box, Input, Span, Strong, Text, Underline, useUiHost } from "../../ui";
 import { useState, useCallback, useEffect, useRef, useMemo, type RefObject } from "react";
 import { useShortcut, useViewport } from "../../react/input";
 import { TextAttributes } from "../../ui";
@@ -12,7 +12,7 @@ import { resolveBrokerConfigFields, type BrokerAdapter, type BrokerConfigField }
 import { buildBrokerProfileConfig, validateBrokerProfileValues } from "../../brokers/profile-form";
 import { createBrokerInstanceId } from "../../utils/broker-instances";
 import { isBackNavigationKey, isPlainEscape } from "../../utils/back-navigation";
-import { detectShortcutPlatform, formatPrimaryShortcut } from "../../utils/shortcut-labels";
+import { detectShortcutPlatform, formatPrimaryShortcut, getShortcutDisplayMode } from "../../utils/shortcut-labels";
 import { syncBrokerInstance } from "../../brokers/sync-broker-instance";
 import { debugLog } from "../../utils/debug-log";
 import { ToggleList, type ToggleListItem } from "../toggle-list";
@@ -1199,8 +1199,10 @@ function ShortcutsStep({
   pluginRegistry: PluginRegistry;
   disabledPlugins: string[];
 }) {
+  const uiHost = useUiHost();
   const shortcutPlatform = detectShortcutPlatform();
-  const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform);
+  const shortcutDisplayMode = getShortcutDisplayMode(uiHost.kind);
+  const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform, shortcutDisplayMode);
   const keyboardShortcuts = [
     { key: "Ctrl+P / `", desc: "Open the command bar" },
     { key: "Tab", desc: "Switch between panels" },
@@ -1243,7 +1245,7 @@ function ShortcutsStep({
   return (
     <Box flexDirection="column" paddingX={2}>
       <Box height={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{"Useful shortcuts"}</Text>
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{"After launch shortcuts"}</Text>
       </Box>
       <Box height={1} />
 

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -1495,6 +1495,7 @@ describe("ChatContent", () => {
       },
       registerPane: () => {},
       registerPaneTemplate: () => {},
+      registerDetailTab: () => {},
       registerShortcut: () => {},
       registerCommand: (command: { id: string; wizardLayout?: string; wizard?: Array<{ key: string }> }) => {
         registeredCommands.push(command);

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -873,7 +873,7 @@ export function ChatContent({
           ) : (
             <>
               <Text fg={colors.positive}>Verify your email to send messages.</Text>
-              <Text fg={colors.textDim}>Ctrl+P: Resend Verification Email</Text>
+              <Text fg={colors.textDim}>Ctrl+P, then Resend Verification Email</Text>
             </>
           )}
         </Box>

--- a/src/plugins/builtin/help.test.tsx
+++ b/src/plugins/builtin/help.test.tsx
@@ -16,19 +16,22 @@ afterEach(() => {
   setSharedRegistryForTests(undefined);
 });
 
-async function renderHelpPane(runtime = createTestPluginRuntime()) {
+async function renderHelpPane(
+  runtime = createTestPluginRuntime(),
+  size = { width: 88, height: 36 },
+) {
   testSetup = await testRender(
     <PluginRenderProvider pluginId="help" runtime={runtime}>
       <HelpPane
         paneId="help:main"
         paneType="help"
         focused
-        width={88}
-        height={36}
+        width={size.width}
+        height={size.height}
         close={() => {}}
       />
     </PluginRenderProvider>,
-    { width: 88, height: 36 },
+    size,
   );
 
   await testSetup.renderOnce();
@@ -102,7 +105,7 @@ describe("HelpPane", () => {
       getShortcutPluginId: () => "gloomberb-cloud",
     } as any);
 
-    await renderHelpPane();
+    await renderHelpPane(createTestPluginRuntime(), { width: 88, height: 80 });
 
     const frame = testSetup!.captureCharFrame();
     expect(frame).toMatch(/AW\s+<ticker>/);
@@ -111,6 +114,13 @@ describe("HelpPane", () => {
     expect(frame).toContain("Add Alert (Alerts)");
     expect(frame).toContain("Shift+C");
     expect(frame).toContain("Toggle chat (Gloomberb Cloud)");
+    expect(frame).toContain("Ctrl+W");
+    expect(frame).toContain("Ctrl+,");
+    expect(frame).not.toContain("Ctrl+Shift+O");
+    expect(frame).not.toContain("Pop the focused pane");
+    expect(frame).not.toContain("Cmd+W");
+    expect(frame).not.toContain("Cmd+,");
+    expect(frame).not.toContain("Cmd+K");
     expect(frame).not.toContain("Cmd/Ctrl");
     expect(frame).not.toContain("CmdOrCtrl");
   });

--- a/src/plugins/builtin/help.tsx
+++ b/src/plugins/builtin/help.tsx
@@ -1,4 +1,4 @@
-import { Box, ScrollBox, Text } from "../../ui";
+import { Box, ScrollBox, Text, useUiHost } from "../../ui";
 import { TextAttributes } from "../../ui";
 import { useState } from "react";
 import type { ReactNode } from "react";
@@ -7,7 +7,7 @@ import { colors, hoverBg } from "../../theme/colors";
 import { getSharedRegistry } from "../registry";
 import { usePluginAppActions } from "../plugin-runtime";
 import { commands as coreCommands } from "../../components/command-bar/command-registry";
-import { detectShortcutPlatform, formatPrimaryShortcut } from "../../utils/shortcut-labels";
+import { detectShortcutPlatform, formatPrimaryShortcut, getShortcutDisplayMode } from "../../utils/shortcut-labels";
 
 function ShortcutBadge({ label }: { label: string }) {
   return (
@@ -219,8 +219,20 @@ export function HelpPane({ width, height }: PaneProps) {
   const commandShortcuts = resolveCommandShortcuts(registry);
   const pluginShortcuts = resolvePluginShortcuts(registry);
   const windowTemplates = resolveWindowTemplates(registry);
+  const uiHost = useUiHost();
+  const isDesktopWeb = uiHost.kind === "desktop-web";
   const shortcutPlatform = detectShortcutPlatform();
-  const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform);
+  const shortcutDisplayMode = getShortcutDisplayMode(uiHost.kind);
+  const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform, shortcutDisplayMode);
+  const commandBarBadges = shortcutDisplayMode === "terminal"
+    ? ["Ctrl+P", "`"]
+    : ["Ctrl+P", platformShortcut("K"), "`"];
+  const copyBadges = shortcutDisplayMode === "terminal"
+    ? ["Ctrl+Shift+C"]
+    : [platformShortcut("C")];
+  const pasteBadges = shortcutDisplayMode === "terminal"
+    ? ["Ctrl+Shift+V"]
+    : [platformShortcut("V")];
 
   const openDebugLog = () => {
     showWidget("debug");
@@ -272,7 +284,7 @@ export function HelpPane({ width, height }: PaneProps) {
 
           <HelpSection title="Command Bar">
             <ShortcutRow
-              badges={["Ctrl+P", "Cmd+K", "`"]}
+              badges={commandBarBadges}
               description="Open or toggle the command bar from anywhere."
               compact={compact}
             />
@@ -367,12 +379,12 @@ export function HelpPane({ width, height }: PaneProps) {
               compact={compact}
             />
             <ShortcutRow
-              badges={["Cmd+C", "Ctrl+Shift+C"]}
+              badges={copyBadges}
               description="Copy the active terminal selection."
               compact={compact}
             />
             <ShortcutRow
-              badges={["Cmd+V", "Ctrl+Shift+V"]}
+              badges={pasteBadges}
               description="Paste clipboard text into the active input."
               compact={compact}
             />
@@ -399,11 +411,13 @@ export function HelpPane({ width, height }: PaneProps) {
               description="Dock or float the focused pane."
               compact={compact}
             />
-            <ShortcutRow
-              badges={[platformShortcut(["Shift", "O"])]}
-              description="Pop the focused pane out to a desktop window."
-              compact={compact}
-            />
+            {isDesktopWeb && (
+              <ShortcutRow
+                badges={[platformShortcut(["Shift", "O"])]}
+                description="Pop the focused pane out to a desktop window."
+                compact={compact}
+              />
+            )}
             <ShortcutRow
               badges={[platformShortcut(["Shift", "L"])]}
               description="Open layout actions."

--- a/src/utils/shortcut-labels.test.ts
+++ b/src/utils/shortcut-labels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatPlatformShortcutLabel, formatPrimaryShortcut } from "./shortcut-labels";
+import { formatPlatformShortcutLabel, formatPrimaryShortcut, getShortcutDisplayMode } from "./shortcut-labels";
 
 describe("shortcut labels", () => {
   test("renders command-or-control shortcuts for the active platform", () => {
@@ -8,5 +8,12 @@ describe("shortcut labels", () => {
     expect(formatPlatformShortcutLabel("CmdOrCtrl+W", "win32")).toBe("Ctrl+W");
     expect(formatPrimaryShortcut(["Shift", "G"], "darwin")).toBe("Cmd+Shift+G");
     expect(formatPrimaryShortcut(",", "linux")).toBe("Ctrl+,");
+  });
+
+  test("renders terminal shortcuts with control even on macOS", () => {
+    const mode = getShortcutDisplayMode("opentui");
+    expect(formatPrimaryShortcut("W", "darwin", mode)).toBe("Ctrl+W");
+    expect(formatPlatformShortcutLabel("CmdOrCtrl+,", "darwin", mode)).toBe("Ctrl+,");
+    expect(getShortcutDisplayMode("desktop-web")).toBe("platform");
   });
 });

--- a/src/utils/shortcut-labels.ts
+++ b/src/utils/shortcut-labels.ts
@@ -1,4 +1,5 @@
 export type ShortcutPlatform = "darwin" | "win32" | "linux" | "unknown";
+export type ShortcutDisplayMode = "platform" | "terminal";
 
 function platformFromProcess(): ShortcutPlatform | null {
   const platform = (globalThis as { process?: { platform?: string } }).process?.platform;
@@ -35,22 +36,32 @@ export function isMacShortcutPlatform(platform: ShortcutPlatform = detectShortcu
   return platform === "darwin";
 }
 
-export function getPrimaryShortcutModifier(platform: ShortcutPlatform = detectShortcutPlatform()): "Cmd" | "Ctrl" {
+export function getShortcutDisplayMode(uiKind: "opentui" | "desktop-web" | undefined): ShortcutDisplayMode {
+  return uiKind === "opentui" ? "terminal" : "platform";
+}
+
+export function getPrimaryShortcutModifier(
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+  mode: ShortcutDisplayMode = "platform",
+): "Cmd" | "Ctrl" {
+  if (mode === "terminal") return "Ctrl";
   return isMacShortcutPlatform(platform) ? "Cmd" : "Ctrl";
 }
 
 export function formatPrimaryShortcut(
   keys: string | readonly string[],
   platform: ShortcutPlatform = detectShortcutPlatform(),
+  mode: ShortcutDisplayMode = "platform",
 ): string {
   const keyParts = typeof keys === "string" ? [keys] : keys;
-  return [getPrimaryShortcutModifier(platform), ...keyParts].join("+");
+  return [getPrimaryShortcutModifier(platform, mode), ...keyParts].join("+");
 }
 
 export function formatPlatformShortcutLabel(
   label: string,
   platform: ShortcutPlatform = detectShortcutPlatform(),
+  mode: ShortcutDisplayMode = "platform",
 ): string {
-  const primaryModifier = getPrimaryShortcutModifier(platform);
+  const primaryModifier = getPrimaryShortcutModifier(platform, mode);
   return label.replace(/Cmd\/Ctrl|CmdOrCtrl/g, primaryModifier);
 }


### PR DESCRIPTION
Updates shortcut labeling so the OpenTUI renderer shows Control-based paths on macOS while the desktop renderer keeps platform-native Command labels.
The help pane and onboarding shortcut screen now use the active renderer to decide labels, and TUI help no longer advertises the desktop-only pop-out shortcut.
The README matches the terminal shortcut surface and calls out desktop-only Command/pop-out behavior separately.
Also clarifies the chat verification prompt to route through the command bar and updates focused tests for these surfaces.
Validation: bun test src/utils/shortcut-labels.test.ts src/plugins/builtin/help.test.tsx src/components/onboarding/onboarding-wizard.test.tsx src/plugins/builtin/chat.test.tsx; bun test src/components/layout/shell.test.tsx --filter "resolves pane management shortcuts"; git diff --check; tmux onboarding smoke.
