### PR TITLE
Fix top news story details and ticker columns

### DIFF
--- a/src/capabilities/factories.ts
+++ b/src/capabilities/factories.ts
@@ -95,6 +95,7 @@ export function newsProvider(options: {
       supports: op((input: any) => options.provider.supports?.(input.query) ?? true, "query"),
       getCachedNews: op((input: any) => options.provider.getCachedNews?.(input.query) ?? [], "query"),
       fetchNews: op((input: any) => options.provider.fetchNews(input.query), "query"),
+      fetchNewsStory: op((input: any) => options.provider.fetchNewsStory?.(input.storyId) ?? null, "query"),
     },
   };
 }

--- a/src/components/ui/table-layout.test.ts
+++ b/src/components/ui/table-layout.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { getTableWidth, hasMeaningfulTableHorizontalOverflow } from "./table-layout";
+import {
+  buildTableGridTemplateColumns,
+  getTableWidth,
+  hasMeaningfulTableHorizontalOverflow,
+} from "./table-layout";
 
 describe("table layout", () => {
   test("detects only meaningful horizontal table overflow", () => {
@@ -12,5 +16,27 @@ describe("table layout", () => {
     expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth)).toBe(false);
     expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth - 1)).toBe(false);
     expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth - 2)).toBe(true);
+  });
+
+  test("keeps non-flex web table columns fixed", () => {
+    const template = buildTableGridTemplateColumns([
+      { width: 4, align: "right" },
+      { width: 40, flexGrow: 1 },
+      { width: 24 },
+      { width: 5, align: "right" },
+    ]);
+
+    expect(template).toBe(
+      "minmax(4ch, 4ch) minmax(14ch, 40fr) minmax(8ch, 24ch) minmax(5ch, 5ch)",
+    );
+  });
+
+  test("keeps proportional web table columns when no column is flexible", () => {
+    const template = buildTableGridTemplateColumns([
+      { width: 12 },
+      { width: 8, align: "right" },
+    ]);
+
+    expect(template).toBe("minmax(8ch, 12fr) minmax(8ch, 8fr)");
   });
 });

--- a/src/components/ui/table-layout.ts
+++ b/src/components/ui/table-layout.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
 import type { ScrollBoxRenderable } from "../../ui";
 
