### PR TITLE
Use ticker badges in table ticker columns

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export { StaticChartSurface } from "./chart/static-chart-surface";
 export type { QuoteFlashDirection } from "./ticker-list-table";
 export { TickerListTableView } from "./ticker-list-table-view";
 export type { TickerListVisibleRange } from "./ticker-list-table-view";
+export { TickerBadgeList } from "./ticker-badge-list";
 export { DataTableView } from "./data-table-view";
 export type { DataTableKeyEvent } from "./data-table-view";
 export { DataTableStackView } from "./data-table-stack-view";

--- a/src/components/ticker-badge-list.tsx
+++ b/src/components/ticker-badge-list.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { Box, Text, TextAttributes } from "../ui";
+import { colors } from "../theme/colors";
+import type { InlineTickerCatalogEntry } from "../state/use-inline-tickers";
+import { TickerBadge } from "./ticker-badge";
+
+export interface TickerBadgeListProps {
+  symbols: readonly string[];
+  width: number;
+  catalog: Record<string, InlineTickerCatalogEntry>;
+  fallbackColor?: string;
+  openTicker: (symbol: string) => void;
+}
+
+export function TickerBadgeList({
+  symbols,
+  width,
+  catalog,
+  fallbackColor = colors.textBright,
+  openTicker,
+}: TickerBadgeListProps) {
+  const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
+
+  return (
+    <Box flexDirection="row" width={width} height={1} overflow="hidden">
+      {symbols.map((symbol) => {
+        const entry = catalog[symbol];
+        if (entry?.status === "missing") {
+          return (
+            <Box key={symbol} paddingRight={1} flexShrink={0}>
+              <Text fg={fallbackColor} attributes={TextAttributes.BOLD}>{symbol}</Text>
+            </Box>
+          );
+        }
+
+        return (
+          <TickerBadge
+            key={symbol}
+            symbol={symbol}
+            status="ready"
+            quote={entry?.quote ?? null}
+            hovered={hoveredSymbol === symbol}
+            onHoverStart={() => setHoveredSymbol(symbol)}
+            onHoverEnd={() => {
+              setHoveredSymbol((current) => (current === symbol ? null : current));
+            }}
+            onOpen={openTicker}
+          />
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/components/ticker-badge.tsx
+++ b/src/components/ticker-badge.tsx
@@ -73,7 +73,7 @@ export function TickerBadge({
   const interactive = status === "ready";
 
   return (
-    <Box paddingRight={1}>
+    <Box paddingRight={1} flexShrink={0}>
       <Box
         paddingX={1}
         backgroundColor={backgroundColor}

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -28,6 +28,7 @@ export type DataTableColumn = Pick<
 
 export interface DataTableCell {
   text: string;
+  content?: ReactNode;
   color?: string;
   backgroundColor?: string;
   attributes?: number;
@@ -468,15 +469,19 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
                             }, event);
                           }}
                         >
-                          <Text
-                            attributes={cell.attributes ?? TextAttributes.NONE}
-                            fg={
-                              cell.color ??
-                              (selected ? colors.selectedText : colors.text)
-                            }
-                          >
-                            {padTo(cell.text, column.width, column.align)}
-                          </Text>
+                          {cell.content !== undefined ? (
+                            cell.content
+                          ) : (
+                            <Text
+                              attributes={cell.attributes ?? TextAttributes.NONE}
+                              fg={
+                                cell.color ??
+                                (selected ? colors.selectedText : colors.text)
+                              }
+                            >
+                              {padTo(cell.text, column.width, column.align)}
+                            </Text>
+                          )}
                         </Box>
                       );
                     })}

--- a/src/plugins/builtin/cloud-tweets.tsx
+++ b/src/plugins/builtin/cloud-tweets.tsx
@@ -7,6 +7,7 @@ import {
   EmptyState,
   SegmentedControl,
   Tabs,
+  TickerBadgeList,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
@@ -244,7 +245,7 @@ function tweetImageUrls(tweet: CloudTweetPayload): string[] {
 function buildTweetColumns(width: number): TweetColumn[] {
   const timeWidth = 7;
   const authorWidth = 16;
-  const tickersWidth = 14;
+  const tickersWidth = 24;
   const likesWidth = 7;
   const viewsWidth = 8;
   const textWidth = Math.max(
@@ -416,6 +417,19 @@ function TweetSearchTable({
   });
   const rows = useMemo(() => sortedTweets(data?.tweets ?? [], sort.columnId, sort.direction), [data?.tweets, sort]);
   const columns = useMemo(() => buildTweetColumns(width), [width]);
+  const tableTickerTexts = useMemo(() => {
+    const seen = new Set<string>();
+    const texts: string[] = [];
+    for (const tweet of rows) {
+      for (const symbol of tweetTickers(tweet)) {
+        if (seen.has(symbol)) continue;
+        seen.add(symbol);
+        texts.push(`$${symbol}`);
+      }
+    }
+    return texts;
+  }, [rows]);
+  const { catalog: tickerCatalog, openTicker } = useInlineTickers(tableTickerTexts);
   const selectedIndex = rows.findIndex((tweet) => tweet.id === selectedTweetId);
   const activeIndex = selectedIndex >= 0 ? selectedIndex : rows.length > 0 ? 0 : -1;
   const selectedTweet = rows[activeIndex] ?? null;
@@ -489,14 +503,28 @@ function TweetSearchTable({
         };
       case "text":
         return { text: normalizeTweetDisplayText(tweet.text), color: selectedColor ?? colors.text };
-      case "tickers":
-        return { text: tweetTickers(tweet).map((ticker) => `$${ticker}`).join(" "), color: selectedColor ?? colors.positive };
+      case "tickers": {
+        const tickers = tweetTickers(tweet);
+        return {
+          text: tickers.map((ticker) => `$${ticker}`).join(" "),
+          content: (
+            <TickerBadgeList
+              symbols={tickers}
+              width={column.width}
+              catalog={tickerCatalog}
+              fallbackColor={selectedColor ?? colors.positive}
+              openTicker={openTicker}
+            />
+          ),
+          color: selectedColor ?? colors.positive,
+        };
+      }
       case "likes":
         return { text: formatMetric(tweet.metrics.likes), color: selectedColor ?? colors.textDim };
       case "views":
         return { text: formatMetric(tweet.metrics.views), color: selectedColor ?? colors.textDim };
     }
-  }, []);
+  }, [openTicker, tickerCatalog]);
 
   const emptyContent = error && isAuthError(error)
     ? <CloudAuthNotice message={error} showSignup />

--- a/src/plugins/builtin/news-wire/news-table.test.tsx
+++ b/src/plugins/builtin/news-wire/news-table.test.tsx
@@ -198,7 +198,8 @@ describe("NewsArticleStackView", () => {
     });
 
     const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("NFLX PARA");
+    expect(frame).toContain("NFLX");
+    expect(frame).toContain("PARA");
     expect(frame).not.toContain("NFLX:XNAS");
     expect(frame).not.toContain("PARA:XNAS");
   });

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { TextAttributes } from "../../../ui";
 import {
   DataTableStackView,
+  TickerBadgeList,
   type DataTableCell,
   type DataTableColumn,
 } from "../../../components";
 import type { MarketNewsItem } from "../../../types/news-source";
 import { colors } from "../../../theme/colors";
 import { collectNewsDisplayTickers } from "../../../news/ticker-symbols";
