### PR TITLE
Fix Ask AI conversation hydration loop

### DIFF
--- a/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
+++ b/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
@@ -1,5 +1,5 @@
 import { Box, ScrollBox, Text, useUiCapabilities } from "../../../ui";
-import { useRef, useEffect, useState, useCallback } from "react";
+import { useRef, useEffect, useState, useCallback, type SetStateAction } from "react";
 import { useShortcut } from "../../../react/input";
 import { TextAttributes } from "../../../ui";
 import { type ScrollBoxRenderable, type TextareaRenderable } from "../../../ui";
@@ -33,7 +33,22 @@ const chatHistories = new Map<string, ChatMessage[]>();
 export { __setDetectedProvidersForTests };
 export type { AiProvider };
 
+function sameMessages(left: readonly ChatMessage[], right: readonly ChatMessage[]): boolean {
+  return left.length === right.length && left.every((message, index) => {
+    const other = right[index];
+    if (!other) return false;
+    return message.role === other.role
+      && message.content === other.content
+      && message.loading === other.loading;
+  });
+}
+
+function historyKeyFor(providerId: string, symbol: string): string {
+  return `conversation:${providerId}:${symbol}`;
+}
+
 export function __setAskAiHistoryForTests(symbol: string, messages: ChatMessage[]): void {
+  chatHistories.set(historyKeyFor("claude", symbol), messages);
   chatHistories.set(symbol, messages);
 }
 
@@ -58,7 +73,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
   const [providers] = useState(() => detectProviders());
   const defaultProviderId = resolveDefaultAiProviderId(providers);
   const [providerId, setProviderId] = usePluginState<string>("providerId", defaultProviderId);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [conversationMessagesByKey, setConversationMessagesByKey] = useState<Record<string, ChatMessage[]>>({});
   const [inputFocused, setInputFocused] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<TextareaRenderable>(null);
@@ -73,6 +88,18 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
   const conversationKey = tickerSymbol && currentProvider
     ? `conversation:${currentProvider.id}:${tickerSymbol}`
     : "__conversation:none__";
