### PR TITLE
Support detail back navigation shortcuts

### DIFF
--- a/patches/@opentui%2Fcore@0.1.90.patch
+++ b/patches/@opentui%2Fcore@0.1.90.patch
@@ -1,5 +1,5 @@
 diff --git a/index-e89anq5x.js b/index-e89anq5x.js
-index e3b6cf9..14a46d7 100644
+index e3b6cf9f90b13698966eec991fa7a1b2e1e22d96..709940f3998e5cb1caa88642fa68fa9ace80b7b1 100644
 --- a/index-e89anq5x.js
 +++ b/index-e89anq5x.js
 @@ -6328,17 +6328,27 @@ class MouseParser {
@@ -66,16 +66,39 @@ index e3b6cf9..14a46d7 100644
              consumed: index - offset + 1
            };
          }
-@@ -6408,7 +6418,7 @@ class MouseParser {
+@@ -6408,10 +6418,12 @@ class MouseParser {
        consumed: 6
      };
    }
 -  decodeSgrEvent(rawButtonCode, wireX, wireY, pressRelease) {
+-    const button = rawButtonCode & 3;
 +  decodeSgrEvent(rawButtonCode, wireX, wireY, pressRelease, context = void 0) {
-     const button = rawButtonCode & 3;
++    const encodedButton = rawButtonCode & 3;
++    const isExtendedButton = (rawButtonCode & 128) !== 0;
++    const button = isExtendedButton ? 8 + encodedButton : encodedButton;
      const isScroll = (rawButtonCode & 64) !== 0;
-     const scrollDirection = !isScroll ? undefined : MouseParser.SCROLL_DIRECTIONS[button];
-@@ -6443,11 +6453,26 @@ class MouseParser {
+-    const scrollDirection = !isScroll ? undefined : MouseParser.SCROLL_DIRECTIONS[button];
++    const scrollDirection = !isScroll ? undefined : MouseParser.SCROLL_DIRECTIONS[encodedButton];
+     const isMotion = (rawButtonCode & 32) !== 0;
+     const modifiers = {
+       shift: (rawButtonCode & 4) !== 0,
+@@ -6422,7 +6434,7 @@ class MouseParser {
+     let scrollInfo;
+     if (isMotion) {
+       const isDragging = this.mouseButtonsPressed.size > 0;
+-      if (button === 3) {
++      if (!isExtendedButton && encodedButton === 3) {
+         type = "move";
+       } else if (isDragging) {
+         type = "drag";
+@@ -6437,17 +6449,32 @@ class MouseParser {
+       };
+     } else {
+       type = pressRelease === "M" ? "down" : "up";
+-      if (type === "down" && button !== 3) {
++      if (type === "down" && (isExtendedButton || encodedButton !== 3)) {
+         this.mouseButtonsPressed.add(button);
+       } else if (type === "up") {
          this.mouseButtonsPressed.clear();
        }
      }
@@ -90,9 +113,10 @@ index e3b6cf9..14a46d7 100644
 +    const pixelY = pixelModeDetected ? Math.max(wireY - 1, 0) : void 0;
      return {
        type,
-       button: button === 3 ? 0 : button,
+-      button: button === 3 ? 0 : button,
 -      x: wireX - 1,
 -      y: wireY - 1,
++      button: !isExtendedButton && encodedButton === 3 ? 0 : button,
 +      x: pixelModeDetected && pixelX !== void 0
 +        ? this.projectPixelToCell(pixelX, context?.pixelWidth ?? 0, context?.terminalWidth ?? 0)
 +        : wireX - 1,
@@ -104,7 +128,7 @@ index e3b6cf9..14a46d7 100644
        modifiers,
        scroll: scrollInfo
      };
-@@ -6856,7 +6881,13 @@ var DEFAULT_PROTOCOL_CONTEXT = {
+@@ -6856,7 +6883,13 @@ var DEFAULT_PROTOCOL_CONTEXT = {
    kittyKeyboardEnabled: false,
    privateCapabilityRepliesActive: false,
    pixelResolutionQueryActive: false,
@@ -119,7 +143,7 @@ index e3b6cf9..14a46d7 100644
  };
  var RXVT_DOLLAR_CSI_RE = /^\x1b\[\d+\$$/;
  var SYSTEM_CLOCK = new SystemClock;
-@@ -7149,7 +7180,13 @@ class StdinParser {
+@@ -7149,7 +7182,13 @@ class StdinParser {
        kittyKeyboardEnabled: options.protocolContext?.kittyKeyboardEnabled ?? false,
        privateCapabilityRepliesActive: options.protocolContext?.privateCapabilityRepliesActive ?? false,
        pixelResolutionQueryActive: options.protocolContext?.pixelResolutionQueryActive ?? false,
@@ -134,7 +158,7 @@ index e3b6cf9..14a46d7 100644
      };
    }
    get bufferCapacity() {
-@@ -7952,11 +7989,14 @@ class StdinParser {
+@@ -7952,11 +7991,14 @@ class StdinParser {
      });
    }
    emitMouse(rawBytes, encoding) {
@@ -150,7 +174,7 @@ index e3b6cf9..14a46d7 100644
      this.events.push({
        type: "mouse",
        raw: decodeLatin1(rawBytes),
-@@ -17295,6 +17335,8 @@ class MouseEvent {
+@@ -17295,6 +17337,8 @@ class MouseEvent {
    button;
    x;
    y;
@@ -159,7 +183,7 @@ index e3b6cf9..14a46d7 100644
    source;
    modifiers;
    scroll;
-@@ -17314,6 +17356,8 @@ class MouseEvent {
+@@ -17314,6 +17358,8 @@ class MouseEvent {
      this.button = attributes.button;
      this.x = attributes.x;
      this.y = attributes.y;
@@ -168,7 +192,7 @@ index e3b6cf9..14a46d7 100644
      this.modifiers = attributes.modifiers;
      this.scroll = attributes.scroll;
      this.source = attributes.source;
-@@ -17479,6 +17523,8 @@ class CliRenderer extends EventEmitter8 {
+@@ -17479,6 +17525,8 @@ class CliRenderer extends EventEmitter8 {
    resizeDebounceDelay = 100;
    enableMouseMovement = false;
    _useMouse = true;
@@ -177,7 +201,7 @@ index e3b6cf9..14a46d7 100644
    autoFocus = true;
    _useAlternateScreen = env.OTUI_USE_ALTERNATE_SCREEN;
    _suspendedMouseEnabled = false;
-@@ -17507,7 +17553,7 @@ class CliRenderer extends EventEmitter8 {
+@@ -17507,7 +17555,7 @@ class CliRenderer extends EventEmitter8 {
      this.handleResize(width, height);
    }).bind(this);
    _capabilities = null;
@@ -186,7 +210,7 @@ index e3b6cf9..14a46d7 100644
    _hasPointer = false;
    _lastPointerModifiers = { shift: false, alt: false, ctrl: false };
    _currentMousePointerStyle = undefined;
-@@ -17661,7 +17707,13 @@ Captured output:
+@@ -17661,7 +17709,13 @@ Captured output:
          kittyKeyboardEnabled: useKittyForParsing,
          privateCapabilityRepliesActive: false,
          pixelResolutionQueryActive: false,
@@ -201,7 +225,7 @@ index e3b6cf9..14a46d7 100644
        },
        clock: this.clock
      });
-@@ -17983,12 +18035,14 @@ Captured output:
+@@ -17983,12 +18037,14 @@ Captured output:
    enableMouse() {
      this._useMouse = true;
      this.lib.enableMouse(this.rendererPtr, this.enableMouseMovement);
@@ -216,7 +240,7 @@ index e3b6cf9..14a46d7 100644
    }
    enableKittyKeyboard(flags = 3) {
      this.lib.enableKittyKeyboard(this.rendererPtr, flags);
-@@ -17998,6 +18052,64 @@ Captured output:
+@@ -17998,6 +18054,64 @@ Captured output:
      this.lib.disableKittyKeyboard(this.rendererPtr);
      this.updateStdinParserProtocolContext({ kittyKeyboardEnabled: false }, true);
    }
@@ -281,7 +305,7 @@ index e3b6cf9..14a46d7 100644
    set useThread(useThread) {
      this._useThread = useThread;
      this.lib.setUseThread(this.rendererPtr, useThread);
-@@ -18031,6 +18143,7 @@ Captured output:
+@@ -18031,6 +18145,7 @@ Captured output:
      if (this._useMouse) {
        this.enableMouse();
      }
@@ -289,7 +313,7 @@ index e3b6cf9..14a46d7 100644
      this.queryPixelResolution();
    }
    stdinListener = ((chunk) => {
-@@ -18070,6 +18183,7 @@ Captured output:
+@@ -18070,6 +18185,7 @@ Captured output:
      if (isCapabilityResponse(sequence)) {
        this.lib.processCapabilityResponse(this.rendererPtr, sequence);
        this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr);
@@ -297,7 +321,7 @@ index e3b6cf9..14a46d7 100644
        this.emit("capabilities" /* CAPABILITIES */, this._capabilities);
        return true;
      }
-@@ -18079,6 +18193,7 @@ Captured output:
+@@ -18079,6 +18195,7 @@ Captured output:
      if (sequence === "\x1B[I") {
        if (this.shouldRestoreModesOnNextFocus) {
          this.lib.restoreTerminalModes(this.rendererPtr);
@@ -305,7 +329,7 @@ index e3b6cf9..14a46d7 100644
          this.shouldRestoreModesOnNextFocus = false;
        }
        if (this._terminalFocusState !== true) {
-@@ -18187,6 +18302,7 @@ Captured output:
+@@ -18187,6 +18304,7 @@ Captured output:
          }
          this.waitingForPixelResolution = false;
          this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: false }, true);
@@ -313,7 +337,7 @@ index e3b6cf9..14a46d7 100644
          return true;
        }
        return false;
-@@ -18221,9 +18337,15 @@ Captured output:
+@@ -18221,9 +18339,15 @@ Captured output:
          return false;
        }
        mouseEvent.y -= this.renderOffset;
@@ -329,7 +353,7 @@ index e3b6cf9..14a46d7 100644
      this._hasPointer = true;
      this._lastPointerModifiers = mouseEvent.modifiers;
      if (this._console.visible) {
-@@ -18352,6 +18474,8 @@ Captured output:
+@@ -18352,6 +18476,8 @@ Captured output:
        button: 0,
        x: this._latestPointer.x,
        y: this._latestPointer.y,
@@ -338,7 +362,7 @@ index e3b6cf9..14a46d7 100644
        modifiers: this._lastPointerModifiers
      };
      if (lastOver && !lastOver.isDestroyed) {
-@@ -18435,6 +18559,7 @@ Captured output:
+@@ -18435,6 +18561,7 @@ Captured output:
      const prevWidth = this._terminalWidth;
      this._terminalWidth = width;
      this._terminalHeight = height;
@@ -346,7 +370,7 @@ index e3b6cf9..14a46d7 100644
      this.queryPixelResolution();
      this.setCapturedRenderable(undefined);
      this.stdinParser?.resetMouseState();
-@@ -18712,6 +18837,7 @@ Captured output:
+@@ -18712,6 +18839,7 @@ Captured output:
      }
      this._isRunning = false;
      this.waitingForPixelResolution = false;

--- a/src/components/data-table-stack-view.test.tsx
+++ b/src/components/data-table-stack-view.test.tsx
@@ -160,6 +160,13 @@ async function emitKeypress(event: { name?: string; sequence?: string }) {
   });
 }
 
+async function emitTerminalMouseBack(x: number, y: number) {
+  await act(async () => {
+    await testSetup!.mockMouse.emitMouseEvent("down", x, y, 128 as any);
+    await testSetup!.renderOnce();
+  });
+}
+
 describe("DataTableStackView", () => {
   test("owns table navigation, detail open, and back navigation", async () => {
     testSetup = await testRender(<Harness />, { width: 60, height: 12 });
@@ -179,14 +186,42 @@ describe("DataTableStackView", () => {
 
     await emitKeypress({ name: "escape", sequence: "\u001b" });
     await renderSettled();
-    expect(testSetup.captureCharFrame()).toContain("Second detail");
-
-    await emitKeypress({ name: "backspace", sequence: "\u007f" });
-    await renderSettled();
 
     const rootFrame = testSetup.captureCharFrame();
     expect(rootFrame).toContain("Second row");
     expect(rootFrame).not.toContain("Second detail");
+  });
+
+  test("closes detail from backspace", async () => {
+    testSetup = await testRender(<Harness />, { width: 60, height: 12 });
+
+    await renderSettled();
+    await emitKeypress({ name: "enter", sequence: "\r" });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).toContain("First detail");
+
+    await emitKeypress({ name: "backspace", sequence: "\u007f" });
+    await renderSettled();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("First row");
+    expect(frame).not.toContain("First detail");
+  });
+
+  test("closes detail from the terminal mouse back button", async () => {
+    testSetup = await testRender(<Harness />, { width: 60, height: 12 });
+
+    await renderSettled();
+    await emitKeypress({ name: "enter", sequence: "\r" });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).toContain("First detail");
+
+    await emitTerminalMouseBack(30, 4);
+    await renderSettled();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("First row");
+    expect(frame).not.toContain("First detail");
   });
 
   test("skips section rows while navigating through the stack view", async () => {

--- a/src/components/ui/page-stack-view.tsx
+++ b/src/components/ui/page-stack-view.tsx
@@ -1,8 +1,11 @@
 import { Box, Text, TextAttributes, useUiHost } from "../../ui";
 import { useShortcut } from "../../react/input";
-import { type ComponentType, type ReactNode } from "react";
+import { useCallback, type ComponentType, type ReactNode } from "react";
 import { colors } from "../../theme/colors";
-import { isDetailBackNavigationKey } from "../../utils/back-navigation";
+import {
+  isDetailBackNavigationKey,
+  isMouseBackNavigationEvent,
+} from "../../utils/back-navigation";
 
 export interface PageStackViewProps {
   focused: boolean;
@@ -41,12 +44,28 @@ export function PageStackView({
     );
   }
 
+  const goBack = useCallback((event?: {
+    preventDefault?: () => void;
+    stopPropagation?: () => void;
+  }) => {
+    event?.stopPropagation?.();
+    event?.preventDefault?.();
+    onBack();
+  }, [onBack]);
+
   useShortcut((event) => {
     if (!focused || !detailOpen || !isDetailBackNavigationKey(event)) return;
-    event.stopPropagation?.();
-    event.preventDefault?.();
-    onBack();
+    goBack(event);
   });
+
+  const handleMouseDown = useCallback((event: {
+    button?: unknown;
+    preventDefault?: () => void;
+    stopPropagation?: () => void;
+  }) => {
+    if (!focused || !detailOpen || !isMouseBackNavigationEvent(event)) return;
+    goBack(event);
+  }, [detailOpen, focused, goBack]);
 
   if (!detailOpen) {
     return (
@@ -57,16 +76,26 @@ export function PageStackView({
   }
 
   return (
-    <Box flexDirection="column" flexGrow={1} overflow="hidden">
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      overflow="hidden"
+      onMouseDown={handleMouseDown}
+    >
       <Box height={1} flexDirection="row">
         <Box
           onMouseDown={(event) => {
-            event.preventDefault?.();
-            event.stopPropagation?.();
-            onBack();
+            goBack(event);
           }}
+          backgroundColor={colors.selected}
         >
-          <Text fg={colors.textBright}>{`← ${backLabel}`}</Text>
+          <Text
+            fg={colors.selectedText}
+            bg={colors.selected}
+            attributes={TextAttributes.BOLD}
+          >
+            {`← ${backLabel}`}
+          </Text>
         </Box>
         {detailTitle ? (
           <>

--- a/src/plugins/prediction-markets/pane.test.tsx
+++ b/src/plugins/prediction-markets/pane.test.tsx
@@ -378,7 +378,7 @@ describe("prediction markets pane interactions", () => {
     ).toBe("polymarket:pm-1");
   });
 
-  test("supports detail outcome navigation and backspace return from the keyboard", async () => {
+  test("supports detail outcome navigation and escape return from the keyboard", async () => {
     attachPredictionMarketsPersistence(new MemoryPersistence());
 
     globalThis.fetch = (async (input: Request | string | URL) => {
@@ -511,20 +511,13 @@ describe("prediction markets pane interactions", () => {
     await flushFrames(testSetup);
 
     const escapeFrame = testSetup.captureCharFrame();
-    expect(escapeFrame).toContain("\u2190 Back");
-    expect(escapeFrame).toContain("Rule 2");
+    expect(escapeFrame).toContain("search markets");
+    expect(escapeFrame).not.toContain("Rule 2");
     expect(
       harnessStateRef.current?.paneState[TEST_PANE_ID]?.pluginState?.[
         "prediction-markets"
       ]?.selectedDetailMarketKey,
     ).toBe("kalshi:KXFED-27APR-T4.50");
-
-    await emitKeypress(testSetup, { name: "backspace", sequence: "\u007f" });
-    await flushFrames(testSetup);
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("search markets");
-    expect(frame).not.toContain("Rule 2");
   });
 
   test("opens full-page detail from a row double click and preserves the browse selection", async () => {

--- a/src/renderers/electrobun/view/input-host.tsx
+++ b/src/renderers/electrobun/view/input-host.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
 import { InputHostProvider, type InputHost, type KeyEventLike, type ShortcutOptions } from "../../../react/input";
 import {
+  isMouseBackNavigationButton,
+  MOUSE_BACK_NAVIGATION_EVENT_NAME,
+} from "../../../utils/back-navigation";
+import {
   hasWebCtrlModifier,
   isEditableKeyboardTarget,
   normalizeWebKeyName,
@@ -21,6 +25,32 @@ function toKeyEventLike(event: KeyboardEvent): KeyEventLike {
     name: key,
     sequence: webKeySequence(event),
     ctrl: hasWebCtrlModifier(event),
+    shift: event.shiftKey,
+    alt: event.altKey,
+    meta: event.metaKey,
+    super: event.metaKey,
+    targetEditable: isEditableKeyboardTarget(event.target),
+    get defaultPrevented() {
+      return event.defaultPrevented;
+    },
+    get propagationStopped() {
+      return propagationStopped;
+    },
+    preventDefault: () => event.preventDefault(),
+    stopPropagation: () => {
+      propagationStopped = true;
+      event.stopPropagation();
+    },
+  };
+}
+
+function toMouseBackKeyEventLike(event: MouseEvent): KeyEventLike {
+  let propagationStopped = false;
+  return {
+    key: MOUSE_BACK_NAVIGATION_EVENT_NAME,
+    name: MOUSE_BACK_NAVIGATION_EVENT_NAME,
+    sequence: "",
+    ctrl: event.ctrlKey,
     shift: event.shiftKey,
     alt: event.altKey,
     meta: event.metaKey,
@@ -68,22 +98,49 @@ function getViewport() {
 export function WebInputHostProvider({ children }: { children: ReactNode }) {
   const shortcutsRef = useRef<ShortcutEntry[]>([]);
 
+  const dispatchShortcut = (shortcutEvent: KeyEventLike) => {
+    for (const phase of ["normal", "after"] as const) {
+      if (phase === "after" && (shortcutEvent.defaultPrevented || shortcutEvent.propagationStopped)) break;
+      for (const entry of shortcutsRef.current) {
+        if (entry.phase !== phase || !entry.enabledRef.current) continue;
+        entry.handlerRef.current(shortcutEvent);
+        if (shortcutEvent.propagationStopped) break;
+      }
+      if (shortcutEvent.propagationStopped) break;
+    }
+  };
+
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const shortcutEvent = toKeyEventLike(event);
-      for (const phase of ["normal", "after"] as const) {
-        if (phase === "after" && (shortcutEvent.defaultPrevented || shortcutEvent.propagationStopped)) break;
-        for (const entry of shortcutsRef.current) {
-          if (entry.phase !== phase || !entry.enabledRef.current) continue;
-          entry.handlerRef.current(shortcutEvent);
-          if (shortcutEvent.propagationStopped) break;
-        }
-        if (shortcutEvent.propagationStopped) break;
-      }
+      dispatchShortcut(shortcutEvent);
       if (shouldConsumeWebAppKeyDown(event)) event.preventDefault();
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    const preventBrowserBack = (event: MouseEvent) => {
+      if (!isMouseBackNavigationButton(event.button)) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    const onMouseUp = (event: MouseEvent) => {
+      if (!isMouseBackNavigationButton(event.button)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dispatchShortcut(toMouseBackKeyEventLike(event));
+    };
+
+    window.addEventListener("mousedown", preventBrowserBack, true);
+    window.addEventListener("auxclick", preventBrowserBack, true);
+    window.addEventListener("mouseup", onMouseUp, true);
+    return () => {
+      window.removeEventListener("mousedown", preventBrowserBack, true);
+      window.removeEventListener("auxclick", preventBrowserBack, true);
+      window.removeEventListener("mouseup", onMouseUp, true);
+    };
   }, []);
 
   const host = useMemo<InputHost>(() => ({

--- a/src/utils/back-navigation.ts
+++ b/src/utils/back-navigation.ts
@@ -1,10 +1,19 @@
 export interface BackNavigationEventLike {
   name?: string;
+  key?: string;
   ctrl?: boolean;
   meta?: boolean;
   option?: boolean;
   shift?: boolean;
 }
+
+export interface BackNavigationMouseEventLike {
+  button?: unknown;
+}
+
+export const MOUSE_BACK_NAVIGATION_EVENT_NAME = "mouse-back";
+export const WEB_MOUSE_BACK_NAVIGATION_BUTTON = 3;
+export const TERMINAL_MOUSE_BACK_NAVIGATION_BUTTON = 8;
 
 export function isPlainBackspace(event: BackNavigationEventLike): boolean {
   return event.name === "backspace"
@@ -29,5 +38,19 @@ export function isBackNavigationKey(event: BackNavigationEventLike): boolean {
 export function isDetailBackNavigationKey(
   event: BackNavigationEventLike,
 ): boolean {
-  return isPlainBackspace(event);
+  return isPlainBackspace(event)
+    || isPlainEscape(event)
+    || event.name === MOUSE_BACK_NAVIGATION_EVENT_NAME
+    || event.key === MOUSE_BACK_NAVIGATION_EVENT_NAME;
+}
+
+export function isMouseBackNavigationButton(button: unknown): boolean {
+  return button === WEB_MOUSE_BACK_NAVIGATION_BUTTON
+    || button === TERMINAL_MOUSE_BACK_NAVIGATION_BUTTON;
+}
+
+export function isMouseBackNavigationEvent(
+  event: BackNavigationMouseEventLike | null | undefined,
+): boolean {
+  return isMouseBackNavigationButton(event?.button);
 }


### PR DESCRIPTION
Adds shared detail-back handling so stacked detail panes can return with Escape, Backspace, and mouse back buttons.
Desktop WebKit intercepts the mouse back button before browser navigation and routes it through the app shortcut pipeline.
The TUI path preserves extended xterm side-button reports in the existing OpenTUI patch and makes the terminal back affordance more visible.
