### PR TITLE
Add Home and Monitor default layouts

### DIFF
--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -19,6 +19,7 @@ afterEach(() => {
 describe("StatusBar", () => {
   test("opens the command bar from the shortcut hint", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
+    config.layouts = [{ name: "Home", layout: cloneLayout(config.layout) }];
     const state = {
       ...createInitialState(config),
       statusBarVisible: true,

--- a/src/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/components/onboarding/onboarding-wizard.test.tsx
@@ -166,10 +166,14 @@ describe("OnboardingWizard", () => {
     } as unknown as PluginRegistry;
 
     let completedConfig: AppConfig | null = null;
+    const config = {
+      ...createDefaultConfig(tempDataDir),
+      disabledPlugins: ["demo-plugin"],
+    };
 
     testSetup = await testRender(
       <OnboardingWizard
-        config={createDefaultConfig(tempDataDir)}
+        config={config}
         pluginRegistry={pluginRegistry}
         onComplete={(nextConfig) => {
           completedConfig = nextConfig;
@@ -216,7 +220,7 @@ describe("OnboardingWizard", () => {
     }
 
     frame = testSetup.captureCharFrame();
-    expect(frame).toContain("Select plugins to enable");
+    expect(frame).toContain("After launch shortcuts");
 
     for (let index = 0; index < 3 && !frame.includes("Imported 1 position"); index += 1) {
       await emitKeypress(testSetup, { name: "return", sequence: "\r" });
@@ -241,6 +245,7 @@ describe("OnboardingWizard", () => {
       throw new Error("Onboarding did not complete.");
     }
     const finalConfig: AppConfig = completedConfig;
+    expect(finalConfig.disabledPlugins).toEqual([]);
     expect(finalConfig.portfolios.some((portfolio) => portfolio.id === "broker:demo-demo-broker:ACC-1")).toBe(true);
     expect(finalConfig.layout.instances.find((instance) => instance.paneId === "portfolio-list")?.params?.collectionId)
       .toBe("broker:demo-demo-broker:ACC-1");

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -15,7 +15,6 @@ import { isBackNavigationKey, isPlainEscape } from "../../utils/back-navigation"
 import { detectShortcutPlatform, formatPrimaryShortcut, getShortcutDisplayMode } from "../../utils/shortcut-labels";
 import { syncBrokerInstance } from "../../brokers/sync-broker-instance";
 import { debugLog } from "../../utils/debug-log";
-import { ToggleList, type ToggleListItem } from "../toggle-list";
 import { TextField, ExternalLink, ListView, type ListViewItem } from "../ui";
 
 interface OnboardingWizardProps {
@@ -24,8 +23,8 @@ interface OnboardingWizardProps {
   onComplete: (config: AppConfig) => void | Promise<void>;
 }
 
-type Step = "welcome" | "theme" | "portfolio" | "plugins" | "shortcuts" | "ready";
-const STEPS: Step[] = ["welcome", "theme", "portfolio", "plugins", "shortcuts", "ready"];
+type Step = "welcome" | "theme" | "portfolio" | "shortcuts" | "ready";
+const STEPS: Step[] = ["welcome", "theme", "portfolio", "shortcuts", "ready"];
 
 // Sub-steps within the portfolio step
 type PortfolioSub = "choose" | "manual-name" | "broker-setup" | "broker-fields" | "broker-sync";
@@ -44,23 +43,6 @@ const onboardingLog = debugLog.createLogger("onboarding");
 interface BrokerSyncSummary {
   portfolioId: string | null;
   positionsImported: number;
-}
-
-function getToggleablePlugins(pluginRegistry: PluginRegistry) {
-  const result: Array<{ id: string; name: string; description: string; order: number }> = [];
-  for (const [, plugin] of pluginRegistry.allPlugins) {
-    if (plugin.toggleable) {
-      result.push({
-        id: plugin.id,
-        name: plugin.name,
-        description: plugin.description ?? "",
-        order: plugin.order ?? Number.MAX_SAFE_INTEGER,
-      });
-    }
-  }
-  return result
-    .sort((left, right) => left.order - right.order || left.name.localeCompare(right.name))
-    .map(({ order: _order, ...plugin }) => plugin);
 }
 
 function summarizeError(error: unknown): string {
@@ -123,13 +105,6 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
   const [brokerSyncSummary, setBrokerSyncSummary] = useState<BrokerSyncSummary | null>(null);
   const [isFinishing, setIsFinishing] = useState(false);
   const [finishError, setFinishError] = useState<string | null>(null);
-
-  // Plugin state
-  const toggleablePlugins = useMemo(() => getToggleablePlugins(pluginRegistry), [pluginRegistry]);
-  const [disabledPlugins, setDisabledPlugins] = useState<string[]>(() => (
-    config.disabledPlugins.filter((pluginId) => pluginId !== "gloomberb-cloud")
-  ));
-  const [pluginIdx, setPluginIdx] = useState(0);
 
   const inputRef = useRef<InputRenderable>(null);
   const brokerSyncAttemptRef = useRef(0);
@@ -346,7 +321,7 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
         portfolios: isBroker
           ? (baseConfig ?? config).portfolios
           : [{ id: "main", name: portfolioName || "Main Portfolio", currency: "USD" }],
-        disabledPlugins,
+        disabledPlugins: [],
         onboardingComplete: true,
       };
 
@@ -359,7 +334,6 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
   }, [
     brokerSyncedConfig,
     config,
-    disabledPlugins,
     isFinishing,
     onComplete,
     portfolioName,
@@ -575,22 +549,6 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
           setBrokerSelectIdx((index) => Math.min(optionCount - 1, index + 1));
         }
       }
-    } else if (step === "plugins") {
-      if (event.name === "up" || event.name === "k") {
-        setPluginIdx((i) => Math.max(0, i - 1));
-      } else if (event.name === "down" || event.name === "j") {
-        setPluginIdx((i) => Math.min(toggleablePlugins.length - 1, i + 1));
-      } else if (event.name === "space" || event.name === " ") {
-        event.stopPropagation?.();
-        const plugin = toggleablePlugins[pluginIdx];
-        if (plugin) {
-          setDisabledPlugins((prev) =>
-            prev.includes(plugin.id)
-              ? prev.filter((id) => id !== plugin.id)
-              : [...prev, plugin.id]
-          );
-        }
-      }
     }
   });
 
@@ -660,21 +618,8 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
             brokerSyncError={brokerSyncError}
           />
         )}
-        {step === "plugins" && (
-          <PluginsStep
-            plugins={toggleablePlugins}
-            disabledPlugins={disabledPlugins}
-            selectedIdx={pluginIdx}
-            onToggle={(id) => {
-              setDisabledPlugins((prev) =>
-                prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-              );
-            }}
-            onSelect={setPluginIdx}
-          />
-        )}
         {step === "shortcuts" && (
-          <ShortcutsStep pluginRegistry={pluginRegistry} disabledPlugins={disabledPlugins} />
+          <ShortcutsStep pluginRegistry={pluginRegistry} />
         )}
         {step === "ready" && (
           <ReadyStep
@@ -1140,65 +1085,7 @@ function PortfolioStep({
   );
 }
 
-function PluginsStep({
-  plugins,
-  disabledPlugins,
-  selectedIdx,
-  onToggle,
-  onSelect,
-}: {
-  plugins: { id: string; name: string; description: string }[];
-  disabledPlugins: string[];
-  selectedIdx: number;
-  onToggle: (id: string) => void;
-  onSelect: (idx: number) => void;
-}) {
-  const items: ToggleListItem[] = plugins.map((p) => ({
-    id: p.id,
-    label: p.name,
-    enabled: !disabledPlugins.includes(p.id),
-    description: p.description,
-  }));
-
-  return (
-    <Box flexDirection="column" paddingX={2}>
-      <Box height={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{"Select plugins to enable"}</Text>
-      </Box>
-
-      <Box height={2} />
-
-      <ToggleList
-        items={items}
-        selectedIdx={selectedIdx}
-        onToggle={onToggle}
-        onSelect={onSelect}
-      />
-
-      <Box height={1} />
-      <Box height={1}>
-        <Text fg={colors.textMuted}>{"Use \u2191\u2193 to navigate \u00b7 space to toggle"}</Text>
-      </Box>
-      <Box height={1} />
-      <Box height={1}>
-        <Text fg={colors.textDim}>{"Toggle plugins anytime from the command bar"}</Text>
-      </Box>
-      <Box height={1} flexDirection="row">
-        <Text fg={colors.textDim}>{"with the "}</Text>
-        <Text fg={colors.text} attributes={TextAttributes.BOLD}>{"PL"}</Text>
-        <Text fg={colors.textDim}>{" prefix."}</Text>
-      </Box>
-    </Box>
-  );
-}
-
-function ShortcutsStep({
-  pluginRegistry,
-  disabledPlugins,
-}: {
-  pluginRegistry: PluginRegistry;
-  disabledPlugins: string[];
-}) {
+function ShortcutsStep({ pluginRegistry }: { pluginRegistry: PluginRegistry }) {
   const uiHost = useUiHost();
   const shortcutPlatform = detectShortcutPlatform();
   const shortcutDisplayMode = getShortcutDisplayMode(uiHost.kind);
@@ -1210,8 +1097,6 @@ function ShortcutsStep({
     { key: platformShortcut(["Shift", "D"]), desc: "Dock or float the focused pane" },
     { key: "q", desc: "Quit" },
   ];
-
-  const disabledSet = useMemo(() => new Set(disabledPlugins), [disabledPlugins]);
 
   const commandPrefixes = useMemo(() => {
     const builtIn = [
@@ -1227,8 +1112,6 @@ function ShortcutsStep({
 
     for (const [, template] of pluginRegistry.paneTemplates) {
       if (!template.shortcut) continue;
-      const pluginId = pluginRegistry.getPaneTemplatePluginId(template.id);
-      if (pluginId && disabledSet.has(pluginId)) continue;
       if (builtInKeys.has(template.shortcut.prefix)) continue;
       const label = template.shortcut.argPlaceholder
         ? `${template.shortcut.prefix} <${template.shortcut.argPlaceholder}>`
@@ -1238,7 +1121,7 @@ function ShortcutsStep({
 
     pluginPrefixes.sort((a, b) => a.key.localeCompare(b.key));
     return [...builtIn, ...pluginPrefixes];
-  }, [pluginRegistry, disabledSet]);
+  }, [pluginRegistry]);
 
   const COL = 20;
 
@@ -1318,7 +1201,7 @@ function ReadyStep({
       </Box>
       <Box height={1}>
         <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{"\u2713"}</Text>
-        <Text fg={colors.text}>{" Plugins selected"}</Text>
+        <Text fg={colors.text}>{" Plugins enabled"}</Text>
       </Box>
       <Box height={2} />
       {brokerName ? (

--- a/src/plugins/pane-manager.test.ts
+++ b/src/plugins/pane-manager.test.ts
@@ -72,7 +72,7 @@ describe("pane-manager split-tree drops", () => {
     const next = gridlockAllPanes(layout);
 
     expect(next.floating).toHaveLength(0);
-    expect(getDockedPaneIds(next)).toHaveLength(5);
+    expect(getDockedPaneIds(next)).toHaveLength(layout.instances.length);
   });
 
   test("gridlock infers a matching tiled layout from arranged windows", () => {

--- a/src/renderers/electrobun/bun/desktop-workspace.test.ts
+++ b/src/renderers/electrobun/bun/desktop-workspace.test.ts
@@ -20,7 +20,7 @@ describe("desktop workspace", () => {
     expect(snapshot.config.layouts[snapshot.config.activeLayoutIndex]?.layout.detached).toEqual([
       { instanceId: "chat:main", x: 100, y: 120, width: 800, height: 540 },
     ]);
-    expect(snapshot.config.layout.floating).toHaveLength(0);
+    expect(snapshot.config.layout.floating.some((entry) => entry.instanceId === "chat:main")).toBe(false);
   });
 
   test("docking a detached pane onto a frame edge clears detached placement", () => {

--- a/src/state/app-context.test.tsx
+++ b/src/state/app-context.test.tsx
@@ -86,6 +86,9 @@ describe("appReducer command bar state", () => {
 
   test("tracks layout undo and redo history", () => {
     const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    const defaultRatio = initial.config.layout.dockRoot && initial.config.layout.dockRoot.kind === "split"
+      ? initial.config.layout.dockRoot.ratio
+      : null;
     const changedLayout = cloneLayout(initial.config.layout);
     if (!changedLayout.dockRoot || changedLayout.dockRoot.kind !== "split") {
       throw new Error("expected split dock root");
@@ -103,7 +106,7 @@ describe("appReducer command bar state", () => {
     const undone = appReducer(changed, { type: "UNDO_LAYOUT" });
     expect(undone.config.layout.dockRoot && undone.config.layout.dockRoot.kind === "split"
       ? undone.config.layout.dockRoot.ratio
-      : null).toBe(0.4);
+      : null).toBe(defaultRatio);
     expect(undone.layoutHistory[0]?.future).toHaveLength(1);
 
     const redone = appReducer(undone, { type: "REDO_LAYOUT" });
@@ -115,6 +118,10 @@ describe("appReducer command bar state", () => {
 
   test("keeps layout history isolated per saved layout", () => {
     const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    const defaultRatio = initial.config.layout.dockRoot && initial.config.layout.dockRoot.kind === "split"
+      ? initial.config.layout.dockRoot.ratio
+      : null;
+    const newLayoutIndex = initial.config.layouts.length;
 
     const firstLayout = cloneLayout(initial.config.layout);
     if (!firstLayout.dockRoot || firstLayout.dockRoot.kind !== "split") {
@@ -126,10 +133,10 @@ describe("appReducer command bar state", () => {
     state = appReducer(state, { type: "NEW_LAYOUT", name: "Research" });
 
     const noUndoOnFreshLayout = appReducer(state, { type: "UNDO_LAYOUT" });
-    expect(noUndoOnFreshLayout.config.activeLayoutIndex).toBe(1);
+    expect(noUndoOnFreshLayout.config.activeLayoutIndex).toBe(newLayoutIndex);
     expect(noUndoOnFreshLayout.config.layout.dockRoot && noUndoOnFreshLayout.config.layout.dockRoot.kind === "split"
       ? noUndoOnFreshLayout.config.layout.dockRoot.ratio
-      : null).toBe(0.4);
+      : null).toBe(defaultRatio);
 
     const secondLayout = cloneLayout(noUndoOnFreshLayout.config.layout);
     if (!secondLayout.dockRoot || secondLayout.dockRoot.kind !== "split") {
@@ -144,14 +151,14 @@ describe("appReducer command bar state", () => {
     expect(firstUndone.config.activeLayoutIndex).toBe(0);
     expect(firstUndone.config.layout.dockRoot && firstUndone.config.layout.dockRoot.kind === "split"
       ? firstUndone.config.layout.dockRoot.ratio
-      : null).toBe(0.4);
+      : null).toBe(defaultRatio);
 
-    const backToSecond = appReducer(firstUndone, { type: "SWITCH_LAYOUT", index: 1 });
+    const backToSecond = appReducer(firstUndone, { type: "SWITCH_LAYOUT", index: newLayoutIndex });
     const secondUndone = appReducer(backToSecond, { type: "UNDO_LAYOUT" });
-    expect(secondUndone.config.activeLayoutIndex).toBe(1);
+    expect(secondUndone.config.activeLayoutIndex).toBe(newLayoutIndex);
     expect(secondUndone.config.layout.dockRoot && secondUndone.config.layout.dockRoot.kind === "split"
       ? secondUndone.config.layout.dockRoot.ratio
-      : null).toBe(0.4);
+      : null).toBe(defaultRatio);
   });
 
   test("tracks manual update-check feedback", () => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -162,11 +162,11 @@ export const DEFAULT_PORTFOLIO_COLUMN_IDS = [
   "pnl_pct",
 ];
 
-export const DEFAULT_LAYOUT: LayoutConfig = {
+export const DEFAULT_HOME_LAYOUT: LayoutConfig = {
   dockRoot: {
     kind: "split",
     axis: "horizontal",
-    ratio: 0.4,
+    ratio: 0.34,
     first: {
       kind: "split",
       axis: "vertical",
@@ -174,7 +174,13 @@ export const DEFAULT_LAYOUT: LayoutConfig = {
       first: { kind: "pane", instanceId: "portfolio-list:main" },
       second: { kind: "pane", instanceId: "chat:main" },
     },
-    second: { kind: "pane", instanceId: "ticker-detail:main" },
+    second: {
+      kind: "split",
+      axis: "vertical",
+      ratio: 0.46,
+      first: { kind: "pane", instanceId: "ticker-detail:main" },
+      second: { kind: "pane", instanceId: "ticker-detail:nvda" },
+    },
   },
   instances: [
     {
@@ -200,6 +206,18 @@ export const DEFAULT_LAYOUT: LayoutConfig = {
       binding: { kind: "follow", sourceInstanceId: "portfolio-list:main" },
     },
     {
+      instanceId: "ticker-detail:nvda",
+      paneId: "ticker-detail",
+      title: "NVDA",
+      settings: {
+        hideTabs: false,
+        lockedTabId: "overview",
+        chartRangePreset: "5Y",
+        chartResolution: "auto",
+      },
+      binding: { kind: "fixed", symbol: "NVDA" },
+    },
+    {
       instanceId: "chat:main",
       paneId: "chat",
       settings: {
@@ -207,10 +225,65 @@ export const DEFAULT_LAYOUT: LayoutConfig = {
       },
       binding: { kind: "none" },
     },
+    {
+      instanceId: "help:main",
+      paneId: "help",
+      binding: { kind: "none" },
+    },
+  ],
+  floating: [
+    { instanceId: "help:main", x: 12, y: 4, width: 88, height: 32, zIndex: 90 },
+  ],
+  detached: [],
+};
+
+export const DEFAULT_MONITOR_LAYOUT: LayoutConfig = {
+  dockRoot: {
+    kind: "split",
+    axis: "vertical",
+    ratio: 0.48,
+    first: {
+      kind: "split",
+      axis: "horizontal",
+      ratio: 0.42,
+      first: { kind: "pane", instanceId: "news-top:main" },
+      second: { kind: "pane", instanceId: "prediction-markets:main" },
+    },
+    second: {
+      kind: "split",
+      axis: "horizontal",
+      ratio: 0.42,
+      first: { kind: "pane", instanceId: "world-indices:main" },
+      second: { kind: "pane", instanceId: "econ-calendar:main" },
+    },
+  },
+  instances: [
+    {
+      instanceId: "news-top:main",
+      paneId: "news-top",
+      binding: { kind: "none" },
+    },
+    {
+      instanceId: "prediction-markets:main",
+      paneId: "prediction-markets",
+      binding: { kind: "none" },
+    },
+    {
+      instanceId: "world-indices:main",
+      paneId: "world-indices",
+      binding: { kind: "none" },
+    },
+    {
+      instanceId: "econ-calendar:main",
+      paneId: "econ-calendar",
+      binding: { kind: "none" },
+    },
   ],
   floating: [],
   detached: [],
 };
+
+export const DEFAULT_LAYOUT = DEFAULT_HOME_LAYOUT;
 
 let nextPaneInstanceSeq = 0;
 
@@ -502,7 +575,7 @@ export function findPaneInstance(layout: LayoutConfig, instanceId: string): Pane
 }
 
 export function createDefaultConfig(dataDir: string): AppConfig {
-  const layout = cloneLayout(DEFAULT_LAYOUT);
+  const layout = cloneLayout(DEFAULT_HOME_LAYOUT);
   return {
     dataDir,
     configVersion: CURRENT_CONFIG_VERSION,
@@ -511,7 +584,10 @@ export function createDefaultConfig(dataDir: string): AppConfig {
     portfolios: [{ id: "main", name: "Main Portfolio", currency: "USD" }],
     watchlists: [{ id: "watchlist", name: "Watchlist" }],
     layout,
-    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+    layouts: [
+      { name: "Home", layout: cloneLayout(layout) },
+      { name: "Monitor", layout: cloneLayout(DEFAULT_MONITOR_LAYOUT) },
+    ],
     activeLayoutIndex: 0,
     brokerInstances: [],
     plugins: ["portfolio-list", "ticker-detail", "manual-entry", "ibkr"],


### PR DESCRIPTION
Adds Home and Monitor as the default saved layouts for new configs: Home opens collection, chat, followed detail, fixed NVDA detail, and floating Help; Monitor opens top news, prediction markets, world indices, and economic calendar. Onboarding now skips the plugin-toggle step, enables all plugins by saving `disabledPlugins: []`, and shows plugin shortcuts directly. Updates affected layout, status bar, pane manager, desktop workspace, app context, and onboarding tests. Validation: `git diff --check`; secret scan over the diff; focused `bun test`; `bun run build`; tmux onboarding smoke.
