### PR TITLE
Fix desktop ticker tab switching

### DIFF
--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -176,7 +176,7 @@ function cleanDomProps(props: Record<string, unknown>): Record<string, unknown> 
     "margin", "marginX", "marginY", "marginLeft", "marginRight", "marginTop", "marginBottom",
     "bold", "underline", "inverse", "dim", "italic", "strikethrough", "attributes", "content", "position", "left", "right", "top", "bottom",
     "zIndex", "width", "height", "minWidth", "minHeight", "maxWidth", "maxHeight", "gap",
-    "border", "borderStyle", "borderColor", "overflow", "selectable", "name", "color",
+    "border", "borderStyle", "borderColor", "overflow", "selectable", "visible", "name", "color",
     "focused", "focusedBackgroundColor", "textColor", "focusedTextColor", "placeholderColor",
     "cursorColor", "selectionBg", "selectionFg", "showCursor", "keyBindings", "wrapText", "wrapMode",
     "initialValue", "value", "onInput", "onChange", "onSubmit", "onCursorChange", "onMouse",
@@ -445,7 +445,11 @@ const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { children?:
         onMouseUp={(event) => callMouseHandler(propsRef.current.onMouseUp, event, "up")}
         onMouseOut={handleMouseOut}
         onWheel={typeof props.onMouseScroll === "function" ? handleWheel : undefined}
-        style={{ ...commonStyle(props), ...(props.style as CSSProperties | undefined) }}
+        style={{
+          ...commonStyle(props),
+          ...(props.style as CSSProperties | undefined),
+          ...(props.visible === false ? { display: "none" } : undefined),
+        }}
       >
         {children as ReactNode}
       </div>


### PR DESCRIPTION
Desktop web boxes now honor visible={false}, so previously visited ticker-detail tabs stay mounted for state preservation without stacking inactive tab bodies into the pane. The root cause was the Electrobun renderer forwarding the shared visible prop to the DOM without mapping it to layout visibility. Validated with bun run desktop:view:build and bun test src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx src/plugins/builtin/ticker-detail.test.tsx.