### PR TITLE
Polish Fear & Greed desktop layout

### DIFF
--- a/src/components/speedometer-gauge.tsx
+++ b/src/components/speedometer-gauge.tsx
@@ -48,18 +48,11 @@ const DESKTOP_CENTER_Y = 182;
 const DESKTOP_ARC_RADIUS = 138;
 const DESKTOP_NEEDLE_RADIUS = 104;
 const DESKTOP_LABEL_POSITIONS = [
-  { x: 90, y: 84 },
-  { x: 172, y: 44 },
-  { x: 260, y: 30 },
-  { x: 348, y: 44 },
-  { x: 430, y: 84 },
-];
-const DESKTOP_TICK_LABEL_POSITIONS = [
-  { x: 78, y: 224 },
-  { x: 170, y: 224 },
-  { x: 260, y: 224 },
-  { x: 350, y: 224 },
-  { x: 442, y: 224 },
+  { x: 76, y: 84 },
+  { x: 154, y: 44 },
+  { x: 260, y: 18 },
+  { x: 366, y: 44 },
+  { x: 444, y: 84 },
 ];
 
 function SvgText(props: SVGProps<SVGTextElement>) {
@@ -418,19 +411,12 @@ function DesktopGauge({
             </SvgText>
           );
         })}
-        {[min, min + (max - min) * 0.25, min + (max - min) * 0.5, min + (max - min) * 0.75, max].map((tick, index) => {
+        {[min, min + (max - min) * 0.25, min + (max - min) * 0.5, min + (max - min) * 0.75, max].map((tick) => {
           const angle = valueToDegrees(tick, min, max);
           const outer = polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_ARC_RADIUS + 16, angle);
           const inner = polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_ARC_RADIUS - 10, angle);
-          const label = DESKTOP_TICK_LABEL_POSITIONS[index]
-            ?? polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_ARC_RADIUS + 34, angle);
           return (
-            <g key={tick}>
-              <line x1={inner.x} y1={inner.y} x2={outer.x} y2={outer.y} stroke={colors.textDim} strokeWidth="2" />
-              <SvgText x={label.x} y={label.y} fill={colors.textDim} textAnchor="middle" fontFamily="inherit" fontSize="13">
-                {formatGaugeValue(tick)}
-              </SvgText>
-            </g>
+            <line key={tick} x1={inner.x} y1={inner.y} x2={outer.x} y2={outer.y} stroke={colors.textDim} strokeWidth="2" />
           );
         })}
         <line
