### PR TITLE
Fix ticker pane focus stealing

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -95,6 +95,10 @@ import {
   createPaneTemplateOrThrow,
 } from "./components/command-bar/workflow-ops";
 import { getPaneTemplateDisplayLabel } from "./components/command-bar/pane-template-display";
+import {
+  resolveTickerNavigationDetailPane,
+  shouldFocusTickerNavigationTarget,
+} from "./plugins/ticker-navigation";
 import { debugLog } from "./utils/debug-log";
 import type { MarketDataCoordinator } from "./market-data/coordinator";
 import { instrumentFromTicker } from "./market-data/request-types";
@@ -1273,8 +1277,9 @@ function AppInner({
     activatePane(instance.instanceId, nextLayout);
   };
 
-  pluginRegistry.navigateTickerFn = (rawSymbol) => {
+  pluginRegistry.navigateTickerFn = (rawSymbol, options) => {
     if (isDetachedWindow) return;
+    const sourcePaneId = options?.sourcePaneId ?? stateRef.current.focusedPaneId;
     (async () => {
       try {
       // Resolve or create the ticker in the local database
@@ -1297,45 +1302,31 @@ function AppInner({
         }
       }
 
-      // Active panel resolution — navigate the focused or linked detail pane:
-      // 1. If the focused pane IS a ticker-detail, retarget it directly
-      // 2. If a ticker-detail follows the focused pane, retarget that
+      // Active panel resolution — navigate the initiating or linked detail pane:
+      // 1. If the source pane IS a ticker-detail, retarget it directly
+      // 2. If a ticker-detail follows the source pane, retarget that
       // 3. Any follow-mode ticker-detail in the layout
       // 4. Any ticker-detail in the layout
       // 5. Fall back to pinning a new pane
       const currentState = stateRef.current;
       const currentLayout = currentState.config.layout;
-      const focused = currentState.focusedPaneId;
-
-      const focusedInstance = focused
-        ? findPaneInstance(currentLayout, focused)
-        : null;
-
-      const detailPane =
-        (focusedInstance?.paneId === "ticker-detail" && isPaneInLayout(currentLayout, focusedInstance.instanceId)
-          ? focusedInstance
-          : null)
-        ?? currentLayout.instances.find((inst) =>
-          inst.paneId === "ticker-detail"
-          && inst.binding?.kind === "follow"
-          && inst.binding.sourceInstanceId === focused
-          && isPaneInLayout(currentLayout, inst.instanceId),
-        )
-        ?? currentLayout.instances.find((inst) =>
-          inst.paneId === "ticker-detail"
-          && inst.binding?.kind === "follow"
-          && isPaneInLayout(currentLayout, inst.instanceId),
-        )
-        ?? currentLayout.instances.find((inst) =>
-          inst.paneId === "ticker-detail"
-          && isPaneInLayout(currentLayout, inst.instanceId),
-        );
+      const detailPane = resolveTickerNavigationDetailPane(currentLayout, sourcePaneId);
+      const focusIfStillOwned = (paneId: string, layout: LayoutConfig) => {
+        if (!shouldFocusTickerNavigationTarget({
+          sourcePaneId,
+          currentFocusedPaneId: stateRef.current.focusedPaneId,
+          targetPaneId: paneId,
+        })) {
+          return;
+        }
+        activatePane(paneId, layout);
+      };
 
       if (detailPane) {
         if (detailPane.binding?.kind === "follow") {
           const sourceId = detailPane.binding.sourceInstanceId;
           dispatch({ type: "UPDATE_PANE_STATE", paneId: sourceId, patch: { cursorSymbol: symbol } });
-          activatePane(detailPane.instanceId, currentLayout);
+          focusIfStillOwned(detailPane.instanceId, currentLayout);
         } else {
           const nextLayout = {
             ...currentLayout,
@@ -1346,9 +1337,13 @@ function AppInner({
             )),
           };
           persistLayout(nextLayout);
-          activatePane(detailPane.instanceId, nextLayout);
+          focusIfStillOwned(detailPane.instanceId, nextLayout);
         }
-      } else {
+      } else if (shouldFocusTickerNavigationTarget({
+        sourcePaneId,
+        currentFocusedPaneId: stateRef.current.focusedPaneId,
+        targetPaneId: null,
+      })) {
         pluginRegistry.pinTicker(symbol, { floating: false });
       }
       } catch (err) {

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -27,7 +27,6 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
   const rendererHost = useRendererHost();
   const config = useAppSelector((state) => state.config);
   const paneState = useAppSelector((state) => state.paneState);
-  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
   const inputCaptured = useAppSelector((state) => state.inputCaptured);
   const [windowFocused, setWindowFocused] = useState(() => (
     typeof document === "undefined" ? true : document.hasFocus()
@@ -51,12 +50,6 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     setWindowFocused(true);
     dispatch({ type: "FOCUS_PANE", paneId: desktopWindowBridge.paneId });
   }, [desktopWindowBridge.paneId, dispatch]);
-
-  useEffect(() => {
-    if (windowFocused && focusedPaneId !== desktopWindowBridge.paneId) {
-      focusPane();
-    }
-  }, [desktopWindowBridge.paneId, focusPane, focusedPaneId, windowFocused]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") return;

--- a/src/plugins/plugin-runtime.test.tsx
+++ b/src/plugins/plugin-runtime.test.tsx
@@ -20,6 +20,7 @@ import {
   usePluginPaneActions,
   usePluginPaneState,
   usePluginState,
+  usePluginTickerActions,
   useSetPluginConfigStates,
 } from "./plugin-runtime";
 
@@ -242,6 +243,39 @@ describe("plugin runtime hooks", () => {
       "workflow:set-alert",
       "notify:Saved",
     ]);
+  });
+
+  test("scopes ticker navigation to the rendering pane", async () => {
+    const calls: string[] = [];
+    let actions: ReturnType<typeof usePluginTickerActions> | null = null;
+
+    const runtime = createTestPluginRuntime({
+      navigateTicker(symbol: string, options?: { sourcePaneId?: string | null }) {
+        calls.push(`${symbol}:${options?.sourcePaneId ?? ""}`);
+      },
+    });
+
+    function HookProbe() {
+      actions = usePluginTickerActions();
+      return <text>ticker-actions</text>;
+    }
+
+    testSetup = await testRender(
+      <PaneInstanceProvider paneId="comparison-chart:main">
+        <PluginRenderProvider pluginId="comparison-chart" runtime={runtime}>
+          <HookProbe />
+        </PluginRenderProvider>
+      </PaneInstanceProvider>,
+      { width: 40, height: 5 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    actions?.navigateTicker("MSFT");
+
+    expect(calls).toEqual(["MSFT:comparison-chart:main"]);
   });
 
   test("exposes renderer pane actions through the plugin hook", async () => {

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -13,6 +13,7 @@ import {
   useAppDispatch,
   useAppSelector,
   useAppStateRef,
+  useOptionalPaneInstanceId,
   usePaneInstanceId,
   type PaneRuntimeState,
 } from "../state/app-context";
@@ -30,7 +31,7 @@ export interface PluginRuntimeAccess {
   syncBrokerInstance(instanceId: string): Promise<void>;
   removeBrokerInstance(instanceId: string): Promise<void>;
   pinTicker(symbol: string, options?: { floating?: boolean; paneType?: string }): void;
-  navigateTicker(symbol: string): void;
+  navigateTicker(symbol: string, options?: { sourcePaneId?: string | null }): void;
   selectTicker(symbol: string, paneId?: string): void;
   switchTab(tabId: string, paneId?: string): void;
   switchPanel(panel: "left" | "right"): void;
@@ -85,9 +86,13 @@ function usePluginRenderContext(): PluginRenderContextValue {
 
 export function usePluginTickerActions() {
   const { runtime } = usePluginRenderContext();
+  const sourcePaneId = useOptionalPaneInstanceId();
+  const navigateTicker = useCallback((symbol: string) => {
+    runtime.navigateTicker(symbol, { sourcePaneId });
+  }, [runtime, sourcePaneId]);
   return {
     pinTicker: runtime.pinTicker,
-    navigateTicker: runtime.navigateTicker,
+    navigateTicker,
   };
 }
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -141,7 +141,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   hidePaneFn: ((paneId: string) => void) = () => {};
   focusPaneFn: ((paneId: string) => void) = () => {};
   pinTickerFn: ((symbol: string, options?: { floating?: boolean; paneType?: string }) => void) = () => {};
-  navigateTickerFn: ((symbol: string) => void) = () => {};
+  navigateTickerFn: ((symbol: string, options?: { sourcePaneId?: string | null }) => void) = () => {};
   getMarketData = () => this.marketData;
   getCapability = (capabilityId: string) => this.capabilities.get(capabilityId)?.capability ?? null;
   getBrokerAdapter = (brokerType: string) => this.brokersMap.get(brokerType) ?? null;
@@ -154,8 +154,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
   pinTicker = (symbol: string, options?: { floating?: boolean; paneType?: string }) => {
     this.pinTickerFn(symbol, options);
   };
-  navigateTicker = (symbol: string) => {
-    this.navigateTickerFn(symbol);
+  navigateTicker = (symbol: string, options?: { sourcePaneId?: string | null }) => {
+    this.navigateTickerFn(symbol, options);
   };
   selectTicker = (symbol: string, paneId?: string) => {
     this.selectTickerFn(symbol, paneId);

--- a/src/plugins/ticker-navigation.test.ts
+++ b/src/plugins/ticker-navigation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createPaneInstance, type LayoutConfig, type PaneInstanceConfig } from "../types/config";
+import {
+  resolveTickerNavigationDetailPane,
+  shouldFocusTickerNavigationTarget,
+} from "./ticker-navigation";
+
+function createLayout(instances: PaneInstanceConfig[]): LayoutConfig {
+  return {
+    dockRoot: { kind: "pane", instanceId: instances[0]?.instanceId ?? "" },
+    instances,
+    floating: instances.slice(1).map((instance, index) => ({
+      instanceId: instance.instanceId,
+      x: 2 + index,
+      y: 2 + index,
+      width: 40,
+      height: 12,
+    })),
+    detached: [],
+  };
+}
+
+describe("resolveTickerNavigationDetailPane", () => {
+  test("prefers the detail pane following the pane that opened ticker navigation", () => {
+    const layout = createLayout([
+      createPaneInstance("portfolio-list", {
+        instanceId: "portfolio-list:main",
+        binding: { kind: "none" },
+      }),
+      createPaneInstance("comparison-chart", {
+        instanceId: "comparison-chart:main",
+        binding: { kind: "none" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:portfolio",
+        binding: { kind: "follow", sourceInstanceId: "portfolio-list:main" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:compare",
+        binding: { kind: "follow", sourceInstanceId: "comparison-chart:main" },
+      }),
+    ]);
+
+    expect(
+      resolveTickerNavigationDetailPane(layout, "comparison-chart:main")?.instanceId,
+    ).toBe("ticker-detail:compare");
+  });
+});
+
+describe("shouldFocusTickerNavigationTarget", () => {
+  test("does not focus stale async ticker navigation after the user moves to another pane", () => {
+    expect(shouldFocusTickerNavigationTarget({
+      sourcePaneId: "comparison-chart:main",
+      currentFocusedPaneId: "portfolio-list:main",
+      targetPaneId: "ticker-detail:compare",
+    })).toBe(false);
+  });
+
+  test("keeps focusing when the source pane still owns the latest interaction", () => {
+    expect(shouldFocusTickerNavigationTarget({
+      sourcePaneId: "comparison-chart:main",
+      currentFocusedPaneId: "comparison-chart:main",
+      targetPaneId: "ticker-detail:compare",
+    })).toBe(true);
+  });
+});

--- a/src/plugins/ticker-navigation.ts
+++ b/src/plugins/ticker-navigation.ts
@@ -1,0 +1,44 @@
+import { findPaneInstance, type LayoutConfig, type PaneInstanceConfig } from "../types/config";
+import { isPaneInLayout } from "./pane-manager";
+
+export function resolveTickerNavigationDetailPane(
+  layout: LayoutConfig,
+  sourcePaneId: string | null,
+): PaneInstanceConfig | null {
+  const sourceInstance = sourcePaneId ? findPaneInstance(layout, sourcePaneId) : null;
+
+  return (
+    sourceInstance?.paneId === "ticker-detail" && isPaneInLayout(layout, sourceInstance.instanceId)
+      ? sourceInstance
+      : null
+  )
+    ?? layout.instances.find((instance) =>
+      instance.paneId === "ticker-detail"
+      && instance.binding?.kind === "follow"
+      && instance.binding.sourceInstanceId === sourcePaneId
+      && isPaneInLayout(layout, instance.instanceId)
+    )
+    ?? layout.instances.find((instance) =>
+      instance.paneId === "ticker-detail"
+      && instance.binding?.kind === "follow"
+      && isPaneInLayout(layout, instance.instanceId)
+    )
+    ?? layout.instances.find((instance) =>
+      instance.paneId === "ticker-detail"
+      && isPaneInLayout(layout, instance.instanceId)
+    )
+    ?? null;
+}
+
+export function shouldFocusTickerNavigationTarget({
+  sourcePaneId,
+  currentFocusedPaneId,
+  targetPaneId,
+}: {
+  sourcePaneId: string | null;
+  currentFocusedPaneId: string | null;
+  targetPaneId: string | null;
+}): boolean {
+  if (!sourcePaneId) return true;
+  return currentFocusedPaneId === sourcePaneId || currentFocusedPaneId === targetPaneId;
+}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -449,7 +449,7 @@ export interface GloomPluginContext {
   hidePane(paneId: string): void;
   focusPane(paneId: string): void;
   pinTicker(symbol: string, options?: { floating?: boolean; paneType?: string }): void;
-  navigateTicker(symbol: string): void;
+  navigateTicker(symbol: string, options?: { sourcePaneId?: string | null }): void;
   openPaneSettings(paneId?: string): void;
 
   on<K extends keyof PluginEvents>(event: K, handler: (payload: PluginEvents[K]) => void): () => void;


### PR DESCRIPTION
This PR prevents ticker-detail panes from stealing focus after PF, CMP, or another pane opens. Ticker navigation now carries the source pane through the plugin runtime and only focuses the ticker detail if that source still owns the current interaction after async resolution. Detached pane windows no longer reassert focus from shared state sync alone, while real window or mouse focus still updates pane focus.