### PR TITLE
Fix pane focus cycling and desktop layering

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,6 +17,7 @@ import { Header } from "./components/layout/header";
 import { StatusBar } from "./components/layout/status-bar";
 import { Shell } from "./components/layout/shell";
 import { DetachedPaneShell } from "./components/layout/detached-pane-shell";
+import { getVisiblePaneCycleOrder } from "./components/layout/pane-cycle-order";
 import { CommandBar } from "./components/command-bar/command-bar";
 import { OnboardingWizard } from "./components/onboarding/onboarding-wizard";
 import { useDialog, useDialogState } from "./ui/dialog";
@@ -1441,18 +1442,20 @@ function AppInner({
     if (state.commandBarOpen || state.inputCaptured) return;
 
     if (event.name === "tab") {
-      // Build pane order from current layout for cycling
-      const layout = state.config.layout;
-      const paneOrder = [
-        ...getDockedPaneIds(layout),
-        ...layout.floating.map((entry) => entry.instanceId),
-      ];
+      const paneOrder = getVisiblePaneCycleOrder(
+        state.config.layout,
+        pluginRegistry,
+        state.config.disabledPlugins,
+      );
+      if (paneOrder.length === 0) return;
 
       if (event.shift) {
         dispatch({ type: "FOCUS_PREV", paneOrder });
       } else {
         dispatch({ type: "FOCUS_NEXT", paneOrder });
       }
+      event.preventDefault();
+      event.stopPropagation();
     } else if (!isDetachedWindow && event.name === "q" && !(focusedPane?.paneId === "ticker-detail" && focusedDetailTab === "financials")) {
       rendererHost.requestExit();
     } else if (event.name === "r") {

--- a/src/components/layout/pane-cycle-order.test.ts
+++ b/src/components/layout/pane-cycle-order.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import type { PluginRegistry } from "../../plugins/registry";
+import { createDefaultConfig } from "../../types/config";
+import { getVisiblePaneCycleOrder } from "./pane-cycle-order";
+
+function createRegistry(options: {
+  paneIds: readonly string[];
+  disabledPaneIds?: Record<string, readonly string[]>;
+}): PluginRegistry {
+  return {
+    panes: new Map(options.paneIds.map((paneId) => [paneId, {}])),
+    getPluginPaneIds: (pluginId: string) => [...(options.disabledPaneIds?.[pluginId] ?? [])],
+  } as unknown as PluginRegistry;
+}
+
+describe("getVisiblePaneCycleOrder", () => {
+  test("skips disabled and unregistered panes when cycling focus", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-pane-cycle-order");
+    const registry = createRegistry({
+      paneIds: ["portfolio-list", "chat", "ticker-detail"],
+      disabledPaneIds: { chat: ["chat"] },
+    });
+
+    expect(getVisiblePaneCycleOrder(config.layout, registry, ["chat"])).toEqual([
+      "portfolio-list:main",
+      "ticker-detail:main",
+      "ticker-detail:nvda",
+    ]);
+  });
+});

--- a/src/components/layout/pane-cycle-order.ts
+++ b/src/components/layout/pane-cycle-order.ts
@@ -1,0 +1,32 @@
+import { getDockedPaneIds } from "../../plugins/pane-manager";
+import type { PluginRegistry } from "../../plugins/registry";
+import { findPaneInstance, type LayoutConfig } from "../../types/config";
+
+function disabledPaneTypes(pluginRegistry: PluginRegistry, disabledPlugins: readonly string[]): Set<string> {
+  const paneTypes = new Set<string>();
+  for (const pluginId of disabledPlugins) {
+    for (const paneId of pluginRegistry.getPluginPaneIds(pluginId)) {
+      paneTypes.add(paneId);
+    }
+  }
+  return paneTypes;
+}
+
+export function getVisiblePaneCycleOrder(
+  layout: LayoutConfig,
+  pluginRegistry: PluginRegistry,
+  disabledPlugins: readonly string[],
+): string[] {
+  const disabledTypes = disabledPaneTypes(pluginRegistry, disabledPlugins);
+  const isVisiblePane = (instanceId: string) => {
+    const instance = findPaneInstance(layout, instanceId);
+    return !!instance
+      && !disabledTypes.has(instance.paneId)
+      && pluginRegistry.panes.has(instance.paneId);
+  };
+
+  return [
+    ...getDockedPaneIds(layout),
+    ...layout.floating.map((entry) => entry.instanceId),
+  ].filter(isVisiblePane);
+}

--- a/src/core/state/app-state.ts
+++ b/src/core/state/app-state.ts
@@ -387,10 +387,12 @@ function removeHistoryIndex(layoutHistory: Record<number, LayoutHistoryEntry>, r
 
 /** If paneId is a floating pane, bump its zIndex to the top. */
 function bringFloatingToFront(layout: LayoutConfig, paneId: string): LayoutConfig {
-  const entry = layout.floating.find((e) => e.instanceId === paneId);
+  const entryIndex = layout.floating.findIndex((e) => e.instanceId === paneId);
+  const entry = entryIndex >= 0 ? layout.floating[entryIndex] : undefined;
   if (!entry) return layout;
   const maxZ = layout.floating.reduce((max, e) => Math.max(max, e.zIndex ?? 50), 0);
-  if ((entry.zIndex ?? 50) >= maxZ) return layout; // already on top
+  const topEqualIndex = layout.floating.findLastIndex((e) => (e.zIndex ?? 50) === maxZ);
+  if ((entry.zIndex ?? 50) === maxZ && entryIndex === topEqualIndex) return layout; // already on top
   return {
     ...layout,
     floating: layout.floating.map((e) =>
@@ -792,7 +794,8 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case "FOCUS_PREV": {
       if (action.paneOrder.length === 0) return state;
-      const currentIndex = state.focusedPaneId ? action.paneOrder.indexOf(state.focusedPaneId) : 0;
+      const focusedIndex = state.focusedPaneId ? action.paneOrder.indexOf(state.focusedPaneId) : -1;
+      const currentIndex = focusedIndex >= 0 ? focusedIndex : 0;
       const nextPaneId = action.paneOrder[(currentIndex - 1 + action.paneOrder.length) % action.paneOrder.length]!;
       return focusPaneState(state, nextPaneId);
     }

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -21,6 +21,7 @@ input, textarea { cursor: text; user-select: text; }
 button, [data-gloom-interactive="true"] { cursor: pointer; }
 [data-gloom-role="pane-window"] {
   background-clip: padding-box;
+  isolation: isolate;
 }
 [data-gloom-role="detached-pane-window"] {
   border: 0;

--- a/src/state/app-context.test.ts
+++ b/src/state/app-context.test.ts
@@ -111,6 +111,38 @@ describe("resolveTickerForPane", () => {
     )?.zIndex).toBe(21);
   });
 
+  test("raises the session-focused floating pane above tied saved z-order", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    config.layout = {
+      ...config.layout,
+      dockRoot: null,
+      floating: [
+        { instanceId: "ticker-detail:main", x: 4, y: 2, width: 60, height: 22, zIndex: 50 },
+        { instanceId: "chat:main", x: 8, y: 4, width: 48, height: 18, zIndex: 50 },
+      ],
+    };
+    config.layouts = config.layouts.map((entry, index) => (
+      index === config.activeLayoutIndex ? { ...entry, layout: cloneLayout(config.layout) } : entry
+    ));
+    const sessionSnapshot: AppSessionSnapshot = {
+      paneState: {},
+      focusedPaneId: "ticker-detail:main",
+      activePanel: "right",
+      statusBarVisible: true,
+      openPaneIds: ["ticker-detail:main", "chat:main"],
+      hydrationTargets: [],
+      exchangeCurrencies: ["USD"],
+      savedAt: Date.now(),
+    };
+
+    const state = createInitialState(config, sessionSnapshot);
+    const tickerEntry = state.config.layout.floating.find((entry) => entry.instanceId === "ticker-detail:main");
+    const chatEntry = state.config.layout.floating.find((entry) => entry.instanceId === "chat:main");
+
+    expect(tickerEntry?.zIndex).toBe(51);
+    expect((tickerEntry?.zIndex ?? 0) > (chatEntry?.zIndex ?? 0)).toBe(true);
+  });
+
   test("raises the desktop-snapshot focused floating pane during hydration", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     config.layout = {
@@ -455,6 +487,19 @@ describe("quote merging", () => {
 });
 
 describe("layout focus fallback", () => {
+  test("cycles backward from a stale focused pane to the last visible pane", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const state = createInitialState(config);
+    state.focusedPaneId = "hidden:stale";
+
+    const next = appReducer(state, {
+      type: "FOCUS_PREV",
+      paneOrder: ["portfolio-list:main", "ticker-detail:main", "ticker-detail:nvda"],
+    });
+
+    expect(next.focusedPaneId).toBe("ticker-detail:nvda");
+  });
+
   test("focuses the highest remaining floating pane when the focused floating pane closes", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     const backgroundPane = createPaneInstance("chat", {


### PR DESCRIPTION
Fixes pane focus cycling so Tab and Shift+Tab traverse only visible, registered panes and wrap from stale focus instead of landing on no active pane.

It also prevents desktop startup pane overlap by isolating pane-window paint and raising the session-focused floating pane above tied saved z-order. This keeps overlapping floating panes from showing multiple pane contents at once after launch.
