### PR TITLE
Add analyst rating targets and sorting

### DIFF
--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import type { AnalystRatingRecord } from "../../../types/financials";
+import {
+  nextRatingSortPreference,
+  sortRatingRows,
+  type RatingSortPreference,
+} from "./index";
+
+const ratings: AnalystRatingRecord[] = [
+  {
+    date: "2026-05-06",
+    firm: "Beta Capital",
+    action: "Raises",
+    current: "Neutral",
+    prior: "Neutral",
+    currentPriceTarget: 385,
+    priorPriceTarget: 270,
+  },
+  {
+    date: "2026-05-07",
+    firm: "Alpha Research",
+    action: "Downgrade",
+    current: "Hold",
+    prior: "Buy",
+    currentPriceTarget: 340,
+    priorPriceTarget: 335,
+  },
+  {
+    date: "2026-05-06",
+    firm: "Zenith",
+    action: "Upgrade",
+    current: "Buy",
+    prior: "Neutral",
+    currentPriceTarget: 525,
+    priorPriceTarget: 265,
+  },
+  {
+    date: "2026-05-05",
+    firm: "No Target",
+    action: "Reiterates",
+    current: "Buy",
+    prior: "Buy",
+  },
+];
+
+describe("analyst rating sorting", () => {
+  test("sorts date newest first by default", () => {
+    const preference: RatingSortPreference = { columnId: "date", direction: "desc" };
+
+    expect(sortRatingRows(ratings, preference).map((row) => row.firm)).toEqual([
+      "Alpha Research",
+      "Beta Capital",
+      "Zenith",
+      "No Target",
+    ]);
+  });
+
+  test("sorts target by current target value with missing targets last", () => {
+    const preference: RatingSortPreference = { columnId: "target", direction: "desc" };
+
+    expect(sortRatingRows(ratings, preference).map((row) => row.firm)).toEqual([
+      "Zenith",
+      "Beta Capital",
+      "Alpha Research",
+      "No Target",
+    ]);
+  });
+
+  test("sorts text columns alphabetically with recent dates as a tie-breaker", () => {
+    const preference: RatingSortPreference = { columnId: "firm", direction: "asc" };
+
+    expect(sortRatingRows(ratings, preference).map((row) => row.firm)).toEqual([
+      "Alpha Research",
+      "Beta Capital",
+      "No Target",
+      "Zenith",
+    ]);
+  });
+
+  test("uses sensible first-click directions per column", () => {
+    expect(nextRatingSortPreference({ columnId: "date", direction: "desc" }, "date")).toEqual({
+      columnId: "date",
+      direction: "asc",
+    });
+    expect(nextRatingSortPreference({ columnId: "date", direction: "desc" }, "target")).toEqual({
+      columnId: "target",
+      direction: "desc",
+    });
+    expect(nextRatingSortPreference({ columnId: "target", direction: "desc" }, "firm")).toEqual({
+      columnId: "firm",
+      direction: "asc",
+    });
+  });
+});

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -7,7 +7,7 @@ import {
   type DataTableColumn,
   type DataTableKeyEvent,
 } from "../../../components";
-import type { AnalystResearchData, CorporateActionsData, TickerFinancials } from "../../../types/financials";
+import type { AnalystRatingRecord, AnalystResearchData, CorporateActionsData, TickerFinancials } from "../../../types/financials";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { usePaneInstance, usePaneTicker } from "../../../state/app-context";
 import { blendHex, colors, priceColor } from "../../../theme/colors";
@@ -110,6 +110,32 @@ function ratingActionColor(action: string | undefined): string {
   return colors.textDim;
 }
 