+  const historyKey = tickerSymbol && currentProvider ? historyKeyFor(currentProvider.id, tickerSymbol) : null;
+  const messages = conversationMessagesByKey[conversationKey] ?? [];
+  const setMessages = useCallback((nextValue: SetStateAction<ChatMessage[]>) => {
+    setConversationMessagesByKey((previous) => {
+      const previousMessages = previous[conversationKey] ?? [];
+      const nextMessages = typeof nextValue === "function"
+        ? (nextValue as (value: ChatMessage[]) => ChatMessage[])(previousMessages)
+        : nextValue;
+      if (sameMessages(previousMessages, nextMessages)) return previous;
+      return { ...previous, [conversationKey]: nextMessages };
+    });
+  }, [conversationKey]);
   const [persistedConversation, setPersistedConversation] = usePluginState<PersistedConversation | null>(
     conversationKey,
     null,
@@ -81,36 +108,39 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
 
   useEffect(() => {
     if (!tickerSymbol) {
-      setMessages((previous) => (previous.length === 0 ? previous : []));
+      setConversationMessagesByKey((previous) => {
+        const previousMessages = previous[conversationKey] ?? [];
+        return previousMessages.length === 0 ? previous : { ...previous, [conversationKey]: [] };
+      });
       return;
     }
 
-    if (persistedConversation && Date.now() - persistedConversation.updatedAt <= ASK_AI_RETENTION_MS) {
-      chatHistories.set(tickerSymbol, persistedConversation.messages);
+    if (historyKey && persistedConversation && Date.now() - persistedConversation.updatedAt <= ASK_AI_RETENTION_MS) {
+      chatHistories.set(historyKey, persistedConversation.messages);
     }
 
-    const nextMessages = chatHistories.get(tickerSymbol) ?? [];
-    setMessages((previous) => (
-      previous.length === nextMessages.length && previous.every((message, index) => message === nextMessages[index])
-        ? previous
-        : nextMessages
-    ));
-  }, [persistedConversation, tickerSymbol]);
+    const nextMessages = (historyKey ? chatHistories.get(historyKey) : null) ?? chatHistories.get(tickerSymbol) ?? [];
+    setConversationMessagesByKey((previous) => {
+      const previousMessages = previous[conversationKey] ?? [];
+      return sameMessages(previousMessages, nextMessages) ? previous : { ...previous, [conversationKey]: nextMessages };
+    });
+  }, [conversationKey, historyKey, persistedConversation, tickerSymbol]);
 
   useEffect(() => {
-    if (!tickerSymbol || !currentProvider || messages.length === 0) return;
+    if (!tickerSymbol || !currentProvider || !historyKey || messages.length === 0) return;
     const hasLoading = messages.some((message) => message.loading);
     if (hasLoading) {
-      chatHistories.set(tickerSymbol, messages);
+      chatHistories.set(historyKey, messages);
       return;
     }
     const trimmed = messages.slice(-ASK_AI_HISTORY_LIMIT);
-    chatHistories.set(tickerSymbol, trimmed);
+    chatHistories.set(historyKey, trimmed);
+    if (persistedConversation && sameMessages(persistedConversation.messages, trimmed)) return;
     setPersistedConversation({
       updatedAt: Date.now(),
       messages: trimmed,
     });
-  }, [currentProvider, messages, setPersistedConversation, tickerSymbol]);
+  }, [currentProvider, historyKey, messages, persistedConversation, setPersistedConversation, tickerSymbol]);
 
   useEffect(() => {
     const sb = scrollRef.current;

--- a/src/plugins/builtin/ask-ai.test.tsx
+++ b/src/plugins/builtin/ask-ai.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act } from "react";
+import { act, useReducer } from "react";
 import { PaneFooterBar, PaneFooterProvider } from "../../components/layout/pane-footer";
 import { testRender } from "../../renderers/opentui/test-utils";
-import { AppContext, PaneInstanceProvider, createInitialState } from "../../state/app-context";
+import { AppContext, PaneInstanceProvider, appReducer, createInitialState } from "../../state/app-context";
 import { createStatefulTestPluginRuntime } from "../../test-support/plugin-runtime";
 import { createDefaultConfig } from "../../types/config";
 import { Box } from "../../ui";
@@ -257,5 +257,92 @@ describe("AskAiTab", () => {
     });
 
     expect(opened).toEqual(["AAPL"]);
+  });
+
+  test("does not persist previous ticker messages while hydrating a newly selected ticker", async () => {
+    setProviders([
+      { id: "claude", name: "Claude", command: "claude", available: true, buildArgs: () => [] },
+    ]);
+
+    const runtime = createStatefulTestPluginRuntime();
+    runtime.setResumeState("ai", "conversation:claude:AAPL", {
+      updatedAt: Date.now(),
+      messages: [
+        { role: "user", content: "AAPL question" },
+        { role: "assistant", content: "AAPL answer", loading: false },
+      ],
+    }, 1);
+    runtime.setResumeState("ai", "conversation:claude:MSFT", {
+      updatedAt: Date.now(),
+      messages: [
+        { role: "user", content: "MSFT question" },
+        { role: "assistant", content: "MSFT answer", loading: false },
+      ],
+    }, 1);
+
+    let selectSymbol: ((symbol: string) => void) | null = null;
+
+    const config = createDefaultConfig("/tmp/gloomberb-ai-navigation");
+    const initialState = createInitialState(config);
+    initialState.focusedPaneId = PANE_ID;
+    initialState.paneState["portfolio-list:main"] = {
+      ...initialState.paneState["portfolio-list:main"],
+      cursorSymbol: "AAPL",
+    };
+    initialState.tickers = new Map([
+      ["AAPL", makeTicker("AAPL", "Apple Inc.")],
+      ["MSFT", makeTicker("MSFT", "Microsoft Corporation")],
+    ]);
+
+    function NavigableAskAiHarness() {
+      const [state, dispatch] = useReducer(appReducer, initialState);
+      selectSymbol = (symbol) => {
+        dispatch({
+          type: "UPDATE_PANE_STATE",
+          paneId: "portfolio-list:main",
+          patch: { cursorSymbol: symbol },
+        });
+      };
+
+      return (
+        <AppContext value={{ state, dispatch }}>
+          <PaneInstanceProvider paneId={PANE_ID}>
+            <PluginRenderProvider pluginId="ai" runtime={runtime}>
+              <PaneFooterProvider>
+                {(footer) => (
+                  <Box flexDirection="column" width={60} height={12}>
+                    <AskAiTab width={60} height={11} focused onCapture={() => {}} />
+                    <PaneFooterBar footer={footer} focused width={60} />
+                  </Box>
+                )}
+              </PaneFooterProvider>
+            </PluginRenderProvider>
+          </PaneInstanceProvider>
+        </AppContext>
+      );
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<NavigableAskAiHarness />, {
+        width: 60,
+        height: 12,
+      });
+    });
+    await flushFrame();
+
+    expect(testSetup.captureCharFrame()).toContain("AAPL answer");
+
+    await act(() => {
+      selectSymbol?.("MSFT");
+    });
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("MSFT answer");
+    expect(frame).not.toContain("AAPL answer");
+    expect((runtime.getResumeState("ai", "conversation:claude:MSFT") as any)?.messages).toEqual([
+      { role: "user", content: "MSFT question" },
+      { role: "assistant", content: "MSFT answer", loading: false },
+    ]);
   });
 });


### PR DESCRIPTION
Fixes #246.

This fixes the Ask AI tab's per-ticker conversation hydration so switching tickers cannot write the previous ticker's messages into the newly selected ticker's conversation.
Ask AI messages are now scoped by provider and ticker before they are persisted, and unchanged hydrated conversations are not re-saved.
A regression covers navigating between tickers with existing conversations.
