### PR TITLE
Add Fear & Greed market overview pane

### DIFF
--- a/src/components/chart/static-chart-surface.tsx
+++ b/src/components/chart/static-chart-surface.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Box, ChartSurface, Text, useUiCapabilities } from "../../ui";
+import { Box, ChartSurface, Text, useNativeRenderer, useUiCapabilities } from "../../ui";
 import type { ProjectedChartPoint } from "./chart-data";
 import {
   buildChartScene,
@@ -8,7 +8,7 @@ import {
   renderChart,
   type RenderChartOptions,
 } from "./chart-renderer";
-import { renderNativeChartBase, type NativeChartBitmap } from "./native/chart-rasterizer";
+import { computeBitmapSize, renderNativeChartBase, type NativeChartBitmap } from "./native/chart-rasterizer";
 
 export interface StaticChartSurfaceProps extends Omit<
   RenderChartOptions,
@@ -47,10 +47,12 @@ export function StaticChartSurface({
 }: StaticChartSurfaceProps) {
   const {
     canvasCharts,
+    nativeCharts,
     cellWidthPx = 8,
     cellHeightPx = 18,
     pixelRatio = 1,
   } = useUiCapabilities();
+  const nativeRenderer = useNativeRenderer();
   const timeAxisRows = showTimeAxis ? 1 : 0;
   const labelRows = yAxisLabel ? 1 : 0;
   const totalWidth = Math.max(1, Math.floor(width));
@@ -101,14 +103,36 @@ export function StaticChartSurface({
     : 0;
   const axisGap = axisWidth > 0 ? 1 : 0;
   const plotWidth = Math.max(1, totalWidth - axisWidth - axisGap);
+  const rendererResolution = nativeRenderer.resolution;
+  const rendererTerminalWidth = nativeRenderer.terminalWidth;
+  const rendererTerminalHeight = nativeRenderer.terminalHeight;
   const bitmapSize = useMemo(() => {
-    if (!canvasCharts) return null;
+    if (nativeCharts && rendererResolution && rendererTerminalWidth > 0 && rendererTerminalHeight > 0) {
+      return computeBitmapSize(
+        { x: 0, y: 0, width: plotWidth, height: plotHeight },
+        rendererResolution,
+        rendererTerminalWidth,
+        rendererTerminalHeight,
+      );
+    }
+    if (!canvasCharts && !nativeCharts) return null;
     const scale = Math.max(1, pixelRatio);
     return {
       pixelWidth: Math.max(1, Math.round(plotWidth * cellWidthPx * scale)),
       pixelHeight: Math.max(1, Math.round(plotHeight * cellHeightPx * scale)),
     };
-  }, [canvasCharts, cellHeightPx, cellWidthPx, pixelRatio, plotHeight, plotWidth]);
+  }, [
+    canvasCharts,
+    cellHeightPx,
+    cellWidthPx,
+    nativeCharts,
+    pixelRatio,
+    plotHeight,
+    plotWidth,
+    rendererResolution,
+    rendererTerminalHeight,
+    rendererTerminalWidth,
+  ]);
   const renderOptions = useMemo<RenderChartOptions>(() => ({
     width: plotWidth,
     height: plotHeight,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,8 @@
 
 export { PriceSelectorDialog } from "./price-selector-dialog";
 export { StaticChartSurface } from "./chart/static-chart-surface";
+export { SpeedometerGauge } from "./speedometer-gauge";
+export type { SpeedometerSegment } from "./speedometer-gauge";
 export type { QuoteFlashDirection } from "./ticker-list-table";
 export { TickerListTableView } from "./ticker-list-table-view";
 export type { TickerListVisibleRange } from "./ticker-list-table-view";

--- a/src/components/speedometer-gauge.test.tsx
+++ b/src/components/speedometer-gauge.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../renderers/opentui/test-utils";
+import { colors } from "../theme/colors";
+import { SpeedometerGauge, type SpeedometerSegment } from "./speedometer-gauge";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+const segments: SpeedometerSegment[] = [
+  { from: 0, to: 24.999, label: "EXTREME FEAR", color: colors.negative },
+  { from: 25, to: 44.999, label: "FEAR", color: colors.warning },
+  { from: 45, to: 55, label: "NEUTRAL", color: colors.neutral },
+  { from: 55.001, to: 75, label: "GREED", color: colors.positive },
+  { from: 75.001, to: 100, label: "EXTREME GREED", color: colors.positive },
+];
+
+describe("SpeedometerGauge", () => {
+  test("keeps the terminal fallback compact in wide panes", async () => {
+    testSetup = await testRender(
+      <SpeedometerGauge value={67} valueLabel="GREED" width={120} segments={segments} />,
+      { width: 124, height: 14 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Current reading GREED");
+    expect(frame).toContain("67");
+
+    const labelLine = frame.split("\n").find((line) => line.includes("EXT FEAR") && line.includes("EXT GREED"));
+    expect(labelLine).toBeTruthy();
+    expect(labelLine!.indexOf("EXT GREED") - labelLine!.indexOf("EXT FEAR")).toBeLessThanOrEqual(58);
+  });
+});

--- a/src/components/speedometer-gauge.tsx
+++ b/src/components/speedometer-gauge.tsx
@@ -1,0 +1,554 @@
+import { useMemo } from "react";
+import { Box, ChartSurface, Span, Text, TextAttributes, useNativeRenderer, useUiCapabilities, useUiHost } from "../ui";
+import { computeBitmapSize, type NativeChartBitmap } from "./chart/native/chart-rasterizer";
+import { colors } from "../theme/colors";
+
+export interface SpeedometerSegment {
+  from: number;
+  to: number;
+  label: string;
+  color: string;
+}
+
+export interface SpeedometerGaugeProps {
+  value: number;
+  valueLabel: string;
+  width: number;
+  segments: SpeedometerSegment[];
+  min?: number;
+  max?: number;
+  currentLabel?: string;
+  minWidth?: number;
+  maxWidth?: number;
+}
+
+interface GaugeCell {
+  char: string;
+  color?: string;
+}
+
+interface GaugeChunk {
+  text: string;
+  color?: string;
+}
+
+interface RgbaColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+const DEFAULT_MIN_WIDTH = 34;
+const DEFAULT_MAX_WIDTH = 50;
+const DESKTOP_VIEWBOX_WIDTH = 520;
+const DESKTOP_VIEWBOX_HEIGHT = 232;
+const DESKTOP_CENTER_X = 260;
+const DESKTOP_CENTER_Y = 182;
+const DESKTOP_ARC_RADIUS = 138;
+const DESKTOP_NEEDLE_RADIUS = 104;
+const DESKTOP_LABEL_POSITIONS = [
+  { x: 90, y: 84 },
+  { x: 172, y: 44 },
+  { x: 260, y: 30 },
+  { x: 348, y: 44 },
+  { x: 430, y: 84 },
+];
+const DESKTOP_TICK_LABEL_POSITIONS = [
+  { x: 78, y: 224 },
+  { x: 170, y: 224 },
+  { x: 260, y: 224 },
+  { x: 350, y: 224 },
+  { x: 442, y: 224 },
+];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normalizeValue(value: number, min: number, max: number): number {
+  if (max <= min) return 0;
+  return clamp((value - min) / (max - min), 0, 1);
+}
+
+function valueToAngle(value: number, min: number, max: number): number {
+  return Math.PI - normalizeValue(value, min, max) * Math.PI;
+}
+
+function valueToDegrees(value: number, min: number, max: number): number {
+  return -90 + normalizeValue(value, min, max) * 180;
+}
+
+function formatGaugeValue(value: number): string {
+  if (!Number.isFinite(value)) return "--";
+  return String(Math.round(value));
+}
+
+function segmentForValue(value: number, segments: SpeedometerSegment[]): SpeedometerSegment | null {
+  return segments.find((segment) => value >= segment.from && value <= segment.to)
+    ?? segments[segments.length - 1]
+    ?? null;
+}
+
+function blankGaugeLine(width: number): GaugeCell[] {
+  return Array.from({ length: width }, () => ({ char: " " }));
+}
+
+function placeText(cells: GaugeCell[], label: string, center: number, color?: string): void {
+  const width = cells.length;
+  if (width <= 0) return;
+  const text = label.length > width ? label.slice(0, width) : label;
+  const start = Math.max(0, Math.min(width - text.length, Math.round(center - text.length / 2)));
+  for (let index = 0; index < text.length; index += 1) {
+    cells[start + index] = { char: text[index]!, color };
+  }
+}
+
+function cellsToChunks(cells: GaugeCell[]): GaugeChunk[] {
+  const chunks: GaugeChunk[] = [];
+  for (const cell of cells) {
+    const last = chunks[chunks.length - 1];
+    if (last && last.color === cell.color) {
+      last.text += cell.char;
+    } else {
+      chunks.push({ text: cell.char, color: cell.color });
+    }
+  }
+  return chunks;
+}
+
+function segmentColorForScore(score: number, segments: SpeedometerSegment[]): string {
+  return segmentForValue(score, segments)?.color ?? colors.textDim;
+}
+
+function labelForSegment(segment: SpeedometerSegment, gaugeWidth: number): string {
+  if (gaugeWidth >= 64) return segment.label;
+  const compact = compactSegmentLabel(segment);
+  if (gaugeWidth >= 44) {
+    return compact === "NEUTRAL" ? "NEUT" : compact;
+  }
+  if (compact === "EXT FEAR") return "XF";
+  if (compact === "EXT GREED") return "XG";
+  if (compact === "NEUTRAL") return "NEUT";
+  return compact;
+}
+
+function compactSegmentLabel(segment: SpeedometerSegment): string {
+  return segment.label.replace(/^EXTREME /, "EXT ");
+}
+
+function renderLabelRow(width: number, min: number, max: number, segments: SpeedometerSegment[]): GaugeChunk[] {
+  const cells = blankGaugeLine(width);
+  for (const segment of segments) {
+    const centerValue = (segment.from + segment.to) / 2;
+    const center = normalizeValue(centerValue, min, max) * (width - 1);
+    placeText(cells, labelForSegment(segment, width), center, segment.color);
+  }
+  return cellsToChunks(cells);
+}
+
+function renderTickRow(width: number, min: number, max: number): GaugeChunk[] {
+  const cells = blankGaugeLine(width);
+  for (const tick of [min, min + (max - min) * 0.25, min + (max - min) * 0.5, min + (max - min) * 0.75, max]) {
+    placeText(cells, formatGaugeValue(tick), normalizeValue(tick, min, max) * (width - 1), colors.textDim);
+  }
+  return cellsToChunks(cells);
+}
+
+function renderArcRows(value: number, min: number, max: number, width: number, segments: SpeedometerSegment[]): GaugeChunk[][] {
+  const dialHeight = 7;
+  const dial = Array.from({ length: dialHeight }, () => blankGaugeLine(width));
+  const centerX = Math.floor((width - 1) / 2);
+  const centerY = dialHeight - 1;
+  const radiusX = Math.max(8, (width - 4) / 2);
+  const radiusY = dialHeight - 1;
+
+  for (let step = 0; step <= 220; step += 1) {
+    const normalized = step / 220;
+    const score = min + normalized * (max - min);
+    const angle = Math.PI - normalized * Math.PI;
+    const x = Math.round(centerX + Math.cos(angle) * radiusX);
+    const y = Math.round(centerY - Math.sin(angle) * radiusY);
+    if (dial[y]?.[x]) {
+      dial[y]![x] = { char: "●", color: segmentColorForScore(score, segments) };
+    }
+  }
+
+  for (const tick of [min, min + (max - min) * 0.25, min + (max - min) * 0.5, min + (max - min) * 0.75, max]) {
+    const angle = valueToAngle(tick, min, max);
+    const x = Math.round(centerX + Math.cos(angle) * radiusX);
+    const y = Math.round(centerY - Math.sin(angle) * radiusY);
+    if (dial[y]?.[x]) {
+      dial[y]![x] = { char: "│", color: colors.textDim };
+    }
+  }
+
+  const pointerAngle = valueToAngle(value, min, max);
+  const pointerChar = Math.abs(Math.cos(pointerAngle)) < 0.22
+    ? "│"
+    : Math.cos(pointerAngle) > 0
+      ? "/"
+      : "\\";
+  for (let t = 0.14; t <= 0.75; t += 0.06) {
+    const x = Math.round(centerX + Math.cos(pointerAngle) * radiusX * t);
+    const y = Math.round(centerY - Math.sin(pointerAngle) * radiusY * t);
+    if (dial[y]?.[x]) {
+      dial[y]![x] = { char: pointerChar, color: colors.textBright };
+    }
+  }
+
+  placeText(dial[centerY]!, formatGaugeValue(value), centerX, colors.textBright);
+  return dial.map(cellsToChunks);
+}
+
+function GaugeLine({ chunks }: { chunks: GaugeChunk[] }) {
+  return (
+    <Text>
+      {chunks.map((chunk, index) => (
+        <Span key={`${index}-${chunk.text}`} fg={chunk.color}>{chunk.text}</Span>
+      ))}
+    </Text>
+  );
+}
+
+function parseHex(hex: string, alpha = 1): RgbaColor {
+  const normalized = hex.replace("#", "");
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+    a: Math.round(clamp(alpha, 0, 1) * 255),
+  };
+}
+
+function blendPixel(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+  color: RgbaColor,
+  opacity = 1,
+) {
+  if (x < 0 || y < 0 || x >= width || y >= height) return;
+
+  const alpha = clamp((color.a / 255) * opacity, 0, 1);
+  if (alpha <= 0) return;
+
+  const index = (y * width + x) * 4;
+  const dstAlpha = data[index + 3]! / 255;
+  const outAlpha = alpha + dstAlpha * (1 - alpha);
+  if (outAlpha <= 0) return;
+
+  const dstFactor = dstAlpha * (1 - alpha);
+  data[index] = Math.round((color.r * alpha + data[index]! * dstFactor) / outAlpha);
+  data[index + 1] = Math.round((color.g * alpha + data[index + 1]! * dstFactor) / outAlpha);
+  data[index + 2] = Math.round((color.b * alpha + data[index + 2]! * dstFactor) / outAlpha);
+  data[index + 3] = Math.round(outAlpha * 255);
+}
+
+function drawCircle(data: Uint8Array, width: number, height: number, centerX: number, centerY: number, radius: number, color: RgbaColor) {
+  const minX = Math.floor(centerX - radius - 1);
+  const maxX = Math.ceil(centerX + radius + 1);
+  const minY = Math.floor(centerY - radius - 1);
+  const maxY = Math.ceil(centerY + radius + 1);
+
+  for (let y = minY; y <= maxY; y += 1) {
+    for (let x = minX; x <= maxX; x += 1) {
+      const distance = Math.hypot(x + 0.5 - centerX, y + 0.5 - centerY);
+      const coverage = 1 - clamp((distance - (radius - 0.75)) / 1.5, 0, 1);
+      if (coverage > 0) blendPixel(data, width, height, x, y, color, coverage);
+    }
+  }
+}
+
+function drawLine(data: Uint8Array, width: number, height: number, x0: number, y0: number, x1: number, y1: number, color: RgbaColor, thickness: number) {
+  const half = thickness / 2;
+  const minX = Math.floor(Math.min(x0, x1) - half - 1);
+  const maxX = Math.ceil(Math.max(x0, x1) + half + 1);
+  const minY = Math.floor(Math.min(y0, y1) - half - 1);
+  const maxY = Math.ceil(Math.max(y0, y1) + half + 1);
+  const dx = x1 - x0;
+  const dy = y1 - y0;
+  const segmentLengthSq = dx * dx + dy * dy || 1;
+
+  for (let y = minY; y <= maxY; y += 1) {
+    for (let x = minX; x <= maxX; x += 1) {
+      const projection = clamp((((x + 0.5) - x0) * dx + ((y + 0.5) - y0) * dy) / segmentLengthSq, 0, 1);
+      const nearestX = x0 + dx * projection;
+      const nearestY = y0 + dy * projection;
+      const distance = Math.hypot(x + 0.5 - nearestX, y + 0.5 - nearestY);
+      const coverage = 1 - clamp((distance - half) / 1.2, 0, 1);
+      if (coverage > 0) blendPixel(data, width, height, x, y, color, coverage);
+    }
+  }
+}
+
+function renderGaugeBitmap(
+  value: number,
+  min: number,
+  max: number,
+  segments: SpeedometerSegment[],
+  pixelWidth: number,
+  pixelHeight: number,
+): NativeChartBitmap {
+  const pixels = new Uint8Array(pixelWidth * pixelHeight * 4);
+  const centerX = pixelWidth / 2;
+  const centerY = pixelHeight * 0.84;
+  const radius = Math.min(pixelWidth * 0.42, pixelHeight * 0.72);
+  const arcThickness = Math.max(4, Math.min(pixelWidth, pixelHeight) * 0.038);
+
+  for (const segment of segments) {
+    const start = valueToAngle(segment.from, min, max);
+    const end = valueToAngle(segment.to, min, max);
+    const steps = Math.max(8, Math.ceil(Math.abs(end - start) * radius * 0.36));
+    const color = parseHex(segment.color, 0.9);
+    for (let index = 0; index <= steps; index += 1) {
+      const t = index / steps;
+      const angle = start + (end - start) * t;
+      const x = centerX + Math.cos(angle) * radius;
+      const y = centerY - Math.sin(angle) * radius;
+      drawCircle(pixels, pixelWidth, pixelHeight, x, y, arcThickness, color);
+    }
+  }
+
+  for (const tick of [min, min + (max - min) * 0.25, min + (max - min) * 0.5, min + (max - min) * 0.75, max]) {
+    const angle = valueToAngle(tick, min, max);
+    const innerX = centerX + Math.cos(angle) * (radius - arcThickness * 1.45);
+    const innerY = centerY - Math.sin(angle) * (radius - arcThickness * 1.45);
+    const outerX = centerX + Math.cos(angle) * (radius + arcThickness * 1.25);
+    const outerY = centerY - Math.sin(angle) * (radius + arcThickness * 1.25);
+    drawLine(pixels, pixelWidth, pixelHeight, innerX, innerY, outerX, outerY, parseHex(colors.textDim, 0.8), Math.max(1, arcThickness * 0.22));
+  }
+
+  const angle = valueToAngle(value, min, max);
+  const needleEndX = centerX + Math.cos(angle) * (radius * 0.76);
+  const needleEndY = centerY - Math.sin(angle) * (radius * 0.76);
+  drawLine(pixels, pixelWidth, pixelHeight, centerX, centerY, needleEndX, needleEndY, parseHex(colors.textBright, 0.98), Math.max(3, arcThickness * 0.48));
+
+  return { width: pixelWidth, height: pixelHeight, pixels };
+}
+
+function polarToCartesian(centerX: number, centerY: number, radius: number, angleDegrees: number) {
+  const angleRadians = (angleDegrees - 90) * Math.PI / 180;
+  return {
+    x: centerX + radius * Math.cos(angleRadians),
+    y: centerY + radius * Math.sin(angleRadians),
+  };
+}
+
+function describeArc(centerX: number, centerY: number, radius: number, startAngle: number, endAngle: number): string {
+  const start = polarToCartesian(centerX, centerY, radius, endAngle);
+  const end = polarToCartesian(centerX, centerY, radius, startAngle);
+  const largeArcFlag = endAngle - startAngle <= 180 ? "0" : "1";
+  return `M ${start.x.toFixed(2)} ${start.y.toFixed(2)} A ${radius} ${radius} 0 ${largeArcFlag} 0 ${end.x.toFixed(2)} ${end.y.toFixed(2)}`;
+}
+
+function DesktopGauge({
+  value,
+  valueLabel,
+  width,
+  segments,
+  min,
+  max,
+  currentLabel,
+  minWidth,
+  maxWidth,
+}: Required<SpeedometerGaugeProps>) {
+  const gaugeWidth = Math.min(Math.max(width - 2, minWidth), maxWidth);
+  const needleAngle = valueToDegrees(value, min, max);
+  const needleEnd = polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_NEEDLE_RADIUS, needleAngle);
+
+  return (
+    <Box
+      width={gaugeWidth}
+      height={12}
+      marginTop={1}
+      overflow="hidden"
+      style={{ alignSelf: "center", maxWidth: 420 }}
+    >
+      <svg
+        viewBox={`0 0 ${DESKTOP_VIEWBOX_WIDTH} ${DESKTOP_VIEWBOX_HEIGHT}`}
+        width="100%"
+        height="100%"
+        role="img"
+        aria-label={`${currentLabel} ${formatGaugeValue(value)} ${valueLabel}`}
+        style={{ display: "block" }}
+      >
+        {segments.map((segment) => (
+          <path
+            key={segment.label}
+            d={describeArc(
+              DESKTOP_CENTER_X,
+              DESKTOP_CENTER_Y,
+              DESKTOP_ARC_RADIUS,
+              valueToDegrees(segment.from, min, max),
+              valueToDegrees(segment.to, min, max),
+            )}
+            fill="none"
+            stroke={segment.color}
+            strokeWidth="22"
+            strokeLinecap="butt"
+            opacity={value >= segment.from && value <= segment.to ? 0.96 : 0.42}
+          />
+        ))}
+        {segments.map((segment, index) => {
+          const fixedPoint = segments.length === DESKTOP_LABEL_POSITIONS.length
+            ? DESKTOP_LABEL_POSITIONS[index]
+            : null;
+          const midpoint = (valueToDegrees(segment.from, min, max) + valueToDegrees(segment.to, min, max)) / 2;
+          const point = fixedPoint ?? polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_ARC_RADIUS + 36, midpoint);
+          return (
+            <text
+              key={`label:${segment.label}`}
+              x={point.x}
+              y={point.y}
+              fill={segment.color}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontFamily="inherit"
+              fontSize="14"
+              fontWeight="700"
+            >
+              {compactSegmentLabel(segment)}
+            </text>
+          );
+        })}
+        {[min, min + (max - min) * 0.25, min + (max - min) * 0.5, min + (max - min) * 0.75, max].map((tick, index) => {
+          const angle = valueToDegrees(tick, min, max);
+          const outer = polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_ARC_RADIUS + 16, angle);
+          const inner = polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_ARC_RADIUS - 10, angle);
+          const label = DESKTOP_TICK_LABEL_POSITIONS[index]
+            ?? polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_ARC_RADIUS + 34, angle);
+          return (
+            <g key={tick}>
+              <line x1={inner.x} y1={inner.y} x2={outer.x} y2={outer.y} stroke={colors.textDim} strokeWidth="2" />
+              <text x={label.x} y={label.y} fill={colors.textDim} textAnchor="middle" fontFamily="inherit" fontSize="13">
+                {formatGaugeValue(tick)}
+              </text>
+            </g>
+          );
+        })}
+        <line
+          x1={DESKTOP_CENTER_X}
+          y1={DESKTOP_CENTER_Y}
+          x2={needleEnd.x}
+          y2={needleEnd.y}
+          stroke={colors.textBright}
+          strokeWidth="7"
+          strokeLinecap="round"
+        />
+        <circle cx={DESKTOP_CENTER_X} cy={DESKTOP_CENTER_Y} r="27" fill={colors.bg} />
+        <text x={DESKTOP_CENTER_X} y={DESKTOP_CENTER_Y + 18} fill={colors.textBright} textAnchor="middle" fontFamily="inherit" fontSize="31" fontWeight="800">
+          {formatGaugeValue(value)}
+        </text>
+      </svg>
+    </Box>
+  );
+}
+
+function TerminalGauge({
+  value,
+  valueLabel,
+  width,
+  segments,
+  min,
+  max,
+  currentLabel,
+  minWidth,
+  maxWidth,
+}: Required<SpeedometerGaugeProps>) {
+  const {
+    nativeCharts,
+    cellWidthPx = 8,
+    cellHeightPx = 18,
+    pixelRatio = 1,
+  } = useUiCapabilities();
+  const nativeRenderer = useNativeRenderer();
+  const gaugeWidth = Math.max(minWidth, Math.min(maxWidth, Math.floor(width - 4)));
+  const labelRow = useMemo(() => renderLabelRow(gaugeWidth, min, max, segments), [gaugeWidth, max, min, segments]);
+  const tickRow = useMemo(() => renderTickRow(gaugeWidth, min, max), [gaugeWidth, max, min]);
+  const arcRows = useMemo(() => renderArcRows(value, min, max, gaugeWidth, segments), [gaugeWidth, max, min, segments, value]);
+  const rendererResolution = nativeRenderer.resolution;
+  const rendererTerminalWidth = nativeRenderer.terminalWidth;
+  const rendererTerminalHeight = nativeRenderer.terminalHeight;
+  const bitmap = useMemo<NativeChartBitmap | null>(() => {
+    if (!nativeCharts) return null;
+    const bitmapSize = rendererResolution && rendererTerminalWidth > 0 && rendererTerminalHeight > 0
+      ? computeBitmapSize(
+        { x: 0, y: 0, width: gaugeWidth, height: arcRows.length },
+        rendererResolution,
+        rendererTerminalWidth,
+        rendererTerminalHeight,
+      )
+      : null;
+    const scale = Math.max(1, pixelRatio);
+    const pixelWidth = bitmapSize?.pixelWidth ?? Math.max(1, Math.round(gaugeWidth * cellWidthPx * scale));
+    const pixelHeight = bitmapSize?.pixelHeight ?? Math.max(1, Math.round(arcRows.length * cellHeightPx * scale));
+    return renderGaugeBitmap(
+      value,
+      min,
+      max,
+      segments,
+      pixelWidth,
+      pixelHeight,
+    );
+  }, [
+    arcRows.length,
+    cellHeightPx,
+    cellWidthPx,
+    gaugeWidth,
+    max,
+    min,
+    nativeCharts,
+    pixelRatio,
+    rendererResolution,
+    rendererTerminalHeight,
+    rendererTerminalWidth,
+    segments,
+    value,
+  ]);
+
+  return (
+    <Box flexDirection="column" alignItems="center" marginTop={1}>
+      <GaugeLine chunks={labelRow} />
+      <ChartSurface width={gaugeWidth} height={arcRows.length} flexDirection="column" bitmaps={bitmap ? [bitmap] : null}>
+        {arcRows.map((chunks, index) => (
+          <GaugeLine key={index} chunks={chunks} />
+        ))}
+      </ChartSurface>
+      <GaugeLine chunks={tickRow} />
+      <Box flexDirection="row" marginTop={1}>
+        <Text fg={colors.textDim}>{currentLabel} </Text>
+        <Text fg={segmentColorForScore(value, segments)} attributes={TextAttributes.BOLD}>{valueLabel}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export function SpeedometerGauge({
+  value,
+  valueLabel,
+  width,
+  segments,
+  min = 0,
+  max = 100,
+  currentLabel = "Current reading",
+  minWidth = DEFAULT_MIN_WIDTH,
+  maxWidth = DEFAULT_MAX_WIDTH,
+}: SpeedometerGaugeProps) {
+  const props = {
+    value,
+    valueLabel,
+    width,
+    segments,
+    min,
+    max,
+    currentLabel,
+    minWidth,
+    maxWidth,
+  };
+  return useUiHost().kind === "desktop-web"
+    ? <DesktopGauge {...props} />
+    : <TerminalGauge {...props} />;
+}

--- a/src/plugins/builtin/fear-greed/fear-greed-data.test.ts
+++ b/src/plugins/builtin/fear-greed/fear-greed-data.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeFearGreedData, type CnnFearGreedGraphData } from "./fear-greed-data";
+
+describe("fear-greed data normalization", () => {
+  test("combines latest score with chart history and aligned overlay series", () => {
+    const charts: CnnFearGreedGraphData = {
+      fear_and_greed: {
+        score: 65,
+        rating: "greed",
+        timestamp: "2026-05-08T23:59:55+00:00",
+      },
+      fear_and_greed_historical: {
+        score: 65,
+        rating: "greed",
+        data: [
+          { x: 2000, y: 62, rating: "greed" },
+          { x: 1000, y: 58, rating: "greed" },
+        ],
+      },
+      market_momentum_sp500: {
+        score: 99.6,
+        rating: "extreme greed",
+        timestamp: 2000,
+        data: [
+          { x: 1000, y: 100 },
+          { x: 2000, y: 110 },
+        ],
+      },
+      market_momentum_sp125: {
+        timestamp: 2000,
+        data: [
+          { x: 1000, y: 92 },
+          { x: 2000, y: 96 },
+        ],
+      },
+      stock_price_strength: {
+        score: 61.4,
+        rating: "greed",
+        data: [{ x: 1000, y: 3.8 }],
+      },
+    };
+    const latest: CnnFearGreedGraphData = {
+      fear_and_greed: {
+        score: 70.4,
+        rating: "greed",
+        timestamp: "2026-05-09T12:00:00+00:00",
+        previous_close: 67.5,
+        previous_1_week: 71.1,
+        previous_1_month: 29.1,
+        previous_1_year: 57.6,
+      },
+    };
+
+    const data = normalizeFearGreedData(charts, latest);
+
+    expect(data.overall.score).toBe(70.4);
+    expect(data.overall.previousClose).toBe(67.5);
+    expect(data.overall.history.map((point) => point.close)).toEqual([58, 62]);
+
+    const momentum = data.indicators.find((indicator) => indicator.definition.id === "market-momentum");
+    expect(momentum?.rating).toBe("extreme greed");
+    expect(momentum?.points.map((point) => point.close)).toEqual([100, 110]);
+    expect(momentum?.secondaryPoints).toEqual([
+      { index: 0, value: 92 },
+      { index: 1, value: 96 },
+    ]);
+  });
+
+  test("rejects responses without an index score", () => {
+    expect(() => normalizeFearGreedData({})).toThrow("index score");
+  });
+});

--- a/src/plugins/builtin/fear-greed/fear-greed-data.ts
+++ b/src/plugins/builtin/fear-greed/fear-greed-data.ts
@@ -1,0 +1,366 @@
+import type { ProjectedChartPoint } from "../../../components/chart/chart-data";
+import type { OverlayPoint } from "../../../components/chart/indicators/types";
+
+const CNN_FEAR_GREED_GRAPH_URL = "https://production.dataviz.cnn.io/index/fearandgreed/graphdata";
+const CNN_REFERER = "https://www.cnn.com/markets/fear-and-greed";
+const CNN_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+export type FearGreedRating = "extreme fear" | "fear" | "neutral" | "greed" | "extreme greed";
+
+type CnnGraphKey =
+  | "fear_and_greed"
+  | "fear_and_greed_historical"
+  | "market_momentum_sp500"
+  | "market_momentum_sp125"
+  | "stock_price_strength"
+  | "stock_price_breadth"
+  | "put_call_options"
+  | "market_volatility_vix"
+  | "market_volatility_vix_50"
+  | "safe_haven_demand"
+  | "junk_bond_demand";
+
+interface CnnPoint {
+  x?: unknown;
+  y?: unknown;
+  rating?: unknown;
+}
+
+interface CnnSeries {
+  timestamp?: unknown;
+  score?: unknown;
+  rating?: unknown;
+  previous_close?: unknown;
+  previous_1_week?: unknown;
+  previous_1_month?: unknown;
+  previous_1_year?: unknown;
+  data?: unknown;
+}
+
+export type CnnFearGreedGraphData = Partial<Record<CnnGraphKey, CnnSeries>>;
+
+interface NormalizedRawPoint {
+  x: number;
+  y: number;
+  rating: FearGreedRating | null;
+}
+
+export interface FearGreedOverall {
+  score: number;
+  rating: FearGreedRating;
+  updatedAt: Date | null;
+  previousClose: number | null;
+  previousWeek: number | null;
+  previousMonth: number | null;
+  previousYear: number | null;
+  history: ProjectedChartPoint[];
+}
+
+export type FearGreedValueFormat = "score" | "number" | "percent" | "ratio";
+
+export interface FearGreedIndicatorDefinition {
+  id: string;
+  title: string;
+  subtitle: string;
+  primaryKey: CnnGraphKey;
+  primaryLabel: string;
+  secondaryKey?: CnnGraphKey;
+  secondaryLabel?: string;
+  valueFormat: FearGreedValueFormat;
+}
+
+export interface FearGreedIndicator {
+  definition: FearGreedIndicatorDefinition;
+  score: number | null;
+  rating: FearGreedRating;
+  updatedAt: Date | null;
+  points: ProjectedChartPoint[];
+  secondaryPoints: OverlayPoint[];
+  latestValue: number | null;
+  latestSecondaryValue: number | null;
+}
+
+export interface FearGreedData {
+  overall: FearGreedOverall;
+  indicators: FearGreedIndicator[];
+}
+
+export const FEAR_GREED_INDICATORS: FearGreedIndicatorDefinition[] = [
+  {
+    id: "market-momentum",
+    title: "Market Momentum",
+    subtitle: "S&P 500 and its 125-day moving average",
+    primaryKey: "market_momentum_sp500",
+    primaryLabel: "S&P 500",
+    secondaryKey: "market_momentum_sp125",
+    secondaryLabel: "125-day moving average",
+    valueFormat: "number",
+  },
+  {
+    id: "stock-price-strength",
+    title: "Stock Price Strength",
+    subtitle: "Net new 52-week highs and lows on the NYSE",
+    primaryKey: "stock_price_strength",
+    primaryLabel: "Net highs/lows",
+    valueFormat: "percent",
+  },
+  {
+    id: "stock-price-breadth",
+    title: "Stock Price Breadth",
+    subtitle: "McClellan Volume Summation Index",
+    primaryKey: "stock_price_breadth",
+    primaryLabel: "McClellan index",
+    valueFormat: "number",
+  },
+  {
+    id: "put-call-options",
+    title: "Put and Call Options",
+    subtitle: "5-day average put/call ratio",
+    primaryKey: "put_call_options",
+    primaryLabel: "Put/call ratio",
+    valueFormat: "ratio",
+  },
+  {
+    id: "market-volatility",
+    title: "Market Volatility",
+    subtitle: "VIX and its 50-day moving average",
+    primaryKey: "market_volatility_vix",
+    primaryLabel: "VIX",
+    secondaryKey: "market_volatility_vix_50",
+    secondaryLabel: "50-day moving average",
+    valueFormat: "number",
+  },
+  {
+    id: "safe-haven-demand",
+    title: "Safe Haven Demand",
+    subtitle: "Difference in 20-day stock and bond returns",
+    primaryKey: "safe_haven_demand",
+    primaryLabel: "Stocks vs. bonds",
+    valueFormat: "percent",
+  },
+  {
+    id: "junk-bond-demand",
+    title: "Junk Bond Demand",
+    subtitle: "Yield spread: junk bonds vs. investment grade",
+    primaryKey: "junk_bond_demand",
+    primaryLabel: "Yield spread",
+    valueFormat: "percent",
+  },
+];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function normalizeRating(value: unknown): FearGreedRating | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  switch (normalized) {
+    case "extreme fear":
+    case "fear":
+    case "neutral":
+    case "greed":
+    case "extreme greed":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+function fallbackRatingForScore(score: number | null): FearGreedRating {
+  if (score == null) return "neutral";
+  if (score < 25) return "extreme fear";
+  if (score < 45) return "fear";
+  if (score <= 55) return "neutral";
+  if (score <= 75) return "greed";
+  return "extreme greed";
+}
+
+function parseTimestamp(value: unknown): Date | null {
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  const millis = finiteNumber(value);
+  if (millis == null) return null;
+  const parsed = new Date(millis);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function normalizeRawPoints(series: CnnSeries | undefined): NormalizedRawPoint[] {
+  if (!series || !Array.isArray(series.data)) return [];
+  const points: NormalizedRawPoint[] = [];
+  for (const item of series.data) {
+    if (!isObject(item)) continue;
+    const point = item as CnnPoint;
+    const x = finiteNumber(point.x);
+    const y = finiteNumber(point.y);
+    if (x == null || y == null) continue;
+    points.push({ x, y, rating: normalizeRating(point.rating) });
+  }
+  return points.sort((left, right) => left.x - right.x);
+}
+
+function toProjectedPoints(points: NormalizedRawPoint[]): ProjectedChartPoint[] {
+  return points.map((point) => ({
+    date: new Date(point.x),
+    open: point.y,
+    high: point.y,
+    low: point.y,
+    close: point.y,
+    volume: 0,
+  }));
+}
+
+function toSecondaryOverlay(primaryPoints: NormalizedRawPoint[], secondaryPoints: NormalizedRawPoint[]): OverlayPoint[] {
+  const indexByTimestamp = new Map(primaryPoints.map((point, index) => [point.x, index] as const));
+  const overlay: OverlayPoint[] = [];
+  for (let index = 0; index < secondaryPoints.length; index += 1) {
+    const point = secondaryPoints[index]!;
+    const matchedIndex = indexByTimestamp.get(point.x) ?? (index < primaryPoints.length ? index : null);
+    if (matchedIndex == null) continue;
+    overlay.push({ index: matchedIndex, value: point.y });
+  }
+  return overlay;
+}
+
+function latestValue(points: NormalizedRawPoint[]): number | null {
+  return points.length > 0 ? points[points.length - 1]!.y : null;
+}
+
+function latestRating(series: CnnSeries | undefined, points: NormalizedRawPoint[], score: number | null): FearGreedRating {
+  return normalizeRating(series?.rating)
+    ?? (points.length > 0 ? points[points.length - 1]!.rating : null)
+    ?? fallbackRatingForScore(score);
+}
+
+function latestTimestamp(series: CnnSeries | undefined, points: NormalizedRawPoint[]): Date | null {
+  return parseTimestamp(series?.timestamp)
+    ?? (points.length > 0 ? new Date(points[points.length - 1]!.x) : null);
+}
+
+export function normalizeFearGreedData(
+  charts: CnnFearGreedGraphData,
+  latest: CnnFearGreedGraphData = charts,
+): FearGreedData {
+  const latestOverallSeries = latest.fear_and_greed ?? charts.fear_and_greed;
+  const historySeries = charts.fear_and_greed_historical ?? latest.fear_and_greed_historical;
+  const historyRawPoints = normalizeRawPoints(historySeries);
+  const latestScore = finiteNumber(latestOverallSeries?.score)
+    ?? finiteNumber(historySeries?.score)
+    ?? latestValue(historyRawPoints);
+
+  if (latestScore == null) {
+    throw new Error("CNN Fear & Greed response did not include an index score");
+  }
+
+  const overall: FearGreedOverall = {
+    score: latestScore,
+    rating: normalizeRating(latestOverallSeries?.rating) ?? fallbackRatingForScore(latestScore),
+    updatedAt: parseTimestamp(latestOverallSeries?.timestamp) ?? latestTimestamp(historySeries, historyRawPoints),
+    previousClose: finiteNumber(latestOverallSeries?.previous_close),
+    previousWeek: finiteNumber(latestOverallSeries?.previous_1_week),
+    previousMonth: finiteNumber(latestOverallSeries?.previous_1_month),
+    previousYear: finiteNumber(latestOverallSeries?.previous_1_year),
+    history: toProjectedPoints(historyRawPoints),
+  };
+
+  const indicators = FEAR_GREED_INDICATORS.flatMap((definition): FearGreedIndicator[] => {
+    const series = charts[definition.primaryKey] ?? latest[definition.primaryKey];
+    const primaryPoints = normalizeRawPoints(series);
+    if (primaryPoints.length === 0) return [];
+
+    const secondarySeries = definition.secondaryKey
+      ? (charts[definition.secondaryKey] ?? latest[definition.secondaryKey])
+      : undefined;
+    const secondaryRawPoints = normalizeRawPoints(secondarySeries);
+    const score = finiteNumber(series?.score);
+
+    return [{
+      definition,
+      score,
+      rating: latestRating(series, primaryPoints, score),
+      updatedAt: latestTimestamp(series, primaryPoints),
+      points: toProjectedPoints(primaryPoints),
+      secondaryPoints: toSecondaryOverlay(primaryPoints, secondaryRawPoints),
+      latestValue: latestValue(primaryPoints),
+      latestSecondaryValue: latestValue(secondaryRawPoints),
+    }];
+  });
+
+  return { overall, indicators };
+}
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function isDomRuntime(): boolean {
+  return typeof (globalThis as { document?: unknown }).document !== "undefined";
+}
+
+function cnnFetchHeaders(): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: "application/json,text/plain,*/*",
+  };
+
+  if (!isDomRuntime()) {
+    headers["User-Agent"] = CNN_USER_AGENT;
+    headers.Referer = CNN_REFERER;
+  }
+
+  return headers;
+}
+
+async function fetchCnnGraphData(url: string, fetcher: typeof fetch): Promise<CnnFearGreedGraphData> {
+  const response = await fetcher(url, { headers: cnnFetchHeaders() });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`CNN Fear & Greed request failed (${response.status}): ${body.slice(0, 120)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`CNN Fear & Greed returned non-JSON data: ${body.slice(0, 120)}`);
+  }
+
+  if (!isObject(parsed)) {
+    throw new Error("CNN Fear & Greed response was not an object");
+  }
+
+  return parsed as CnnFearGreedGraphData;
+}
+
+export async function fetchFearGreedData(options: {
+  date?: Date;
+  fetcher?: typeof fetch;
+} = {}): Promise<FearGreedData> {
+  const fetcher = options.fetcher ?? fetch;
+  const date = options.date ?? new Date();
+  const latestUrl = `${CNN_FEAR_GREED_GRAPH_URL}/${formatLocalDate(date)}`;
+
+  const [chartsResult, latestResult] = await Promise.allSettled([
+    fetchCnnGraphData(CNN_FEAR_GREED_GRAPH_URL, fetcher),
+    fetchCnnGraphData(latestUrl, fetcher),
+  ]);
+
+  const charts = chartsResult.status === "fulfilled" ? chartsResult.value : null;
+  const latest = latestResult.status === "fulfilled" ? latestResult.value : null;
+
+  if (!charts && !latest) {
+    const reason = chartsResult.status === "rejected" ? chartsResult.reason : latestResult.reason;
+    throw reason instanceof Error ? reason : new Error(String(reason));
+  }
+
+  return normalizeFearGreedData(charts ?? latest!, latest ?? charts ?? undefined);
+}

--- a/src/plugins/builtin/fear-greed/index.tsx
+++ b/src/plugins/builtin/fear-greed/index.tsx
@@ -1,0 +1,478 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { SpeedometerGauge, StaticChartSurface, usePaneFooter, type SpeedometerSegment } from "../../../components";
+import type { GloomPlugin, PaneProps } from "../../../types/plugin";
+import { colors, blendHex } from "../../../theme/colors";
+import { resolveChartPalette } from "../../../components/chart/chart-renderer";
+import type { ChartIndicatorOverlays } from "../../../components/chart/chart-types";
+import { formatNumber } from "../../../utils/format";
+import {
+  fetchFearGreedData,
+  type FearGreedData,
+  type FearGreedIndicator,
+  type FearGreedRating,
+  type FearGreedValueFormat,
+} from "./fear-greed-data";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const FEAR_GREED_GAUGE_SEGMENTS: SpeedometerSegment[] = [
+  { from: 0, to: 24.999, label: "EXTREME FEAR", color: colors.negative },
+  { from: 25, to: 44.999, label: "FEAR", color: colors.warning },
+  { from: 45, to: 55, label: "NEUTRAL", color: colors.neutral },
+  { from: 55.001, to: 75, label: "GREED", color: colors.positive },
+  { from: 75.001, to: 100, label: "EXTREME GREED", color: colors.positive },
+];
+
+let sharedCache: { data: FearGreedData; fetchedAt: number } | null = null;
+let activeFetch: Promise<FearGreedData> | null = null;
+
+async function loadFearGreed(force = false): Promise<FearGreedData> {
+  if (!force && sharedCache && Date.now() - sharedCache.fetchedAt < CACHE_TTL_MS) {
+    return sharedCache.data;
+  }
+  if (activeFetch) return activeFetch;
+
+  activeFetch = fetchFearGreedData()
+    .then((data) => {
+      sharedCache = { data, fetchedAt: Date.now() };
+      return data;
+    })
+    .finally(() => {
+      activeFetch = null;
+    });
+  return activeFetch;
+}
+
+function ratingLabel(rating: FearGreedRating): string {
+  return rating.toUpperCase();
+}
+
+function ratingColor(rating: FearGreedRating): string {
+  switch (rating) {
+    case "extreme fear":
+      return colors.negative;
+    case "fear":
+      return colors.warning;
+    case "neutral":
+      return colors.neutral;
+    case "greed":
+    case "extreme greed":
+      return colors.positive;
+  }
+}
+
+function ratingTrend(rating: FearGreedRating): "positive" | "negative" | "neutral" {
+  switch (rating) {
+    case "extreme fear":
+    case "fear":
+      return "negative";
+    case "neutral":
+      return "neutral";
+    case "greed":
+    case "extreme greed":
+      return "positive";
+  }
+}
+
+function formatScore(score: number | null | undefined): string {
+  if (score == null || Number.isNaN(score)) return "--";
+  return String(Math.round(score));
+}
+
+function formatIndicatorValue(value: number | null | undefined, format: FearGreedValueFormat): string {
+  if (value == null || Number.isNaN(value)) return "--";
+  switch (format) {
+    case "score":
+      return formatScore(value);
+    case "percent":
+      return `${formatNumber(value, 2)}%`;
+    case "ratio":
+      return value.toFixed(2);
+    case "number": {
+      const abs = Math.abs(value);
+      if (abs >= 1000) return formatNumber(value, 0);
+      if (abs >= 100) return formatNumber(value, 1);
+      return formatNumber(value, 2);
+    }
+  }
+}
+
+function formatAxisValue(format: FearGreedValueFormat): (value: number) => string {
+  return (value) => formatIndicatorValue(value, format);
+}
+
+function formatUpdatedAt(date: Date | null): string {
+  if (!date) return "Last updated --";
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((entry) => entry.type === type)?.value ?? "";
+  return `Last updated ${part("month")} ${part("day")} at ${part("hour")}:${part("minute")} ${part("dayPeriod")} ET`;
+}
+
+function formatAge(ms: number): string {
+  const secs = Math.max(0, Math.floor(ms / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h ago`;
+}
+
+function SentimentBadge({ rating }: { rating: FearGreedRating }) {
+  const color = ratingColor(rating);
+  return (
+    <Box height={1} paddingX={1} backgroundColor={blendHex(colors.bg, color, 0.28)}>
+      <Text fg={color} attributes={TextAttributes.BOLD}>{ratingLabel(rating)}</Text>
+    </Box>
+  );
+}
+
+function PreviousScoreGrid({ data, width }: { data: FearGreedData; width: number }) {
+  const items = [
+    { label: "Previous close", value: data.overall.previousClose },
+    { label: "1 week ago", value: data.overall.previousWeek },
+    { label: "1 month ago", value: data.overall.previousMonth },
+    { label: "1 year ago", value: data.overall.previousYear },
+  ];
+  const columns = width >= 84 ? 4 : 2;
+  const columnWidth = Math.max(18, Math.floor((width - 2) / columns));
+  const rows = Array.from({ length: Math.ceil(items.length / columns) }, (_, rowIndex) => (
+    items.slice(rowIndex * columns, rowIndex * columns + columns)
+  ));
+
+  return (
+    <Box flexDirection="column" paddingX={1} marginTop={1}>
+      {rows.map((row, rowIndex) => (
+        <Box key={rowIndex} flexDirection="row" height={1}>
+          {row.map((item) => {
+            const value = item.value;
+            const color = value == null ? colors.textDim : ratingColor(value < 25 ? "extreme fear" : value < 45 ? "fear" : value <= 55 ? "neutral" : "greed");
+            return (
+              <Box key={item.label} width={columnWidth} flexShrink={0} flexDirection="row">
+                <Text fg={colors.textDim}>{item.label}: </Text>
+                <Text fg={color} attributes={TextAttributes.BOLD}>{formatScore(value)}</Text>
+              </Box>
+            );
+          })}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function chartOverlay(indicator: FearGreedIndicator): ChartIndicatorOverlays | null {
+  if (indicator.secondaryPoints.length === 0) return null;
+  return {
+    smaLines: [{
+      period: 0,
+      points: indicator.secondaryPoints,
+      color: colors.warning,
+    }],
+    emaLines: [],
+    bollinger: null,
+    rsi: null,
+    macd: null,
+  };
+}
+
+function SentimentChart({
+  title,
+  subtitle,
+  rating,
+  score,
+  points,
+  width,
+  valueFormat,
+  updatedAt,
+  primaryLabel,
+  secondaryLabel,
+  secondaryValue,
+  overlays,
+}: {
+  title: string;
+  subtitle: string;
+  rating: FearGreedRating;
+  score: number | null;
+  points: FearGreedIndicator["points"];
+  width: number;
+  valueFormat: FearGreedValueFormat;
+  updatedAt: Date | null;
+  primaryLabel: string;
+  secondaryLabel?: string;
+  secondaryValue?: number | null;
+  overlays?: ChartIndicatorOverlays | null;
+}) {
+  const chartWidth = Math.max(24, width - 2);
+  const chartHeight = width >= 96 ? 12 : 10;
+  const color = ratingColor(rating);
+  const basePalette = resolveChartPalette(colors, ratingTrend(rating));
+  const palette = {
+    ...basePalette,
+    lineColor: color,
+    fillColor: blendHex(colors.bg, color, 0.18),
+    gridColor: blendHex(colors.bg, colors.border, 0.55),
+  };
+  const latest = points.length > 0 ? points[points.length - 1]!.close : null;
+
+  return (
+    <Box flexDirection="column" marginTop={2} paddingX={1}>
+      <Box flexDirection="row" height={1}>
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{title.toUpperCase()}</Text>
+        <Box flexGrow={1} />
+        <SentimentBadge rating={rating} />
+      </Box>
+      <Box height={1} marginTop={1}>
+        <Text fg={colors.text} attributes={TextAttributes.BOLD}>{subtitle}</Text>
+      </Box>
+      <Box flexDirection="row" height={1}>
+        <Text fg={color}>● </Text>
+        <Text fg={colors.textDim}>{primaryLabel}</Text>
+        {secondaryLabel ? (
+          <>
+            <Text fg={colors.warning}>  ● </Text>
+            <Text fg={colors.textDim}>{secondaryLabel}</Text>
+          </>
+        ) : null}
+        <Box flexGrow={1} />
+        <Text fg={colors.textDim}>score </Text>
+        <Text fg={color} attributes={TextAttributes.BOLD}>{formatScore(score)}</Text>
+        <Text fg={colors.textDim}>  latest </Text>
+        <Text fg={colors.text}>{formatIndicatorValue(latest, valueFormat)}</Text>
+        {secondaryLabel && secondaryValue != null ? (
+          <>
+            <Text fg={colors.textDim}>  avg </Text>
+            <Text fg={colors.text}>{formatIndicatorValue(secondaryValue, valueFormat)}</Text>
+          </>
+        ) : null}
+      </Box>
+      {points.length >= 2 ? (
+        <Box marginTop={1}>
+          <StaticChartSurface
+            points={points}
+            width={chartWidth}
+            height={chartHeight}
+            mode="line"
+            colors={palette}
+            indicators={overlays}
+            showTimeAxis
+            timeAxisColor={colors.textDim}
+            yAxisColor={colors.textDim}
+            formatYAxisValue={formatAxisValue(valueFormat)}
+          />
+        </Box>
+      ) : (
+        <Box height={chartHeight} marginTop={1} justifyContent="center" alignItems="center">
+          <Text fg={colors.textMuted}>Not enough chart data</Text>
+        </Box>
+      )}
+      <Box height={1} marginTop={1}>
+        <Text fg={colors.textDim}>{formatUpdatedAt(updatedAt)}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+function IndexHistoryChart({ data, width }: { data: FearGreedData; width: number }) {
+  const indicator: FearGreedIndicator = {
+    definition: {
+      id: "index-history",
+      title: "Index History",
+      subtitle: "Fear & Greed score over the past year",
+      primaryKey: "fear_and_greed_historical",
+      primaryLabel: "Fear & Greed",
+      valueFormat: "score",
+    },
+    score: data.overall.score,
+    rating: data.overall.rating,
+    updatedAt: data.overall.updatedAt,
+    points: data.overall.history,
+    secondaryPoints: [],
+    latestValue: data.overall.score,
+    latestSecondaryValue: null,
+  };
+
+  return (
+    <SentimentChart
+      title={indicator.definition.title}
+      subtitle={indicator.definition.subtitle}
+      rating={indicator.rating}
+      score={indicator.score}
+      points={indicator.points}
+      width={width}
+      valueFormat={indicator.definition.valueFormat}
+      updatedAt={indicator.updatedAt}
+      primaryLabel={indicator.definition.primaryLabel}
+    />
+  );
+}
+
+function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
+  const [data, setData] = useState<FearGreedData | null>(sharedCache?.data ?? null);
+  const [loading, setLoading] = useState(!sharedCache);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRefreshed, setLastRefreshed] = useState<number | null>(sharedCache?.fetchedAt ?? null);
+  const [now, setNow] = useState(Date.now());
+  const fetchGenRef = useRef(0);
+
+  const load = useCallback(async (force = false) => {
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const nextData = await loadFearGreed(force);
+      if (fetchGenRef.current !== gen) return;
+      setData(nextData);
+      setLastRefreshed(Date.now());
+    } catch (err) {
+      if (fetchGenRef.current !== gen) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (fetchGenRef.current === gen) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!sharedCache) {
+      void load();
+    }
+  }, [load]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 10_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const refresh = useCallback(() => {
+    void load(true);
+  }, [load]);
+
+  useShortcut((event) => {
+    if (!focused) return;
+    if (event.name === "r") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+    }
+  });
+
+  const footerAge = lastRefreshed ? `refreshed ${formatAge(now - lastRefreshed)}` : loading ? "loading" : "";
+  usePaneFooter(paneId, () => ({
+    info: [
+      ...(data ? [{
+        id: "score",
+        parts: [
+          { text: `${formatScore(data.overall.score)} ${ratingLabel(data.overall.rating)}`, color: ratingColor(data.overall.rating), bold: true },
+        ],
+      }] : []),
+      ...(footerAge ? [{ id: "age", parts: [{ text: footerAge, tone: loading ? "muted" as const : "value" as const }] }] : []),
+      ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+    ],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }],
+  }), [data, error, footerAge, loading, paneId, refresh]);
+
+  if (loading && !data) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Text fg={colors.textMuted}>Loading Fear & Greed...</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        <Box flexGrow={1} justifyContent="center" alignItems="center" paddingX={1}>
+          <Text fg={colors.negative}>{error ?? "Fear & Greed data unavailable"}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <ScrollBox flexGrow={1} scrollY focusable={false}>
+        <Box flexDirection="column" paddingBottom={1}>
+          <SpeedometerGauge
+            value={data.overall.score}
+            valueLabel={ratingLabel(data.overall.rating)}
+            width={width}
+            segments={FEAR_GREED_GAUGE_SEGMENTS}
+          />
+          {loading ? (
+            <Box height={1} paddingX={1} marginTop={1} justifyContent="center">
+              <Text fg={colors.textMuted}>refreshing...</Text>
+            </Box>
+          ) : null}
+          <PreviousScoreGrid data={data} width={width} />
+          {error ? (
+            <Box paddingX={1} marginTop={1}>
+              <Text fg={colors.warning}>{error}</Text>
+            </Box>
+          ) : null}
+          <IndexHistoryChart data={data} width={width} />
+          <Box flexDirection="row" paddingX={1} marginTop={2} height={1}>
+            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>7 FEAR & GREED INDICATORS</Text>
+          </Box>
+          {data.indicators.map((indicator) => (
+            <SentimentChart
+              key={indicator.definition.id}
+              title={indicator.definition.title}
+              subtitle={indicator.definition.subtitle}
+              rating={indicator.rating}
+              score={indicator.score}
+              points={indicator.points}
+              width={width}
+              valueFormat={indicator.definition.valueFormat}
+              updatedAt={indicator.updatedAt}
+              primaryLabel={indicator.definition.primaryLabel}
+              secondaryLabel={indicator.definition.secondaryLabel}
+              secondaryValue={indicator.latestSecondaryValue}
+              overlays={chartOverlay(indicator)}
+            />
+          ))}
+        </Box>
+      </ScrollBox>
+    </Box>
+  );
+}
+
+export const fearGreedPlugin: GloomPlugin = {
+  id: "fear-greed",
+  name: "Fear & Greed",
+  version: "1.0.0",
+  description: "CNN Fear & Greed sentiment gauge and market indicator charts.",
+  toggleable: true,
+
+  panes: [
+    {
+      id: "fear-greed",
+      name: "Fear & Greed",
+      icon: "G",
+      component: FearGreedPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 110, height: 36 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "fear-greed-pane",
+      paneId: "fear-greed",
+      label: "Fear & Greed",
+      description: "CNN Fear & Greed sentiment gauge with the seven indicator charts.",
+      keywords: ["fear", "greed", "sentiment", "cnn", "market", "indicators", "gauge"],
+      shortcut: { prefix: "FNG" },
+    },
+  ],
+};

--- a/src/plugins/builtin/plugin-groups.ts
+++ b/src/plugins/builtin/plugin-groups.ts
@@ -4,6 +4,7 @@ import { correlationPlugin } from "./correlation";
 import { earningsPlugin } from "./earnings";
 import { registerEconCalendarFeature } from "./econ";
 import { fxMatrixPlugin } from "./fx-matrix";
+import { fearGreedPlugin } from "./fear-greed";
 import { holdersPlugin } from "./holders";
 import { insiderPlugin } from "./insider";
 import { marketMoversPlugin } from "./market-movers";
@@ -74,6 +75,7 @@ export const marketOverviewPlugin = createPluginGroup({
     correlationPlugin,
     worldIndicesPlugin,
     marketMoversPlugin,
+    fearGreedPlugin,
     sectorsPlugin,
     fxMatrixPlugin,
   ],

--- a/src/renderers/opentui/chart-surface.tsx
+++ b/src/renderers/opentui/chart-surface.tsx
@@ -1,0 +1,179 @@
+import { createElement, forwardRef, useCallback, useEffect, useMemo, useRef, useState, type ForwardedRef, type ReactNode } from "react";
+import {
+  computeBitmapSize,
+  intersectCellRects,
+  type CellRect,
+  type NativeChartBitmap,
+} from "../../components/chart/native/chart-rasterizer";
+import { getCachedKittySupport, ensureKittySupport } from "../../components/chart/native/kitty-support";
+import { getNativeSurfaceManager } from "../../components/chart/native/surface-manager";
+import {
+  getRenderableCellRect,
+  resolveNativeSurfaceVisibleRect,
+  type NativeSurfaceRenderableNode,
+} from "../../components/chart/native/surface-visibility";
+import { useOptionalPaneInstanceId } from "../../state/app-context";
+import { useNativeRenderer, type BoxRenderable, type ChartSurfaceProps } from "../../ui";
+
+interface NativeRenderableNode extends BoxRenderable, NativeSurfaceRenderableNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  parent: NativeRenderableNode | null;
+  onLifecyclePass: (() => void) | null;
+}
+
+interface SurfaceTarget {
+  rect: CellRect;
+  visibleRect: CellRect | null;
+  bitmapKey: string;
+}
+
+let nextChartSurfaceId = 1;
+
+function assignRef(ref: ForwardedRef<unknown>, value: unknown) {
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+  if (ref) {
+    (ref as { current: unknown }).current = value;
+  }
+}
+
+function sameRect(left: CellRect | null, right: CellRect | null): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.x === right.x
+    && left.y === right.y
+    && left.width === right.width
+    && left.height === right.height;
+}
+
+function sameTarget(left: SurfaceTarget | null, right: SurfaceTarget | null): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.bitmapKey === right.bitmapKey
+    && sameRect(left.rect, right.rect)
+    && sameRect(left.visibleRect, right.visibleRect);
+}
+
+function hashBitmap(bitmap: NativeChartBitmap): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < bitmap.pixels.length; index += 1) {
+    hash ^= bitmap.pixels[index]!;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function bitmapKey(bitmap: NativeChartBitmap): string {
+  return `${bitmap.width}x${bitmap.height}:${hashBitmap(bitmap)}`;
+}
+
+export const OpenTuiChartSurface = forwardRef<unknown, ChartSurfaceProps>(function OpenTuiChartSurface(
+  { children, bitmap, bitmaps, crosshair: _crosshair, ...props },
+  forwardedRef,
+) {
+  const renderer = useNativeRenderer();
+  const paneId = useOptionalPaneInstanceId();
+  const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);
+  const surfaceId = useRef(`opentui-chart:${nextChartSurfaceId++}`).current;
+  const renderableRef = useRef<NativeRenderableNode | null>(null);
+  const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
+  const [target, setTarget] = useState<SurfaceTarget | null>(null);
+  const nativeBitmap = (bitmaps?.[0] ?? bitmap ?? null) as NativeChartBitmap | null;
+  const nativeBitmapKey = useMemo(() => (nativeBitmap ? bitmapKey(nativeBitmap) : null), [nativeBitmap]);
+
+  const setRenderableRef = useCallback((node: unknown) => {
+    renderableRef.current = node as NativeRenderableNode | null;
+    assignRef(forwardedRef, node);
+  }, [forwardedRef]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setKittySupport(getCachedKittySupport(renderer));
+    ensureKittySupport(renderer).then((supported) => {
+      if (!cancelled) setKittySupport(supported);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [renderer]);
+
+  useEffect(() => {
+    const renderable = renderableRef.current;
+    if (!renderable || !nativeBitmap || !nativeBitmapKey || kittySupport !== true) {
+      setTarget(null);
+      return;
+    }
+
+    let mountTimer: Timer | null = null;
+    const previousLifecyclePass = renderable.onLifecyclePass;
+    const syncTarget = () => {
+      const rect = getRenderableCellRect(renderable);
+      if (!renderer.resolution || renderer.terminalWidth <= 0 || renderer.terminalHeight <= 0) {
+        setTarget((current) => (current === null ? current : null));
+        return;
+      }
+
+      const visibleRect = resolveNativeSurfaceVisibleRect(renderable, renderer.terminalWidth, renderer.terminalHeight);
+      const clippedVisibleRect = visibleRect ? intersectCellRects(rect, visibleRect) : null;
+      const expectedSize = computeBitmapSize(rect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
+      const nextTarget: SurfaceTarget = {
+        rect,
+        visibleRect: clippedVisibleRect,
+        bitmapKey: `${nativeBitmapKey}:${expectedSize.pixelWidth}x${expectedSize.pixelHeight}`,
+      };
+      setTarget((current) => (sameTarget(current, nextTarget) ? current : nextTarget));
+    };
+    const lifecyclePass = () => {
+      previousLifecyclePass?.();
+      syncTarget();
+    };
+
+    renderable.onLifecyclePass = lifecyclePass;
+    renderer.registerLifecyclePass(renderable);
+    syncTarget();
+    mountTimer = setTimeout(() => {
+      syncTarget();
+      renderer.requestRender();
+    }, 0);
+
+    return () => {
+      if (mountTimer) clearTimeout(mountTimer);
+      if (renderable.onLifecyclePass === lifecyclePass) {
+        renderable.onLifecyclePass = previousLifecyclePass;
+      }
+      renderer.unregisterLifecyclePass(renderable);
+      setTarget(null);
+    };
+  }, [kittySupport, nativeBitmap, nativeBitmapKey, renderer]);
+
+  useEffect(() => {
+    return () => {
+      nativeSurfaceManager.removeSurface(surfaceId);
+    };
+  }, [nativeSurfaceManager, surfaceId]);
+
+  useEffect(() => {
+    if (kittySupport !== true || !target?.visibleRect || !nativeBitmap) {
+      nativeSurfaceManager.removeSurface(surfaceId);
+      return;
+    }
+
+    nativeSurfaceManager.upsertSurface({
+      id: surfaceId,
+      paneId: paneId ?? "__global__",
+      rect: target.rect,
+      visibleRect: target.visibleRect,
+      bitmap: nativeBitmap,
+      bitmapKey: target.bitmapKey,
+    });
+    renderer.requestRender();
+  }, [kittySupport, nativeBitmap, nativeSurfaceManager, paneId, renderer, surfaceId, target]);
+
+  const showFallback = kittySupport !== true || !target || !nativeBitmap;
+  return createElement("box" as any, { ...props, ref: setRenderableRef }, showFallback ? children as ReactNode : null);
+});

--- a/src/renderers/opentui/ui-host.tsx
+++ b/src/renderers/opentui/ui-host.tsx
@@ -4,6 +4,7 @@ import "opentui-spinner/react";
 import { TextAttributes, type UiHost, type TextProps } from "../../ui/host";
 import { renderAsciiText } from "../../ui/ascii-font";
 import { OpenTuiImageSurface } from "./image-surface";
+import { OpenTuiChartSurface } from "./chart-surface";
 
 function mapTextAttributes(appAttributes: number | undefined, props?: TextProps): number | undefined {
   const flags = typeof appAttributes === "number" ? appAttributes : 0;
@@ -43,7 +44,9 @@ function mapTextContent(content: unknown): unknown {
 
 export const openTuiUiHost: UiHost = {
   kind: "opentui",
-  capabilities: {},
+  capabilities: {
+    nativeCharts: true,
+  },
   Box: ({ children, ...props }) => <box {...props}>{children}</box>,
   Text: ({ children, ...props }) => {
     const textProps = stripTextProps(props);
@@ -66,7 +69,7 @@ export const openTuiUiHost: UiHost = {
   ScrollBox: ({ children, ...props }) => <scrollbox {...props}>{children}</scrollbox>,
   Input: ({ children, ...props }) => createElement("input" as any, props, children),
   Textarea: ({ children, ...props }) => createElement("textarea" as any, props, children),
-  ChartSurface: ({ children, bitmap: _bitmap, bitmaps: _bitmaps, crosshair: _crosshair, ...props }) => <box {...props}>{children}</box>,
+  ChartSurface: OpenTuiChartSurface,
   ImageSurface: OpenTuiImageSurface,
   SpinnerMark: ({ children, ...props }) => createElement("spinner" as any, props, children),
   AsciiText: ({ text, font = "tiny", color, fg, bg, backgroundColor, selectable = false, ...props }) => {

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -245,6 +245,7 @@ export interface UiHost {
     cellHeightPx?: number;
     pixelRatio?: number;
     canvasCharts?: boolean;
+    nativeCharts?: boolean;
     nativeContextMenu?: boolean;
   };
   Box: ComponentType<BoxProps>;


### PR DESCRIPTION
Adds a CNN Fear & Greed market overview pane with the latest score, previous readings, index history, and all seven indicator charts. The charts reuse the shared static chart renderer and OpenTUI chart surface so kitty terminals get native bitmap rendering while non-kitty terminals keep text fallbacks. It also introduces a reusable speedometer gauge with desktop SVG, kitty bitmap, and terminal fallback rendering, including compact layout polish for desktop and terminal panes.