### PR TITLE
Stack narrow Fear and Greed pane layout

### DIFF
--- a/src/components/speedometer-gauge.tsx
+++ b/src/components/speedometer-gauge.tsx
@@ -20,6 +20,7 @@ export interface SpeedometerGaugeProps {
   currentLabel?: string;
   minWidth?: number;
   maxWidth?: number;
+  compact?: boolean;
 }
 
 interface GaugeCell {
@@ -43,6 +44,7 @@ const DEFAULT_MIN_WIDTH = 34;
 const DEFAULT_MAX_WIDTH = 50;
 const DESKTOP_VIEWBOX_WIDTH = 520;
 const DESKTOP_VIEWBOX_HEIGHT = 232;
+const DESKTOP_COMPACT_VIEWBOX_HEIGHT = 214;
 const DESKTOP_CENTER_X = 260;
 const DESKTOP_CENTER_Y = 182;
 const DESKTOP_ARC_RADIUS = 138;
@@ -351,21 +353,24 @@ function DesktopGauge({
   currentLabel,
   minWidth,
   maxWidth,
+  compact,
 }: Required<SpeedometerGaugeProps>) {
   const gaugeWidth = Math.min(Math.max(width - 2, minWidth), maxWidth);
+  const gaugeHeight = compact ? 9 : 12;
+  const viewBoxHeight = compact ? DESKTOP_COMPACT_VIEWBOX_HEIGHT : DESKTOP_VIEWBOX_HEIGHT;
   const needleAngle = valueToDegrees(value, min, max);
   const needleEnd = polarToCartesian(DESKTOP_CENTER_X, DESKTOP_CENTER_Y, DESKTOP_NEEDLE_RADIUS, needleAngle);
 
   return (
     <Box
       width={gaugeWidth}
-      height={12}
-      marginTop={1}
+      height={gaugeHeight}
+      marginTop={compact ? 0 : 1}
       overflow="hidden"
       style={{ alignSelf: "center", maxWidth: 420 }}
     >
       <svg
-        viewBox={`0 0 ${DESKTOP_VIEWBOX_WIDTH} ${DESKTOP_VIEWBOX_HEIGHT}`}
+        viewBox={`0 0 ${DESKTOP_VIEWBOX_WIDTH} ${viewBoxHeight}`}
         width="100%"
         height="100%"
         role="img"
@@ -535,6 +540,7 @@ export function SpeedometerGauge({
   currentLabel = "Current reading",
   minWidth = DEFAULT_MIN_WIDTH,
   maxWidth = DEFAULT_MAX_WIDTH,
+  compact = false,
 }: SpeedometerGaugeProps) {
   const props = {
     value,
@@ -546,6 +552,7 @@ export function SpeedometerGauge({
     currentLabel,
     minWidth,
     maxWidth,
+    compact,
   };
   return useUiHost().kind === "desktop-web"
     ? <DesktopGauge {...props} />

--- a/src/plugins/builtin/fear-greed/index.tsx
+++ b/src/plugins/builtin/fear-greed/index.tsx
@@ -16,6 +16,8 @@ import {
 } from "./fear-greed-data";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const DESKTOP_SUMMARY_STACK_WIDTH = 84;
+const CHART_META_STACK_WIDTH = 84;
 const FEAR_GREED_GAUGE_SEGMENTS: SpeedometerSegment[] = [
   { from: 0, to: 24.999, label: "EXTREME FEAR", color: colors.negative },
   { from: 25, to: 44.999, label: "FEAR", color: colors.warning },
@@ -141,7 +143,7 @@ function PreviousScoreGrid({ data, width, layout = "grid" }: { data: FearGreedDa
     { label: "1 month ago", value: data.overall.previousMonth },
     { label: "1 year ago", value: data.overall.previousYear },
   ];
-  const columns = width >= 84 ? 4 : 2;
+  const columns = width >= 84 ? 4 : width >= 42 ? 2 : 1;
   const columnWidth = Math.max(18, Math.floor((width - 2) / columns));
   const rows = Array.from({ length: Math.ceil(items.length / columns) }, (_, rowIndex) => (
     items.slice(rowIndex * columns, rowIndex * columns + columns)
@@ -226,6 +228,7 @@ function SentimentChart({
   overlays?: ChartIndicatorOverlays | null;
 }) {
   const isDesktopWeb = useUiHost().kind === "desktop-web";
+  const stackMeta = width < CHART_META_STACK_WIDTH;
   const chartWidth = Math.max(24, width - 2);
   const chartHeight = width >= 96 ? 12 : 10;
   const color = ratingColor(rating);
@@ -245,27 +248,36 @@ function SentimentChart({
         <Box flexGrow={1} />
         <SentimentBadge rating={rating} />
       </Box>
-      <Box flexDirection="row" height={1}>
-        <Text fg={color}>● </Text>
-        <Text fg={colors.textDim}>{primaryLabel}</Text>
-        {secondaryLabel ? (
-          <>
-            <Text fg={colors.warning}>  ● </Text>
-            <Text fg={colors.textDim}>{secondaryLabel}</Text>
-          </>
-        ) : null}
-        <Box flexGrow={1} />
-        <Text fg={colors.textDim}>score </Text>
-        <Text fg={color} attributes={TextAttributes.BOLD}>{formatScore(score)}</Text>
-        <Text fg={colors.textDim}>  latest </Text>
-        <Text fg={colors.text}>{formatIndicatorValue(latest, valueFormat)}</Text>
-        {secondaryLabel && secondaryValue != null ? (
-          <>
-            <Text fg={colors.textDim}>  avg </Text>
-            <Text fg={colors.text}>{formatIndicatorValue(secondaryValue, valueFormat)}</Text>
-          </>
-        ) : null}
-      </Box>
+      {stackMeta ? (
+        <>
+          <Box flexDirection="row" height={1} overflow="hidden">
+            <SeriesLegend color={color} primaryLabel={primaryLabel} secondaryLabel={secondaryLabel} />
+          </Box>
+          <Box flexDirection="row" height={1} overflow="hidden">
+            <ChartStats
+              color={color}
+              latest={latest}
+              score={score}
+              secondaryLabel={secondaryLabel}
+              secondaryValue={secondaryValue}
+              valueFormat={valueFormat}
+            />
+          </Box>
+        </>
+      ) : (
+        <Box flexDirection="row" height={1} overflow="hidden">
+          <SeriesLegend color={color} primaryLabel={primaryLabel} secondaryLabel={secondaryLabel} />
+          <Box flexGrow={1} />
+          <ChartStats
+            color={color}
+            latest={latest}
+            score={score}
+            secondaryLabel={secondaryLabel}
+            secondaryValue={secondaryValue}
+            valueFormat={valueFormat}
+          />
+        </Box>
+      )}
       {points.length >= 2 ? (
         <Box marginTop={1}>
           <StaticChartSurface
@@ -290,6 +302,60 @@ function SentimentChart({
         <Text fg={colors.textDim}>{formatUpdatedAt(updatedAt)}</Text>
       </Box>
     </Box>
+  );
+}
+
+function SeriesLegend({
+  color,
+  primaryLabel,
+  secondaryLabel,
+}: {
+  color: string;
+  primaryLabel: string;
+  secondaryLabel?: string;
+}) {
+  return (
+    <>
+      <Text fg={color}>● </Text>
+      <Text fg={colors.textDim}>{primaryLabel}</Text>
+      {secondaryLabel ? (
+        <>
+          <Text fg={colors.warning}>  ● </Text>
+          <Text fg={colors.textDim}>{secondaryLabel}</Text>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+function ChartStats({
+  color,
+  latest,
+  score,
+  secondaryLabel,
+  secondaryValue,
+  valueFormat,
+}: {
+  color: string;
+  latest: number | null;
+  score: number | null;
+  secondaryLabel?: string;
+  secondaryValue?: number | null;
+  valueFormat: FearGreedValueFormat;
+}) {
+  return (
+    <>
+      <Text fg={colors.textDim}>score </Text>
+      <Text fg={color} attributes={TextAttributes.BOLD}>{formatScore(score)}</Text>
+      <Text fg={colors.textDim}>  latest </Text>
+      <Text fg={colors.text}>{formatIndicatorValue(latest, valueFormat)}</Text>
+      {secondaryLabel && secondaryValue != null ? (
+        <>
+          <Text fg={colors.textDim}>  avg </Text>
+          <Text fg={colors.text}>{formatIndicatorValue(secondaryValue, valueFormat)}</Text>
+        </>
+      ) : null}
+    </>
   );
 }
 
@@ -368,6 +434,11 @@ function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
     void load(true);
   }, [load]);
 
+  const stackDesktopSummary = isDesktopWeb && width < DESKTOP_SUMMARY_STACK_WIDTH;
+  const desktopSummaryRailWidth = stackDesktopSummary ? Math.max(18, Math.min(width - 2, 42)) : 26;
+  const desktopSummaryGaugeMaxWidth = Math.max(1, Math.min(width - 2, 50));
+  const desktopSummaryGaugeMinWidth = Math.min(34, desktopSummaryGaugeMaxWidth);
+
   useShortcut((event) => {
     if (!focused) return;
     if (event.name === "r") {
@@ -417,14 +488,25 @@ function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
       <ScrollBox flexGrow={1} scrollY focusable={false}>
         <Box flexDirection="column" paddingBottom={1}>
           {isDesktopWeb ? (
-            <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4} paddingX={1}>
+            <Box
+              flexDirection={stackDesktopSummary ? "column" : "row"}
+              alignItems="center"
+              justifyContent="center"
+              gap={stackDesktopSummary ? 0 : 4}
+              paddingX={1}
+            >
               <SpeedometerGauge
                 value={data.overall.score}
                 valueLabel={ratingLabel(data.overall.rating)}
                 width={width}
                 segments={FEAR_GREED_GAUGE_SEGMENTS}
+                minWidth={stackDesktopSummary ? desktopSummaryGaugeMinWidth : undefined}
+                maxWidth={stackDesktopSummary ? desktopSummaryGaugeMaxWidth : undefined}
+                compact={stackDesktopSummary}
               />
-              <PreviousScoreGrid data={data} width={26} layout="rail" />
+              <Box marginTop={0}>
+                <PreviousScoreGrid data={data} width={desktopSummaryRailWidth} layout="rail" />
+              </Box>
             </Box>
           ) : (
             <>


### PR DESCRIPTION
Stacks the Fear & Greed summary vertically in narrow desktop panes so the previous-score rail no longer clips beside the speedometer.
Adds a compact desktop gauge mode for stacked layouts to reduce empty space around the dial.
Splits chart legend and score metadata onto separate rows at narrow widths so indicator headers remain readable.
