### PR TITLE
Centralize tab keyboard handling

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -272,6 +272,7 @@ function CommandBarHarness({
     ...createInitialState(config),
     commandBarOpen: true,
     commandBarQuery: query,
+    focusedPaneId: "portfolio-list:main",
     tickers: new Map(tickers.map((ticker) => [ticker.metadata.ticker, ticker])),
     config: { ...config, disabledPlugins },
     paneState: selectedTicker

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useRendererHost, useUiCapabilities } from "../../ui";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShortcut, useViewport } from "../../react/input";
 import { useAppDispatch, useAppSelector } from "../../state/app-context";
 import type { DesktopWindowBridge } from "../../types/desktop-window";
@@ -11,6 +11,11 @@ import { PaneContent } from "./pane-content";
 import { getPaneBodyWidth } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX, TITLEBAR_TRAFFIC_LIGHT_WIDTH } from "./titlebar-overlay";
+import {
+  createDoubleEscapeCloseState,
+  recordDoubleEscapeClose,
+  resetDoubleEscapeClose,
+} from "../../utils/double-escape-close";
 
 interface DetachedPaneShellProps {
   pluginRegistry: PluginRegistry;
@@ -28,6 +33,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
   const config = useAppSelector((state) => state.config);
   const paneState = useAppSelector((state) => state.paneState);
   const inputCaptured = useAppSelector((state) => state.inputCaptured);
+  const doubleEscapeCloseRef = useRef(createDoubleEscapeCloseState());
   const [windowFocused, setWindowFocused] = useState(() => (
     typeof document === "undefined" ? true : document.hasFocus()
   ));
@@ -73,6 +79,21 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
       window.removeEventListener("blur", handleBlur);
     };
   }, [focusPane]);
