### PR TITLE
Route desktop fetches through backend

### DIFF
--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -197,6 +197,7 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
   const [activeTab, setActiveTab] = useState<TabId>("gainers");
   const [quotes, setQuotes] = useState<ScreenerQuote[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<MarketMoverSortPreference>(DEFAULT_SORT_PREFERENCE);
   const [summaryQuotes, setSummaryQuotes] = useState<MarketSummaryQuote[]>([]);
@@ -260,12 +261,14 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
     if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
       setQuotes(cached.data);
       setSelectedSymbol(null);
+      setLoadError(null);
       return;
     }
 
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
     setLoading(true);
+    setLoadError(null);
 
     try {
       let data: ScreenerQuote[];
@@ -318,7 +321,12 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
       cacheRef.current.set(tab, { data, fetchedAt: Date.now() });
       setQuotes(data);
       setSelectedSymbol(null);
-    } catch { /* leave existing data */ }
+      setLoadError(null);
+    } catch (error) {
+      if (fetchGenRef.current === gen) {
+        setLoadError(error instanceof Error ? error.message : "Market movers unavailable");
+      }
+    }
     finally {
       if (fetchGenRef.current === gen) setLoading(false);
     }
@@ -461,7 +469,8 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
         onSelect={(row) => setSelectedSymbol(row.symbol)}
         onActivate={(row) => openSymbol(row.symbol)}
         renderCell={renderCell}
-        emptyStateTitle={loading ? "Loading movers..." : "No data"}
+        emptyStateTitle={loading ? "Loading movers..." : loadError ?? "No data"}
+        emptyStateHint={loadError ? "Yahoo Finance did not return market movers." : undefined}
       />
     </Box>
   );

--- a/src/plugins/builtin/market-movers/screener.test.ts
+++ b/src/plugins/builtin/market-movers/screener.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { parseScreenerResponse, parseTrendingResponse } from "./screener";
+import {
+  createYahooScreenerApi,
+  fetchScreener,
+  parseScreenerResponse,
+  parseTrendingResponse,
+} from "./screener";
 
 const SAMPLE_SCREENER_RESPONSE = {
   finance: {
@@ -121,5 +126,38 @@ describe("parseTrendingResponse", () => {
     const results = parseTrendingResponse(data);
     expect(results).toHaveLength(1);
     expect(results[0]!.symbol).toBe("SPY");
+  });
+});
+
+describe("fetchScreener", () => {
+  test("falls back to the secondary Yahoo host when the primary host fails", async () => {
+    const requestedHosts: string[] = [];
+    const userAgents: string[] = [];
+    const api = createYahooScreenerApi(async (url, init) => {
+      const parsed = new URL(url);
+      requestedHosts.push(parsed.host);
+      userAgents.push(String((init?.headers as Record<string, string> | undefined)?.["User-Agent"] ?? ""));
+
+      if (parsed.host === "query2.finance.yahoo.com") {
+        return new Response("Forbidden", { status: 403 });
+      }
+
+      expect(parsed.pathname).toBe("/v1/finance/screener/predefined/saved");
+      expect(parsed.searchParams.get("formatted")).toBe("false");
+      expect(parsed.searchParams.get("lang")).toBe("en-US");
+      expect(parsed.searchParams.get("region")).toBe("US");
+      expect(parsed.searchParams.get("scrIds")).toBe("day_gainers");
+      expect(parsed.searchParams.get("count")).toBe("2");
+      return Response.json(SAMPLE_SCREENER_RESPONSE);
+    });
+
+    const results = await fetchScreener("day_gainers", 2, api);
+
+    expect(requestedHosts).toEqual([
+      "query2.finance.yahoo.com",
+      "query1.finance.yahoo.com",
+    ]);
+    expect(userAgents.every((agent) => agent.includes("Mozilla/5.0"))).toBe(true);
+    expect(results.map((result) => result.symbol)).toEqual(["AAPL", "MSFT"]);
   });
 });

