### PR TITLE
Fix gridlock chart layout crash

### DIFF
--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -157,10 +157,14 @@ export function createPixelBuffer(width: number, heightPixels: number): PixelBuf
 }
 
 function setPixel(buf: PixelBuffer, x: number, y: number, color: string, layer: number) {
-  if (x >= 0 && x < buf.width && y >= 0 && y < buf.height) {
-    const existing = buf.pixels[y]![x];
+  const px = Math.round(x);
+  const py = Math.round(y);
+  if (px >= 0 && px < buf.width && py >= 0 && py < buf.height) {
+    const row = buf.pixels[py];
+    if (!row) return;
+    const existing = row[px];
     if (!existing || layer >= existing.layer) {
-      buf.pixels[y]![x] = { color, layer };
+      row[px] = { color, layer };
     }
   }
 }
@@ -178,17 +182,22 @@ export function drawLine(
   color: string,
   layer: number = LAYER_DATA,
 ) {
-  let dx = Math.abs(x1 - x0);
-  let dy = Math.abs(y1 - y0);
-  const sx = x0 < x1 ? 1 : -1;
-  const sy = y0 < y1 ? 1 : -1;
+  const startX = Math.round(x0);
+  const startY = Math.round(y0);
+  const endX = Math.round(x1);
+  const endY = Math.round(y1);
+  if (![startX, startY, endX, endY].every(Number.isFinite)) return;
+  let dx = Math.abs(endX - startX);
+  let dy = Math.abs(endY - startY);
+  const sx = startX < endX ? 1 : -1;
+  const sy = startY < endY ? 1 : -1;
   let err = dx - dy;
-  let x = x0;
-  let y = y0;
+  let x = startX;
+  let y = startY;
 
   while (true) {
     setPixel(buf, x, y, color, layer);
-    if (x === x1 && y === y1) break;
+    if (x === endX && y === endY) break;
     const e2 = 2 * err;
     if (e2 > -dy) {
       err -= dy;
@@ -492,11 +501,14 @@ export function drawGridLines(
   yPositions: number[],
   color: string,
 ) {
-  for (const y of yPositions) {
+  for (const rawY of yPositions) {
+    const y = Math.round(rawY);
     if (y < 0 || y >= buf.height) continue;
     // Dotted horizontal line — dot every 6th column (≈ every 3 terminal columns)
+    const row = buf.pixels[y];
+    if (!row) continue;
     for (let x = 0; x < buf.width; x++) {
-      if (x % 6 === 0 && !buf.pixels[y]![x]) {
+      if (x % 6 === 0 && !row[x]) {
         setPixel(buf, x, y, color, LAYER_GRID);
       }
     }

--- a/src/components/chart/comparison-chart-renderer.test.ts
+++ b/src/components/chart/comparison-chart-renderer.test.ts
@@ -119,6 +119,32 @@ describe("renderComparisonChart", () => {
     expect(result.activeDate?.toISOString()).toBe("2024-01-03T00:00:00.000Z");
   });
 
+  test("renders when precise desktop layout passes a fractional chart height", () => {
+    const projection = projectComparisonChartData([
+      makeSeries("AAPL", "#00ff00", [10, 12, 11, 13]),
+    ], 12, {
+      panOffset: 0,
+      zoomLevel: 1,
+      renderMode: "area",
+    }, "percent");
+
+    const result = renderComparisonChart(projection, {
+      width: 12,
+      height: 6.5,
+      cursorX: null,
+      cursorY: null,
+      selectedSymbol: "AAPL",
+      colors: {
+        bgColor: "#000000",
+        gridColor: "#333333",
+        crosshairColor: "#ffffff",
+      },
+    });
+
+    expect(result.lines.length).toBeGreaterThan(0);
+    expect(textLines(result).some((line) => /[^\s]/.test(line))).toBe(true);
+  });
+
   test("keeps terminal comparison chart cells transparent", () => {
     const projection = projectComparisonChartData([
       makeSeries("AAPL", "#00ff00", [10, 12, 11, 13]),

--- a/src/components/chart/comparison-chart-renderer.ts
+++ b/src/components/chart/comparison-chart-renderer.ts
@@ -80,6 +80,11 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
+function normalizeCount(value: number, min: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(Math.floor(value), min);
+}
+
 function getComparisonDotX(index: number, count: number, width: number): number {
   if (count <= 1) return Math.round(Math.max(width - 1, 0) / 2);
   return Math.round((index / (count - 1)) * Math.max(width - 1, 0));
@@ -260,15 +265,17 @@ export function buildComparisonChartScene(
 
   const min = Math.min(...values);
   const max = Math.max(...values);
+  const width = normalizeCount(opts.width, 1);
+  const height = normalizeCount(opts.height, 1);
   const selectedSeries = getSelectedSeries(projection.series, opts.selectedSymbol);
-  const activeIdx = getActiveIndex(projection.dates.length, opts.width, opts.cursorX);
+  const activeIdx = getActiveIndex(projection.dates.length, width, opts.cursorX);
   const activeDate = projection.dates[activeIdx] ?? projection.dates[projection.dates.length - 1]!;
   const selectedPoint = selectedSeries?.points[activeIdx] ?? null;
-  const chartRows = opts.height;
+  const chartRows = height;
   const range = max - min || 1;
   const cursorX = opts.cursorX === null
     ? null
-    : clamp(opts.cursorX, 0, Math.max(opts.width - 1, 0));
+    : clamp(opts.cursorX, 0, Math.max(width - 1, 0));
   const fallbackValue = selectedPoint?.value ?? selectedSeries?.latestValue ?? min;
   const cursorY = cursorX === null
     ? null
@@ -282,7 +289,7 @@ export function buildComparisonChartScene(
   const cursorColumn = cursorX === null ? null : Math.round(cursorX);
   const cursorDotX = cursorX === null
     ? null
-    : Math.round((cursorX / Math.max(opts.width - 1, 1)) * Math.max(opts.width * 2 - 1, 0));
+    : Math.round((cursorX / Math.max(width - 1, 1)) * Math.max(width * 2 - 1, 0));
   const cursorRow = cursorY === null ? null : Math.round(cursorY);
   const crosshairValue = cursorY === null
     ? null
@@ -291,8 +298,8 @@ export function buildComparisonChartScene(
   return {
     dates: projection.dates,
     series: projection.series,
-    width: opts.width,
-    height: opts.height,
+    width,
+    height,
     chartRows,
     mode: projection.effectiveMode,
     axisMode: projection.effectiveAxisMode,

--- a/src/components/layout/pane-sizing.ts
+++ b/src/components/layout/pane-sizing.ts
@@ -7,9 +7,10 @@ export function shouldReservePaneFooter(nativePaneChrome: boolean | undefined, s
 }
 
 export function getPaneBodyHeight(height: number, reserveFooter = true): number {
-  return Math.max(1, height - PANE_HEADER_ROWS - (reserveFooter ? PANE_FOOTER_ROWS : 0));
+  const cellHeight = Math.max(1, Math.floor(height));
+  return Math.max(1, cellHeight - PANE_HEADER_ROWS - (reserveFooter ? PANE_FOOTER_ROWS : 0));
 }
 
 export function getPaneBodyWidth(width: number): number {
-  return Math.max(1, width);
+  return Math.max(1, Math.floor(width));
 }

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -47,7 +47,7 @@ export function PaneWrapper({
   const showFooter = hasPaneFooterContent(footer);
   const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
   const bodyHeight = typeof height === "number"
-    ? title ? getPaneBodyHeight(height, reserveFooter) : height
+    ? title ? getPaneBodyHeight(height, reserveFooter) : Math.max(1, Math.floor(height))
     : undefined;
 
   return (


### PR DESCRIPTION
Gridlock could pass fractional desktop pane dimensions into chart rendering, which let pixel drawing index a non-integer row and crash the Electrobun renderer. This normalizes pane and chart dimensions to whole cells and hardens shared chart drawing before it touches the pixel buffer. It also adds a regression for fractional comparison-chart heights.