### PR TITLE
Fix tweet newlines and X Feed actions

### DIFF
--- a/src/components/ticker-badge-text.test.tsx
+++ b/src/components/ticker-badge-text.test.tsx
@@ -135,6 +135,29 @@ describe("TickerBadgeText", () => {
     expect(frame.split("\n").filter((line) => line.trim()).length).toBeGreaterThan(1);
   });
 
+  test("renders hard line breaks as separate rows", async () => {
+    testSetup = await testRender(
+      <TickerBadgeText
+        text={"First $TSLA line\nSecond line"}
+        lineWidth={60}
+        catalog={{ TSLA: makeCatalogEntry() }}
+        textColor="#ffffff"
+        openTicker={() => {}}
+      />,
+      { width: 60, height: 5 },
+    );
+
+    await testSetup.renderOnce();
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const firstRow = lines.findIndex((line) => line.includes("First"));
+    const secondRow = lines.findIndex((line) => line.includes("Second line"));
+
+    expect(firstRow).toBeGreaterThanOrEqual(0);
+    expect(secondRow).toBeGreaterThan(firstRow);
+    expect(lines[firstRow]).toContain("TSLA -5%");
+  });
+
   test("opens detected links without trailing punctuation when clicked", async () => {
     const opened: string[] = [];
     testSetup = await testRender(

--- a/src/components/ticker-badge-text.tsx
+++ b/src/components/ticker-badge-text.tsx
@@ -48,52 +48,64 @@ export function TickerBadgeText({
   openLink = openUrl,
 }: TickerBadgeTextProps) {
   const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
-  const tokens = tokenizeInlineContent(text);
+  const lines = text.split("\n");
 
   return (
     <Box
-      flexDirection="row"
-      flexWrap="wrap"
+      flexDirection="column"
       width={lineWidth}
     >
-      {tokens.map((token, index) => {
-        if (token.kind === "text") {
-          if (!token.value) return null;
-          return splitTextForWrap(token.value, lineWidth).map((part, partIndex) => (
-            <Text key={`text:${index}:${partIndex}`} fg={textColor}>{part}</Text>
-          ));
-        }
-
-        if (token.kind === "link") {
-          return (
-            <ExternalLinkText
-              key={`link:${index}`}
-              url={token.url}
-              label={token.value}
-              color={textColor}
-              onOpen={openLink}
-            />
-          );
-        }
-
-        const entry = catalog[token.symbol];
-        if (!entry || entry.status === "missing") {
-          return <Text key={`raw:${index}`} fg={textColor}>{token.value}</Text>;
-        }
+      {lines.map((line, lineIndex) => {
+        if (!line) return <Box key={`line:${lineIndex}`} height={1} />;
 
         return (
-          <TickerBadge
-            key={`badge:${index}:${token.symbol}`}
-            symbol={token.symbol}
-            status={entry.status}
-            quote={entry.quote}
-            hovered={hoveredSymbol === token.symbol}
-            onHoverStart={() => setHoveredSymbol(token.symbol)}
-            onHoverEnd={() => {
-              setHoveredSymbol((current) => (current === token.symbol ? null : current));
-            }}
-            onOpen={openTicker}
-          />
+          <Box
+            key={`line:${lineIndex}`}
+            flexDirection="row"
+            flexWrap="wrap"
+            width={lineWidth}
+          >
+            {tokenizeInlineContent(line).map((token, index) => {
+              if (token.kind === "text") {
+                if (!token.value) return null;
+                return splitTextForWrap(token.value, lineWidth).map((part, partIndex) => (
+                  <Text key={`text:${lineIndex}:${index}:${partIndex}`} fg={textColor}>{part}</Text>
+                ));
+              }
+
+              if (token.kind === "link") {
+                return (
+                  <ExternalLinkText
+                    key={`link:${lineIndex}:${index}`}
+                    url={token.url}
+                    label={token.value}
+                    color={textColor}
+                    onOpen={openLink}
+                  />
+                );
+              }
+
+              const entry = catalog[token.symbol];
+              if (!entry || entry.status === "missing") {
+                return <Text key={`raw:${lineIndex}:${index}`} fg={textColor}>{token.value}</Text>;
+              }
+
+              return (
+                <TickerBadge
+                  key={`badge:${lineIndex}:${index}:${token.symbol}`}
+                  symbol={token.symbol}
+                  status={entry.status}
+                  quote={entry.quote}
+                  hovered={hoveredSymbol === token.symbol}
+                  onHoverStart={() => setHoveredSymbol(token.symbol)}
+                  onHoverEnd={() => {
+                    setHoveredSymbol((current) => (current === token.symbol ? null : current));
+                  }}
+                  onOpen={openTicker}
+                />
+              );
+            })}
+          </Box>
         );
       })}
     </Box>

--- a/src/plugins/builtin/cloud-tweets.tsx
+++ b/src/plugins/builtin/cloud-tweets.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } fro
 import { Box, ScrollBox, Text, TextAttributes, Textarea, useRendererHost, type TextareaRenderable } from "../../ui";
 import { useShortcut } from "../../react/input";
 import {
-  Button,
   DataTableStackView,
   EmptyState,
   SegmentedControl,
@@ -22,7 +21,7 @@ import { useInlineTickers } from "../../state/use-inline-tickers";
 import { apiClient, type CloudTweetPayload, type CloudTweetQueryType, type CloudTweetSearchResponse } from "../../utils/api-client";
 import { collectUniqueTickerSymbols } from "../../utils/ticker-tokenizer";
 import { formatCompact, formatTimeAgo } from "../../utils/format";
-import { decodeHtmlEntities } from "../../utils/html-entities";
+import { normalizeTweetText } from "../../utils/tweet-text";
 import { toTimestampMillis } from "../../utils/timestamp";
 import { normalizedHttpUrl } from "../../utils/url";
 import { colors } from "../../theme/colors";
@@ -139,7 +138,11 @@ function formatMetric(value: number | null | undefined): string {
 }
 
 function normalizeTweetDisplayText(value: string): string {
-  return decodeHtmlEntities(value).replace(/\s+/g, " ").trim();
+  return normalizeTweetText(value, { preserveLineBreaks: true });
+}
+
+function normalizeTweetCellText(value: string): string {
+  return normalizeTweetText(value);
 }
 
 function tweetTickers(tweet: CloudTweetPayload): string[] {
@@ -480,7 +483,7 @@ function TweetSearchTable({
           attributes: TextAttributes.BOLD,
         };
       case "text":
-        return { text: normalizeTweetDisplayText(tweet.text), color: selectedColor ?? colors.text };
+        return { text: normalizeTweetCellText(tweet.text), color: selectedColor ?? colors.text };
       case "tickers": {
         const tickers = tweetTickers(tweet);
         return {
@@ -762,7 +765,7 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
       return;
     }
 
-    if (event.name === "t" || event.name === "n") {
+    if (event.name === "n") {
       event.preventDefault?.();
       event.stopPropagation?.();
       openCreateEditor();
@@ -774,7 +777,7 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
       openEditEditor(activeFeed);
       return;
     }
-    if (event.name === "w" && activeFeed) {
+    if (event.name === "d" && activeFeed) {
       event.preventDefault?.();
       event.stopPropagation?.();
       removeFeed(activeFeed.id);
@@ -831,13 +834,16 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
       ]
       : [],
     hints: editorState
-      ? [{ id: "save", key: "Ctrl+S", label: "save", onPress: saveEditor }]
+      ? [
+        { id: "save", key: "Ctrl+S", label: "save", onPress: saveEditor },
+        { id: "cancel", key: "Esc", label: "cancel", onPress: closeEditor },
+      ]
       : [
-        { id: "new", key: "t", label: "new", onPress: openCreateEditor },
+        { id: "new", key: "n", label: "ew", onPress: openCreateEditor },
         { id: "edit", key: "e", label: "dit", onPress: () => openEditEditor(activeFeed), disabled: !activeFeed },
-        { id: "delete", key: "w", label: "delete", onPress: activeFeed ? () => removeFeed(activeFeed.id) : undefined, disabled: !activeFeed },
+        { id: "delete", key: "d", label: "elete", onPress: activeFeed ? () => removeFeed(activeFeed.id) : undefined, disabled: !activeFeed },
       ],
-  }), [activeFeed, editorState, openCreateEditor, openEditEditor, removeFeed, saveEditor]);
+  }), [activeFeed, closeEditor, editorState, openCreateEditor, openEditEditor, removeFeed, saveEditor]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -861,21 +867,6 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
         />
       </Box>
 
-      <Box height={1} flexDirection="row" gap={1}>
-        {editorState ? (
-          <>
-            <Button label="Save" variant="primary" onPress={saveEditor} />
-            <Button label="Cancel" variant="ghost" onPress={closeEditor} />
-          </>
-        ) : (
-          <>
-            <Button label="New Feed" variant="primary" onPress={openCreateEditor} />
-            <Button label="Edit" variant="secondary" onPress={() => openEditEditor(activeFeed)} disabled={!activeFeed} />
-            <Button label="Delete" variant="ghost" onPress={() => activeFeed && removeFeed(activeFeed.id)} disabled={!activeFeed} />
-          </>
-        )}
-      </Box>
-
       {editorState ? (
         <TwitterFeedEditor
           editor={editorState}
@@ -892,7 +883,7 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
         <TweetSearchTable
           focused={focused}
           width={width}
-          height={Math.max(1, height - 2)}
+          height={Math.max(1, height - 1)}
           requestKey={`feed:${activeFeed.id}:${activeFeed.query}:${activeFeed.queryType}`}
           footerId="twitter-feed-search"
           load={loadActiveFeed}

--- a/src/utils/tweet-text.test.ts
+++ b/src/utils/tweet-text.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeTweetText } from "./tweet-text";
+
+describe("normalizeTweetText", () => {
+  test("preserves tweet line breaks for detail rendering", () => {
+    expect(normalizeTweetText("First&nbsp;line\r\n\r\nSecond\tline", { preserveLineBreaks: true }))
+      .toBe("First line\n\nSecond line");
+  });
+
+  test("collapses tweet line breaks for compact table rendering", () => {
+    expect(normalizeTweetText("First&nbsp;line\nSecond\tline")).toBe("First line Second line");
+  });
+});

--- a/src/utils/tweet-text.ts
+++ b/src/utils/tweet-text.ts
@@ -1,0 +1,18 @@
+import { decodeHtmlEntities } from "./html-entities";
+
+export function normalizeTweetText(
+  value: string,
+  options: { preserveLineBreaks?: boolean } = {},
+): string {
+  const decoded = decodeHtmlEntities(value).replace(/\r\n?/g, "\n");
+
+  if (!options.preserveLineBreaks) {
+    return decoded.replace(/\s+/g, " ").trim();
+  }
+
+  return decoded
+    .split("\n")
+    .map((line) => line.replace(/[^\S\n]+/g, " ").trim())
+    .join("\n")
+    .trim();
+}


### PR DESCRIPTION
This PR preserves tweet newlines in tweet details by splitting compact table text from multiline detail text and teaching inline ticker text to render hard breaks.
It also removes the redundant X Feed action row and aligns footer shortcuts with their labels: `[n]ew`, `[e]dit`, `[d]elete`, and `[r]efresh`.
Validation: `bun run build`; `bun test src/utils/tweet-text.test.ts src/components/ticker-badge-text.test.tsx`; tmux smoke of the X Feed surface.
Full `bun test` was also run and still fails in pre-existing broker/portfolio analytics tests around missing plugin render context.