+import { useInlineTickers } from "../../../state/use-inline-tickers";
 
 export type NewsColumnId = "rank" | "time" | "source" | "title" | "tickers" | "categories" | "importance";
 
@@ -102,7 +104,7 @@ function buildColumns(width: number, columnIds: NewsColumnId[]): NewsTableColumn
     rank: 4,
     time: 4,
     source: 10,
-    tickers: 10,
+    tickers: 24,
     categories: 10,
     importance: 5,
   };
@@ -173,6 +175,19 @@ export function NewsArticleStackView({
     () => sortNewsArticles(articles, sortPreference),
     [articles, sortPreference],
   );
+  const tableTickerTexts = useMemo(() => {
+    const seen = new Set<string>();
+    const texts: string[] = [];
+    for (const article of sortedArticles) {
+      for (const symbol of collectNewsDisplayTickers(article.tickers)) {
+        if (seen.has(symbol)) continue;
+        seen.add(symbol);
+        texts.push(`$${symbol}`);
+      }
+    }
+    return texts;
+  }, [sortedArticles]);
+  const { catalog: tickerCatalog, openTicker } = useInlineTickers(tableTickerTexts);
   const columns = useMemo(() => buildColumns(width, columnIds), [columnIds, width]);
   const selectedIdx = sortedArticles.findIndex((article) => article.id === selectedArticleId);
   const activeIdx = selectedIdx >= 0 ? selectedIdx : sortedArticles.length > 0 ? 0 : -1;
@@ -223,11 +238,22 @@ export function NewsArticleStackView({
             ? TextAttributes.NONE
             : TextAttributes.BOLD,
         };
-      case "tickers":
+      case "tickers": {
+        const tickers = collectNewsDisplayTickers(item.tickers);
         return {
-          text: collectNewsDisplayTickers(item.tickers).join(" "),
+          text: tickers.join(" "),
+          content: (
+            <TickerBadgeList
+              symbols={tickers}
+              width={column.width}
+              catalog={tickerCatalog}
+              fallbackColor={selectedColor ?? colors.textBright}
+              openTicker={openTicker}
+            />
+          ),
           color: selectedColor ?? colors.textBright,
         };
+      }
       case "categories":
         return { text: item.categories[0] ?? "—", color: selectedColor ?? colors.textDim };
       case "importance":
@@ -236,7 +262,7 @@ export function NewsArticleStackView({
           color: selectedColor ?? (item.importance >= 80 ? colors.positive : colors.textDim),
         };
     }
-  }, [readArticleIds, titleForArticle]);
+  }, [openTicker, readArticleIds, tickerCatalog, titleForArticle]);
 
   return (
     <DataTableStackView<MarketNewsItem, NewsTableColumn>

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -420,16 +420,30 @@ function WebDataTableRowInner<
               onActivateRow?.(item, index);
             }}
           >
