### PR TITLE
Fix startup pane focus

### DIFF
--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -115,7 +115,7 @@ export function FloatingPaneWrapper({
       />
 
       {/* Content */}
-      <Box height={bodyHeight} overflow="hidden">
+      <Box height={bodyHeight} overflow="hidden" backgroundColor={bg}>
         {children}
       </Box>
 

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -86,6 +86,7 @@ export function PaneWrapper({
         flexGrow={bodyHeight == null ? 1 : 0}
         flexBasis={bodyHeight == null ? 0 : undefined}
         overflow="hidden"
+        backgroundColor={bg}
       >
         {children}
       </Box>

--- a/src/core/state/app-state.ts
+++ b/src/core/state/app-state.ts
@@ -318,23 +318,13 @@ function getTopFloatingPaneId(layout: LayoutConfig): string | null {
   return topInstanceId;
 }
 
-function resolveFocusedPaneId(
-  previousLayout: LayoutConfig,
-  nextLayout: LayoutConfig,
-  focusedPaneId: string | null,
-): string | null {
+function resolveFocusedPaneId(nextLayout: LayoutConfig, focusedPaneId: string | null): string | null {
   const paneOrder = getPaneOrder(nextLayout);
   if (paneOrder.length === 0) return null;
   if (focusedPaneId && paneOrder.includes(focusedPaneId)) {
     return focusedPaneId;
   }
-  const previouslyFloating = focusedPaneId
-    ? previousLayout.floating.some((entry) => entry.instanceId === focusedPaneId)
-    : false;
-  if (previouslyFloating) {
-    return getTopFloatingPaneId(nextLayout) ?? paneOrder[0] ?? null;
-  }
-  return paneOrder[0] ?? null;
+  return getTopFloatingPaneId(nextLayout) ?? paneOrder[0] ?? null;
 }
 
 function getPanelFocusTarget(layout: LayoutConfig, panel: "left" | "right"): string | null {
@@ -446,7 +436,7 @@ function withFocusedPane(state: AppState, config: AppConfig): AppState {
       layouts: syncLayouts(config.layouts, config.activeLayoutIndex, normalizedLayout),
     };
   const nextPaneState = reconcilePaneState(nextConfig, state.paneState);
-  const focusedPaneId = resolveFocusedPaneId(state.config.layout, nextConfig.layout, state.focusedPaneId);
+  const focusedPaneId = resolveFocusedPaneId(nextConfig.layout, state.focusedPaneId);
   const focusedConfig = bringFocusedFloatingPaneToFront(nextConfig, focusedPaneId);
   return {
     ...state,
@@ -854,7 +844,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
 export function createInitialState(config: AppConfig, sessionSnapshot: AppSessionSnapshot | null = null): AppState {
   const paneState = reconcilePaneState(config, sessionSnapshot?.paneState ?? {});
-  const defaultFocusedPaneId = getPaneOrder(config.layout)[0] ?? null;
+  const defaultFocusedPaneId = getTopFloatingPaneId(config.layout) ?? getPaneOrder(config.layout)[0] ?? null;
   const focusedPaneId = sessionSnapshot?.focusedPaneId
     && config.layout.instances.some((instance) => instance.instanceId === sessionSnapshot.focusedPaneId)
     ? sessionSnapshot.focusedPaneId

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -37,8 +37,12 @@ import {
   type WindowFrame,
   type WindowMinimumSize,
 } from "./window-frame";
-
-const MAIN_WINDOW_RPC_KEY = "main";
+import {
+  detachedRpcKey,
+  focusWindowForRpcKey,
+  MAIN_WINDOW_RPC_KEY,
+  paneIdFromDetachedRpcKey,
+} from "./window-focus";
 
 type DesktopRpc = ReturnType<typeof BrowserView.defineRPC<ElectrobunDesktopRpcSchema>>;
 type WindowMoveEvent = { data?: { x?: number; y?: number } };
@@ -101,10 +105,6 @@ function requireDesktopWorkspace(): DesktopWorkspace {
   return desktopWorkspace;
 }
 
-function detachedRpcKey(instanceId: string): string {
-  return `detached:${instanceId}`;
-}
-
 function registerWindowRpc(key: string, rpc: DesktopRpc): void {
   windowRpcs.set(key, rpc);
   rpcWindowKeys.set(rpc, key);
@@ -156,10 +156,11 @@ function normalizeInitWindowTarget(
   if (rpcKey === MAIN_WINDOW_RPC_KEY) {
     return { kind: "main" };
   }
-  if (rpcKey?.startsWith("detached:")) {
+  const detachedPaneId = paneIdFromDetachedRpcKey(rpcKey);
+  if (detachedPaneId) {
     return {
       kind: "detached",
-      paneId: rpcKey.slice("detached:".length) || undefined,
+      paneId: detachedPaneId,
     };
   }
   const kind = payload.kind === "detached" ? "detached" : "main";
@@ -881,7 +882,7 @@ async function handleDesktop(
       }
       const snapshot = workspace.popOutPane(payload.paneId, resolveDetachedWindowFrame(payload.paneId));
       await commitDesktopSnapshot(snapshot);
-      (detachedWindows.get(payload.paneId) as any)?.focus?.();
+      focusWindowForRpcKey(detachedRpcKey(payload.paneId), mainWindow, detachedWindows);
       return null;
     }
     case "desktop.dockDetachedPane": {
@@ -911,7 +912,7 @@ async function handleDesktop(
       if (typeof payload.paneId !== "string") {
         throw new Error("desktop.focusDetachedPane requires paneId.");
       }
-      (detachedWindows.get(payload.paneId) as any)?.focus?.();
+      focusWindowForRpcKey(detachedRpcKey(payload.paneId), mainWindow, detachedWindows);
       return null;
     default:
       throw new Error(`Unknown desktop method: ${method}`);
@@ -1055,6 +1056,9 @@ async function handleBackendRequest(
     case "host.copyText":
       Utils.clipboardWriteText(normalizeText(payload.text) ?? "");
       return null;
+    case "host.focusWindow":
+      focusWindowForRpcKey(getRpcWindowKey(rpc), mainWindow, detachedWindows);
+      return null;
     case "host.copyPngImage": {
       const pngBase64 = normalizeText(payload.pngBase64);
       if (!pngBase64) throw new Error("host.copyPngImage requires PNG data.");
@@ -1141,6 +1145,7 @@ mainWindow = new BrowserWindow({
   sandbox: false,
 });
 updateWindowFrameCache(mainWindow, DEFAULT_WINDOW_FRAME, MAIN_WINDOW_MIN_SIZE);
+focusWindowForRpcKey(MAIN_WINDOW_RPC_KEY, mainWindow, detachedWindows);
 (mainWindow as any).on?.("move", (event: WindowMoveEvent) => {
   applyWindowMoveEvent(mainWindow, event);
 });

--- a/src/renderers/electrobun/bun/window-focus.ts
+++ b/src/renderers/electrobun/bun/window-focus.ts
@@ -1,0 +1,37 @@
+export const MAIN_WINDOW_RPC_KEY = "main";
+
+const DETACHED_WINDOW_RPC_PREFIX = "detached:";
+
+export interface FocusableElectrobunWindow {
+  focus?: () => void;
+}
+
+export function detachedRpcKey(instanceId: string): string {
+  return `${DETACHED_WINDOW_RPC_PREFIX}${instanceId}`;
+}
+
+export function paneIdFromDetachedRpcKey(rpcKey: string | undefined): string | null {
+  if (!rpcKey?.startsWith(DETACHED_WINDOW_RPC_PREFIX)) return null;
+  return rpcKey.slice(DETACHED_WINDOW_RPC_PREFIX.length) || null;
+}
+
+export function resolveWindowForRpcKey<T>(
+  rpcKey: string | undefined,
+  mainWindow: T | null,
+  detachedWindows: ReadonlyMap<string, T>,
+): T | null {
+  if (rpcKey === MAIN_WINDOW_RPC_KEY) return mainWindow;
+  const paneId = paneIdFromDetachedRpcKey(rpcKey);
+  return paneId ? detachedWindows.get(paneId) ?? null : null;
+}
+
+export function focusWindowForRpcKey(
+  rpcKey: string | undefined,
+  mainWindow: FocusableElectrobunWindow | null,
+  detachedWindows: ReadonlyMap<string, FocusableElectrobunWindow>,
+): boolean {
+  const window = resolveWindowForRpcKey(rpcKey, mainWindow, detachedWindows);
+  if (!window?.focus) return false;
+  window.focus();
+  return true;
+}

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -6,7 +6,7 @@ import { UiHostProvider } from "../../../ui/host";
 import { debugLog } from "../../../utils/debug-log";
 import { measurePerfAsync } from "../../../utils/perf-marks";
 import { startMainThreadMonitor } from "../../../utils/main-thread-monitor";
-import { initElectrobunBackend } from "./backend-rpc";
+import { backendRequest, initElectrobunBackend } from "./backend-rpc";
 import { installElectrobunAiHost } from "./ai-host";
 import { installElectrobunBrokerRemoteClient } from "./broker-remote-client";
 import { installElectrobunConfigStoreHost } from "./config-host";
@@ -45,8 +45,23 @@ debugLog.mirrorToConsole({
 });
 const stopMainThreadMonitor = startMainThreadMonitor("electrobun.web", { mirrorToConsole: true });
 
+rootElement.tabIndex = -1;
 root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
 bootLog.warn("diagnostic console mirror enabled", { sources: ELECTROBUN_WEB_CONSOLE_LOG_SOURCES });
+
+function focusWebSurface(): void {
+  window.focus();
+  rootElement.focus({ preventScroll: true });
+}
+
+function requestStartupFocus(): void {
+  focusWebSurface();
+  requestAnimationFrame(() => {
+    void backendRequest("host.focusWindow")
+      .catch(() => null)
+      .then(() => focusWebSurface());
+  });
+}
 
 async function boot() {
   bootLog.info("boot started");
@@ -85,6 +100,7 @@ async function boot() {
       </UiHostProvider>,
     );
   });
+  requestStartupFocus();
   bootLog.info("root render scheduled", {
     layoutPanes: config.layout.instances.length,
     floatingPanes: config.layout.floating.length,

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -1,5 +1,6 @@
 @keyframes gloom-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 html, body, #root { width: 100%; height: 100%; min-height: 100%; overflow: hidden; background: #000; }
+#root:focus { outline: none; }
 body {
   --cell-w: 8px;
   --cell-h: 18px;

--- a/src/state/app-context.test.ts
+++ b/src/state/app-context.test.ts
@@ -487,6 +487,26 @@ describe("quote merging", () => {
 });
 
 describe("layout focus fallback", () => {
+  test("starts with the top floating pane focused when no session pane is active", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const layout = {
+      ...cloneLayout(config.layout),
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      floating: [
+        { instanceId: "chat:main", x: 4, y: 2, width: 36, height: 10, zIndex: 70 },
+        { instanceId: "ticker-detail:main", x: 12, y: 4, width: 36, height: 10, zIndex: 95 },
+      ],
+    };
+
+    const state = createInitialState({
+      ...config,
+      layout,
+      layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+    });
+
+    expect(state.focusedPaneId).toBe("ticker-detail:main");
+  });
+
   test("cycles backward from a stale focused pane to the last visible pane", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     const state = createInitialState(config);


### PR DESCRIPTION
This fixes startup focus selection so the top floating pane is active immediately when there is no saved focused pane, preventing overlapping pane content from leaking through before interaction.

Pane bodies now render an explicit background, and the Electrobun startup path focuses both the native window and the web surface so Tab works without an initial click.