### PR TITLE
Hide inactive pane footer hints

### DIFF
--- a/src/components/layout/pane-footer.test.tsx
+++ b/src/components/layout/pane-footer.test.tsx
@@ -100,8 +100,8 @@ describe("PaneFooterBar", () => {
     })).toBe(true);
   });
 
-  test("renders info left and hints right", async () => {
-    testSetup = await testRender(<FooterHarness />, { width: 64, height: 1 });
+  test("renders focused info left and hints right", async () => {
+    testSetup = await testRender(<FooterHarness focused />, { width: 64, height: 1 });
     await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
@@ -110,6 +110,18 @@ describe("PaneFooterBar", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Rows 12");
     expect(frame).toContain("[r]efresh");
+  });
+
+  test("hides hints on inactive footers but keeps info visible", async () => {
+    testSetup = await testRender(<FooterHarness />, { width: 64, height: 1 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Rows 12");
+    expect(frame).not.toContain("[r]efresh");
   });
 
   test("keeps raw external URLs out of footer text", async () => {
@@ -127,7 +139,7 @@ describe("PaneFooterBar", () => {
 
   test("calls hint onPress from mouse interaction", async () => {
     let refreshCount = 0;
-    testSetup = await testRender(<FooterHarness onRefresh={() => { refreshCount += 1; }} />, { width: 64, height: 1 });
+    testSetup = await testRender(<FooterHarness focused onRefresh={() => { refreshCount += 1; }} />, { width: 64, height: 1 });
     await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();

--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -276,12 +276,13 @@ function FooterContent({
   showBackground?: boolean;
 }) {
   const hasInfo = footer.info.length > 0;
-  const hasHints = footer.hints.length > 0;
+  const visibleHints = focused ? footer.hints : [];
+  const hasHints = visibleHints.length > 0;
   const dividerColor = focused ? colors.borderFocused : colors.border;
   const backgroundColor = showBackground ? blendHex(colors.bg, dividerColor, focused ? 0.12 : 0.06) : undefined;
   const availableWidth = width && width > 0 ? Math.floor(width) : null;
   const hintsWidth = hasHints
-    ? Math.min(availableWidth ?? totalHintsWidth(footer.hints), totalHintsWidth(footer.hints))
+    ? Math.min(availableWidth ?? totalHintsWidth(visibleHints), totalHintsWidth(visibleHints))
     : 0;
   const infoWidth = availableWidth !== null && hasInfo
     ? Math.max(0, availableWidth - hintsWidth)
@@ -324,11 +325,11 @@ function FooterContent({
             overflow="hidden"
             {...(availableWidth !== null ? { width: hintsWidth } : { flexGrow: 1 })}
           >
-          {footer.hints.map((hint, index) => (
-            <Box key={hint.id} flexDirection="row">
-              <HintView hint={hint} prefixSpace={index > 0} />
-            </Box>
-          ))}
+            {visibleHints.map((hint, index) => (
+              <Box key={hint.id} flexDirection="row">
+                <HintView hint={hint} prefixSpace={index > 0} />
+              </Box>
+            ))}
           </Box>
         </>
       )}


### PR DESCRIPTION
Pane footers now only render shortcut hints for the focused pane, while inactive panes keep their status text visible. This fixes duplicated active-looking hint chips across adjacent pane status bars. Added a regression test for inactive footer hints alongside the focused footer behavior. Validation: bun test src/components/layout/pane-footer.test.tsx, bun run build, git diff --check, and a tmux smoke run.