-interface TableWidthColumn {
+export interface TableWidthColumn {
   width: number;
   flexGrow?: number;
+  align?: string;
 }
 
 const TRAILING_COLUMN_GUTTER_WIDTH = 1;
@@ -30,6 +31,43 @@ export function expandTableColumns<C extends TableWidthColumn>(
   return columns.map((column, index) => {
     return index === growIndex ? { ...column, width: column.width + extraWidth } : column;
   });
+}
+
+function normalizedColumnWidth(column: TableWidthColumn): number {
+  return Math.max(1, Math.floor(column.width));
+}
+
+function columnMinCh(column: TableWidthColumn): number {
+  const width = normalizedColumnWidth(column);
+  if ((column.flexGrow ?? 0) > 0) {
+    return Math.max(8, Math.min(18, Math.floor(width * 0.35)));
+  }
+  if (column.align === "right") {
+    return Math.max(3, Math.min(width, 8));
+  }
+  if (width >= 16) {
+    return Math.max(8, Math.min(16, Math.floor(width * 0.35)));
+  }
+  return Math.max(1, Math.min(width, 8));
+}
+
+function columnFlexWeight(column: TableWidthColumn): number {
+  const flexGrow = column.flexGrow ?? 0;
+  const baseWeight = normalizedColumnWidth(column);
+  return flexGrow > 0 ? baseWeight * Math.max(1, flexGrow) : baseWeight;
+}
+
+export function buildTableGridTemplateColumns(columns: readonly TableWidthColumn[]): string {
+  const hasFlexColumn = columns.some((column) => (column.flexGrow ?? 0) > 0);
+  return columns
+    .map((column) => {
+      const width = normalizedColumnWidth(column);
+      if (!hasFlexColumn || (column.flexGrow ?? 0) > 0) {
+        return `minmax(${columnMinCh(column)}ch, ${columnFlexWeight(column)}fr)`;
+      }
+      return `minmax(${columnMinCh(column)}ch, ${width}ch)`;
+    })
+    .join(" ");
 }
 
 export function useMeasuredTableContentWidth(

--- a/src/news/aggregator.test.ts
+++ b/src/news/aggregator.test.ts
@@ -6,7 +6,7 @@ import type { MarketNewsItem } from "../types/news-source";
 function makeItem(overrides: Partial<MarketNewsItem> & { url: string }): MarketNewsItem {
   return {
     ...overrides,
-    id: overrides.url,
+    id: overrides.id ?? overrides.url,
     title: "Test headline",
     url: overrides.url,
     source: "Test",
@@ -47,6 +47,17 @@ function makeCachedSource(id: string, cachedItems: MarketNewsItem[], fetchItems:
     provider: {
       getCachedNews: () => cachedItems,
       fetchNews: mock(async () => fetchItems),
+    },
+  });
+}
+
+function makeStorySource(id: string, items: MarketNewsItem[], story: MarketNewsItem): NewsCapability {
+  return newsProvider({
+    id,
+    name: id,
+    provider: {
+      fetchNews: mock(async () => items),
+      fetchNewsStory: mock(async (storyId: string) => storyId === story.id ? story : null),
     },
   });
 }
@@ -263,5 +274,42 @@ describe("NewsService", () => {
     expect(state.articles).toHaveLength(1);
     expect(state.articles[0]!.url).toBe(fallbackItem.url);
     expect(state.sourceIds).toEqual(["fallback"]);
+  });
+
+  it("loads story detail and merges source items into existing query state", async () => {
+    const listArticle = makeItem({
+      id: "story-1",
+      url: "https://detail.example.com/story",
+      items: [],
+    });
+    const detailArticle = makeItem({
+      ...listArticle,
+      items: [{
+        id: "item-2",
+        sourceKey: "wire-b",
+        sourceName: "Wire B",
+        title: "Follow-up",
+        url: "https://detail.example.com/follow-up",
+        publishedAt: new Date("2026-04-01T10:05:00.000Z"),
+      }, {
+        id: "item-1",
+        sourceKey: "wire-a",
+        sourceName: "Wire A",
+        title: "Original",
+        url: "https://detail.example.com/original",
+        publishedAt: new Date("2026-04-01T10:00:00.000Z"),
+      }],
+    });
+
+    agg.register(makeStorySource("cloud", [listArticle], detailArticle));
+
+    const initial = await agg.load({ feed: "top", limit: 10 });
+    expect(initial.articles[0]?.items).toEqual([]);
+
+    const detail = await agg.loadStory("story-1");
+    const state = agg.getQueryState({ feed: "top", limit: 10 });
+
+    expect(detail?.items?.map((item) => item.id)).toEqual(["item-2", "item-1"]);
+    expect(state.articles[0]?.items?.map((item) => item.id)).toEqual(["item-2", "item-1"]);
   });
 });

--- a/src/news/aggregator.ts
+++ b/src/news/aggregator.ts
@@ -120,6 +120,16 @@ function dedupeArticles(items: NewsArticle[]): NewsArticle[] {
   return sortByPublishedAt([...byKey.values()]).slice(0, MAX_ARTICLES);
 }
 
