### PR TITLE
Fix light theme desktop chrome

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 import { Box, SpinnerMark, Text, TextAttributes, useUiCapabilities } from "../../ui";
 import { useEffect, type ReactNode } from "react";
-import { colors, priceColor } from "../../theme/colors";
+import { blendHex, colors, priceColor } from "../../theme/colors";
 import { useAppActive } from "../../state/app-activity";
 import { useAppDispatch, useAppSelector } from "../../state/app-context";
 import {
@@ -23,8 +23,8 @@ const UPDATE_NOTICE_DURATION_MS = 5_000;
 
 function DesktopHeaderPill({
   children,
-  backgroundColor = "rgba(8, 12, 15, 0.34)",
-  borderColor = "rgba(132, 145, 161, 0.22)",
+  backgroundColor = blendHex(colors.header, colors.bg, 0.28),
+  borderColor = blendHex(colors.border, colors.headerText, 0.22),
 }: {
   children: ReactNode;
   backgroundColor?: string;
@@ -173,8 +173,8 @@ export function Header() {
             Gloomberb
           </Text>
           <DesktopHeaderPill
-            backgroundColor="rgba(84, 201, 159, 0.12)"
-            borderColor="rgba(84, 201, 159, 0.28)"
+            backgroundColor={blendHex(colors.header, colors.headerText, 0.1)}
+            borderColor={blendHex(colors.border, colors.headerText, 0.28)}
           >
             <Text fg={colors.headerText} style={{ fontSize: 11 }}>v{VERSION}</Text>
           </DesktopHeaderPill>
@@ -184,8 +184,11 @@ export function Header() {
         </Box>
         {mktLabel ? (
           <Box paddingRight={1}>
-            <DesktopHeaderPill borderColor="rgba(132, 145, 161, 0.18)">
-              <Text fg={mktColor}>{mktLabel}</Text>
+            <DesktopHeaderPill
+              backgroundColor={blendHex(colors.header, mktColor, 0.12)}
+              borderColor={blendHex(colors.border, mktColor, 0.3)}
+            >
+              <Text fg={mktColor} style={{ fontSize: 11, fontWeight: 700 }}>{mktLabel}</Text>
             </DesktopHeaderPill>
           </Box>
         ) : null}

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -9,7 +9,7 @@ import type {
   PaneSettingTextField,
 } from "../types/plugin";
 import type { PluginRegistry } from "../plugins/registry";
-import { colors } from "../theme/colors";
+import { blendHex, colors } from "../theme/colors";
 import { Button, DialogFrame, ListView, MultiSelectDialogContent, TextField } from "./ui";
 import { NativeSelect, openNativeSelect, type NativeSelectElement } from "./ui/native-select";
 
@@ -78,6 +78,14 @@ const DESKTOP_TEXT_STYLE = {
 
 function desktopText(weight?: number) {
   return weight ? { ...DESKTOP_TEXT_STYLE, fontWeight: weight } : DESKTOP_TEXT_STYLE;
+}
+
+function desktopSubtleSurface(): string {
+  return blendHex(colors.panel, colors.bg, 0.22);
+}
+
+function desktopHoverSurface(): string {
+  return blendHex(colors.bg, colors.borderFocused, 0.08);
 }
 
 function DesktopDialogSurface({
@@ -149,7 +157,7 @@ function DesktopSwitch({
       flexDirection="row"
       alignItems="center"
       justifyContent={checked ? "flex-end" : "flex-start"}
-      backgroundColor={checked ? colors.selected : "rgba(255, 255, 255, 0.07)"}
+      backgroundColor={checked ? colors.selected : desktopSubtleSurface()}
       onMouseDown={(event: any) => {
         event.stopPropagation?.();
         event.preventDefault?.();
@@ -182,7 +190,7 @@ function DesktopValuePill({ value }: { value: string }) {
     <Box
       flexDirection="row"
       alignItems="center"
-      backgroundColor="rgba(255, 255, 255, 0.06)"
+      backgroundColor={desktopSubtleSurface()}
       style={{
         border: `1px solid ${colors.border}`,
         borderRadius: 6,
@@ -236,7 +244,7 @@ function DesktopSettingsRow({
     <Box
       flexDirection="column"
       minHeight={field.description ? undefined : 2}
-      backgroundColor={hovered || selected ? "rgba(255, 255, 255, 0.045)" : "transparent"}
+      backgroundColor={hovered || selected ? desktopHoverSurface() : "transparent"}
       onMouseMove={onHover}
       onMouseDown={field.type === "select" ? undefined : (event: any) => {
         event.stopPropagation?.();

--- a/src/renderers/electrobun/view/desktop-controls.tsx
+++ b/src/renderers/electrobun/view/desktop-controls.tsx
@@ -14,13 +14,27 @@ import type { PageStackViewProps } from "../../../components/ui/page-stack-view"
 import type { SegmentedControlProps } from "../../../components/ui/toggle";
 
 const CONTROL_RADIUS = 6;
-const PANEL_BORDER = blendHex(colors.border, colors.borderFocused, 0.18);
-const PANEL_FILL = blendHex(colors.panel, colors.bg, 0.22);
+
+function panelBorder(): string {
+  return blendHex(colors.border, colors.borderFocused, 0.18);
+}
+
+function panelFill(): string {
+  return blendHex(colors.panel, colors.bg, 0.22);
+}
+
+function subtlePanelFill(): string {
+  return blendHex(colors.panel, colors.bg, 0.42);
+}
+
+function selectedPanelFill(): string {
+  return blendHex(colors.selected, colors.bg, 0.42);
+}
 
 function controlBorderColor(focused = false, active = false): string {
   if (active) return colors.borderFocused;
   if (focused) return blendHex(colors.borderFocused, colors.textBright, 0.24);
-  return PANEL_BORDER;
+  return panelBorder();
 }
 
 function controlShadow(active = false): string {
@@ -33,8 +47,8 @@ function buttonPalette(props: Pick<ButtonProps, "variant" | "active" | "disabled
   if (props.disabled) {
     return {
       fg: colors.textMuted,
-      bg: "rgba(63, 72, 82, 0.35)",
-      border: PANEL_BORDER,
+      bg: subtlePanelFill(),
+      border: panelBorder(),
     };
   }
   if (props.active) {
@@ -62,14 +76,14 @@ function buttonPalette(props: Pick<ButtonProps, "variant" | "active" | "disabled
       return {
         fg: colors.textDim,
         bg: "rgba(0, 0, 0, 0)",
-        border: PANEL_BORDER,
+        border: panelBorder(),
       };
     case "secondary":
     default:
       return {
         fg: colors.text,
-        bg: PANEL_FILL,
-        border: PANEL_BORDER,
+        bg: panelFill(),
+        border: panelBorder(),
       };
   }
 }
@@ -248,7 +262,7 @@ export function WebMessageComposer({
       flexDirection="row"
       width={width}
       height={height}
-      backgroundColor={PANEL_FILL}
+      backgroundColor={panelFill()}
       onMouseDown={requestFocus}
       data-gloom-role="desktop-message-composer"
       style={{
@@ -350,7 +364,7 @@ export function WebListView({
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const baseBg = bgColor ?? colors.bg;
-  const activeBg = selectedBgColor ?? "rgba(84, 201, 159, 0.12)";
+  const activeBg = selectedBgColor ?? selectedPanelFill();
   const rowHoverBg = hoverBgColor ?? hoverBg();
   const selectedItem = selectedIndex >= 0 ? items[selectedIndex] : undefined;
   const activeScrollIndex = scrollIndex ?? selectedIndex;
@@ -435,10 +449,10 @@ export function WebListView({
               backgroundColor: "transparent",
             }
             : {
-              border: `1px solid ${PANEL_BORDER}`,
+              border: `1px solid ${panelBorder()}`,
               borderRadius: CONTROL_RADIUS,
               padding: 4,
-              backgroundColor: "rgba(9, 12, 15, 0.22)",
+              backgroundColor: subtlePanelFill(),
             }}
         >
           <Box flexDirection="column" gap={rowGap}>
@@ -454,9 +468,9 @@ export function WebListView({
       {showSelectedDescription && selectedItem?.description && (
         <Box
           flexDirection="row"
-          backgroundColor="rgba(9, 12, 15, 0.22)"
+          backgroundColor={subtlePanelFill()}
           style={{
-            border: `1px solid ${PANEL_BORDER}`,
+            border: `1px solid ${panelBorder()}`,
             borderRadius: CONTROL_RADIUS,
             paddingInline: 10,
           }}
@@ -478,9 +492,9 @@ export function WebSegmentedControl({
   return (
     <Box
       flexDirection="row"
-      backgroundColor="rgba(8, 11, 14, 0.32)"
+      backgroundColor={panelFill()}
       style={{
-        border: `1px solid ${PANEL_BORDER}`,
+        border: `1px solid ${panelBorder()}`,
         borderRadius: CONTROL_RADIUS,
         padding: 2,
       }}
@@ -531,7 +545,7 @@ export function WebDialogFrame({
         flexDirection="row"
         alignItems="center"
         style={{
-          borderBottom: showTitleDivider ? `1px solid ${PANEL_BORDER}` : "none",
+          borderBottom: showTitleDivider ? `1px solid ${panelBorder()}` : "none",
           paddingBottom: showTitleDivider ? 8 : 0,
           marginBottom: showTitleDivider ? 10 : 14,
         }}
@@ -545,7 +559,7 @@ export function WebDialogFrame({
         <Box
           height={1}
           style={{
-            borderTop: `1px solid ${PANEL_BORDER}`,
+            borderTop: `1px solid ${panelBorder()}`,
             paddingTop: 8,
             marginTop: 10,
           }}
@@ -600,7 +614,7 @@ export function WebPageStackView({
           height={1}
           flexDirection="row"
           alignItems="center"
-          backgroundColor={PANEL_FILL}
+          backgroundColor={panelFill()}
           onMouseDown={(event) => {
             event.preventDefault?.();
             event.stopPropagation?.();
@@ -608,7 +622,7 @@ export function WebPageStackView({
           }}
           data-gloom-interactive="true"
           style={{
-            border: `1px solid ${PANEL_BORDER}`,
+            border: `1px solid ${panelBorder()}`,
             borderRadius: CONTROL_RADIUS,
             paddingInline: 8,
             cursor: "pointer",

--- a/src/renderers/electrobun/view/dialog-host.tsx
+++ b/src/renderers/electrobun/view/dialog-host.tsx
@@ -2,6 +2,7 @@
 /** @jsxImportSource react */
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { DialogHostProvider, type DialogApi } from "../../../ui/dialog";
+import { blendHex, colors } from "../../../theme/colors";
 
 interface DialogState {
   id: string;
@@ -13,6 +14,8 @@ let nextDialogId = 1;
 
 export function WebDialogHostProvider({ children }: { children: ReactNode }) {
   const [dialogState, setDialogState] = useState<DialogState | null>(null);
+  const dialogBorder = blendHex(colors.border, colors.borderFocused, 0.18);
+  const dialogBg = blendHex(colors.panel, colors.bg, 0.12);
 
   const close = useCallback((value?: unknown) => {
     setDialogState((current) => {
@@ -46,7 +49,14 @@ export function WebDialogHostProvider({ children }: { children: ReactNode }) {
             if (event.target === event.currentTarget) close(undefined);
           }}
         >
-          <div className="gloom-dialog">
+          <div
+            className="gloom-dialog"
+            style={{
+              borderColor: dialogBorder,
+              background: dialogBg,
+              color: colors.text,
+            }}
+          >
             {typeof dialogState.content === "function"
               ? dialogState.content({
                 dialogId: dialogState.id,


### PR DESCRIPTION
This fixes desktop chrome that kept dark-theme surfaces after switching to light themes.

Desktop controls now recompute their panel fills and borders from the active theme, so the back button, message composers, segmented controls, list panels, and dialog frames no longer retain stale dark colors. Settings dialogs and header badges also use theme-derived surfaces, including the market-state and version pills.