### PR TITLE
Fix TUI pane menus and help layout

### DIFF
--- a/src/components/layout/pane-header.test.tsx
+++ b/src/components/layout/pane-header.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../renderers/opentui/test-utils";
+import { PaneHeader } from "./pane-header";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+});
+
+describe("PaneHeader", () => {
+  test("fires the terminal action handler from the visible action text", async () => {
+    let actions = 0;
+    testSetup = await testRender(
+      <PaneHeader
+        title="Portfolio"
+        width={40}
+        focused
+        showActions
+        onActionMouseDown={() => { actions += 1; }}
+      />,
+      { width: 40, height: 3 },
+    );
+
+    await testSetup.renderOnce();
+    const actionCol = testSetup.captureCharFrame().split("\n")[0]?.indexOf("...");
+    expect(actionCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(actionCol! + 1, 0);
+    });
+
+    expect(actions).toBe(1);
+  });
+});

--- a/src/components/layout/pane-header.tsx
+++ b/src/components/layout/pane-header.tsx
@@ -66,6 +66,31 @@ function DesktopPaneButton({
   );
 }
 
+function TerminalPaneButton({
+  text,
+  fg,
+  role,
+  onMouseDown,
+}: {
+  text: string;
+  fg: string;
+  role: string;
+  onMouseDown?: (event: any) => void;
+}) {
+  return (
+    <Box
+      height={1}
+      width={text.length}
+      flexDirection="row"
+      data-gloom-role={role}
+      data-gloom-interactive={onMouseDown ? "true" : undefined}
+      onMouseDown={onMouseDown}
+    >
+      <Text fg={fg} selectable={false}>{text}</Text>
+    </Box>
+  );
+}
+
 export function PaneHeader({
   title,
   width,
@@ -174,7 +199,20 @@ export function PaneHeader({
         <Text fg={bc} selectable={false}>{"┌─"}</Text>
         <Text fg={textColor} selectable={false}>{`${PANE_HEADER_GRIP}${clippedTitle}`}</Text>
         <Text fg={bc} selectable={false}>{fill}</Text>
-        <Text fg={textColor} selectable={false}>{`${actionText}${closeText}`}</Text>
+        <TerminalPaneButton
+          text={actionText}
+          fg={textColor}
+          role="pane-action"
+          onMouseDown={onActionMouseDown}
+        />
+        {floating && (
+          <TerminalPaneButton
+            text={closeText}
+            fg={textColor}
+            role="pane-close"
+            onMouseDown={onCloseMouseDown}
+          />
+        )}
         <Text fg={bc} selectable={false}>{"─┐"}</Text>
       </Box>
     );
@@ -187,8 +225,22 @@ export function PaneHeader({
   return (
     <Box height={PANE_HEADER_HEIGHT} width={width} backgroundColor={backgroundColor} flexDirection="row">
       <Text fg={textColor} selectable={false}>
-        {`${PANE_HEADER_GRIP}${clippedTitle}${padding}${actionText}${closeText}`}
+        {`${PANE_HEADER_GRIP}${clippedTitle}${padding}`}
       </Text>
+      <TerminalPaneButton
+        text={actionText}
+        fg={textColor}
+        role="pane-action"
+        onMouseDown={onActionMouseDown}
+      />
+      {floating && (
+        <TerminalPaneButton
+          text={closeText}
+          fg={textColor}
+          role="pane-close"
+          onMouseDown={onCloseMouseDown}
+        />
+      )}
     </Box>
   );
 }

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -621,12 +621,17 @@ describe("Shell", () => {
     );
 
     await testSetup.renderOnce();
+    const actionCol = testSetup.captureCharFrame().split("\n")[0]?.indexOf("...");
+    expect(actionCol).toBeGreaterThanOrEqual(0);
     await act(async () => {
-      await testSetup!.mockMouse.click(37, 1);
+      await testSetup!.mockMouse.click(actionCol! + 1, 1);
     });
     await testSetup.renderOnce();
 
-    expect(testSetup.captureCharFrame()).toContain("Settings");
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Settings");
+    expect(frame).toContain("Ctrl+,");
+    expect(frame).not.toContain("CmdOrCtrl");
   });
 
   test("shows a Pop Out action in the pane menu when a desktop bridge is available", async () => {
@@ -666,12 +671,55 @@ describe("Shell", () => {
     );
 
     await testSetup.renderOnce();
+    const floatingActionCol = testSetup.captureCharFrame().split("\n")[0]?.indexOf("...");
+    expect(floatingActionCol).toBeGreaterThanOrEqual(0);
     await act(async () => {
-      await testSetup!.mockMouse.click(37, 1);
+      await testSetup!.mockMouse.click(floatingActionCol! + 1, 1);
     });
     await testSetup.renderOnce();
 
     expect(testSetup.captureCharFrame()).toContain("Pop Out");
+  });
+
+  test("shows the pane menu above a high z-index floating pane", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+    if (!detailPane) throw new Error("missing default detail pane");
+
+    const floatingOnlyLayout = {
+      dockRoot: null,
+      instances: [{ ...detailPane }],
+      floating: [{ instanceId: "ticker-detail:main", x: 0, y: 0, width: 40, height: 8, zIndex: 195 }],
+    };
+    const nextConfig = {
+      ...config,
+      layout: cloneLayout(floatingOnlyLayout),
+      layouts: [{ name: "Default", layout: cloneLayout(floatingOnlyLayout) }],
+    };
+    const state = {
+      ...createInitialState(nextConfig),
+      focusedPaneId: "ticker-detail:main",
+    };
+    const pluginRegistry = createShellPluginRegistry();
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <DialogProvider dialogOptions={{ style: { backgroundColor: "#000000", borderColor: "#ffffff", borderStyle: "single" } }}>
+          <Shell pluginRegistry={pluginRegistry} />
+        </DialogProvider>
+      </AppContext>,
+      { width: 40, height: 10 },
+    );
+
+    await testSetup.renderOnce();
+    const highZActionCol = testSetup.captureCharFrame().split("\n")[0]?.indexOf("...");
+    expect(highZActionCol).toBeGreaterThanOrEqual(0);
+    await act(async () => {
+      await testSetup!.mockMouse.click(highZActionCol! + 1, 1);
+    });
+    await testSetup.renderOnce();
+
+    expect(testSetup.captureCharFrame()).toContain("Dock Pane");
   });
 
   test("applies a chart resolution chip on the first click even when the chart pane is unfocused", async () => {

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,4 +1,4 @@
-import { AsciiText, Box, Text, useContextMenu } from "../../ui";
+import { AsciiText, Box, Text, compactContextMenuItems, useContextMenu, useUiHost } from "../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNativeRenderer, useRendererHost, useUiCapabilities } from "../../ui";
 import { useShortcut, useViewport, type KeyEventLike } from "../../react/input";
@@ -55,6 +55,11 @@ import { getPaneBodyHeight, getPaneBodyWidth, shouldReservePaneFooter } from "./
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX } from "./titlebar-overlay";
 import { capturePaneScreenshotPngBase64 } from "../../utils/dom-screenshot";
+import {
+  formatPlatformShortcutLabel,
+  getShortcutDisplayMode,
+  type ShortcutDisplayMode,
+} from "../../utils/shortcut-labels";
 
 interface ShellProps {
   pluginRegistry: PluginRegistry;
@@ -100,7 +105,8 @@ interface ActionMenuState {
   paneId: string;
   x: number;
   y: number;
-  items: Array<{ id: string; label: string; action: () => void }>;
+  width: number;
+  items: Array<{ id: string; label: string; accelerator?: string; action: () => void }>;
 }
 
 interface FloatingPreviewRect {
@@ -172,7 +178,9 @@ interface ShellMouseEvent {
 }
 
 const DEFAULT_HEADER_HEIGHT = 1;
-const MENU_WIDTH = 18;
+const MENU_MIN_WIDTH = 18;
+const MENU_MAX_WIDTH = 44;
+const MENU_Z_INDEX = 10_000;
 const PANE_DRAG_THRESHOLD = 2;
 const PRECISE_PANE_DRAG_THRESHOLD = 0.15;
 const PANE_MANAGEMENT_ACCELERATORS = {
@@ -686,16 +694,40 @@ function menuForPane(
   return baseActions;
 }
 
-function menuItemsForFallback(items: ContextMenuItem[]): Array<{ id: string; label: string; action: () => void }> {
+function menuItemsForFallback(
+  items: ContextMenuItem[],
+  shortcutDisplayMode: ShortcutDisplayMode,
+): Array<{ id: string; label: string; accelerator?: string; action: () => void }> {
   return items.flatMap((item) => {
     if (item.type === "divider" || item.type === "role" || item.enabled === false || item.hidden === true) return [];
     if (!item.onSelect) return [];
     return [{
       id: item.id,
       label: item.label,
+      accelerator: item.accelerator
+        ? formatPlatformShortcutLabel(item.accelerator, undefined, shortcutDisplayMode)
+        : undefined,
       action: () => { void item.onSelect?.(); },
     }];
   });
+}
+
+function actionMenuWidth(
+  items: Array<{ label: string; accelerator?: string }>,
+  availableWidth: number,
+): number {
+  const requested = Math.max(
+    MENU_MIN_WIDTH,
+    ...items.map((item) => item.label.length + (item.accelerator ? item.accelerator.length + 3 : 0) + 2),
+  );
+  return Math.max(MENU_MIN_WIDTH, Math.min(MENU_MAX_WIDTH, availableWidth, requested));
+}
+
+function truncateMenuText(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (text.length <= width) return text;
+  if (width <= 3) return ".".repeat(width);
+  return `${text.slice(0, width - 3)}...`;
 }
 
 function resolveExternalDockPreview(
@@ -748,6 +780,8 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   const statusBarVisible = useAppSelector(selectStatusBarVisible);
   const renderer = useNativeRenderer();
   const rendererHost = useRendererHost();
+  const uiKind = useUiHost().kind;
+  const shortcutDisplayMode = getShortcutDisplayMode(uiKind);
   const { nativePaneChrome, nativeContextMenu, precisePointer, titleBarOverlay, cellHeightPx } = useUiCapabilities();
   const { showContextMenu } = useContextMenu();
   const { width, height } = useViewport();
@@ -764,6 +798,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     setHoveredPaneId((current) => (current === paneId ? current : paneId));
   }, []);
   const [menuState, setMenuState] = useState<ActionMenuState | null>(null);
+  const [hoveredMenuItemId, setHoveredMenuItemId] = useState<string | null>(null);
   const overlayOpen = commandBarOpen || dialogOpen || !!menuState;
 
   const dragRef = useRef<DragMode | null>(null);
@@ -848,10 +883,12 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   const openPaneSettings = useCallback((paneId: string) => {
     pluginRegistry.openPaneSettingsFn(paneId);
     setMenuState(null);
+    setHoveredMenuItemId(null);
   }, [pluginRegistry]);
 
   const copyPaneScreenshot = useCallback(async (paneId: string) => {
     setMenuState(null);
+    setHoveredMenuItemId(null);
     try {
       await new Promise((resolve) => setTimeout(resolve, 0));
       if (!rendererHost.copyPngImage) {
@@ -1047,6 +1084,13 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     const pane = paneMap.get(paneId);
     if (!pane) return;
     focusPane(paneId);
+    const context = {
+      kind: "pane" as const,
+      paneId,
+      paneType: pane.instance.paneId,
+      title: getPaneTitle(pane),
+      floating: !!pane.floating,
+    };
     const items = menuForPane(
       pane,
       visibleLayout,
@@ -1059,26 +1103,29 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
       desktopWindowBridge,
       nativePaneChrome && rendererHost.copyPngImage ? copyPaneScreenshot : undefined,
     );
-    void showContextMenu({
-      kind: "pane",
-      paneId,
-      paneType: pane.instance.paneId,
-      title: getPaneTitle(pane),
-      floating: !!pane.floating,
-    }, items, event).then((shown) => {
+    void showContextMenu(context, items, event).then((shown) => {
       if (shown) return;
-      const fallbackItems = menuItemsForFallback(items);
+      const pluginItems = pluginRegistry.getContextMenuItems?.(context) ?? [];
+      const fallbackSourceItems = compactContextMenuItems([
+        ...items,
+        ...(items.length > 0 && pluginItems.length > 0 ? [contextMenuDivider(`${context.kind}:plugin-divider`)] : []),
+        ...pluginItems,
+      ]);
+      const fallbackItems = menuItemsForFallback(fallbackSourceItems, shortcutDisplayMode);
       if (fallbackItems.length === 0) return;
-      const menuX = Math.max(0, Math.min(width - MENU_WIDTH, rect.x + Math.max(0, rect.width - MENU_WIDTH)));
+      const menuWidth = actionMenuWidth(fallbackItems, width);
+      const menuX = Math.max(0, Math.min(width - menuWidth, rect.x + Math.max(0, rect.width - menuWidth)));
       const menuY = Math.max(0, Math.min(contentHeight - 1, rect.y + 1));
+      setHoveredMenuItemId(fallbackItems[0]?.id ?? null);
       setMenuState({
         paneId,
         x: menuX,
         y: menuY,
+        width: menuWidth,
         items: fallbackItems,
       });
     });
-  }, [contentHeight, copyPaneScreenshot, desktopWindowBridge, focusPane, getPaneTitle, nativePaneChrome, openPaneSettings, paneMap, persistLayout, pluginRegistry, rendererHost.copyPngImage, showContextMenu, visibleLayout, width]);
+  }, [contentHeight, copyPaneScreenshot, desktopWindowBridge, focusPane, getPaneTitle, nativePaneChrome, openPaneSettings, paneMap, persistLayout, pluginRegistry, rendererHost.copyPngImage, shortcutDisplayMode, showContextMenu, visibleLayout, width]);
 
   const handleFloatingClose = useCallback((paneId: string) => {
     persistLayout(removePane(visibleLayout, paneId));
@@ -1232,6 +1279,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     if (event.type === "down") {
       if (menuState) {
         setMenuState(null);
+        setHoveredMenuItemId(null);
       }
 
       for (const { pane, rect: visibleRect } of [...visibleFloatingPanes].sort((a, b) => (b.pane.floating?.zIndex ?? 50) - (a.pane.floating?.zIndex ?? 50))) {
@@ -1401,7 +1449,10 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   }), [appHeaderHeight]);
 
   const focusNativePane = useCallback((paneId: string) => {
-    if (menuState) setMenuState(null);
+    if (menuState) {
+      setMenuState(null);
+      setHoveredMenuItemId(null);
+    }
     focusPane(paneId);
   }, [focusPane, menuState]);
 
@@ -1460,7 +1511,10 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   const startNativeDividerDrag = useCallback((divider: DockDividerLayout, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
     const pointer = getShellPointer(event);
-    if (menuState) setMenuState(null);
+    if (menuState) {
+      setMenuState(null);
+      setHoveredMenuItemId(null);
+    }
     dragRef.current = {
       type: "divider",
       path: divider.path,
@@ -1482,7 +1536,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     handleActiveDrag(event);
   }, [handleActiveDrag]);
 
-  const handleNativePaneAction = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
+  const handlePaneAction = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
     if (event.button === 2) return;
     event.stopPropagation();
     event.preventDefault();
@@ -1493,7 +1547,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     openPaneMenu(paneId, rect, event);
   }, [openPaneMenu]);
 
-  const handleNativeFloatingClose = useCallback((paneId: string, event: ShellMouseEvent) => {
+  const handleFloatingCloseMouseDown = useCallback((paneId: string, event: ShellMouseEvent) => {
     event.stopPropagation();
     event.preventDefault();
     handleFloatingClose(paneId);
@@ -1558,7 +1612,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
                     onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
                     onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
                     onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(leaf.instanceId, leaf.rect, event) : undefined}
-                    onActionMouseDown={nativePaneChrome ? (event) => handleNativePaneAction(leaf.instanceId, leaf.rect, event) : undefined}
+                    onActionMouseDown={(event) => handlePaneAction(leaf.instanceId, leaf.rect, event)}
                   >
                     <PaneContent
                       component={pane.def.component}
@@ -1606,8 +1660,8 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
                   onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
                   onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
                   onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(pane.instance.instanceId, preview, event) : undefined}
-                  onActionMouseDown={nativePaneChrome ? (event) => handleNativePaneAction(pane.instance.instanceId, preview, event) : undefined}
-                  onCloseMouseDown={nativePaneChrome ? (event) => handleNativeFloatingClose(pane.instance.instanceId, event) : undefined}
+                  onActionMouseDown={(event) => handlePaneAction(pane.instance.instanceId, preview, event)}
+                  onCloseMouseDown={(event) => handleFloatingCloseMouseDown(pane.instance.instanceId, event)}
                   onResizeMouseDown={nativePaneChrome ? (event) => startNativeFloatResize(pane.instance.instanceId, preview, event) : undefined}
                   onResizeMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
                   onResizeMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
@@ -1759,30 +1813,46 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
           position="absolute"
           left={menuState.x}
           top={menuState.y}
-          width={MENU_WIDTH}
+          width={menuState.width}
           height={menuState.items.length + 2}
           backgroundColor={colors.panel}
           border
           borderStyle="single"
           borderColor={colors.borderFocused}
-          zIndex={99}
+          zIndex={MENU_Z_INDEX}
           flexDirection="column"
         >
-          {menuState.items.map((item) => (
-            <Box
-              key={item.id}
-              height={1}
-              paddingLeft={1}
-              onMouseDown={(mouseEvent: any) => {
-                mouseEvent.stopPropagation();
-                mouseEvent.preventDefault();
-                setMenuState(null);
-                item.action();
-              }}
-            >
-              <Text fg={colors.text}>{item.label}</Text>
-            </Box>
-          ))}
+          {menuState.items.map((item) => {
+            const hovered = hoveredMenuItemId === item.id;
+            const innerWidth = Math.max(1, menuState.width - 2);
+            const accelerator = item.accelerator ?? "";
+            const acceleratorWidth = accelerator.length;
+            const labelWidth = accelerator ? Math.max(1, innerWidth - acceleratorWidth - 1) : innerWidth;
+            const label = truncateMenuText(item.label, labelWidth);
+            const spacer = accelerator ? " ".repeat(Math.max(1, innerWidth - label.length - acceleratorWidth)) : "";
+            const line = truncateMenuText(`${label}${spacer}${accelerator}`, innerWidth).padEnd(innerWidth, " ");
+            return (
+              <Box
+                key={item.id}
+                height={1}
+                width={innerWidth}
+                backgroundColor={hovered ? colors.selected : colors.panel}
+                onMouseMove={() => setHoveredMenuItemId(item.id)}
+                onMouseDown={(mouseEvent: any) => {
+                  mouseEvent.stopPropagation();
+                  mouseEvent.preventDefault();
+                  setMenuState(null);
+                  setHoveredMenuItemId(null);
+                  item.action();
+                }}
+                data-gloom-interactive="true"
+              >
+                <Text fg={hovered ? colors.selectedText : colors.text}>
+                  {line}
+                </Text>
+              </Box>
+            );
+          })}
         </Box>
       )}
     </Box>

--- a/src/plugins/builtin/help.test.tsx
+++ b/src/plugins/builtin/help.test.tsx
@@ -125,6 +125,21 @@ describe("HelpPane", () => {
     expect(frame).not.toContain("CmdOrCtrl");
   });
 
+  test("keeps shortcuts and descriptions on the same row when narrow", async () => {
+    await renderHelpPane(createTestPluginRuntime(), { width: 70, height: 80 });
+
+    const lines = testSetup!.captureCharFrame().split("\n").map(withoutScrollbar);
+    const closeCommandRow = lines.findIndex((line) => line.includes("Close the command bar."));
+    const securityDetailsRow = lines.findIndex((line) => line.includes("Open security details"));
+
+    expect(closeCommandRow).toBeGreaterThanOrEqual(0);
+    expect(lines[closeCommandRow]).toContain("Esc");
+    expect(lines[closeCommandRow]).toContain("`");
+    expect(securityDetailsRow).toBeGreaterThanOrEqual(0);
+    expect(lines[securityDetailsRow]).toContain("DES");
+    expect(lines[securityDetailsRow]).toContain("<ticker>");
+  });
+
   test("opens the debug log from the mouse action", async () => {
     const calls: string[] = [];
     const runtime = createTestPluginRuntime({

--- a/src/plugins/builtin/help.tsx
+++ b/src/plugins/builtin/help.tsx
@@ -22,14 +22,12 @@ function ShortcutBadge({ label }: { label: string }) {
 function ShortcutRow({
   badges,
   description,
-  compact,
 }: {
   badges: string[];
   description: string;
-  compact: boolean;
 }) {
   return (
-    <Box flexDirection={compact ? "column" : "row"} gap={1}>
+    <Box flexDirection="row" gap={1}>
       <Box flexDirection="row" gap={1} flexShrink={0}>
         {badges.map((badge) => <ShortcutBadge key={badge} label={badge} />)}
       </Box>
@@ -214,7 +212,6 @@ function resolvePluginShortcuts(registry: ReturnType<typeof getSharedRegistry>):
 export function HelpPane({ width, height }: PaneProps) {
   const registry = getSharedRegistry();
   const { openCommandBar, showWidget } = usePluginAppActions();
-  const compact = width < 78;
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
   const commandShortcuts = resolveCommandShortcuts(registry);
   const pluginShortcuts = resolvePluginShortcuts(registry);
@@ -258,7 +255,7 @@ export function HelpPane({ width, height }: PaneProps) {
             </Box>
           </Box>
 
-          <Box flexDirection={compact ? "column" : "row"} gap={1}>
+          <Box flexDirection="row" gap={1}>
             <ActionButton
               id="debug"
               label="Open Debug Log"
@@ -286,32 +283,26 @@ export function HelpPane({ width, height }: PaneProps) {
             <ShortcutRow
               badges={commandBarBadges}
               description="Open or toggle the command bar from anywhere."
-              compact={compact}
             />
             <ShortcutRow
               badges={["<ticker>"]}
               description="Search for a ticker or open the best matching security."
-              compact={compact}
             />
             <ShortcutRow
               badges={["Up/Down", "Ctrl+P/N"]}
               description="Move through command bar results."
-              compact={compact}
             />
             <ShortcutRow
               badges={["Enter", "Shift+Enter"]}
               description="Run the selected result or its secondary action."
-              compact={compact}
             />
             <ShortcutRow
               badges={["Tab"]}
               description="Accept an inferred shortcut argument from the focused ticker."
-              compact={compact}
             />
             <ShortcutRow
               badges={["Esc", "`"]}
               description="Close the command bar."
-              compact={compact}
             />
           </HelpSection>
 
@@ -321,7 +312,6 @@ export function HelpPane({ width, height }: PaneProps) {
                 key={shortcut.id}
                 badges={shortcut.badges}
                 description={shortcut.description}
-                compact={compact}
               />
             ))}
           </HelpSection>
@@ -332,7 +322,6 @@ export function HelpPane({ width, height }: PaneProps) {
                 key={template.id}
                 badges={template.badges}
                 description={template.description}
-                compact={compact}
               />
             )) : (
               <Text fg={colors.textDim}>No shortcut window templates are currently registered.</Text>
@@ -346,7 +335,6 @@ export function HelpPane({ width, height }: PaneProps) {
                   key={shortcut.id}
                   badges={shortcut.badges}
                   description={shortcut.description}
-                  compact={compact}
                 />
               ))}
             </HelpSection>
@@ -356,42 +344,34 @@ export function HelpPane({ width, height }: PaneProps) {
             <ShortcutRow
               badges={["Tab", "Shift+Tab"]}
               description="Move focus between panes and floating windows."
-              compact={compact}
             />
             <ShortcutRow
               badges={["Ctrl+1-9"]}
               description="Switch saved layouts by number."
-              compact={compact}
             />
             <ShortcutRow
               badges={["r", "Shift+R"]}
               description="Refresh the focused ticker or refresh everything."
-              compact={compact}
             />
             <ShortcutRow
               badges={["a"]}
               description="Open ticker actions for the focused ticker."
-              compact={compact}
             />
             <ShortcutRow
               badges={["q"]}
               description="Quit the terminal app."
-              compact={compact}
             />
             <ShortcutRow
               badges={copyBadges}
               description="Copy the active terminal selection."
-              compact={compact}
             />
             <ShortcutRow
               badges={pasteBadges}
               description="Paste clipboard text into the active input."
-              compact={compact}
             />
             <ShortcutRow
               badges={["u"]}
               description="Install an available app update when one is shown."
-              compact={compact}
             />
           </HelpSection>
 
@@ -399,39 +379,32 @@ export function HelpPane({ width, height }: PaneProps) {
             <ShortcutRow
               badges={[platformShortcut("W")]}
               description="Close the focused pane, docked or floating."
-              compact={compact}
             />
             <ShortcutRow
               badges={[platformShortcut(",")]}
               description="Edit settings for the focused pane."
-              compact={compact}
             />
             <ShortcutRow
               badges={[platformShortcut(["Shift", "D"])]}
               description="Dock or float the focused pane."
-              compact={compact}
             />
             {isDesktopWeb && (
               <ShortcutRow
                 badges={[platformShortcut(["Shift", "O"])]}
                 description="Pop the focused pane out to a desktop window."
-                compact={compact}
               />
             )}
             <ShortcutRow
               badges={[platformShortcut(["Shift", "L"])]}
               description="Open layout actions."
-              compact={compact}
             />
             <ShortcutRow
               badges={[platformShortcut(["Shift", "G"])]}
               description="Gridlock all windows."
-              compact={compact}
             />
             <ShortcutRow
               badges={["Esc"]}
               description="Cancel an active pane drag."
-              compact={compact}
             />
           </HelpSection>
 

--- a/src/renderers/opentui/dialog-host.test.tsx
+++ b/src/renderers/opentui/dialog-host.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, expect, test } from "bun:test";
+import { act, useEffect, useState } from "react";
+import { useDialog } from "../../ui/dialog";
+import { testRender } from "./test-utils";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+});
+
+function NestedDialogContent() {
+  useDialog();
+  return <text>Nested dialog context works</text>;
+}
+
+function DialogProbe() {
+  const dialog = useDialog();
+  const [opened, setOpened] = useState(false);
+
+  useEffect(() => {
+    if (opened) return;
+    setOpened(true);
+    void dialog.alert({
+      content: () => <NestedDialogContent />,
+    });
+  }, [dialog, opened]);
+
+  return <text>Dialog probe</text>;
+}
+
+test("provides dialog context to OpenTUI dialog content", async () => {
+  testSetup = await testRender(<DialogProbe />, { width: 80, height: 16 });
+
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+
+  expect(testSetup.captureCharFrame()).toContain("Nested dialog context works");
+});

--- a/src/renderers/opentui/dialog-host.tsx
+++ b/src/renderers/opentui/dialog-host.tsx
@@ -1,14 +1,37 @@
 import type { ReactNode } from "react";
+import { useMemo } from "react";
 import {
   DialogProvider as OpenTuiDialogProvider,
   useDialog as useOpenTuiDialog,
   useDialogState as useOpenTuiDialogState,
 } from "@opentui-ui/dialog/react";
-import { DialogHostProvider } from "../../ui/dialog";
+import { DialogHostProvider, type DialogApi } from "../../ui/dialog";
+
+function renderDialogContent(content: unknown, context: Record<string, unknown>): ReactNode {
+  return typeof content === "function"
+    ? (content as (context: Record<string, unknown>) => ReactNode)(context)
+    : content as ReactNode;
+}
 
 function OpenTuiDialogBridge({ children }: { children: ReactNode }) {
-  const dialog = useOpenTuiDialog();
+  const openTuiDialog = useOpenTuiDialog();
   const isOpen = useOpenTuiDialogState((state) => state.isOpen);
+  const dialog = useMemo<DialogApi>(() => {
+    const wrapOptions = (options: Record<string, unknown>) => ({
+      ...options,
+      content: (context: Record<string, unknown>) => (
+        <DialogHostProvider dialog={dialog} isOpen={true}>
+          {renderDialogContent(options.content, context)}
+        </DialogHostProvider>
+      ),
+    });
+
+    return {
+      alert: (options) => openTuiDialog.alert(wrapOptions(options)),
+      prompt: (options) => openTuiDialog.prompt(wrapOptions(options)),
+    };
+  }, [openTuiDialog]);
+
   return (
     <DialogHostProvider dialog={dialog} isOpen={isOpen}>
       {children}

--- a/src/utils/shortcut-labels.test.ts
+++ b/src/utils/shortcut-labels.test.ts
@@ -12,6 +12,7 @@ describe("shortcut labels", () => {
 
   test("renders terminal shortcuts with control even on macOS", () => {
     const mode = getShortcutDisplayMode("opentui");
+
     expect(formatPrimaryShortcut("W", "darwin", mode)).toBe("Ctrl+W");
     expect(formatPlatformShortcutLabel("CmdOrCtrl+,", "darwin", mode)).toBe("Ctrl+,");
     expect(getShortcutDisplayMode("desktop-web")).toBe("platform");


### PR DESCRIPTION
Fixes the terminal pane action menu by making OpenTUI header controls clickable, rendering fallback menu items above panes with hover state, plugin context items, and terminal Ctrl shortcut labels.
It also wraps OpenTUI dialog content with the shared dialog provider so pane settings can open without useDialog errors, and removes Help pane compact stacking so actions and shortcut rows stay aligned at narrow widths.
Validated with focused OpenTUI tests, the shell pane-menu test file, the packaged build, diff/secret checks, and tmux smokes for the pane menu/settings dialog and narrow Help pane.
