### PR TITLE
Fix chat backspace lag

### DIFF
--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -83,6 +83,15 @@ class MemoryPersistence implements PluginPersistence {
   }
 }
 
+class TrackingPersistence extends MemoryPersistence {
+  stateWrites = 0;
+
+  setState(key: string, value: unknown, options?: { schemaVersion?: number }): void {
+    this.stateWrites += 1;
+    super.setState(key, value, options);
+  }
+}
+
 afterEach(() => {
   apiClient.dispose();
   apiClient.setSessionToken(null);
@@ -207,6 +216,34 @@ describe("ChatController", () => {
       sourceKey: TRANSCRIPT_SOURCE,
       schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
     })).toBeNull();
+  });
+
+  test("defers draft persistence and subscriber sync until the user pauses or leaves", () => {
+    const persistence = new TrackingPersistence();
+    const controller = new ChatController();
+    const draftSnapshots: string[] = [];
+
+    controller.attachPersistence(persistence);
+    const unsubscribe = controller.subscribe((snapshot) => {
+      draftSnapshots.push(snapshot.draft);
+    });
+    draftSnapshots.length = 0;
+    persistence.stateWrites = 0;
+
+    controller.setDraft("h");
+    controller.setDraft("he");
+
+    expect(controller.getSnapshot().draft).toBe("he");
+    expect(draftSnapshots).toEqual([]);
+    expect(persistence.stateWrites).toBe(0);
+    expect(persistence.getState("channel:everyone", { schemaVersion: 1 })).toBeNull();
+
+    unsubscribe();
+    controller.dispose();
+
+    expect(persistence.getState<{ draft: string }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
+      draft: "he",
+    });
   });
 
   test("pauses verification polling while the app is backgrounded", () => {

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -16,6 +16,7 @@ const TRANSCRIPT_CACHE_POLICY = {
   staleMs: 30 * 24 * 60 * 60_000,
   expireMs: 90 * 24 * 60 * 60_000,
 };
+const DRAFT_SYNC_DEBOUNCE_MS = 250;
 const VERIFICATION_POLL_MS = 5_000;
 const ISO_TIMESTAMP_CURSOR = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
 const USERNAME_MENTION = /(^|[^A-Za-z0-9_])@([A-Za-z][A-Za-z0-9_]{2,29})(?![A-Za-z0-9_])/g;
@@ -125,6 +126,7 @@ export class ChatController {
   private wsConnection: ChatConnection | null = null;
   private wsConnected = false;
   private verificationPollTimer: ReturnType<typeof setInterval> | null = null;
+  private draftSyncTimer: ReturnType<typeof setTimeout> | null = null;
   private openViewCount = 0;
   private pendingMessageSeq = 0;
   private notifyFn: (notification: AppNotificationRequest) => void = () => {};
@@ -309,8 +311,7 @@ export class ChatController {
   setDraft(draft: string): void {
     if (draft === this.draft) return;
     this.draft = draft;
-    this.persistChannelState();
-    this.emit();
+    this.scheduleDraftSync();
   }
 
   setReplyToId(replyToId: string | null): void {
@@ -326,6 +327,7 @@ export class ChatController {
     }
     return () => {
       this.openViewCount = Math.max(0, this.openViewCount - 1);
+      this.flushDraftSync();
     };
   }
 
@@ -381,6 +383,7 @@ export class ChatController {
       listeners: this.listeners.size,
       hasConnection: !!this.wsConnection,
     });
+    this.flushDraftSync();
     this.stopVerificationPolling();
     this.wsConnection?.close();
     this.wsConnection = null;
@@ -568,6 +571,11 @@ export class ChatController {
   }
 
   private persistChannelState(): void {
+    this.clearDraftSyncTimer();
+    this.writeChannelState();
+  }
+
+  private writeChannelState(): void {
     const value = {
       draft: this.draft,
       replyToId: this.replyToId,
@@ -580,6 +588,28 @@ export class ChatController {
     this.persistence?.setState(CHANNEL_STATE_KEY, value, {
       schemaVersion: CHANNEL_SCHEMA_VERSION,
     });
+  }
+
+  private scheduleDraftSync(): void {
+    this.clearDraftSyncTimer();
+    this.draftSyncTimer = setTimeout(() => {
+      this.draftSyncTimer = null;
+      this.writeChannelState();
+      this.emit();
+    }, DRAFT_SYNC_DEBOUNCE_MS);
+    this.draftSyncTimer.unref?.();
+  }
+
+  private clearDraftSyncTimer(): void {
+    if (!this.draftSyncTimer) return;
+    clearTimeout(this.draftSyncTimer);
+    this.draftSyncTimer = null;
+  }
+
+  private flushDraftSync(): void {
+    if (!this.draftSyncTimer) return;
+    this.clearDraftSyncTimer();
+    this.writeChannelState();
   }
 
   private persistTranscript(): void {

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -222,6 +222,11 @@ export function ChatContent({
 }: ChatContentProps) {
   const dispatch = useAppDispatch();
   const initialSnapshot = controller.getSnapshot();
+  const { nativePaneChrome } = useUiCapabilities();
+  const contentWidth = Math.max(width - 2, 1);
+  const composerPrefixWidth = nativePaneChrome ? 0 : 3;
+  const composerTextWidth = Math.max(contentWidth - composerPrefixWidth, 1);
+  const inputValueRef = useRef(initialSnapshot.draft);
   const [messages, setMessages] = useState<ChatMessage[]>(initialSnapshot.messages);
   const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
   const [user, setUser] = useState<{ id: string; username: string; emailVerified: boolean } | null>(initialSnapshot.user);
@@ -229,15 +234,13 @@ export function ChatContent({
   const [loadingOlderMessages, setLoadingOlderMessages] = useState(initialSnapshot.loadingOlderMessages);
   const [hasOlderMessages, setHasOlderMessages] = useState(initialSnapshot.hasOlderMessages);
   const [inputFocused, setInputFocused] = useState(false);
-  const [inputValue, setInputValue] = useState(initialSnapshot.draft);
+  const [composerRows, setComposerRows] = useState(() => estimateComposerHeight(initialSnapshot.draft, composerTextWidth));
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [followMessages, setFollowMessages] = useState(true);
-  const contentWidth = Math.max(width - 2, 1);
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(() => (
     initialSnapshot.replyToId ? initialSnapshot.messages.find((message) => message.id === initialSnapshot.replyToId) ?? null : null
   ));
-  const { nativePaneChrome } = useUiCapabilities();
   const inputRef = useRef<TextareaRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const applyingExternalDraftRef = useRef(false);
@@ -250,9 +253,6 @@ export function ChatContent({
   const canSend = !!user?.emailVerified;
   const nativeComposerTopGap = nativePaneChrome && canSend ? NATIVE_CHAT_COMPOSER_TOP_GAP_PX : 0;
   const messageBodyWidth = Math.max(contentWidth - 4, 1);
-  const composerPrefixWidth = nativePaneChrome ? 0 : 3;
-  const composerTextWidth = Math.max(contentWidth - composerPrefixWidth, 1);
-  const composerRows = estimateComposerHeight(inputValue, composerTextWidth);
   const composerHeight = canSend
     ? nativePaneChrome
       ? Math.min(CHAT_COMPOSER_MAX_ROWS + 1, Math.max(2, composerRows + 1))
@@ -260,10 +260,18 @@ export function ChatContent({
     : 0;
   const selectionActive = selectedIdx >= 0 && selectedIdx < messages.length;
   const stickyTranscript = followMessages && !selectionActive;
+  const updateComposerRows = useCallback((draft: string) => {
+    const nextRows = estimateComposerHeight(draft, composerTextWidth);
+    setComposerRows((current) => (current === nextRows ? current : nextRows));
+  }, [composerTextWidth]);
 
   useEffect(() => {
     return controller.attachView();
   }, [controller]);
+
+  useEffect(() => {
+    updateComposerRows(inputValueRef.current);
+  }, [updateComposerRows]);
 
   useEffect(() => {
     const unsubscribe = controller.subscribe((snapshot) => {
@@ -273,7 +281,10 @@ export function ChatContent({
       setLoading(snapshot.loading);
       setLoadingOlderMessages(snapshot.loadingOlderMessages);
       setHasOlderMessages(snapshot.hasOlderMessages);
-      setInputValue((current) => (current === snapshot.draft ? current : snapshot.draft));
+      if (inputValueRef.current !== snapshot.draft) {
+        inputValueRef.current = snapshot.draft;
+        updateComposerRows(snapshot.draft);
+      }
       const textarea = inputRef.current;
       if (textarea && textarea.editBuffer.getText() !== snapshot.draft) {
         applyingExternalDraftRef.current = true;
@@ -288,12 +299,10 @@ export function ChatContent({
     void controller.refreshSession().catch(() => {});
     void controller.refreshMessages().catch(() => {});
     return unsubscribe;
-  }, [controller]);
+  }, [controller, updateComposerRows]);
 
   const { catalog, openTicker } = useInlineTickers(messages.map((message) => message.content));
 
-  const inputValueRef = useRef(inputValue);
-  inputValueRef.current = inputValue;
   const replyToRef = useRef(replyTo);
   replyToRef.current = replyTo;
 
@@ -423,9 +432,9 @@ export function ChatContent({
   const commitLocalDraft = useCallback((draft: string) => {
     if (applyingExternalDraftRef.current) return;
     inputValueRef.current = draft;
-    setInputValue((current) => (current === draft ? current : draft));
+    updateComposerRows(draft);
     controller.setDraft(draft);
-  }, [controller]);
+  }, [controller, updateComposerRows]);
 
   useEffect(() => {
     const textarea = inputRef.current;
@@ -834,7 +843,7 @@ export function ChatContent({
 
           <MessageComposer
             inputRef={inputRef}
-            initialValue={inputValue}
+            initialValue={inputValueRef.current}
             focused={inputFocused && focused}
             placeholder={inputPlaceholder}
             terminalPrefix=" > "


### PR DESCRIPTION
## Summary
- Fix chat composer backspace lag by keeping local draft edits out of the full chat pane render loop.
- Debounce draft persistence and controller subscriber sync so held backspace no longer writes plugin state and re-emits snapshots for every key repeat.
- Add a regression test for deferred draft persistence and sync.

## Root Cause
Every draft edit, including repeated Backspace, synchronously updated React state for the whole chat pane, persisted plugin state, and emitted a controller snapshot.

## Validation
- bun test src/plugins/builtin/chat-controller.test.ts
- bun test src/plugins/builtin/chat.test.tsx
- bun run desktop:view:build
- bun run build
- git diff --check
- tmux smoke: opened chat, focused composer, typed and backspaced text, then killed the session
