### PR TITLE
Fix pane arrow key scrolling

### DIFF
--- a/src/components/layout/pane-content.tsx
+++ b/src/components/layout/pane-content.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback } from "react";
 import { PaneInstanceProvider } from "../../state/app-context";
+import { PaneKeyboardScrollController } from "../../state/pane-scroll-registry";
 import type { PaneDef } from "../../types/plugin";
 
 interface PaneContentProps {
@@ -27,6 +28,7 @@ export const PaneContent = memo(function PaneContent({
 
   return (
     <PaneInstanceProvider paneId={paneId}>
+      <PaneKeyboardScrollController paneId={paneId} focused={focused} />
       <Component
         paneId={paneId}
         paneType={paneType}

--- a/src/components/layout/pane-keyboard-scroll.test.tsx
+++ b/src/components/layout/pane-keyboard-scroll.test.tsx
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useReducer, type ReactNode } from "react";
+import { testRender } from "../../renderers/opentui/test-utils";
+import { useShortcut } from "../../react/input";
+import { AppContext, appReducer, createInitialState } from "../../state/app-context";
+import { Box, ScrollBox, Text, type ScrollBoxRenderable } from "../../ui";
+import { DataTableStackView } from "../data-table-stack-view";
+import { type DataTableColumn } from "../ui";
+import { createDefaultConfig } from "../../types/config";
+import type { PaneProps } from "../../types/plugin";
+import { PaneContent } from "./pane-content";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let scrollRef: ScrollBoxRenderable | null = null;
+let hiddenScrollRef: ScrollBoxRenderable | null = null;
+
+afterEach(() => {
+  if (testSetup) {
+    act(() => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+  scrollRef = null;
+  hiddenScrollRef = null;
+});
+
+function emitDownArrow() {
+  return act(async () => {
+    testSetup!.mockInput.pressArrow("down");
+    await testSetup!.renderOnce();
+  });
+}
+
+async function renderHarness(component: ReactNode) {
+  await act(async () => {
+    testSetup = await testRender(component, { width: 30, height: 5 });
+  });
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+function LongScrollPane({ width, height }: PaneProps) {
+  return (
+    <Box width={width} height={height}>
+      <ScrollBox
+        ref={(node) => {
+          scrollRef = node;
+        }}
+        height={height}
+        scrollY
+        focusable={false}
+      >
+        <Box flexDirection="column">
+          {Array.from({ length: 20 }, (_, index) => (
+            <Box key={index} height={1}>
+              <Text>{`Row ${index}`}</Text>
+            </Box>
+          ))}
+        </Box>
+      </ScrollBox>
+    </Box>
+  );
+}
+
+function ConsumingScrollPane(props: PaneProps) {
+  useShortcut((event) => {
+    if (event.name !== "down") return;
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  return <LongScrollPane {...props} />;
+}
+
+function HiddenMountedTabPane({ width, height }: PaneProps) {
+  const renderRows = () => Array.from({ length: 20 }, (_, index) => (
+    <Box key={index} height={1}>
+      <Text>{`Tab row ${index}`}</Text>
+    </Box>
+  ));
+
+  return (
+    <Box width={width} height={height}>
+      <ScrollBox
+        ref={(node) => {
+          scrollRef = node;
+        }}
+        height={height}
+        scrollY
+        focusable={false}
+      >
+        <Box flexDirection="column">{renderRows()}</Box>
+      </ScrollBox>
+      <Box visible={false} height={height}>
+        <ScrollBox
+          ref={(node) => {
+            hiddenScrollRef = node;
+          }}
+          height={height}
+          scrollY
+          focusable={false}
+        >
+          <Box flexDirection="column">{renderRows()}</Box>
+        </ScrollBox>
+      </Box>
+    </Box>
+  );
+}
+
+interface TestRow {
+  id: string;
+}
+
+const columns: DataTableColumn[] = [{ id: "label", label: "Label", width: 10, align: "left" }];
+const rows: TestRow[] = [{ id: "row-1" }];
+
+function StackDetailPane({ focused, width, height }: PaneProps) {
+  const detailContent = (
+    <ScrollBox
+      ref={(node) => {
+        scrollRef = node;
+      }}
+      flexGrow={1}
+      scrollY
+      focusable={false}
+    >
+      <Box flexDirection="column">
+        {Array.from({ length: 20 }, (_, index) => (
+          <Box key={index} height={1}>
+            <Text>{`Tweet detail row ${index}`}</Text>
+          </Box>
+        ))}
+      </Box>
+    </ScrollBox>
+  );
+
+  return (
+    <DataTableStackView<TestRow>
+      focused={focused}
+      detailOpen
+      onBack={() => {}}
+      detailContent={detailContent}
+      detailTitle="Tweet"
+      selectedIndex={0}
+      rootWidth={width}
+      rootHeight={height}
+      columns={columns}
+      items={rows}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      getItemKey={(row) => row.id}
+      isSelected={(_row, index) => index === 0}
+      onSelect={() => {}}
+      renderCell={(row) => ({ text: row.id })}
+      emptyStateTitle="No rows"
+    />
+  );
+}
+
+function Harness({
+  component = LongScrollPane,
+  focused = true,
+}: {
+  component?: (props: PaneProps) => ReactNode;
+  focused?: boolean;
+}) {
+  const initialState = createInitialState(createDefaultConfig("/tmp/gloomberb-pane-keyboard-scroll-test"));
+  const [state, dispatch] = useReducer(appReducer, initialState);
+
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <PaneContent
+        component={component}
+        paneId="test-pane:main"
+        paneType="test-pane"
+        focused={focused}
+        width={30}
+        height={5}
+      />
+    </AppContext>
+  );
+}
+
+describe("pane keyboard scrolling", () => {
+  test("scrolls the focused pane's vertical scrollbox with arrow keys", async () => {
+    await renderHarness(<Harness />);
+
+    expect(scrollRef?.scrollTop).toBe(0);
+    await emitDownArrow();
+
+    expect(scrollRef?.scrollTop).toBe(3);
+  });
+
+  test("does not steal arrows from existing pane shortcut handlers", async () => {
+    await renderHarness(<Harness component={ConsumingScrollPane} />);
+
+    expect(scrollRef?.scrollTop).toBe(0);
+    await emitDownArrow();
+
+    expect(scrollRef?.scrollTop).toBe(0);
+  });
+
+  test("ignores mounted scrollboxes inside hidden tabs", async () => {
+    await renderHarness(<Harness component={HiddenMountedTabPane} />);
+
+    expect(scrollRef?.scrollTop).toBe(0);
+    expect(hiddenScrollRef?.scrollTop).toBe(0);
+    await emitDownArrow();
+
+    expect(scrollRef?.scrollTop).toBe(3);
+    expect(hiddenScrollRef?.scrollTop).toBe(0);
+  });
+
+  test("scrolls stack detail content without requiring a pane-local detail handler", async () => {
+    await renderHarness(<Harness component={StackDetailPane} />);
+
+    expect(scrollRef?.scrollTop).toBe(0);
+    await emitDownArrow();
+
+    expect(scrollRef?.scrollTop).toBe(3);
+  });
+});

--- a/src/react/input.ts
+++ b/src/react/input.ts
@@ -9,14 +9,22 @@ export interface KeyEventLike {
   alt: boolean;
   meta: boolean;
   super?: boolean;
+  readonly defaultPrevented?: boolean;
+  readonly propagationStopped?: boolean;
   preventDefault(): void;
   stopPropagation(): void;
+}
+
+export interface ShortcutOptions {
+  enabled?: boolean;
+  scope?: string;
+  phase?: "normal" | "after";
 }
 
 export interface InputHost {
   useShortcut(
     handler: (event: KeyEventLike) => void,
-    options?: { enabled?: boolean; scope?: string },
+    options?: ShortcutOptions,
   ): void;
   useViewport(): { width: number; height: number };
 }
@@ -43,7 +51,7 @@ function useInputHost(): InputHost {
 
 export function useShortcut(
   handler: (event: KeyEventLike) => void,
-  options?: { enabled?: boolean; scope?: string },
+  options?: ShortcutOptions,
 ): void {
   useInputHost().useShortcut(handler, options);
 }

--- a/src/renderers/electrobun/view/input-host.tsx
+++ b/src/renderers/electrobun/view/input-host.tsx
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 /** @jsxImportSource react */
-import { useEffect, useMemo, useSyncExternalStore, type ReactNode } from "react";
-import { InputHostProvider, type InputHost, type KeyEventLike } from "../../../react/input";
+import { useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
+import { InputHostProvider, type InputHost, type KeyEventLike, type ShortcutOptions } from "../../../react/input";
 import { hasWebCtrlModifier, normalizeWebKeyName, shouldConsumeWebAppKeyDown, webKeySequence } from "./key-event";
 
 export const WEB_CELL_WIDTH = 8;
@@ -9,6 +9,7 @@ export const WEB_CELL_HEIGHT = 18;
 
 function toKeyEventLike(event: KeyboardEvent): KeyEventLike {
   const key = normalizeWebKeyName(event.key);
+  let propagationStopped = false;
   return {
     key,
     name: key,
@@ -18,10 +19,28 @@ function toKeyEventLike(event: KeyboardEvent): KeyEventLike {
     alt: event.altKey,
     meta: event.metaKey,
     super: event.metaKey,
+    get defaultPrevented() {
+      return event.defaultPrevented;
+    },
+    get propagationStopped() {
+      return propagationStopped;
+    },
     preventDefault: () => event.preventDefault(),
-    stopPropagation: () => event.stopPropagation(),
+    stopPropagation: () => {
+      propagationStopped = true;
+      event.stopPropagation();
+    },
   };
 }
+
+interface ShortcutEntry {
+  handlerRef: { current: (event: KeyEventLike) => void };
+  enabledRef: { current: boolean };
+  phase: NonNullable<ShortcutOptions["phase"]>;
+  order: number;
+}
+
+let nextShortcutOrder = 1;
 
 function subscribeViewport(listener: () => void): () => void {
   window.addEventListener("resize", listener);
@@ -40,17 +59,45 @@ function getViewport() {
 }
 
 export function WebInputHostProvider({ children }: { children: ReactNode }) {
+  const shortcutsRef = useRef<ShortcutEntry[]>([]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const shortcutEvent = toKeyEventLike(event);
+      for (const phase of ["normal", "after"] as const) {
+        if (phase === "after" && (shortcutEvent.defaultPrevented || shortcutEvent.propagationStopped)) break;
+        for (const entry of shortcutsRef.current) {
+          if (entry.phase !== phase || !entry.enabledRef.current) continue;
+          entry.handlerRef.current(shortcutEvent);
+          if (shortcutEvent.propagationStopped) break;
+        }
+        if (shortcutEvent.propagationStopped) break;
+      }
+      if (shouldConsumeWebAppKeyDown(event)) event.preventDefault();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   const host = useMemo<InputHost>(() => ({
     useShortcut(handler, options) {
-      useEffect(() => {
-        if (options?.enabled === false) return;
-        const onKeyDown = (event: KeyboardEvent) => {
-          handler(toKeyEventLike(event));
-          if (shouldConsumeWebAppKeyDown(event)) event.preventDefault();
+      const handlerRef = useRef(handler);
+      const enabledRef = useRef(options?.enabled !== false);
+      handlerRef.current = handler;
+      enabledRef.current = options?.enabled !== false;
+
+      useLayoutEffect(() => {
+        const entry: ShortcutEntry = {
+          handlerRef,
+          enabledRef,
+          phase: options?.phase ?? "normal",
+          order: nextShortcutOrder++,
         };
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
-      }, [handler, options?.enabled, options?.scope]);
+        shortcutsRef.current = [...shortcutsRef.current, entry].sort((a, b) => a.order - b.order);
+        return () => {
+          shortcutsRef.current = shortcutsRef.current.filter((current) => current !== entry);
+        };
+      }, [options?.phase, options?.scope]);
     },
     useViewport() {
       return useSyncExternalStore(subscribeViewport, getViewport, getViewport);

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -960,6 +960,15 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
           height: toCellY(element?.clientHeight ?? 0),
         };
       },
+      getBoundingClientRect() {
+        const rect = getElement()?.getBoundingClientRect();
+        return {
+          x: rect?.x ?? 0,
+          y: rect?.y ?? 0,
+          width: rect?.width ?? 0,
+          height: rect?.height ?? 0,
+        };
+      },
       horizontalScrollBar,
       verticalScrollBar,
       scrollTo(target: number | { x?: number; y?: number }, y?: number) {
@@ -1012,7 +1021,13 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         onMouseOut={(event) => callMouseHandler(props.onMouseOut, event, "out")}
         onScroll={scrollable ? handleScroll : undefined}
         onWheel={scrollable ? handleWheel : undefined}
-        style={{ ...commonStyle(props), overflowX, overflowY, ...(props.style as CSSProperties | undefined) }}
+        style={{
+          ...commonStyle(props),
+          overflowX,
+          overflowY,
+          ...(props.style as CSSProperties | undefined),
+          ...(props.visible === false ? { display: "none" } : undefined),
+        }}
       >
         {children as ReactNode}
       </div>

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -38,6 +38,12 @@ export function toKeyEventLike(event: {
     alt: event.alt ?? false,
     meta: event.meta ?? event.super ?? false,
     super: event.super ?? event.meta ?? false,
+    get defaultPrevented() {
+      return event.defaultPrevented ?? false;
+    },
+    get propagationStopped() {
+      return event.propagationStopped ?? false;
+    },
     preventDefault: () => event.preventDefault?.(),
     stopPropagation: () => event.stopPropagation?.(),
   };

--- a/src/renderers/opentui/input-host.tsx
+++ b/src/renderers/opentui/input-host.tsx
@@ -1,14 +1,53 @@
-import { useMemo, type ReactNode } from "react";
-import { InputHostProvider, type InputHost } from "../../react/input";
+import { useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
+import { InputHostProvider, type InputHost, type KeyEventLike, type ShortcutOptions } from "../../react/input";
 import { toKeyEventLike, useKeyboard, useTerminalDimensions } from "./host";
 
+interface ShortcutEntry {
+  handlerRef: { current: (event: KeyEventLike) => void };
+  enabledRef: { current: boolean };
+  phase: NonNullable<ShortcutOptions["phase"]>;
+  order: number;
+}
+
+let nextShortcutOrder = 1;
+
 export function OpenTuiInputHostProvider({ children }: { children: ReactNode }) {
+  const shortcutsRef = useRef<ShortcutEntry[]>([]);
+  const dispatchShortcut = (event: KeyEventLike) => {
+    const shortcuts = shortcutsRef.current;
+    for (const phase of ["normal", "after"] as const) {
+      if (phase === "after" && (event.defaultPrevented || event.propagationStopped)) return;
+      for (const entry of shortcuts) {
+        if (entry.phase !== phase || !entry.enabledRef.current) continue;
+        entry.handlerRef.current(event);
+        if (event.propagationStopped) return;
+      }
+    }
+  };
+
+  useKeyboard((event) => {
+    dispatchShortcut(toKeyEventLike(event));
+  });
+
   const host = useMemo<InputHost>(() => ({
     useShortcut(handler, options) {
-      useKeyboard((event) => {
-        if (options?.enabled === false) return;
-        handler(toKeyEventLike(event));
-      });
+      const handlerRef = useRef(handler);
+      const enabledRef = useRef(options?.enabled !== false);
+      handlerRef.current = handler;
+      enabledRef.current = options?.enabled !== false;
+
+      useLayoutEffect(() => {
+        const entry: ShortcutEntry = {
+          handlerRef,
+          enabledRef,
+          phase: options?.phase ?? "normal",
+          order: nextShortcutOrder++,
+        };
+        shortcutsRef.current = [...shortcutsRef.current, entry].sort((a, b) => a.order - b.order);
+        return () => {
+          shortcutsRef.current = shortcutsRef.current.filter((current) => current !== entry);
+        };
+      }, [options?.phase, options?.scope]);
     },
     useViewport() {
       const dimensions = useTerminalDimensions();

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -183,6 +183,10 @@ export function usePaneInstanceId(): string {
   return paneId;
 }
 
+export function useOptionalPaneInstanceId(): string | null {
+  return useContext(PaneContext);
+}
+
 export function usePaneInstance(): PaneInstanceConfig | null {
   const paneId = useContext(PaneContext);
   return useAppSelector((state) => (paneId ? findPaneInstance(state.config.layout, paneId) ?? null : null));

--- a/src/state/pane-scroll-registry.tsx
+++ b/src/state/pane-scroll-registry.tsx
@@ -1,0 +1,254 @@
+import { useImperativeHandle, useLayoutEffect, useRef, type ForwardedRef, type RefObject } from "react";
+import { useShortcut } from "../react/input";
+import { useNativeRenderer, type ScrollBoxRenderable } from "../ui/host";
+import { useAppSelector, useOptionalPaneInstanceId } from "./app-context";
+
+type ScrollDirection = "up" | "down";
+
+interface PaneScrollAction {
+  direction: ScrollDirection;
+  resolveTarget(scrollBox: ScrollBoxRenderable): number | null;
+}
+
+interface PaneScrollEntry {
+  order: number;
+  ref: RefObject<ScrollBoxRenderable | null>;
+  onScrollActivity?: (event: { scroll: { direction: ScrollDirection; delta: number } }) => void;
+}
+
+interface PaneScrollKeyEvent {
+  name?: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  alt?: boolean;
+  option?: boolean;
+  defaultPrevented?: boolean;
+  propagationStopped?: boolean;
+  preventDefault?: () => void;
+  stopPropagation?: () => void;
+}
+
+const paneScrollBoxes = new Map<string, Map<number, PaneScrollEntry>>();
+let nextScrollEntryId = 1;
+let nextScrollEntryOrder = 1;
+const MIN_ARROW_SCROLL_LINES = 3;
+
+function hasHiddenAncestor(scrollBox: ScrollBoxRenderable): boolean {
+  let node: unknown = scrollBox;
+  const seen = new Set<unknown>();
+
+  while (node && typeof node === "object" && !seen.has(node)) {
+    seen.add(node);
+    const renderable = node as { visible?: unknown; parent?: unknown };
+    if (renderable.visible === false) return true;
+    node = renderable.parent;
+  }
+
+  return false;
+}
+
+function hasCollapsedBounds(scrollBox: ScrollBoxRenderable): boolean {
+  const bounds = scrollBox.getBoundingClientRect?.();
+  return bounds != null && (bounds.width <= 0 || bounds.height <= 0);
+}
+
+function isVisibleScrollBox(scrollBox: ScrollBoxRenderable): boolean {
+  return !hasHiddenAncestor(scrollBox) && !hasCollapsedBounds(scrollBox);
+}
+
+function clampScrollTop(scrollBox: ScrollBoxRenderable, target: number): number | null {
+  const viewportHeight = Math.max(0, scrollBox.viewport?.height ?? 0);
+  if (viewportHeight <= 0) return null;
+  const maxScrollTop = Math.max(0, scrollBox.scrollHeight - viewportHeight);
+  if (maxScrollTop <= 0) return null;
+  return Math.max(0, Math.min(maxScrollTop, target));
+}
+
+function scrollTargetByDelta(scrollBox: ScrollBoxRenderable, delta: number): number | null {
+  const target = clampScrollTop(scrollBox, scrollBox.scrollTop + delta);
+  return target == null || target === scrollBox.scrollTop ? null : target;
+}
+
+function arrowScrollLines(scrollBox: ScrollBoxRenderable): number {
+  return Math.max(MIN_ARROW_SCROLL_LINES, Math.floor((scrollBox.viewport?.height ?? 0) / 4));
+}
+
+function resolveKeyScrollAction(event: PaneScrollKeyEvent): PaneScrollAction | null {
+  if (event.ctrl || event.meta || event.alt || event.option) return null;
+
+  switch (event.name) {
+    case "down":
+      return {
+        direction: "down",
+        resolveTarget: (scrollBox) => scrollTargetByDelta(scrollBox, arrowScrollLines(scrollBox)),
+      };
+    case "up":
+      return {
+        direction: "up",
+        resolveTarget: (scrollBox) => scrollTargetByDelta(scrollBox, -arrowScrollLines(scrollBox)),
+      };
+    case "pagedown":
+      return {
+        direction: "down",
+        resolveTarget: (scrollBox) => scrollTargetByDelta(
+          scrollBox,
+          Math.max(1, (scrollBox.viewport?.height ?? 1) - 1),
+        ),
+      };
+    case "pageup":
+      return {
+        direction: "up",
+        resolveTarget: (scrollBox) => scrollTargetByDelta(
+          scrollBox,
+          -Math.max(1, (scrollBox.viewport?.height ?? 1) - 1),
+        ),
+      };
+    case "home":
+      return {
+        direction: "up",
+        resolveTarget: (scrollBox) => (
+          scrollBox.scrollTop > 0 ? 0 : null
+        ),
+      };
+    case "end":
+      return {
+        direction: "down",
+        resolveTarget: (scrollBox) => {
+          const target = clampScrollTop(scrollBox, Number.MAX_SAFE_INTEGER);
+          return target == null || target === scrollBox.scrollTop ? null : target;
+        },
+      };
+    default:
+      return null;
+  }
+}
+
+function getEntryScore(entry: PaneScrollEntry, scrollBox: ScrollBoxRenderable): number {
+  const viewportHeight = scrollBox.viewport?.height ?? 0;
+  const scrollHeight = scrollBox.scrollHeight;
+  return viewportHeight * 100_000 + Math.min(scrollHeight, 99_999) + entry.order / 100_000;
+}
+
+function findScrollableEntry(paneId: string, action: PaneScrollAction): {
+  entry: PaneScrollEntry;
+  scrollBox: ScrollBoxRenderable;
+  target: number;
+} | null {
+  const entries = paneScrollBoxes.get(paneId);
+  if (!entries) return null;
+
+  let best: { entry: PaneScrollEntry; scrollBox: ScrollBoxRenderable; target: number; score: number } | null = null;
+  for (const entry of entries.values()) {
+    const scrollBox = entry.ref.current;
+    if (!scrollBox) continue;
+    if (!isVisibleScrollBox(scrollBox)) continue;
+
+    const target = action.resolveTarget(scrollBox);
+    if (target == null) continue;
+
+    const score = getEntryScore(entry, scrollBox);
+    if (!best || score > best.score) {
+      best = { entry, scrollBox, target, score };
+    }
+  }
+
+  if (!best) return null;
+  return { entry: best.entry, scrollBox: best.scrollBox, target: best.target };
+}
+
+function scrollPaneByKey(paneId: string, event: PaneScrollKeyEvent): boolean {
+  const action = resolveKeyScrollAction(event);
+  if (!action) return false;
+
+  const match = findScrollableEntry(paneId, action);
+  if (!match) return false;
+
+  const previousTop = match.scrollBox.scrollTop;
+  match.scrollBox.scrollTo(match.target);
+  if (match.scrollBox.scrollTop !== match.target) {
+    match.scrollBox.scrollTop = match.target;
+  }
+
+  const delta = Math.abs(match.scrollBox.scrollTop - previousTop);
+  if (delta > 0) {
+    match.entry.onScrollActivity?.({ scroll: { direction: action.direction, delta } });
+  }
+  return delta > 0;
+}
+
+export function useForwardedScrollBoxRef<T>(
+  forwardedRef: ForwardedRef<T>,
+): RefObject<T | null> {
+  const localRef = useRef<T | null>(null);
+  useImperativeHandle(forwardedRef, () => localRef.current as T);
+  return localRef;
+}
+
+export function useRegisterPaneScrollBox(
+  ref: RefObject<ScrollBoxRenderable | null>,
+  options: {
+    enabled: boolean;
+    onScrollActivity?: PaneScrollEntry["onScrollActivity"];
+  },
+): void {
+  const paneId = useOptionalPaneInstanceId();
+  const entryIdRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!paneId || !options.enabled) return;
+
+    const entryId = nextScrollEntryId++;
+    entryIdRef.current = entryId;
+    let entries = paneScrollBoxes.get(paneId);
+    if (!entries) {
+      entries = new Map();
+      paneScrollBoxes.set(paneId, entries);
+    }
+    entries.set(entryId, {
+      order: nextScrollEntryOrder++,
+      ref,
+      onScrollActivity: options.onScrollActivity,
+    });
+
+    return () => {
+      const currentEntries = paneScrollBoxes.get(paneId);
+      currentEntries?.delete(entryId);
+      if (currentEntries?.size === 0) {
+        paneScrollBoxes.delete(paneId);
+      }
+      if (entryIdRef.current === entryId) {
+        entryIdRef.current = null;
+      }
+    };
+  }, [paneId, options.enabled, options.onScrollActivity, ref]);
+}
+
+export function PaneKeyboardScrollController({
+  paneId,
+  focused,
+}: {
+  paneId: string;
+  focused: boolean;
+}) {
+  const nativeRenderer = useNativeRenderer();
+  const inputCaptured = useAppSelector((state) => state.inputCaptured);
+  const focusedRef = useRef(focused);
+  const inputCapturedRef = useRef(inputCaptured);
+  const paneIdRef = useRef(paneId);
+
+  focusedRef.current = focused;
+  inputCapturedRef.current = inputCaptured;
+  paneIdRef.current = paneId;
+
+  useShortcut((event) => {
+    if (!focusedRef.current || inputCapturedRef.current) return;
+    if (event.defaultPrevented || event.propagationStopped) return;
+    if (!scrollPaneByKey(paneIdRef.current, event)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    nativeRenderer.requestRender();
+  }, { phase: "after" });
+
+  return null;
+}

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -99,6 +99,9 @@ export interface ScrollBoxRenderable {
   scrollLeft?: number;
   scrollHeight: number;
   viewport?: { width: number; height: number };
+  visible?: boolean;
+  parent?: unknown;
+  getBoundingClientRect?: () => { x: number; y: number; width: number; height: number };
   horizontalScrollBar?: { visible: boolean };
   verticalScrollBar?: { visible: boolean };
   scrollTo(target: number | { x?: number; y?: number }, y?: number): void;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,4 +1,5 @@
 import { createElement, forwardRef } from "react";
+import { useForwardedScrollBoxRef, useRegisterPaneScrollBox } from "../state/pane-scroll-registry";
 import { useUiHost } from "./host";
 export {
   RGBA,
@@ -85,7 +86,14 @@ Underline.displayName = "Underline";
 
 export const ScrollBox = forwardRef<any, import("./host").ScrollBoxProps>((props, ref) => {
   const { ScrollBox: HostScrollBox } = useUiHost();
-  return createElement(HostScrollBox as any, { ...props, ref });
+  const localRef = useForwardedScrollBoxRef<any>(ref);
+  useRegisterPaneScrollBox(localRef, {
+    enabled: props.scrollY === true,
+    onScrollActivity: typeof props.onMouseScroll === "function"
+      ? props.onMouseScroll as (event: { scroll: { direction: "up" | "down"; delta: number } }) => void
+      : undefined,
+  });
+  return createElement(HostScrollBox as any, { ...props, ref: localRef });
 });
 ScrollBox.displayName = "ScrollBox";
 


### PR DESCRIPTION
Adds shared pane-level keyboard scrolling so arrow, page, home, and end keys scroll the active pane after pane-local shortcuts decline the event.
The root cause was that scrollable detail content relied on pane-specific handlers, and mounted hidden tab content could still be selected as the scroll target.
This registers vertical scrollboxes per pane, ignores hidden or collapsed scroll targets, and updates both OpenTUI and Electrobun input dispatch to support normal and after phases without stealing existing shortcuts.
Validation: targeted pane/table/detail tests, import-boundary tests, build, desktop view build, whitespace check, and secret-pattern scan all passed.
