### PR TITLE
Improve alert ticker lookup flow

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -537,6 +537,70 @@ describe("CommandBar", () => {
     expect(workflowFrame).toContain("AMD");
   });
 
+  test("prefills alert command targets from the resolved quote", async () => {
+    const quoteProvider = createTestDataProvider({
+      id: "test",
+      search: async () => [],
+      getQuote: async (symbol: string) => ({
+        symbol,
+        price: 201.5,
+        currency: "USD",
+        change: 1,
+        changePercent: 0.5,
+        name: "Advanced Micro Devices",
+        exchangeName: "NASDAQ",
+        lastUpdated: Date.now(),
+        dataSource: "live",
+      }),
+    });
+
+    testSetup = await testRender(<CommandBarHarness
+      query="SA AMD"
+      dataProvider={quoteProvider}
+      configurePluginRegistry={(pluginRegistry) => {
+        (pluginRegistry.commands as Map<string, any>).set("set-alert", {
+          id: "set-alert",
+          label: "Add Alert",
+          description: "Create a price alert from a symbol, condition, and target price",
+          keywords: ["add", "set", "alert", "price", "trigger"],
+          shortcut: "SA",
+          shortcutArg: {
+            placeholder: "symbol condition price",
+            kind: "ticker",
+            parse: (arg: string) => ({ symbol: arg.trim().toUpperCase() }),
+          },
+          category: "data",
+          wizardLayout: "form",
+          wizard: [
+            { key: "symbol", label: "Symbol", type: "text" },
+            {
+              key: "condition",
+              label: "Condition",
+              type: "select",
+              options: [{ label: "Above", value: "above" }],
+            },
+            { key: "price", label: "Target Price", type: "number" },
+          ],
+          execute: async () => {},
+        });
+      }}
+    />, {
+      width: 90,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    const workflowFrame = await waitForFrameToContain("Advanced Micro Devices");
+    expect(workflowFrame).toContain("201.5");
+  });
+
   test("updates workflow select fields from the option picker", async () => {
     testSetup = await testRender(<CommandBarHarness
       query="SA AMD"
@@ -611,6 +675,8 @@ describe("CommandBar", () => {
   test("opens plugin command workflows from a launch request", async () => {
     testSetup = await testRender(<CommandBarHarness
       query=""
+      selectedTicker="AMD"
+      extraTickers={[makeTicker("AMD", "Advanced Micro Devices")]}
       configureState={(state) => ({
         ...state,
         commandBarLaunchRequest: {
@@ -625,6 +691,13 @@ describe("CommandBar", () => {
           label: "Set Alert",
           keywords: ["alert", "price", "trigger"],
           shortcut: "SA",
+          shortcutArg: {
+            placeholder: "symbol condition price",
+            kind: "ticker",
+            parse: (_arg: string, context?: { activeTicker: string | null }) => (
+              context?.activeTicker ? { symbol: context.activeTicker } : {}
+            ),
+          },
           category: "data",
           wizardLayout: "form",
           wizard: [
@@ -652,6 +725,7 @@ describe("CommandBar", () => {
     expect(frame).toContain("Set Alert");
     expect(frame).toContain("Symbol");
     expect(frame).toContain("Condition");
+    expect(frame).toContain("AMD");
   });
 
   test("renders theme prefix results in the root query", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -35,6 +35,7 @@ import type { DataProvider } from "../../types/data-provider";
 import type { TickerRepository } from "../../data/ticker-repository";
 import type { PluginRegistry } from "../../plugins/registry";
 import type { TickerRecord } from "../../types/ticker";
+import type { Quote } from "../../types/financials";
 import type {
   CommandDef,
   PaneSettingField,
@@ -231,6 +232,44 @@ function getWorkflowFieldDescription(field: CommandBarWorkflowField, active: boo
   return field.type === "textarea" && active ? `${description} Ctrl+S submits.` : description;
 }
 
+function isSetAlertWorkflow(route: CommandBarRoute | null): route is CommandBarWorkflowRoute {
+  return route?.kind === "workflow"
+    && route.payload.kind === "plugin-command"
+    && route.payload.actionId === "set-alert";
+}
+
+function normalizeAlertWorkflowSymbol(value: CommandBarFieldValue | undefined): string {
+  return coerceFieldString(value).trim().toUpperCase();
+}
+
+function formatAlertWorkflowPrice(value: number): string {
+  return Number.isFinite(value) ? String(value) : "";
+}
+
+function formatAlertWorkflowQuote(quote: Quote): string {
+  const price = formatAlertWorkflowPrice(quote.price);
+  const exchange = quote.fullExchangeName || quote.exchangeName || quote.listingExchangeName || "";
+  const name = quote.name || quote.symbol;
+  const source = quote.dataSource === "delayed" ? "delayed" : quote.dataSource || "";
+  return [quote.symbol, name, exchange, price, source].filter(Boolean).join("  ");
+}
+
+function summarizeAlertWorkflowQuoteError(symbol: string, error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return `No quote found for "${symbol}".`;
+}
+
+function updateAlertWorkflowFieldDescriptions(
+  fields: CommandBarWorkflowField[],
+  descriptions: Partial<Record<"symbol" | "price", string | undefined>>,
+): CommandBarWorkflowField[] {
+  return fields.map((field) => {
+    if (field.id !== "symbol" && field.id !== "price") return field;
+    const description = descriptions[field.id];
+    return field.description === description ? field : { ...field, description };
+  });
+}
+
 function estimateWorkflowBodyRows(route: CommandBarWorkflowRoute): number {
   const visibleFields = getVisibleWorkflowFields(route.fields, route.values);
   const introRows = (route.subtitle ? 1 : 0)
@@ -400,6 +439,7 @@ export function CommandBar({
   const rootSearchRequestIdRef = useRef(0);
   const rootLastSearchedQueryRef = useRef<string | null>(null);
   const tickerSearchCacheRef = useRef<Map<string, TickerSearchCandidate[]>>(new Map());
+  const alertWorkflowQuoteRequestRef = useRef(0);
   const skipTickerSearchDebounceRef = useRef(false);
   const lastMainBrowseRef = useRef<CommandBarMainSnapshot>({ query: "", selectedIdx: 0 });
   const previousRootSelectionContextRef = useRef<{ query: string; mode: string } | null>(null);
@@ -1814,9 +1854,18 @@ export function CommandBar({
     if (launch.kind === "plugin-command") {
       const command = pluginRegistry.commands.get(launch.commandId);
       if (!command?.wizard || command.wizard.length === 0) return;
-      openPluginCommandWorkflow(command);
+      let values: Record<string, string> | undefined;
+      try {
+        values = command.shortcutArg?.parse?.("", {
+          activeTicker: activeTickerSymbol,
+        });
+      } catch {
+        values = undefined;
+      }
+      openPluginCommandWorkflow(command, values ? { values } : undefined);
     }
   }, [
+    activeTickerSymbol,
     openPluginCommandWorkflow,
     pluginRegistry,
     state.commandBarLaunchRequest,
@@ -2256,10 +2305,9 @@ export function CommandBar({
     command: CommandDef,
     shortcutArg: string,
   ): Record<string, string> => {
-    if (!shortcutArg.trim()) return {};
     return command.shortcutArg?.parse?.(shortcutArg, {
       activeTicker: activeTickerSymbol,
-    }) ?? { shortcut: shortcutArg };
+    }) ?? (shortcutArg.trim() ? { shortcut: shortcutArg } : {});
   }, [activeTickerSymbol]);
 
   const createPluginCommandItem = useCallback((
@@ -2304,7 +2352,8 @@ export function CommandBar({
           return;
         }
         if (command.wizard && command.wizard.length > 0) {
-          openPluginCommandWorkflow(command);
+          const values = parsePluginCommandShortcutArg(command, "");
+          openPluginCommandWorkflow(command, { values });
           return;
         }
         const confirm = resolvePluginCommandConfirm(command);
@@ -4330,6 +4379,111 @@ export function CommandBar({
       return next;
     });
   }, []);
+
+  const alertWorkflowActive = isSetAlertWorkflow(currentRoute);
+  const alertWorkflowSymbol = alertWorkflowActive
+    ? normalizeAlertWorkflowSymbol(currentRoute.values.symbol)
+    : "";
+
+  useEffect(() => {
+    if (!alertWorkflowActive) return;
+
+    const requestId = alertWorkflowQuoteRequestRef.current + 1;
+    alertWorkflowQuoteRequestRef.current = requestId;
+
+    if (!alertWorkflowSymbol) {
+      updateTopRoute((route) => {
+        if (!isSetAlertWorkflow(route)) return route;
+        return {
+          ...route,
+          fields: updateAlertWorkflowFieldDescriptions(route.fields, {
+            symbol: "Enter a symbol to validate it.",
+            price: "Target fills from the current price after the symbol resolves.",
+          }),
+          payloadMeta: {
+            ...(route.payloadMeta ?? {}),
+            alertQuoteSymbol: "",
+            alertQuoteStatus: "idle",
+          },
+        };
+      });
+      return;
+    }
+
+    updateTopRoute((route) => {
+      if (!isSetAlertWorkflow(route)) return route;
+      if (normalizeAlertWorkflowSymbol(route.values.symbol) !== alertWorkflowSymbol) return route;
+      return {
+        ...route,
+        fields: updateAlertWorkflowFieldDescriptions(route.fields, {
+          symbol: `Checking ${alertWorkflowSymbol}...`,
+          price: "Target fills from the current price after the symbol resolves.",
+        }),
+        payloadMeta: {
+          ...(route.payloadMeta ?? {}),
+          alertQuoteSymbol: alertWorkflowSymbol,
+          alertQuoteStatus: "checking",
+        },
+      };
+    });
+
+    void dataProvider.getQuote(alertWorkflowSymbol, "")
+      .then((quote) => {
+        if (alertWorkflowQuoteRequestRef.current !== requestId) return;
+        if (!quote || typeof quote.price !== "number" || !Number.isFinite(quote.price)) {
+          throw new Error(`No quote found for "${alertWorkflowSymbol}".`);
+        }
+
+        const quotePrice = formatAlertWorkflowPrice(quote.price);
+        updateTopRoute((route) => {
+          if (!isSetAlertWorkflow(route)) return route;
+          if (normalizeAlertWorkflowSymbol(route.values.symbol) !== alertWorkflowSymbol) return route;
+
+          const currentPrice = coerceFieldString(route.values.price).trim();
+          const previousAutoPrice = String(route.payloadMeta?.alertAutoPrice ?? "");
+          const shouldPrefill = currentPrice.length === 0 || currentPrice === previousAutoPrice;
+          const nextValues = shouldPrefill
+            ? { ...route.values, price: quotePrice }
+            : route.values;
+
+          return {
+            ...route,
+            values: nextValues,
+            fields: updateAlertWorkflowFieldDescriptions(route.fields, {
+              symbol: formatAlertWorkflowQuote(quote),
+              price: `Current price ${quotePrice}; edit to set the target.`,
+            }),
+            payloadMeta: {
+              ...(route.payloadMeta ?? {}),
+              alertQuoteSymbol: alertWorkflowSymbol,
+              alertQuoteStatus: "valid",
+              alertAutoPrice: quotePrice,
+            },
+          };
+        });
+      })
+      .catch((error) => {
+        if (alertWorkflowQuoteRequestRef.current !== requestId) return;
+        const message = summarizeAlertWorkflowQuoteError(alertWorkflowSymbol, error);
+        updateTopRoute((route) => {
+          if (!isSetAlertWorkflow(route)) return route;
+          if (normalizeAlertWorkflowSymbol(route.values.symbol) !== alertWorkflowSymbol) return route;
+          return {
+            ...route,
+            fields: updateAlertWorkflowFieldDescriptions(route.fields, {
+              symbol: message,
+              price: undefined,
+            }),
+            payloadMeta: {
+              ...(route.payloadMeta ?? {}),
+              alertQuoteSymbol: alertWorkflowSymbol,
+              alertQuoteStatus: "invalid",
+              alertQuoteError: message,
+            },
+          };
+        });
+      });
+  }, [alertWorkflowActive, alertWorkflowSymbol, dataProvider, updateTopRoute]);
 
   const moveWorkflowFocus = useCallback((delta: number) => {
     if (currentRoute?.kind !== "workflow") return;

--- a/src/plugins/builtin/alerts/index.test.tsx
+++ b/src/plugins/builtin/alerts/index.test.tsx
@@ -39,6 +39,8 @@ function makeAlert(
     status,
     triggeredAt: status === "triggered" ? Date.now() - 30_000 : undefined,
     lastCheckedPrice: status === "triggered" ? targetPrice + 1 : undefined,
+    lastCheckedAt: status === "triggered" ? Date.now() - 30_000 : undefined,
+    lastQuoteUpdatedAt: status === "triggered" ? Date.now() - 30_000 : undefined,
   };
 }
 
@@ -169,9 +171,10 @@ describe("AlertsPane", () => {
     await renderSettled();
     const frame = testSetup.captureCharFrame();
 
-    expect(frame).toContain("Status");
+    expect(frame).toContain("State");
     expect(frame).toContain("Symbol");
-    expect(frame).toContain("Condition");
+    expect(frame).toContain("Current");
+    expect(frame).toContain("Away");
     expect(frame).toContain("AAPL");
     expect(frame).toContain("MSFT");
     expect(frame).toContain("[a]dd alert");
@@ -188,24 +191,24 @@ describe("AlertsPane", () => {
   test("keeps alert targets visible at the default floating pane width", async () => {
     testSetup = await testRender(
       <AlertsHarness
-        width={65}
+        width={82}
         height={8}
         alerts={[makeAlert("alert-aapl", "AAPL", "above", 200)]}
       />,
-      { width: 65, height: 8 },
+      { width: 82, height: 8 },
     );
 
     await renderSettled();
     const frame = testSetup.captureCharFrame();
 
-    expect(frame).toContain("Status");
-    expect(frame).toContain("Condition");
+    expect(frame).toContain("State");
+    expect(frame).toContain("Current");
     expect(frame).toContain("Target");
     expect(frame).toContain("200");
     expect(frame).toContain("[a]dd alert");
   });
 
-  test("opens the command-bar alert workflow from keyboard and mouse", async () => {
+  test("opens the shared alert workflow from keyboard and mouse", async () => {
     const workflowCalls: string[] = [];
     const runtime = makeRuntime({
       openPluginCommandWorkflow(commandId: string) {
@@ -223,6 +226,14 @@ describe("AlertsPane", () => {
       await testSetup!.mockInput.typeText("a");
       await testSetup!.renderOnce();
     });
+    expect(workflowCalls).toEqual(["set-alert"]);
+
+    testSetup.renderer.destroy();
+    testSetup = await testRender(<AlertsHarness alerts={[]} runtime={runtime} />, {
+      width: 110,
+      height: 12,
+    });
+    await renderSettled();
     await clickFrameText("[a]");
 
     expect(workflowCalls).toEqual(["set-alert", "set-alert"]);
@@ -270,7 +281,15 @@ describe("alertsPlugin command", () => {
         },
       },
       marketData: {
-        getQuote: async () => null,
+        getQuote: async (symbol: string) => ({
+          symbol,
+          price: 201.5,
+          currency: "USD",
+          change: 1,
+          changePercent: 0.5,
+          lastUpdated: Date.now(),
+          dataSource: "live",
+        }),
       },
       notify(notification: any) {
         notifications.push(notification);
@@ -291,6 +310,7 @@ describe("alertsPlugin command", () => {
       expect(command?.shortcut).toBe("SA");
       expect(command?.shortcutArg?.placeholder).toBe("symbol condition price");
       expect(command?.shortcutArg?.parse("AMD")).toEqual({ symbol: "AMD" });
+      expect(command?.shortcutArg?.parse("", { activeTicker: "MSFT" })).toEqual({ symbol: "MSFT" });
       expect(command?.shortcutArg?.parse("AMD above 200")).toEqual({
         symbol: "AMD",
         condition: "above",
@@ -305,6 +325,7 @@ describe("alertsPlugin command", () => {
         symbol: "AAPL",
         condition: "above",
         targetPrice: 200,
+        lastCheckedPrice: 201.5,
         status: "active",
       });
       expect(notifications[0]?.body).toContain("AAPL");

--- a/src/plugins/builtin/alerts/index.tsx
+++ b/src/plugins/builtin/alerts/index.tsx
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TextAttributes } from "../../../ui";
-import { DataTableView, usePaneFooter, type DataTableCell, type DataTableColumn, type DataTableKeyEvent } from "../../../components";
+import {
+  DataTableView,
+  usePaneFooter,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+} from "../../../components";
 import type { GloomPlugin, GloomPluginContext, PaneProps } from "../../../types/plugin";
 import type { AlertCondition, AlertRule } from "./types";
 import { colors } from "../../../theme/colors";
-import { usePluginAppActions, usePluginConfigState } from "../../plugin-runtime";
+import { useMarketData, usePluginAppActions, usePluginConfigState } from "../../plugin-runtime";
 import {
   createAlert,
   evaluateAlert,
@@ -12,9 +18,14 @@ import {
   serializeAlerts,
   deserializeAlerts,
 } from "./alert-engine";
+import type { DataProvider } from "../../../types/data-provider";
+import type { Quote } from "../../../types/financials";
+import { formatMarketPrice } from "../../../utils/market-format";
+import { formatQuoteAgeWithSource } from "../../../utils/quote-time";
 
 const ALERTS_KEY = "alerts";
 const POLL_INTERVAL_MS = 30_000;
+const PANE_QUOTE_REFRESH_MS = 30_000;
 
 function relativeTime(ts: number): string {
   const diff = Date.now() - ts;
@@ -26,6 +37,92 @@ function relativeTime(ts: number): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function normalizeAlertSymbol(value: string | null | undefined): string {
+  return value?.trim().toUpperCase() ?? "";
+}
+
+function createQuoteErrorMessage(symbol: string, error?: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return `No quote found for "${symbol}".`;
+}
+
+async function resolveAlertQuote(marketData: Pick<DataProvider, "getQuote">, symbol: string): Promise<Quote> {
+  const quote = await marketData.getQuote(symbol, "");
+  if (!quote || typeof quote.price !== "number" || !Number.isFinite(quote.price)) {
+    throw new Error(`No quote found for "${symbol}".`);
+  }
+  return quote;
+}
+
+function quoteAlertFields(quote: Quote, checkedAt = Date.now()): Pick<
+  AlertRule,
+  "lastCheckedPrice" | "lastCheckedAt" | "lastQuoteUpdatedAt" | "lastQuoteSource" | "lastQuoteProviderId"
+> & { lastCheckError?: undefined } {
+  return {
+    lastCheckedPrice: quote.price,
+    lastCheckedAt: checkedAt,
+    lastQuoteUpdatedAt: quote.lastUpdated,
+    lastQuoteSource: quote.dataSource,
+    lastQuoteProviderId: quote.providerId,
+    lastCheckError: undefined,
+  };
+}
+
+function quoteErrorAlertFields(error: string, checkedAt = Date.now()): Pick<
+  AlertRule,
+  "lastCheckedAt" | "lastCheckError"
+> {
+  return {
+    lastCheckedAt: checkedAt,
+    lastCheckError: error,
+  };
+}
+
+function formatCurrentPrice(alert: AlertRule, maxWidth = 9): string {
+  if (alert.lastCheckError) return "No quote";
+  return alert.lastCheckedPrice == null
+    ? "-"
+    : formatMarketPrice(alert.lastCheckedPrice, { maxWidth, minimumFractionDigits: 2 });
+}
+
+function formatAlertTargetPrice(alert: AlertRule, maxWidth = 9): string {
+  return formatMarketPrice(alert.targetPrice, { maxWidth, minimumFractionDigits: 2 });
+}
+
+function formatAlertDistance(alert: AlertRule): string {
+  const currentPrice = alert.lastCheckedPrice;
+  if (alert.lastCheckError) return "-";
+  if (currentPrice == null || !Number.isFinite(currentPrice) || currentPrice === 0) return "-";
+  const percent = ((alert.targetPrice - currentPrice) / currentPrice) * 100;
+  if (!Number.isFinite(percent)) return "-";
+  const abs = Math.abs(percent);
+  const decimals = abs < 10 ? 1 : 0;
+  return `${percent >= 0 ? "+" : ""}${percent.toFixed(decimals)}%`;
+}
+
+function formatQuoteChecked(alert: AlertRule): string {
+  if (alert.lastCheckError) return "No quote";
+  if (alert.lastQuoteUpdatedAt) {
+    return formatQuoteAgeWithSource({
+      lastUpdated: alert.lastQuoteUpdatedAt,
+      dataSource: alert.lastQuoteSource,
+    });
+  }
+  if (alert.lastCheckedAt) return relativeTime(alert.lastCheckedAt);
+  return "-";
+}
+
+function conditionLabel(condition: AlertCondition): string {
+  switch (condition) {
+    case "above":
+      return "Above";
+    case "below":
+      return "Below";
+    case "crosses":
+      return "Cross";
+  }
 }
 
 interface AlertCommandInput {
@@ -56,15 +153,21 @@ function parseAlertCondition(value: string | undefined): AlertCondition | null {
   }
 }
 
-function parseAlertShortcutValues(input: string): Record<string, string> {
+function parseAlertShortcutValues(
+  input: string,
+  context?: { activeTicker: string | null },
+): Record<string, string> {
   const parts = input.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return {};
+  if (parts.length === 0) {
+    const activeTicker = normalizeAlertSymbol(context?.activeTicker);
+    return activeTicker ? { symbol: activeTicker } : {};
+  }
   if (parts.length > 3) {
     throw new Error("Use SA SYMBOL above|below|crosses PRICE.");
   }
 
   const values: Record<string, string> = {
-    symbol: parts[0]!.toUpperCase(),
+    symbol: normalizeAlertSymbol(parts[0]),
   };
 
   if (parts[1]) {
@@ -107,21 +210,25 @@ function parseAlertCommandValues(values?: Record<string, string>): AlertCommandI
 type AlertColumnId =
   | "status"
   | "symbol"
-  | "condition"
+  | "current"
   | "target"
-  | "last"
+  | "away"
+  | "condition"
+  | "quote"
   | "triggered"
   | "rearm";
 
 type AlertColumn = DataTableColumn & { id: AlertColumnId };
 
 const ALERT_COLUMNS: AlertColumn[] = [
-  { id: "status", label: "Status", width: 6, align: "left" },
-  { id: "symbol", label: "Symbol", width: 8, align: "left" },
-  { id: "condition", label: "Condition", width: 9, align: "left" },
-  { id: "target", label: "Target", width: 8, align: "right" },
-  { id: "last", label: "Last", width: 8, align: "right" },
-  { id: "triggered", label: "Triggered", width: 9, align: "left" },
+  { id: "status", label: "State", width: 6, align: "left" },
+  { id: "symbol", label: "Symbol", width: 7, align: "left" },
+  { id: "current", label: "Current", width: 9, align: "right" },
+  { id: "target", label: "Target", width: 9, align: "right" },
+  { id: "away", label: "Away", width: 8, align: "right" },
+  { id: "condition", label: "Trigger", width: 7, align: "left" },
+  { id: "quote", label: "Quote", width: 8, align: "left" },
+  { id: "triggered", label: "Alerted", width: 8, align: "left" },
   { id: "rearm", label: "", width: 6, align: "left" },
 ];
 
@@ -132,8 +239,10 @@ const ALERT_TABLE_CONTENT_WIDTH = ALERT_COLUMNS.reduce(
 
 export function AlertsPane({ focused, width, height, close }: PaneProps) {
   const [alertsJson, setAlertsJson] = usePluginConfigState<string>(ALERTS_KEY, "[]");
+  const marketData = useMarketData();
   const { openPluginCommandWorkflow } = usePluginAppActions();
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const marketDataId = marketData?.id ?? null;
   const showHorizontalScrollbar = ALERT_TABLE_CONTENT_WIDTH > width;
 
   const { alerts, rows, activeCount, triggeredCount } = useMemo(() => {
@@ -151,8 +260,12 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     };
   }, [alertsJson]);
 
-  const saveAlerts = useCallback((next: AlertRule[]) => {
-    setAlertsJson(serializeAlerts(next));
+  const saveAlerts = useCallback((next: AlertRule[] | ((current: AlertRule[]) => AlertRule[])) => {
+    setAlertsJson((currentJson) => {
+      const current = deserializeAlerts(currentJson);
+      const resolved = typeof next === "function" ? next(current) : next;
+      return serializeAlerts(resolved);
+    });
   }, [setAlertsJson]);
 
   const deleteAlert = useCallback((id: string) => {
@@ -163,12 +276,12 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
   const rearmAlert = useCallback((id: string) => {
     saveAlerts(
       alerts.map((a) =>
-        a.id === id ? { ...a, status: "active" as const, triggeredAt: undefined } : a,
+        a.id === id ? { ...a, status: "active" as const, triggeredAt: undefined, lastCheckError: undefined } : a,
       ),
     );
   }, [alerts, saveAlerts]);
 
-  const openSetAlertCommand = useCallback(() => {
+  const startAddAlert = useCallback(() => {
     openPluginCommandWorkflow("set-alert");
   }, [openPluginCommandWorkflow]);
 
@@ -176,6 +289,39 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     const selected = rows[selectedIdx];
     if (selected) deleteAlert(selected.id);
   }, [deleteAlert, rows, selectedIdx]);
+
+  useEffect(() => {
+    if (!marketData || rows.length === 0) return;
+    const now = Date.now();
+    const dueAlerts = rows.filter((alert) => (
+      !alert.lastCheckedAt || now - alert.lastCheckedAt > PANE_QUOTE_REFRESH_MS
+    ));
+    if (dueAlerts.length === 0) return;
+
+    let cancelled = false;
+    void Promise.all(dueAlerts.map(async (alert) => {
+      try {
+        const quote = await resolveAlertQuote(marketData, alert.symbol);
+        return { id: alert.id, patch: quoteAlertFields(quote) };
+      } catch (error) {
+        return {
+          id: alert.id,
+          patch: quoteErrorAlertFields(createQuoteErrorMessage(alert.symbol, error)),
+        };
+      }
+    })).then((updates) => {
+      if (cancelled || updates.length === 0) return;
+      const patches = new Map(updates.map((update) => [update.id, update.patch]));
+      saveAlerts((current) => current.map((alert) => {
+        const patch = patches.get(alert.id);
+        return patch ? { ...alert, ...patch } : alert;
+      }));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [marketDataId, rows, saveAlerts]);
 
   usePaneFooter("alerts", () => ({
     info: [
@@ -195,10 +341,16 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
       }] : []),
     ],
     hints: [
-      { id: "add", key: "a", label: "dd alert", onPress: openSetAlertCommand },
+      { id: "add", key: "a", label: "dd alert", onPress: startAddAlert },
       { id: "delete", key: "d", label: "elete", onPress: deleteSelectedAlert, disabled: rows.length === 0 },
     ],
-  }), [activeCount, deleteSelectedAlert, openSetAlertCommand, rows.length, triggeredCount]);
+  }), [
+    activeCount,
+    deleteSelectedAlert,
+    rows.length,
+    startAddAlert,
+    triggeredCount,
+  ]);
 
   useEffect(() => {
     setSelectedIdx((prev) => (rows.length === 0 ? 0 : Math.min(prev, rows.length - 1)));
@@ -212,7 +364,7 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     }
     if (event.name === "a" || event.name === "n") {
       event.preventDefault?.();
-      openSetAlertCommand();
+      startAddAlert();
       return true;
     }
     if (event.name === "escape") {
@@ -221,7 +373,7 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
       return true;
     }
     return false;
-  }, [close, deleteSelectedAlert, openSetAlertCommand]);
+  }, [close, deleteSelectedAlert, startAddAlert]);
 
   const renderCell = useCallback((
     alert: AlertRule,
@@ -249,16 +401,26 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
           color: selectedColor ?? colors.textBright,
           attributes: TextAttributes.BOLD,
         };
-      case "condition":
+      case "current":
         return {
-          text: alert.condition,
-          color: selectedColor,
+          text: formatCurrentPrice(alert, column.width),
+          color: selectedColor ?? (alert.lastCheckError ? colors.negative : colors.text),
         };
       case "target":
-        return { text: String(alert.targetPrice), color: selectedColor };
-      case "last":
+        return { text: formatAlertTargetPrice(alert, column.width), color: selectedColor };
+      case "away":
         return {
-          text: alert.lastCheckedPrice == null ? "-" : String(alert.lastCheckedPrice),
+          text: formatAlertDistance(alert),
+          color: selectedColor ?? colors.textDim,
+        };
+      case "condition":
+        return {
+          text: conditionLabel(alert.condition),
+          color: selectedColor,
+        };
+      case "quote":
+        return {
+          text: formatQuoteChecked(alert),
           color: selectedColor ?? colors.textDim,
         };
       case "triggered":
@@ -333,7 +495,7 @@ export const alertsPlugin: GloomPlugin = {
       shortcut: "SA",
       shortcutArg: {
         placeholder: "symbol condition price",
-        kind: "text",
+        kind: "ticker",
         parse: parseAlertShortcutValues,
       },
       wizardLayout: "form",
@@ -363,16 +525,21 @@ export const alertsPlugin: GloomPlugin = {
       ],
       async execute(values) {
         const input = parseAlertCommandValues(values);
-        if (!input) return;
+        if (!input) throw new Error("Use a symbol, condition, and target price.");
 
-        const alert = createAlert(input.symbol, input.condition, input.price);
+        const quote = await resolveAlertQuote(ctx.marketData, input.symbol);
+
+        const alert = {
+          ...createAlert(quote.symbol || input.symbol, input.condition, input.price),
+          ...quoteAlertFields(quote),
+        };
         const existing = loadAlerts(ctx);
         existing.push(alert);
         saveAlerts(ctx, existing);
 
         ctx.notify({
-          body: `Alert set: ${formatAlertDescription(alert)}`,
-          type: "info",
+          body: `Alert set: ${formatAlertDescription(alert)} (current ${formatMarketPrice(quote.price, { minimumFractionDigits: 2 })})`,
+          type: "success",
         });
       },
     });
@@ -394,6 +561,8 @@ export const alertsPlugin: GloomPlugin = {
           const quote = await ctx.marketData.getQuote(alert.symbol, "");
           if (!quote || typeof quote.price !== "number") {
             ctx.log.warn("poll: no quote", { symbol: alert.symbol });
+            Object.assign(alert, quoteErrorAlertFields(`No quote found for "${alert.symbol}".`));
+            changed = true;
             continue;
           }
 
@@ -412,10 +581,12 @@ export const alertsPlugin: GloomPlugin = {
             });
             changed = true;
           }
-          alert.lastCheckedPrice = quote.price;
+          Object.assign(alert, quoteAlertFields(quote));
           changed = true;
         } catch (err) {
           ctx.log.error("poll: error", { symbol: alert.symbol, error: String(err) });
+          Object.assign(alert, quoteErrorAlertFields(createQuoteErrorMessage(alert.symbol, err)));
+          changed = true;
         }
       }
 
@@ -434,7 +605,7 @@ export const alertsPlugin: GloomPlugin = {
       component: AlertsPane,
       defaultPosition: "right",
       defaultMode: "floating",
-      defaultFloatingSize: { width: 65, height: 20 },
+      defaultFloatingSize: { width: 82, height: 20 },
     });
 
     ctx.registerPaneTemplate({

--- a/src/plugins/builtin/alerts/types.ts
+++ b/src/plugins/builtin/alerts/types.ts
@@ -1,3 +1,4 @@
+import type { QuoteDataSource } from "../../../types/financials";
 
 export type AlertCondition = "above" | "below" | "crosses";
 export type AlertStatus = "active" | "triggered" | "expired";
@@ -11,5 +12,10 @@ export interface AlertRule {
   status: AlertStatus;
   triggeredAt?: number;
   lastCheckedPrice?: number;
+  lastCheckedAt?: number;
+  lastCheckError?: string;
+  lastQuoteUpdatedAt?: number;
+  lastQuoteSource?: QuoteDataSource;
+  lastQuoteProviderId?: string;
   message?: string;
 }


### PR DESCRIPTION
Alerts now use one shared Add Alert command workflow from both the command bar and the alert pane, with ticker validation, active-ticker seeding, and target prefill from the resolved current price.
The alert pane now shows current price, distance to target, quote freshness/source, and quote lookup errors for existing alerts while widening the default floating pane to fit the table.
Alert creation and polling now persist quote metadata so invalid or stale symbols are visible instead of ambiguous.
Validated with focused alert and command-bar tests, `bun run build`, `git diff --check`, a secret scan, and a tmux smoke run with `bun run start`.
