### PR TITLE
Fix desktop pane chrome and inline quote crash

### DIFF
--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -368,6 +368,11 @@ export function PaneFooterBar({
   const empty = !hasPaneFooterContent(resolvedFooter);
   const borderColor = focused ? colors.borderFocused : colors.border;
   const topBorderColor = colors.border;
+  const nativeBackgroundColor = empty
+    ? "transparent"
+    : focused
+      ? blendHex(colors.bg, colors.borderFocused, 0.06)
+      : blendHex(colors.panel, colors.border, 0.12);
   const reservedRight = Math.max(0, reserveRight);
   const rightPadding = reservedRight > 0 ? reservedRight : 1;
 
@@ -385,7 +390,7 @@ export function PaneFooterBar({
         style={{
           "--pane-footer-border-color": empty ? "transparent" : topBorderColor,
           borderTop: `1px solid ${empty ? "transparent" : topBorderColor}`,
-          backgroundColor: empty ? "transparent" : focused ? "rgba(84, 201, 159, 0.05)" : "rgba(20, 25, 30, 0.55)",
+          backgroundColor: nativeBackgroundColor,
           boxShadow: empty ? "none" : "inset 0 1px 0 rgba(255,255,255,0.03)",
         }}
       >

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -945,6 +945,7 @@ describe("Shell", () => {
       dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
       instances: [{ ...mainPane }, { ...detailPane }],
       floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 }],
+      detached: [],
     };
     const state = {
       ...createInitialState({
@@ -988,6 +989,7 @@ describe("Shell", () => {
       dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
       instances: [{ ...mainPane }, { ...detailPane }],
       floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 }],
+      detached: [],
     };
     const state = {
       ...createInitialState({
@@ -1011,6 +1013,49 @@ describe("Shell", () => {
     await testSetup.renderOnce();
     await act(async () => {
       testSetup!.mockInput.pressKey("w", { meta: true });
+      await testSetup!.renderOnce();
+    });
+
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId)).toEqual(["portfolio-list:main"]);
+    expect(updateLayout?.layout.floating).toEqual([]);
+  });
+
+  test("closes the focused floating pane with Ctrl+W while plugin input is captured", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+    if (!mainPane || !detailPane) throw new Error("missing default panes");
+
+    const mixedLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 }],
+      detached: [],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(mixedLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(mixedLayout) }],
+      }),
+      focusedPaneId: "ticker-detail:main",
+      inputCaptured: true,
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <TestDialogProvider>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 12 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressKey("w", { ctrl: true });
       await testSetup!.renderOnce();
     });
 

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -216,6 +216,14 @@ export function resolvePaneManagementShortcut(
   return null;
 }
 
+function inputCaptureAllowsPaneManagementShortcut(
+  shortcut: PaneManagementShortcut,
+  event: Pick<KeyEventLike, "meta" | "super" | "targetEditable">,
+): boolean {
+  if (shortcut !== "close") return false;
+  return event.meta || event.super || event.targetEditable !== true;
+}
+
 export function resolveAppHeaderHeightCells(options: { titleBarOverlay?: boolean; cellHeightPx?: number }): number {
   if (!options.titleBarOverlay || !options.cellHeightPx || options.cellHeightPx <= 0) return DEFAULT_HEADER_HEIGHT;
   return TITLEBAR_OVERLAY_HEIGHT_PX / options.cellHeightPx;
@@ -964,7 +972,8 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     }
 
     const shortcut = resolvePaneManagementShortcut(event);
-    if (!shortcut || dragRef.current || overlayOpen || inputCaptured) return;
+    if (!shortcut || dragRef.current || overlayOpen) return;
+    if (inputCaptured && !inputCaptureAllowsPaneManagementShortcut(shortcut, event)) return;
 
     let handled = false;
     switch (shortcut) {
@@ -1699,7 +1708,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
               "data-active": active ? "true" : "false",
               style: { "--divider-color": active ? colors.borderFocused : colors.border } as any,
             } : {})}
-            onMouseDown={nativePaneChrome ? (event) => startNativeDividerDrag(divider, event) : undefined}
+            onMouseDown={nativePaneChrome ? (event: ShellMouseEvent) => startNativeDividerDrag(divider, event) : undefined}
             onMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
             onMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
           />

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -21,6 +21,7 @@ type ViewMode = "table" | "chart";
 type HolderColumnId = "holder" | "value" | "shares" | "changeShares" | "changePercent" | "percentHeld" | "reportDate";
 type HolderColumn = DataTableColumn & { id: HolderColumnId };
 type SortDirection = "asc" | "desc";
