### PR TITLE
Add dim floating pane borders

### DIFF
--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -30,6 +30,24 @@ interface FloatingPaneWrapperProps {
   children: ReactNode;
 }
 
+function TerminalFloatingPaneBorder({ width, height }: { width: number; height: number }) {
+  const borderWidth = Math.max(0, Math.floor(width));
+  const borderHeight = Math.max(0, Math.floor(height));
+  const bodyHeight = Math.max(0, borderHeight - 2);
+  if (borderWidth < 2 || bodyHeight <= 0) return null;
+
+  return (
+    <>
+      <Box position="absolute" top={1} left={0} width={1} height={bodyHeight}>
+        <Text fg={colors.border} selectable={false}>{"│".repeat(bodyHeight)}</Text>
+      </Box>
+      <Box position="absolute" top={1} left={borderWidth - 1} width={1} height={bodyHeight}>
+        <Text fg={colors.border} selectable={false}>{"│".repeat(bodyHeight)}</Text>
+      </Box>
+    </>
+  );
+}
+
 /** Pure visual wrapper; Shell owns the interaction state and supplies handlers. */
 export function FloatingPaneWrapper({
   paneId,
@@ -101,7 +119,17 @@ export function FloatingPaneWrapper({
         {children}
       </Box>
 
-      {reserveFooter && <PaneFooterBar footer={footer} focused={focused} width={width} reserveRight={2} />}
+      {reserveFooter && (
+        <PaneFooterBar
+          footer={footer}
+          focused={focused}
+          width={width}
+          reserveRight={2}
+          showBorder={!nativePaneChrome && !focused}
+        />
+      )}
+
+      {!nativePaneChrome && !focused && <TerminalFloatingPaneBorder width={width} height={height} />}
 
       {nativePaneChrome ? (
         <Box
@@ -117,7 +145,7 @@ export function FloatingPaneWrapper({
         />
       ) : (
         <Box position="absolute" bottom={0} right={0} width={2} height={1}>
-          <Text fg={focused ? colors.borderFocused : colors.textDim} selectable={false}>{focused ? "─◢" : " ◢"}</Text>
+          <Text fg={focused ? colors.borderFocused : colors.border} selectable={false}>{"─◢"}</Text>
         </Box>
       )}
     </Box>

--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -357,11 +357,13 @@ export function PaneFooterBar({
   focused,
   width = 0,
   reserveRight = 0,
+  showBorder = false,
 }: {
   footer?: CombinedPaneFooter | null;
   focused: boolean;
   width?: number;
   reserveRight?: number;
+  showBorder?: boolean;
 }) {
   const { nativePaneChrome } = useUiCapabilities();
   const resolvedFooter = footer ?? EMPTY_FOOTER;
@@ -399,15 +401,15 @@ export function PaneFooterBar({
     );
   }
 
-  if (focused) {
+  if (focused || showBorder) {
     const contentWidth = Math.max(0, Math.floor(width) - 1 - reservedRight - (reservedRight > 0 ? 0 : 1));
     return (
-      <Box height={1} width={width} flexDirection="row" data-gloom-role="pane-footer" data-focused="true" data-empty={empty ? "true" : "false"}>
+      <Box height={1} width={width} flexDirection="row" data-gloom-role="pane-footer" data-focused={focused ? "true" : "false"} data-empty={empty ? "true" : "false"}>
         <Text fg={borderColor} selectable={false}>└</Text>
         <Box width={contentWidth} height={1} overflow="hidden">
           {empty
             ? <Text fg={borderColor} selectable={false}>{"─".repeat(contentWidth)}</Text>
-            : <FooterContent footer={resolvedFooter} focused width={contentWidth} />}
+            : <FooterContent footer={resolvedFooter} focused={focused} width={contentWidth} />}
         </Box>
         {reservedRight === 0 && <Text fg={borderColor} selectable={false}>┘</Text>}
       </Box>

--- a/src/components/layout/pane-header.tsx
+++ b/src/components/layout/pane-header.tsx
@@ -108,7 +108,6 @@ export function PaneHeader({
   const backgroundColor = floating ? floatingPaneTitleBg(focused) : paneTitleBg(focused);
   const actionText = showActions ? PANE_HEADER_ACTION : "     ";
   const closeText = floating ? PANE_HEADER_CLOSE : "";
-  const bc = colors.borderFocused;
   const textColor = paneTitleText(focused, floating);
 
   if (nativePaneChrome) {
@@ -184,9 +183,10 @@ export function PaneHeader({
     );
   }
 
-  if (focused) {
+  if (focused || floating) {
     // Build: ┌─:: Title ─────────── ... x─┐
     // Reserve 2 for corners, 1 for ─ after ┌, 1 for ─ before ┐
+    const borderColor = focused ? colors.borderFocused : colors.border;
     const innerWidth = Math.max(0, width - 4);
     const contentWidth = PANE_HEADER_GRIP.length + closeText.length + actionText.length;
     const titleWidth = Math.max(0, innerWidth - contentWidth);
@@ -196,9 +196,9 @@ export function PaneHeader({
 
     return (
       <Box height={PANE_HEADER_HEIGHT} width={width} backgroundColor={backgroundColor} flexDirection="row">
-        <Text fg={bc} selectable={false}>{"┌─"}</Text>
+        <Text fg={borderColor} selectable={false}>{"┌─"}</Text>
         <Text fg={textColor} selectable={false}>{`${PANE_HEADER_GRIP}${clippedTitle}`}</Text>
-        <Text fg={bc} selectable={false}>{fill}</Text>
+        <Text fg={borderColor} selectable={false}>{fill}</Text>
         <TerminalPaneButton
           text={actionText}
           fg={textColor}
@@ -213,7 +213,7 @@ export function PaneHeader({
             onMouseDown={onCloseMouseDown}
           />
         )}
-        <Text fg={bc} selectable={false}>{"─┐"}</Text>
+        <Text fg={borderColor} selectable={false}>{"─┐"}</Text>
       </Box>
     );
   }

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -586,8 +586,8 @@ function resolveHeaderHitAreas(
   actionStart: number | null;
   closeStart: number | null;
 } {
-  // When focused, the header renders ┌─...─┐ adding 2 chars on each side
-  let rightEdge = options.focused ? width - 2 : width;
+  // Focused panes and all floating panes render ┌─...─┐, adding 2 chars on each side.
+  let rightEdge = options.focused || options.floating ? width - 2 : width;
   let closeStart: number | null = null;
   let actionStart: number | null = null;
 


### PR DESCRIPTION
Adds dim terminal border chrome to unfocused floating panes so overlapping windows are easier to distinguish.

The focused pane keeps the accent border, while inactive floating panes use the theme border around the header, sides, footer, and resize corner.

The floating header hit-area math now matches the bordered header so menu and close clicks stay aligned.

Fixes #283.