--- a/src/plugins/builtin/market-movers/screener.ts
+++ b/src/plugins/builtin/market-movers/screener.ts
@@ -1,14 +1,54 @@
-import { createThrottledFetch } from "../../../utils/throttled-fetch";
+import { createThrottledFetch, type ThrottledFetchTransport } from "../../../utils/throttled-fetch";
 
-const screenerClient = createThrottledFetch({
-  requestsPerMinute: 15,
-  maxRetries: 2,
-  timeoutMs: 10_000,
-  defaultHeaders: {
-    "User-Agent": "Gloomberb/0.4.1",
-    Accept: "application/json",
-  },
-});
+const YAHOO_FINANCE_HOSTS = [
+  "query2.finance.yahoo.com",
+  "query1.finance.yahoo.com",
+] as const;
+
+const YAHOO_FINANCE_HEADERS = {
+  "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+  Accept: "application/json,text/plain,*/*",
+  "Accept-Language": "en-US,en;q=0.9",
+  Referer: "https://finance.yahoo.com/",
+};
+
+export interface YahooScreenerApi {
+  fetchJson<T = unknown>(path: string, params: Record<string, string | number>): Promise<T>;
+}
+
+export function createYahooScreenerApi(transport?: ThrottledFetchTransport): YahooScreenerApi {
+  const client = createThrottledFetch({
+    requestsPerMinute: 15,
+    maxRetries: 2,
+    timeoutMs: 10_000,
+    defaultHeaders: YAHOO_FINANCE_HEADERS,
+    transport,
+  });
+
+  return {
+    async fetchJson<T = unknown>(path: string, params: Record<string, string | number>): Promise<T> {
+      let lastError: unknown;
+      for (const host of YAHOO_FINANCE_HOSTS) {
+        const url = new URL(`https://${host}${path}`);
+        for (const [key, value] of Object.entries(params)) {
+          url.searchParams.set(key, String(value));
+        }
+
+        try {
+          return await client.fetchJson<T>(url.toString());
+        } catch (error) {
+          lastError = error;
+        }
+      }
+
+      throw lastError instanceof Error
+        ? lastError
+        : new Error("Yahoo Finance screener request failed");
+    },
+  };
+}
+
+const screenerApi = createYahooScreenerApi();
 
 export type ScreenerCategory = "day_gainers" | "day_losers" | "most_actives";
 
@@ -75,9 +115,18 @@ export function parseScreenerResponse(data: any): ScreenerQuote[] {
   }
 }
 
-export async function fetchScreener(category: ScreenerCategory, count = 25): Promise<ScreenerQuote[]> {
-  const url = `https://query2.finance.yahoo.com/v1/finance/screener/predefined/saved?scrIds=${category}&count=${count}`;
-  const data = await screenerClient.fetchJson(url);
+export async function fetchScreener(
+  category: ScreenerCategory,
+  count = 25,
+  api: YahooScreenerApi = screenerApi,
+): Promise<ScreenerQuote[]> {
+  const data = await api.fetchJson("/v1/finance/screener/predefined/saved", {
+    formatted: "false",
+    lang: "en-US",
+    region: "US",
+    scrIds: category,
+    count,
+  });
   return parseScreenerResponse(data);
 }
 
@@ -96,9 +145,13 @@ export function parseTrendingResponse(data: any): TrendingSymbol[] {
   }
 }
 
-export async function fetchTrending(count = 25): Promise<TrendingSymbol[]> {
-  const url = `https://query2.finance.yahoo.com/v1/finance/trending/US?count=${count}`;
-  const data = await screenerClient.fetchJson(url);
+export async function fetchTrending(
+  count = 25,
+  api: YahooScreenerApi = screenerApi,
+): Promise<TrendingSymbol[]> {
+  const data = await api.fetchJson("/v1/finance/trending/US", {
+    count,
+  });
   return parseTrendingResponse(data);
 }
 

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -12,6 +12,7 @@ import type {
 import type { InstrumentSearchResult } from "../types/instrument";
 import { debugLog } from "./debug-log";
 import { canonicalExchange, normalizeSymbol, publicTickerKey } from "./exchanges";
+import { httpFetch } from "./http-transport";
 import { normalizeTimestamp } from "./timestamp";
 
 const DEFAULT_API_URL = "https://api.gloom.sh";
@@ -26,10 +27,10 @@ const HARD_SESSION_INVALID_PATTERNS = [
 type CloudApiResponse = Pick<Response, "ok" | "status" | "headers" | "text">;
 type CloudApiFetchTransport = (url: string, init?: RequestInit) => Promise<CloudApiResponse>;
 
-let cloudApiFetchTransport: CloudApiFetchTransport = (url, init) => fetch(url, init);
+let cloudApiFetchTransport: CloudApiFetchTransport = httpFetch;
 
 export function setCloudApiFetchTransport(transport: CloudApiFetchTransport | null): void {
-  cloudApiFetchTransport = transport ?? ((url, init) => fetch(url, init));
+  cloudApiFetchTransport = transport ?? httpFetch;
 }
 
 function getCloudApiBaseUrl(): string {

--- a/src/utils/throttled-fetch.test.ts
+++ b/src/utils/throttled-fetch.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test, mock, beforeEach, afterAll } from "bun:test";
 import { createThrottledFetch } from "./throttled-fetch";
+import { setHttpFetchTransport } from "./http-transport";
 
 // Mock global fetch
 const originalFetch = globalThis.fetch;
 let fetchMock: ReturnType<typeof mock>;
 
 beforeEach(() => {
+  setHttpFetchTransport(null);
   fetchMock = mock(() => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })));
   globalThis.fetch = fetchMock as any;
 });
@@ -156,9 +158,29 @@ describe("createThrottledFetch", () => {
     expect(transportMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  test("uses the shared HTTP transport by default", async () => {
+    const transportMock = mock((url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.example.com/shared");
+      expect((init?.headers as Record<string, string>)["X-Shared"]).toBe("1");
+      return Promise.resolve(new Response("shared", { status: 203 }));
+    });
+    setHttpFetchTransport(transportMock);
+
+    const client = createThrottledFetch({
+      defaultHeaders: { "X-Shared": "1" },
+    });
+    const resp = await client.fetch("https://api.example.com/shared");
+
+    expect(resp.status).toBe(203);
+    expect(await resp.text()).toBe("shared");
+    expect(transportMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 // Restore
 afterAll(() => {
+  setHttpFetchTransport(null);
   globalThis.fetch = originalFetch;
 });

--- a/src/utils/throttled-fetch.ts
+++ b/src/utils/throttled-fetch.ts
@@ -7,6 +7,8 @@
  *   const data = await client.fetch("https://api.example.com/data");
  */
 
+import { httpFetch } from "./http-transport";
+
 const DEFAULT_REQUESTS_PER_MINUTE = 30;
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -50,7 +52,7 @@ export function createThrottledFetch(
   const defaultHeaders = options.defaultHeaders ?? {};
   const dedupeGetRequests = options.dedupeGetRequests ?? true;
   const fetchTransport =
-    options.transport ?? ((url: string, init?: RequestInit) => globalThis.fetch(url, init));
+    options.transport ?? httpFetch;
 
   // Sliding window: track timestamps of recent requests per host
   const hostTimestamps = new Map<string, number[]>();


### PR DESCRIPTION
Routes shared throttled HTTP clients through the renderer-aware HTTP transport so Electrobun desktop requests go through the Bun backend instead of browser fetch. This fixes Market Movers on desktop, where Yahoo screener calls could fail in the WebKit renderer and leave the pane showing only `No data`. The Market Movers provider now also uses browser-like Yahoo headers, falls back between Yahoo query hosts, and surfaces load errors instead of silently swallowing them.