+function mergeNewsArticle(base: NewsArticle, detail: NewsArticle): NewsArticle {
+  const detailItems = detail.items ?? [];
+  const baseItems = base.items ?? [];
+  return {
+    ...base,
+    ...detail,
+    items: detailItems.length > 0 ? detailItems : baseItems,
+  };
+}
+
 function filterArticlesForQuery(items: NewsArticle[], query: NewsQuery): NewsArticle[] {
   let filtered = items;
   if (query.since) {
@@ -262,6 +272,24 @@ export class NewsService {
 
   async load(query: NewsQuery): Promise<NewsQueryState> {
     return this.refreshQuery(normalizeQuery(query), true);
+  }
+
+  async loadStory(storyId: string): Promise<NewsArticle | null> {
+    const sources = this.enabledSources({ feed: "latest" })
+      .filter((source) => !!source.provider.fetchNewsStory);
+
+    for (const source of sources) {
+      try {
+        const article = await source.provider.fetchNewsStory?.(storyId);
+        if (!article) continue;
+        this.mergeStoryDetail(article);
+        return article;
+      } catch {
+        // Continue to lower-priority sources.
+      }
+    }
+
+    return null;
   }
 
   async poll(query: NewsQuery = DEFAULT_GLOBAL_QUERY): Promise<void> {
@@ -411,6 +439,26 @@ export class NewsService {
 
   private rebuildArticlePool(): void {
     this.articles = dedupeArticles([...this.queryStates.values()].flatMap((state) => state.articles));
+  }
+
+  private mergeStoryDetail(article: NewsArticle): void {
+    let changed = false;
+    for (const [key, state] of this.queryStates) {
+      let stateChanged = false;
+      const nextArticles = state.articles.map((existing) => {
+        if (existing.id !== article.id) return existing;
+        stateChanged = true;
+        changed = true;
+        return mergeNewsArticle(existing, article);
+      });
+      if (stateChanged) {
+        this.queryStates.set(key, { ...state, articles: nextArticles });
+      }
+    }
+
+    if (!changed) return;
+    this.rebuildArticlePool();
+    this.notify();
   }
 
   getTopStories(count = 20): NewsArticle[] {

--- a/src/news/hooks.ts
+++ b/src/news/hooks.ts
@@ -1,6 +1,6 @@
-import { useEffect, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { buildNewsQueryKey, type NewsService } from "./aggregator";
-import type { NewsQuery, NewsQueryState } from "./types";
+import type { NewsArticle, NewsQuery, NewsQueryState } from "./types";
 
 let sharedService: NewsService | null = null;
 
@@ -36,4 +36,8 @@ export function useNewsArticles(query: NewsQuery | null | undefined): NewsQueryS
   }, [key]);
 
   return query && sharedService ? sharedService.getQueryState(query) : idleState();
+}
+
+export function useLoadNewsStory(): (storyId: string) => Promise<NewsArticle | null> {
+  return useCallback(async (storyId: string) => sharedService?.loadStory(storyId) ?? null, []);
 }

--- a/src/plugins/builtin/news-wire/breaking-pane.tsx
+++ b/src/plugins/builtin/news-wire/breaking-pane.tsx
@@ -1,7 +1,7 @@
 import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PaneProps } from "../../../types/plugin";
-import { useNewsArticles } from "../../../news/hooks";
+import { useLoadNewsStory, useNewsArticles } from "../../../news/hooks";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../plugin-runtime";
 import { Spinner } from "../../../components";
 import type { MarketNewsItem } from "../../../types/news-source";
@@ -41,7 +41,8 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
   const [aiRunning, setAiRunning] = useState(false);
   const [spinFrame, setSpinFrame] = useState(0);
   const processingRef = useRef(false);
-  const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
+  const loadNewsStory = useLoadNewsStory();
+  const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles, loadNewsStory);
   const { readArticleIds, markArticleRead } = useNewsReadState();
 
   useEffect(() => {

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -2,7 +2,7 @@ import { Box } from "../../../ui";
 import { useEffect, useMemo } from "react";
 import type { PaneProps } from "../../../types/plugin";
 import type { MarketNewsItem } from "../../../types/news-source";
-import { useNewsArticles } from "../../../news/hooks";
+import { useLoadNewsStory, useNewsArticles } from "../../../news/hooks";
 import type { NewsQueryPhase } from "../../../news/types";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../plugin-runtime";
 import { Spinner, Tabs } from "../../../components";
@@ -43,7 +43,8 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
   const [sortPreference, setSortPreference] = usePluginPaneState<NewsSortPreference>("industry:sort", DEFAULT_SORT);
   const { articles, allArticles, phase } = useIndustryArticles(category);
   const loading = phase === "loading" || (phase === "refreshing" && articles.length === 0);
-  const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
+  const loadNewsStory = useLoadNewsStory();
+  const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles, loadNewsStory);
   const { readArticleIds, markArticleRead } = useNewsReadState();
   const counts = useMemo(() => {
     const next: Record<string, number> = { all: allArticles.length };

--- a/src/plugins/builtin/news-wire/news-detail-view.tsx
+++ b/src/plugins/builtin/news-wire/news-detail-view.tsx
@@ -10,9 +10,27 @@ import { collectNewsDisplayTickers } from "../../../news/ticker-symbols";
 import { useInlineTickers } from "../../../state/use-inline-tickers";
 import { wrapTextLines } from "../../../utils/text-wrap";
 
-export function useNewsArticleDetail(articles: MarketNewsItem[]) {
+function hasStoryItems(article: MarketNewsItem | null): boolean {
+  return (article?.items?.length ?? 0) > 0;
+}
+
+function mergeLoadedArticle(base: MarketNewsItem, loaded: MarketNewsItem | null | undefined): MarketNewsItem {
+  if (!loaded) return base;
+  return {
+    ...base,
+    ...loaded,
+    items: hasStoryItems(loaded) ? loaded.items : base.items,
+  };
+}
+
+export function useNewsArticleDetail(
+  articles: MarketNewsItem[],
+  loadArticleDetail?: (articleId: string) => Promise<MarketNewsItem | null>,
+) {
   const [detailArticleId, setDetailArticleId] = useState<string | null>(null);
-  const detailArticle = useMemo(
+  const [loadedArticles, setLoadedArticles] = useState<Map<string, MarketNewsItem>>(() => new Map());
+  const requestedArticleIds = useRef<Set<string>>(new Set());
+  const baseDetailArticle = useMemo(
     () => (
       detailArticleId
         ? articles.find((article) => article.id === detailArticleId) ?? null
@@ -20,12 +38,36 @@ export function useNewsArticleDetail(articles: MarketNewsItem[]) {
     ),
     [articles, detailArticleId],
   );
+  const detailArticle = useMemo(() => (
+    baseDetailArticle && detailArticleId
+      ? mergeLoadedArticle(baseDetailArticle, loadedArticles.get(detailArticleId))
+      : baseDetailArticle
+  ), [baseDetailArticle, detailArticleId, loadedArticles]);
 
   useEffect(() => {
-    if (detailArticleId && !detailArticle) {
+    if (detailArticleId && !baseDetailArticle) {
       setDetailArticleId(null);
     }
-  }, [detailArticle, detailArticleId]);
+  }, [baseDetailArticle, detailArticleId]);
+
+  useEffect(() => {
+    if (!detailArticleId || !baseDetailArticle || hasStoryItems(detailArticle)) return;
+    if (!loadArticleDetail || requestedArticleIds.current.has(detailArticleId)) return;
+
+    requestedArticleIds.current.add(detailArticleId);
+    void loadArticleDetail(detailArticleId)
+      .then((loadedArticle) => {
+        if (!loadedArticle) return;
+        setLoadedArticles((current) => {
+          const next = new Map(current);
+          next.set(detailArticleId, loadedArticle);
+          return next;
+        });
+      })
+      .catch(() => {
+        requestedArticleIds.current.delete(detailArticleId);
+      });
+  }, [baseDetailArticle, detailArticle, detailArticleId, loadArticleDetail]);
 
   const openArticle = useCallback((article: MarketNewsItem) => {
     setDetailArticleId(article.id);

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -1,6 +1,6 @@
 import { Box } from "../../../ui";
 import type { NewsQuery } from "../../../news/types";
-import { useNewsArticles } from "../../../news/hooks";
+import { useLoadNewsStory, useNewsArticles } from "../../../news/hooks";
 import type { PaneProps } from "../../../types/plugin";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../plugin-runtime";
 import { Spinner } from "../../../components";
@@ -45,7 +45,8 @@ export function NewsPresetPane({
     `${paneKey}:sort`,
     defaultSort,
   );
-  const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles);
+  const loadNewsStory = useLoadNewsStory();
+  const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles, loadNewsStory);
   const { readArticleIds, markArticleRead } = useNewsReadState();
 
   useNewsArticleFooter({

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -24,7 +24,11 @@ import type {
   DataTableProps,
   DataTableSectionHeader,
 } from "../../../components/ui/data-table";
-import { getTableWidth, hasMeaningfulTableHorizontalOverflow } from "../../../components/ui/table-layout";
+import {
+  buildTableGridTemplateColumns,
+  getTableWidth,
+  hasMeaningfulTableHorizontalOverflow,
+} from "../../../components/ui/table-layout";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
 import { useScrollbarActivity } from "./scrollbar-activity";
 
@@ -82,32 +86,6 @@ function clippedCellTextStyle(
     textOverflow: "ellipsis",
     textAlign: column.align,
   };
-}
-
-function columnMinCh(column: DataTableColumn): number {
-  const width = Math.max(1, Math.floor(column.width));
-  if ((column.flexGrow ?? 0) > 0) {
-    return Math.max(8, Math.min(18, Math.floor(width * 0.35)));
-  }
-  if (column.align === "right") {
-    return Math.max(3, Math.min(width, 8));
-  }
-  if (width >= 16) {
-    return Math.max(8, Math.min(16, Math.floor(width * 0.35)));
-  }
-  return Math.max(1, Math.min(width, 8));
-}
-
-function columnFlexWeight(column: DataTableColumn): number {
-  const flexGrow = column.flexGrow ?? 0;
-  const baseWeight = Math.max(1, Math.floor(column.width));
-  return flexGrow > 0 ? baseWeight * Math.max(1, flexGrow) : baseWeight;
-}
-
-function buildGridTemplateColumns(columns: readonly DataTableColumn[]): string {
-  return columns
-    .map((column) => `minmax(${columnMinCh(column)}ch, ${columnFlexWeight(column)}fr)`)
-    .join(" ");
 }
 
 function toCellY(pixels: number): number {
@@ -494,7 +472,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const [scrollbarActive, markScrollbarActive] = useScrollbarActivity();
   const tableWidth = useMemo(() => getTableWidth(columns), [columns]);
   const gridTemplateColumns = useMemo(
-    () => buildGridTemplateColumns(columns),
+    () => buildTableGridTemplateColumns(columns),
     [columns],
   );
   const selectRow = useCallback((item: T, index: number) => {

--- a/src/sources/gloomberb-cloud.test.ts
+++ b/src/sources/gloomberb-cloud.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createGloomberbCloudCapabilities, GloomberbCloudProvider } from "./gloomberb-cloud";
 import type { NewsCapability } from "../capabilities";
-import { apiClient, type AuthUser } from "../utils/api-client";
+import { apiClient, type AuthUser, type CloudNewsPayload } from "../utils/api-client";
 
 const verifiedUser: AuthUser = {
   id: "user-1",
@@ -21,7 +21,55 @@ const originalGetCloudHolders = apiClient.getCloudHolders.bind(apiClient);
 const originalGetCloudAnalystResearch = apiClient.getCloudAnalystResearch.bind(apiClient);
 const originalGetCloudCorporateActions = apiClient.getCloudCorporateActions.bind(apiClient);
 const originalGetCloudNews = apiClient.getCloudNews.bind(apiClient);
+const originalGetCloudNewsStory = apiClient.getCloudNewsStory.bind(apiClient);
 const originalSubscribeQuotes = apiClient.subscribeQuotes.bind(apiClient);
+
+function makeCloudNewsPayload(overrides: Partial<CloudNewsPayload> = {}): CloudNewsPayload {
+  return {
+    id: "story-1",
+    headline: "Apple raises guidance",
+    summary: "Apple lifted its outlook after stronger iPhone demand.",
+    topic: "guidance",
+    topics: ["guidance"],
+    category: "guidance",
+    sentiment: "positive",
+    sectors: ["information_technology"],
+    firstPublishedAt: "2026-04-01T10:00:00.000Z",
+    lastPublishedAt: "2026-04-01T10:05:00.000Z",
+    firstSeenAt: "2026-04-01T10:00:10.000Z",
+    lastSeenAt: "2026-04-01T10:05:10.000Z",
+    primaryUrl: "https://example.com/aapl-guidance",
+    primarySource: "example-wire",
+    scores: {
+      importance: 91,
+      urgency: 74,
+      marketImpact: 88,
+      novelty: 86,
+      confidence: 95,
+    },
+    flags: {
+      breaking: true,
+      developing: false,
+      stale: false,
+    },
+    variantCount: 1,
+    sourceCount: 1,
+    sources: ["example-wire"],
+    entities: [],
+    tickerLinks: [{
+      symbol: "AAPL",
+      exchange: "XNAS",
+      canonicalTicker: "AAPL:XNAS",
+      relationType: "direct",
+      displayTier: "primary",
+      confidence: 0.98,
+      relevanceScore: 95,
+      impactScore: 93,
+      sentiment: "positive",
+    }],
+    ...overrides,
+  };
+}
 
 afterEach(() => {
   apiClient.ensureVerifiedSession = originalEnsureVerifiedSession;
@@ -31,6 +79,7 @@ afterEach(() => {
   apiClient.getCloudAnalystResearch = originalGetCloudAnalystResearch;
   apiClient.getCloudCorporateActions = originalGetCloudCorporateActions;
   apiClient.getCloudNews = originalGetCloudNews;
+  apiClient.getCloudNewsStory = originalGetCloudNewsStory;
   apiClient.subscribeQuotes = originalSubscribeQuotes;
 });
 
@@ -495,5 +544,41 @@ describe("GloomberbCloudProvider", () => {
       novelty: 71,
       confidence: 93,
     });
+  });
+
+  test("fetches story detail with ordered source items", async () => {
+    let requestedStoryId = "";
+    apiClient.getCloudNewsStory = async (storyId) => {
+      requestedStoryId = storyId;
+      return makeCloudNewsPayload({
+        id: storyId,
+        items: [{
+          id: "item-2",
+          sourceKey: "wire-b",
+          sourceName: "Wire B",
+          title: "Follow-up",
+          summary: "More details emerged.",
+          url: "https://example.com/follow-up",
+          publishedAt: "2026-04-01T10:05:00.000Z",
+          hasArticleText: true,
+        }, {
+          id: "item-1",
+          sourceKey: "wire-a",
+          sourceName: "Wire A",
+          title: "Original",
+          summary: "The first report.",
+          url: "https://example.com/original",
+          publishedAt: "2026-04-01T10:00:00.000Z",
+          hasArticleText: false,
+        }],
+      });
+    };
+
+    const source = createGloomberbCloudCapabilities().find((capability) => capability.kind === "news") as NewsCapability;
+    const story = await source.provider.fetchNewsStory?.("story-1");
+
+    expect(requestedStoryId).toBe("story-1");
+    expect(story?.items?.map((item) => item.id)).toEqual(["item-2", "item-1"]);
+    expect(story?.items?.[0]?.publishedAt).toEqual(new Date("2026-04-01T10:05:00.000Z"));
   });
 });

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -575,6 +575,13 @@ export function createGloomberbCloudCapabilities(provider = createGloomberbCloud
           );
           return response.items.map((item) => mapCloudNewsArticle(item, query.ticker));
         },
+        async fetchNewsStory(storyId: string): Promise<NewsArticle | null> {
+          const story = await withCloudFallback(
+            () => apiClient.getCloudNewsStory(storyId),
+            "Cloud news story is unavailable",
+          );
+          return mapCloudNewsArticle(story);
+        },
       },
     }),
   ];

--- a/src/types/capability-route-source.ts
+++ b/src/types/capability-route-source.ts
@@ -6,6 +6,7 @@ export interface NewsDataProvider {
   supports?(query: NewsQuery): boolean;
   getCachedNews?(query: NewsQuery): NewsArticle[];
   fetchNews(query: NewsQuery): Promise<NewsArticle[]>;
+  fetchNewsStory?(storyId: string): Promise<NewsArticle | null>;
 }
 
 export interface CapabilityRouteSource {

--- a/src/utils/api-client.test.ts
+++ b/src/utils/api-client.test.ts
@@ -320,4 +320,36 @@ describe("apiClient cloud news", () => {
     expect(url.searchParams.get("cursor")).toBe("cursor-1");
     expect(result).toEqual({ items: [], nextCursor: null });
   });
+
+  test("fetches news story details from the story route", async () => {
+    let seenUrl = "";
+    globalThis.fetch = mockFetch(async (input: Request | string | URL) => {
+      seenUrl = String(input);
+      return createResponse({
+        id: "story-1",
+        headline: "Story headline",
+        summary: "Story summary",
+        category: "general",
+        sentiment: "neutral",
+        sectors: [],
+        firstPublishedAt: "2026-04-01T10:00:00.000Z",
+        lastPublishedAt: "2026-04-01T10:05:00.000Z",
+        firstSeenAt: "2026-04-01T10:00:10.000Z",
+        lastSeenAt: "2026-04-01T10:05:10.000Z",
+        primaryUrl: "https://example.com/story",
+        primarySource: "example-wire",
+        variantCount: 2,
+        sourceCount: 2,
+        sources: ["example-wire"],
+        entities: [],
+        tickerLinks: [],
+        items: [],
+      });
+    });
+
+    const story = await apiClient.getCloudNewsStory("story-1");
+
+    expect(new URL(seenUrl).pathname).toBe("/news/story-1");
+    expect(story.id).toBe("story-1");
+  });
 });

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -1093,6 +1093,10 @@ class GloomApiClient {
     return this.request<CloudNewsListResponse>(`/news${query ? `?${query}` : ""}`);
   }
 
+  async getCloudNewsStory(storyId: string): Promise<CloudNewsPayload> {
+    return this.request<CloudNewsPayload>(`/news/${encodeURIComponent(storyId)}`);
+  }
+
   async getCloudTickerTweets(params: {
     ticker: string;
     limit?: number;


### PR DESCRIPTION
This fixes Top News details so opening a grouped story loads the Cloud story detail and shows the same source-item timeline that Breaking News already shows. The news provider contract now supports lazy story-detail fetches and merges returned items into the existing pane state without making list refreshes heavier. It also moves web table grid column sizing into the shared table layout helper so non-flex ticker columns stay compact while flexible columns keep expanding.