### PR TITLE
Speed up portfolio market data loading

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -515,6 +515,96 @@ function AppInner({
     });
   }, [performRefreshQuote]);
 
+  const refreshTickersBatch = useCallback((entries: Array<{ ticker: TickerRecord; priority: number }>) => {
+    const runnable = entries.filter(({ ticker }) => {
+      const symbol = ticker.metadata.ticker;
+      return !refreshInFlight.has(symbol) && !pendingRefreshesRef.current.financials.has(symbol);
+    });
+    if (runnable.length === 0) return;
+    for (const { ticker } of runnable) {
+      pendingRefreshesRef.current.financials.add(ticker.metadata.ticker);
+    }
+    const priority = Math.min(...runnable.map((entry) => entry.priority));
+    refreshQueueRef.current.queue.enqueue({
+      key: `financials-batch:${priority}:${runnable.map(({ ticker }) => ticker.metadata.ticker).join(",")}`,
+      priority,
+      run: async () => {
+        const instrumentEntries = runnable.flatMap(({ ticker }) => {
+          const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+          return instrument ? [{ ticker, instrument }] : [];
+        });
+        for (const { ticker } of runnable) {
+          const symbol = ticker.metadata.ticker;
+          refreshInFlight.add(symbol);
+          dispatch({ type: "SET_REFRESHING", symbol, refreshing: true });
+        }
+        try {
+          const entries = await marketData.loadSnapshotsBatch(instrumentEntries.map((entry) => entry.instrument));
+          entries.forEach((entry, index) => {
+            const ticker = instrumentEntries[index]?.ticker;
+            const data = entry.data ?? entry.lastGoodData;
+            if (ticker && data) {
+              pluginRegistry.events.emit("ticker:refreshed", { symbol: ticker.metadata.ticker, financials: data });
+              const currency = data.quote?.currency;
+              if (currency) void marketData.loadFxRate(currency).catch(() => {});
+            }
+          });
+          void marketData.loadFxRate(state.config.baseCurrency).catch(() => {});
+        } finally {
+          for (const { ticker } of runnable) {
+            const symbol = ticker.metadata.ticker;
+            refreshInFlight.delete(symbol);
+            pendingRefreshesRef.current.financials.delete(symbol);
+            dispatch({ type: "SET_REFRESHING", symbol, refreshing: false });
+          }
+        }
+      },
+    });
+  }, [dispatch, marketData, pluginRegistry.events, state.config.baseCurrency]);
+
+  const refreshQuotesBatch = useCallback((entries: Array<{ ticker: TickerRecord; priority: number }>) => {
+    const runnable = entries.filter(({ ticker }) => {
+      const symbol = ticker.metadata.ticker;
+      return !refreshInFlight.has(symbol)
+        && !quoteRefreshInFlight.has(symbol)
+        && !pendingRefreshesRef.current.financials.has(symbol)
+        && !pendingRefreshesRef.current.quotes.has(symbol);
+    });
+    if (runnable.length === 0) return;
+    for (const { ticker } of runnable) {
+      pendingRefreshesRef.current.quotes.add(ticker.metadata.ticker);
+    }
+    const priority = Math.min(...runnable.map((entry) => entry.priority));
+    refreshQueueRef.current.queue.enqueue({
+      key: `quotes-batch:${priority}:${runnable.map(({ ticker }) => ticker.metadata.ticker).join(",")}`,
+      priority,
+      run: async () => {
+        const instrumentEntries = runnable.flatMap(({ ticker }) => {
+          const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+          return instrument ? [{ ticker, instrument }] : [];
+        });
+        for (const { ticker } of runnable) {
+          quoteRefreshInFlight.add(ticker.metadata.ticker);
+        }
+        try {
+          const entries = await marketData.loadQuotesBatch(instrumentEntries.map((entry) => entry.instrument));
+          entries.forEach((entry) => {
+            const quote = entry.data ?? entry.lastGoodData;
+            const currency = quote?.currency;
+            if (currency) void marketData.loadFxRate(currency).catch(() => {});
+          });
+          void marketData.loadFxRate(state.config.baseCurrency).catch(() => {});
+        } finally {
+          for (const { ticker } of runnable) {
+            const symbol = ticker.metadata.ticker;
+            quoteRefreshInFlight.delete(symbol);
+            pendingRefreshesRef.current.quotes.delete(symbol);
+          }
+        }
+      },
+    });
+  }, [marketData, state.config.baseCurrency]);
+
   const primeCachedFinancials = useCallback((entries: Array<{ ticker: TickerRecord; financials: TickerFinancials }>) => {
     const primeEntries = entries.flatMap(({ ticker, financials }) => {
       const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
@@ -725,6 +815,8 @@ function AppInner({
           primeCachedFinancials,
           refreshTicker,
           refreshQuote,
+          refreshTickersBatch,
+          refreshQuotesBatch,
           autoImportBrokerPositions,
           persistedBrokerAccounts,
         }), {
@@ -736,7 +828,7 @@ function AppInner({
         // Will show empty state
       }
     })();
-  }, [autoImportBrokerPositions, dataProvider, dispatch, primeCachedFinancials, tickerRepository, refreshQuote, refreshTicker, sessionSnapshot, state.config, state.initialized]);
+  }, [autoImportBrokerPositions, dataProvider, dispatch, primeCachedFinancials, tickerRepository, refreshQuote, refreshQuotesBatch, refreshTicker, refreshTickersBatch, sessionSnapshot, state.config, state.initialized]);
 
   const focusedTickerSymbol = getFocusedTickerSymbol(state);
 

