### PR TITLE
Fix data table scrollbar visibility

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -13,6 +13,7 @@ import { EmptyState } from "./status";
 import {
   expandTableColumns,
   getTableWidth,
+  hasMeaningfulTableHorizontalOverflow,
   tableContentWidthProps,
   useMeasuredTableContentWidth,
 } from "./table-layout";
@@ -199,10 +200,16 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
     ],
   );
   const tableWidth = useMemo(() => getTableWidth(columns), [columns]);
-  const { contentWidth, measureContentWidth } = useMeasuredTableContentWidth(tableWidth, headerScrollRef, scrollRef);
+  const {
+    contentWidth: measuredContentWidth,
+    viewportWidth: measuredViewportWidth,
+    measureContentWidth,
+  } = useMeasuredTableContentWidth(tableWidth, headerScrollRef, scrollRef);
+  const horizontalScrollbarVisible = showHorizontalScrollbar
+    && hasMeaningfulTableHorizontalOverflow(tableWidth, measuredViewportWidth);
   const displayColumns = useMemo(
-    () => expandTableColumns(columns, contentWidth),
-    [columns, contentWidth],
+    () => expandTableColumns(columns, measuredContentWidth),
+    [columns, measuredContentWidth],
   );
   const handleRowMouseDown =
     useDoubleClickActivation<DataTableRowPointerTarget<T>>({
@@ -269,17 +276,18 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
   useEffect(() => {
     if (headerScrollRef.current) {
       headerScrollRef.current.horizontalScrollBar.visible = false;
-      if (!showHorizontalScrollbar) {
+      if (!horizontalScrollbarVisible) {
         headerScrollRef.current.scrollLeft = 0;
       }
     }
     if (scrollRef.current) {
-      scrollRef.current.horizontalScrollBar.visible = showHorizontalScrollbar;
-      if (!showHorizontalScrollbar) {
+      scrollRef.current.horizontalScrollBar.visible = horizontalScrollbarVisible;
+      scrollRef.current.verticalScrollBar.visible = items.length > scrollRef.current.viewport.height;
+      if (!horizontalScrollbarVisible) {
         scrollRef.current.scrollLeft = 0;
       }
     }
-  }, [columns.length, headerScrollRef, items.length, scrollRef, showHorizontalScrollbar]);
+  }, [columns.length, headerScrollRef, horizontalScrollbarVisible, items.length, measuredViewportHeight, scrollRef]);
 
   useEffect(() => {
     if (applyScrollToIndex()) return;
@@ -318,7 +326,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
         <Box
           flexDirection="row"
           height={1}
-          {...tableContentWidthProps(contentWidth)}
+          {...tableContentWidthProps(measuredContentWidth)}
           paddingX={1}
           backgroundColor={colors.panel}
         >
@@ -396,7 +404,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
                       key={getItemKey(item, index)}
                       flexDirection="row"
                       height={1}
-                      {...tableContentWidthProps(contentWidth)}
+                      {...tableContentWidthProps(measuredContentWidth)}
                       paddingX={1}
                       backgroundColor={sectionHeader.backgroundColor ?? colors.bg}
                       onMouseDown={(event) => {
@@ -433,7 +441,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
                     key={getItemKey(item, index)}
                     flexDirection="row"
                     height={1}
-                    {...tableContentWidthProps(contentWidth)}
+                    {...tableContentWidthProps(measuredContentWidth)}
                     paddingX={1}
                     backgroundColor={rowBg}
                     onMouseMove={() => {

--- a/src/components/ui/table-layout.test.ts
+++ b/src/components/ui/table-layout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { getTableWidth, hasMeaningfulTableHorizontalOverflow } from "./table-layout";
+
+describe("table layout", () => {
+  test("detects only meaningful horizontal table overflow", () => {
+    const tableWidth = getTableWidth([
+      { width: 12 },
+      { width: 8 },
+    ]);
+
+    expect(hasMeaningfulTableHorizontalOverflow(tableWidth, 0)).toBe(false);
+    expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth)).toBe(false);
+    expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth - 1)).toBe(false);
+    expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth - 2)).toBe(true);
+  });
+});

--- a/src/components/ui/table-layout.ts
+++ b/src/components/ui/table-layout.ts
@@ -6,8 +6,14 @@ interface TableWidthColumn {
   flexGrow?: number;
 }
 
+const TRAILING_COLUMN_GUTTER_WIDTH = 1;
+
 export function getTableWidth(columns: readonly TableWidthColumn[]): number {
   return columns.reduce((sum, column) => sum + column.width + 1, 2);
+}
+
+export function hasMeaningfulTableHorizontalOverflow(tableWidth: number, viewportWidth: number): boolean {
+  return viewportWidth > 0 && tableWidth - viewportWidth > TRAILING_COLUMN_GUTTER_WIDTH;
 }
 
 export function expandTableColumns<C extends TableWidthColumn>(
@@ -34,9 +40,9 @@ export function useMeasuredTableContentWidth(
   const [viewportWidth, setViewportWidth] = useState(0);
 
   const measureContentWidth = useCallback(() => {
-    const nextWidth = scrollRef?.current?.viewport?.width
-      ?? headerScrollRef?.current?.viewport?.width
-      ?? 0;
+    const bodyWidth = scrollRef?.current?.viewport?.width || scrollRef?.current?.width || 0;
+    const headerWidth = headerScrollRef?.current?.viewport?.width || headerScrollRef?.current?.width || 0;
+    const nextWidth = bodyWidth || headerWidth;
     setViewportWidth((current) => current === nextWidth ? current : nextWidth);
   }, [headerScrollRef, scrollRef]);
   const scheduleContentWidthMeasure = useCallback(() => {
@@ -48,6 +54,7 @@ export function useMeasuredTableContentWidth(
 
   return {
     contentWidth: Math.max(tableWidth, viewportWidth),
+    viewportWidth,
     measureContentWidth: scheduleContentWidthMeasure,
   };
 }

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -5,7 +5,7 @@ import { DialogProvider } from "@opentui-ui/dialog/react";
 import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core";
 import { Button } from "./button";
 import { ChoiceDialog } from "./choice-dialog";
-import { DataTable } from "./data-table";
+import { DataTable, type DataTableColumn } from "./data-table";
 import { TextField } from "./fields";
 import { ListView } from "./list-view";
 import { MultiSelectDialogButton } from "./multi-select-dialog";
@@ -21,12 +21,13 @@ import { Tabs } from "./tabs";
 import { ToggleList } from "../toggle-list";
 import { AppContext, PaneInstanceProvider, createInitialState } from "../../state/app-context";
 import { createDefaultConfig } from "../../types/config";
+import { DataTableView } from "../data-table-view";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let setListSelection: ((index: number) => void) | null = null;
 let selectedTableRow: string | null = null;
 let activatedTableRow: string | null = null;
-let tableHorizontalScrollbarVisible: boolean | null = null;
+let tableScrollBoxForTest: ScrollBoxRenderable | null = null;
 let closedTab: string | null = null;
 let addedTab = false;
 let resolvedChoice: string | null = null;
@@ -125,34 +126,47 @@ function DataTableSectionHarness() {
   );
 }
 
-function DataTableNoHorizontalScrollHarness() {
+function DataTableHorizontalScrollHarness({
+  columns = [{ id: "name", label: "NAME", width: 12, align: "left" }],
+  containerWidth = 32,
+  containerHeight = 5,
+  rowCount = 1,
+  showHorizontalScrollbar,
+}: {
+  columns?: DataTableColumn[];
+  containerWidth?: number;
+  containerHeight?: number;
+  rowCount?: number;
+  showHorizontalScrollbar?: boolean;
+}) {
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
-  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const items = Array.from({ length: rowCount }, (_, index) => ({
+    id: `row-${index}`,
+    name: index === 0 ? "Alpha" : `Alpha ${index + 1}`,
+  }));
 
   useEffect(() => {
-    tableHorizontalScrollbarVisible = scrollRef.current?.horizontalScrollBar.visible ?? null;
+    tableScrollBoxForTest = scrollRef.current;
   });
 
   return (
-    <DataTable
-      columns={[{ id: "name", label: "NAME", width: 12, align: "left" }]}
-      items={[{ id: "alpha", name: "Alpha" }]}
+    <DataTableView
+      rootWidth={containerWidth}
+      rootHeight={containerHeight}
+      columns={columns}
+      items={items}
       sortColumnId={null}
       sortDirection="asc"
       onHeaderClick={() => {}}
       headerScrollRef={headerScrollRef}
       scrollRef={scrollRef}
-      syncHeaderScroll={() => {}}
-      onBodyScrollActivity={() => {}}
-      hoveredIdx={hoveredIdx}
-      setHoveredIdx={setHoveredIdx}
       getItemKey={(row) => row.id}
       isSelected={() => false}
       onSelect={() => {}}
       renderCell={(row) => ({ text: row.name })}
       emptyStateTitle="No rows."
-      showHorizontalScrollbar={false}
+      showHorizontalScrollbar={showHorizontalScrollbar}
     />
   );
 }
@@ -253,7 +267,7 @@ afterEach(() => {
   setListSelection = null;
   selectedTableRow = null;
   activatedTableRow = null;
-  tableHorizontalScrollbarVisible = null;
+  tableScrollBoxForTest = null;
   closedTab = null;
   addedTab = false;
   resolvedChoice = null;
@@ -650,10 +664,11 @@ describe("shared UI kit", () => {
 
   test("hides data table horizontal scrolling when disabled", async () => {
     const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    tableScrollBoxForTest = null;
     testSetup = await testRender(
       <AppContext value={{ state, dispatch: () => {} }}>
         <PaneInstanceProvider paneId="portfolio-list:main">
-          <DataTableNoHorizontalScrollHarness />
+          <DataTableHorizontalScrollHarness showHorizontalScrollbar={false} />
         </PaneInstanceProvider>
       </AppContext>,
       { width: 32, height: 5 },
@@ -664,7 +679,73 @@ describe("shared UI kit", () => {
       await testSetup!.renderOnce();
     });
 
-    expect(tableHorizontalScrollbarVisible).toBe(false);
+    expect(tableScrollBoxForTest?.horizontalScrollBar.visible).toBe(false);
+  });
+
+  test("hides data table horizontal scrolling when content fits", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    tableScrollBoxForTest = null;
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="portfolio-list:main">
+          <DataTableHorizontalScrollHarness />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 32, height: 5 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(tableScrollBoxForTest?.horizontalScrollBar.visible).toBe(false);
+  });
+
+  test("shows data table horizontal scrolling when content overflows", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    tableScrollBoxForTest = null;
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="portfolio-list:main">
+          <DataTableHorizontalScrollHarness
+            containerWidth={24}
+            columns={[
+              { id: "name", label: "NAME", width: 24, align: "left" },
+              { id: "price", label: "PRICE", width: 18, align: "right" },
+            ]}
+          />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 24, height: 5 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(tableScrollBoxForTest?.horizontalScrollBar.visible).toBe(true);
+  });
+
+  test("shows data table vertical scrolling when rows overflow", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    tableScrollBoxForTest = null;
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="portfolio-list:main">
+          <DataTableHorizontalScrollHarness rowCount={20} containerHeight={5} />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 32, height: 5 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(tableScrollBoxForTest?.verticalScrollBar.visible).toBe(true);
   });
 
   test("virtualizes data table rows by default", async () => {

--- a/src/plugins/builtin/cloud-tweets.tsx
+++ b/src/plugins/builtin/cloud-tweets.tsx
@@ -546,7 +546,6 @@ function TweetSearchTable({
       emptyContent={emptyContent}
       emptyStateTitle={loading ? "Loading tweets..." : error ?? "No tweets"}
       emptyStateHint={data?.query}
-      showHorizontalScrollbar={false}
     />
   );
 }

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -24,6 +24,7 @@ import type {
   DataTableProps,
   DataTableSectionHeader,
 } from "../../../components/ui/data-table";
+import { getTableWidth, hasMeaningfulTableHorizontalOverflow } from "../../../components/ui/table-layout";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
 import { useScrollbarActivity } from "./scrollbar-activity";
 
@@ -489,7 +490,9 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const headerVertical = useScrollbarState(false);
   const bodyHorizontal = useScrollbarState(showHorizontalScrollbar);
   const bodyVertical = useScrollbarState(true);
+  const [viewportWidth, setViewportWidth] = useState(0);
   const [scrollbarActive, markScrollbarActive] = useScrollbarActivity();
+  const tableWidth = useMemo(() => getTableWidth(columns), [columns]);
   const gridTemplateColumns = useMemo(
     () => buildGridTemplateColumns(columns),
     [columns],
@@ -538,6 +541,25 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const totalHeight = virtualize
     ? rowVirtualizer.getTotalSize()
     : WEB_CELL_HEIGHT + items.length * WEB_CELL_HEIGHT;
+  const horizontalScrollEnabled = showHorizontalScrollbar
+    && hasMeaningfulTableHorizontalOverflow(tableWidth, viewportWidth);
+  const scrollContentWidth = horizontalScrollEnabled
+    ? Math.max(1, tableWidth * WEB_CELL_WIDTH)
+    : "100%";
+  const measureViewportWidth = useCallback(() => {
+    const element = bodyElementRef.current;
+    const nextValue = element ? toCellX(element.clientWidth) : 0;
+    setViewportWidth((current) => current === nextValue ? current : nextValue);
+  }, []);
+
+  useEffect(() => {
+    measureViewportWidth();
+    const element = bodyElementRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measureViewportWidth);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [measureViewportWidth]);
 
   useEffect(() => {
     if (scrollToIndex == null || items.length === 0) return;
@@ -589,11 +611,11 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
 
   useEffect(() => {
     headerHorizontal.bar.visible = false;
-    bodyHorizontal.bar.visible = showHorizontalScrollbar;
-    if (!showHorizontalScrollbar) {
+    bodyHorizontal.bar.visible = horizontalScrollEnabled;
+    if (!horizontalScrollEnabled) {
       if (bodyElementRef.current) bodyElementRef.current.scrollLeft = 0;
     }
-  }, [bodyHorizontal.bar, headerHorizontal.bar, showHorizontalScrollbar]);
+  }, [bodyHorizontal.bar, headerHorizontal.bar, horizontalScrollEnabled]);
 
   const rootStyle: CSSProperties = {
     display: "flex",
@@ -610,7 +632,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     flex: "1 1 0px",
     minWidth: 0,
     minHeight: 0,
-    overflowX: showHorizontalScrollbar ? "auto" : "hidden",
+    overflowX: horizontalScrollEnabled ? "auto" : "hidden",
     overflowY: "auto",
     backgroundColor: colors.bg,
   };
@@ -621,7 +643,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
         ref={bodyElementRef}
         data-gloom-role="data-table-body-scroll"
         data-gloom-scrollbar-x={
-          showHorizontalScrollbar && bodyHorizontal.visible
+          horizontalScrollEnabled && bodyHorizontal.visible
             ? "visible"
             : "hidden"
         }
@@ -646,7 +668,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
           data-gloom-role="data-table-scroll-content"
           style={{
             position: "relative",
-            width: "100%",
+            width: scrollContentWidth,
             height: items.length > 0 ? totalHeight : "100%",
             minHeight: WEB_CELL_HEIGHT,
           }}


### PR DESCRIPTION
Fixes #270.

Data tables now measure their viewport before showing horizontal scrollbar chrome, so fitted tables do not render useless scrollbars while overflowing tables still scroll. The shared OpenTUI table also restores vertical scrollbar visibility when rows overflow, and the desktop table path uses the same meaningful-overflow rule. The Tweets table now relies on the shared behavior instead of disabling horizontal scrolling outright.