### PR TITLE
Align chart cursor axis labels

### DIFF
--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -7,6 +7,8 @@ import {
 } from "./chart-data";
 import { stepCursorTowards } from "./cursor-motion";
 import { buildChartScene, buildCursorTimeAxisSegments, buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
+import { buildCursorTimeAxisOverlay } from "./time-axis-label";
+import { buildCursorPriceAxisOverlay } from "./price-axis-labels";
 import type { PricePoint } from "../../types/financials";
 import type { ChartRenderMode } from "./chart-types";
 
@@ -427,6 +429,47 @@ describe("renderChart", () => {
 
     expect(segments.map((segment) => segment.text).join("")).toHaveLength(width);
     expect(segments.find((segment) => segment.highlighted)?.text).toBe("12:30");
+  });
+
+  test("positions desktop cursor x-axis overlay from exact pixels", () => {
+    const dates = Array.from({ length: 13 }, (_, index) => new Date(2026, 0, 5, 9, 30 + index * 30));
+    const width = 72;
+    const cursorPixelX = 291.5;
+    const cellWidthPx = 8;
+    const segments = buildCursorTimeAxisSegments({
+      timeLabels: buildTimeAxis(dates, width),
+      width,
+      cursorColumn: 36,
+      cursorDate: dates[6]!,
+      dates,
+    });
+    const overlay = buildCursorTimeAxisOverlay({
+      segments,
+      width,
+      cursorPixelX,
+      cellWidthPx,
+    });
+
+    expect(overlay.label).toBe("12:30");
+    expect(overlay.baseText).toHaveLength(width);
+    expect(overlay.leftPercent).toBeCloseTo((cursorPixelX / (width * cellWidthPx - 1)) * 100, 5);
+  });
+
+  test("positions desktop cursor y-axis overlay from exact pixels", () => {
+    const height = 8;
+    const cellHeightPx = 18;
+    const cursorPixelY = 45.25;
+    const overlay = buildCursorPriceAxisOverlay({
+      axisWidth: 7,
+      axisSectionWidth: 8,
+      height,
+      cursorPixelY,
+      cursorLabel: "$214.03",
+      cellHeightPx,
+    });
+
+    expect(overlay.labelText).toBe("$214.03 ");
+    expect(overlay.topPercent).toBeCloseTo((cursorPixelY / (height * cellHeightPx - 1)) * 100, 5);
   });
 
   test("shows second precision when the visible window reaches second-level data", () => {

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -95,8 +95,9 @@ import {
   resolveNativeSurfaceVisibleRect,
   type NativeSurfaceRenderableNode,
 } from "./native/surface-visibility";
-import { formatAxisCell, formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
+import { formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
 import { TimeAxisLabel } from "./time-axis-label";
+import { PriceAxisLabels } from "./price-axis-labels";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
   area: "A",
@@ -1827,17 +1828,16 @@ function ComparisonStockChartView({
   );
 
   const axisBox = (
-    <Box width={axisSectionWidth} height={chartHeight} flexDirection="column">
-      {Array.from({ length: chartHeight }, (_, row) => {
-        const isCursorRow = cursorAxisLabel !== null && cursorRow === row;
-        const label = isCursorRow ? cursorAxisLabel : (axisLabels.get(row) ?? null);
-        return (
-          <Text key={row} fg={isCursorRow ? chartColors.crosshairColor : colors.textDim}>
-            {formatAxisCell(label, axisWidth).padEnd(axisSectionWidth)}
-          </Text>
-        );
-      })}
-    </Box>
+    <PriceAxisLabels
+      axisLabels={axisLabels}
+      axisWidth={axisWidth}
+      axisSectionWidth={axisSectionWidth}
+      height={chartHeight}
+      cursorRow={cursorRow}
+      cursorPixelY={hasDisplayCursor ? displayCursor.pixelY : null}
+      cursorLabel={cursorAxisLabel}
+      cursorColor={chartColors.crosshairColor}
+    />
   );
 
   const legendRowsData = Array.from({ length: Math.ceil(symbols.length / legendColumns) }, (_, rowIndex) => (
@@ -1947,6 +1947,7 @@ function ComparisonStockChartView({
           timeLabels={timeAxisLabel}
           width={chartWidth}
           cursorColumn={cursorTimeAxisColumn}
+          cursorPixelX={hasDisplayCursor ? displayCursor.pixelX : null}
           cursorDate={cursorTimeAxisDate}
           dates={projection.dates}
           cursorColor={chartColors.crosshairColor}

--- a/src/components/chart/price-axis-labels.tsx
+++ b/src/components/chart/price-axis-labels.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from "react";
+import { Box, Text, useUiCapabilities } from "../../ui";
+import { colors } from "../../theme/colors";
+import { formatAxisCell } from "./chart-renderer";
+
+interface PriceAxisLabelsProps {
+  axisLabels: ReadonlyMap<number, string>;
+  axisWidth: number;
+  axisSectionWidth: number;
+  height: number;
+  cursorRow: number | null;
+  cursorPixelY?: number | null;
+  cursorLabel: string | null;
+  cursorColor: string;
+}
+
+interface CursorPriceAxisOverlay {
+  labelText: string | null;
+  topPercent: number | null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function buildCursorPriceAxisOverlay({
+  axisWidth,
+  axisSectionWidth,
+  height,
+  cursorPixelY,
+  cursorLabel,
+  cellHeightPx,
+}: {
+  axisWidth: number;
+  axisSectionWidth: number;
+  height: number;
+  cursorPixelY: number | null | undefined;
+  cursorLabel: string | null;
+  cellHeightPx: number;
+}): CursorPriceAxisOverlay {
+  const labelText = cursorLabel === null
+    ? null
+    : formatAxisCell(cursorLabel, axisWidth).padEnd(axisSectionWidth);
+  const pixelHeight = Math.max(height * cellHeightPx, 1);
+  let topPercent: number | null = null;
+
+  if (labelText && cursorPixelY !== null && cursorPixelY !== undefined && Number.isFinite(cursorPixelY) && pixelHeight > 1) {
+    const halfLabelHeight = Math.min(cellHeightPx / 2, (pixelHeight - 1) / 2);
+    const topPx = clamp(cursorPixelY, halfLabelHeight, Math.max(pixelHeight - halfLabelHeight, halfLabelHeight));
+    topPercent = (topPx / Math.max(pixelHeight - 1, 1)) * 100;
+  }
+
+  return { labelText, topPercent };
+}
+
+export function PriceAxisLabels({
+  axisLabels,
+  axisWidth,
+  axisSectionWidth,
+  height,
+  cursorRow,
+  cursorPixelY = null,
+  cursorLabel,
+  cursorColor,
+}: PriceAxisLabelsProps) {
+  const { cellHeightPx = 18, fractionalViewport = false } = useUiCapabilities();
+  const overlay = useMemo(() => buildCursorPriceAxisOverlay({
+    axisWidth,
+    axisSectionWidth,
+    height,
+    cursorPixelY,
+    cursorLabel,
+    cellHeightPx,
+  }), [axisSectionWidth, axisWidth, cellHeightPx, cursorLabel, cursorPixelY, height]);
+  const usePixelOverlay = fractionalViewport && overlay.labelText !== null && overlay.topPercent !== null;
+
+  return (
+    <Box
+      width={axisSectionWidth}
+      height={height}
+      flexDirection="column"
+      overflow="hidden"
+      style={usePixelOverlay ? { position: "relative" } : undefined}
+    >
+      {Array.from({ length: height }, (_, row) => {
+        const isCursorRow = !usePixelOverlay && cursorLabel !== null && cursorRow === row;
+        const label = isCursorRow ? cursorLabel : (axisLabels.get(row) ?? null);
+        return (
+          <Text key={row} fg={isCursorRow ? cursorColor : colors.textDim}>
+            {formatAxisCell(label, axisWidth).padEnd(axisSectionWidth)}
+          </Text>
+        );
+      })}
+      {usePixelOverlay ? (
+        <Text
+          width={axisSectionWidth}
+          fg={cursorColor}
+          bg={colors.bg}
+          style={{
+            position: "absolute",
+            left: 0,
+            top: `${overlay.topPercent}%`,
+            transform: "translateY(-50%)",
+            whiteSpace: "pre",
+            pointerEvents: "none",
+            zIndex: 1,
+          }}
+        >
+          {overlay.labelText}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -82,7 +82,6 @@ import {
 } from "./chart-viewport";
 import {
   buildChartScene,
-  formatAxisCell,
   formatCursorAxisValue,
   getActivePointIndex,
   getPointTerminalColumn,
@@ -128,6 +127,7 @@ import {
 import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { TimeAxisLabel } from "./time-axis-label";
+import { PriceAxisLabels } from "./price-axis-labels";
 
 const MODE_CHIPS: Record<ChartRenderMode, string> = {
   area: "A",
@@ -3437,6 +3437,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         timeLabels={timeAxisLabel}
         width={chartWidth}
         cursorColumn={cursorTimeAxisColumn}
+        cursorPixelX={hasDisplayCursor ? displayCursor.pixelX : null}
         cursorDate={cursorTimeAxisDate}
         dates={timeAxisDates}
         cursorColor={chartColors.crosshairColor}
@@ -3955,17 +3956,16 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   );
 
   const axisBox = (
-    <Box width={axisSectionWidth} height={chartHeight} flexDirection="column">
-      {Array.from({ length: chartHeight }, (_, row) => {
-        const isCursorRow = cursorAxisLabel !== null && cursorRow === row;
-        const label = isCursorRow ? cursorAxisLabel : (axisLabels.get(row) ?? null);
-        return (
-          <Text key={row} fg={isCursorRow ? chartColors.crosshairColor : colors.textDim}>
-            {formatAxisCell(label, axisWidth).padEnd(axisSectionWidth)}
-          </Text>
-        );
-      })}
-    </Box>
+    <PriceAxisLabels
+      axisLabels={axisLabels}
+      axisWidth={axisWidth}
+      axisSectionWidth={axisSectionWidth}
+      height={chartHeight}
+      cursorRow={cursorRow}
+      cursorPixelY={hasDisplayCursor ? displayCursor.pixelY : null}
+      cursorLabel={cursorAxisLabel}
+      cursorColor={chartColors.crosshairColor}
+    />
   );
 
   if (compact) {

--- a/src/components/chart/time-axis-label.tsx
+++ b/src/components/chart/time-axis-label.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Span, Text } from "../../ui";
+import { Box, Span, Text, useUiCapabilities } from "../../ui";
 import { colors } from "../../theme/colors";
 import { buildCursorTimeAxisSegments } from "./chart-renderer";
 
@@ -7,19 +7,60 @@ interface TimeAxisLabelProps {
   timeLabels: string;
   width: number;
   cursorColumn: number | null;
+  cursorPixelX?: number | null;
   cursorDate: Date | string | number | null;
   dates: Array<Date | string | number>;
   cursorColor: string;
+}
+
+interface CursorTimeAxisOverlay {
+  baseText: string;
+  label: string | null;
+  leftPercent: number | null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function buildCursorTimeAxisOverlay({
+  segments,
+  width,
+  cursorPixelX,
+  cellWidthPx,
+}: {
+  segments: ReturnType<typeof buildCursorTimeAxisSegments>;
+  width: number;
+  cursorPixelX: number | null | undefined;
+  cellWidthPx: number;
+}): CursorTimeAxisOverlay {
+  const baseText = segments
+    .map((segment) => (segment.highlighted ? " ".repeat(segment.text.length) : segment.text))
+    .join("")
+    .padEnd(width)
+    .slice(0, width);
+  const label = segments.find((segment) => segment.highlighted)?.text ?? null;
+  const pixelWidth = Math.max(width * cellWidthPx, 1);
+  let leftPercent: number | null = null;
+  if (label && cursorPixelX !== null && cursorPixelX !== undefined && Number.isFinite(cursorPixelX) && pixelWidth > 1) {
+    const halfLabelWidth = Math.min((label.length * cellWidthPx) / 2, (pixelWidth - 1) / 2);
+    const leftPx = clamp(cursorPixelX, halfLabelWidth, Math.max(pixelWidth - halfLabelWidth, halfLabelWidth));
+    leftPercent = (leftPx / Math.max(pixelWidth - 1, 1)) * 100;
+  }
+
+  return { baseText, label, leftPercent };
 }
 
 export function TimeAxisLabel({
   timeLabels,
   width,
   cursorColumn,
+  cursorPixelX = null,
   cursorDate,
   dates,
   cursorColor,
 }: TimeAxisLabelProps) {
+  const { cellWidthPx = 8, fractionalViewport = false } = useUiCapabilities();
   const segments = useMemo(() => buildCursorTimeAxisSegments({
     timeLabels,
     width,
@@ -27,6 +68,42 @@ export function TimeAxisLabel({
     cursorDate,
     dates,
   }), [cursorColumn, cursorDate, dates, timeLabels, width]);
+  const overlay = useMemo(() => buildCursorTimeAxisOverlay({
+    segments,
+    width,
+    cursorPixelX,
+    cellWidthPx,
+  }), [cellWidthPx, cursorPixelX, segments, width]);
+
+  if (fractionalViewport && overlay.label && overlay.leftPercent !== null) {
+    return (
+      <Box
+        width={width}
+        height={1}
+        overflow="hidden"
+        style={{ position: "relative" }}
+      >
+        <Text fg={colors.textDim} style={{ whiteSpace: "pre" }}>
+          {overlay.baseText}
+        </Text>
+        <Text
+          fg={cursorColor}
+          bg={colors.bg}
+          style={{
+            position: "absolute",
+            left: `${overlay.leftPercent}%`,
+            top: 0,
+            transform: "translateX(-50%)",
+            whiteSpace: "pre",
+            pointerEvents: "none",
+            zIndex: 1,
+          }}
+        >
+          {overlay.label}
+        </Text>
+      </Box>
+    );
+  }
 
   return (
     <Text style={{ whiteSpace: "pre" }}>


### PR DESCRIPTION
Desktop axis labels were still derived from rounded terminal cells, which made them lag the crosshair during pixel-precise chart interactions.

This aligns the x-axis date and y-axis price labels to the cursor pixel position on desktop while keeping the terminal fallback cell-based. It adds shared price-axis label rendering and applies the behavior to both stock and comparison charts.