--- a/src/capabilities/factories.ts
+++ b/src/capabilities/factories.ts
@@ -26,6 +26,8 @@ export function assetDataProvider(provider: AssetDataProvider): AssetDataCapabil
     operations: {
       canProvide: op((input: any) => provider.canProvide?.(input.ticker, input.exchange, input.context) ?? true, "query"),
       getCachedFinancialsForTargets: op((input: any) => provider.getCachedFinancialsForTargets?.(input.targets ?? [], input.options) ?? new Map()),
+      getQuotesBatch: op((input: any) => provider.getQuotesBatch?.(input.targets ?? [], input.options) ?? Promise.resolve([])),
+      getTickerFinancialsBatch: op((input: any) => provider.getTickerFinancialsBatch?.(input.targets ?? [], input.options) ?? Promise.resolve([])),
       getTickerFinancials: op((input: any) => provider.getTickerFinancials(input.ticker, input.exchange, input.context)),
       getQuote: op((input: any) => provider.getQuote(input.ticker, input.exchange, input.context)),
       getExchangeRate: op((input: any) => provider.getExchangeRate(input.fromCurrency)),

--- a/src/components/table-view-shared.tsx
+++ b/src/components/table-view-shared.tsx
@@ -140,6 +140,12 @@ export function useResetTableScroll({
   resetScrollKey?: unknown;
   afterReset?: () => void;
 }) {
+  const afterResetRef = useRef(afterReset);
+
+  useEffect(() => {
+    afterResetRef.current = afterReset;
+  }, [afterReset]);
+
   useEffect(() => {
     if (resetScrollKey === undefined) return;
     const body = scrollRef.current;
@@ -151,8 +157,8 @@ export function useResetTableScroll({
     if (header) {
       header.scrollLeft = 0;
     }
-    if (afterReset) {
-      queueMicrotask(afterReset);
+    if (afterResetRef.current) {
+      queueMicrotask(afterResetRef.current);
     }
-  }, [afterReset, headerScrollRef, resetScrollKey, scrollRef]);
+  }, [headerScrollRef, resetScrollKey, scrollRef]);
 }

--- a/src/components/ticker-list-table-view.tsx
+++ b/src/components/ticker-list-table-view.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useRef,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -93,6 +94,7 @@ export function TickerListTableView({
   const selectedIndex = tableProps.tickers.findIndex(
     (ticker) => ticker.metadata.ticker === tableProps.cursorSymbol,
   );
+  const lastScrollCursorSymbolRef = useRef<string | null | undefined>(undefined);
 
   const emitVisibleRange = useCallback(() => {
     if (!onVisibleRangeChange) return;
@@ -185,7 +187,19 @@ export function TickerListTableView({
 
   useEffect(() => {
     const scrollBox = effectiveScrollRef.current;
-    if (!scrollBox?.viewport || selectedIndex < 0) return;
+    if (!scrollBox?.viewport || selectedIndex < 0) {
+      queueMicrotask(emitVisibleRange);
+      return;
+    }
+
+    const shouldScrollToCursor =
+      lastScrollCursorSymbolRef.current !== tableProps.cursorSymbol;
+    lastScrollCursorSymbolRef.current = tableProps.cursorSymbol;
+
+    if (!shouldScrollToCursor) {
+      queueMicrotask(emitVisibleRange);
+      return;
+    }
 
     const viewportHeight = Math.max(scrollBox.viewport.height, 1);
     if (selectedIndex < scrollBox.scrollTop) {
@@ -194,7 +208,7 @@ export function TickerListTableView({
       scrollBox.scrollTo(selectedIndex - viewportHeight + 1);
     }
     queueMicrotask(emitVisibleRange);
-  }, [effectiveScrollRef, emitVisibleRange, selectedIndex]);
+  }, [effectiveScrollRef, emitVisibleRange, selectedIndex, tableProps.cursorSymbol]);
 
   return (
     <TableViewFrame

--- a/src/components/ticker-list-table.test.tsx
+++ b/src/components/ticker-list-table.test.tsx
@@ -1,13 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, useState } from "react";
+import { act, useEffect, useRef, useState } from "react";
 import { testRender } from "../renderers/opentui/test-utils";
 import type { ColumnConfig } from "../types/config";
 import type { TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
+import type { ScrollBoxRenderable } from "../ui";
 import { TickerListTable, type TickerTableCell } from "./ticker-list-table";
+import { TickerListTableView } from "./ticker-list-table-view";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let setHarnessCursorSymbol: ((symbol: string) => void) | null = null;
+let setHarnessTickers: ((tickers: TickerRecord[]) => void) | null = null;
+let tableScrollRef: ScrollBoxRenderable | null = null;
 let resolveCellCallCount = 0;
 
 const columns: ColumnConfig[] = [
@@ -75,6 +79,34 @@ function LargeTickerListTableHarness() {
   );
 }
 
+function ReorderingTickerListTableViewHarness() {
+  const [rows, setRows] = useState(manyTickers);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  setHarnessTickers = setRows;
+
+  useEffect(() => {
+    tableScrollRef = scrollRef.current;
+    return () => {
+      if (tableScrollRef === scrollRef.current) {
+        tableScrollRef = null;
+      }
+    };
+  });
+
+  return (
+    <TickerListTableView
+      focused
+      columns={columns}
+      tickers={rows}
+      cursorSymbol="T0"
+      setCursorSymbol={() => {}}
+      resolveCell={resolveCell}
+      financialsMap={financialsMap}
+      scrollRef={scrollRef}
+    />
+  );
+}
+
 afterEach(async () => {
   if (testSetup) {
     await act(async () => {
@@ -84,6 +116,8 @@ afterEach(async () => {
   }
   resolveCellCallCount = 0;
   setHarnessCursorSymbol = null;
+  setHarnessTickers = null;
+  tableScrollRef = null;
 });
 
 describe("TickerListTable", () => {
@@ -125,5 +159,29 @@ describe("TickerListTable", () => {
     expect(frame).toContain("T0");
     expect(frame).not.toContain("T999");
     expect(resolveCellCallCount).toBeLessThan(40);
+  });
+
+  test("preserves manual scroll when market data reorders rows around the same cursor", async () => {
+    testSetup = await testRender(
+      <ReorderingTickerListTableViewHarness />,
+      { width: 20, height: 8 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    tableScrollRef!.scrollTop = 20;
+    expect(tableScrollRef?.scrollTop).toBe(20);
+
+    await act(async () => {
+      setHarnessTickers?.([...manyTickers.slice(1), manyTickers[0]!]);
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(tableScrollRef?.scrollTop).toBe(20);
   });
 });

--- a/src/market-data/coordinator.test.ts
+++ b/src/market-data/coordinator.test.ts
@@ -632,4 +632,79 @@ describe("MarketDataCoordinator", () => {
     expect(financials?.quote?.marketCap).toBe(3_640_775_908_600);
     expect(financials?.fundamentals?.trailingPE).toBe(31.4);
   });
+
+  it("batch loads only missing quotes when fresh quote data is already stored", async () => {
+    const batchTargets: QuoteSubscriptionTarget[][] = [];
+    const provider = createProvider({
+      getQuote: async () => ({
+        symbol: "AAPL",
+        price: 100,
+        currency: "USD",
+        change: 0,
+        changePercent: 0,
+        lastUpdated: 1_700_000_000_000,
+      }),
+      getQuotesBatch: async (targets) => {
+        batchTargets.push(targets);
+        return targets.map((target) => ({
+          target,
+          quote: {
+            symbol: target.symbol,
+            price: target.symbol === "MSFT" ? 200 : 300,
+            currency: "USD",
+            change: 0,
+            changePercent: 0,
+            lastUpdated: 1_700_000_000_000,
+          },
+        }));
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const aapl = { symbol: "AAPL", exchange: "NASDAQ" };
+    const msft = { symbol: "MSFT", exchange: "NASDAQ" };
+
+    await coordinator.loadQuote(aapl);
+    await coordinator.loadQuotesBatch([aapl, msft]);
+
+    expect(batchTargets).toHaveLength(1);
+    expect(batchTargets[0]?.map((target) => target.symbol)).toEqual(["MSFT"]);
+    expect(coordinator.getQuoteEntry(aapl).data?.price).toBe(100);
+    expect(coordinator.getQuoteEntry(msft).data?.price).toBe(200);
+  });
+
+  it("batch loads snapshots through provider batch support", async () => {
+    const batchSymbols: string[][] = [];
+    const provider = createProvider({
+      getTickerFinancialsBatch: async (targets) => {
+        batchSymbols.push(targets.map((target) => target.symbol));
+        return targets.map((target) => ({
+          target,
+          financials: {
+            quote: {
+              symbol: target.symbol,
+              price: target.symbol === "AAPL" ? 150 : 250,
+              currency: "USD",
+              change: 0,
+              changePercent: 0,
+              lastUpdated: 1_700_000_000_000,
+            },
+            fundamentals: { trailingPE: target.symbol === "AAPL" ? 20 : 30 },
+            annualStatements: [],
+            quarterlyStatements: [],
+            priceHistory: [],
+          },
+        }));
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+
+    await coordinator.loadSnapshotsBatch([
+      { symbol: "AAPL", exchange: "NASDAQ" },
+      { symbol: "MSFT", exchange: "NASDAQ" },
+    ]);
+
+    expect(batchSymbols).toEqual([["AAPL", "MSFT"]]);
+    expect(coordinator.getTickerFinancialsSync({ symbol: "AAPL", exchange: "NASDAQ" })?.quote?.price).toBe(150);
+    expect(coordinator.getTickerFinancialsSync({ symbol: "MSFT", exchange: "NASDAQ" })?.fundamentals?.trailingPE).toBe(30);
+  });
 });

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -1,4 +1,4 @@
-import type { DataProvider, SecFilingItem } from "../types/data-provider";
+import type { CachedFinancialsTarget, DataProvider, QuoteSubscriptionTarget, SecFilingItem } from "../types/data-provider";
 import type { NewsArticle } from "../news/types";
 import type { OptionsChain, PricePoint, Quote, TickerFinancials } from "../types/financials";
 import type { ChartRequest, InstrumentRef, NewsRequest, OptionsRequest, SecFilingsRequest } from "./request-types";
@@ -39,6 +39,7 @@ const SEC_FILINGS_CACHE_TTL_MS = 10 * 60_000;
 const SEC_CONTENT_CACHE_TTL_MS = 24 * 60 * 60_000;
 const ARTICLE_SUMMARY_CACHE_TTL_MS = 24 * 60 * 60_000;
 const FX_CACHE_TTL_MS = 30 * 60_000;
+const QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS = 250;
 
 function createBaselineChartRequest(instrument: InstrumentRef): ChartRequest {
   return {
@@ -223,6 +224,13 @@ export class MarketDataCoordinator {
   private readonly keyVersions = new Map<string, number>();
   private readonly inFlight = new Map<string, Promise<unknown>>();
   private readonly chartRequests = new Map<string, ChartRequest>();
+  private readonly quoteSubscriptions = new Map<string, {
+    target: QuoteSubscriptionTarget;
+    refCount: number;
+    unsubscribe: (() => void) | null;
+    removeTimer: ReturnType<typeof setTimeout> | null;
+  }>();
+  private pendingQuoteSubscriptionKeys = new Set<string>();
 
   private readonly quoteStore = new QueryStore<Quote>((key) => this.bump(key));
   private readonly snapshotStore = new QueryStore<TickerFinancials>((key) => this.bump(key));
@@ -427,6 +435,63 @@ export class MarketDataCoordinator {
     return promise;
   }
 
+  private cachedFinancialsTargetFromInstrument(instrument: InstrumentRef): CachedFinancialsTarget {
+    return {
+      symbol: instrument.symbol,
+      exchange: instrument.exchange,
+      brokerId: instrument.brokerId,
+      brokerInstanceId: instrument.brokerInstanceId,
+      instrument: instrument.instrument ?? null,
+    };
+  }
+
+  private quoteTargetFromInstrument(instrument: InstrumentRef): QuoteSubscriptionTarget {
+    return {
+      symbol: instrument.symbol,
+      exchange: instrument.exchange ?? "",
+      context: toMarketDataContext(instrument),
+    };
+  }
+
+  private storeSnapshotData(
+    instrument: InstrumentRef,
+    data: TickerFinancials,
+    source: string,
+    attempts: ProviderAttempt[],
+  ): QueryEntry<TickerFinancials> {
+    const normalized = normalizeTickerFinancialsPriceHistory(data);
+    const snapshotKey = buildSnapshotKey(instrument);
+    const entry = this.snapshotStore.update(snapshotKey, (current) =>
+      readyEntry(current, normalized, source, attempts, { keepLastGoodOnEmpty: true })
+    );
+    if (normalized.quote) {
+      this.quoteStore.set(buildQuoteKey(instrument), readyEntry(this.getQuoteEntry(instrument), normalized.quote, normalized.quote.providerId ?? source, attempts));
+    }
+    this.profileStore.set(buildProfileKey(instrument), readyEntry(this.profileStore.get(buildProfileKey(instrument)), normalized.profile ?? null, source, attempts, { keepLastGoodOnEmpty: true }));
+    this.fundamentalsStore.set(buildFundamentalsKey(instrument), readyEntry(this.fundamentalsStore.get(buildFundamentalsKey(instrument)), normalized.fundamentals ?? null, source, attempts, { keepLastGoodOnEmpty: true }));
+    this.statementsStore.set(
+      buildStatementsKey(instrument),
+      readyEntry(
+        this.statementsStore.get(buildStatementsKey(instrument)),
+        {
+          annualStatements: normalized.annualStatements ?? [],
+          quarterlyStatements: normalized.quarterlyStatements ?? [],
+        },
+        source,
+        attempts,
+        { keepLastGoodOnEmpty: true },
+      ),
+    );
+    if ((normalized.priceHistory ?? []).length > 0) {
+      const chartRequest = createBaselineChartRequest(instrument);
+      this.chartStore.set(
+        buildChartKey(chartRequest),
+        readyEntry(this.getChartEntry(chartRequest), normalized.priceHistory, source, attempts, { keepLastGoodOnEmpty: true }),
+      );
+    }
+    return entry;
+  }
+
   private findChartSeedEntry(
     key: string,
     request: ChartRequest,
@@ -485,42 +550,17 @@ export class MarketDataCoordinator {
       const startedAt = Date.now();
       traceMarketData("snapshot:start", { key, symbol: instrument.symbol, exchange: instrument.exchange ?? "" });
       try {
-        const data = normalizeTickerFinancialsPriceHistory(await this.dataProvider.getTickerFinancials(
+        const data = await this.dataProvider.getTickerFinancials(
           instrument.symbol,
           instrument.exchange ?? "",
           {
             ...toMarketDataContext(instrument),
             cacheMode: options.forceRefresh ? "refresh" : "default",
           },
-        ));
+        );
         const source = data.quote?.providerId ?? this.dataProvider.id;
         const attempts = [createAttempt(source, startedAt, data ? "success" : "empty")];
-        const entry = this.snapshotStore.update(key, (current) => readyEntry(current, data, source, attempts, { keepLastGoodOnEmpty: true }));
-        if (data.quote) {
-          this.quoteStore.set(buildQuoteKey(instrument), readyEntry(this.getQuoteEntry(instrument), data.quote, data.quote.providerId ?? source, attempts));
-        }
-        this.profileStore.set(buildProfileKey(instrument), readyEntry(this.profileStore.get(buildProfileKey(instrument)), data.profile ?? null, source, attempts, { keepLastGoodOnEmpty: true }));
-        this.fundamentalsStore.set(buildFundamentalsKey(instrument), readyEntry(this.fundamentalsStore.get(buildFundamentalsKey(instrument)), data.fundamentals ?? null, source, attempts, { keepLastGoodOnEmpty: true }));
-        this.statementsStore.set(
-          buildStatementsKey(instrument),
-          readyEntry(
-            this.statementsStore.get(buildStatementsKey(instrument)),
-            {
-              annualStatements: data.annualStatements ?? [],
-              quarterlyStatements: data.quarterlyStatements ?? [],
-            },
-            source,
-            attempts,
-            { keepLastGoodOnEmpty: true },
-          ),
-        );
-        if ((data.priceHistory ?? []).length > 0) {
-          const chartRequest = createBaselineChartRequest(instrument);
-          this.chartStore.set(
-            buildChartKey(chartRequest),
-            readyEntry(this.getChartEntry(chartRequest), data.priceHistory, source, attempts, { keepLastGoodOnEmpty: true }),
-          );
-        }
+        const entry = this.storeSnapshotData(instrument, data, source, attempts);
         traceMarketData("snapshot:ready", {
           key,
           symbol: instrument.symbol,
@@ -536,6 +576,49 @@ export class MarketDataCoordinator {
         return this.snapshotStore.update(key, (current) => errorEntry(current, attempt));
       }
     });
+  }
+
+  async loadSnapshotsBatch(
+    instruments: InstrumentRef[],
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<QueryEntry<TickerFinancials>[]> {
+    const uniqueInstruments = [...new Map(instruments.map((instrument) => [buildSnapshotKey(instrument), instrument] as const)).values()];
+    const results = new Map<string, QueryEntry<TickerFinancials>>();
+    const misses: InstrumentRef[] = [];
+
+    for (const instrument of uniqueInstruments) {
+      const key = buildSnapshotKey(instrument);
+      const current = this.snapshotStore.get(key);
+      if (!options.forceRefresh && hasFreshEntryData(current, SNAPSHOT_CACHE_TTL_MS)) {
+        results.set(key, current);
+      } else {
+        misses.push(instrument);
+      }
+    }
+
+    if (misses.length > 0 && this.dataProvider.getTickerFinancialsBatch) {
+      const batchResults = await this.dataProvider.getTickerFinancialsBatch(
+        misses.map((instrument) => this.cachedFinancialsTargetFromInstrument(instrument)),
+        { forceRefresh: options.forceRefresh },
+      );
+      batchResults.forEach((item, index) => {
+        const instrument = misses[index];
+        if (!instrument) return;
+        const key = buildSnapshotKey(instrument);
+        if (!item.financials) return;
+        const source = item.financials.quote?.providerId ?? this.dataProvider.id;
+        const attempts = [createAttempt(source, Date.now(), "success")];
+        results.set(key, this.storeSnapshotData(instrument, item.financials, source, attempts));
+      });
+    }
+
+    await Promise.all(misses.map(async (instrument) => {
+      const key = buildSnapshotKey(instrument);
+      if (results.has(key)) return;
+      results.set(key, await this.loadSnapshot(instrument, options));
+    }));
+
+    return instruments.map((instrument) => results.get(buildSnapshotKey(instrument)) ?? this.getSnapshotEntry(instrument));
   }
 
   async loadQuote(
@@ -565,6 +648,48 @@ export class MarketDataCoordinator {
         return this.quoteStore.update(key, (current) => errorEntry(current, attempt));
       }
     });
+  }
+
+  async loadQuotesBatch(
+    instruments: InstrumentRef[],
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<QueryEntry<Quote>[]> {
+    const uniqueInstruments = [...new Map(instruments.map((instrument) => [buildQuoteKey(instrument), instrument] as const)).values()];
+    const results = new Map<string, QueryEntry<Quote>>();
+    const misses: InstrumentRef[] = [];
+
+    for (const instrument of uniqueInstruments) {
+      const key = buildQuoteKey(instrument);
+      const current = this.quoteStore.get(key);
+      if (!options.forceRefresh && hasFreshEntryData(current, SNAPSHOT_CACHE_TTL_MS)) {
+        results.set(key, current);
+      } else {
+        misses.push(instrument);
+      }
+    }
+
+    if (misses.length > 0 && this.dataProvider.getQuotesBatch) {
+      const batchResults = await this.dataProvider.getQuotesBatch(
+        misses.map((instrument) => this.quoteTargetFromInstrument(instrument)),
+        { forceRefresh: options.forceRefresh },
+      );
+      batchResults.forEach((item, index) => {
+        const instrument = misses[index];
+        if (!instrument || !item.quote) return;
+        const key = buildQuoteKey(instrument);
+        const source = item.quote.providerId ?? this.dataProvider.id;
+        const attempts = [createAttempt(source, Date.now(), "success")];
+        results.set(key, this.quoteStore.update(key, (current) => readyQuoteEntry(current, item.quote!, source, attempts)));
+      });
+    }
+
+    await Promise.all(misses.map(async (instrument) => {
+      const key = buildQuoteKey(instrument);
+      if (results.has(key)) return;
+      results.set(key, await this.loadQuote(instrument, options));
+    }));
+
+    return instruments.map((instrument) => results.get(buildQuoteKey(instrument)) ?? this.getQuoteEntry(instrument));
   }
 
   async loadChart(
@@ -798,26 +923,71 @@ export class MarketDataCoordinator {
       return () => {};
     }
 
-    const normalizedTargets = targets.map(({ instrument }) => ({
-      symbol: instrument.symbol,
-      exchange: instrument.exchange ?? "",
-      context: toMarketDataContext(instrument),
-    }));
-
-    return this.dataProvider.subscribeQuotes(normalizedTargets, (target, quote) => {
-      const instrument: InstrumentRef = {
-        symbol: target.symbol,
-        exchange: target.exchange ?? "",
-        brokerId: target.context?.brokerId,
-        brokerInstanceId: target.context?.brokerInstanceId,
-        instrument: target.context?.instrument ?? null,
-      };
+    const subscribedKeys = new Set<string>();
+    for (const { instrument } of targets) {
       const key = buildQuoteKey(instrument);
-      const current = this.quoteStore.get(key);
-      if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, quote)) return;
-      const attempts = [createAttempt(quote.providerId ?? this.dataProvider.id, Date.now(), "success")];
-      this.quoteStore.set(key, readyQuoteEntry(current, quote, quote.providerId ?? this.dataProvider.id, attempts));
-    });
+      subscribedKeys.add(key);
+      const existing = this.quoteSubscriptions.get(key);
+      if (existing) {
+        existing.refCount += 1;
+        if (existing.removeTimer) {
+          clearTimeout(existing.removeTimer);
+          existing.removeTimer = null;
+        }
+        continue;
+      }
+      this.quoteSubscriptions.set(key, {
+        target: this.quoteTargetFromInstrument(instrument),
+        refCount: 1,
+        unsubscribe: null,
+        removeTimer: null,
+      });
+      this.pendingQuoteSubscriptionKeys.add(key);
+    }
+    this.flushQuoteSubscriptions();
+
+    return () => {
+      for (const key of subscribedKeys) {
+        const existing = this.quoteSubscriptions.get(key);
+        if (!existing) continue;
+        existing.refCount = Math.max(0, existing.refCount - 1);
+        if (existing.refCount > 0 || existing.removeTimer) continue;
+        existing.removeTimer = setTimeout(() => {
+          const current = this.quoteSubscriptions.get(key);
+          if (!current || current.refCount > 0) return;
+          current.unsubscribe?.();
+          this.quoteSubscriptions.delete(key);
+          this.pendingQuoteSubscriptionKeys.delete(key);
+        }, QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS);
+      }
+    };
+  }
+
+  private flushQuoteSubscriptions(): void {
+    const keys = this.pendingQuoteSubscriptionKeys;
+    this.pendingQuoteSubscriptionKeys = new Set();
+    for (const key of keys) {
+      const entry = this.quoteSubscriptions.get(key);
+      if (!entry || entry.refCount === 0 || entry.unsubscribe) continue;
+      entry.unsubscribe = this.dataProvider.subscribeQuotes?.([entry.target], (target, quote) => {
+        const instrument: InstrumentRef = {
+          symbol: target.symbol,
+          exchange: target.exchange ?? "",
+          brokerId: target.context?.brokerId,
+          brokerInstanceId: target.context?.brokerInstanceId,
+          instrument: target.context?.instrument ?? null,
+        };
+        this.applyStreamQuote(instrument, quote);
+      }) ?? null;
+    }
+  }
+
+  private applyStreamQuote(instrument: InstrumentRef, quote: Quote): void {
+    const key = buildQuoteKey(instrument);
+    const current = this.quoteStore.get(key);
+    if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, quote)) return;
+    const attempts = [createAttempt(quote.providerId ?? this.dataProvider.id, Date.now(), "success")];
+    this.quoteStore.set(key, readyQuoteEntry(current, quote, quote.providerId ?? this.dataProvider.id, attempts));
   }
 }
 

--- a/src/plugins/builtin/portfolio-list/pane.tsx
+++ b/src/plugins/builtin/portfolio-list/pane.tsx
@@ -471,32 +471,29 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     if (queue.length === 0) return;
 
     let cancelled = false;
-    const runNext = async (): Promise<void> => {
-      if (cancelled) return;
-      const nextTicker = queue.shift();
-      if (!nextTicker) return;
-
-      const key = `${nextTicker.metadata.ticker}:${nextTicker.metadata.exchange ?? ""}`;
-      const instrument = instrumentFromTicker(nextTicker, nextTicker.metadata.ticker);
-      warmupInFlightRef.current.add(key);
-      warmupAttemptRef.current.set(key, nowTimestamp);
+    const runBatch = async (): Promise<void> => {
+      const entries = queue.flatMap((ticker) => {
+        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+        if (!instrument) return [];
+        const key = `${ticker.metadata.ticker}:${ticker.metadata.exchange ?? ""}`;
+        warmupInFlightRef.current.add(key);
+        warmupAttemptRef.current.set(key, nowTimestamp);
+        return [{ key, instrument }];
+      });
+      if (entries.length === 0) return;
       try {
-        if (instrument) {
-          await sharedCoordinator.loadSnapshot(instrument);
-        }
+        await sharedCoordinator.loadSnapshotsBatch(entries.map((entry) => entry.instrument));
       } catch {
         // Best-effort warmup for visible rows only.
       } finally {
-        warmupInFlightRef.current.delete(key);
-      }
-
-      if (mountedRef.current && !cancelled) {
-        await runNext();
+        for (const entry of entries) {
+          warmupInFlightRef.current.delete(entry.key);
+        }
       }
     };
 
     const timeoutId = setTimeout(() => {
-      void runNext();
+      if (!cancelled && mountedRef.current) void runBatch();
     }, VISIBLE_FINANCIAL_WARMUP_DELAY_MS);
 
     return () => {

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -6,7 +6,7 @@ import { PluginRegistry } from "../../../plugins/registry";
 import type { AppServices } from "../../../core/app-services";
 import type { AppConfig } from "../../../types/config";
 import type { DataProvider, QuoteSubscriptionTarget } from "../../../types/data-provider";
-import type { Quote } from "../../../types/financials";
+import type { Quote, TickerFinancials } from "../../../types/financials";
 import type { NewsArticle, NewsQuery } from "../../../news/types";
 import type { TickerRecord, TickerMetadata } from "../../../types/ticker";
 import { newsProvider, type CapabilityManifest } from "../../../capabilities";
@@ -21,7 +21,6 @@ import { debugLog } from "../../../utils/debug-log";
 import { measurePerf } from "../../../utils/perf-marks";
 import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 
-const REMOTE_DATA_REQUEST_CACHE_LIMIT = 150;
 const servicesLog = debugLog.createLogger("services");
 const ASSET_DATA_CAPABILITY_ID = "asset-data.asset-data-router";
 const NEWS_CAPABILITY_ID = "news.core";
@@ -58,6 +57,9 @@ type PayloadBuilder = (...args: any[]) => Record<string, unknown>;
 
 const assetDataPayloads: Record<string, PayloadBuilder> = {
   canProvide: (ticker, exchange, context) => ({ ticker, exchange, context }),
+  getCachedFinancialsForTargets: (targets, options) => ({ targets, options }),
+  getQuotesBatch: (targets, options) => ({ targets, options }),
+  getTickerFinancialsBatch: (targets, options) => ({ targets, options }),
   getTickerFinancials: (ticker, exchange, context) => ({ ticker, exchange, context }),
   getQuote: (ticker, exchange, context) => ({ ticker, exchange, context }),
   getExchangeRate: (fromCurrency) => ({ fromCurrency }),
@@ -96,21 +98,16 @@ function hasRendererOperation(operations: Set<string> | null, operationId: strin
 }
 
 function createCapabilityInvoker() {
-  const requestCache = new Map<string, Promise<unknown>>();
+  const inFlightRequests = new Map<string, Promise<unknown>>();
   return function invoke<T>(capabilityId: string, operationId: string, payload: unknown): Promise<T> {
     const requestPayload = { capabilityId, operationId, payload };
     const key = JSON.stringify(requestPayload);
-    const cached = requestCache.get(key);
-    if (cached) return cached as Promise<T>;
-    const promise = backendRequest<T>("capability.invoke", requestPayload).catch((error) => {
-      requestCache.delete(key);
-      throw error;
+    const inFlight = inFlightRequests.get(key);
+    if (inFlight) return inFlight as Promise<T>;
+    const promise = backendRequest<T>("capability.invoke", requestPayload).finally(() => {
+      inFlightRequests.delete(key);
     });
-    requestCache.set(key, promise);
-    if (requestCache.size > REMOTE_DATA_REQUEST_CACHE_LIMIT) {
-      const oldestKey = requestCache.keys().next().value;
-      if (oldestKey) requestCache.delete(oldestKey);
-    }
+    inFlightRequests.set(key, promise);
     return promise;
   };
 }
@@ -120,10 +117,69 @@ function createRemoteAssetDataClient(): RemoteAssetDataClient {
   const assetDataOperations = getRendererOperationIds(ASSET_DATA_CAPABILITY_ID);
   const newsOperations = getRendererOperationIds(NEWS_CAPABILITY_ID);
   let nextSubscriptionId = 1;
+  const quoteListeners = new Map<string, {
+    target: QuoteSubscriptionTarget;
+    listeners: Set<(target: QuoteSubscriptionTarget, quote: Quote) => void>;
+  }>();
+  let quoteBackendSubscriptionId: string | null = null;
+  let disposeQuoteBackendMessages: (() => void) | null = null;
+  let quoteBackendFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const quoteTargetKey = (target: QuoteSubscriptionTarget) =>
+    `${target.symbol}:${target.exchange ?? ""}:${target.context?.brokerId ?? ""}:${target.context?.brokerInstanceId ?? ""}:${target.context?.instrument?.conId ?? target.context?.instrument?.localSymbol ?? ""}`;
+
+  const scheduleQuoteBackendSubscriptionFlush = () => {
+    if (quoteBackendFlushTimer) return;
+    quoteBackendFlushTimer = setTimeout(() => {
+      quoteBackendFlushTimer = null;
+      flushQuoteBackendSubscription();
+    }, 25);
+  };
+
+  const flushQuoteBackendSubscription = () => {
+    if (!hasRendererOperation(assetDataOperations, "subscribeQuotes")) return;
+    const targets = [...quoteListeners.values()].map((entry) => entry.target);
+    const previousSubscriptionId = quoteBackendSubscriptionId;
+    if (previousSubscriptionId) {
+      quoteBackendSubscriptionId = null;
+      disposeQuoteBackendMessages?.();
+      disposeQuoteBackendMessages = null;
+      void backendRequest("capability.unsubscribe", { subscriptionId: previousSubscriptionId }).catch(() => {});
+    }
+    if (targets.length === 0) return;
+
+    const subscriptionId = `quote:${nextSubscriptionId++}`;
+    quoteBackendSubscriptionId = subscriptionId;
+    disposeQuoteBackendMessages = onCapabilityEvent(subscriptionId, (message) => {
+      const event = message.event as { target: QuoteSubscriptionTarget; quote: Quote };
+      const key = quoteTargetKey(event.target);
+      for (const listener of quoteListeners.get(key)?.listeners ?? []) {
+        listener(event.target, event.quote);
+      }
+    });
+    void backendRequest("capability.subscribe", {
+      subscriptionId,
+      capabilityId: ASSET_DATA_CAPABILITY_ID,
+      operationId: "subscribeQuotes",
+      payload: { targets },
+    }).catch((error) => {
+      if (quoteBackendSubscriptionId === subscriptionId) {
+        quoteBackendSubscriptionId = null;
+        disposeQuoteBackendMessages?.();
+        disposeQuoteBackendMessages = null;
+      }
+      console.error("Failed to subscribe to backend quotes", error);
+    });
+  };
+
   const base = {
     id: "desktop-backend",
     name: "Gloomberb Backend",
-    getCachedFinancialsForTargets: () => new Map(),
+    getCachedFinancialsForTargets: (targets, options) => (
+      hasRendererOperation(assetDataOperations, "getCachedFinancialsForTargets")
+        ? invoke<Map<string, TickerFinancials>>(ASSET_DATA_CAPABILITY_ID, "getCachedFinancialsForTargets", { targets, options })
+        : new Map()
+    ),
     getNews: (query: NewsQuery) => (
       hasRendererOperation(newsOperations, "fetchNews")
         ? invoke<NewsArticle[]>(NEWS_CAPABILITY_ID, "fetchNews", { query })
@@ -142,28 +198,29 @@ function createRemoteAssetDataClient(): RemoteAssetDataClient {
       ).values()];
       if (uniqueTargets.length === 0) return () => {};
 
-      const subscriptionId = `quote:${nextSubscriptionId++}`;
-      const disposeMessages = onCapabilityEvent(subscriptionId, (message) => {
-        const event = message.event as { target: QuoteSubscriptionTarget; quote: Quote };
-        onQuote(event.target, event.quote);
-      });
       let disposed = false;
-
-      void backendRequest("capability.subscribe", {
-        subscriptionId,
-        capabilityId: ASSET_DATA_CAPABILITY_ID,
-        operationId: "subscribeQuotes",
-        payload: { targets: uniqueTargets },
-      }).catch((error) => {
-        disposeMessages();
-        console.error("Failed to subscribe to backend quotes", error);
-      });
+      for (const target of uniqueTargets) {
+        const key = quoteTargetKey(target);
+        const entry = quoteListeners.get(key) ?? { target, listeners: new Set() };
+        entry.target = target;
+        entry.listeners.add(onQuote);
+        quoteListeners.set(key, entry);
+      }
+      scheduleQuoteBackendSubscriptionFlush();
 
       return () => {
         if (disposed) return;
         disposed = true;
-        disposeMessages();
-        void backendRequest("capability.unsubscribe", { subscriptionId }).catch(() => {});
+        for (const target of uniqueTargets) {
+          const key = quoteTargetKey(target);
+          const entry = quoteListeners.get(key);
+          if (!entry) continue;
+          entry.listeners.delete(onQuote);
+          if (entry.listeners.size === 0) {
+            quoteListeners.delete(key);
+          }
+        }
+        scheduleQuoteBackendSubscriptionFlush();
       };
     },
   };

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -5,15 +5,24 @@ import {
   type ManualChartResolution,
 } from "../components/chart/chart-resolution";
 import { assetDataProvider, newsProvider, type PluginCapability } from "../capabilities";
-import type { AssetDataProvider, MarketDataRequestContext, NewsItem, QuoteSubscriptionTarget, SearchRequestContext, SecFilingItem } from "../types/data-provider";
+import type {
+  AssetDataProvider,
+  CachedFinancialsTarget,
+  MarketDataRequestContext,
+  NewsItem,
+  QuoteBatchResult,
+  QuoteSubscriptionTarget,
+  SearchRequestContext,
+  SecFilingItem,
+  TickerFinancialsBatchResult,
+} from "../types/data-provider";
 import type { AnalystResearchData, CorporateActionsData, HolderData, OptionsChain, PricePoint, Quote, TickerFinancials } from "../types/financials";
 import type { InstrumentSearchResult } from "../types/instrument";
 import {
   apiClient,
   type CloudAnalystResearchPayload,
-  type CloudCompanyProfile,
   type CloudCorporateActionsPayload,
-  type CloudFundamentals,
+  type CloudMarketBatchItem,
   type CloudHoldersPayload,
   type CloudMarketResponse,
   type CloudNewsPayload,
@@ -101,6 +110,34 @@ function mapPricePoint(point: CloudPricePointPayload, divisor = 1): PricePoint {
     close: normalizePriceValueByDivisor(point.close, divisor) ?? point.close,
     volume: point.volume,
   };
+}
+
+function mapCloudFinancials(financials: TickerFinancials): TickerFinancials {
+  const quote = financials.quote ? mapQuote(financials.quote as CloudQuotePayload) : undefined;
+  const divisor = quote ? resolveCurrencyUnit(quote.currency).divisor : 1;
+  return {
+    quote,
+    quoteContributions: financials.quoteContributions,
+    profile: financials.profile,
+    fundamentals: financials.fundamentals,
+    annualStatements: financials.annualStatements ?? [],
+    quarterlyStatements: financials.quarterlyStatements ?? [],
+    priceHistory: (financials.priceHistory ?? []).map((point) =>
+      point.date instanceof Date
+        ? point
+        : mapPricePoint(point as unknown as CloudPricePointPayload, divisor)
+    ),
+  };
+}
+
+function mapBatchError<T>(
+  item: CloudMarketBatchItem<T>,
+  fallbackMessage: string,
+): Error {
+  if (isEmptyCloudStatus(item.status)) {
+    return createProviderMiss(item.reasonCode ?? fallbackMessage);
+  }
+  return new Error(item.reasonCode ?? fallbackMessage);
 }
 
 function normalizeStringArray(value: unknown): string[] {
@@ -358,25 +395,43 @@ export class GloomberbCloudProvider implements AssetDataProvider {
   async getTickerFinancials(ticker: string, exchange = "", _context?: MarketDataRequestContext): Promise<TickerFinancials> {
     await requireVerifiedSession();
     return withCloudFallback(async () => {
-      const [quoteResponse, profileResponse, fundamentalsResponse, statementsResponse] = await Promise.all([
-        apiClient.getCloudQuote(ticker, exchange),
-        apiClient.getCloudProfile(ticker, exchange),
-        apiClient.getCloudFundamentals(ticker, exchange),
-        apiClient.getCloudStatements(ticker, exchange, "both"),
-      ]);
-      const quote = mapQuote(unwrapRequiredCloudResponse(quoteResponse, `Cloud quote is unavailable for ${ticker}`));
-      const profile = unwrapOptionalCloudResponse(profileResponse) as CloudCompanyProfile | null;
-      const fundamentals = unwrapOptionalCloudResponse(fundamentalsResponse) as CloudFundamentals | null;
-      const statements = unwrapOptionalCloudResponse(statementsResponse);
-      return {
-        quote,
-        profile: profile ?? undefined,
-        fundamentals: fundamentals ?? undefined,
-        annualStatements: statements?.annualStatements ?? [],
-        quarterlyStatements: statements?.quarterlyStatements ?? [],
-        priceHistory: [],
-      };
+      const response = await apiClient.getCloudFinancials(ticker, exchange);
+      return mapCloudFinancials(unwrapRequiredCloudResponse(response, `Cloud financials are unavailable for ${ticker}`));
     }, `Cloud financials are unavailable for ${ticker}`);
+  }
+
+  async getTickerFinancialsBatch(
+    targets: CachedFinancialsTarget[],
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<TickerFinancialsBatchResult[]> {
+    await requireVerifiedSession();
+    return withCloudFallback(async () => {
+      const response = await apiClient.getCloudFinancialsBatch(
+        targets.map((target) => ({
+          symbol: target.symbol,
+          exchange: target.exchange,
+        })),
+        options.forceRefresh ? "refresh" : "cache-first",
+      );
+      const payload = unwrapRequiredCloudResponse(response, "Cloud financials are unavailable");
+      return payload.items.map((item, index) => {
+        const target = targets[index] ?? {
+          symbol: item.symbol,
+          exchange: item.exchange,
+        };
+        if ((item.status === "success" || item.status === "partial") && item.data) {
+          return {
+            target,
+            financials: mapCloudFinancials(item.data),
+          };
+        }
+        return {
+          target,
+          financials: null,
+          error: mapBatchError(item, `Cloud financials are unavailable for ${target.symbol}`),
+        };
+      });
+    }, "Cloud financials are unavailable");
   }
 
   async getQuote(ticker: string, exchange = "", _context?: MarketDataRequestContext): Promise<Quote> {
@@ -388,6 +443,40 @@ export class GloomberbCloudProvider implements AssetDataProvider {
       )),
       `Cloud quotes are unavailable for ${ticker}`,
     );
+  }
+
+  async getQuotesBatch(
+    targets: QuoteSubscriptionTarget[],
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<QuoteBatchResult[]> {
+    await requireVerifiedSession();
+    return withCloudFallback(async () => {
+      const response = await apiClient.getCloudQuotesBatch(
+        targets.map((target) => ({
+          symbol: target.symbol,
+          exchange: target.exchange,
+        })),
+        options.forceRefresh ? "refresh" : "cache-first",
+      );
+      const payload = unwrapRequiredCloudResponse(response, "Cloud quotes are unavailable");
+      return payload.items.map((item, index) => {
+        const target = targets[index] ?? {
+          symbol: item.symbol,
+          exchange: item.exchange,
+        };
+        if ((item.status === "success" || item.status === "partial") && item.data) {
+          return {
+            target,
+            quote: mapQuote(item.data),
+          };
+        }
+        return {
+          target,
+          quote: null,
+          error: mapBatchError(item, `Cloud quotes are unavailable for ${target.symbol}`),
+        };
+      });
+    }, "Cloud quotes are unavailable");
   }
 
   async getExchangeRate(fromCurrency: string): Promise<number> {

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -8,9 +8,11 @@ import type {
   CachedFinancialsTarget,
   DataProvider,
   MarketDataRequestContext,
+  QuoteBatchResult,
   QuoteSubscriptionTarget,
   SearchRequestContext,
   SecFilingItem,
+  TickerFinancialsBatchResult,
 } from "../types/data-provider";
 import type { CapabilityRouteSource } from "../types/capability-route-source";
 import { routeSourcePriority } from "../types/capability-route-source";
@@ -343,6 +345,135 @@ export class AssetDataRouter implements DataProvider {
       if (cached != null) results.set(currency, cached);
     }
     return results;
+  }
+
+  async getQuotesBatch(
+    targets: QuoteSubscriptionTarget[],
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<QuoteBatchResult[]> {
+    const forceRefresh = options.forceRefresh === true;
+    const results = new Array<QuoteBatchResult | null>(targets.length).fill(null);
+    const misses: Array<{ index: number; target: QuoteSubscriptionTarget }> = [];
+
+    targets.forEach((target, index) => {
+      const context = target.context;
+      const entityKey = this.getEntityKey(target.symbol, target.exchange, context?.instrument);
+      const variantKeys = this.getTickerVariantCandidates(target.exchange);
+      const sourceKeys = [
+        ...this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate)),
+        ...this.getProviderSourceKeys(),
+      ];
+      const rawCached = this.selectCachedResource<Quote>("quote", entityKey, variantKeys, sourceKeys, false);
+      const cached = rawCached && !isQuoteStaleForCurrentSession(rawCached.value)
+        ? rawCached
+        : null;
+      if (cached && !forceRefresh && !cached.stale) {
+        results[index] = { target, quote: cached.value };
+        return;
+      }
+      misses.push({ index, target });
+    });
+
+    const batchProvider = this.providersInPriorityOrder().find((provider) => provider.getQuotesBatch);
+    const providerMisses = misses.filter(({ target }) => !this.hasBrokerContext(target.context));
+    const providerIndexes = new Map<string, Array<{ index: number; target: QuoteSubscriptionTarget }>>();
+    if (batchProvider && providerMisses.length > 0) {
+      for (const entry of providerMisses) {
+        const key = this.quoteBatchKey(entry.target);
+        const bucket = providerIndexes.get(key) ?? [];
+        bucket.push(entry);
+        providerIndexes.set(key, bucket);
+      }
+      const uniqueTargets = [...providerIndexes.values()].map((bucket) => bucket[0]!.target);
+      const batchResults = await batchProvider.getQuotesBatch!(uniqueTargets, options).catch(() => []);
+      for (const item of batchResults) {
+        if (!item.quote) continue;
+        const key = this.quoteBatchKey(item.target);
+        const sourceKey = this.providerSourceKey(batchProvider);
+        for (const entry of providerIndexes.get(key) ?? []) {
+          const entityKey = this.getEntityKey(entry.target.symbol, entry.target.exchange, entry.target.context?.instrument);
+          const variantKey = this.getTickerVariantCandidates(entry.target.exchange)[0] ?? "";
+          this.cacheResource("quote", entityKey, variantKey, sourceKey, item.quote, this.resolveProviderPolicy("quote", batchProvider));
+          results[entry.index] = { target: entry.target, quote: item.quote };
+        }
+      }
+    }
+
+    await Promise.all(misses.map(async ({ index, target }) => {
+      if (results[index]) return;
+      try {
+        const quote = await this.getQuote(target.symbol, target.exchange, {
+          ...target.context,
+          cacheMode: forceRefresh ? "refresh" : "default",
+        });
+        results[index] = { target, quote };
+      } catch (error) {
+        results[index] = { target, quote: null, error };
+      }
+    }));
+
+    return results.map((result, index) => result ?? { target: targets[index]!, quote: null });
+  }
+
+  async getTickerFinancialsBatch(
+    targets: CachedFinancialsTarget[],
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<TickerFinancialsBatchResult[]> {
+    const forceRefresh = options.forceRefresh === true;
+    const results = new Array<TickerFinancialsBatchResult | null>(targets.length).fill(null);
+    const misses: Array<{ index: number; target: CachedFinancialsTarget }> = [];
+
+    targets.forEach((target, index) => {
+      const context = this.contextFromCachedTarget(target);
+      const cached = this.readCachedMergedFinancialsSelection(target.symbol, target.exchange, context, true);
+      if (cached.value && !forceRefresh) {
+        results[index] = { target, financials: cached.value };
+        return;
+      }
+      misses.push({ index, target });
+    });
+
+    const batchProvider = this.providersInPriorityOrder().find((provider) => provider.getTickerFinancialsBatch);
+    const providerMisses = misses.filter(({ target }) => !this.hasCachedTargetBrokerContext(target));
+    const providerIndexes = new Map<string, Array<{ index: number; target: CachedFinancialsTarget }>>();
+    if (batchProvider && providerMisses.length > 0) {
+      for (const entry of providerMisses) {
+        const key = this.cachedFinancialsBatchKey(entry.target);
+        const bucket = providerIndexes.get(key) ?? [];
+        bucket.push(entry);
+        providerIndexes.set(key, bucket);
+      }
+      const uniqueTargets = [...providerIndexes.values()].map((bucket) => bucket[0]!.target);
+      const batchResults = await batchProvider.getTickerFinancialsBatch!(uniqueTargets, options).catch(() => []);
+      for (const item of batchResults) {
+        if (!item.financials) continue;
+        const key = this.cachedFinancialsBatchKey(item.target);
+        const value = resolveTickerFinancialsQuoteState(normalizeTickerFinancialsPriceHistory(item.financials));
+        if (!value) continue;
+        const sourceKey = this.providerSourceKey(batchProvider);
+        for (const entry of providerIndexes.get(key) ?? []) {
+          const entityKey = this.getEntityKey(entry.target.symbol, entry.target.exchange, entry.target.instrument ?? undefined);
+          const variantKey = this.getTickerVariantCandidates(entry.target.exchange)[0] ?? "";
+          this.cacheResource("financials", entityKey, variantKey, sourceKey, value, this.resolveProviderPolicy("financials", batchProvider));
+          results[entry.index] = { target: entry.target, financials: value };
+        }
+      }
+    }
+
+    await Promise.all(misses.map(async ({ index, target }) => {
+      if (results[index]) return;
+      try {
+        const financials = await this.getTickerFinancials(target.symbol, target.exchange, {
+          ...this.contextFromCachedTarget(target),
+          cacheMode: forceRefresh ? "refresh" : "default",
+        });
+        results[index] = { target, financials };
+      } catch (error) {
+        results[index] = { target, financials: null, error };
+      }
+    }));
+
+    return results.map((result, index) => result ?? { target: targets[index]!, financials: null });
   }
 
   async getTickerFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<TickerFinancials> {
@@ -1005,14 +1136,42 @@ export class AssetDataRouter implements DataProvider {
     );
   }
 
-  private getStreamingBrokerCandidate(target: QuoteSubscriptionTarget): BrokerCandidate | null {
-    const hasBrokerContext = !!(
-      target.context?.brokerId
-      || target.context?.brokerInstanceId
-      || target.context?.instrument?.brokerId
-      || target.context?.instrument?.brokerInstanceId
+  private hasBrokerContext(context?: MarketDataRequestContext): boolean {
+    return !!(
+      context?.brokerId ||
+      context?.brokerInstanceId ||
+      context?.instrument?.brokerId ||
+      context?.instrument?.brokerInstanceId
     );
-    if (!hasBrokerContext) return null;
+  }
+
+  private hasCachedTargetBrokerContext(target: CachedFinancialsTarget): boolean {
+    return !!(
+      target.brokerId ||
+      target.brokerInstanceId ||
+      target.instrument?.brokerId ||
+      target.instrument?.brokerInstanceId
+    );
+  }
+
+  private contextFromCachedTarget(target: CachedFinancialsTarget): MarketDataRequestContext {
+    return {
+      brokerId: target.brokerId,
+      brokerInstanceId: target.brokerInstanceId,
+      instrument: target.instrument ?? null,
+    };
+  }
+
+  private quoteBatchKey(target: QuoteSubscriptionTarget): string {
+    return `${target.symbol.trim().toUpperCase()}:${canonicalExchange(target.exchange ?? "")}`;
+  }
+
+  private cachedFinancialsBatchKey(target: CachedFinancialsTarget): string {
+    return `${target.symbol.trim().toUpperCase()}:${canonicalExchange(target.exchange ?? "")}`;
+  }
+
+  private getStreamingBrokerCandidate(target: QuoteSubscriptionTarget): BrokerCandidate | null {
+    if (!this.hasBrokerContext(target.context)) return null;
     return this.getBrokerCandidatesForContext(target.context, false)
       .find((candidate) => typeof candidate.broker.subscribeQuotes === "function") ?? null;
   }

--- a/src/state/app-bootstrap.ts
+++ b/src/state/app-bootstrap.ts
@@ -54,6 +54,8 @@ export interface InitializeAppStateArgs {
   primeCachedFinancials?: (entries: Array<{ ticker: TickerRecord; financials: TickerFinancials }>) => void;
   refreshTicker: (symbol: string, exchange?: string, tickerOverride?: TickerRecord | null, priority?: number) => void;
   refreshQuote: (symbol: string, exchange?: string, tickerOverride?: TickerRecord | null, priority?: number) => void;
+  refreshTickersBatch?: (entries: Array<{ ticker: TickerRecord; priority: number }>) => void;
+  refreshQuotesBatch?: (entries: Array<{ ticker: TickerRecord; priority: number }>) => void;
   autoImportBrokerPositions: (tickerMap: Map<string, TickerRecord>) => Promise<void>;
   persistedBrokerAccounts?: Record<string, BrokerAccount[]>;
 }
@@ -211,11 +213,11 @@ function buildCachedFinancialTarget(ticker: TickerRecord): CachedFinancialsTarge
   };
 }
 
-function resolveCachedFinancialPrimeEntries(
+async function resolveCachedFinancialPrimeEntries(
   refreshPlan: RefreshPlanEntry[],
   sessionSnapshot: AppSessionSnapshot | null | undefined,
   dataProvider: DataProvider,
-): Array<{ ticker: TickerRecord; financials: TickerFinancials }> {
+): Promise<Array<{ ticker: TickerRecord; financials: TickerFinancials }>> {
   if (!dataProvider.getCachedFinancialsForTargets) return [];
 
   const sessionTargetsBySymbol = new Map<string, CachedFinancialsTarget>();
@@ -226,7 +228,7 @@ function resolveCachedFinancialPrimeEntries(
   const financialEntries = refreshPlan.filter((entry) => entry.mode === "financials");
   if (financialEntries.length === 0) return [];
 
-  const cachedFinancials = dataProvider.getCachedFinancialsForTargets(
+  const cachedFinancials = await dataProvider.getCachedFinancialsForTargets(
     financialEntries.map(({ ticker }) => (
       sessionTargetsBySymbol.get(ticker.metadata.ticker.trim().toUpperCase()) ?? buildCachedFinancialTarget(ticker)
     )),
@@ -252,6 +254,8 @@ export async function initializeAppState({
   primeCachedFinancials,
   refreshTicker,
   refreshQuote,
+  refreshTickersBatch,
+  refreshQuotesBatch,
   autoImportBrokerPositions,
   persistedBrokerAccounts = {},
 }: InitializeAppStateArgs): Promise<void> {
@@ -341,7 +345,7 @@ export async function initializeAppState({
   });
 
   if (primeCachedFinancials) {
-    const cachedPrimeEntries = measurePerf(
+    const cachedPrimeEntries = await measurePerfAsync(
       "startup.resolve-cached-financial-prime",
       () => resolveCachedFinancialPrimeEntries(refreshPlan, sessionSnapshot, dataProvider),
       { financialRefreshCount: refreshPlan.filter((entry) => entry.mode === "financials").length },
@@ -362,10 +366,19 @@ export async function initializeAppState({
   });
 
   measurePerf("startup.enqueue-refresh-plan", () => {
-    for (const entry of refreshPlan) {
-      if (entry.mode === "financials") {
+    const financialEntries = refreshPlan.filter((entry) => entry.mode === "financials");
+    const quoteEntries = refreshPlan.filter((entry) => entry.mode === "quote");
+    if (refreshTickersBatch) {
+      refreshTickersBatch(financialEntries.map((entry) => ({ ticker: entry.ticker, priority: entry.priority })));
+    } else {
+      for (const entry of financialEntries) {
         refreshTicker(entry.ticker.metadata.ticker, entry.ticker.metadata.exchange, entry.ticker, entry.priority);
-      } else {
+      }
+    }
+    if (refreshQuotesBatch) {
+      refreshQuotesBatch(quoteEntries.map((entry) => ({ ticker: entry.ticker, priority: entry.priority })));
+    } else {
+      for (const entry of quoteEntries) {
         refreshQuote(entry.ticker.metadata.ticker, entry.ticker.metadata.exchange, entry.ticker, entry.priority);
       }
     }

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -92,6 +92,18 @@ export interface QuoteSubscriptionTarget {
   route?: "auto" | "provider" | "broker";
 }
 
+export interface QuoteBatchResult {
+  target: QuoteSubscriptionTarget;
+  quote: Quote | null;
+  error?: unknown;
+}
+
+export interface TickerFinancialsBatchResult {
+  target: CachedFinancialsTarget;
+  financials: TickerFinancials | null;
+  error?: unknown;
+}
+
 export interface AssetDataProvider {
   readonly id: string;
   readonly name: string;
@@ -99,7 +111,9 @@ export interface AssetDataProvider {
   readonly cachePolicy?: CachePolicyMap;
 
   canProvide?(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<boolean> | boolean;
-  getCachedFinancialsForTargets?(targets: CachedFinancialsTarget[], options?: { allowExpired?: boolean }): Map<string, TickerFinancials>;
+  getCachedFinancialsForTargets?(targets: CachedFinancialsTarget[], options?: { allowExpired?: boolean }): Map<string, TickerFinancials> | Promise<Map<string, TickerFinancials>>;
+  getQuotesBatch?(targets: QuoteSubscriptionTarget[], options?: { forceRefresh?: boolean }): Promise<QuoteBatchResult[]>;
+  getTickerFinancialsBatch?(targets: CachedFinancialsTarget[], options?: { forceRefresh?: boolean }): Promise<TickerFinancialsBatchResult[]>;
   getTickerFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<TickerFinancials>;
   getQuote(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<Quote>;
   getExchangeRate(fromCurrency: string): Promise<number>;

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -16,6 +16,7 @@ import { normalizeTimestamp } from "./timestamp";
 
 const DEFAULT_API_URL = "https://api.gloom.sh";
 const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
+const QUOTE_SUBSCRIPTION_FLUSH_MS = 25;
 const cloudApiLog = debugLog.createLogger("cloud-api");
 const HARD_SESSION_INVALID_PATTERNS = [
   /\b(user|account)\b.*\b(not found|deleted|removed|disabled|deactivated|suspended)\b/i,
@@ -306,6 +307,23 @@ export interface CloudMarketResponse<T> {
   };
 }
 
+export interface CloudMarketBatchTarget {
+  symbol: string;
+  exchange?: string;
+}
+
+export interface CloudMarketBatchItem<T> {
+  symbol: string;
+  exchange: string;
+  status: CloudMarketStatus;
+  data: T | null;
+  reasonCode?: string;
+}
+
+export interface CloudMarketBatchPayload<T> {
+  items: Array<CloudMarketBatchItem<T>>;
+}
+
 export interface CloudVerificationResponse {
   sent: boolean;
   email?: string;
@@ -392,6 +410,9 @@ class GloomApiClient {
   private readonly channelListeners = new Map<string, Set<ChannelListener>>();
   private readonly quoteListeners = new Map<string, Set<QuoteListener>>();
   private readonly quoteTargets = new Map<string, QuoteStreamTarget>();
+  private readonly pendingQuoteSubscribes = new Map<string, QuoteStreamTarget>();
+  private readonly pendingQuoteUnsubscribes = new Map<string, QuoteStreamTarget>();
+  private quoteSubscriptionFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     this.baseUrl = getCloudApiBaseUrl();
@@ -654,6 +675,62 @@ class GloomApiClient {
     }
   }
 
+  private scheduleQuoteSubscriptionFlush(): void {
+    if (this.quoteSubscriptionFlushTimer) return;
+    this.quoteSubscriptionFlushTimer = setTimeout(() => {
+      this.quoteSubscriptionFlushTimer = null;
+      this.flushQueuedQuoteSubscriptions();
+    }, QUOTE_SUBSCRIPTION_FLUSH_MS);
+  }
+
+  private queueQuoteSubscribes(targets: QuoteStreamTarget[]): void {
+    for (const target of targets) {
+      const key = marketKey(target.symbol, target.exchange);
+      this.pendingQuoteUnsubscribes.delete(key);
+      this.pendingQuoteSubscribes.set(key, target);
+    }
+    this.scheduleQuoteSubscriptionFlush();
+  }
+
+  private queueQuoteUnsubscribes(targets: QuoteStreamTarget[]): void {
+    for (const target of targets) {
+      const key = marketKey(target.symbol, target.exchange);
+      if (this.pendingQuoteSubscribes.delete(key)) continue;
+      this.pendingQuoteUnsubscribes.set(key, target);
+    }
+    this.scheduleQuoteSubscriptionFlush();
+  }
+
+  private flushQueuedQuoteSubscriptions(): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) {
+      this.pendingQuoteSubscribes.clear();
+      this.pendingQuoteUnsubscribes.clear();
+      return;
+    }
+    const subscribes = [...this.pendingQuoteSubscribes.values()];
+    const unsubscribes = [...this.pendingQuoteUnsubscribes.values()];
+    this.pendingQuoteSubscribes.clear();
+    this.pendingQuoteUnsubscribes.clear();
+    if (subscribes.length > 0) {
+      this.sendSocketMessage({
+        type: "market.subscribe",
+        symbols: subscribes.map((target) => ({
+          symbol: target.symbol,
+          exchange: target.exchange ?? "",
+        })),
+      });
+    }
+    if (unsubscribes.length > 0) {
+      this.sendSocketMessage({
+        type: "market.unsubscribe",
+        symbols: unsubscribes.map((target) => ({
+          symbol: target.symbol,
+          exchange: target.exchange ?? "",
+        })),
+      });
+    }
+  }
+
   private async handleSocketMessage(raw: string): Promise<void> {
     let parsed: any;
     try {
@@ -879,13 +956,7 @@ class GloomApiClient {
         count: newSubscriptions.length,
         symbols: newSubscriptions.map((target) => marketKey(target.symbol, target.exchange)),
       });
-      this.sendSocketMessage({
-        type: "market.subscribe",
-        symbols: newSubscriptions.map((target) => ({
-          symbol: target.symbol,
-          exchange: target.exchange ?? "",
-        })),
-      });
+      this.queueQuoteSubscribes(newSubscriptions);
     }
 
     return () => {
@@ -911,13 +982,7 @@ class GloomApiClient {
           count: removedTargets.length,
           symbols: removedTargets.map((target) => marketKey(target.symbol, target.exchange)),
         });
-        this.sendSocketMessage({
-          type: "market.unsubscribe",
-          symbols: removedTargets.map((target) => ({
-            symbol: target.symbol,
-            exchange: target.exchange ?? "",
-          })),
-        });
+        this.queueQuoteUnsubscribes(removedTargets);
       }
 
       if (!this.shouldKeepSocketOpen()) {
@@ -934,6 +999,12 @@ class GloomApiClient {
     this.channelListeners.clear();
     this.quoteListeners.clear();
     this.quoteTargets.clear();
+    this.pendingQuoteSubscribes.clear();
+    this.pendingQuoteUnsubscribes.clear();
+    if (this.quoteSubscriptionFlushTimer) {
+      clearTimeout(this.quoteSubscriptionFlushTimer);
+      this.quoteSubscriptionFlushTimer = null;
+    }
     this.reconnectDelayMs = 1000;
     this.teardownSocket();
   }
@@ -953,6 +1024,16 @@ class GloomApiClient {
     return this.request<CloudMarketResponse<CloudQuotePayload>>(`/market/quote?${params.toString()}`);
   }
 
+  async getCloudQuotesBatch(
+    targets: CloudMarketBatchTarget[],
+    mode: "cache-first" | "refresh" = "cache-first",
+  ): Promise<CloudMarketResponse<CloudMarketBatchPayload<CloudQuotePayload>>> {
+    return this.request<CloudMarketResponse<CloudMarketBatchPayload<CloudQuotePayload>>>("/market/quotes/batch", {
+      method: "POST",
+      body: JSON.stringify({ targets, mode }),
+    });
+  }
+
   async getCloudProfile(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudCompanyProfile>> {
     const params = new URLSearchParams({ symbol });
     if (exchange) params.set("exchange", exchange);
@@ -963,6 +1044,22 @@ class GloomApiClient {
     const params = new URLSearchParams({ symbol });
     if (exchange) params.set("exchange", exchange);
     return this.request<CloudMarketResponse<CloudFundamentals>>(`/market/fundamentals?${params.toString()}`);
+  }
+
+  async getCloudFinancials(symbol: string, exchange?: string): Promise<CloudMarketResponse<TickerFinancials>> {
+    const params = new URLSearchParams({ symbol });
+    if (exchange) params.set("exchange", exchange);
+    return this.request<CloudMarketResponse<TickerFinancials>>(`/market/financials?${params.toString()}`);
+  }
+
+  async getCloudFinancialsBatch(
+    targets: CloudMarketBatchTarget[],
+    mode: "cache-first" | "refresh" = "cache-first",
+  ): Promise<CloudMarketResponse<CloudMarketBatchPayload<TickerFinancials>>> {
+    return this.request<CloudMarketResponse<CloudMarketBatchPayload<TickerFinancials>>>("/market/financials/batch", {
+      method: "POST",
+      body: JSON.stringify({ targets, mode }),
+    });
   }
 
   async getCloudHolders(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudHoldersPayload>> {


### PR DESCRIPTION
Speeds up portfolio and watchlist hydration by adding cache-first batch quote and financial APIs through the cloud provider, router, coordinator, and desktop capability bridge.

Startup primes cached financial rows before initialization and enqueues batched quote and snapshot refresh work instead of per-ticker waterfalls. Visible portfolio warmups load one batch for the window, quote subscriptions are aggregated and batched to reduce websocket churn, and ticker tables preserve manual scroll when market data reorders rows around the same selected cursor.