-            <span
-              title={cell.text}
-              style={clippedCellTextStyle(
-                column,
-                cell.color ?? (selected ? colors.selectedText : colors.text),
-                cell.attributes ?? TextAttributes.NONE,
-              )}
-            >
-              {cell.text}
-            </span>
+            {cell.content !== undefined ? (
+              <div
+                title={cell.text}
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  minWidth: 0,
+                  overflow: "hidden",
+                }}
+              >
+                {cell.content}
+              </div>
+            ) : (
+              <span
+                title={cell.text}
+                style={clippedCellTextStyle(
+                  column,
+                  cell.color ?? (selected ? colors.selectedText : colors.text),
+                  cell.attributes ?? TextAttributes.NONE,
+                )}
+              >
+                {cell.text}
+              </span>
+            )}
           </div>
         );
       })}


### PR DESCRIPTION
Uses the shared ticker badge component for ticker columns in the news wire and cloud tweet tables, with a reusable TickerBadgeList and DataTableCell.content support in both terminal and Electrobun table renderers. Ticker columns are widened so the badge keeps the percent change visible and remains clickable through the existing inline ticker resolver. Validation passed for focused table/ticker tests, desktop view build, packaged build/sign/smoke, and a tmux terminal smoke. Full bun test currently has unrelated chat/broker/analytics plugin-context harness failures, while the focused PR tests pass.