### PR TITLE
Fix TUI table wheel redraw

### DIFF
--- a/src/components/table-view-shared.tsx
+++ b/src/components/table-view-shared.tsx
@@ -129,6 +129,60 @@ export function useTableBodyScrollActivity({
   }, [afterScroll, onBodyScrollActivity, syncHeaderScroll]);
 }
 
+export function useScrollBoxScrollActivity({
+  scrollRef,
+  onVerticalScroll,
+  onHorizontalScroll,
+}: {
+  scrollRef: RefObject<ScrollBoxRenderable | null>;
+  onVerticalScroll?: () => void;
+  onHorizontalScroll?: () => void;
+}) {
+  const onVerticalScrollRef = useRef(onVerticalScroll);
+  const onHorizontalScrollRef = useRef(onHorizontalScroll);
+  const verticalScrollScheduledRef = useRef(false);
+  const horizontalScrollScheduledRef = useRef(false);
+
+  useEffect(() => {
+    onVerticalScrollRef.current = onVerticalScroll;
+    onHorizontalScrollRef.current = onHorizontalScroll;
+  }, [onHorizontalScroll, onVerticalScroll]);
+
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox) return;
+    let active = true;
+
+    const handleVerticalChange = () => {
+      if (verticalScrollScheduledRef.current) return;
+      verticalScrollScheduledRef.current = true;
+      queueMicrotask(() => {
+        verticalScrollScheduledRef.current = false;
+        if (!active) return;
+        onVerticalScrollRef.current?.();
+      });
+    };
+    const handleHorizontalChange = () => {
+      if (horizontalScrollScheduledRef.current) return;
+      horizontalScrollScheduledRef.current = true;
+      queueMicrotask(() => {
+        horizontalScrollScheduledRef.current = false;
+        if (!active) return;
+        onHorizontalScrollRef.current?.();
+      });
+    };
+
+    scrollBox.verticalScrollBar.on("change", handleVerticalChange);
+    scrollBox.horizontalScrollBar.on("change", handleHorizontalChange);
+
+    return () => {
+      active = false;
+      scrollBox.verticalScrollBar.off("change", handleVerticalChange);
+      scrollBox.horizontalScrollBar.off("change", handleHorizontalChange);
+    };
+  }, [scrollRef]);
+}
+
 export function useResetTableScroll({
   headerScrollRef,
   scrollRef,

--- a/src/components/ticker-list-table.test.tsx
+++ b/src/components/ticker-list-table.test.tsx
@@ -64,6 +64,16 @@ function TickerListTableHarness() {
 
 function LargeTickerListTableHarness() {
   const [cursorSymbol, setCursorSymbol] = useState("T0");
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  useEffect(() => {
+    tableScrollRef = scrollRef.current;
+    return () => {
+      if (tableScrollRef === scrollRef.current) {
+        tableScrollRef = null;
+      }
+    };
+  });
 
   return (
     <TickerListTable
@@ -75,6 +85,7 @@ function LargeTickerListTableHarness() {
       setCursorSymbol={setCursorSymbol}
       resolveCell={resolveCell}
       financialsMap={financialsMap}
+      scrollRef={scrollRef}
     />
   );
 }
@@ -159,6 +170,18 @@ describe("TickerListTable", () => {
     expect(frame).toContain("T0");
     expect(frame).not.toContain("T999");
     expect(resolveCellCallCount).toBeLessThan(40);
+
+    await act(async () => {
+      for (let index = 0; index < 12; index++) {
+        await testSetup!.mockMouse.scroll(2, 2, "down");
+      }
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    const scrollTop = tableScrollRef?.scrollTop ?? 0;
+    expect(scrollTop).toBeGreaterThan(0);
+    expect(testSetup.captureCharFrame()).toContain(`T${scrollTop}`);
   });
 
   test("preserves manual scroll when market data reorders rows around the same cursor", async () => {

--- a/src/components/ticker-list-table.tsx
+++ b/src/components/ticker-list-table.tsx
@@ -1,4 +1,13 @@
-import { Box, ScrollBox, Text, tickerContextMenuItems, useContextMenu, useRendererHost, useUiCapabilities } from "../ui";
+import {
+  Box,
+  ScrollBox,
+  Text,
+  tickerContextMenuItems,
+  useContextMenu,
+  useNativeRenderer,
+  useRendererHost,
+  useUiCapabilities,
+} from "../ui";
 import { memo, useCallback, useMemo, useRef, useState, type RefObject } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../ui";
 import { EmptyState } from "./ui";
@@ -12,8 +21,8 @@ import { renderChart, resolveChartPalette, type StyledContent } from "./chart/ch
 import type { ProjectedChartPoint } from "./chart/chart-data";
 import { tableContentWidthProps, useMeasuredTableContentWidth } from "./ui/table-layout";
 import { useViewport } from "../react/input";
-import { useRafCallback } from "../react/use-raf-callback";
 import { measurePerf } from "../utils/perf-marks";
+import { useScrollBoxScrollActivity } from "./table-view-shared";
 
 export interface TickerTableCell {
   text: string;
@@ -328,6 +337,7 @@ export function TickerListTable({
   const hoveredIdxRef = useRef(hoveredIdx);
   const appViewport = useViewport();
   const renderer = useRendererHost();
+  const nativeRenderer = useNativeRenderer();
   const { showContextMenu } = useContextMenu();
   const { nativeContextMenu } = useUiCapabilities();
   const [scrollVersion, setScrollVersion] = useState(0);
@@ -387,12 +397,16 @@ export function TickerListTable({
       setScrollVersion((current) => current + 1);
     }
     onBodyScrollActivity?.();
-  }, [onBodyScrollActivity, virtualize]);
+    nativeRenderer.requestRender();
+  }, [nativeRenderer, onBodyScrollActivity, virtualize]);
   const syncHeader = useCallback(() => {
     syncHeaderScroll?.();
   }, [syncHeaderScroll]);
-  const scheduleBodyScrollActivity = useRafCallback(handleBodyScrollActivity);
-  const scheduleHeaderScrollSync = useRafCallback(syncHeader);
+  useScrollBoxScrollActivity({
+    scrollRef: effectiveScrollRef,
+    onVerticalScroll: handleBodyScrollActivity,
+    onHorizontalScroll: syncHeader,
+  });
   const setHoveredIdxIfChanged = useCallback((index: number | null) => {
     if (hoveredIdxRef.current === index) return;
     setHoveredIdx(index);
@@ -448,10 +462,6 @@ export function TickerListTable({
         scrollX
         scrollY
         focusable={false}
-        onMouseDown={scheduleHeaderScrollSync}
-        onMouseUp={scheduleBodyScrollActivity}
-        onMouseDrag={scheduleBodyScrollActivity}
-        onMouseScroll={scheduleBodyScrollActivity}
         onSizeChange={measureContentWidth}
       >
         {tickers.length === 0 ? (

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,4 +1,4 @@
-import { Box, ScrollBox, Text, useUiHost } from "../../ui";
+import { Box, ScrollBox, Text, useNativeRenderer, useUiHost } from "../../ui";
 import { useCallback, useEffect, useMemo, useState, type ComponentType, type ReactNode, type RefObject } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
@@ -6,9 +6,9 @@ import type { ColumnConfig } from "../../types/config";
 import { useAppDispatch, usePaneInstance } from "../../state/app-context";
 import { useViewport } from "../../react/input";
 import { padTo } from "../../utils/format";
-import { useRafCallback } from "../../react/use-raf-callback";
 import { measurePerf } from "../../utils/perf-marks";
 import { useDoubleClickActivation } from "../use-double-click-activation";
+import { useScrollBoxScrollActivity } from "../table-view-shared";
 import { EmptyState } from "./status";
 import {
   expandTableColumns,
@@ -158,6 +158,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const dispatch = useAppDispatch();
   const paneInstanceId = usePaneInstance()?.instanceId ?? null;
   const appViewport = useViewport();
+  const nativeRenderer = useNativeRenderer();
   const [scrollVersion, setScrollVersion] = useState(0);
   const scrollTop = virtualize ? (scrollRef.current?.scrollTop ?? 0) : 0;
   const measuredViewportHeight = scrollRef.current?.viewport?.height;
@@ -228,9 +229,13 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
       setScrollVersion((current) => current + 1);
     }
     onBodyScrollActivity();
-  }, [onBodyScrollActivity, virtualize]);
-  const scheduleBodyScrollActivity = useRafCallback(handleBodyScrollActivity);
-  const scheduleHeaderScrollSync = useRafCallback(syncHeaderScroll);
+    nativeRenderer.requestRender();
+  }, [nativeRenderer, onBodyScrollActivity, virtualize]);
+  useScrollBoxScrollActivity({
+    scrollRef,
+    onVerticalScroll: handleBodyScrollActivity,
+    onHorizontalScroll: syncHeaderScroll,
+  });
   const focusPane = useCallback(() => {
     if (!paneInstanceId) return;
     dispatch({ type: "FOCUS_PANE", paneId: paneInstanceId });
@@ -376,11 +381,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
         focusable={false}
         onMouseDown={() => {
           focusPane();
-          scheduleHeaderScrollSync();
         }}
-        onMouseUp={scheduleBodyScrollActivity}
-        onMouseDrag={scheduleBodyScrollActivity}
-        onMouseScroll={scheduleBodyScrollActivity}
         onSizeChange={measureContentWidth}
       >
         {items.length === 0 ? (

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -179,6 +179,15 @@ function DataTableVirtualizationHarness() {
     name: `Row ${index}`,
   }));
 
+  useEffect(() => {
+    tableScrollBoxForTest = scrollRef.current;
+    return () => {
+      if (tableScrollBoxForTest === scrollRef.current) {
+        tableScrollBoxForTest = null;
+      }
+    };
+  });
+
   return (
     <DataTable
       columns={[{ id: "name", label: "NAME", width: 12, align: "left" }]}
@@ -787,8 +796,9 @@ describe("shared UI kit", () => {
     expect(tableScrollBoxForTest?.verticalScrollBar.visible).toBe(true);
   });
 
-  test("virtualizes data table rows by default", async () => {
+  test("virtualizes data table rows and refreshes after wheel scrolling", async () => {
     const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    tableScrollBoxForTest = null;
     testSetup = await testRender(
       <AppContext value={{ state, dispatch: () => {} }}>
         <PaneInstanceProvider paneId="portfolio-list:main">
@@ -805,5 +815,22 @@ describe("shared UI kit", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Row 0");
     expect(frame).not.toContain("Row 99");
+    expect(tableScrollBoxForTest?.scrollTop).toBe(0);
+
+    await act(async () => {
+      for (let index = 0; index < 12; index++) {
+        await testSetup!.mockMouse.scroll(2, 2, "down");
+      }
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await testSetup!.renderOnce();
+    });
+    await testSetup.renderOnce();
+
+    const scrollTop = tableScrollBoxForTest?.scrollTop ?? 0;
+    expect(scrollTop).toBeGreaterThan(0);
+
+    const scrolledFrame = testSetup.captureCharFrame();
+    expect(scrolledFrame).toContain(`Row ${scrollTop}`);
   });
 });


### PR DESCRIPTION
OpenTUI scrollboxes emit wheel handlers before their scroll position changes, which let virtualized tables repaint stale windows or blank spacer blocks until a later frame. This routes the shared DataTable and ticker-list table refreshes through post-scroll scrollbar change events, coalesces wheel bursts in a microtask, and requests a native frame so rows update promptly. It also adds focused wheel-scroll regression coverage for both shared table paths.