### PR TITLE
Fix comparison chart ticker and crosshair UX

### DIFF
--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -918,6 +918,76 @@ function writeAxisLabel(axis: string[], start: number, label: string) {
   }
 }
 
+export interface AxisLabelSegment {
+  text: string;
+  highlighted: boolean;
+}
+
+function formatCursorTimeAxisValue(
+  value: Date | string | number,
+  dates: Array<Date | string | number>,
+  width: number,
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (isNaN(date.getTime())) return "—";
+
+  const normalizedDates = dates.map((entry) => (entry instanceof Date ? entry : new Date(entry)));
+  const validDates = normalizedDates.filter((entry) => !isNaN(entry.getTime()));
+  if (validDates.length === 0) return formatDateShort(date);
+
+  const first = validDates[0]!;
+  const last = validDates[validDates.length - 1]!;
+  const spanMs = Math.max(last.getTime() - first.getTime(), 1);
+  const roughLabelCount = Math.max(Math.floor(normalizeCount(width, 0) / 10), 2);
+  const minGapMs = getMinPositiveGapMs(validDates);
+  const effectiveStepMs = Math.max(spanMs / Math.max(roughLabelCount - 1, 1), minGapMs || 0);
+  const unit = resolveAxisLabelUnit(effectiveStepMs);
+  const counterpart = isSameCalendarDay(first, last)
+    ? first
+    : isSameCalendarDay(date, first)
+      ? last
+      : first;
+
+  return formatTimeAxisBoundaryLabel(date, unit, counterpart);
+}
+
+export function buildCursorTimeAxisSegments({
+  timeLabels,
+  width,
+  cursorColumn,
+  cursorDate,
+  dates,
+}: {
+  timeLabels: string;
+  width: number;
+  cursorColumn: number | null;
+  cursorDate: Date | string | number | null;
+  dates: Array<Date | string | number>;
+}): AxisLabelSegment[] {
+  const axisWidth = normalizeCount(width, 0);
+  if (axisWidth <= 0) return [];
+
+  const base = timeLabels.padEnd(axisWidth).slice(0, axisWidth);
+  if (cursorColumn === null || cursorDate === null) {
+    return [{ text: base, highlighted: false }];
+  }
+
+  const label = formatCursorTimeAxisValue(cursorDate, dates, axisWidth);
+  if (!label) return [{ text: base, highlighted: false }];
+
+  const axis = base.split("");
+  const column = Math.max(Math.min(Math.round(cursorColumn), axisWidth - 1), 0);
+  const start = resolveAxisLabelStart(column, label, axisWidth);
+  const end = Math.min(start + label.length, axisWidth);
+  writeAxisLabel(axis, start, label);
+
+  return [
+    { text: axis.slice(0, start).join(""), highlighted: false },
+    { text: axis.slice(start, end).join(""), highlighted: true },
+    { text: axis.slice(end).join(""), highlighted: false },
+  ].filter((segment) => segment.text.length > 0);
+}
+
 export function buildTimeAxis(dates: Array<Date | string | number>, width: number): string {
   const axisWidth = normalizeCount(width, 0);
   if (dates.length === 0 || axisWidth <= 0) return "";

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -6,7 +6,7 @@ import {
   resolveStableOhlcProjectionOptions,
 } from "./chart-data";
 import { stepCursorTowards } from "./cursor-motion";
-import { buildChartScene, buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
+import { buildChartScene, buildCursorTimeAxisSegments, buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
 import type { PricePoint } from "../../types/financials";
 import type { ChartRenderMode } from "./chart-types";
 
@@ -412,6 +412,21 @@ describe("renderChart", () => {
     expect(buildTimeAxis(dates, 72)).toBe(
       "09:30     10:30 11:00       12:00      13:00       14:00 14:30     15:30",
     );
+  });
+
+  test("overlays the cursor date on the x-axis without changing its width", () => {
+    const dates = Array.from({ length: 13 }, (_, index) => new Date(2026, 0, 5, 9, 30 + index * 30));
+    const width = 72;
+    const segments = buildCursorTimeAxisSegments({
+      timeLabels: buildTimeAxis(dates, width),
+      width,
+      cursorColumn: 36,
+      cursorDate: dates[6]!,
+      dates,
+    });
+
+    expect(segments.map((segment) => segment.text).join("")).toHaveLength(width);
+    expect(segments.find((segment) => segment.highlighted)?.text).toBe("12:30");
   });
 
   test("shows second precision when the visible window reaches second-level data", () => {

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -96,6 +96,7 @@ import {
   type NativeSurfaceRenderableNode,
 } from "./native/surface-visibility";
 import { formatAxisCell, formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
+import { TimeAxisLabel } from "./time-axis-label";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
   area: "A",
@@ -110,6 +111,7 @@ interface ComparisonStockChartProps {
   symbols: string[];
   axisMode: ChartAxisMode;
   onOpenSymbol: (symbol: string) => void;
+  onEditTickers?: () => void;
 }
 
 interface ComparisonChartSymbolSource {
@@ -512,6 +514,7 @@ function ComparisonStockChartView({
   preferredRenderer,
   symbolSources,
   onOpenSymbol,
+  onEditTickers,
 }: ComparisonStockChartViewProps) {
   const renderer = useNativeRenderer();
   const { canvasCharts, cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1 } = useUiCapabilities();
@@ -546,6 +549,7 @@ function ComparisonStockChartView({
   const lastCanvasBaseBitmapRef = useRef<{ key: string; bitmap: NativeChartBitmap } | null>(null);
   const displayCursorRef = useRef<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
   const targetCursorRef = useRef<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
+  const mouseCrosshairDisabledRef = useRef(false);
   const cursorMotionKindRef = useRef<ChartCursorMotionKind>("discrete");
   const animationFrameRef = useRef<number | null>(null);
   const pendingCanonicalResetRef = useRef(1);
@@ -1034,6 +1038,14 @@ function ComparisonStockChartView({
     selectedSymbol: viewState.selectedSymbol,
     colors: chartColors,
   }), [chartColors, chartHeight, chartWidth, projection, viewState.selectedSymbol]);
+  const displayScene = useMemo(() => buildComparisonChartScene(projection, {
+    width: chartWidth,
+    height: chartHeight,
+    cursorX: displayCursorX,
+    cursorY: displayCursorY,
+    selectedSymbol: viewState.selectedSymbol,
+    colors: chartColors,
+  }), [chartColors, chartHeight, chartWidth, displayCursorX, displayCursorY, projection, viewState.selectedSymbol]);
 
   const staticResult = useMemo(() => renderComparisonChart(projection, {
     width: chartWidth,
@@ -1085,6 +1097,12 @@ function ComparisonStockChartView({
     };
 
     return [
+      ...(onEditTickers ? [{
+        id: "tickers",
+        key: "t",
+        label: "ickers",
+        onPress: onEditTickers,
+      }] : []),
       {
         id: "mode",
         key: "m",
@@ -1108,25 +1126,12 @@ function ComparisonStockChartView({
       { id: "reset", key: "0", label: "reset", onPress: resetView },
       ...(width >= 72 ? [{ id: "range", key: "1-7", label: "range", onPress: cycleRange }] : []),
     ];
-  }, [effectiveResolution, resolutionChips, series, supportMap, viewState.presetRange, visibleDateWindow, width]);
+  }, [effectiveResolution, onEditTickers, resolutionChips, series, supportMap, viewState.presetRange, visibleDateWindow, width]);
 
   usePaneFooter("comparison-chart", () => ({
     order: 10,
     hints: footerHints,
   }), [footerHints]);
-
-  const liveScene = useMemo(() => (
-    effectiveRenderer === "kitty"
-      ? staticScene
-      : buildComparisonChartScene(projection, {
-        width: chartWidth,
-        height: chartHeight,
-        cursorX: displayCursorX,
-        cursorY: displayCursorY,
-        selectedSymbol: viewState.selectedSymbol,
-        colors: chartColors,
-      })
-  ), [chartColors, chartHeight, chartWidth, displayCursorX, displayCursorY, effectiveRenderer, projection, staticScene, viewState.selectedSymbol]);
 
   const nativeCrosshair = useMemo<NativeCrosshairOverlay | null>(() => {
     if (displayCursor.cellX === null || displayCursor.cellY === null) return null;
@@ -1414,7 +1419,11 @@ function ComparisonStockChartView({
         setResolution(nextResolution);
         return;
       }
+      case "t":
+        onEditTickers?.();
+        return;
       case "h":
+        mouseCrosshairDisabledRef.current = false;
         cursorMotionKindRef.current = "discrete";
         setViewState((current) => ({
           ...current,
@@ -1422,6 +1431,7 @@ function ComparisonStockChartView({
         }));
         return;
       case "l":
+        mouseCrosshairDisabledRef.current = false;
         cursorMotionKindRef.current = "discrete";
         setViewState((current) => ({
           ...current,
@@ -1429,6 +1439,7 @@ function ComparisonStockChartView({
         }));
         return;
       case "escape":
+        mouseCrosshairDisabledRef.current = true;
         updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
         setViewState((current) => ({ ...current, cursorX: null, cursorY: null }));
         return;
@@ -1485,6 +1496,7 @@ function ComparisonStockChartView({
   });
 
   const handlePlotMove = (event: ChartMouseEvent) => {
+    if (mouseCrosshairDisabledRef.current) return;
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (!localPointer) return;
     const selectionCursor = resolveSelectionCursor(localPointer, projection.dates.length, chartWidth);
@@ -1503,6 +1515,7 @@ function ComparisonStockChartView({
   };
 
   const handlePlotDown = (event: ChartMouseEvent) => {
+    mouseCrosshairDisabledRef.current = false;
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (!localPointer) return;
     const selectionCursor = resolveSelectionCursor(localPointer, projection.dates.length, chartWidth);
@@ -1525,6 +1538,7 @@ function ComparisonStockChartView({
   };
 
   const handlePlotDrag = (event: ChartMouseEvent) => {
+    if (mouseCrosshairDisabledRef.current && !dragRef.current) return;
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (localPointer) {
       const selectionCursor = resolveSelectionCursor(localPointer, projection.dates.length, chartWidth);
@@ -1610,7 +1624,8 @@ function ComparisonStockChartView({
   }
 
   const hasChartData = series.some((entry) => entry.points.length > 0);
-  const cursorScene = effectiveRenderer === "kitty" ? staticScene : liveScene;
+  const hasDisplayCursor = displayCursorX !== null && displayCursorY !== null;
+  const cursorScene = hasDisplayCursor ? displayScene : staticScene;
   const selectedSeries = hasChartData ? (cursorScene?.selectedSeries ?? staticResult.selectedSeries) : null;
   const selectedPoint = hasChartData ? (cursorScene?.selectedPoint ?? staticResult.selectedPoint) : null;
   const selectedRawValue = selectedPoint?.rawValue ?? selectedSeries?.latestRawValue ?? null;
@@ -1638,6 +1653,8 @@ function ComparisonStockChartView({
     start: visibleWindow.dates[0] ?? null,
     end: visibleWindow.dates[visibleWindow.dates.length - 1] ?? null,
   });
+  const cursorTimeAxisColumn = hasDisplayCursor ? displayScene?.cursorColumn ?? null : null;
+  const cursorTimeAxisDate = hasDisplayCursor ? displayScene?.activeDate ?? null : null;
 
   const canvasBitmapSize = useMemo(() => {
     if (!canvasCharts) return null;
@@ -1926,7 +1943,14 @@ function ComparisonStockChartView({
       </Box>
 
       <Box height={timeAxisRows}>
-        <Text fg={colors.textDim}>{timeAxisLabel}</Text>
+        <TimeAxisLabel
+          timeLabels={timeAxisLabel}
+          width={chartWidth}
+          cursorColumn={cursorTimeAxisColumn}
+          cursorDate={cursorTimeAxisDate}
+          dates={projection.dates}
+          cursorColor={chartColors.crosshairColor}
+        />
       </Box>
 
       {legendRows > 0 && (

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -127,6 +127,7 @@ import {
 } from "./native/surface-visibility";
 import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
+import { TimeAxisLabel } from "./time-axis-label";
 
 const MODE_CHIPS: Record<ChartRenderMode, string> = {
   area: "A",
@@ -1497,6 +1498,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const lastCanvasBaseBitmapRef = useRef<{ key: string; bitmap: NativeChartBitmap } | null>(null);
   const displayCursorRef = useRef<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
   const targetCursorRef = useRef<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
+  const mouseCrosshairDisabledRef = useRef(false);
   const cursorMotionKindRef = useRef<ChartCursorMotionKind>("discrete");
   const animationFrameRef = useRef<number | null>(null);
   const pendingCanonicalResetRef = useRef(1);
@@ -2889,6 +2891,11 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     if (!interactive) return;
 
     switch (key) {
+      case "escape":
+        mouseCrosshairDisabledRef.current = true;
+        updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
+        commitSelectionCursor({ cursorX: null, cursorY: null });
+        return;
       case "left":
         if (event.shift) {
           if (effectiveResolution === "auto") {
@@ -2906,6 +2913,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
             return { ...cleared, panOffset: current.panOffset + panStep };
           });
         } else {
+          mouseCrosshairDisabledRef.current = false;
           cursorMotionKindRef.current = "discrete";
           const pointCount = projection.points.length;
           const currentIndex = pointCount <= 0
@@ -2957,6 +2965,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
             return cleared.panOffset === nextPanOffset ? cleared : { ...cleared, panOffset: nextPanOffset };
           });
         } else {
+          mouseCrosshairDisabledRef.current = false;
           cursorMotionKindRef.current = "discrete";
           const pointCount = projection.points.length;
           const currentIndex = pointCount <= 0
@@ -3041,6 +3050,19 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     colors: chartColors,
     timeAxisDates,
   }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, selectionCursorX, selectionCursorY, showVolume, timeAxisDates, volumeHeight]);
+  const displayScene = useMemo(() => buildChartScene(projection.points, {
+    width: chartWidth,
+    height: chartHeight,
+    showVolume: showVolume && !compact,
+    volumeHeight,
+    cursorX: displayCursorX,
+    cursorY: displayCursorY,
+    mode: projection.effectiveMode,
+    axisMode,
+    colors: chartColors,
+    timeAxisDates,
+    indicators,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
   const snappedSelectionCursorX = selectionScene
     ? getPointTerminalColumn(selectionScene.activeIdx, projection.points.length, chartWidth, projection.effectiveMode)
     : null;
@@ -3402,6 +3424,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     : null;
   const isUpdating = !compact && (renderBodyState.updating || boundsBodyState.updating);
   const timeAxisLabel = selectionScene?.timeLabels ?? staticResult.timeLabels;
+  const cursorTimeAxisColumn = hasDisplayCursor ? displayScene?.cursorColumn ?? null : null;
+  const cursorTimeAxisDate = hasDisplayCursor ? displayScene?.dateAtCursor ?? null : null;
   const timeAxisBox = (
     <Box
       height={1}
@@ -3409,7 +3433,14 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       overflow="hidden"
       data-gloom-role="chart-time-axis"
     >
-      <Text fg={colors.textDim} style={{ whiteSpace: "pre" }}>{timeAxisLabel}</Text>
+      <TimeAxisLabel
+        timeLabels={timeAxisLabel}
+        width={chartWidth}
+        cursorColumn={cursorTimeAxisColumn}
+        cursorDate={cursorTimeAxisDate}
+        dates={timeAxisDates}
+        cursorColor={chartColors.crosshairColor}
+      />
     </Box>
   );
   const chartFooterHints = useMemo<PaneHint[]>(() => {
@@ -3556,6 +3587,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
 
   const handlePlotMove = (event: ChartMouseEvent) => {
     if (!interactive || compact) return;
+    if (mouseCrosshairDisabledRef.current) return;
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (!localPointer) return;
     const selectionCursor = resolveSelectionCursor(localPointer, projection.points.length, chartWidth, projection.effectiveMode);
@@ -3577,6 +3609,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     if (compact) return;
     if (!interactive) onActivate?.();
     focusPaneForMouseInteraction(event);
+    mouseCrosshairDisabledRef.current = false;
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (!localPointer) return;
     const selectionCursor = resolveSelectionCursor(localPointer, projection.points.length, chartWidth, projection.effectiveMode);
@@ -3601,6 +3634,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
 
   const handlePlotDrag = (event: ChartMouseEvent) => {
     if (compact || (!interactive && !dragRef.current)) return;
+    if (mouseCrosshairDisabledRef.current && !dragRef.current) return;
     const localPointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (localPointer) {
       const selectionCursor = resolveSelectionCursor(localPointer, projection.points.length, chartWidth, projection.effectiveMode);

--- a/src/components/chart/time-axis-label.tsx
+++ b/src/components/chart/time-axis-label.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { Span, Text } from "../../ui";
+import { colors } from "../../theme/colors";
+import { buildCursorTimeAxisSegments } from "./chart-renderer";
+
+interface TimeAxisLabelProps {
+  timeLabels: string;
+  width: number;
+  cursorColumn: number | null;
+  cursorDate: Date | string | number | null;
+  dates: Array<Date | string | number>;
+  cursorColor: string;
+}
+
+export function TimeAxisLabel({
+  timeLabels,
+  width,
+  cursorColumn,
+  cursorDate,
+  dates,
+  cursorColor,
+}: TimeAxisLabelProps) {
+  const segments = useMemo(() => buildCursorTimeAxisSegments({
+    timeLabels,
+    width,
+    cursorColumn,
+    cursorDate,
+    dates,
+  }), [cursorColumn, cursorDate, dates, timeLabels, width]);
+
+  return (
+    <Text style={{ whiteSpace: "pre" }}>
+      {segments.map((segment, index) => (
+        <Span
+          key={index}
+          fg={segment.highlighted ? cursorColor : colors.textDim}
+        >
+          {segment.text}
+        </Span>
+      ))}
+    </Text>
+  );
+}

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -2201,6 +2201,50 @@ describe("CommandBar", () => {
     expect(frame).toContain("AAPL,");
   });
 
+  test("CMP with one resolved ticker opens inline completion instead of creating a one-symbol chart", async () => {
+    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query="CMP AMD"
+      extraTickers={[makeTicker("AMD", "Advanced Micro Devices")]}
+      configurePluginRegistry={(pluginRegistry) => {
+        (pluginRegistry.panes as Map<string, any>).set("comparison-chart", {
+          id: "comparison-chart",
+          name: "Comparison Chart",
+          component: () => null,
+          defaultPosition: "right",
+        });
+        (pluginRegistry.paneTemplates as Map<string, any>).set("comparison-chart-pane", {
+          id: "comparison-chart-pane",
+          paneId: "comparison-chart",
+          label: "Comparison Chart",
+          description: "Compare multiple symbols in one pane",
+          shortcut: { prefix: "CMP", argPlaceholder: "tickers", argKind: "ticker-list" },
+          wizard: [{ key: "tickers", label: "Tickers", type: "text" }],
+          canCreate: (_context: unknown, options?: { symbols?: string[] | null }) => !options?.symbols || options.symbols.length >= 2,
+        });
+        pluginRegistry.createPaneFromTemplateAsyncFn = async (templateId, options) => {
+          created.push({ templateId, options });
+        };
+      }}
+    />, {
+      width: 100,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    const frame = await waitForFrameToContain("Tickers");
+    expect(created).toEqual([]);
+    expect(frame).toContain("Comparison Chart");
+    expect(frame).toContain("AMD");
+  });
+
   test("AI <prompt> opens the inline workflow and prefills the textarea prompt", async () => {
     const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
 

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -2266,10 +2266,15 @@ export function CommandBar({
           activeCollectionId,
           buildSharedWorkflowDeps(),
         );
-        await openPaneTemplateDirect(template, {
+        const createOptions = {
           arg: trimmedList,
           symbols,
-        });
+        };
+        if (template.canCreate && !template.canCreate(getPaneTemplateContext(), createOptions)) {
+          openPaneTemplateWorkflow(template, { arg: trimmedArg });
+          return;
+        }
+        await openPaneTemplateDirect(template, createOptions);
       } catch {
         openPaneTemplateWorkflow(template, { arg: trimmedArg });
       }

--- a/src/components/command-bar/workflow-ops.ts
+++ b/src/components/command-bar/workflow-ops.ts
@@ -14,6 +14,7 @@ import { cleanPortfolioPaneSettings, resolvePortfolioPaneCollectionId } from "..
 import {
   buildComparisonChartPaneTitle,
   COMPARISON_CHART_PANE_ID,
+  MIN_COMPARISON_CHART_SYMBOLS,
 } from "../../plugins/builtin/comparison-chart";
 import { getPaneTemplateDisplayLabel } from "./pane-template-display";
 
@@ -415,6 +416,9 @@ export async function applyPaneSettingFieldValue(
       descriptor.context.activeCollectionId,
       deps,
     );
+    if (symbols.length < MIN_COMPARISON_CHART_SYMBOLS) {
+      throw new Error(`Enter at least ${MIN_COMPARISON_CHART_SYMBOLS} tickers.`);
+    }
     const nextLayout = updatePaneInstance(state.config.layout, targetId, (instance) => ({
       ...instance,
       title: buildComparisonChartPaneTitle(symbols),

--- a/src/plugins/builtin/comparison-chart.test.tsx
+++ b/src/plugins/builtin/comparison-chart.test.tsx
@@ -109,7 +109,7 @@ function createRegistrySpy(spy: { selected: string[]; focused: string[] }): Plug
   } as unknown as PluginRegistry;
 }
 
-function createRuntimeSpy(spy: { selected: string[]; focused: string[] }): PluginRuntimeAccess {
+function createRuntimeSpy(spy: { selected: string[]; focused: string[]; settings?: string[] }): PluginRuntimeAccess {
   return createTestPluginRuntime({
     pinTicker: (symbol: string) => {
       spy.selected.push(symbol);
@@ -118,6 +118,9 @@ function createRuntimeSpy(spy: { selected: string[]; focused: string[] }): Plugi
     navigateTicker: (symbol: string) => {
       spy.selected.push(symbol);
       spy.focused.push("ticker-detail");
+    },
+    openPaneSettings: (paneId) => {
+      spy.settings?.push(paneId ?? "");
     },
   });
 }
@@ -196,7 +199,7 @@ async function mountComparisonHarness(
   settings: Record<string, unknown>,
   tickers: TickerRecord[],
   financials: Array<[string, TickerFinancials]>,
-  spy: { selected: string[]; focused: string[] } = { selected: [], focused: [] },
+  spy: { selected: string[]; focused: string[]; settings?: string[] } = { selected: [], focused: [] },
 ) {
   actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
   testSetup = await createTestRenderer({ width: 120, height: 20 });
@@ -251,6 +254,21 @@ describe("comparisonChartPlugin", () => {
     });
   });
 
+  test("requires at least two symbols when creating a comparison pane", async () => {
+    const template = comparisonChartPlugin.paneTemplates?.[0]!;
+    const context = {
+      config: createDefaultConfig("/tmp/gloomberb-compare"),
+      layout: { dockRoot: null, instances: [], floating: [], detached: [] },
+      focusedPaneId: null,
+      activeTicker: null,
+      activeCollectionId: null,
+    };
+
+    expect(template.canCreate?.(context, { arg: "AMD" })).toBe(true);
+    expect(template.canCreate?.(context, { arg: "AMD", symbols: ["AMD"] })).toBe(false);
+    expect(await template.createInstance?.(context, { symbols: ["AMD"] })).toBeNull();
+  });
+
   test("renders one shared overlay chart with the mixed-currency warning", async () => {
     const provider = createProvider({
       AAPL: [100, 102, 104, 106],
@@ -284,6 +302,7 @@ describe("comparisonChartPlugin", () => {
     expect(frame).toContain("2:1W");
     expect(frame).toContain("1D");
     expect(frame).toContain("view:");
+    expect(frame).toContain("[t]ickers");
     expect(frame).toContain("[m]ode");
     expect(frame).toContain("[r]es");
     expect(frame).not.toContain("[up/down]legend");
@@ -363,5 +382,37 @@ describe("comparisonChartPlugin", () => {
 
     expect(spy.selected).toEqual(["MSFT"]);
     expect(spy.focused).toEqual(["ticker-detail"]);
+  });
+
+  test("opens comparison ticker settings from the t shortcut", async () => {
+    const spy = { selected: [] as string[], focused: [] as string[], settings: [] as string[] };
+    const provider = createProvider({
+      AAPL: [100, 102, 104],
+      MSFT: [200, 202, 204],
+    }, {
+      AAPL: "USD",
+      MSFT: "USD",
+    });
+    setSharedMarketDataForTests(provider);
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedRegistryForTests(createRegistrySpy(spy));
+
+    await mountComparisonHarness({
+      axisMode: "percent",
+      symbols: ["AAPL", "MSFT"],
+      symbolsText: "AAPL, MSFT",
+    }, [
+      makeTicker("AAPL", "USD"),
+      makeTicker("MSFT", "USD"),
+    ], [
+      ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104])],
+      ["MSFT", makeFinancials("MSFT", "USD", [200, 202, 204])],
+    ], spy);
+
+    await flushFrames();
+    await pressComparisonInput(() => testSetup!.mockInput.pressKey("t"));
+
+    expect(spy.settings).toEqual([TEST_PANE_ID]);
   });
 });

--- a/src/plugins/builtin/comparison-chart.tsx
+++ b/src/plugins/builtin/comparison-chart.tsx
@@ -8,7 +8,7 @@ import {
   DEFAULT_COMPARISON_CHART_RESOLUTION,
   normalizeChartResolution,
 } from "../../components/chart/chart-resolution";
-import { usePluginTickerActions } from "../../plugins/plugin-runtime";
+import { usePluginAppActions, usePluginTickerActions } from "../../plugins/plugin-runtime";
 import { usePaneInstance } from "../../state/app-context";
 import { colors } from "../../theme/colors";
 import type { GloomPlugin, PaneProps, PaneSettingsDef } from "../../types/plugin";
@@ -16,6 +16,7 @@ import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } fro
 
 export const COMPARISON_CHART_PANE_ID = "comparison-chart";
 export const COMPARISON_CHART_TEMPLATE_ID = "comparison-chart-pane";
+export const MIN_COMPARISON_CHART_SYMBOLS = 2;
 
 interface ComparisonChartPaneSettings {
   axisMode: ChartAxisMode;
@@ -77,7 +78,7 @@ function buildComparisonChartSettingsDef(): PaneSettingsDef {
       {
         key: "symbolsText",
         label: "Tickers",
-        description: `Enter 1-${MAX_TICKER_LIST_SIZE} tickers separated by commas.`,
+        description: `Enter ${MIN_COMPARISON_CHART_SYMBOLS}-${MAX_TICKER_LIST_SIZE} tickers separated by commas.`,
         type: "text",
         placeholder: "AAPL, MSFT, NVDA",
       },
@@ -102,12 +103,16 @@ export function buildComparisonChartPaneTitle(symbols: string[]): string {
 }
 function ComparisonChartPane({ paneId, focused, width, height }: PaneProps) {
   const { navigateTicker } = usePluginTickerActions();
+  const { openPaneSettings } = usePluginAppActions();
   const pane = usePaneInstance();
   const settings = useMemo(() => getComparisonChartPaneSettings(pane?.settings), [pane?.settings]);
 
   const openTicker = useCallback((symbol: string) => {
     navigateTicker(symbol);
   }, [navigateTicker]);
+  const editTickers = useCallback(() => {
+    openPaneSettings(paneId);
+  }, [openPaneSettings, paneId]);
 
   if (settings.symbols.length === 0) {
     return (
@@ -127,6 +132,7 @@ function ComparisonChartPane({ paneId, focused, width, height }: PaneProps) {
         symbols={settings.symbols}
         axisMode={settings.axisMode}
         onOpenSymbol={openTicker}
+        onEditTickers={editTickers}
       />
     </Box>
   );
@@ -162,15 +168,15 @@ export const comparisonChartPlugin: GloomPlugin = {
           label: "Comparison Tickers",
           placeholder: "AAPL, MSFT, NVDA",
           body: [
-            `Enter 1-${MAX_TICKER_LIST_SIZE} ticker symbols separated by commas.`,
+            `Enter ${MIN_COMPARISON_CHART_SYMBOLS}-${MAX_TICKER_LIST_SIZE} ticker symbols separated by commas.`,
           ],
           type: "text",
         },
       ],
-      canCreate: (_context, options) => !options?.symbols || options.symbols.length > 0,
+      canCreate: (_context, options) => !options?.symbols || options.symbols.length >= MIN_COMPARISON_CHART_SYMBOLS,
       createInstance: (_context, options) => {
         const symbols = options?.symbols ?? [];
-        if (symbols.length === 0) return null;
+        if (symbols.length < MIN_COMPARISON_CHART_SYMBOLS) return null;
         return {
           title: buildComparisonChartPaneTitle(symbols),
           placement: "floating",

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -37,6 +37,7 @@ export interface PluginRuntimeAccess {
   openCommandBar(query?: string): void;
   showPane(paneId: string): void;
   hidePane(paneId: string): void;
+  openPaneSettings(paneId?: string): void;
   openPluginCommandWorkflow(commandId: string): void;
   notify(notification: AppNotificationRequest): void;
   subscribeResumeState(pluginId: string, key: string, listener: () => void): () => void;
@@ -120,6 +121,9 @@ export function usePluginAppActions() {
   const hidePane = useCallback((paneId: string) => {
     runtime.hidePane(paneId);
   }, [runtime]);
+  const openPaneSettings = useCallback((paneId?: string) => {
+    runtime.openPaneSettings(paneId);
+  }, [runtime]);
   const openPluginCommandWorkflow = useCallback((commandId: string) => {
     runtime.openPluginCommandWorkflow(commandId);
   }, [runtime]);
@@ -131,6 +135,7 @@ export function usePluginAppActions() {
     openCommandBar,
     showPane,
     hidePane,
+    openPaneSettings,
     openPluginCommandWorkflow,
     notify,
   };

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -169,6 +169,9 @@ export class PluginRegistry implements PluginRuntimeAccess {
   openCommandBar = (query?: string) => {
     this.openCommandBarFn(query);
   };
+  openPaneSettings = (paneId?: string) => {
+    this.openPaneSettingsFn(paneId);
+  };
   openPluginCommandWorkflow = (commandId: string) => {
     this.openPluginCommandWorkflowFn(commandId);
   };

--- a/src/test-support/plugin-runtime.ts
+++ b/src/test-support/plugin-runtime.ts
@@ -25,6 +25,7 @@ export function createTestPluginRuntime(
     openCommandBar() {},
     showPane() {},
     hidePane() {},
+    openPaneSettings() {},
     openPluginCommandWorkflow() {},
     notify() {},
     subscribeResumeState: () => () => {},


### PR DESCRIPTION
Comparison charts now require at least two symbols, so `CMP AMD` keeps the command workflow open instead of creating a one-ticker comparison. The comparison pane adds a `[t]ickers` shortcut that opens pane settings, matching the existing pane-settings flow. Both ticker and comparison charts now keep crosshair reactivation click-driven after Escape and render the active X-axis time label like the Y-axis label. The root cause was that the comparison template accepted any resolved symbol list and its mouse-move handler restored a hidden cursor immediately after Escape, while the shared time axis only rendered static boundary labels.