### PR TITLE
Make desktop toasts follow theme

### DIFF
--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -295,18 +295,11 @@ body.gloom-dragging {
   min-width: 260px;
   max-width: 420px;
   padding: 10px 12px;
-  border: 1px solid #3a4148;
-  background: #151b20;
-  color: #d8dde3;
+  border: 1px solid;
   box-shadow: 0 12px 24px rgba(0,0,0,.28);
 }
-.gloom-toast-success { border-color: #54c99f; }
-.gloom-toast-error { border-color: #ff6b5f; }
 .gloom-toast-action {
   margin-top: 8px;
-  color: #101417;
-  background: #d8dde3;
-  border: 0;
   padding: 4px 8px;
   border-radius: 4px;
 }

--- a/src/renderers/electrobun/view/toast-host.tsx
+++ b/src/renderers/electrobun/view/toast-host.tsx
@@ -1,16 +1,41 @@
 /// <reference lib="dom" />
 /** @jsxImportSource react */
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { colors } from "../../../theme/colors";
 import { ToastHostProvider, type ToastHost, type ToastOptions } from "../../../ui/toast";
+
+type WebToastType = "info" | "success" | "error";
 
 interface ToastEntry {
   id: number;
   body: string;
-  type: "info" | "success" | "error";
+  type: WebToastType;
   action?: ToastOptions["action"];
 }
 
 let nextToastId = 1;
+
+function webToastBorderColor(type: WebToastType): string {
+  if (type === "success") return colors.positive;
+  if (type === "error") return colors.negative;
+  return colors.borderFocused;
+}
+
+function getToastStyle(type: WebToastType): CSSProperties {
+  return {
+    background: colors.panel,
+    borderColor: webToastBorderColor(type),
+    color: colors.text,
+  };
+}
+
+function getToastActionStyle(): CSSProperties {
+  return {
+    background: colors.selected,
+    border: `1px solid ${colors.borderFocused}`,
+    color: colors.selectedText,
+  };
+}
 
 export function WebToastHostProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastEntry[]>([]);
@@ -33,11 +58,12 @@ export function WebToastHostProvider({ children }: { children: ReactNode }) {
       return (
         <div className="gloom-toast-viewport">
           {toasts.map((toast) => (
-            <div key={toast.id} className={`gloom-toast gloom-toast-${toast.type}`}>
+            <div key={toast.id} className="gloom-toast" style={getToastStyle(toast.type)}>
               <div>{toast.body}</div>
               {toast.action && (
                 <button
                   className="gloom-toast-action"
+                  style={getToastActionStyle()}
                   onClick={() => {
                     toast.action?.onClick();
                     dismiss(toast.id);


### PR DESCRIPTION
Desktop toasts were still using hard-coded dark colors while the rest of the Electrobun UI reads from the active theme.

This moves toast and toast-action colors into the desktop toast host so they use the shared palette for background, text, selected actions, and semantic borders.

The CSS now only owns toast layout and spacing, so light themes no longer get a dark toast overlay.