+
+  useShortcut((event) => {
+    const doubleEscapeState = doubleEscapeCloseRef.current;
+    const isEscape = event.name === "escape" || event.name === "esc";
+    if (isEscape) {
+      if (recordDoubleEscapeClose(doubleEscapeState, desktopWindowBridge.paneId, Date.now())) {
+        event.preventDefault();
+        event.stopPropagation();
+        void desktopWindowBridge.closeDetachedPane?.(desktopWindowBridge.paneId);
+      }
+      return;
+    }
+
+    resetDoubleEscapeClose(doubleEscapeState);
+  }, { phase: "before" });
 
   useShortcut((event) => {
     if (event.name !== "w" || (!event.ctrl && !event.meta && !event.super)) return;

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -6,6 +6,7 @@ import { act, createElement, useReducer } from "react";
 import { AppContext, appReducer, createInitialState } from "../../state/app-context";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { setSharedMarketDataForTests } from "../../plugins/registry";
+import { useShortcut } from "../../react/input";
 import { cloneLayout, createDefaultConfig } from "../../types/config";
 import type { PluginRegistry } from "../../plugins/registry";
 import { setSharedRegistryForTests } from "../../plugins/registry";
@@ -16,6 +17,7 @@ import type { PaneProps } from "../../types/plugin";
 import { StockChart } from "../chart/stock-chart";
 import { StatusBar } from "./status-bar";
 import { Header } from "./header";
+import { DetachedPaneShell } from "./detached-pane-shell";
 import {
   buildNativeWindowState,
   constrainFloatingRectToBounds,
@@ -209,6 +211,31 @@ function createChartShellDataProvider(historyBySymbol: Record<string, PricePoint
     getArticleSummary: async () => null,
     getPriceHistory: async (symbol) => historyBySymbol[symbol] ?? [],
   };
+}
+
+async function emitKeypress(event: { name?: string; sequence?: string }) {
+  await act(async () => {
+    const keyEvent = {
+      ctrl: false,
+      meta: false,
+      option: false,
+      shift: false,
+      eventType: "press",
+      repeated: false,
+      defaultPrevented: false,
+      propagationStopped: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+      stopPropagation() {
+        this.propagationStopped = true;
+      },
+      ...event,
+    };
+    testSetup!.renderer.keyInput.emit("keypress", keyEvent as any);
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
 }
 
 function HeaderHarness({
@@ -933,6 +960,177 @@ describe("Shell", () => {
     expect(updateLayout?.layout.instances).toEqual([]);
     expect(updateLayout?.layout.floating).toEqual([]);
     expect(updateLayout?.layout.dockRoot).toBeNull();
+  });
+
+  test("closes the focused pane after double Escape", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    if (!mainPane) throw new Error("missing default portfolio pane");
+
+    const singlePaneLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }],
+      floating: [],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(singlePaneLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(singlePaneLayout) }],
+      }),
+      focusedPaneId: "portfolio-list:main",
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <TestDialogProvider>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 10 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(actions).toContainEqual({ type: "PUSH_LAYOUT_HISTORY" });
+    expect(updateLayout?.layout.instances).toEqual([]);
+    expect(updateLayout?.layout.floating).toEqual([]);
+    expect(updateLayout?.layout.dockRoot).toBeNull();
+  });
+
+  test("closes on double Escape even when the focused pane handles the first Escape", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    if (!mainPane) throw new Error("missing default portfolio pane");
+
+    let consumedEscapes = 0;
+    function EscapeConsumerPane() {
+      useShortcut((event) => {
+        if (event.name !== "escape") return;
+        consumedEscapes += 1;
+        event.preventDefault();
+        event.stopPropagation();
+      });
+      return <text>Escape Consumer</text>;
+    }
+
+    const singlePaneLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }],
+      floating: [],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(singlePaneLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(singlePaneLayout) }],
+      }),
+      focusedPaneId: "portfolio-list:main",
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <TestDialogProvider>
+          <Shell
+            pluginRegistry={createShellPluginRegistry({
+              portfolioListComponent: EscapeConsumerPane,
+            })}
+          />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 10 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    expect(consumedEscapes).toBe(1);
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(consumedEscapes).toBe(1);
+    expect(updateLayout?.layout.dockRoot).toBeNull();
+  });
+
+  test("closes on double Escape while pane input is captured", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    if (!mainPane) throw new Error("missing default portfolio pane");
+
+    const singlePaneLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }],
+      floating: [],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(singlePaneLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(singlePaneLayout) }],
+      }),
+      focusedPaneId: "portfolio-list:main",
+      inputCaptured: true,
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <TestDialogProvider>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 10 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(updateLayout?.layout.dockRoot).toBeNull();
+  });
+
+  test("closes a detached pane window after double Escape", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const state = {
+      ...createInitialState(config),
+      focusedPaneId: "portfolio-list:main",
+    };
+    const closedPaneIds: string[] = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <TestDialogProvider>
+          <DetachedPaneShell
+            pluginRegistry={createShellPluginRegistry()}
+            desktopWindowBridge={{
+              kind: "detached",
+              paneId: "portfolio-list:main",
+              subscribeState: () => () => {},
+              closeDetachedPane: async (paneId) => {
+                closedPaneIds.push(paneId);
+              },
+            }}
+          />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 10 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    expect(closedPaneIds).toEqual([]);
+
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    expect(closedPaneIds).toEqual(["portfolio-list:main"]);
   });
 
   test("closes the focused floating pane with Ctrl+W", async () => {

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -58,6 +58,11 @@ import {
   getShortcutDisplayMode,
   type ShortcutDisplayMode,
 } from "../../utils/shortcut-labels";
+import {
+  createDoubleEscapeCloseState,
+  recordDoubleEscapeClose,
+  resetDoubleEscapeClose,
+} from "../../utils/double-escape-close";
 
 interface ShellProps {
   pluginRegistry: PluginRegistry;
@@ -808,6 +813,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   const overlayOpen = commandBarOpen || dialogOpen || !!menuState;
 
   const dragRef = useRef<DragMode | null>(null);
+  const doubleEscapeCloseRef = useRef(createDoubleEscapeCloseState());
   const [dragFloatingRect, setDragFloatingRect] = useState<{ paneId: string; rect: FloatingRect } | null>(null);
   const [dragCursor, setDragCursor] = useState<{ x: number; y: number } | null>(null);
   const [dividerPreview, setDividerPreview] = useState<DividerPreviewState | null>(null);
@@ -964,13 +970,36 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     return true;
   }, [contentHeight, persistLayout, visibleLayout, width]);
 
+  useEffect(() => {
+    if (overlayOpen) {
+      resetDoubleEscapeClose(doubleEscapeCloseRef.current);
+    }
+  }, [overlayOpen]);
+
   useShortcut((event) => {
-    if (event.name === "escape") {
+    const isEscape = event.name === "escape" || event.name === "esc";
+    if (isEscape) {
+      const doubleEscapeState = doubleEscapeCloseRef.current;
+      if (!dragRef.current && !overlayOpen) {
+        if (recordDoubleEscapeClose(doubleEscapeState, focusedPaneId, Date.now()) && closeFocusedPane()) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+      } else {
+        resetDoubleEscapeClose(doubleEscapeState);
+      }
+
       if (!dragRef.current) return;
       cancelActiveDrag();
-      return;
+      event.preventDefault();
+      event.stopPropagation();
+    } else {
+      resetDoubleEscapeClose(doubleEscapeCloseRef.current);
     }
+  }, { phase: "before" });
 
+  useShortcut((event) => {
     const shortcut = resolvePaneManagementShortcut(event);
     if (!shortcut || dragRef.current || overlayOpen) return;
     if (inputCaptured && !inputCaptureAllowsPaneManagementShortcut(shortcut, event)) return;

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useShortcut } from "../../react/input";
 import { Box, ScrollBox, Text, useUiHost } from "../../ui";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
@@ -21,6 +22,8 @@ export interface TabsProps {
   closeMode?: "active" | "always";
   addLabel?: string;
   onAdd?: () => void;
+  focused?: boolean;
+  keyboardNavigation?: boolean;
 }
 
 const WHEEL_DELTA_PER_CELL = 8;
@@ -34,6 +37,8 @@ export function Tabs({
   closeMode = "always",
   addLabel = "+",
   onAdd,
+  focused = false,
+  keyboardNavigation = true,
 }: TabsProps) {
   const ui = useUiHost();
   const NativeTabs = ui.Tabs;
@@ -51,6 +56,34 @@ export function Tabs({
     closeFg: colors.textMuted,
     addFg: colors.textMuted,
   };
+  const selectAdjacentTab = useCallback((direction: -1 | 1) => {
+    const enabledTabs = tabs.filter((tab) => !tab.disabled);
+    if (enabledTabs.length === 0) return;
+
+    const activeIndex = enabledTabs.findIndex((tab) => tab.value === activeValue);
+    const nextIndex = activeIndex >= 0
+      ? Math.max(0, Math.min(activeIndex + direction, enabledTabs.length - 1))
+      : direction > 0 ? 0 : enabledTabs.length - 1;
+    const nextTab = enabledTabs[nextIndex];
+    if (!nextTab || nextTab.value === activeValue) return;
+    onSelect(nextTab.value);
+  }, [activeValue, onSelect, tabs]);
+
+  useShortcut((event) => {
+    if (event.ctrl || event.meta || event.alt || event.targetEditable) return;
+
+    if (event.name === "h" || event.name === "left") {
+      event.preventDefault();
+      event.stopPropagation();
+      selectAdjacentTab(-1);
+      return;
+    }
+    if (event.name === "l" || event.name === "right") {
+      event.preventDefault();
+      event.stopPropagation();
+      selectAdjacentTab(1);
+    }
+  }, { enabled: focused && keyboardNavigation });
 
   if (NativeTabs) {
     return (

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -333,6 +333,46 @@ describe("shared UI kit", () => {
     expect(frame).toContain("Insider");
   });
 
+  test("moves focused tabs with arrow keys and leaves Tab for pane focus", async () => {
+    let lastSelected = "overview";
+
+    function KeyboardTabsHarness() {
+      const [activeValue, setActiveValue] = useState("overview");
+      return (
+        <Tabs
+          tabs={[
+            { label: "Overview", value: "overview" },
+            { label: "News", value: "news" },
+            { label: "Chart", value: "chart" },
+          ]}
+          activeValue={activeValue}
+          onSelect={(value) => {
+            lastSelected = value;
+            setActiveValue(value);
+          }}
+          focused
+        />
+      );
+    }
+
+    testSetup = await testRender(<KeyboardTabsHarness />, { width: 40, height: 4 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      testSetup!.mockInput.pressArrow("right");
+      await testSetup!.renderOnce();
+    });
+
+    expect(lastSelected).toBe("news");
+
+    await act(async () => {
+      testSetup!.mockInput.pressTab();
+      await testSetup!.renderOnce();
+    });
+
+    expect(lastSelected).toBe("news");
+  });
+
   test("renders tab actions for editable tab sets", async () => {
     testSetup = await testRender(
       <Tabs

--- a/src/plugins/builtin/ai/screener-pane.tsx
+++ b/src/plugins/builtin/ai/screener-pane.tsx
@@ -759,11 +759,11 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
       removeTab(activeTab.id);
       return;
     }
-    if (event.name === "[" || event.name === "left") {
+    if (event.name === "[") {
       cycleTabs(-1);
       return;
     }
-    if (event.name === "]" || event.name === "right") {
+    if (event.name === "]") {
       cycleTabs(1);
       return;
     }
@@ -917,6 +917,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
           variant="pill"
           closeMode="active"
           onAdd={editorState ? undefined : addTab}
+          focused={focused && !editorState}
         />
       </Box>
 

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -1,7 +1,6 @@
 import { Box, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TextAttributes } from "../../../ui";
-import { useShortcut } from "../../../react/input";
 import { DataTableView, Tabs, type DataTableColumn } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import type { ColumnConfig } from "../../../types/config";
@@ -278,7 +277,6 @@ export function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     () => portfolios.find((portfolio) => portfolio.id === activePortfolioId) ?? null,
     [activePortfolioId, portfolios],
   );
-  const activePortfolioIndex = portfolios.findIndex((portfolio) => portfolio.id === activePortfolioId);
   const portfolioTabs = useMemo(
     () => portfolios.map((portfolio) => ({ label: portfolio.name, value: portfolio.id })),
     [portfolios],
@@ -555,22 +553,6 @@ export function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     setSectorSort((current) => nextSectorSortPreference(current, columnId));
   }, []);
 
-  useShortcut((event) => {
-    if (!focused) return;
-
-    const key = event.name;
-    if ((key === "h" || key === "left") && activePortfolioIndex > 0) {
-      const previousPortfolio = portfolios[activePortfolioIndex - 1];
-      if (previousPortfolio) handlePortfolioSelect(previousPortfolio.id);
-      return;
-    }
-    if ((key === "l" || key === "right") && activePortfolioIndex >= 0 && activePortfolioIndex < portfolios.length - 1) {
-      const nextPortfolio = portfolios[activePortfolioIndex + 1];
-      if (nextPortfolio) handlePortfolioSelect(nextPortfolio.id);
-      return;
-    }
-  });
-
   useEffect(() => {
     if (activePortfolioId !== currentPortfolioId) {
       setCurrentPortfolioId(activePortfolioId);
@@ -592,6 +574,7 @@ export function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
                 activeValue={activePortfolioId}
                 onSelect={handlePortfolioSelect}
                 compact
+                focused={focused}
               />
             </Box>
           </Box>

--- a/src/plugins/builtin/cloud-tweets.tsx
+++ b/src/plugins/builtin/cloud-tweets.tsx
@@ -863,6 +863,7 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
           variant="pill"
           closeMode="active"
           onAdd={editorState ? undefined : openCreateEditor}
+          focused={focused && !editorState}
         />
       </Box>
 

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -866,6 +866,7 @@ function HoldersView({ focused, width, height }: { focused: boolean; width: numb
           onSelect={(value) => setViewMode(value as ViewMode)}
           compact
           variant="bare"
+          focused={focused}
         />
       </Box>
 

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -345,22 +345,6 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
   const handleTableKeyDown = useCallback((event: DataTableKeyEvent) => {
     const key = event.name;
 
-    if (key === "tab" || key === "right" || key === "l") {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      const currentTabIdx = TABS.findIndex((t) => t.id === activeTab);
-      setActiveTab(TABS[(currentTabIdx + 1) % TABS.length]!.id);
-      setSelectedSymbol(null);
-      return true;
-    }
-    if (key === "left" || key === "h") {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      const currentTabIdx = TABS.findIndex((t) => t.id === activeTab);
-      setActiveTab(TABS[(currentTabIdx - 1 + TABS.length) % TABS.length]!.id);
-      setSelectedSymbol(null);
-      return true;
-    }
     if (key === "r") {
       event.preventDefault?.();
       event.stopPropagation?.();
@@ -451,6 +435,7 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
           }}
           compact
           variant="bare"
+          focused={focused}
         />
       </Box>
 

--- a/src/plugins/builtin/news-wire/industry-pane.tsx
+++ b/src/plugins/builtin/news-wire/industry-pane.tsx
@@ -65,21 +65,6 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     setSelectedArticleId(null);
   }, [category, setSelectedArticleId]);
 
-  const handleRootKeyDown = (event: {
-    name?: string;
-    preventDefault?: () => void;
-    stopPropagation?: () => void;
-  }) => {
-    if (event.name !== "left" && event.name !== "right" && event.name !== "h" && event.name !== "l") return;
-    event.stopPropagation?.();
-    event.preventDefault?.();
-    const index = SECTOR_TABS.indexOf(category);
-    const delta = event.name === "left" || event.name === "h" ? -1 : 1;
-    const nextIndex = Math.max(0, Math.min(SECTOR_TABS.length - 1, index + delta));
-    setCategory(SECTOR_TABS[nextIndex]!);
-    return true;
-  };
-
   useNewsArticleFooter({
     registrationId: "news-wire:industry",
     focused,
@@ -94,6 +79,7 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
         onSelect={(value) => setCategory(value as SectorNewsSelection)}
         compact
         variant="bare"
+        focused={focused}
       />
     </Box>
   );
@@ -127,7 +113,6 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
       detailContent={detailContent}
       detailTitle={detailArticle?.title}
       rootBefore={rootBefore}
-      onRootKeyDown={handleRootKeyDown}
       columns={["time", "source", "title", "tickers", "categories"]}
       emptyContent={loading && articles.length === 0 ? (
         <Box width="100%" paddingX={1} paddingY={1}>

--- a/src/plugins/builtin/notes.tsx
+++ b/src/plugins/builtin/notes.tsx
@@ -473,6 +473,7 @@ function createQuickNotesPane(notesFiles: NotesFiles) {
             variant="pill"
             closeMode="active"
             onAdd={addTab}
+            focused={focused && !editing && !renaming}
           />
         </Box>
         {/* Rename input */}

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -246,23 +246,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       return true;
     }
 
-    if (!interactive) return false;
-
-    const numExp = chain?.expirationDates.length ?? 0;
-    if (event.name === "h" || event.name === "left") {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      setExpIdx((i) => Math.max(i - 1, 0));
-      return true;
-    }
-    if (event.name === "l" || event.name === "right") {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      setExpIdx((i) => Math.min(i + 1, Math.max(numExp - 1, 0)));
-      return true;
-    }
     return false;
-  }, [chain?.expirationDates.length, enterInteractive, exitInteractive, interactive, strikes.length]);
+  }, [enterInteractive, exitInteractive, interactive, strikes.length]);
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view options.</Text>;
   if (loading && !chain) return <Spinner label="Loading options chain..." />;
@@ -299,6 +284,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
             }}
             compact
             variant="bare"
+            focused={focused && interactive}
           />
         </Box>
         {loading && <Spinner />}

--- a/src/plugins/builtin/portfolio-list/pane.tsx
+++ b/src/plugins/builtin/portfolio-list/pane.tsx
@@ -282,7 +282,6 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     [tickers, financialsMap, activeSort, columnContext, columns],
   );
 
-  const currentTabIdx = visibleCollections.findIndex((collection) => collection.id === activeCollectionId);
   const selectedIdx = sortedTickers.findIndex((ticker) => ticker.metadata.ticker === cursorSymbol);
   const safeSelectedIdx = selectedIdx >= 0 ? selectedIdx : 0;
 
@@ -359,35 +358,15 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       return true;
     }
 
-    if (showCollectionTabs && (key === "h" || key === "left")) {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      const previousCollection = visibleCollections[Math.max(currentTabIdx - 1, 0)];
-      if (previousCollection) handleCollectionSelect(previousCollection.id);
-      return true;
-    }
-
-    if (showCollectionTabs && (key === "l" || key === "right")) {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      const nextCollection = visibleCollections[Math.min(currentTabIdx + 1, visibleCollections.length - 1)];
-      if (nextCollection) handleCollectionSelect(nextCollection.id);
-      return true;
-    }
-
     return false;
   }, [
     cashDrawerExpanded,
-    currentTabIdx,
     focused,
     openTickerFloating,
     safeSelectedIdx,
     setCashDrawerExpanded,
-    handleCollectionSelect,
     showCashDrawer,
-    showCollectionTabs,
     sortedTickers,
-    visibleCollections,
   ]);
 
   useEffect(() => {
@@ -590,6 +569,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
                 activeValue={activeCollectionId}
                 onSelect={handleCollectionSelect}
                 compact
+                focused={focused}
               />
             </Box>
           </Box>

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -84,26 +84,17 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
     return next;
   }, [mountedTabIds, resolvedTabId, visibleTabIds]);
 
-  const allTabsRef = useRef(allTabs);
-  allTabsRef.current = allTabs;
-
   const stateRef = useRef({
     focused,
     chartInteractive,
     pluginCaptured,
     activeTabId: resolvedTabId,
-    tabIdx: Math.max(0, allTabs.findIndex((tab) => tab.id === resolvedTabId)),
-    allTabCount: allTabs.length,
-    hideTabs: paneSettings.hideTabs,
   });
   stateRef.current = {
     focused,
     chartInteractive,
     pluginCaptured,
     activeTabId: resolvedTabId,
-    tabIdx: Math.max(0, allTabs.findIndex((tab) => tab.id === resolvedTabId)),
-    allTabCount: allTabs.length,
-    hideTabs: paneSettings.hideTabs,
   };
 
   const setChartInteractiveEager = useCallback((value: boolean) => {
@@ -162,17 +153,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
       if (currentState.chartInteractive) return;
     }
 
-    if (currentState.hideTabs) return;
-
-    const tabs = allTabsRef.current;
-    if (event.name === "h" || event.name === "left") {
-      const nextIndex = Math.max(currentState.tabIdx - 1, 0);
-      setActiveTabId(tabs[nextIndex]!.id);
-    } else if (event.name === "l" || event.name === "right") {
-      const nextIndex = Math.min(currentState.tabIdx + 1, currentState.allTabCount - 1);
-      setActiveTabId(tabs[nextIndex]!.id);
-    }
-  }, [setActiveTabId, setChartInteractiveEager]);
+  }, [setChartInteractiveEager]);
 
   useShortcut(handleKeyboard);
 
@@ -196,6 +177,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
           tabs={allTabs.map((tab) => ({ label: tab.name, value: tab.id }))}
           activeValue={resolvedTabId}
           onSelect={setActiveTabId}
+          focused={focused && !pluginCaptured && !(resolvedTabId === "chart" && chartInteractive)}
         />
       )}
 

--- a/src/plugins/prediction-markets/controller.ts
+++ b/src/plugins/prediction-markets/controller.ts
@@ -11,7 +11,6 @@ import { getAdjacentPredictionCategoryId } from "./categories";
 import { usePredictionMarketsDataState } from "./controller-data";
 import { resolvePredictionKeyboardCommand } from "./keyboard";
 import {
-  getAdjacentPredictionDetailTab,
   getAdjacentPredictionVenueScope,
   parsePredictionSearchShortcut,
   parsePredictionVenueScope,
@@ -517,20 +516,6 @@ export function usePredictionMarketsController({
           } else {
             scrollDetailBy(-1);
           }
-          return;
-        }
-
-        if (command === "previous-category") {
-          event.stopPropagation?.();
-          event.preventDefault?.();
-          setDetailTab(getAdjacentPredictionDetailTab(detailTab, "previous"));
-          return;
-        }
-
-        if (command === "next-category") {
-          event.stopPropagation?.();
-          event.preventDefault?.();
-          setDetailTab(getAdjacentPredictionDetailTab(detailTab, "next"));
           return;
         }
 

--- a/src/plugins/prediction-markets/detail/pane.tsx
+++ b/src/plugins/prediction-markets/detail/pane.tsx
@@ -243,6 +243,7 @@ export function PredictionMarketDetailPane({
           activeValue={detailTab}
           onSelect={(value) => onDetailTabChange(value as PredictionDetailTab)}
           compact
+          focused={focused}
         />
       </Box>
 

--- a/src/react/input.ts
+++ b/src/react/input.ts
@@ -19,7 +19,7 @@ export interface KeyEventLike {
 export interface ShortcutOptions {
   enabled?: boolean;
   scope?: string;
-  phase?: "normal" | "after";
+  phase?: "before" | "normal" | "after";
 }
 
 export interface InputHost {

--- a/src/renderers/electrobun/view/input-host.tsx
+++ b/src/renderers/electrobun/view/input-host.tsx
@@ -99,7 +99,7 @@ export function WebInputHostProvider({ children }: { children: ReactNode }) {
   const shortcutsRef = useRef<ShortcutEntry[]>([]);
 
   const dispatchShortcut = (shortcutEvent: KeyEventLike) => {
-    for (const phase of ["normal", "after"] as const) {
+    for (const phase of ["before", "normal", "after"] as const) {
       if (phase === "after" && (shortcutEvent.defaultPrevented || shortcutEvent.propagationStopped)) break;
       for (const entry of shortcutsRef.current) {
         if (entry.phase !== phase || !entry.enabledRef.current) continue;

--- a/src/renderers/opentui/input-host.tsx
+++ b/src/renderers/opentui/input-host.tsx
@@ -15,7 +15,7 @@ export function OpenTuiInputHostProvider({ children }: { children: ReactNode }) 
   const shortcutsRef = useRef<ShortcutEntry[]>([]);
   const dispatchShortcut = (event: KeyEventLike) => {
     const shortcuts = shortcutsRef.current;
-    for (const phase of ["normal", "after"] as const) {
+    for (const phase of ["before", "normal", "after"] as const) {
       if (phase === "after" && (event.defaultPrevented || event.propagationStopped)) return;
       for (const entry of shortcuts) {
         if (entry.phase !== phase || !entry.enabledRef.current) continue;

--- a/src/utils/double-escape-close.test.ts
+++ b/src/utils/double-escape-close.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createDoubleEscapeCloseState,
+  recordDoubleEscapeClose,
+  resetDoubleEscapeClose,
+} from "./double-escape-close";
+
+describe("double escape close detector", () => {
+  test("matches a second escape for the same target inside the threshold", () => {
+    const state = createDoubleEscapeCloseState();
+
+    expect(recordDoubleEscapeClose(state, "pane:a", 1000)).toBe(false);
+    expect(recordDoubleEscapeClose(state, "pane:a", 1200)).toBe(true);
+    expect(state.targetId).toBe(null);
+  });
+
+  test("requires the same target and a recent first escape", () => {
+    const state = createDoubleEscapeCloseState();
+
+    expect(recordDoubleEscapeClose(state, "pane:a", 1000)).toBe(false);
+    expect(recordDoubleEscapeClose(state, "pane:b", 1100)).toBe(false);
+    expect(recordDoubleEscapeClose(state, "pane:b", 2000)).toBe(false);
+    expect(recordDoubleEscapeClose(state, "pane:b", 2100)).toBe(true);
+  });
+
+  test("can be reset by non-escape input", () => {
+    const state = createDoubleEscapeCloseState();
+
+    expect(recordDoubleEscapeClose(state, "pane:a", 1000)).toBe(false);
+    resetDoubleEscapeClose(state);
+    expect(recordDoubleEscapeClose(state, "pane:a", 1100)).toBe(false);
+  });
+});

--- a/src/utils/double-escape-close.ts
+++ b/src/utils/double-escape-close.ts
@@ -1,0 +1,40 @@
+export const DOUBLE_ESCAPE_CLOSE_MS = 650;
+
+export interface DoubleEscapeCloseState {
+  lastAt: number;
+  targetId: string | null;
+}
+
+export function createDoubleEscapeCloseState(): DoubleEscapeCloseState {
+  return {
+    lastAt: 0,
+    targetId: null,
+  };
+}
+
+export function resetDoubleEscapeClose(state: DoubleEscapeCloseState) {
+  state.lastAt = 0;
+  state.targetId = null;
+}
+
+export function recordDoubleEscapeClose(
+  state: DoubleEscapeCloseState,
+  targetId: string | null | undefined,
+  now: number,
+  thresholdMs = DOUBLE_ESCAPE_CLOSE_MS,
+): boolean {
+  if (!targetId) {
+    resetDoubleEscapeClose(state);
+    return false;
+  }
+
+  const matched = state.targetId === targetId && now - state.lastAt <= thresholdMs;
+  if (matched) {
+    resetDoubleEscapeClose(state);
+    return true;
+  }
+
+  state.targetId = targetId;
+  state.lastAt = now;
+  return false;
+}


### PR DESCRIPTION
Centralizes keyboard navigation in the shared Tabs component so focused panes switch tabs consistently without individual pane handlers.
Wires the shared tab behavior through market movers, portfolio, analytics, ticker detail, options, notes, cloud tweets, holders, news wire, AI screener, and prediction market detail surfaces while removing duplicate pane-local shortcut code.
Adds before-phase shortcut dispatch and a shared double-Escape detector so a second Escape closes the focused pane or detached window without stealing the first Escape from panes and overlays.