+function formatPriceTarget(value: number | undefined, currency: string): string {
+  if (value == null) return "-";
+  return formatCurrency(value, currency)
+    .replace(/\.00\b/, "")
+    .replace(/(\.\d)0\b/, "$1");
+}
+
+function formatRatingTarget(row: AnalystResearchData["ratings"][number], currency: string): string {
+  const current = row.currentPriceTarget;
+  const prior = row.priorPriceTarget;
+  if (current == null && prior == null) return "-";
+  if (current == null) return ` ${formatPriceTarget(prior, currency)}`;
+  if (prior == null) return ` ${formatPriceTarget(current, currency)}`;
+  return ` ${formatPriceTarget(prior, currency)} → ${formatPriceTarget(current, currency)}`;
+}
+
+function ratingTargetDelta(row: AnalystResearchData["ratings"][number]): number | null {
+  if (row.currentPriceTarget == null || row.priorPriceTarget == null) return null;
+  return row.currentPriceTarget - row.priorPriceTarget;
+}
+
+function ratingTargetBackground(delta: number | null): string | undefined {
+  if (delta == null || delta === 0) return undefined;
+  return blendHex(colors.bg, delta > 0 ? colors.positive : colors.negative, 0.42);
+}
+
 function AnalystSummary({ data, width }: { data: AnalystResearchData | null; width: number }) {
   const target = data?.priceTarget;
   const upside = targetUpside(target);
@@ -170,26 +196,135 @@ function AnalystSummary({ data, width }: { data: AnalystResearchData | null; wid
   );
 }
 
-type RatingColumnId = "date" | "firm" | "action" | "current" | "prior";
+export type RatingColumnId = "date" | "firm" | "action" | "current" | "target" | "prior";
 type RatingColumn = DataTableColumn & { id: RatingColumnId };
+export type SortDirection = "asc" | "desc";
+
+export interface RatingSortPreference {
+  columnId: RatingColumnId;
+  direction: SortDirection;
+}
+
+const DEFAULT_RATING_SORT: RatingSortPreference = {
+  columnId: "date",
+  direction: "desc",
+};
+
+const DEFAULT_RATING_SORT_DIRECTIONS: Record<RatingColumnId, SortDirection> = {
+  date: "desc",
+  firm: "asc",
+  action: "asc",
+  current: "asc",
+  target: "desc",
+  prior: "asc",
+};
 
 const RATING_COLUMNS: RatingColumn[] = [
   { id: "date", label: "DATE", width: 10, align: "left" },
-  { id: "firm", label: "FIRM", width: 24, align: "left" },
-  { id: "action", label: "ACTION", width: 11, align: "left" },
-  { id: "current", label: "RATING", width: 14, align: "left" },
-  { id: "prior", label: "PRIOR", width: 14, align: "left" },
+  { id: "firm", label: "FIRM", width: 20, align: "left" },
+  { id: "action", label: "ACTION", width: 10, align: "left" },
+  { id: "current", label: "RATING", width: 13, align: "left" },
+  { id: "target", label: "TARGET", width: 13, align: "left" },
+  { id: "prior", label: "PRIOR", width: 13, align: "left" },
 ];
+
+function normalizedText(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLocaleLowerCase() : null;
+}
+
+function ratingTargetSortValue(row: AnalystRatingRecord): number | null {
+  return row.currentPriceTarget ?? row.priorPriceTarget ?? null;
+}
+
+function ratingSortValue(row: AnalystRatingRecord, columnId: RatingColumnId): string | number | null {
+  switch (columnId) {
+    case "date":
+      return normalizedText(row.date);
+    case "firm":
+      return normalizedText(row.firm);
+    case "action":
+      return normalizedText(row.action);
+    case "current":
+      return normalizedText(row.current);
+    case "target":
+      return ratingTargetSortValue(row);
+    case "prior":
+      return normalizedText(row.prior);
+  }
+}
+
+function compareSortValues(
+  left: string | number | null,
+  right: string | number | null,
+  direction: SortDirection,
+): number {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+
+  const comparison = typeof left === "string" && typeof right === "string"
+    ? left.localeCompare(right)
+    : Number(left) - Number(right);
+  return direction === "asc" ? comparison : -comparison;
+}
+
+export function sortRatingRows<T extends AnalystRatingRecord>(
+  rows: readonly T[],
+  preference: RatingSortPreference,
+): T[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => {
+      const primary = compareSortValues(
+        ratingSortValue(left.row, preference.columnId),
+        ratingSortValue(right.row, preference.columnId),
+        preference.direction,
+      );
+      if (primary !== 0) return primary;
+
+      const dateTieBreak = preference.columnId === "date"
+        ? 0
+        : compareSortValues(
+          ratingSortValue(left.row, "date"),
+          ratingSortValue(right.row, "date"),
+          "desc",
+        );
+      if (dateTieBreak !== 0) return dateTieBreak;
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.row);
+}
+
+export function nextRatingSortPreference(
+  current: RatingSortPreference,
+  columnId: string,
+): RatingSortPreference {
+  const typedColumnId = columnId as RatingColumnId;
+  if (current.columnId !== typedColumnId) {
+    return {
+      columnId: typedColumnId,
+      direction: DEFAULT_RATING_SORT_DIRECTIONS[typedColumnId] ?? "asc",
+    };
+  }
+  return {
+    columnId: typedColumnId,
+    direction: current.direction === "asc" ? "desc" : "asc",
+  };
+}
 
 function AnalystResearchView({ focused, width, height }: { focused: boolean; width: number; height: number }) {
   const dataProvider = useAssetData();
   const { symbol, exchange } = useSymbolBinding();
+  const [sortPreference, setSortPreference] = useState<RatingSortPreference>(DEFAULT_RATING_SORT);
   const loader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
     if (!dataProvider?.getAnalystResearch) throw new Error("Analyst data unavailable");
     return dataProvider.getAnalystResearch(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
   }, [dataProvider]);
   const { data, loading, error, reload } = useTickerRequest<AnalystResearchData>(loader, symbol, exchange);
-  const rows = data?.ratings ?? [];
+  const rows = useMemo(() => sortRatingRows(data?.ratings ?? [], sortPreference), [data?.ratings, sortPreference]);
+  const ratingCurrency = data?.priceTarget?.currency ?? data?.currency ?? "USD";
 
   const renderCell = useCallback((
     row: AnalystResearchData["ratings"][number],
@@ -207,10 +342,20 @@ function AnalystResearchView({ focused, width, height }: { focused: boolean; wid
         return { text: row.action ?? "-", color: selectedColor ?? ratingActionColor(row.action) };
       case "current":
         return { text: row.current ?? "-", color: selectedColor ?? colors.text };
+      case "target": {
+        const delta = ratingTargetDelta(row);
+        const hasTarget = row.currentPriceTarget != null || row.priorPriceTarget != null;
+        return {
+          text: formatRatingTarget(row, ratingCurrency),
+          color: selectedColor ?? (hasTarget ? colors.textBright : colors.textDim),
+          backgroundColor: rowState.selected ? undefined : ratingTargetBackground(delta),
+          attributes: hasTarget ? TextAttributes.BOLD : undefined,
+        };
+      }
       case "prior":
         return { text: row.prior ?? "-", color: selectedColor ?? colors.textDim };
     }
-  }, []);
+  }, [ratingCurrency]);
 
   const handleKeyDown = useCallback((event: DataTableKeyEvent) => {
     if (event.name !== "r") return false;
@@ -219,6 +364,9 @@ function AnalystResearchView({ focused, width, height }: { focused: boolean; wid
     reload();
     return true;
   }, [reload]);
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextRatingSortPreference(current, columnId));
+  }, []);
 
   usePaneFooter("analyst-research", () => ({
     info: [
@@ -237,15 +385,14 @@ function AnalystResearchView({ focused, width, height }: { focused: boolean; wid
       onRootKeyDown={handleKeyDown}
       columns={RATING_COLUMNS}
       items={rows}
-      sortColumnId={null}
-      sortDirection="desc"
-      onHeaderClick={() => {}}
+      sortColumnId={sortPreference.columnId}
+      sortDirection={sortPreference.direction}
+      onHeaderClick={handleHeaderClick}
       getItemKey={(row, index) => `${row.date}:${row.firm}:${index}`}
       isSelected={() => false}
       onSelect={() => {}}
       renderCell={renderCell}
       emptyStateTitle={loading ? "Loading analyst data..." : error ?? "No analyst data"}
-      showHorizontalScrollbar={false}
     />
   );
 }

--- a/src/plugins/builtin/ticker-detail.test.tsx
+++ b/src/plugins/builtin/ticker-detail.test.tsx
@@ -19,6 +19,7 @@ import {
   type BrokerInstanceConfig,
 } from "../../types/config";
 import { createTestPluginRuntime } from "../../test-support/plugin-runtime";
+import { EventBus } from "../event-bus";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerFinancials } from "../../types/financials";
 import type { DetailTabDef } from "../../types/plugin";
@@ -541,6 +542,43 @@ describe("TickerDetailPane", () => {
     await flushFrame();
     const frame = testSetup.captureCharFrame();
     expect(frame).not.toContain("SEC");
+  });
+
+  test("refreshes plugin tabs when registration completes after the pane mounted", async () => {
+    const detailTabs = new Map<string, DetailTabDef>();
+    const events = new EventBus();
+    setSharedRegistryForTests({
+      detailTabs,
+      events,
+      getDetailTabPluginId: () => "company-research",
+    } as unknown as PluginRegistry);
+    setOptionsProvider(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={null}
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).not.toContain("Analyst");
+
+    await act(async () => {
+      detailTabs.set("analyst-research", {
+        id: "analyst-research",
+        name: "Analyst",
+        order: 32,
+        component: () => <text>Analyst body</text>,
+        isVisible: ({ ticker }) => !!ticker,
+      });
+      events.emit("plugin:registered", { pluginId: "company-research" });
+    });
+    await flushFrame();
+
+    expect(testSetup.captureCharFrame()).toContain("Analyst");
   });
 
   test("passes visible tab content height to plugin tabs", async () => {

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -1,6 +1,6 @@
 import { Box } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { DetailTabDef, PaneProps } from "../../../types/plugin";
 import { quoteSubscriptionTargetFromTicker } from "../../../market-data/request-types";
 import {
@@ -33,6 +33,29 @@ function sameStringSet(left: Set<string>, right: Set<string>): boolean {
   return true;
 }
 
+function registryDetailTabsSnapshot(registry: ReturnType<typeof getSharedRegistry>): string {
+  if (!registry) return "";
+  return [...registry.detailTabs.values()]
+    .map((tab) => `${tab.id}:${tab.name}:${tab.order}:${registry.getDetailTabPluginId?.(tab.id) ?? ""}`)
+    .join("\0");
+}
+
+function useRegistryDetailTabsSnapshot(registry: ReturnType<typeof getSharedRegistry>): string {
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    const events = registry?.events;
+    if (!events) return () => {};
+    const unregisterRegistered = events.on("plugin:registered", onStoreChange);
+    const unregisterUnregistered = events.on("plugin:unregistered", onStoreChange);
+    return () => {
+      unregisterRegistered();
+      unregisterUnregistered();
+    };
+  }, [registry]);
+
+  const getSnapshot = useCallback(() => registryDetailTabsSnapshot(registry), [registry]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
 export function TickerDetailPane({ focused, width, height }: PaneProps) {
   const dispatch = useAppDispatch();
   const config = useAppSelector((state) => state.config);
@@ -54,6 +77,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
 
   const disabledPlugins = config.disabledPlugins;
   const registry = getSharedRegistry();
+  const detailTabsSnapshot = useRegistryDetailTabsSnapshot(registry);
   const pluginTabs = useMemo<DetailTabDef[]>(() => (
     registry
       ? [...registry.detailTabs.values()].filter((tab) => {
@@ -61,7 +85,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
         return !ownerId || !disabledPlugins.includes(ownerId);
       })
       : []
-  ), [disabledPlugins, registry]);
+  ), [disabledPlugins, registry, detailTabsSnapshot]);
   const allTabs = buildVisibleDetailTabs(pluginTabs, ticker, financials, {
     config,
     hasOptionsChain,

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -195,6 +195,128 @@ describe("AssetDataRouter", () => {
     expect(holders.holders[0]?.name).toBe("Vanguard Group Inc");
   });
 
+  test("falls back to later analyst providers when rating targets are missing", async () => {
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getAnalystResearch(symbol) {
+        return {
+          providerId: "cloud",
+          symbol,
+          ratings: [{ date: "2026-05-01", firm: "Cloud Firm", action: "Raises", current: "Buy", prior: "Buy" }],
+          recommendations: [],
+          earningsEstimates: [],
+          revenueEstimates: [],
+        };
+      },
+    };
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getAnalystResearch(symbol) {
+        return {
+          providerId: "yahoo",
+          symbol,
+          ratings: [{
+            date: "2026-05-01",
+            firm: "Yahoo Firm",
+            action: "Raises",
+            current: "Buy",
+            prior: "Buy",
+            currentPriceTarget: 680,
+            priorPriceTarget: 595,
+          }],
+          recommendations: [],
+          earningsEstimates: [],
+          revenueEstimates: [],
+        };
+      },
+    };
+
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
+    const research = await router.getAnalystResearch("AAPL", "NASDAQ");
+
+    expect(research.providerId).toBe("yahoo");
+    expect(research.ratings[0]?.currentPriceTarget).toBe(680);
+    expect(research.ratings[0]?.priorPriceTarget).toBe(595);
+  });
+
+  test("prefers cached analyst records with rating targets", async () => {
+    const dbPath = createTempDbPath("cached-analyst-targets");
+    const persistence = new AppPersistence(dbPath);
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getAnalystResearch(symbol) {
+        return {
+          providerId: "cloud",
+          symbol,
+          ratings: [{ date: "2026-05-01", firm: "Cloud Firm", action: "Raises", current: "Buy", prior: "Buy" }],
+          recommendations: [],
+          earningsEstimates: [],
+          revenueEstimates: [],
+        };
+      },
+    };
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getAnalystResearch(symbol) {
+        return {
+          providerId: "yahoo",
+          symbol,
+          ratings: [{
+            date: "2026-05-01",
+            firm: "Yahoo Firm",
+            action: "Raises",
+            current: "Buy",
+            prior: "Buy",
+            currentPriceTarget: 680,
+            priorPriceTarget: 595,
+          }],
+          recommendations: [],
+          earningsEstimates: [],
+          revenueEstimates: [],
+        };
+      },
+    };
+    const unavailableProvider = (id: string, priority: number): DataProvider => ({
+      ...fallbackProvider,
+      id,
+      name: id,
+      priority,
+      async getAnalystResearch() {
+        throw new Error(`${id} should not be fetched`);
+      },
+    });
+
+    try {
+      const seedRouter = new AssetDataRouter(yahooProvider, [cloudProvider], persistence.resources);
+      await seedRouter.getAnalystResearch("AAPL", "NASDAQ");
+
+      const cachedRouter = new AssetDataRouter(
+        unavailableProvider("yahoo", 1000),
+        [unavailableProvider("cloud", 100)],
+        persistence.resources,
+      );
+      const research = await cachedRouter.getAnalystResearch("AAPL", "NASDAQ");
+
+      expect(research.providerId).toBe("yahoo");
+      expect(research.ratings[0]?.currentPriceTarget).toBe(680);
+      expect(research.ratings[0]?.priorPriceTarget).toBe(595);
+    } finally {
+      persistence.close();
+    }
+  });
+
   test("prefers broker quotes over fallback quotes", async () => {
     const router = new AssetDataRouter(fallbackProvider);
     const broker: BrokerAdapter = {

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -150,6 +150,16 @@ function hasAnalystResearchValue(data: AnalystResearchData): boolean {
     || data.revenueEstimates.length > 0;
 }
 
+function hasAnalystRatingPriceTargets(data: AnalystResearchData): boolean {
+  return data.ratings.some((rating) => (
+    rating.currentPriceTarget != null || rating.priorPriceTarget != null
+  ));
+}
+
+function isAnalystResearchMissingRatingTargets(data: AnalystResearchData): boolean {
+  return data.ratings.length > 0 && !hasAnalystRatingPriceTargets(data);
+}
+
 function hasCorporateActionsValue(data: CorporateActionsData): boolean {
   return data.dividends.length > 0
     || data.splits.length > 0
@@ -518,9 +528,9 @@ export class AssetDataRouter implements DataProvider {
   async getAnalystResearch(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<AnalystResearchData> {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
-    const cached = this.selectCachedResource<AnalystResearchData>("analystResearch", entityKey, variantKeys, this.getProviderSourceKeys(), false);
+    const cached = this.selectCachedAnalystResearch(entityKey, variantKeys, this.getProviderSourceKeys(), false);
     const forceRefresh = context?.cacheMode === "refresh";
-    if (cached && !forceRefresh) {
+    if (cached && !forceRefresh && !isAnalystResearchMissingRatingTargets(cached.value)) {
       this.scheduleRevalidation(this.makeRevalidationKey("analystResearch", ticker, exchange, context), async () => {
         await this.revalidateAnalystResearch(ticker, exchange, context);
       });
@@ -876,7 +886,17 @@ export class AssetDataRouter implements DataProvider {
     sourceKeys: string[],
     allowExpired: boolean,
   ): CachedResourceRecord<T> | null {
-    return this.listCachedResources(kind, entityKey, variantKeys, sourceKeys, allowExpired)[0] ?? null;
+    return this.listCachedResources<T>(kind, entityKey, variantKeys, sourceKeys, allowExpired)[0] ?? null;
+  }
+
+  private selectCachedAnalystResearch(
+    entityKey: string,
+    variantKeys: string[],
+    sourceKeys: string[],
+    allowExpired: boolean,
+  ): CachedResourceRecord<AnalystResearchData> | null {
+    const records = this.listCachedResources<AnalystResearchData>("analystResearch", entityKey, variantKeys, sourceKeys, allowExpired);
+    return records.find((record) => !isAnalystResearchMissingRatingTargets(record.value)) ?? records[0] ?? null;
   }
 
   private selectCachedArrayResource<T>(
@@ -1579,6 +1599,7 @@ export class AssetDataRouter implements DataProvider {
     const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     let firstEmptyResult: SourceResult<AnalystResearchData> | null = null;
+    let firstIncompleteResult: SourceResult<AnalystResearchData> | null = null;
     let lastError: unknown = null;
 
     for (const provider of this.providersInPriorityOrder()) {
@@ -1587,7 +1608,13 @@ export class AssetDataRouter implements DataProvider {
         const value = await provider.getAnalystResearch(ticker, exchange, context);
         const sourceKey = this.providerSourceKey(provider);
         this.cacheResource("analystResearch", entityKey, variantKey, sourceKey, value, this.resolveProviderPolicy("analystResearch", provider));
-        if (hasAnalystResearchValue(value)) return { sourceKey, value };
+        if (hasAnalystResearchValue(value)) {
+          if (isAnalystResearchMissingRatingTargets(value)) {
+            firstIncompleteResult ??= { sourceKey, value };
+            continue;
+          }
+          return { sourceKey, value };
+        }
         firstEmptyResult ??= { sourceKey, value };
       } catch (error) {
         lastError = error;
@@ -1597,6 +1624,7 @@ export class AssetDataRouter implements DataProvider {
       }
     }
 
+    if (firstIncompleteResult) return firstIncompleteResult;
     if (firstEmptyResult) return firstEmptyResult;
     if (lastError) throw lastError;
     return null;

--- a/src/sources/yahoo-finance.test.ts
+++ b/src/sources/yahoo-finance.test.ts
@@ -32,4 +32,48 @@ describe("YahooFinanceClient exchange aliases", () => {
     });
     expect(history[0]?.close).toBe(200);
   });
+
+  test("preserves analyst rating price targets from upgrade history", async () => {
+    const provider = new YahooFinanceClient() as any;
+    let requestUrl = "";
+    provider.getSymbolsToTry = () => ["AMD"];
+    provider.fetchJsonWithCrumb = async (_label: string, url: string) => {
+      requestUrl = url;
+      return {
+        quoteSummary: {
+          result: [{
+            price: { symbol: "AMD", currency: "USD", exchangeName: "NasdaqGS" },
+            financialData: {},
+            recommendationTrend: { trend: [] },
+            earningsTrend: { trend: [] },
+            upgradeDowngradeHistory: {
+              history: [{
+                epochGradeDate: 1778188318,
+                firm: "Citigroup",
+                toGrade: "Neutral",
+                fromGrade: "Neutral",
+                action: "main",
+                priceTargetAction: "Raises",
+                currentPriceTarget: 358,
+                priorPriceTarget: 248,
+              }],
+            },
+          }],
+        },
+      };
+    };
+
+    const research = await provider.getAnalystResearch("AMD", "NASDAQ");
+
+    expect(requestUrl).toContain("upgradeDowngradeHistory");
+    expect(research.ratings[0]).toMatchObject({
+      date: "2026-05-07",
+      firm: "Citigroup",
+      action: "Raises",
+      current: "Neutral",
+      prior: "Neutral",
+      currentPriceTarget: 358,
+      priorPriceTarget: 248,
+    });
+  });
 });

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -179,6 +179,8 @@ type QuoteSummaryResponse = {
           priceTargetAction?: string;
           toGrade?: string;
           fromGrade?: string;
+          currentPriceTarget?: { raw?: number } | number | null;
+          priorPriceTarget?: { raw?: number } | number | null;
         }>;
       };
       earningsTrend?: {
@@ -412,12 +414,16 @@ function mapYahooAnalystResearchResponse(
         const action = normalizeYahooRatingAction(rating.action, rating.priceTargetAction);
         const current = rating.toGrade?.trim();
         const prior = rating.fromGrade?.trim();
+        const currentPriceTarget = financeRawNumber(rating.currentPriceTarget);
+        const priorPriceTarget = financeRawNumber(rating.priorPriceTarget);
         return {
           date,
           firm,
           ...(action ? { action } : {}),
           ...(current ? { current } : {}),
           ...(prior ? { prior } : {}),
+          ...(currentPriceTarget != null ? { currentPriceTarget } : {}),
+          ...(priorPriceTarget != null ? { priorPriceTarget } : {}),
         };
       })
       .filter((rating): rating is AnalystResearchData["ratings"][number] => rating !== null)

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -141,6 +141,8 @@ export interface AnalystRatingRecord {
   action?: string;
   current?: string;
   prior?: string;
+  currentPriceTarget?: number;
+  priorPriceTarget?: number;
 }
 
 export interface AnalystEstimateRecord {


### PR DESCRIPTION
Shows per-rating analyst price targets from Yahoo upgrade/downgrade history and keeps routing past provider or cached analyst rows that lack target values when richer data is available.

Adds a sortable target column to Analyst Research, with sensible default and first-click ordering for date, firm, action, rating, target, and prior rating.

Keeps the Analyst detail tab visible when plugin tabs finish registering after the ticker detail pane has already mounted.