### PR TITLE
Fix terminal quit hang

### DIFF
--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -34,38 +34,56 @@ export async function startOpenTuiApp(): Promise<void> {
       cliLaunchRequest = dispatchResult.request;
     }
   }
-  startMainThreadMonitor("opentui");
+  const stopMainThreadMonitor = startMainThreadMonitor("opentui");
 
-  let dataDir = await getDataDir();
-  if (!dataDir) {
-    dataDir = join(process.env.HOME || "~", ".gloomberb");
+  let host: Awaited<ReturnType<typeof createOpenTuiHost>> | null = null;
+  let exitTimer: ReturnType<typeof setTimeout> | null = null;
+  const finishProcessExit = () => {
+    stopMainThreadMonitor();
+    if (exitTimer) return;
+    exitTimer = setTimeout(() => {
+      process.exit(process.exitCode ?? 0);
+    }, 0);
+  };
+  try {
+    let dataDir = await getDataDir();
+    if (!dataDir) {
+      dataDir = join(process.env.HOME || "~", ".gloomberb");
+    }
+
+    if (!existsSync(dataDir)) {
+      mkdirSync(dataDir, { recursive: true });
+    }
+
+    const config = await measurePerfAsync("startup.opentui.init-data-dir", () => initDataDir(dataDir));
+    host = await measurePerfAsync("startup.opentui.create-host", () => createOpenTuiHost());
+    host.renderer.once("destroy", finishProcessExit);
+
+    host.render(
+      <UiHostProvider ui={openTuiUiHost} renderer={host.rendererHost} nativeRenderer={host.nativeRenderer}>
+        <OpenTuiInputHostProvider>
+          <ToastHostProvider host={openTuiToastHost}>
+            <OpenTuiDialogHostProvider
+              size="medium"
+              dialogOptions={{ style: { backgroundColor: colors.bg, borderColor: colors.borderFocused, borderStyle: "single", paddingX: 2, paddingY: 1 } }}
+              backdropColor="#000000"
+              backdropOpacity={0.8}
+            >
+              <App
+                config={config}
+                externalPlugins={externalPlugins}
+                cliLaunchRequest={cliLaunchRequest}
+              />
+            </OpenTuiDialogHostProvider>
+          </ToastHostProvider>
+        </OpenTuiInputHostProvider>
+      </UiHostProvider>,
+    );
+  } catch (error) {
+    if (exitTimer) clearTimeout(exitTimer);
+    stopMainThreadMonitor();
+    host?.renderer.off("destroy", finishProcessExit);
+    host?.destroy();
+    throw error;
   }
-
-  if (!existsSync(dataDir)) {
-    mkdirSync(dataDir, { recursive: true });
-  }
-
-  const config = await measurePerfAsync("startup.opentui.init-data-dir", () => initDataDir(dataDir));
-  const host = await measurePerfAsync("startup.opentui.create-host", () => createOpenTuiHost());
-
-  host.render(
-    <UiHostProvider ui={openTuiUiHost} renderer={host.rendererHost} nativeRenderer={host.nativeRenderer}>
-      <OpenTuiInputHostProvider>
-        <ToastHostProvider host={openTuiToastHost}>
-          <OpenTuiDialogHostProvider
-            size="medium"
-            dialogOptions={{ style: { backgroundColor: colors.bg, borderColor: colors.borderFocused, borderStyle: "single", paddingX: 2, paddingY: 1 } }}
-            backdropColor="#000000"
-            backdropOpacity={0.8}
-          >
-            <App
-              config={config}
-              externalPlugins={externalPlugins}
-              cliLaunchRequest={cliLaunchRequest}
-            />
-          </OpenTuiDialogHostProvider>
-        </ToastHostProvider>
-      </OpenTuiInputHostProvider>
-    </UiHostProvider>,
-  );
 }


### PR DESCRIPTION
Fixes #286.

Quitting the OpenTUI app now stops the main-thread monitor and exits the Bun process after the renderer has destroyed and restored the terminal. The startup path also tears down the monitor and host if initialization fails, preventing leftover handles from keeping the process alive.