+type PreventableMouseEvent = { preventDefault(): void };
 
 interface SortPreference {
   columnId: HolderColumnId;
@@ -452,7 +453,7 @@ function Tile({ tile, selected, currency, onSelect }: {
       width={renderWidth}
       height={renderHeight}
       backgroundColor={selected ? colors.selected : tileColor(tile.row)}
-      onMouseDown={(event) => {
+      onMouseDown={(event: PreventableMouseEvent) => {
         event.preventDefault();
         onSelect();
       }}
@@ -538,7 +539,7 @@ function DesktopTile({ tile, chartWidth, chartHeight, selected, hovered, currenc
     <Box
       data-gloom-role="holders-desktop-tile"
       style={style}
-      onMouseDown={(event) => {
+      onMouseDown={(event: PreventableMouseEvent) => {
         event.preventDefault();
         onSelect();
       }}
@@ -682,6 +683,7 @@ function HoldersTreemap({ rows, width, height, selectedId, onSelect, currency }:
 }
 
 function HoldersView({ focused, width, height }: { focused: boolean; width: number; height: number }) {
+  const { nativePaneChrome } = useUiCapabilities();
   const { symbol, ticker } = usePaneTicker();
   const dataProvider = useAssetData();
   const [viewMode, setViewMode] = usePluginPaneState<ViewMode>("viewMode", "chart");
@@ -853,6 +855,7 @@ function HoldersView({ focused, width, height }: { focused: boolean; width: numb
     : loading
       ? "Loading holders..."
       : error ?? "No holders available";
+  const chartHeight = Math.max(1, height - 1 - (nativePaneChrome ? 1 : 0));
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -889,7 +892,7 @@ function HoldersView({ focused, width, height }: { focused: boolean; width: numb
         <HoldersTreemap
           rows={sortedRows}
           width={width}
-          height={Math.max(1, height - 1)}
+          height={chartHeight}
           selectedId={selectedId}
           onSelect={(row) => setSelectedId(row.id)}
           currency={currency}

--- a/src/react/input.ts
+++ b/src/react/input.ts
@@ -9,6 +9,7 @@ export interface KeyEventLike {
   alt: boolean;
   meta: boolean;
   super?: boolean;
+  targetEditable?: boolean;
   readonly defaultPrevented?: boolean;
   readonly propagationStopped?: boolean;
   preventDefault(): void;

--- a/src/renderers/electrobun/view/input-host.tsx
+++ b/src/renderers/electrobun/view/input-host.tsx
@@ -2,7 +2,13 @@
 /** @jsxImportSource react */
 import { useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
 import { InputHostProvider, type InputHost, type KeyEventLike, type ShortcutOptions } from "../../../react/input";
-import { hasWebCtrlModifier, normalizeWebKeyName, shouldConsumeWebAppKeyDown, webKeySequence } from "./key-event";
+import {
+  hasWebCtrlModifier,
+  isEditableKeyboardTarget,
+  normalizeWebKeyName,
+  shouldConsumeWebAppKeyDown,
+  webKeySequence,
+} from "./key-event";
 
 export const WEB_CELL_WIDTH = 8;
 export const WEB_CELL_HEIGHT = 18;
@@ -19,6 +25,7 @@ function toKeyEventLike(event: KeyboardEvent): KeyEventLike {
     alt: event.altKey,
     meta: event.metaKey,
     super: event.metaKey,
+    targetEditable: isEditableKeyboardTarget(event.target),
     get defaultPrevented() {
       return event.defaultPrevented;
     },

--- a/src/renderers/electrobun/view/key-event.ts
+++ b/src/renderers/electrobun/view/key-event.ts
@@ -38,7 +38,7 @@ function targetHasClosest(target: KeyboardTargetLike, selector: string): boolean
   }
 }
 
-function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   const element = getKeyboardTarget(target);
   if (!element) return false;
 

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -71,8 +71,8 @@ button, [data-gloom-interactive="true"] { cursor: pointer; }
   pointer-events: none;
   z-index: 100;
 }
-[data-gloom-role="pane-window"][data-focused="true"] {
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--pane-border-color, #54c99f) 30%, transparent), 0 18px 40px rgba(0, 0, 0, .5);
+[data-gloom-role="pane-window"][data-floating="true"][data-focused="true"] {
+  box-shadow: 0 18px 40px rgba(0, 0, 0, .5);
 }
 [data-gloom-role="pane-window"][data-floating="false"] {
   border: 0;

--- a/src/state/use-inline-tickers.test.tsx
+++ b/src/state/use-inline-tickers.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../renderers/opentui/test-utils";
+import { setSharedMarketDataCoordinator } from "../market-data/coordinator";
+import { setSharedRegistryForTests, type PluginRegistry } from "../plugins/registry";
+import { createDefaultConfig } from "../types/config";
+import { AppContext, createInitialState } from "./app-context";
+import { useInlineTickers } from "./use-inline-tickers";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function InlineTickerHarness() {
+  const { catalog } = useInlineTickers(["$LGD1L"]);
+  return <text>{catalog.LGD1L?.status ?? "none"}</text>;
+}
+
+afterEach(() => {
+  testSetup?.renderer.destroy();
+  testSetup = undefined;
+  setSharedMarketDataCoordinator(null);
+  setSharedRegistryForTests(undefined);
+});
+
+describe("useInlineTickers", () => {
+  test("does not leak rejected quote lookups for existing inline tickers", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-inline-tickers-test");
+    const state = createInitialState(config);
+    state.tickers.set("LGD1L", {
+      metadata: {
+        ticker: "LGD1L",
+        exchange: "NASDAQ",
+        currency: "USD",
+        name: "Unsupported quote",
+        portfolios: [],
+        watchlists: [],
+        positions: [],
+        broker_contracts: [],
+        custom: {},
+        tags: [],
+      },
+    });
+    const actions: unknown[] = [];
+    setSharedRegistryForTests({
+      marketData: {
+        getQuote: async () => {
+          throw new Error("No quote provider available for LGD1L");
+        },
+      },
+      pinTicker: () => {},
+    } as unknown as PluginRegistry);
+
+    await act(async () => {
+      testSetup = await testRender(
+        <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+          <InlineTickerHarness />
+        </AppContext>,
+        { width: 20, height: 1 },
+      );
+    });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    expect(testSetup.captureCharFrame()).toContain("missing");
+    expect(actions).toEqual([]);
+  });
+});

--- a/src/state/use-inline-tickers.ts
+++ b/src/state/use-inline-tickers.ts
@@ -18,6 +18,7 @@ export interface InlineTickerCatalogEntry {
 const resolutionInFlight = new Map<string, Promise<void>>();
 const quoteInFlight = new Map<string, Promise<void>>();
 const missingSymbols = new Set<string>();
+const quoteMissingSymbols = new Set<string>();
 const initialQuoteRequested = new Set<string>();
 
 function normalizeSymbols(texts: readonly string[]): string[] {
@@ -54,6 +55,7 @@ export function useInlineTickers(texts: readonly string[]): {
 
       if (currentTicker && currentQuote) {
         missingSymbols.delete(symbol);
+        quoteMissingSymbols.delete(symbol);
         initialQuoteRequested.delete(symbol);
         continue;
       }
@@ -123,8 +125,12 @@ export function useInlineTickers(texts: readonly string[]): {
               }
               : undefined,
           );
+          quoteMissingSymbols.delete(symbol);
           current.dispatch({ type: "MERGE_QUOTE", symbol, quote });
         })()
+          .catch(() => {
+            quoteMissingSymbols.add(symbol);
+          })
           .finally(() => {
             quoteInFlight.delete(symbol);
           });
@@ -167,7 +173,7 @@ export function useInlineTickers(texts: readonly string[]): {
     const ticker = tickers.get(symbol) ?? null;
     const quote = financials.get(symbol)?.quote ?? null;
     const status: InlineTickerStatus = ticker
-      ? (quote ? "ready" : "loading")
+      ? (quote ? "ready" : quoteMissingSymbols.has(symbol) ? "missing" : "loading")
       : (missingSymbols.has(symbol) ? "missing" : "loading");
     catalog[symbol] = { status, ticker, quote };
   }


### PR DESCRIPTION
Fixes desktop pane chrome issues by letting close shortcuts pass through plugin input capture, using theme-derived native footer backgrounds, removing the extra focused floating-pane outline, and reserving footer space in the Holders chart. It also prevents unsupported inline ticker quote lookups from surfacing as fatal startup errors by marking failed inline quote badges as missing. The root cause was a mix of hardcoded desktop chrome assumptions and an inline quote promise path that only used final cleanup, so quote-provider misses could leak instead of becoming missing inline ticker UI.