### PR TITLE
Fix stuck kitty chart surfaces

### DIFF
--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -82,7 +82,6 @@ import {
 } from "./chart-types";
 import {
   computeBitmapSize,
-  intersectCellRects,
   renderNativeComparisonChartBase,
   renderNativeCrosshairOverlay,
   type CellRect,
@@ -93,6 +92,11 @@ import { ensureKittySupport, getCachedKittySupport } from "./native/kitty-suppor
 import { resolveChartRendererState } from "./native/renderer-selection";
 import { getNativeSurfaceManager } from "./native/surface-manager";
 import { syncCachedNativeSurface } from "./native/surface-sync";
+import {
+  getRenderableCellRect,
+  resolveNativeSurfaceVisibleRect,
+  type NativeSurfaceRenderableNode,
+} from "./native/surface-visibility";
 import { formatAxisCell, formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
@@ -167,14 +171,6 @@ interface DisplayCursorState {
   cellY: number | null;
   pixelX: number | null;
   pixelY: number | null;
-}
-
-interface RenderableNode {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  parent: RenderableNode | null;
 }
 
 const EMPTY_DISPLAY_CURSOR: DisplayCursorState = {
@@ -382,41 +378,6 @@ function resolveCursorMotionKind(
   return event.pixelX !== undefined && event.pixelY !== undefined && getRendererCellMetrics(renderer)
     ? "pixel"
     : "cell";
-}
-
-function extractCellRect(renderable: RenderableNode): CellRect {
-  return {
-    x: renderable.x,
-    y: renderable.y,
-    width: renderable.width,
-    height: renderable.height,
-  };
-}
-
-function resolveVisibleRect(
-  renderable: RenderableNode | null,
-  terminalWidth: number,
-  terminalHeight: number,
-): CellRect | null {
-  if (!renderable) return null;
-
-  let visible: CellRect = {
-    x: 0,
-    y: 0,
-    width: terminalWidth,
-    height: terminalHeight,
-  };
-  let current: RenderableNode | null = renderable;
-
-  while (current) {
-    const currentRect = extractCellRect(current);
-    const nextVisible = intersectCellRects(visible, currentRect);
-    if (!nextVisible) return null;
-    visible = nextVisible;
-    current = current.parent;
-  }
-
-  return visible;
 }
 
 function buildBlankPlotLines(width: number, height: number): string[] {
@@ -1201,8 +1162,9 @@ function ComparisonStockChartView({
 
     const syncPlacement = () => {
       if (effectiveRenderer !== "kitty" || !rendererState.nativeReady || !plotRef.current) return;
-      const rect = extractCellRect(plotRef.current);
-      const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+      const plot = plotRef.current as NativeSurfaceRenderableNode;
+      const rect = getRenderableCellRect(plot);
+      const visibleRect = resolveNativeSurfaceVisibleRect(plot, renderer.terminalWidth, renderer.terminalHeight);
       const previous = lastNativeGeometryRef.current;
       if (previous
         && previous.rect.x === rect.x
@@ -1257,8 +1219,9 @@ function ComparisonStockChartView({
       return;
     }
 
-    const plotRect = extractCellRect(plotRef.current);
-    const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+    const plot = plotRef.current as NativeSurfaceRenderableNode;
+    const plotRect = getRenderableCellRect(plot);
+    const visibleRect = resolveNativeSurfaceVisibleRect(plot, renderer.terminalWidth, renderer.terminalHeight);
     const bitmapSize = computeBitmapSize(plotRect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
     const bitmapKey = buildComparisonNativeBitmapKey(
       symbols.length,
@@ -1314,8 +1277,9 @@ function ComparisonStockChartView({
       return;
     }
 
-    const plotRect = extractCellRect(plotRef.current);
-    const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+    const plot = plotRef.current as NativeSurfaceRenderableNode;
+    const plotRect = getRenderableCellRect(plot);
+    const visibleRect = resolveNativeSurfaceVisibleRect(plot, renderer.terminalWidth, renderer.terminalHeight);
     const bitmapSize = computeBitmapSize(plotRect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
     const renderablePixelSize = getRenderablePixelSize(plotRef.current, renderer);
     const overlayPixelX = scaleLocalPixelCoordinate(

--- a/src/components/chart/native/kitty.test.ts
+++ b/src/components/chart/native/kitty.test.ts
@@ -17,6 +17,7 @@ import { chunkBase64Payload, encodeKittyTransmitRgba } from "./kitty-protocol";
 import { resolveChartRendererState } from "./renderer-selection";
 import { computeSurfaceVisibleFragments, NativeSurfaceManager } from "./surface-manager";
 import { syncCachedNativeSurface } from "./surface-sync";
+import { resolveNativeSurfaceVisibleRect, type NativeSurfaceRenderableNode } from "./surface-visibility";
 
 describe("resolveChartRendererState", () => {
   test("resolves auto and forced kitty correctly", () => {
@@ -95,6 +96,28 @@ describe("computeNativePlacement", () => {
       cropWidth: 40,
       cropHeight: 60,
     });
+  });
+});
+
+describe("resolveNativeSurfaceVisibleRect", () => {
+  test("treats hidden ancestors as invisible for native graphics", () => {
+    const hiddenParent: NativeSurfaceRenderableNode = {
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 20,
+      visible: false,
+      parent: null,
+    };
+    const child: NativeSurfaceRenderableNode = {
+      x: 2,
+      y: 3,
+      width: 20,
+      height: 8,
+      parent: hiddenParent,
+    };
+
+    expect(resolveNativeSurfaceVisibleRect(child, 100, 30)).toBeNull();
   });
 });
 

--- a/src/components/chart/native/surface-visibility.ts
+++ b/src/components/chart/native/surface-visibility.ts
@@ -1,0 +1,48 @@
+import { intersectCellRects, type CellRect } from "./chart-rasterizer";
+
+export interface NativeSurfaceRenderableNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  visible?: boolean;
+  parent: NativeSurfaceRenderableNode | null;
+}
+
+export function getRenderableCellRect(
+  renderable: Pick<NativeSurfaceRenderableNode, "x" | "y" | "width" | "height">,
+): CellRect {
+  return {
+    x: renderable.x,
+    y: renderable.y,
+    width: renderable.width,
+    height: renderable.height,
+  };
+}
+
+export function resolveNativeSurfaceVisibleRect(
+  renderable: NativeSurfaceRenderableNode | null,
+  terminalWidth: number,
+  terminalHeight: number,
+): CellRect | null {
+  if (!renderable) return null;
+
+  let visible: CellRect = {
+    x: 0,
+    y: 0,
+    width: terminalWidth,
+    height: terminalHeight,
+  };
+  let current: NativeSurfaceRenderableNode | null = renderable;
+
+  while (current) {
+    if (current.visible === false) return null;
+
+    const nextVisible = intersectCellRects(visible, getRenderableCellRect(current));
+    if (!nextVisible) return null;
+    visible = nextVisible;
+    current = current.parent;
+  }
+
+  return visible;
+}

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -110,7 +110,6 @@ import {
 } from "./chart-types";
 import {
   computeBitmapSize,
-  intersectCellRects,
   renderNativeChartBase,
   renderNativeCrosshairOverlay,
   type CellRect,
@@ -121,6 +120,11 @@ import { ensureKittySupport, getCachedKittySupport } from "./native/kitty-suppor
 import { resolveChartRendererState } from "./native/renderer-selection";
 import { getNativeSurfaceManager } from "./native/surface-manager";
 import { syncCachedNativeSurface } from "./native/surface-sync";
+import {
+  getRenderableCellRect,
+  resolveNativeSurfaceVisibleRect,
+  type NativeSurfaceRenderableNode,
+} from "./native/surface-visibility";
 import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 
@@ -273,14 +277,6 @@ interface DisplayCursorState {
   cellY: number | null;
   pixelX: number | null;
   pixelY: number | null;
-}
-
-interface RenderableNode {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  parent: RenderableNode | null;
 }
 
 const EMPTY_DISPLAY_CURSOR: DisplayCursorState = {
@@ -520,41 +516,6 @@ function resolveCursorMotionKind(
   return event.pixelX !== undefined && event.pixelY !== undefined && getRendererCellMetrics(renderer)
     ? "pixel"
     : "cell";
-}
-
-function extractCellRect(renderable: RenderableNode): CellRect {
-  return {
-    x: renderable.x,
-    y: renderable.y,
-    width: renderable.width,
-    height: renderable.height,
-  };
-}
-
-function resolveVisibleRect(
-  renderable: RenderableNode | null,
-  terminalWidth: number,
-  terminalHeight: number,
-): CellRect | null {
-  if (!renderable) return null;
-
-  let visible: CellRect = {
-    x: 0,
-    y: 0,
-    width: terminalWidth,
-    height: terminalHeight,
-  };
-  let current: RenderableNode | null = renderable;
-
-  while (current) {
-    const currentRect = extractCellRect(current);
-    const nextVisible = intersectCellRects(visible, currentRect);
-    if (!nextVisible) return null;
-    visible = nextVisible;
-    current = current.parent;
-  }
-
-  return visible;
 }
 
 function buildBlankPlotLines(width: number, height: number): string[] {
@@ -3236,8 +3197,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
 
     const syncPlacement = () => {
       if (effectiveRenderer !== "kitty" || !rendererState.nativeReady || !plotRef.current) return;
-      const rect = extractCellRect(plotRef.current);
-      const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+      const plot = plotRef.current as NativeSurfaceRenderableNode;
+      const rect = getRenderableCellRect(plot);
+      const visibleRect = resolveNativeSurfaceVisibleRect(plot, renderer.terminalWidth, renderer.terminalHeight);
       const previous = lastNativeGeometryRef.current;
       if (previous
         && previous.rect.x === rect.x
@@ -3292,8 +3254,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       return;
     }
 
-    const plotRect = extractCellRect(plotRef.current);
-    const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+    const plot = plotRef.current as NativeSurfaceRenderableNode;
+    const plotRect = getRenderableCellRect(plot);
+    const visibleRect = resolveNativeSurfaceVisibleRect(plot, renderer.terminalWidth, renderer.terminalHeight);
     const bitmapSize = computeBitmapSize(plotRect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
     const bitmapKey = buildNativeBitmapKey(
       projection.points.length,
@@ -3364,8 +3327,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       return;
     }
 
-    const plotRect = extractCellRect(plotRef.current);
-    const visibleRect = resolveVisibleRect(plotRef.current, renderer.terminalWidth, renderer.terminalHeight);
+    const plot = plotRef.current as NativeSurfaceRenderableNode;
+    const plotRect = getRenderableCellRect(plot);
+    const visibleRect = resolveNativeSurfaceVisibleRect(plot, renderer.terminalWidth, renderer.terminalHeight);
     const bitmapSize = computeBitmapSize(plotRect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
     const renderablePixelSize = getRenderablePixelSize(plotRef.current, renderer);
     const overlayPixelX = scaleLocalPixelCoordinate(

--- a/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
+++ b/src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx
@@ -65,6 +65,15 @@ function makeFinancials(length: number): TickerFinancials {
   };
 }
 
+function makeFinancialsWithStatements(length: number): TickerFinancials {
+  const financials = makeFinancials(length);
+  financials.annualStatements = [
+    { date: "2023-12-31", totalRevenue: 90, netIncome: 10 },
+    { date: "2024-12-31", totalRevenue: 110, netIncome: 14 },
+  ];
+  return financials;
+}
+
 function makeDetailConfig(symbol: string): AppConfig {
   const config = createDefaultConfig("/tmp/gloomberb-test");
   config.chartPreferences.renderer = "kitty";
@@ -128,6 +137,13 @@ async function flushFrames(count = 3) {
       await testSetup!.renderOnce();
     });
   }
+}
+
+function getSurfaceVisibleRect(
+  manager: { surfaces: Map<string, { snapshot: { visibleRect: unknown } }> },
+  surfaceId: string,
+): unknown {
+  return manager.surfaces.get(surfaceId)?.snapshot.visibleRect ?? null;
 }
 
 afterEach(() => {
@@ -200,5 +216,55 @@ describe("Ticker detail chart tab switching", () => {
     const returnedOverview = testSetup.captureCharFrame();
     expect(returnedOverview).toContain("AAPL");
     expect(manager.surfaces.has("chart-surface:ticker-detail:test:compact:base")).toBe(true);
+  });
+
+  test("hides the full chart kitty surface when switching to financials", async () => {
+    const symbol = "AAPL";
+    const config = makeDetailConfig(symbol);
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 36 });
+    (testSetup.renderer as { _capabilities: unknown })._capabilities = { kitty_graphics: true };
+    (testSetup.renderer as { _resolution: unknown })._resolution = { width: 1200, height: 960 };
+
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <DetailHarness
+          config={config}
+          ticker={makeTicker(symbol)}
+          financials={makeFinancialsWithStatements(48)}
+        />,
+      );
+    });
+
+    await flushFrames();
+    const manager = getNativeSurfaceManager(testSetup.renderer as never) as unknown as {
+      surfaces: Map<string, { snapshot: { visibleRect: unknown } }>;
+    };
+    const fullSurfaceId = "chart-surface:ticker-detail:test:full:base";
+
+    act(() => {
+      harnessDispatch!({
+        type: "UPDATE_PANE_STATE",
+        paneId: TEST_PANE_ID,
+        patch: { activeTabId: "chart" },
+      });
+    });
+
+    await flushFrames();
+    expect(getSurfaceVisibleRect(manager, fullSurfaceId)).not.toBeNull();
+
+    act(() => {
+      harnessDispatch!({
+        type: "UPDATE_PANE_STATE",
+        paneId: TEST_PANE_ID,
+        patch: { activeTabId: "financials" },
+      });
+    });
+
+    await flushFrames();
+    expect(testSetup.captureCharFrame()).toContain("Income");
+    expect(getSurfaceVisibleRect(manager, fullSurfaceId)).toBeNull();
   });
 });

--- a/src/renderers/opentui/image-surface.tsx
+++ b/src/renderers/opentui/image-surface.tsx
@@ -7,11 +7,16 @@ import {
 } from "../../components/chart/native/chart-rasterizer";
 import { getCachedKittySupport, ensureKittySupport } from "../../components/chart/native/kitty-support";
 import { getNativeSurfaceManager } from "../../components/chart/native/surface-manager";
+import {
+  getRenderableCellRect,
+  resolveNativeSurfaceVisibleRect,
+  type NativeSurfaceRenderableNode,
+} from "../../components/chart/native/surface-visibility";
 import { useOptionalPaneInstanceId } from "../../state/app-context";
 import { useNativeRenderer, type BoxRenderable, type ImageSurfaceProps } from "../../ui";
 import { loadOpenTuiImageBitmap } from "./image-loader";
 
-interface NativeRenderableNode extends BoxRenderable {
+interface NativeRenderableNode extends BoxRenderable, NativeSurfaceRenderableNode {
   x: number;
   y: number;
   width: number;
@@ -83,40 +88,6 @@ function sameTarget(left: SurfaceTarget | null, right: SurfaceTarget | null): bo
     && sameRect(left.visibleRect, right.visibleRect);
 }
 
-function extractCellRect(renderable: Pick<NativeRenderableNode, "x" | "y" | "width" | "height">): CellRect {
-  return {
-    x: renderable.x,
-    y: renderable.y,
-    width: renderable.width,
-    height: renderable.height,
-  };
-}
-
-function resolveVisibleRect(
-  renderable: NativeRenderableNode | null,
-  terminalWidth: number,
-  terminalHeight: number,
-): CellRect | null {
-  if (!renderable) return null;
-
-  let visible: CellRect = {
-    x: 0,
-    y: 0,
-    width: terminalWidth,
-    height: terminalHeight,
-  };
-  let current: NativeRenderableNode | null = renderable;
-
-  while (current) {
-    const nextVisible = intersectCellRects(visible, extractCellRect(current));
-    if (!nextVisible) return null;
-    visible = nextVisible;
-    current = current.parent;
-  }
-
-  return visible;
-}
-
 function insetRect(rect: CellRect, insets: CellInsets): CellRect | null {
   const width = rect.width - insets.left - insets.right;
   const height = rect.height - insets.top - insets.bottom;
@@ -186,14 +157,14 @@ export const OpenTuiImageSurface = forwardRef<unknown, ImageSurfaceProps>(functi
     let mountTimer: Timer | null = null;
     const previousLifecyclePass = renderable.onLifecyclePass;
     const syncTarget = () => {
-      const outerRect = extractCellRect(renderable);
+      const outerRect = getRenderableCellRect(renderable);
       const rect = insetRect(outerRect, insets);
       if (!rect || !renderer.resolution || renderer.terminalWidth <= 0 || renderer.terminalHeight <= 0) {
         setTarget((current) => (current === null ? current : null));
         return;
       }
 
-      const outerVisibleRect = resolveVisibleRect(renderable, renderer.terminalWidth, renderer.terminalHeight);
+      const outerVisibleRect = resolveNativeSurfaceVisibleRect(renderable, renderer.terminalWidth, renderer.terminalHeight);
       const visibleRect = outerVisibleRect ? intersectCellRects(rect, outerVisibleRect) : null;
       const bitmapSize = computeBitmapSize(rect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
       const bitmapKey = `${imageSrc}\n${resolvedObjectFit}\n${bitmapSize.pixelWidth}x${bitmapSize.pixelHeight}`;


### PR DESCRIPTION
Native kitty chart surfaces now share a visibility resolver that treats hidden OpenTUI ancestors as invisible, so a chart bitmap clears when ticker-detail switches from Chart to Financials or another tab.
Stock, comparison, and remote-image surfaces use the same helper instead of duplicated rect traversal.
Added regression coverage for hidden ancestors and the ticker-detail chart-to-financials switch.
Validated with `bun test src/components/chart/native/kitty.test.ts src/plugins/builtin/ticker-detail-chart-tab-switch.test.tsx`, `bun run build`, `git diff --check`, a secret-pattern scan, and a tmux smoke boot.