@@ -443,7 +429,16 @@ function DesktopGauge({
           strokeLinecap="round"
         />
         <circle cx={DESKTOP_CENTER_X} cy={DESKTOP_CENTER_Y} r="27" fill={colors.bg} />
-        <SvgText x={DESKTOP_CENTER_X} y={DESKTOP_CENTER_Y + 18} fill={colors.textBright} textAnchor="middle" fontFamily="inherit" fontSize="31" fontWeight="800">
+        <SvgText
+          x={DESKTOP_CENTER_X}
+          y={DESKTOP_CENTER_Y + 2}
+          fill={colors.textBright}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontFamily="inherit"
+          fontSize="31"
+          fontWeight="800"
+        >
           {formatGaugeValue(value)}
         </SvgText>
       </svg>

--- a/src/plugins/builtin/fear-greed/index.tsx
+++ b/src/plugins/builtin/fear-greed/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import { Box, ScrollBox, Text, TextAttributes, useUiHost } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import { SpeedometerGauge, StaticChartSurface, usePaneFooter, type SpeedometerSegment } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
@@ -134,7 +134,7 @@ function SentimentBadge({ rating }: { rating: FearGreedRating }) {
   );
 }
 
-function PreviousScoreGrid({ data, width }: { data: FearGreedData; width: number }) {
+function PreviousScoreGrid({ data, width, layout = "grid" }: { data: FearGreedData; width: number; layout?: "grid" | "rail" }) {
   const items = [
     { label: "Previous close", value: data.overall.previousClose },
     { label: "1 week ago", value: data.overall.previousWeek },
@@ -146,6 +146,24 @@ function PreviousScoreGrid({ data, width }: { data: FearGreedData; width: number
   const rows = Array.from({ length: Math.ceil(items.length / columns) }, (_, rowIndex) => (
     items.slice(rowIndex * columns, rowIndex * columns + columns)
   ));
+
+  if (layout === "rail") {
+    return (
+      <Box flexDirection="column" width={width} flexShrink={0}>
+        {items.map((item) => {
+          const value = item.value;
+          const color = value == null ? colors.textDim : ratingColor(value < 25 ? "extreme fear" : value < 45 ? "fear" : value <= 55 ? "neutral" : "greed");
+          return (
+            <Box key={item.label} flexDirection="row" height={1}>
+              <Text fg={colors.textDim}>{item.label}: </Text>
+              <Box flexGrow={1} />
+              <Text fg={color} attributes={TextAttributes.BOLD}>{formatScore(value)}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="column" paddingX={1} marginTop={1}>
@@ -184,7 +202,6 @@ function chartOverlay(indicator: FearGreedIndicator): ChartIndicatorOverlays | n
 
 function SentimentChart({
   title,
-  subtitle,
   rating,
   score,
   points,
@@ -197,7 +214,6 @@ function SentimentChart({
   overlays,
 }: {
   title: string;
-  subtitle: string;
   rating: FearGreedRating;
   score: number | null;
   points: FearGreedIndicator["points"];
@@ -209,6 +225,7 @@ function SentimentChart({
   secondaryValue?: number | null;
   overlays?: ChartIndicatorOverlays | null;
 }) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
   const chartWidth = Math.max(24, width - 2);
   const chartHeight = width >= 96 ? 12 : 10;
   const color = ratingColor(rating);
@@ -222,14 +239,11 @@ function SentimentChart({
   const latest = points.length > 0 ? points[points.length - 1]!.close : null;
 
   return (
-    <Box flexDirection="column" marginTop={2} paddingX={1}>
+    <Box flexDirection="column" marginTop={isDesktopWeb ? 1 : 2} paddingX={1}>
       <Box flexDirection="row" height={1}>
         <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{title.toUpperCase()}</Text>
         <Box flexGrow={1} />
         <SentimentBadge rating={rating} />
-      </Box>
-      <Box height={1} marginTop={1}>
-        <Text fg={colors.text} attributes={TextAttributes.BOLD}>{subtitle}</Text>
       </Box>
       <Box flexDirection="row" height={1}>
         <Text fg={color}>● </Text>
@@ -301,7 +315,6 @@ function IndexHistoryChart({ data, width }: { data: FearGreedData; width: number
   return (
     <SentimentChart
       title={indicator.definition.title}
-      subtitle={indicator.definition.subtitle}
       rating={indicator.rating}
       score={indicator.score}
       points={indicator.points}
@@ -314,6 +327,7 @@ function IndexHistoryChart({ data, width }: { data: FearGreedData; width: number
 }
 
 function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
   const [data, setData] = useState<FearGreedData | null>(sharedCache?.data ?? null);
   const [loading, setLoading] = useState(!sharedCache);
   const [error, setError] = useState<string | null>(null);
@@ -402,18 +416,32 @@ function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
     <Box flexDirection="column" width={width} height={height}>
       <ScrollBox flexGrow={1} scrollY focusable={false}>
         <Box flexDirection="column" paddingBottom={1}>
-          <SpeedometerGauge
-            value={data.overall.score}
-            valueLabel={ratingLabel(data.overall.rating)}
-            width={width}
-            segments={FEAR_GREED_GAUGE_SEGMENTS}
-          />
+          {isDesktopWeb ? (
+            <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4} paddingX={1}>
+              <SpeedometerGauge
+                value={data.overall.score}
+                valueLabel={ratingLabel(data.overall.rating)}
+                width={width}
+                segments={FEAR_GREED_GAUGE_SEGMENTS}
+              />
+              <PreviousScoreGrid data={data} width={26} layout="rail" />
+            </Box>
+          ) : (
+            <>
+              <SpeedometerGauge
+                value={data.overall.score}
+                valueLabel={ratingLabel(data.overall.rating)}
+                width={width}
+                segments={FEAR_GREED_GAUGE_SEGMENTS}
+              />
+              <PreviousScoreGrid data={data} width={width} />
+            </>
+          )}
           {loading ? (
             <Box height={1} paddingX={1} marginTop={1} justifyContent="center">
               <Text fg={colors.textMuted}>refreshing...</Text>
             </Box>
           ) : null}
-          <PreviousScoreGrid data={data} width={width} />
           {error ? (
             <Box paddingX={1} marginTop={1}>
               <Text fg={colors.warning}>{error}</Text>
@@ -427,7 +455,6 @@ function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
             <SentimentChart
               key={indicator.definition.id}
               title={indicator.definition.title}
-              subtitle={indicator.definition.subtitle}
               rating={indicator.rating}
               score={indicator.score}
               points={indicator.points}


### PR DESCRIPTION
Polishes the desktop Fear & Greed gauge so the category labels have better spacing, the score is centered, and the bottom numeric scale is removed.

Moves the previous-score figures into a compact rail beside the gauge on desktop, keeps the terminal flow unchanged, and removes redundant chart description rows that duplicate the legends and axes.