### PR TITLE
Improve theme preview performance

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,6 @@
 import { Box, ContextMenuProvider, useNativeRenderer, useRendererHost } from "./ui";
 import { ToastViewport, useToastHost } from "./ui/toast";
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo, type ReactNode } from "react";
 import { useShortcut } from "./react/input";
 import {
   AppProvider,
@@ -23,7 +23,7 @@ import { OnboardingWizard } from "./components/onboarding/onboarding-wizard";
 import { useDialog, useDialogState } from "./ui/dialog";
 import { PluginRegistry } from "./plugins/registry";
 import type { TickerRepository } from "./data/ticker-repository";
-import { colors, syncTheme } from "./theme/colors";
+import { ThemeProvider, useThemeColors } from "./theme/theme-context";
 import {
   createPaneInstance,
   findPaneInstance,
@@ -45,7 +45,7 @@ import type { TickerRecord } from "./types/ticker";
 import type { DataProvider } from "./types/data-provider";
 import type { TickerFinancials } from "./types/financials";
 import type { BrokerAccount } from "./types/trading";
-import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopWindowBridge } from "./types/desktop-window";
+import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState, DesktopWindowBridge } from "./types/desktop-window";
 import type { DesktopApplicationMenuBridge } from "./types/desktop-menu";
 import { resolveTickerSearch, upsertTickerFromSearchResult } from "./utils/ticker-search";
 
@@ -138,6 +138,15 @@ interface AppInnerProps {
   sessionSnapshot?: AppSessionSnapshot | null;
   desktopWindowBridge?: DesktopWindowBridge;
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
+}
+
+function ThemedAppRoot({ children }: { children: ReactNode }) {
+  const themeColors = useThemeColors();
+  return (
+    <Box flexDirection="column" flexGrow={1} backgroundColor={themeColors.bg}>
+      {children}
+    </Box>
+  );
 }
 
 function AppInner({
@@ -1492,20 +1501,20 @@ function AppInner({
   if (desktopWindowBridge?.kind === "detached" && desktopWindowBridge.paneId) {
     return (
       <ContextMenuProvider pluginRegistry={pluginRegistry}>
-        <Box flexDirection="column" flexGrow={1} backgroundColor={colors.bg}>
+        <ThemedAppRoot>
           <DetachedPaneShell
             pluginRegistry={pluginRegistry}
             desktopWindowBridge={{ ...desktopWindowBridge, kind: "detached", paneId: desktopWindowBridge.paneId }}
           />
           <ToastViewport position="bottom-right" />
-        </Box>
+        </ThemedAppRoot>
       </ContextMenuProvider>
     );
   }
 
   return (
     <ContextMenuProvider pluginRegistry={pluginRegistry}>
-      <Box flexDirection="column" flexGrow={1} backgroundColor={colors.bg}>
+      <ThemedAppRoot>
         <Header />
         <Shell
           pluginRegistry={pluginRegistry}
@@ -1523,7 +1532,7 @@ function AppInner({
           />
         )}
         <ToastViewport position="bottom-right" />
-      </Box>
+      </ThemedAppRoot>
     </ContextMenuProvider>
   );
 }
@@ -1535,6 +1544,7 @@ interface AppProps {
   desktopWindowBridge?: DesktopWindowBridge;
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
   desktopSnapshot?: DesktopSharedStateSnapshot | null;
+  desktopThemePreview?: DesktopThemePreviewState | null;
 }
 
 export function App({
@@ -1544,6 +1554,7 @@ export function App({
   desktopWindowBridge,
   desktopApplicationMenuBridge,
   desktopSnapshot = null,
+  desktopThemePreview = null,
 }: AppProps) {
   const renderer = useNativeRenderer();
   const effectiveInitialConfig = useMemo(() => {
@@ -1573,9 +1584,6 @@ export function App({
     return initialCliLaunch.config;
   });
   const [showOnboarding, setShowOnboarding] = useState(!effectiveInitialConfig.onboardingComplete);
-
-  // Keep the shared palette aligned before this render builds any JSX that reads `colors`.
-  syncTheme(config.theme);
 
   useEffect(() => bindAppActivity(renderer), [renderer]);
 
@@ -1632,14 +1640,16 @@ export function App({
 
   if (showOnboarding) {
     return (
-      <OnboardingWizard
-        config={config}
-        pluginRegistry={services.pluginRegistry}
-        onComplete={(updatedConfig) => {
-          setConfig(updatedConfig);
-          setShowOnboarding(false);
-        }}
-      />
+      <ThemeProvider themeId={config.theme}>
+        <OnboardingWizard
+          config={config}
+          pluginRegistry={services.pluginRegistry}
+          onComplete={(updatedConfig) => {
+            setConfig(updatedConfig);
+            setShowOnboarding(false);
+          }}
+        />
+      </ThemeProvider>
     );
   }
 
@@ -1650,6 +1660,7 @@ export function App({
       sessionSnapshot={sessionSnapshot}
       desktopBridge={desktopWindowBridge}
       desktopSnapshot={desktopSnapshot}
+      initialThemePreview={desktopThemePreview}
     >
       <AppInner
         pluginRegistry={services.pluginRegistry}

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -8,6 +8,7 @@ import { buildChartKey } from "../../market-data/selectors";
 import { useAppSelector, usePaneSettingValue } from "../../state/app-context";
 import { usePaneFooter, type PaneHint } from "../layout/pane-footer";
 import { blendHex, colors, getComparisonSeriesColor, priceColor } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 import type { BrokerContractRef } from "../../types/instrument";
 import type { PricePoint } from "../../types/financials";
 import { formatPercentRaw } from "../../utils/format";
@@ -517,6 +518,7 @@ function ComparisonStockChartView({
   onOpenSymbol,
   onEditTickers,
 }: ComparisonStockChartViewProps) {
+  useThemeColors();
   const renderer = useNativeRenderer();
   const { canvasCharts, cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1 } = useUiCapabilities();
   const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);

--- a/src/components/chart/static-chart-surface.tsx
+++ b/src/components/chart/static-chart-surface.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Box, ChartSurface, Text, useNativeRenderer, useUiCapabilities } from "../../ui";
+import { useThemeColors } from "../../theme/theme-context";
 import type { ProjectedChartPoint } from "./chart-data";
 import {
   buildChartScene,
@@ -45,6 +46,7 @@ export function StaticChartSurface({
   yAxisColor,
   formatYAxisValue,
 }: StaticChartSurfaceProps) {
+  useThemeColors();
   const {
     canvasCharts,
     nativeCharts,

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -9,6 +9,7 @@ import { ShortcutHint } from "../ui";
 import { saveConfig } from "../../data/config-store";
 import { getSharedMarketData } from "../../plugins/registry";
 import { colors } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 import { formatCompact } from "../../utils/format";
 import { formatMarketPriceWithCurrency } from "../../utils/market-format";
 import { useChartQueries, useChartQuery } from "../../market-data/hooks";
@@ -1436,6 +1437,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   ticker,
   financials,
 }: ResolvedStockChartProps) {
+  const themeColors = useThemeColors();
   const renderer = useNativeRenderer();
   const { canvasCharts, cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1 } = useUiCapabilities();
   const dispatch = useAppDispatch();
@@ -3013,15 +3015,24 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       : 0;
     const trend = rawChange < 0 ? "negative" : rawChange > 0 ? "positive" : "neutral";
     return resolveChartPalette({
-      bg: colors.bg,
-      border: colors.border,
-      borderFocused: colors.borderFocused,
-      text: colors.text,
-      textDim: colors.textDim,
-      positive: colors.positive,
-      negative: colors.negative,
+      bg: themeColors.bg,
+      border: themeColors.border,
+      borderFocused: themeColors.borderFocused,
+      text: themeColors.text,
+      textDim: themeColors.textDim,
+      positive: themeColors.positive,
+      negative: themeColors.negative,
     }, trend);
-  }, [chartWindow.points]);
+  }, [
+    chartWindow.points,
+    themeColors.bg,
+    themeColors.border,
+    themeColors.borderFocused,
+    themeColors.negative,
+    themeColors.positive,
+    themeColors.text,
+    themeColors.textDim,
+  ]);
 
   const cursorX = viewState.cursorX !== null ? clamp(viewState.cursorX, 0, chartWidth - 1) : null;
   const cursorY = viewState.cursorY !== null ? clamp(viewState.cursorY, 0, chartHeight - 1) : null;

--- a/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
+++ b/src/components/command-bar/__snapshots__/command-bar.test.tsx.snap
@@ -28,34 +28,6 @@ exports[`CommandBar renders the default layout with opencode-style chrome 1`] = 
 "
 `;
 
-exports[`CommandBar renders theme prefix results in the root query 1`] = `
-"                                                                                
-                                                                                
-                Commands                                                        
-                TH                                                              
-                                                                                
-                Themes                                                          
-                Amber                                   current                 
-                Green Phosphor                                                  
-                Cyan                                                            
-                Red Phosphor                                                    
-                Blue Phosphor                                                   
-                Purple Phosphor                                                 
-                Hot Pink                                                        
-                White Phosphor                                                  
-                Tokyo Night                                                     
-                Solarized Dark                                                  
-                Dracula                                                         
-                Nord                                                            
-                Monokai                                                         
-                Catppuccin Mocha                                                
-                                                                                
-                                                                                
-                                                                                
-                                                                                
-"
-`;
-
 exports[`CommandBar renders plugin toggle state 1`] = `
 "                                                                                
                                                                                 

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useReducer } from "react";
 import { TestDialogProvider, testRender } from "../../renderers/opentui/test-utils";
 import { CommandBar } from "./command-bar";
-import { AppContext, type AppState, appReducer, createInitialState, getEffectiveThemeId } from "../../state/app-context";
+import { AppContext, type AppAction, type AppState, appReducer, createInitialState, getEffectiveThemeId } from "../../state/app-context";
 import { createTestDataProvider } from "../../test-support/data-provider";
+import { ThemeProvider, useThemeId } from "../../theme/theme-context";
 import { cloneLayout, createDefaultConfig, type AppConfig } from "../../types/config";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRecord } from "../../types/ticker";
@@ -230,6 +231,10 @@ function makePluginRegistry(hasPaneSettings: (paneId: string) => boolean = () =>
   } as unknown as PluginRegistry;
 }
 
+function ThemeProbe() {
+  return <text>{`theme:${useThemeId()}`}</text>;
+}
+
 function CommandBarHarness({
   query,
   disabledPlugins = [],
@@ -244,6 +249,7 @@ function CommandBarHarness({
   dataProvider = makeDataProvider(),
   hasPaneSettings,
   onCheckForUpdates,
+  onAction,
 }: {
   query: string;
   disabledPlugins?: string[];
@@ -258,6 +264,7 @@ function CommandBarHarness({
   dataProvider?: DataProvider;
   hasPaneSettings?: (paneId: string) => boolean;
   onCheckForUpdates?: () => void | Promise<void>;
+  onAction?: (action: AppAction) => void;
 }) {
   let config = {
     ...createDefaultConfig("/tmp/gloomberb-test"),
@@ -299,24 +306,31 @@ function CommandBarHarness({
   configurePluginRegistry?.(pluginRegistry);
   const [liveState, dispatch] = useReducer(appReducer, state);
   const currentState = live ? liveState : state;
-  const currentDispatch = live ? dispatch : () => {};
+  const currentDispatch = live
+    ? (action: AppAction) => {
+      onAction?.(action);
+      dispatch(action);
+    }
+    : (_action: AppAction) => {};
 
   return (
-    <AppContext value={{ state: currentState, dispatch: currentDispatch }}>
-      <TestDialogProvider>
-        {live && <text>{`theme:${getEffectiveThemeId(currentState)}`}</text>}
-        {showQueryState && <text>{`query:${currentState.commandBarQuery}`}</text>}
-        {currentState.commandBarOpen && (
-          <CommandBar
-            dataProvider={dataProvider}
-            tickerRepository={tickerRepository as any}
-            pluginRegistry={pluginRegistry}
-            quitApp={() => {}}
-            onCheckForUpdates={onCheckForUpdates}
-          />
-        )}
-      </TestDialogProvider>
-    </AppContext>
+    <ThemeProvider themeId={getEffectiveThemeId(currentState)}>
+      <AppContext value={{ state: currentState, dispatch: currentDispatch }}>
+        <TestDialogProvider>
+          {live && <ThemeProbe />}
+          {showQueryState && <text>{`query:${currentState.commandBarQuery}`}</text>}
+          {currentState.commandBarOpen && (
+            <CommandBar
+              dataProvider={dataProvider}
+              tickerRepository={tickerRepository as any}
+              pluginRegistry={pluginRegistry}
+              quitApp={() => {}}
+              onCheckForUpdates={onCheckForUpdates}
+            />
+          )}
+        </TestDialogProvider>
+      </AppContext>
+    </ThemeProvider>
   );
 }
 
@@ -738,7 +752,6 @@ describe("CommandBar", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Commands");
     expect(frame).toContain("TH");
-    expect(frame).toContain("Themes");
     expect(frame).toContain("Amber");
     expect(frame).toContain("Paper");
     expect(frame).toContain("GitHub Light");
@@ -797,12 +810,45 @@ describe("CommandBar", () => {
     await testSetup.renderOnce();
     await act(async () => {
       testSetup!.mockInput.pressArrow("down");
+      await Bun.sleep(220);
       await testSetup!.renderOnce();
     });
     await testSetup.renderOnce();
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("theme:green");
+  });
+
+  test("debounces rapid keyboard theme previews", async () => {
+    const actions: AppAction[] = [];
+    testSetup = await testRender(
+      <CommandBarHarness query="TH " live onAction={(action) => actions.push(action)} />,
+      { width: 80, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      for (let index = 0; index < 6; index++) {
+        testSetup!.mockInput.pressArrow("down");
+      }
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions.filter((action) => action.type === "PREVIEW_THEME")).toHaveLength(0);
+
+    await act(async () => {
+      await Bun.sleep(100);
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions.filter((action) => action.type === "PREVIEW_THEME")).toHaveLength(0);
+
+    await act(async () => {
+      await Bun.sleep(150);
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions.filter((action) => action.type === "PREVIEW_THEME")).toHaveLength(1);
   });
 
   test("does not preview a theme from mouse hover alone", async () => {
@@ -840,6 +886,7 @@ describe("CommandBar", () => {
     await testSetup.renderOnce();
     await act(async () => {
       testSetup!.mockInput.pressArrow("down");
+      await Bun.sleep(220);
       await testSetup!.renderOnce();
     });
     await testSetup.renderOnce();
@@ -887,8 +934,10 @@ describe("CommandBar", () => {
     await testSetup.renderOnce();
     await act(async () => {
       testSetup!.mockInput.pressArrow("down");
+      await Bun.sleep(220);
       await testSetup!.renderOnce();
     });
+    await testSetup.renderOnce();
     expect(testSetup.captureCharFrame()).toContain("theme:green");
 
     await emitKeypress(testSetup, { name: "u", ctrl: true });

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -1,5 +1,5 @@
 import { Box, Input, ScrollBox, Text, Textarea, useUiCapabilities } from "../../ui";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { TextAttributes, type InputRenderable, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
 import { useNativeRenderer } from "../../ui";
@@ -8,7 +8,8 @@ import { Button, NumberField, Spinner, TextField } from "../ui";
 import { NativeSelect, openNativeSelect, type NativeSelectElement } from "../ui/native-select";
 import { ToggleList } from "../toggle-list";
 import {
-  colors,
+  applyTheme,
+  clearTransientThemePreview,
   commandBarBg,
   commandBarHeadingText,
   commandBarHoverBg,
@@ -18,9 +19,10 @@ import {
   commandBarSelectedText,
   commandBarSubtleText,
   commandBarText,
+  getCurrentThemeId,
+  previewTheme,
 } from "../../theme/colors";
 import {
-  getEffectiveThemeId,
   getFocusedCollectionId,
   useAppDispatch,
   useAppSelector,
@@ -28,8 +30,9 @@ import {
   type AppState,
 } from "../../state/app-context";
 import { fuzzyFilter } from "../../utils/fuzzy-search";
-import { commands, getThemeOptions, matchPrefix, type Command } from "./command-registry";
-import { applyTheme, getCurrentThemeId } from "../../theme/colors";
+import { commands, matchPrefix, type Command } from "./command-registry";
+import { useThemeColors } from "../../theme/theme-context";
+import { ThemePicker, type ThemePickerHandle } from "./theme-picker";
 import { exportConfig, importConfig, resetAllData, saveConfig } from "../../data/config-store";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRepository } from "../../data/ticker-repository";
@@ -297,6 +300,309 @@ function getVisibleMultiSelectPickerOptions(
   });
 }
 
+type CommandBarListScrollEvent = {
+  stopPropagation: () => void;
+  preventDefault: () => void;
+  scroll?: { direction?: string; delta?: number };
+};
+
+interface CommandBarListHeaderProps {
+  kind: ListScreenState["kind"];
+  query: string;
+  queryDisplayWidth: number;
+  nativePaneChrome: boolean;
+  inputBg: string;
+  paletteBg: string;
+  paletteText: string;
+  paletteSubtleText: string;
+  cursorColor: string;
+  contentPadding: number;
+  rootGhostSuffix: string | null;
+  rootQueryLength: number;
+  rootShortcutFeedback: string | null;
+  onQueryChange: (query: string) => void;
+}
+
+const CommandBarListHeader = memo(function CommandBarListHeader({
+  kind,
+  query,
+  queryDisplayWidth,
+  nativePaneChrome,
+  inputBg,
+  paletteBg,
+  paletteText,
+  paletteSubtleText,
+  cursorColor,
+  contentPadding,
+  rootGhostSuffix,
+  rootQueryLength,
+  rootShortcutFeedback,
+  onQueryChange,
+}: CommandBarListHeaderProps) {
+  return (
+    <>
+      <Box height={1} paddingX={contentPadding}>
+        <Box
+          width={queryDisplayWidth}
+          height={1}
+          position="relative"
+          backgroundColor={nativePaneChrome ? undefined : inputBg}
+          style={nativePaneChrome ? undefined : {
+            overflow: "hidden",
+          }}
+        >
+          <Input
+            value={query}
+            onInput={onQueryChange}
+            onChange={onQueryChange}
+            placeholder={kind === "root" ? "Search" : "Filter"}
+            focused
+            width={nativePaneChrome ? "100%" : queryDisplayWidth}
+            backgroundColor={nativePaneChrome ? "transparent" : paletteBg}
+            focusedBackgroundColor={nativePaneChrome ? "transparent" : paletteBg}
+            textColor={paletteText}
+            focusedTextColor={paletteText}
+            placeholderColor={paletteSubtleText}
+            cursorColor={cursorColor}
+          />
+          {kind === "root" && rootGhostSuffix && (
+            <Box
+              position="absolute"
+              top={0}
+              left={Math.max(0, Math.min(rootQueryLength, queryDisplayWidth - 1))}
+              width={Math.max(0, queryDisplayWidth - Math.min(rootQueryLength, queryDisplayWidth - 1))}
+              height={1}
+            >
+              <Text fg={paletteSubtleText}>
+                {truncateText(
+                  rootGhostSuffix,
+                  Math.max(0, queryDisplayWidth - Math.min(rootQueryLength, queryDisplayWidth - 1)),
+                )}
+              </Text>
+            </Box>
+          )}
+        </Box>
+      </Box>
+      <Box height={1} paddingX={contentPadding}>
+        {kind === "root" && rootShortcutFeedback
+          ? (
+            <Text fg={paletteSubtleText}>
+              {truncateText(rootShortcutFeedback, queryDisplayWidth)}
+            </Text>
+          )
+          : null}
+      </Box>
+    </>
+  );
+});
+
+interface CommandBarListItemRowProps {
+  item: ResultItem;
+  globalIdx: number;
+  isSelected: boolean;
+  isHovered: boolean;
+  contentPadding: number;
+  labelWidth: number;
+  trailingWidth: number;
+  nativePaneChrome: boolean;
+  paletteBg: string;
+  paletteHoverBg: string;
+  paletteSelectedBg: string;
+  paletteSelectedText: string;
+  paletteSubtleText: string;
+  paletteText: string;
+  panelBg: string;
+  onHoverIndex: (index: number | null) => void;
+  onListScroll: (event: CommandBarListScrollEvent) => void;
+  onRowMouseDown: (event: any, item: ResultItem, globalIdx: number) => void;
+}
+
+const CommandBarListItemRow = memo(function CommandBarListItemRow({
+  item,
+  globalIdx,
+  isSelected,
+  isHovered,
+  contentPadding,
+  labelWidth,
+  trailingWidth,
+  nativePaneChrome,
+  paletteBg,
+  paletteHoverBg,
+  paletteSelectedBg,
+  paletteSelectedText,
+  paletteSubtleText,
+  paletteText,
+  panelBg,
+  onHoverIndex,
+  onListScroll,
+  onRowMouseDown,
+}: CommandBarListItemRowProps) {
+  const presentation = getRowPresentation(item, isSelected, trailingWidth > 0);
+  const label = truncateText(presentation.label, labelWidth);
+  const trailing = truncateText(presentation.trailing, trailingWidth);
+
+  return (
+    <Box
+      key={item.id}
+      flexDirection="row"
+      height={1}
+      paddingX={contentPadding}
+      backgroundColor={isSelected
+        ? paletteSelectedBg
+        : isHovered
+          ? paletteHoverBg
+          : (nativePaneChrome ? panelBg : paletteBg)}
+      onMouseMove={() => onHoverIndex(globalIdx)}
+      onMouseOut={() => onHoverIndex(null)}
+      {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}
+      onMouseDown={(event: any) => onRowMouseDown(event, item, globalIdx)}
+      data-command-bar-row-selected={nativePaneChrome && isSelected ? "true" : undefined}
+      style={nativePaneChrome ? { borderRadius: 6 } : undefined}
+    >
+      <Box width={labelWidth}>
+        <Text fg={isSelected ? paletteSelectedText : presentation.primaryMuted ? paletteSubtleText : paletteText}>
+          {label}
+        </Text>
+      </Box>
+      <Box width={trailingWidth}>
+        <Text fg={isSelected ? paletteSelectedText : paletteSubtleText}>{trailing}</Text>
+      </Box>
+    </Box>
+  );
+});
+
+interface CommandBarListBodyProps {
+  visibleListState: ListScreenState;
+  nativeListRows: CommandBarListRow[];
+  listBodyHeight: number;
+  contentPadding: number;
+  labelWidth: number;
+  nativePaneChrome: boolean;
+  nativeListScrollRef: RefObject<ScrollBoxRenderable | null>;
+  paletteBg: string;
+  paletteHeadingText: string;
+  paletteHoverBg: string;
+  paletteSelectedBg: string;
+  paletteSelectedText: string;
+  paletteSubtleText: string;
+  paletteText: string;
+  panelBg: string;
+  queryDisplayWidth: number;
+  trailingWidth: number;
+  onHoverIndex: (index: number | null) => void;
+  onListScroll: (event: CommandBarListScrollEvent) => void;
+  onRowMouseDown: (event: any, item: ResultItem, globalIdx: number) => void;
+}
+
+const CommandBarListBody = memo(function CommandBarListBody({
+  visibleListState,
+  nativeListRows,
+  listBodyHeight,
+  contentPadding,
+  labelWidth,
+  nativePaneChrome,
+  nativeListScrollRef,
+  paletteBg,
+  paletteHeadingText,
+  paletteHoverBg,
+  paletteSelectedBg,
+  paletteSelectedText,
+  paletteSubtleText,
+  paletteText,
+  panelBg,
+  queryDisplayWidth,
+  trailingWidth,
+  onHoverIndex,
+  onListScroll,
+  onRowMouseDown,
+}: CommandBarListBodyProps) {
+  const visibleRows = useMemo(() => {
+    const rows = nativeListRows;
+    if (nativePaneChrome) return rows;
+    const paddedRows = [...rows];
+    while (paddedRows.length < listBodyHeight) {
+      paddedRows.push({ kind: "filler", id: `filler:${paddedRows.length}` });
+    }
+    return paddedRows;
+  }, [
+    listBodyHeight,
+    nativeListRows,
+    nativePaneChrome,
+  ]);
+
+  const renderedRows = (
+    <>
+      {visibleRows.map((row) => {
+        if (row.kind === "filler" || row.kind === "spacer") {
+          return <Box key={row.id} height={1} />;
+        }
+        if (row.kind === "spinner") {
+          return (
+            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
+              <Spinner label={row.label} />
+            </Box>
+          );
+        }
+        if (row.kind === "message") {
+          return (
+            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
+              <Text fg={paletteText}>{truncateText(row.label, queryDisplayWidth)}</Text>
+            </Box>
+          );
+        }
+        if (row.kind === "heading") {
+          return (
+            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
+              <Text attributes={TextAttributes.BOLD} fg={paletteHeadingText}>
+                {truncateText(row.label, queryDisplayWidth)}
+              </Text>
+            </Box>
+          );
+        }
+
+        const isSelected = row.globalIdx === visibleListState.selectedIdx;
+        const isHovered = row.globalIdx === visibleListState.hoveredIdx && !isSelected;
+        return (
+          <CommandBarListItemRow
+            key={row.item.id}
+            item={row.item}
+            globalIdx={row.globalIdx}
+            isSelected={isSelected}
+            isHovered={isHovered}
+            contentPadding={contentPadding}
+            labelWidth={labelWidth}
+            trailingWidth={trailingWidth}
+            nativePaneChrome={nativePaneChrome}
+            paletteBg={paletteBg}
+            paletteHoverBg={paletteHoverBg}
+            paletteSelectedBg={paletteSelectedBg}
+            paletteSelectedText={paletteSelectedText}
+            paletteSubtleText={paletteSubtleText}
+            paletteText={paletteText}
+            panelBg={panelBg}
+            onHoverIndex={onHoverIndex}
+            onListScroll={onListScroll}
+            onRowMouseDown={onRowMouseDown}
+          />
+        );
+      })}
+    </>
+  );
+
+  return (
+    <ScrollBox
+      ref={nativeListScrollRef}
+      flexDirection="column"
+      height={listBodyHeight}
+      scrollY
+      focusable={false}
+      {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}
+    >
+      {renderedRows}
+    </ScrollBox>
+  );
+});
+
 export function CommandBar({
   dataProvider,
   tickerRepository,
@@ -305,6 +611,7 @@ export function CommandBar({
   onCheckForUpdates,
 }: CommandBarProps) {
   const dispatch = useAppDispatch();
+  const themeColors = useThemeColors();
   const config = useAppSelector((state) => state.config);
   const paneState = useAppSelector((state) => state.paneState);
   const tickers = useAppSelector((state) => state.tickers);
@@ -366,6 +673,8 @@ export function CommandBar({
   const rootQueryRef = useRef(rootQuery);
   rootQueryRef.current = rootQuery;
   const rootModeInfo = resolveCommandBarMode(rootQuery, availableCommands);
+  const rootModeKindRef = useRef(rootModeInfo.kind);
+  rootModeKindRef.current = rootModeInfo.kind;
   const [rootSelectedIdx, setRootSelectedIdx] = useState(0);
   const [rootHoveredIdx, setRootHoveredIdx] = useState<number | null>(null);
   const [rootSearching, setRootSearching] = useState(false);
@@ -390,32 +699,50 @@ export function CommandBar({
   const workflowNativeSelectRefs = useRef(new Map<string, NativeSelectElement>());
   const workflowScrollRef = useRef<ScrollBoxRenderable | null>(null);
   const nativeListScrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const themePickerRef = useRef<ThemePickerHandle | null>(null);
   const visibleListStateRef = useRef<ListScreenState | null>(null);
   const processedLaunchSequenceRef = useRef<number | null>(null);
+  const currentThemePreviewRef = useRef<string | null>(null);
   const currentRoute = routeStack[routeStack.length - 1] ?? null;
   const currentRouteRef = useRef<CommandBarRoute | null>(currentRoute);
   currentRouteRef.current = currentRoute;
   const activeCollectionId = getFocusedCollectionId(state);
   const activePortfolio = state.config.portfolios.find((portfolio) => portfolio.id === activeCollectionId);
 
-  const clearThemePreview = useCallback((themeId: string | null | undefined) => {
-    if (!themeId) return;
-    if (getCurrentThemeId() !== themeId) {
-      applyTheme(themeId);
+  const applyThemePreview = useCallback((themeId: string | null) => {
+    const committedThemeId = stateRef.current.config.theme;
+    const preview = themeId && themeId !== committedThemeId ? themeId : null;
+    if (preview) {
+      previewTheme(preview);
+    } else {
+      clearTransientThemePreview();
+      if (getCurrentThemeId() !== committedThemeId) {
+        applyTheme(committedThemeId);
+      }
     }
-    dispatch({ type: "PREVIEW_THEME", theme: null });
+    if (currentThemePreviewRef.current !== preview) {
+      currentThemePreviewRef.current = preview;
+      dispatch({ type: "PREVIEW_THEME", theme: preview });
+    }
+  }, [dispatch]);
+
+  const clearThemePreview = useCallback((themeId: string | null | undefined) => {
+    themePickerRef.current?.cancelPreview();
+    const targetThemeId = themeId ?? stateRef.current.config.theme;
+    if (!targetThemeId) return;
+    clearTransientThemePreview();
+    if (getCurrentThemeId() !== targetThemeId) {
+      applyTheme(targetThemeId);
+    }
+    if (currentThemePreviewRef.current !== null) {
+      currentThemePreviewRef.current = null;
+      dispatch({ type: "PREVIEW_THEME", theme: null });
+    }
   }, [dispatch]);
 
   const restoreThemePreview = useCallback(() => {
-    const themeRoute = [...routeStack].reverse().find((route) => (
-      route.kind === "mode" && route.screen === "themes"
-    ));
-    if (themeRoute?.kind === "mode" && themeRoute.themeBaseId) {
-      clearThemePreview(themeRoute.themeBaseId);
-      return;
-    }
     clearThemePreview(rootThemeBaseIdRef.current);
-  }, [clearThemePreview, routeStack]);
+  }, [clearThemePreview]);
 
   const closeAll = useCallback((options?: { revertThemePreview?: boolean }) => {
     if (options?.revertThemePreview !== false) {
@@ -460,10 +787,6 @@ export function CommandBar({
     if (!currentRoute) {
       closeAll();
       return;
-    }
-
-    if (currentRoute.kind === "mode" && currentRoute.screen === "themes" && currentRoute.themeBaseId) {
-      clearThemePreview(currentRoute.themeBaseId);
     }
 
     if (routeStack.length === 1 && currentRoute.restoreMain) {
@@ -525,20 +848,22 @@ export function CommandBar({
     pluginRegistry.pinTicker(symbol, { floating: true, paneType: "ticker-detail" });
   }, [pluginRegistry]);
 
-  const previewThemeId = useCallback((themeId: string | undefined) => {
-    if (!themeId) return;
+  const commitTheme = useCallback((themeId: string) => {
+    themePickerRef.current?.cancelPreview();
+    clearTransientThemePreview();
     if (getCurrentThemeId() !== themeId) {
       applyTheme(themeId);
     }
-    const previewTheme = themeId === stateRef.current.config.theme ? null : themeId;
-    if (stateRef.current.themePreview !== previewTheme) {
-      dispatch({ type: "PREVIEW_THEME", theme: previewTheme });
-    }
+    currentThemePreviewRef.current = null;
+    dispatch({ type: "SET_THEME", theme: themeId });
   }, [dispatch]);
 
-  const previewThemeSelection = useCallback((listState: ListScreenState, selectedIdx: number) => {
-    previewThemeId(listState.results[selectedIdx]?.themeId);
-  }, [previewThemeId]);
+  useEffect(() => {
+    return () => {
+      themePickerRef.current?.cancelPreview();
+      clearTransientThemePreview();
+    };
+  }, []);
 
   const focusTicker = useCallback((symbol: string, options?: { forceNewPane?: boolean }) => {
     const currentState = stateRef.current;
@@ -591,7 +916,7 @@ export function CommandBar({
   }, [dispatch, persistLayoutChange, pluginRegistry]);
 
   const openModeRoute = useCallback((
-    screen: "ticker-search" | "themes" | "plugins" | "layout",
+    screen: "ticker-search" | "plugins" | "layout",
     initialQuery = "",
     payload?: Record<string, unknown>,
   ) => {
@@ -604,7 +929,6 @@ export function CommandBar({
       query: initialQuery,
       selectedIdx: 0,
       hoveredIdx: null,
-      themeBaseId: screen === "themes" ? stateRef.current.config.theme : undefined,
       payload,
     });
   }, [pushRoute]);
@@ -1160,44 +1484,6 @@ export function CommandBar({
       successBehavior: options.successBehavior || "close",
     });
   }, [openConfirmRoute]);
-
-  const buildThemeItems = useCallback((
-    query: string,
-    currentThemeId: string | null | undefined,
-    options?: { onSelectTheme?: (themeId: string) => void },
-  ): { items: ResultItem[]; selectedIdx: number } => {
-    let selectedIdx = 0;
-    const filtered = query
-      ? getThemeOptions().filter((theme) => (
-        theme.name.toLowerCase().includes(query.toLowerCase())
-        || theme.id.includes(query.toLowerCase())
-      ))
-      : getThemeOptions();
-    const items = filtered.map((theme, index): ResultItem => {
-      const current = theme.id === currentThemeId;
-      if (current) selectedIdx = index;
-      return {
-        id: `theme:${theme.id}`,
-        label: theme.name,
-        detail: theme.description,
-        category: "Themes",
-        kind: "theme",
-        current,
-        themeId: theme.id,
-        action: () => {
-          options?.onSelectTheme?.(theme.id);
-          const nextConfig = {
-            ...state.config,
-            theme: theme.id,
-          };
-          dispatch({ type: "SET_THEME", theme: theme.id });
-          void saveConfig(nextConfig);
-          closeAll({ revertThemePreview: false });
-        },
-      };
-    });
-    return { items, selectedIdx };
-  }, [closeAll, dispatch, state.config]);
 
   const buildPluginItems = useCallback((query: string): ResultItem[] => {
     const disabledPlugins = state.config.disabledPlugins || [];
@@ -2812,6 +3098,8 @@ export function CommandBar({
         const importPath = getDefaultConfigBackupPath();
         void importConfig(state.config.dataDir, importPath)
           .then((imported) => {
+            themePickerRef.current?.cancelPreview();
+            clearTransientThemePreview();
             dispatch({ type: "SET_CONFIG", config: imported });
             applyTheme(imported.theme);
             dispatch({ type: "SET_THEME", theme: imported.theme });
@@ -2842,6 +3130,10 @@ export function CommandBar({
       case "check-for-updates":
         void onCheckForUpdates?.();
         closeAll({ revertThemePreview: false });
+        return;
+      case "theme":
+        rootThemeBaseIdRef.current = stateRef.current.config.theme;
+        setRootQuery(arg ? `TH ${arg}` : "TH ");
         return;
       case "security-description":
         void runSecurityDescriptionShortcut(arg);
@@ -2879,9 +3171,12 @@ export function CommandBar({
     quitApp,
     runSecurityDescriptionShortcut,
     executeCollectionCommand,
+    setRootQuery,
   ]);
 
   const activeMatch = matchPrefix(rootQuery, availableCommands);
+  const themePickerActive = !currentRoute && activeMatch?.command.id === "theme";
+  const themePickerFilter = themePickerActive ? activeMatch.arg : "";
   const rootSecurityDescriptionArg = activeMatch?.command.id === "security-description" && activeMatch.arg.length >= 1
     ? activeMatch.arg
     : null;
@@ -2903,13 +3198,13 @@ export function CommandBar({
       rootThemeBaseIdRef.current = state.config.theme;
     } else if (rootModeInfo.kind !== "themes" && previousMode === "themes") {
       const rootThemeBaseId = rootThemeBaseIdRef.current;
-      if (rootThemeBaseId && getEffectiveThemeId(state) !== rootThemeBaseId) {
+      if (rootThemeBaseId) {
         clearThemePreview(rootThemeBaseId);
       }
       rootThemeBaseIdRef.current = null;
     }
     previousRootModeRef.current = rootModeInfo.kind;
-  }, [clearThemePreview, currentRoute, rootModeInfo.kind, state.config.theme, state.themePreview]);
+  }, [clearThemePreview, currentRoute, rootModeInfo.kind, state.config.theme]);
 
   const tickerSearchRouteQuery = currentRoute?.kind === "mode" && currentRoute.screen === "ticker-search"
     ? currentRoute.query
@@ -3247,14 +3542,7 @@ export function CommandBar({
     } else if (match && match.command.id === "layout") {
       items.push(...buildLayoutItems(match.arg, { confirmDangerousActions: true }));
     } else if (match && match.command.id === "theme") {
-      const savedThemeId = rootThemeBaseIdRef.current ?? state.config.theme;
-      const themeResult = buildThemeItems(match.arg, savedThemeId, {
-        onSelectTheme: (themeId) => {
-          rootThemeBaseIdRef.current = themeId;
-        },
-      });
-      initialIdx = themeResult.selectedIdx;
-      items.push(...themeResult.items);
+      initialIdx = 0;
     } else if (match && match.command.id === "security-description") {
       if (shortcutItem) {
         items.push(shortcutItem);
@@ -3324,7 +3612,6 @@ export function CommandBar({
     availableCommands,
     buildLayoutItems,
     buildPluginItems,
-    buildThemeItems,
     createPluginCommandItem,
     currentRoute,
     executeCollectionCommand,
@@ -3461,6 +3748,7 @@ export function CommandBar({
     }
     return rootResultModel.items;
   }, [rootProviderResults, rootProviderResultsQuery, rootResultModel.items, rootSecurityDescriptionArg]);
+  const orderedRootResults = useMemo(() => orderListResults(rootResults), [rootResults]);
 
   const rootGhostCompletion = !currentRoute && rootShortcutIntent.kind === "inferred-complete"
     ? rootShortcutIntent.completionQuery
@@ -3666,12 +3954,15 @@ export function CommandBar({
 
     if (match.command.id === "theme") {
       return {
-        id: "theme-route",
+        id: "theme-picker",
         label: "Change Theme",
         detail: "Preview and apply themes",
         category: "Themes",
         kind: "command",
-        action: () => openModeRoute("themes", match.arg),
+        action: () => {
+          rootThemeBaseIdRef.current = stateRef.current.config.theme;
+          setRootQuery(match.arg ? `TH ${match.arg}` : "TH ");
+        },
       };
     }
 
@@ -3737,6 +4028,7 @@ export function CommandBar({
     openModeRoute,
     runDirectCommand,
     runSecurityDescriptionShortcut,
+    setRootQuery,
   ]);
 
   const routeListState = useMemo<ListScreenState | null>(() => {
@@ -3752,7 +4044,7 @@ export function CommandBar({
         query: rootQuery,
         selectedIdx: rootSelectedIdx,
         hoveredIdx: rootHoveredIdx,
-        results: orderListResults(rootResults),
+        results: orderedRootResults,
         searching: rootSearching,
         emptyLabel: emptyState.label,
         emptyDetail: emptyState.detail,
@@ -3763,23 +4055,6 @@ export function CommandBar({
 
     if (currentRoute.kind === "mode") {
       switch (currentRoute.screen) {
-        case "themes": {
-          const results = buildThemeItems(currentRoute.query, currentRoute.themeBaseId).items;
-          return {
-            kind: "mode",
-            title: "Change Theme",
-            subtitle: "Preview themes with the keyboard, then save.",
-            query: currentRoute.query,
-            selectedIdx: currentRoute.selectedIdx,
-            hoveredIdx: currentRoute.hoveredIdx,
-            results: orderListResults(results),
-            searching: false,
-            emptyLabel: getEmptyState("themes", currentRoute.query).label,
-            emptyDetail: getEmptyState("themes", currentRoute.query).detail,
-            footerLeft: getScreenFooterLeft(currentRoute),
-            footerRight: getScreenFooterRight(currentRoute),
-          };
-        }
         case "plugins": {
           const results = buildPluginItems(currentRoute.query);
           return {
@@ -3911,7 +4186,6 @@ export function CommandBar({
     activeTickerSymbol,
     buildLayoutItems,
     buildPluginItems,
-    buildThemeItems,
     closeAll,
     createPaneTemplateItem,
     currentRoute,
@@ -3935,7 +4209,7 @@ export function CommandBar({
     rootHoveredIdx,
     rootModeInfo.kind,
     rootQuery,
-    rootResults,
+    orderedRootResults,
     rootSearching,
     rootSelectedIdx,
     rootShortcutIntent,
@@ -3972,8 +4246,9 @@ export function CommandBar({
   }, [currentRoute, routeListState, updateTopRoute]);
 
   const setActiveListQuery = useCallback((nextQuery: string) => {
-    if (!currentRoute) {
-      if (rootModeInfo.kind === "themes" && resolveCommandBarMode(nextQuery, availableCommands).kind !== "themes") {
+    const route = currentRouteRef.current;
+    if (!route) {
+      if (rootModeKindRef.current === "themes" && resolveCommandBarMode(nextQuery, availableCommands).kind !== "themes") {
         clearThemePreview(rootThemeBaseIdRef.current ?? stateRef.current.config.theme);
         rootThemeBaseIdRef.current = null;
       }
@@ -3981,7 +4256,7 @@ export function CommandBar({
       return;
     }
 
-    if (currentRoute.kind === "mode" || currentRoute.kind === "picker" || currentRoute.kind === "pane-settings") {
+    if (route.kind === "mode" || route.kind === "picker" || route.kind === "pane-settings") {
       updateTopRoute((route) => {
         if (route.kind === "mode" || route.kind === "picker" || route.kind === "pane-settings") {
           return { ...route, query: nextQuery, selectedIdx: 0, hoveredIdx: null };
@@ -3989,19 +4264,21 @@ export function CommandBar({
         return route;
       });
     }
-  }, [availableCommands, clearThemePreview, currentRoute, rootModeInfo.kind, setRootQuery, updateTopRoute]);
+  }, [availableCommands, clearThemePreview, setRootQuery, updateTopRoute]);
 
-  const moveListSelection = useCallback((delta: number) => {
+  const applyListSelectionDelta = useCallback((delta: number) => {
     const listState = visibleListStateRef.current;
     if (!listState || listState.results.length === 0 || delta === 0) return;
     const nextIndex = clampListIndex(listState.selectedIdx + delta, listState.results.length);
+    const selectionChanged = nextIndex !== listState.selectedIdx;
+    const hoverChanged = listState.hoveredIdx !== null;
+    if (!selectionChanged && !hoverChanged) return;
     const nextListState = { ...listState, selectedIdx: nextIndex, hoveredIdx: null };
     visibleListStateRef.current = nextListState;
-    previewThemeSelection(nextListState, nextIndex);
 
     if (!currentRouteRef.current) {
-      setRootSelectedIdx(nextIndex);
-      setRootHoveredIdx(null);
+      setRootSelectedIdx((current) => (current === nextIndex ? current : nextIndex));
+      setRootHoveredIdx((current) => (current === null ? current : null));
       return;
     }
     setRouteStack((current) => {
@@ -4011,24 +4288,34 @@ export function CommandBar({
       if (!top || (top.kind !== "mode" && top.kind !== "picker" && top.kind !== "pane-settings")) {
         return current;
       }
+      if (top.selectedIdx === nextIndex && top.hoveredIdx === null) return current;
       next[next.length - 1] = { ...top, selectedIdx: nextIndex, hoveredIdx: null };
       return next;
     });
-  }, [previewThemeSelection]);
+  }, []);
+
+  const moveListSelection = useCallback((delta: number) => {
+    applyListSelectionDelta(delta);
+  }, [applyListSelectionDelta]);
 
   const setHoveredIndex = useCallback((index: number | null) => {
-    if (!currentRoute) {
+    if (!currentRouteRef.current) {
       setRootHoveredIdx((current) => (current === index ? current : index));
       return;
     }
-    updateTopRoute((route) => {
+    setRouteStack((current) => {
+      if (current.length === 0) return current;
+      const next = [...current];
+      const route = next[next.length - 1];
+      if (!route) return current;
       if (route.kind === "mode" || route.kind === "picker" || route.kind === "pane-settings") {
-        if (route.hoveredIdx === index) return route;
-        return { ...route, hoveredIdx: index };
+        if (route.hoveredIdx === index) return current;
+        next[next.length - 1] = { ...route, hoveredIdx: index };
+        return next;
       }
-      return route;
+      return current;
     });
-  }, [currentRoute, updateTopRoute]);
+  }, []);
 
   const handleListScroll = useCallback((event: {
     stopPropagation: () => void;
@@ -4402,6 +4689,29 @@ export function CommandBar({
     disconnectBrokerInstance,
     executeCollectionCommand,
   ]);
+  const activateListSelectionRef = useRef(activateListSelection);
+  activateListSelectionRef.current = activateListSelection;
+
+  const handleListRowMouseDown = useCallback((event: any, item: ResultItem, globalIdx: number) => {
+    event.stopPropagation?.();
+    event.preventDefault?.();
+    if (!currentRouteRef.current) {
+      setRootSelectedIdx((current) => (current === globalIdx ? current : globalIdx));
+    } else {
+      setRouteStack((current) => {
+        if (current.length === 0) return current;
+        const next = [...current];
+        const route = next[next.length - 1];
+        if (!route || (route.kind !== "mode" && route.kind !== "picker" && route.kind !== "pane-settings")) {
+          return current;
+        }
+        if (route.selectedIdx === globalIdx && route.hoveredIdx === globalIdx) return current;
+        next[next.length - 1] = { ...route, selectedIdx: globalIdx, hoveredIdx: globalIdx };
+        return next;
+      });
+    }
+    activateListSelectionRef.current({ item });
+  }, []);
 
   const confirmCurrentRoute = useCallback(async () => {
     if (currentRoute?.kind !== "confirm") return;
@@ -4539,6 +4849,7 @@ export function CommandBar({
         preventDefault: () => void;
       }) => void) => void;
     };
+    if (!keyInput) return undefined;
     const handleKeyPress = (event: {
       name: string;
       sequence?: string;
@@ -4735,6 +5046,27 @@ export function CommandBar({
         return;
       }
 
+      if (themePickerActive) {
+        if (event.name === "up" || (event.ctrl && event.name === "p")) {
+          event.stopPropagation();
+          event.preventDefault();
+          themePickerRef.current?.move(-1);
+          return;
+        }
+        if (event.name === "down" || (event.ctrl && event.name === "n")) {
+          event.stopPropagation();
+          event.preventDefault();
+          themePickerRef.current?.move(1);
+          return;
+        }
+        if (event.name === "return" || event.name === "enter") {
+          event.stopPropagation();
+          event.preventDefault();
+          themePickerRef.current?.commit();
+          return;
+        }
+      }
+
       const activeListState = visibleListStateRef.current;
       if (!activeListState) return;
 
@@ -4802,13 +5134,13 @@ export function CommandBar({
     if (keyInput.onInternal) {
       keyInput.onInternal("keypress", handleKeyPress);
     } else {
-      renderer.keyInput.on("keypress", handleKeyPress);
+      keyInput.on("keypress", handleKeyPress);
     }
     return () => {
       if (keyInput.offInternal) {
         keyInput.offInternal("keypress", handleKeyPress);
       } else {
-        renderer.keyInput.off("keypress", handleKeyPress);
+        keyInput.off("keypress", handleKeyPress);
       }
     };
   }, [
@@ -4828,6 +5160,7 @@ export function CommandBar({
     renderer,
     rootModeInfo.kind,
     setActiveListQuery,
+    themePickerActive,
     updateWorkflowValue,
   ]);
 
@@ -4849,8 +5182,23 @@ export function CommandBar({
     ? routeListState
     : null;
   const showCustomMultiSelectPicker = currentRoute?.kind === "picker" && currentRoute.pickerId === "field-multi-select";
-  const listRows = visibleListState ? buildListRows(visibleListState) : [];
-  const nativeListRows = visibleListState ? buildNativeListRows(visibleListState, listRows) : [];
+  const listRows = useMemo(
+    () => (visibleListState ? buildListRows(visibleListState) : []),
+    [visibleListState?.results],
+  );
+  const nativeListRows = useMemo(
+    () => (visibleListState ? buildNativeListRows(visibleListState, listRows) : []),
+    [listRows, visibleListState?.emptyLabel, visibleListState?.searching],
+  );
+  const listRowIndexByGlobalIndex = useMemo(() => {
+    const indexByGlobalIndex = new Map<number, number>();
+    listRows.forEach((row, index) => {
+      if (row.kind === "item") {
+        indexByGlobalIndex.set(row.globalIdx, index);
+      }
+    });
+    return indexByGlobalIndex;
+  }, [listRows]);
   const workflowBodyHeight = currentRoute?.kind === "workflow"
     ? Math.min(
       Math.max(9, termHeight - (nativePaneChrome ? 7 : 9)),
@@ -4879,26 +5227,30 @@ export function CommandBar({
   const trailingWidth = Math.max(8, Math.min(12, Math.floor(resultsInnerWidth * 0.18)));
   const labelWidth = Math.max(10, resultsInnerWidth - trailingWidth);
   const queryDisplayWidth = Math.max(8, resultsInnerWidth);
-  const nativeSelectedRowIndex = nativePaneChrome && visibleListState
-    ? nativeListRows.findIndex((row) => row.kind === "item" && row.globalIdx === visibleListState.selectedIdx)
+  const selectedListRowIndex = visibleListState
+    ? listRowIndexByGlobalIndex.get(visibleListState.selectedIdx) ?? -1
     : -1;
+  const selectedScrollRowIndex = selectedListRowIndex;
   const bodySlotKey = showCustomMultiSelectPicker
     ? "picker:field-multi-select"
-    : currentRoute?.kind === "picker"
-      ? `picker:${currentRoute.pickerId}`
-      : currentRoute?.kind ?? "root";
+    : themePickerActive
+      ? "theme-picker"
+      : currentRoute?.kind === "picker"
+        ? `picker:${currentRoute.pickerId}`
+        : currentRoute?.kind ?? "root";
 
-  useEffect(() => {
-    if (!nativePaneChrome || nativeSelectedRowIndex < 0) return;
+  useLayoutEffect(() => {
     const scrollBox = nativeListScrollRef.current;
     if (!scrollBox) return;
+    if (scrollBox.verticalScrollBar) scrollBox.verticalScrollBar.visible = false;
+    if (selectedScrollRowIndex < 0) return;
     const viewportHeight = Math.max(1, scrollBox.viewport?.height ?? listBodyHeight);
-    if (nativeSelectedRowIndex < scrollBox.scrollTop) {
-      scrollBox.scrollTo(nativeSelectedRowIndex);
-    } else if (nativeSelectedRowIndex >= scrollBox.scrollTop + viewportHeight) {
-      scrollBox.scrollTo(nativeSelectedRowIndex - viewportHeight + 1);
+    if (selectedScrollRowIndex < scrollBox.scrollTop) {
+      scrollBox.scrollTo(selectedScrollRowIndex);
+    } else if (selectedScrollRowIndex >= scrollBox.scrollTop + viewportHeight) {
+      scrollBox.scrollTo(selectedScrollRowIndex - viewportHeight + 1);
     }
-  }, [listBodyHeight, nativePaneChrome, nativeSelectedRowIndex, visibleListState?.kind, visibleListState?.query]);
+  }, [listBodyHeight, selectedScrollRowIndex, visibleListState?.kind, visibleListState?.query]);
 
   useEffect(() => {
     if (!nativePaneChrome || currentRoute?.kind !== "workflow") return;
@@ -4918,140 +5270,6 @@ export function CommandBar({
       scrollBox.scrollTo(fieldBottom - viewportHeight);
     }
   }, [bodyHeight, currentRoute, nativePaneChrome]);
-
-  const renderListBody = () => {
-    if (!visibleListState) return null;
-
-    const allRows = listRows;
-    let visibleRows: CommandBarListRow[];
-    if (nativePaneChrome) {
-      visibleRows = nativeListRows;
-    } else if (visibleListState.searching && allRows.length === 0) {
-      visibleRows = [{ kind: "spinner", id: "searching", label: "Searching…" }];
-    } else if (allRows.length === 0) {
-      visibleRows = [{ kind: "message", id: "empty", label: visibleListState.emptyLabel }];
-    } else {
-      const selectedRowIdx = allRows.findIndex((row) => row.kind === "item" && row.globalIdx === visibleListState.selectedIdx);
-      const halfWindow = Math.floor(listBodyHeight / 2);
-      let windowStart = Math.max(0, Math.min(selectedRowIdx - halfWindow, allRows.length - listBodyHeight));
-      if (windowStart < 0) windowStart = 0;
-      visibleRows = allRows.slice(windowStart, windowStart + listBodyHeight);
-      if (visibleListState.searching) {
-        if (visibleRows.length >= listBodyHeight) {
-          visibleRows = visibleRows.slice(0, listBodyHeight - 1);
-        }
-        visibleRows.push({ kind: "spinner", id: "searching", label: "Searching…" });
-      }
-    }
-
-    while (!nativePaneChrome && visibleRows.length < listBodyHeight) {
-      visibleRows.push({ kind: "filler", id: `filler:${visibleRows.length}` });
-    }
-
-    const renderedRows = (
-      <>
-        {visibleRows.map((row) => {
-          if (row.kind === "filler" || row.kind === "spacer") {
-            return <Box key={row.id} height={1} />;
-          }
-          if (row.kind === "spinner") {
-            return (
-              <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: handleListScroll } : {})}>
-                <Spinner label={row.label} />
-              </Box>
-            );
-          }
-          if (row.kind === "message") {
-            return (
-              <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: handleListScroll } : {})}>
-                <Text fg={paletteText}>{truncateText(row.label, queryDisplayWidth)}</Text>
-              </Box>
-            );
-          }
-          if (row.kind === "heading") {
-            return (
-              <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: handleListScroll } : {})}>
-                <Text attributes={TextAttributes.BOLD} fg={paletteHeadingText}>
-                  {truncateText(row.label, queryDisplayWidth)}
-                </Text>
-              </Box>
-            );
-          }
-
-          const isSelected = row.globalIdx === visibleListState.selectedIdx;
-          const isHovered = row.globalIdx === visibleListState.hoveredIdx && !isSelected;
-          const presentation = getRowPresentation(row.item, isSelected, trailingWidth > 0);
-          const label = truncateText(presentation.label, labelWidth);
-          const trailing = truncateText(presentation.trailing, trailingWidth);
-          return (
-            <Box
-              key={row.item.id}
-              flexDirection="row"
-              height={1}
-              paddingX={contentPadding}
-              backgroundColor={isSelected
-                ? paletteSelectedBg
-                : isHovered
-                  ? paletteHoverBg
-                  : (nativePaneChrome ? panelBg : paletteBg)}
-              onMouseMove={() => setHoveredIndex(row.globalIdx)}
-              onMouseOut={() => setHoveredIndex(null)}
-              {...(!nativePaneChrome ? { onMouseScroll: handleListScroll } : {})}
-              onMouseDown={(event: any) => {
-                event.stopPropagation?.();
-                event.preventDefault?.();
-                if (!currentRoute) {
-                  setRootSelectedIdx(row.globalIdx);
-                } else {
-                  updateTopRoute((route) => {
-                    if (route.kind === "mode" || route.kind === "picker" || route.kind === "pane-settings") {
-                      return { ...route, selectedIdx: row.globalIdx, hoveredIdx: row.globalIdx };
-                    }
-                    return route;
-                  });
-                }
-                activateListSelection({ item: row.item });
-              }}
-              data-command-bar-row-selected={nativePaneChrome && isSelected ? "true" : undefined}
-              style={nativePaneChrome ? { borderRadius: 6 } : undefined}
-            >
-              <Box width={labelWidth}>
-                <Text fg={isSelected ? paletteSelectedText : presentation.primaryMuted ? paletteSubtleText : paletteText}>
-                  {label}
-                </Text>
-              </Box>
-              <Box width={trailingWidth}>
-                <Text fg={isSelected ? paletteSelectedText : paletteSubtleText}>{trailing}</Text>
-              </Box>
-            </Box>
-          );
-        })}
-      </>
-    );
-
-    if (nativePaneChrome) {
-      return (
-        <ScrollBox
-          ref={nativeListScrollRef}
-          flexDirection="column"
-          height={listBodyHeight}
-          scrollY
-        >
-          {renderedRows}
-        </ScrollBox>
-      );
-    }
-
-    return (
-      <Box
-        flexDirection="column"
-        height={listBodyHeight}
-        onMouseScroll={handleListScroll}
-      >
-        {renderedRows}
-      </Box>
-    );
-  };
 
   const renderWorkflowBody = () => {
     if (currentRoute?.kind !== "workflow") return null;
@@ -5130,7 +5348,7 @@ export function CommandBar({
                     borderColor={active ? paletteSelectedBg : paletteBg}
                     backgroundColor={nativePaneChrome ? inputBg : fieldBg}
                     style={nativePaneChrome ? {
-                      border: `1px solid ${active ? colors.borderFocused : colors.border}`,
+                      border: `1px solid ${active ? themeColors.borderFocused : themeColors.border}`,
                       borderRadius: 6,
                       overflow: "hidden",
                     } : undefined}
@@ -5144,7 +5362,7 @@ export function CommandBar({
                         focused={!currentRoute.pending}
                         textColor={paletteText}
                         placeholderColor={paletteSubtleText}
-                        backgroundColor={nativePaneChrome ? inputBg : colors.panel}
+                        backgroundColor={nativePaneChrome ? inputBg : themeColors.panel}
                         flexGrow={1}
                         wrapText
                       />
@@ -5225,7 +5443,7 @@ export function CommandBar({
         })}
         {currentRoute.error && (
           <Box height={1}>
-            <Text fg={colors.negative}>{truncateText(currentRoute.error, queryDisplayWidth)}</Text>
+            <Text fg={themeColors.negative}>{truncateText(currentRoute.error, queryDisplayWidth)}</Text>
           </Box>
         )}
         {currentRoute.pendingLabel && currentRoute.pending && (
@@ -5366,10 +5584,9 @@ export function CommandBar({
             <Box flexGrow={1}>
               <Text fg={paletteText} attributes={TextAttributes.BOLD}>
                 {currentRoute?.kind === "mode"
-                  ? currentRoute.screen === "themes" ? "Change Theme"
-                    : currentRoute.screen === "plugins" ? "Manage Plugins"
-                      : currentRoute.screen === "layout" ? "Layout Actions"
-                        : "Security Description"
+                  ? currentRoute.screen === "plugins" ? "Manage Plugins"
+                    : currentRoute.screen === "layout" ? "Layout Actions"
+                      : "Security Description"
                   : currentRoute?.kind === "picker" ? currentRoute.title
                     : currentRoute?.kind === "pane-settings" ? "Pane Settings"
                       : currentRoute?.kind === "workflow" ? currentRoute.title
@@ -5398,61 +5615,80 @@ export function CommandBar({
           )}
           {(visibleListState || currentRoute?.kind === "picker") && visibleListState && (
             <>
-              <Box height={1} paddingX={contentPadding}>
-                <Box
-                  width={queryDisplayWidth}
-                  height={1}
-                  position="relative"
-                  backgroundColor={nativePaneChrome ? undefined : inputBg}
-                  style={nativePaneChrome ? undefined : {
-                    overflow: "hidden",
-                  }}
-                >
-                  <Input
-                    value={visibleListState.query}
-                    onInput={setActiveListQuery}
-                    onChange={setActiveListQuery}
-                    placeholder={visibleListState.kind === "root" ? "Search" : "Filter"}
-                    focused
-                    width={nativePaneChrome ? "100%" : queryDisplayWidth}
-                    backgroundColor={nativePaneChrome ? "transparent" : paletteBg}
-                    focusedBackgroundColor={nativePaneChrome ? "transparent" : paletteBg}
-                    textColor={paletteText}
-                    focusedTextColor={paletteText}
-                    placeholderColor={paletteSubtleText}
-                    cursorColor={colors.textBright}
-                  />
-                  {visibleListState.kind === "root" && rootGhostSuffix && (
-                    <Box
-                      position="absolute"
-                      top={0}
-                      left={Math.max(0, Math.min(rootQuery.length, queryDisplayWidth - 1))}
-                      width={Math.max(0, queryDisplayWidth - Math.min(rootQuery.length, queryDisplayWidth - 1))}
-                      height={1}
-                    >
-                      <Text fg={paletteSubtleText}>
-                        {truncateText(
-                          rootGhostSuffix,
-                          Math.max(0, queryDisplayWidth - Math.min(rootQuery.length, queryDisplayWidth - 1)),
-                        )}
-                      </Text>
-                    </Box>
-                  )}
-                </Box>
-              </Box>
-              <Box height={1} paddingX={contentPadding}>
-                {visibleListState.kind === "root" && rootShortcutFeedback
-                  ? (
-                    <Text fg={paletteSubtleText}>
-                      {truncateText(rootShortcutFeedback, queryDisplayWidth)}
-                    </Text>
-                  )
-                  : null}
-              </Box>
+              <CommandBarListHeader
+                kind={visibleListState.kind}
+                query={visibleListState.query}
+                queryDisplayWidth={queryDisplayWidth}
+                nativePaneChrome={nativePaneChrome}
+                inputBg={inputBg}
+                paletteBg={paletteBg}
+                paletteText={paletteText}
+                paletteSubtleText={paletteSubtleText}
+                cursorColor={themeColors.textBright}
+                contentPadding={contentPadding}
+                rootGhostSuffix={rootGhostSuffix}
+                rootQueryLength={rootQuery.length}
+                rootShortcutFeedback={rootShortcutFeedback}
+                onQueryChange={setActiveListQuery}
+              />
             </>
           )}
 
-          {visibleListState && !showCustomMultiSelectPicker && renderListBody()}
+          {themePickerActive && (
+            <ThemePicker
+              ref={themePickerRef}
+              filter={themePickerFilter}
+              committedThemeId={state.config.theme}
+              height={listBodyHeight}
+              contentPadding={contentPadding}
+              labelWidth={labelWidth}
+              trailingWidth={trailingWidth}
+              queryDisplayWidth={queryDisplayWidth}
+              nativePaneChrome={nativePaneChrome}
+              paletteBg={paletteBg}
+              paletteHoverBg={paletteHoverBg}
+              paletteSelectedBg={paletteSelectedBg}
+              paletteSelectedText={paletteSelectedText}
+              paletteSubtleText={paletteSubtleText}
+              paletteText={paletteText}
+              panelBg={panelBg}
+              onPreview={applyThemePreview}
+              onCommit={(themeId) => {
+                const nextConfig = {
+                  ...stateRef.current.config,
+                  theme: themeId,
+                };
+                commitTheme(themeId);
+                void saveConfig(nextConfig);
+                closeAll({ revertThemePreview: false });
+              }}
+            />
+          )}
+
+          {visibleListState && !themePickerActive && !showCustomMultiSelectPicker && (
+            <CommandBarListBody
+              visibleListState={visibleListState}
+              nativeListRows={nativeListRows}
+              listBodyHeight={listBodyHeight}
+              contentPadding={contentPadding}
+              labelWidth={labelWidth}
+              nativePaneChrome={nativePaneChrome}
+              nativeListScrollRef={nativeListScrollRef}
+              paletteBg={paletteBg}
+              paletteHeadingText={paletteHeadingText}
+              paletteHoverBg={paletteHoverBg}
+              paletteSelectedBg={paletteSelectedBg}
+              paletteSelectedText={paletteSelectedText}
+              paletteSubtleText={paletteSubtleText}
+              paletteText={paletteText}
+              panelBg={panelBg}
+              queryDisplayWidth={queryDisplayWidth}
+              trailingWidth={trailingWidth}
+              onHoverIndex={setHoveredIndex}
+              onListScroll={handleListScroll}
+              onRowMouseDown={handleListRowMouseDown}
+            />
+          )}
           {currentRoute?.kind === "workflow" && renderWorkflowBody()}
           {currentRoute?.kind === "confirm" && renderConfirmBody()}
           {showCustomMultiSelectPicker && renderMultiSelectBody()}

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -1,5 +1,4 @@
 import type { AppAction } from "../../state/app-context";
-import { themes, getThemeIds } from "../../theme/themes";
 
 export type CommandExecutor = (dispatch: React.Dispatch<AppAction>, context: CommandContext) => void | Promise<void>;
 
@@ -238,15 +237,6 @@ export const commands: Command[] = [
     execute: () => {}, // handled by command bar (needs confirm dialog)
   },
 ];
-
-/** Get theme options for the command bar */
-export function getThemeOptions(): Array<{ id: string; name: string; description: string }> {
-  return getThemeIds().map((id) => ({
-    id,
-    name: themes[id]!.name,
-    description: themes[id]!.description,
-  }));
-}
 
 /** Find a command whose prefix matches the start of the input */
 export function matchPrefix(input: string, commandList: Command[] = commands): { command: Command; arg: string } | null {

--- a/src/components/command-bar/helpers.ts
+++ b/src/components/command-bar/helpers.ts
@@ -14,7 +14,7 @@ import type {
 } from "./workflow-types";
 import type { CollectionKind, CollectionMembershipAction } from "./workflow-ops";
 
-export type RouteCommandId = "security-description" | "theme" | "plugins" | "layout";
+export type RouteCommandId = "security-description" | "plugins" | "layout";
 export type CollectionCommandId = "add-watchlist" | "add-portfolio" | "remove-watchlist" | "remove-portfolio";
 
 export function summarizeError(error: unknown): Record<string, string> {
@@ -30,7 +30,6 @@ export function summarizeError(error: unknown): Record<string, string> {
 
 export function isRouteCommandId(commandId: string): commandId is RouteCommandId {
   return commandId === "security-description"
-    || commandId === "theme"
     || commandId === "plugins"
     || commandId === "layout";
 }
@@ -237,12 +236,10 @@ export function normalizeWizardFields(steps: WizardStep[]): {
   return { fields, description, initialValues, pendingLabel, successLabel };
 }
 
-export function routeCommandIdToScreen(commandId: RouteCommandId): "ticker-search" | "themes" | "plugins" | "layout" {
+export function routeCommandIdToScreen(commandId: RouteCommandId): "ticker-search" | "plugins" | "layout" {
   switch (commandId) {
     case "security-description":
       return "ticker-search";
-    case "theme":
-      return "themes";
     case "plugins":
       return "plugins";
     case "layout":

--- a/src/components/command-bar/list-model.ts
+++ b/src/components/command-bar/list-model.ts
@@ -5,10 +5,9 @@ export interface ResultItem {
   label: string;
   detail: string;
   category: string;
-  kind: "command" | "ticker" | "search" | "theme" | "plugin" | "action" | "info";
+  kind: "command" | "ticker" | "search" | "plugin" | "action" | "info";
   right?: string;
   searchText?: string;
-  themeId?: string;
   pluginToggle?: () => void | Promise<void>;
   secondaryAction?: () => void | Promise<void>;
   checked?: boolean;

--- a/src/components/command-bar/theme-picker.tsx
+++ b/src/components/command-bar/theme-picker.tsx
@@ -1,0 +1,254 @@
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Box, ScrollBox, Text } from "../../ui";
+import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
+import { getThemeIds, themes as themeRegistry } from "../../theme/themes";
+import { truncateText } from "./view-model";
+
+const THEME_PREVIEW_DEBOUNCE_MS = 120;
+const THEME_OPTIONS = getThemeIds().map((id) => ({
+  id,
+  name: themeRegistry[id]!.name,
+}));
+
+interface ThemePickerScrollEvent {
+  stopPropagation: () => void;
+  preventDefault: () => void;
+  scroll?: { direction?: string; delta?: number };
+}
+
+interface ThemePickerProps {
+  filter: string;
+  committedThemeId: string;
+  height: number;
+  contentPadding: number;
+  labelWidth: number;
+  trailingWidth: number;
+  queryDisplayWidth: number;
+  nativePaneChrome: boolean;
+  paletteBg: string;
+  paletteHoverBg: string;
+  paletteSelectedBg: string;
+  paletteSelectedText: string;
+  paletteSubtleText: string;
+  paletteText: string;
+  panelBg: string;
+  onPreview: (themeId: string | null) => void;
+  onCommit: (themeId: string) => void;
+}
+
+export interface ThemePickerHandle {
+  move: (delta: number) => boolean;
+  commit: () => boolean;
+  cancelPreview: () => void;
+}
+
+function clampIndex(index: number, length: number): number {
+  return Math.max(0, Math.min(index, Math.max(0, length - 1)));
+}
+
+export const ThemePicker = memo(forwardRef<ThemePickerHandle, ThemePickerProps>(function ThemePicker({
+  filter,
+  committedThemeId,
+  height,
+  contentPadding,
+  labelWidth,
+  trailingWidth,
+  queryDisplayWidth,
+  nativePaneChrome,
+  paletteBg,
+  paletteHoverBg,
+  paletteSelectedBg,
+  paletteSelectedText,
+  paletteSubtleText,
+  paletteText,
+  panelBg,
+  onPreview,
+  onCommit,
+}: ThemePickerProps, ref) {
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPreviewIdRef = useRef<string | null>(null);
+  const committedThemeIdRef = useRef(committedThemeId);
+  const onPreviewRef = useRef(onPreview);
+  const onCommitRef = useRef(onCommit);
+  const normalizedFilter = filter.trim().toLowerCase();
+  const themes = useMemo(() => {
+    if (!normalizedFilter) return THEME_OPTIONS;
+    return THEME_OPTIONS.filter((theme) => (
+      theme.name.toLowerCase().includes(normalizedFilter)
+      || theme.id.toLowerCase().includes(normalizedFilter)
+    ));
+  }, [normalizedFilter]);
+  const [selectedIndex, setSelectedIndex] = useState(() => (
+    Math.max(0, themes.findIndex((theme) => theme.id === committedThemeId))
+  ));
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const themesRef = useRef(themes);
+  const selectedIndexRef = useRef(selectedIndex);
+
+  themesRef.current = themes;
+  selectedIndexRef.current = selectedIndex;
+  committedThemeIdRef.current = committedThemeId;
+  onPreviewRef.current = onPreview;
+  onCommitRef.current = onCommit;
+
+  const cancelPreview = useCallback(() => {
+    if (previewTimerRef.current) {
+      clearTimeout(previewTimerRef.current);
+      previewTimerRef.current = null;
+    }
+    pendingPreviewIdRef.current = null;
+  }, []);
+
+  const requestPreview = useCallback((themeId: string) => {
+    pendingPreviewIdRef.current = themeId;
+    if (previewTimerRef.current) {
+      clearTimeout(previewTimerRef.current);
+    }
+    previewTimerRef.current = setTimeout(() => {
+      previewTimerRef.current = null;
+      const nextThemeId = pendingPreviewIdRef.current;
+      pendingPreviewIdRef.current = null;
+      if (!nextThemeId) return;
+      onPreviewRef.current(nextThemeId === committedThemeIdRef.current ? null : nextThemeId);
+    }, THEME_PREVIEW_DEBOUNCE_MS);
+  }, []);
+
+  const move = useCallback((delta: number): boolean => {
+    const options = themesRef.current;
+    if (options.length === 0 || delta === 0) return false;
+    const nextIndex = clampIndex(selectedIndexRef.current + delta, options.length);
+    if (nextIndex === selectedIndexRef.current) return false;
+    selectedIndexRef.current = nextIndex;
+    setSelectedIndex(nextIndex);
+    setHoveredIndex(null);
+    requestPreview(options[nextIndex]!.id);
+    return true;
+  }, [requestPreview]);
+
+  const commit = useCallback((): boolean => {
+    const selected = themesRef.current[selectedIndexRef.current];
+    if (!selected) return false;
+    cancelPreview();
+    onCommitRef.current(selected.id);
+    return true;
+  }, [cancelPreview]);
+
+  useImperativeHandle(ref, () => ({
+    move,
+    commit,
+    cancelPreview,
+  }), [cancelPreview, commit, move]);
+
+  useEffect(() => {
+    const preferredIndex = themes.findIndex((theme) => theme.id === committedThemeId);
+    const nextIndex = preferredIndex >= 0 ? preferredIndex : 0;
+    selectedIndexRef.current = nextIndex;
+    setSelectedIndex(nextIndex);
+    setHoveredIndex(null);
+  }, [committedThemeId, themes]);
+
+  useEffect(() => cancelPreview, [cancelPreview]);
+
+  useLayoutEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox) return;
+    if (scrollBox.verticalScrollBar) scrollBox.verticalScrollBar.visible = false;
+    if (themes.length === 0) return;
+    const viewportHeight = Math.max(1, scrollBox.viewport?.height ?? height);
+    if (selectedIndex < scrollBox.scrollTop) {
+      scrollBox.scrollTo(selectedIndex);
+    } else if (selectedIndex >= scrollBox.scrollTop + viewportHeight) {
+      scrollBox.scrollTo(selectedIndex - viewportHeight + 1);
+    }
+  }, [height, selectedIndex, themes.length]);
+
+  const handleScroll = useCallback((event: ThemePickerScrollEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    const delta = Math.max(1, Math.round(event.scroll?.delta ?? 1));
+    const direction = event.scroll?.direction;
+    if (direction === "down" || direction === "right") {
+      move(delta);
+    } else if (direction === "up" || direction === "left") {
+      move(-delta);
+    }
+  }, [move]);
+
+  if (themes.length === 0) {
+    return (
+      <Box height={height} paddingX={contentPadding}>
+        <Text fg={paletteSubtleText}>{truncateText("No themes match", queryDisplayWidth)}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <ScrollBox
+      ref={scrollRef}
+      flexDirection="column"
+      height={height}
+      scrollY
+      focusable={false}
+      {...(!nativePaneChrome ? { onMouseScroll: handleScroll } : {})}
+    >
+      {themes.map((theme, index) => {
+        const selected = index === selectedIndex;
+        const hovered = index === hoveredIndex && !selected;
+        const current = theme.id === committedThemeId;
+        const label = truncateText(theme.name, labelWidth);
+        const trailing = current ? "current" : "";
+        return (
+          <Box
+            key={theme.id}
+            flexDirection="row"
+            height={1}
+            paddingX={contentPadding}
+            backgroundColor={selected
+              ? paletteSelectedBg
+              : hovered
+                ? paletteHoverBg
+                : (nativePaneChrome ? panelBg : paletteBg)}
+            onMouseMove={() => setHoveredIndex(index)}
+            onMouseOut={() => setHoveredIndex(null)}
+            onMouseDown={(event: any) => {
+              event.stopPropagation?.();
+              event.preventDefault?.();
+              selectedIndexRef.current = index;
+              setSelectedIndex(index);
+              cancelPreview();
+              onCommitRef.current(theme.id);
+            }}
+            {...(!nativePaneChrome ? { onMouseScroll: handleScroll } : {})}
+            data-command-bar-row-selected={nativePaneChrome && selected ? "true" : undefined}
+            style={nativePaneChrome ? { borderRadius: 6 } : undefined}
+          >
+            <Box width={labelWidth}>
+              <Text
+                fg={selected ? paletteSelectedText : paletteText}
+                attributes={current ? TextAttributes.BOLD : undefined}
+              >
+                {label}
+              </Text>
+            </Box>
+            <Box width={trailingWidth}>
+              <Text fg={selected ? paletteSelectedText : paletteSubtleText}>
+                {truncateText(trailing, trailingWidth)}
+              </Text>
+            </Box>
+          </Box>
+        );
+      })}
+    </ScrollBox>
+  );
+}));

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -46,7 +46,7 @@ describe("command bar view model helpers", () => {
     expect(sections.map((section) => section.category)).toEqual(["Tickers", "Config", "Danger", "Debug"]);
   });
 
-  test("derives row presentation for toggles and current theme rows", () => {
+  test("derives row presentation for toggles and current rows", () => {
     expect(getRowPresentation({
       id: "plugin:news",
       label: "News",
@@ -61,11 +61,11 @@ describe("command bar view model helpers", () => {
     });
 
     expect(getRowPresentation({
-      id: "theme:amber",
+      id: "current:amber",
       label: "Amber",
       detail: "Warm terminal palette",
-      category: "Themes",
-      kind: "theme",
+      category: "Config",
+      kind: "command",
       right: "amber",
       current: true,
     }, false, true)).toMatchObject({

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -20,7 +20,7 @@ export interface CommandBarItemView {
   label: string;
   detail: string;
   category: string;
-  kind: "command" | "ticker" | "search" | "theme" | "plugin" | "action" | "info";
+  kind: "command" | "ticker" | "search" | "plugin" | "action" | "info";
   right?: string;
   checked?: boolean;
   current?: boolean;

--- a/src/components/command-bar/workflow-types.ts
+++ b/src/components/command-bar/workflow-types.ts
@@ -38,11 +38,10 @@ export interface CommandBarRouteBase {
 
 export interface CommandBarModeRoute extends CommandBarRouteBase {
   kind: "mode";
-  screen: "ticker-search" | "themes" | "plugins" | "layout";
+  screen: "ticker-search" | "plugins" | "layout";
   query: string;
   selectedIdx: number;
   hoveredIdx: number | null;
-  themeBaseId?: string;
   payload?: Record<string, unknown>;
 }
 

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -6,6 +6,7 @@ import type { DesktopWindowBridge } from "../../types/desktop-window";
 import { findPaneInstance } from "../../types/config";
 import type { PluginRegistry } from "../../plugins/registry";
 import { colors, floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 import { hasPaneFooterContent, PaneFooterBar, PaneFooterProvider } from "./pane-footer";
 import { PaneContent } from "./pane-content";
 import { getPaneBodyWidth } from "./pane-sizing";
@@ -23,6 +24,7 @@ function stopMouse(event?: { stopPropagation?: () => void; preventDefault?: () =
 }
 
 export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: DetachedPaneShellProps) {
+  useThemeColors();
   const dispatch = useAppDispatch();
   const rendererHost = useRendererHost();
   const config = useAppSelector((state) => state.config);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 import { Box, SpinnerMark, Text, TextAttributes, useUiCapabilities } from "../../ui";
 import { useEffect, type ReactNode } from "react";
 import { blendHex, colors, priceColor } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 import { useAppActive } from "../../state/app-activity";
 import { useAppDispatch, useAppSelector } from "../../state/app-context";
 import {
@@ -121,6 +122,7 @@ function UpdateStatus() {
 }
 
 export function Header() {
+  useThemeColors();
   const baseCurrency = useAppSelector(selectBaseCurrency);
   const appActive = useAppActive();
   const { titleBarOverlay } = useUiCapabilities();

--- a/src/components/layout/pane-content.test.tsx
+++ b/src/components/layout/pane-content.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, type Dispatch } from "react";
+import { testRender } from "../../renderers/opentui/test-utils";
+import { AppProvider, useAppDispatch, type AppAction } from "../../state/app-context";
+import { applyTheme, colors } from "../../theme/colors";
+import { getTheme } from "../../theme/themes";
+import { createDefaultConfig } from "../../types/config";
+import { PaneContent } from "./pane-content";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let capturedDispatch: Dispatch<AppAction> | null = null;
+
+function DispatchCapture() {
+  capturedDispatch = useAppDispatch();
+  return null;
+}
+
+function ThemeColorProbe() {
+  return <text>{colors.textBright}</text>;
+}
+
+describe("PaneContent", () => {
+  afterEach(() => {
+    testSetup?.renderer.destroy();
+    testSetup = undefined;
+    capturedDispatch = null;
+    applyTheme("amber");
+  });
+
+  test("rerenders memoized pane bodies when the theme preview changes", async () => {
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-test"),
+      theme: "amber",
+    };
+
+    testSetup = await testRender(
+      <AppProvider config={config}>
+        <DispatchCapture />
+        <PaneContent
+          component={ThemeColorProbe}
+          paneId="theme-preview:test"
+          paneType="test"
+          focused
+          width={24}
+          height={4}
+        />
+      </AppProvider>,
+      { width: 32, height: 6 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(getTheme("amber").textBright);
+
+    await act(async () => {
+      capturedDispatch?.({ type: "PREVIEW_THEME", theme: "green" });
+      await testSetup!.renderOnce();
+    });
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain(getTheme("green").textBright);
+    expect(frame).not.toContain(getTheme("amber").textBright);
+  });
+});

--- a/src/components/layout/pane-content.tsx
+++ b/src/components/layout/pane-content.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback } from "react";
 import { PaneInstanceProvider } from "../../state/app-context";
 import { PaneKeyboardScrollController } from "../../state/pane-scroll-registry";
+import { useThemeColors } from "../../theme/theme-context";
 import type { PaneDef } from "../../types/plugin";
 
 interface PaneContentProps {
@@ -22,6 +23,7 @@ export const PaneContent = memo(function PaneContent({
   height,
   onClose,
 }: PaneContentProps) {
+  useThemeColors();
   const close = useCallback(() => {
     onClose?.(paneId);
   }, [onClose, paneId]);

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -43,6 +43,7 @@ import {
   selectStatusBarVisible,
 } from "../../state/selectors-ui";
 import { colors } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 import { PANE_HEADER_ACTION, PANE_HEADER_CLOSE } from "./pane-header";
 import { getNativeSurfaceManager, type NativeOccluder, type NativePaneLayer } from "../chart/native/surface-manager";
 import { FloatingPaneWrapper } from "./floating-pane";
@@ -777,6 +778,7 @@ function resolveExternalDockPreview(
 }
 
 export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview }: ShellProps) {
+  useThemeColors();
   const dispatch = useAppDispatch();
   const config = useAppSelector((state) => state.config);
   const paneState = useAppSelector((state) => state.paneState);

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,6 +1,7 @@
 import { Box, Span, Text, TextAttributes, contextMenuDivider, useContextMenu, useUiCapabilities } from "../../ui";
 import { useCallback, useEffect, useState } from "react";
 import { colors, hoverBg } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 import { useAppDispatch, useAppSelector, useFocusedTicker } from "../../state/app-context";
 import {
   selectActiveLayoutIndex,
@@ -57,6 +58,7 @@ function truncate(text: string, width: number): string {
 }
 
 export function StatusBar() {
+  useThemeColors();
   const { nativePaneChrome, nativeContextMenu } = useUiCapabilities();
   const { showContextMenu } = useContextMenu();
   const registry = getSharedRegistry();

--- a/src/components/speedometer-gauge.tsx
+++ b/src/components/speedometer-gauge.tsx
@@ -2,6 +2,7 @@ import { createElement, useMemo, type SVGProps } from "react";
 import { Box, ChartSurface, Span, Text, TextAttributes, useNativeRenderer, useUiCapabilities, useUiHost } from "../ui";
 import { computeBitmapSize, type NativeChartBitmap } from "./chart/native/chart-rasterizer";
 import { colors } from "../theme/colors";
+import { useThemeColors } from "../theme/theme-context";
 
 export interface SpeedometerSegment {
   from: number;
@@ -536,6 +537,7 @@ export function SpeedometerGauge({
   minWidth = DEFAULT_MIN_WIDTH,
   maxWidth = DEFAULT_MAX_WIDTH,
 }: SpeedometerGaugeProps) {
+  useThemeColors();
   const props = {
     value,
     valueLabel,

--- a/src/components/ticker-list-table.tsx
+++ b/src/components/ticker-list-table.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useMemo, useRef, useState, type RefObject } from "re
 import { TextAttributes, type ScrollBoxRenderable } from "../ui";
 import { EmptyState } from "./ui";
 import { colors, hoverBg } from "../theme/colors";
+import { useThemeColors } from "../theme/theme-context";
 import { getSharedRegistry } from "../plugins/registry";
 import type { ColumnConfig } from "../types/config";
 import type { TickerFinancials, PricePoint } from "../types/financials";
@@ -102,6 +103,7 @@ const TickerListHeader = memo(function TickerListHeader({
   onHeaderClick?: (columnId: string) => void;
   onSizeChange?: () => void;
 }) {
+  useThemeColors();
   return (
     <ScrollBox
       ref={headerScrollRef}
@@ -211,6 +213,7 @@ const TickerListRow = memo(function TickerListRow({
   priceHistory?: PricePoint[];
   contentWidth: number;
 }) {
+  useThemeColors();
   const lastActivatedAtRef = useRef<number | null>(null);
   const rowBg = isSelected ? colors.selected : isHovered ? hoverBg() : colors.bg;
 

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -2,6 +2,7 @@ import { Box, ScrollBox, Text, useUiHost } from "../../ui";
 import { useCallback, useEffect, useMemo, useState, type ComponentType, type ReactNode, type RefObject } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 import type { ColumnConfig } from "../../types/config";
 import { useAppDispatch, usePaneInstance } from "../../state/app-context";
 import { useViewport } from "../../react/input";
@@ -155,6 +156,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
   scrollToIndexAlign = "nearest",
   scrollToIndexVersion = 0,
 }: DataTableProps<T, C>) {
+  useThemeColors();
   const dispatch = useAppDispatch();
   const paneInstanceId = usePaneInstance()?.instanceId ?? null;
   const appViewport = useViewport();

--- a/src/components/ui/frame.tsx
+++ b/src/components/ui/frame.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useUiHost } from "../../ui";
 import { TextAttributes } from "../../ui";
 import { type ComponentType, type ReactNode } from "react";
 import { colors } from "../../theme/colors";
+import { useThemeColors } from "../../theme/theme-context";
 
 export interface DialogFrameProps {
   title: string;
@@ -11,6 +12,7 @@ export interface DialogFrameProps {
 }
 
 export function DialogFrame({ title, children, footer, showTitleDivider = true }: DialogFrameProps) {
+  useThemeColors();
   const HostDialogFrame = useUiHost().DialogFrame as ComponentType<DialogFrameProps> | undefined;
   if (HostDialogFrame) {
     return (

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -13,7 +13,7 @@ import * as nodeConfigStoreHost from "../../../data/config-store-node";
 import { cloneLayout, findPaneInstance, type AppConfig } from "../../../types/config";
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
 import type { PaneRuntimeState } from "../../../core/state/app-state";
-import type { DesktopDockPreviewState, DesktopSharedStateSnapshot } from "../../../types/desktop-window";
+import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState } from "../../../types/desktop-window";
 import type { ReleaseInfo, UpdateCheckResult, UpdateProgress } from "../../../updater";
 import { buildSoundCommand } from "../../../notifications/app-notifier";
 import { isPaneDetached } from "../../../plugins/pane-manager";
@@ -61,6 +61,7 @@ let services: AppServices | null = null;
 let mainWindow: BrowserWindow | null = null;
 let desktopWorkspace: DesktopWorkspace | null = null;
 let currentDockPreview: DesktopDockPreviewState = { paneId: null, edge: null };
+let currentThemePreview: DesktopThemePreviewState = { theme: null };
 let desktopUpdateInProgress = false;
 
 const detachedWindows = new Map<string, BrowserWindow>();
@@ -560,6 +561,17 @@ function sendDockPreview(preview: DesktopDockPreviewState): void {
   });
 }
 
+function sendThemePreview(preview: DesktopThemePreviewState): void {
+  if (currentThemePreview.theme === preview.theme) return;
+  currentThemePreview = preview;
+  const encodedPreview = encodeRpcValue(preview) as DesktopThemePreviewState;
+  forEachReadyWindowRpc((rpc) => {
+    rpc.send["desktop.themePreview"]({
+      preview: encodedPreview,
+    });
+  });
+}
+
 function clearDockPreview(paneId?: string): void {
   if (paneId && currentDockPreview.paneId && currentDockPreview.paneId !== paneId) return;
   sendDockPreview({ paneId: null, edge: null });
@@ -848,6 +860,7 @@ async function initialize(
     config: requireConfig(),
     sessionSnapshot: getSessionSnapshot(),
     desktopSnapshot: getDesktopSnapshot(),
+    desktopThemePreview: currentThemePreview,
     pluginState: loadPluginState(),
     capabilityManifests: requireServices().pluginRegistry.capabilities.manifests({ rendererOnly: true }),
     windowKind: windowTarget.kind,
@@ -869,6 +882,9 @@ async function handleDesktop(
       sendDesktopState(snapshot);
       return null;
     }
+    case "desktop.setThemePreview":
+      sendThemePreview((payload.preview ?? { theme: null }) as DesktopThemePreviewState);
+      return null;
     case "desktop.replaceDetachedPaneState":
       if (typeof payload.paneId !== "string") {
         throw new Error("desktop.replaceDetachedPaneState requires paneId.");

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -1,5 +1,5 @@
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
-import type { DesktopDockPreviewState, DesktopSharedStateSnapshot } from "../../../types/desktop-window";
+import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState } from "../../../types/desktop-window";
 import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu";
 import type { AppConfig } from "../../../types/config";
 import type { UpdateProgress } from "../../../updater";
@@ -11,6 +11,7 @@ export interface ElectrobunBackendInit {
   config: AppConfig;
   sessionSnapshot: AppSessionSnapshot | null;
   desktopSnapshot: DesktopSharedStateSnapshot | null;
+  desktopThemePreview: DesktopThemePreviewState;
   pluginState: Record<string, Record<string, unknown>>;
   capabilityManifests: CapabilityManifest[];
   windowKind: "main" | "detached";
@@ -39,6 +40,10 @@ export interface DesktopDockPreviewMessage {
   preview: DesktopDockPreviewState;
 }
 
+export interface DesktopThemePreviewMessage {
+  preview: DesktopThemePreviewState;
+}
+
 export interface UpdateProgressMessage {
   progress: UpdateProgress;
 }
@@ -65,6 +70,7 @@ export interface ElectrobunDesktopRpcSchema {
       "application-menu.select": ApplicationMenuSelectMessage;
       "desktop.state": DesktopStateMessage;
       "desktop.dockPreview": DesktopDockPreviewMessage;
+      "desktop.themePreview": DesktopThemePreviewMessage;
       "update.progress": UpdateProgressMessage;
       "capability.event": CapabilityEventMessage;
     };

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -7,6 +7,7 @@ import {
   type ContextMenuSelectMessage,
   type DesktopDockPreviewMessage,
   type DesktopStateMessage,
+  type DesktopThemePreviewMessage,
   type ElectrobunBackendInit,
   type ElectrobunDesktopRpcSchema,
   type UpdateProgressMessage,
@@ -17,6 +18,7 @@ type ContextMenuSelectListener = (message: ContextMenuSelectMessage) => void;
 type ApplicationMenuSelectListener = (message: ApplicationMenuSelectMessage) => void;
 type DesktopStateListener = (message: DesktopStateMessage) => void;
 type DesktopDockPreviewListener = (message: DesktopDockPreviewMessage) => void;
+type DesktopThemePreviewListener = (message: DesktopThemePreviewMessage) => void;
 type UpdateProgressListener = (message: UpdateProgressMessage) => void;
 type CapabilityEventListener = (message: CapabilityEventMessage) => void;
 
@@ -25,6 +27,7 @@ const contextMenuSelectListeners = new Map<string, Set<ContextMenuSelectListener
 const applicationMenuSelectListeners = new Set<ApplicationMenuSelectListener>();
 const desktopStateListeners = new Set<DesktopStateListener>();
 const desktopDockPreviewListeners = new Set<DesktopDockPreviewListener>();
+const desktopThemePreviewListeners = new Set<DesktopThemePreviewListener>();
 const updateProgressListeners = new Set<UpdateProgressListener>();
 const capabilityEventListeners = new Map<string, Set<CapabilityEventListener>>();
 
@@ -78,6 +81,11 @@ const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
       },
       "desktop.dockPreview": (message) => {
         for (const listener of desktopDockPreviewListeners) {
+          listener({ preview: decodeRpcValue(message.preview) });
+        }
+      },
+      "desktop.themePreview": (message) => {
+        for (const listener of desktopThemePreviewListeners) {
           listener({ preview: decodeRpcValue(message.preview) });
         }
       },
@@ -162,6 +170,13 @@ export function onDesktopDockPreview(listener: DesktopDockPreviewListener): () =
   desktopDockPreviewListeners.add(listener);
   return () => {
     desktopDockPreviewListeners.delete(listener);
+  };
+}
+
+export function onDesktopThemePreview(listener: DesktopThemePreviewListener): () => void {
+  desktopThemePreviewListeners.add(listener);
+  return () => {
+    desktopThemePreviewListeners.delete(listener);
   };
 }
 

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -14,7 +14,7 @@ import {
   type RefObject,
 } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui/host";
-import { colors, hoverBg } from "../../../theme/colors";
+import { useThemeColors } from "../../../theme/theme-context";
 import { useAppDispatch, usePaneInstance } from "../../../state/app-context";
 import { useRafCallback } from "../../../react/use-raf-callback";
 import { measurePerf } from "../../../utils/perf-marks";
@@ -36,6 +36,14 @@ interface VirtualRow {
 }
 
 const TABLE_INLINE_PADDING_PX = 8;
+const CSS_BG = "var(--gloom-bg)";
+const CSS_PANEL = "var(--gloom-panel)";
+const CSS_TEXT = "var(--gloom-text)";
+const CSS_TEXT_DIM = "var(--gloom-text-dim)";
+const CSS_TEXT_BRIGHT = "var(--gloom-text-bright)";
+const CSS_SELECTED = "var(--gloom-selected)";
+const CSS_SELECTED_TEXT = "var(--gloom-selected-text)";
+const CSS_HOVER_BG = "var(--gloom-hover-bg)";
 
 function hasAttribute(attributes: unknown, flag: number): boolean {
   return typeof attributes === "number" && (attributes & flag) !== 0;
@@ -265,6 +273,82 @@ function renderHeaderLabel<C extends DataTableColumn>(
   };
 }
 
+function WebDataTableHeader<C extends DataTableColumn>({
+  columns,
+  focusPane,
+  gridTemplateColumns,
+  onHeaderClick,
+  sortColumnId,
+  sortDirection,
+}: {
+  columns: C[];
+  focusPane: () => void;
+  gridTemplateColumns: string;
+  onHeaderClick: (columnId: string) => void;
+  sortColumnId: string | null;
+  sortDirection: "asc" | "desc";
+}) {
+  useThemeColors();
+  return (
+    <div
+      data-gloom-role="data-table-header-row"
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 2,
+        display: "grid",
+        gridTemplateColumns,
+        columnGap: "1ch",
+        alignItems: "center",
+        width: "100%",
+        minWidth: 0,
+        height: WEB_CELL_HEIGHT,
+        paddingLeft: TABLE_INLINE_PADDING_PX,
+        paddingRight: TABLE_INLINE_PADDING_PX,
+        boxSizing: "border-box",
+        backgroundColor: CSS_PANEL,
+      }}
+    >
+      {columns.map((column) => {
+        const { isSorted, text } = renderHeaderLabel(
+          column,
+          sortColumnId,
+          sortDirection,
+        );
+        return (
+          <div
+            key={column.id}
+            data-gloom-role="data-table-header-cell"
+            data-gloom-interactive="true"
+            style={{
+              minWidth: 0,
+              height: WEB_CELL_HEIGHT,
+              overflow: "hidden",
+              backgroundColor: column.headerBackgroundColor ?? CSS_PANEL,
+            }}
+            onMouseDown={(event) => {
+              focusPane();
+              event.preventDefault();
+              onHeaderClick(column.id);
+            }}
+          >
+            <span
+              title={text}
+              style={clippedCellTextStyle(
+                column,
+                isSorted ? CSS_TEXT : column.headerColor ?? CSS_TEXT_DIM,
+                TextAttributes.BOLD,
+              )}
+            >
+              {text}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function WebDataTableRowInner<
   T,
   C extends DataTableColumn,
@@ -303,6 +387,7 @@ function WebDataTableRowInner<
   selected: boolean;
   setHoveredIdx: (index: number | null) => void;
 }) {
+  useThemeColors();
   const sectionHeader: DataTableSectionHeader | null =
     renderSectionHeader?.(item, index) ?? null;
   const baseRowStyle: CSSProperties = {
@@ -330,7 +415,7 @@ function WebDataTableRowInner<
         data-gloom-role="data-table-section-header"
         style={{
           ...baseRowStyle,
-          backgroundColor: sectionHeader.backgroundColor ?? colors.bg,
+          backgroundColor: sectionHeader.backgroundColor ?? CSS_BG,
         }}
         onMouseDown={(event) => {
           focusPane();
@@ -341,7 +426,7 @@ function WebDataTableRowInner<
           title={sectionHeader.text}
           style={{
             ...cellTextStyle(
-              sectionHeader.color ?? colors.textBright,
+              sectionHeader.color ?? CSS_TEXT_BRIGHT,
               sectionHeader.attributes ?? TextAttributes.BOLD,
             ),
             gridColumn: "1 / -1",
@@ -358,10 +443,10 @@ function WebDataTableRowInner<
   const rowState = { selected, hovered };
   const rowBackgroundColor = getRowBackgroundColor?.(item, index, rowState);
   const rowBg = selected
-    ? colors.selected
+    ? CSS_SELECTED
     : hovered
-      ? hoverBg()
-      : rowBackgroundColor ?? colors.bg;
+      ? CSS_HOVER_BG
+      : rowBackgroundColor ?? CSS_BG;
 
   return (
     <div
@@ -438,7 +523,7 @@ function WebDataTableRowInner<
                 title={cell.text}
                 style={clippedCellTextStyle(
                   column,
-                  cell.color ?? (selected ? colors.selectedText : colors.text),
+                  cell.color ?? (selected ? CSS_SELECTED_TEXT : CSS_TEXT),
                   cell.attributes ?? TextAttributes.NONE,
                 )}
               >
@@ -624,7 +709,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     width: "100%",
     minWidth: 0,
     minHeight: 0,
-    backgroundColor: colors.bg,
+    backgroundColor: CSS_BG,
     overflow: "hidden",
   };
   const bodyScrollerStyle: CSSProperties = {
@@ -634,7 +719,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     minHeight: 0,
     overflowX: horizontalScrollEnabled ? "auto" : "hidden",
     overflowY: "auto",
-    backgroundColor: colors.bg,
+    backgroundColor: CSS_BG,
   };
 
   return (
@@ -673,77 +758,29 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
             minHeight: WEB_CELL_HEIGHT,
           }}
         >
-          <div
-            data-gloom-role="data-table-header-row"
-            style={{
-              position: "sticky",
-              top: 0,
-              zIndex: 2,
-              display: "grid",
-              gridTemplateColumns,
-              columnGap: "1ch",
-              alignItems: "center",
-              width: "100%",
-              minWidth: 0,
-              height: WEB_CELL_HEIGHT,
-              paddingLeft: TABLE_INLINE_PADDING_PX,
-              paddingRight: TABLE_INLINE_PADDING_PX,
-              boxSizing: "border-box",
-              backgroundColor: colors.panel,
-            }}
-          >
-            {columns.map((column) => {
-              const { isSorted, text } = renderHeaderLabel(
-                column,
-                sortColumnId,
-                sortDirection,
-              );
-              return (
-                <div
-                  key={column.id}
-                  data-gloom-role="data-table-header-cell"
-                  data-gloom-interactive="true"
-                  style={{
-                    minWidth: 0,
-                    height: WEB_CELL_HEIGHT,
-                    overflow: "hidden",
-                    backgroundColor: column.headerBackgroundColor ?? colors.panel,
-                  }}
-                  onMouseDown={(event) => {
-                    focusPane();
-                    event.preventDefault();
-                    onHeaderClick(column.id);
-                  }}
-                >
-                  <span
-                    title={text}
-                    style={clippedCellTextStyle(
-                      column,
-                      isSorted ? colors.text : column.headerColor ?? colors.textDim,
-                      TextAttributes.BOLD,
-                    )}
-                  >
-                    {text}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
+          <WebDataTableHeader
+            columns={columns}
+            focusPane={focusPane}
+            gridTemplateColumns={gridTemplateColumns}
+            onHeaderClick={onHeaderClick}
+            sortColumnId={sortColumnId}
+            sortDirection={sortDirection}
+          />
           {items.length === 0 ? (
             emptyContent ?? (
               <div
                 style={{
                   width: "100%",
                   padding: `${WEB_CELL_HEIGHT}px ${WEB_CELL_WIDTH}px`,
-                  color: colors.textDim,
+                  color: CSS_TEXT_DIM,
                   lineHeight: "var(--cell-h)",
                 }}
               >
-                <div style={cellTextStyle(colors.textBright, TextAttributes.BOLD)}>
+                <div style={cellTextStyle(CSS_TEXT_BRIGHT, TextAttributes.BOLD)}>
                   {emptyStateTitle}
                 </div>
                 {emptyStateHint ? (
-                  <div style={cellTextStyle(colors.textDim, TextAttributes.NONE)}>
+                  <div style={cellTextStyle(CSS_TEXT_DIM, TextAttributes.NONE)}>
                     {emptyStateHint}
                   </div>
                 ) : null}

--- a/src/renderers/electrobun/view/desktop-controls.tsx
+++ b/src/renderers/electrobun/view/desktop-controls.tsx
@@ -4,6 +4,7 @@ import { Box, Input, ScrollBox, Text, Textarea, editableTextContextMenuItems, us
 import { TextAttributes, type InputRenderable, type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import { blendHex, colors, hoverBg } from "../../../theme/colors";
+import { useThemeColors } from "../../../theme/theme-context";
 import { isDetailBackNavigationKey } from "../../../utils/back-navigation";
 import type { ButtonProps } from "../../../components/ui/button";
 import type { TextFieldProps } from "../../../components/ui/fields";
@@ -97,6 +98,7 @@ export function WebButton({
   shortcut,
   width,
 }: ButtonProps) {
+  useThemeColors();
   const palette = buttonPalette({ variant, active, disabled });
 
   return (
@@ -156,6 +158,7 @@ export function WebTextField({
   placeholderColor = colors.textDim,
   onMouseDown,
 }: TextFieldProps) {
+  useThemeColors();
   const localInputRef = useRef<InputRenderable>(null);
   const resolvedInputRef = inputRef ?? localInputRef;
   const renderer = useRendererHost();
@@ -245,6 +248,7 @@ export function WebMessageComposer({
   keyBindings,
   wrapText = false,
 }: MessageComposerProps) {
+  useThemeColors();
   const borderColor = focused
     ? blendHex(colors.borderFocused, colors.textBright, 0.24)
     : colors.border;
@@ -361,6 +365,7 @@ export function WebListView({
   scrollable = false,
   autoScrollToIndex = true,
 }: ListViewProps) {
+  useThemeColors();
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const baseBg = bgColor ?? colors.bg;
@@ -489,6 +494,7 @@ export function WebSegmentedControl({
   value,
   onChange,
 }: SegmentedControlProps) {
+  useThemeColors();
   return (
     <Box
       flexDirection="row"
@@ -538,6 +544,7 @@ export function WebDialogFrame({
   footer,
   showTitleDivider = true,
 }: DialogFrameProps) {
+  useThemeColors();
   return (
     <Box flexDirection="column" style={{ padding: 14 }}>
       <Box
@@ -583,6 +590,7 @@ export function WebPageStackView({
   backLabel = "Back",
   backHint,
 }: PageStackViewProps) {
+  useThemeColors();
   useShortcut((event) => {
     if (!focused || !detailOpen || !isDetailBackNavigationKey(event)) return;
     event.stopPropagation?.();

--- a/src/renderers/electrobun/view/desktop-window-bridge.ts
+++ b/src/renderers/electrobun/view/desktop-window-bridge.ts
@@ -2,9 +2,10 @@ import type { PaneRuntimeState } from "../../../core/state/app-state";
 import type {
   DesktopDockPreviewState,
   DesktopSharedStateSnapshot,
+  DesktopThemePreviewState,
   DesktopWindowBridge,
 } from "../../../types/desktop-window";
-import { backendRequest, getElectrobunBackendInitSnapshot, onDesktopDockPreview, onDesktopState } from "./backend-rpc";
+import { backendRequest, getElectrobunBackendInitSnapshot, onDesktopDockPreview, onDesktopState, onDesktopThemePreview } from "./backend-rpc";
 import { detachedSnapshotKey, prepareDetachedSnapshot } from "./desktop-window-snapshot";
 
 export function createDesktopWindowBridge(kind: "main" | "detached", paneId?: string): DesktopWindowBridge {
@@ -19,6 +20,11 @@ export function createDesktopWindowBridge(kind: "main" | "detached", paneId?: st
     syncMainState: kind === "main"
       ? async (snapshot: DesktopSharedStateSnapshot) => {
         await backendRequest("desktop.syncMainState", { snapshot });
+      }
+      : undefined,
+    syncThemePreview: kind === "main"
+      ? async (preview: DesktopThemePreviewState) => {
+        await backendRequest("desktop.setThemePreview", { preview });
       }
       : undefined,
     replaceDetachedPaneState: kind === "detached"
@@ -52,6 +58,11 @@ export function createDesktopWindowBridge(kind: "main" | "detached", paneId?: st
     },
     subscribeDockPreview(listener: (preview: DesktopDockPreviewState) => void) {
       return onDesktopDockPreview((message) => {
+        listener(message.preview);
+      });
+    },
+    subscribeThemePreview(listener: (preview: DesktopThemePreviewState) => void) {
+      return onDesktopThemePreview((message) => {
         listener(message.preview);
       });
     },

--- a/src/renderers/electrobun/view/dialog-host.tsx
+++ b/src/renderers/electrobun/view/dialog-host.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { DialogHostProvider, type DialogApi } from "../../../ui/dialog";
 import { blendHex, colors } from "../../../theme/colors";
+import { useThemeColors } from "../../../theme/theme-context";
 
 interface DialogState {
   id: string;
@@ -13,6 +14,7 @@ interface DialogState {
 let nextDialogId = 1;
 
 export function WebDialogHostProvider({ children }: { children: ReactNode }) {
+  useThemeColors();
   const [dialogState, setDialogState] = useState<DialogState | null>(null);
   const dialogBorder = blendHex(colors.border, colors.borderFocused, 0.18);
   const dialogBg = blendHex(colors.panel, colors.bg, 0.12);

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -78,6 +78,7 @@ async function boot() {
                 desktopWindowBridge={desktopWindowBridge}
                 desktopApplicationMenuBridge={desktopApplicationMenuBridge}
                 desktopSnapshot={desktopSnapshot}
+                desktopThemePreview={init.desktopThemePreview}
               />
             </WebDialogHostProvider>
           </WebToastHostProvider>

--- a/src/state/app-context-selector.test.tsx
+++ b/src/state/app-context-selector.test.tsx
@@ -3,7 +3,9 @@ import { act, useRef, type Dispatch } from "react";
 import { testRender } from "../renderers/opentui/test-utils";
 import { AppProvider, PaneInstanceProvider, useAppDispatch, useAppSelector, usePaneTicker, type AppAction } from "./app-context";
 import { cloneLayout, createDefaultConfig, type AppConfig } from "../types/config";
-import { applyTheme, getCurrentThemeId } from "../theme/colors";
+import { applyTheme } from "../theme/colors";
+import { useThemeId } from "../theme/theme-context";
+import type { DesktopSharedStateSnapshot, DesktopThemePreviewState, DesktopWindowBridge } from "../types/desktop-window";
 
 const TEST_PANE_ID = "ticker-detail:test";
 
@@ -20,6 +22,7 @@ function createTickerDetailConfig(symbol: string): AppConfig {
       binding: { kind: "fixed" as const, symbol },
     }],
     floating: [],
+    detached: [],
   };
 
   return {
@@ -43,7 +46,46 @@ function PaneTickerHarness() {
 
 function ThemeSelectorHarness() {
   const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
-  return <text>{`${focusedPaneId ?? "none"}:${getCurrentThemeId()}`}</text>;
+  const themeId = useThemeId();
+  return <text>{`${focusedPaneId ?? "none"}:${themeId}`}</text>;
+}
+
+function FocusSelectorHarness() {
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+  const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
+  return <text>{`${focusedPaneId ?? "none"}:${renderCountRef.current}`}</text>;
+}
+
+function createDesktopBridge(
+  kind: "main" | "detached",
+  calls: {
+    mainSnapshots?: DesktopSharedStateSnapshot[];
+    themePreviews?: DesktopThemePreviewState[];
+    onThemePreviewSubscribe?: (listener: (preview: DesktopThemePreviewState) => void) => void;
+  } = {},
+): DesktopWindowBridge {
+  return {
+    kind,
+    paneId: kind === "detached" ? TEST_PANE_ID : undefined,
+    syncMainState: kind === "main"
+      ? async (snapshot) => {
+        calls.mainSnapshots?.push(snapshot);
+      }
+      : undefined,
+    syncThemePreview: kind === "main"
+      ? async (preview) => {
+        calls.themePreviews?.push(preview);
+      }
+      : undefined,
+    subscribeState: () => () => {},
+    subscribeThemePreview: kind === "detached"
+      ? (listener) => {
+        calls.onThemePreviewSubscribe?.(listener);
+        return () => {};
+      }
+      : undefined,
+  };
 }
 
 describe("pane selectors", () => {
@@ -100,7 +142,28 @@ describe("pane selectors", () => {
     expect(testSetup.captureCharFrame()).toContain("AAPL:1");
   });
 
-  test("rerenders selector consumers when the theme changes", async () => {
+  test("does not rerender non-theme selector consumers when the theme preview changes", async () => {
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")}>
+        <DispatchCapture />
+        <FocusSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:1`);
+
+    await act(() => {
+      capturedDispatch?.({ type: "PREVIEW_THEME", theme: "green" });
+    });
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:1`);
+  });
+
+  test("rerenders theme hook consumers when the theme changes", async () => {
     testSetup = await testRender(
       <AppProvider config={createTickerDetailConfig("AAPL")}>
         <DispatchCapture />
@@ -121,7 +184,7 @@ describe("pane selectors", () => {
     expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
   });
 
-  test("rerenders selector consumers when the theme preview changes", async () => {
+  test("rerenders theme hook consumers when the theme preview changes", async () => {
     testSetup = await testRender(
       <AppProvider config={createTickerDetailConfig("AAPL")}>
         <DispatchCapture />
@@ -140,6 +203,33 @@ describe("pane selectors", () => {
     await testSetup.renderOnce();
     await testSetup.renderOnce();
     expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
+  });
+
+  test("set theme updates the theme hook and clears the active preview", async () => {
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")}>
+        <DispatchCapture />
+        <ThemeSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    await act(() => {
+      capturedDispatch?.({ type: "PREVIEW_THEME", theme: "green" });
+    });
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
+
+    await act(() => {
+      capturedDispatch?.({ type: "SET_THEME", theme: "red" });
+    });
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain(`${TEST_PANE_ID}:red`);
+    expect(frame).not.toContain(`${TEST_PANE_ID}:green`);
   });
 
   test("falls back to the committed theme when theme preview clears", async () => {
@@ -178,6 +268,101 @@ describe("pane selectors", () => {
       { width: 32, height: 4 },
     );
 
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
+  });
+
+  test("uses the initial desktop theme preview on the first provider render", async () => {
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")} initialThemePreview={{ theme: "green" }}>
+        <ThemeSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
+  });
+
+  test("desktop main preview sync does not publish the full state snapshot", async () => {
+    const mainSnapshots: DesktopSharedStateSnapshot[] = [];
+    const themePreviews: DesktopThemePreviewState[] = [];
+    const bridge = createDesktopBridge("main", { mainSnapshots, themePreviews });
+
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")} desktopBridge={bridge}>
+        <DispatchCapture />
+        <ThemeSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    mainSnapshots.length = 0;
+    themePreviews.length = 0;
+
+    await act(() => {
+      capturedDispatch?.({ type: "PREVIEW_THEME", theme: "green" });
+    });
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    expect(themePreviews).toEqual([{ theme: "green" }]);
+    expect(mainSnapshots).toHaveLength(0);
+  });
+
+  test("desktop committed theme changes still sync through the config snapshot", async () => {
+    const mainSnapshots: DesktopSharedStateSnapshot[] = [];
+    const themePreviews: DesktopThemePreviewState[] = [];
+    const bridge = createDesktopBridge("main", { mainSnapshots, themePreviews });
+
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")} desktopBridge={bridge}>
+        <DispatchCapture />
+        <ThemeSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    mainSnapshots.length = 0;
+    themePreviews.length = 0;
+
+    await act(() => {
+      capturedDispatch?.({ type: "SET_THEME", theme: "green" });
+    });
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    expect(mainSnapshots).toHaveLength(1);
+    expect(mainSnapshots[0]?.config.theme).toBe("green");
+    expect(themePreviews).toHaveLength(0);
+  });
+
+  test("desktop detached windows apply theme preview messages locally", async () => {
+    let previewListener: ((preview: DesktopThemePreviewState) => void) | null = null;
+    const bridge = createDesktopBridge("detached", {
+      onThemePreviewSubscribe: (listener) => {
+        previewListener = listener;
+      },
+    });
+
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")} desktopBridge={bridge}>
+        <ThemeSelectorHarness />
+      </AppProvider>,
+      { width: 32, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    expect(previewListener).not.toBeNull();
+    expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:amber`);
+
+    await act(() => {
+      previewListener?.({ theme: "green" });
+    });
+
+    await testSetup.renderOnce();
     await testSetup.renderOnce();
     expect(testSetup.captureCharFrame()).toContain(`${TEST_PANE_ID}:green`);
   });

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -13,14 +13,14 @@ import {
   type ReactNode,
 } from "react";
 import type { SessionStore } from "../data/session-store";
-import { syncTheme } from "../theme/colors";
+import { ThemeProvider } from "../theme/theme-context";
 import {
   findPaneInstance,
   materializeDetachedPanesAsFloating,
   type AppConfig,
   type PaneInstanceConfig,
 } from "../types/config";
-import type { DesktopSharedStateSnapshot, DesktopWindowBridge } from "../types/desktop-window";
+import type { DesktopSharedStateSnapshot, DesktopThemePreviewState, DesktopWindowBridge } from "../types/desktop-window";
 import { setPaneSetting } from "../pane-settings";
 import { useTickerFinancials } from "../market-data/hooks";
 import {
@@ -142,7 +142,7 @@ export function useAppSelector<T>(selector: (state: AppState) => T): T {
   const context = useRequiredAppContext();
   const selectorRef = useRef(selector);
   selectorRef.current = selector;
-  const lastSnapshotRef = useRef<{ selection: T; themeId: string } | undefined>(undefined);
+  const lastSnapshotRef = useRef<{ selection: T } | undefined>(undefined);
 
   if (!isAppStoreContextValue(context)) {
     return selector(context.state);
@@ -153,12 +153,11 @@ export function useAppSelector<T>(selector: (state: AppState) => T): T {
     () => {
       const state = context.getState();
       const selection = selectorRef.current(state);
-      const themeId = getEffectiveThemeId(state);
       const previous = lastSnapshotRef.current;
-      if (previous && Object.is(previous.selection, selection) && previous.themeId === themeId) {
+      if (previous && Object.is(previous.selection, selection)) {
         return previous;
       }
-      const nextSnapshot = { selection, themeId };
+      const nextSnapshot = { selection };
       lastSnapshotRef.current = nextSnapshot;
       return nextSnapshot;
     },
@@ -166,7 +165,6 @@ export function useAppSelector<T>(selector: (state: AppState) => T): T {
       const state = context.getState();
       return {
         selection: selectorRef.current(state),
-        themeId: getEffectiveThemeId(state),
       };
     },
   );
@@ -303,6 +301,7 @@ export function AppProvider({
   sessionSnapshot = null,
   desktopBridge,
   desktopSnapshot = null,
+  initialThemePreview = null,
 }: {
   config: AppConfig;
   children: ReactNode;
@@ -310,34 +309,40 @@ export function AppProvider({
   sessionSnapshot?: AppSessionSnapshot | null;
   desktopBridge?: DesktopWindowBridge;
   desktopSnapshot?: DesktopSharedStateSnapshot | null;
+  initialThemePreview?: DesktopThemePreviewState | null;
 }) {
   const [state, rawDispatch] = useReducer(
     appReducer,
-    { config, sessionSnapshot, desktopSnapshot },
+    { config, sessionSnapshot, desktopSnapshot, initialThemePreview },
     (initialState: {
       config: AppConfig;
       sessionSnapshot?: AppSessionSnapshot | null;
       desktopSnapshot?: DesktopSharedStateSnapshot | null;
+      initialThemePreview?: DesktopThemePreviewState | null;
     }) => {
       const {
         config: initialConfig,
         sessionSnapshot: initialSessionSnapshot,
         desktopSnapshot: initialDesktopSnapshot,
+        initialThemePreview: initialDesktopThemePreview,
       } = initialState;
-      const nextState = createInitialState(initialConfig, initialSessionSnapshot);
-      return initialDesktopSnapshot
-        ? appReducer(nextState, { type: "HYDRATE_DESKTOP_SNAPSHOT", snapshot: initialDesktopSnapshot })
+      const baseState = createInitialState(initialConfig, initialSessionSnapshot);
+      const nextState = initialDesktopSnapshot
+        ? appReducer(baseState, { type: "HYDRATE_DESKTOP_SNAPSHOT", snapshot: initialDesktopSnapshot })
+        : baseState;
+      return initialDesktopThemePreview
+        ? appReducer(nextState, { type: "PREVIEW_THEME", theme: initialDesktopThemePreview.theme })
         : nextState;
     },
   );
-  // Sync the current theme before descendants read the shared palette during this render.
-  syncTheme(getEffectiveThemeId(state));
+  const effectiveThemeId = getEffectiveThemeId(state);
   const previousRecentTickers = useRef(state.recentTickers);
   const stateRef = useRef(state);
   const listenersRef = useRef(new Set<() => void>());
   const storeRef = useRef<AppContextStoreValue | null>(null);
   const lastMainSyncRef = useRef<string | null>(null);
   const lastDetachedPaneSyncRef = useRef<string | null>(null);
+  const lastThemePreviewSyncRef = useRef<string | null | undefined>(undefined);
 
   stateRef.current = state;
 
@@ -421,12 +426,35 @@ export function AppProvider({
 
   useEffect(() => {
     if (desktopBridge?.kind !== "main" || !desktopBridge.syncMainState) return;
-    const snapshot = buildDesktopSnapshot(state);
+    const snapshot = buildDesktopSnapshot(stateRef.current);
     const signature = serializeDesktopSnapshot(snapshot);
     if (signature === lastMainSyncRef.current) return;
     lastMainSyncRef.current = signature;
     void desktopBridge.syncMainState(snapshot);
-  }, [buildDesktopSnapshot, desktopBridge, serializeDesktopSnapshot, state]);
+  }, [
+    buildDesktopSnapshot,
+    desktopBridge,
+    serializeDesktopSnapshot,
+    state.activePanel,
+    state.config,
+    state.focusedPaneId,
+    state.paneState,
+    state.statusBarVisible,
+  ]);
+
+  useEffect(() => {
+    if (desktopBridge?.kind !== "main" || !desktopBridge.syncThemePreview) return;
+    if (lastThemePreviewSyncRef.current === state.themePreview) return;
+    lastThemePreviewSyncRef.current = state.themePreview;
+    void desktopBridge.syncThemePreview({ theme: state.themePreview });
+  }, [desktopBridge, state.themePreview]);
+
+  useEffect(() => {
+    if (desktopBridge?.kind !== "detached" || !desktopBridge.subscribeThemePreview) return;
+    return desktopBridge.subscribeThemePreview((preview) => {
+      dispatch({ type: "PREVIEW_THEME", theme: preview.theme });
+    });
+  }, [desktopBridge, dispatch]);
 
   useEffect(() => {
     if (desktopBridge?.kind !== "detached" || !desktopBridge.replaceDetachedPaneState || !desktopBridge.paneId) return;
@@ -445,5 +473,9 @@ export function AppProvider({
 
   usePersistSessionSnapshot(sessionStore, state, APP_SESSION_ID, APP_SESSION_SCHEMA_VERSION);
 
-  return <AppContext.Provider value={storeRef.current}>{children}</AppContext.Provider>;
+  return (
+    <ThemeProvider themeId={effectiveThemeId}>
+      <AppContext.Provider value={storeRef.current}>{children}</AppContext.Provider>
+    </ThemeProvider>
+  );
 }

--- a/src/theme/colors.test.ts
+++ b/src/theme/colors.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  applyTheme,
+  clearTransientThemePreview,
+  getCurrentThemeId,
+  previewTheme,
+  syncTheme,
+} from "./colors";
+import { DEFAULT_THEME, getTheme } from "./themes";
+
+const originalDocument = (globalThis as Record<string, unknown>).document;
+
+function setDocument(value: unknown): void {
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function installDocumentStyleMock() {
+  const values = new Map<string, string>();
+  setDocument({
+    documentElement: {
+      style: {
+        setProperty(name: string, value: string) {
+          values.set(name, value);
+        },
+      },
+    },
+  });
+  return values;
+}
+
+afterEach(() => {
+  if (originalDocument === undefined) {
+    Reflect.deleteProperty(globalThis, "document");
+  } else {
+    setDocument(originalDocument);
+  }
+  clearTransientThemePreview();
+  syncTheme(DEFAULT_THEME);
+});
+
+describe("theme colors", () => {
+  test("syncs CSS variables when a theme is applied", () => {
+    const values = installDocumentStyleMock();
+    const theme = getTheme("midnight");
+
+    applyTheme("midnight");
+
+    expect(values.get("--gloom-bg")).toBe(theme.bg);
+    expect(values.get("--gloom-panel")).toBe(theme.panel);
+    expect(values.get("--gloom-text-dim")).toBe(theme.textDim);
+    expect(values.get("--gloom-selected")).toBe(theme.selected);
+    expect(values.get("--gloom-hover-bg")).toBeString();
+  });
+
+  test("does not let provider sync clobber a pending preview", () => {
+    const values = installDocumentStyleMock();
+    const preview = getTheme("midnight");
+
+    previewTheme("midnight");
+    syncTheme(DEFAULT_THEME);
+
+    expect(getCurrentThemeId()).toBe("midnight");
+    expect(values.get("--gloom-bg")).toBe(preview.bg);
+
+    clearTransientThemePreview();
+    syncTheme(DEFAULT_THEME);
+
+    expect(getCurrentThemeId()).toBe(DEFAULT_THEME);
+    expect(values.get("--gloom-bg")).toBe(getTheme(DEFAULT_THEME).bg);
+  });
+});

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -5,7 +5,33 @@ import { getTheme, DEFAULT_THEME, type Theme } from "./themes";
 // React components re-read these on each render triggered by the SET_THEME action.
 export const colors: Omit<Theme, "name" | "description"> = { ...getTheme(DEFAULT_THEME) };
 
+export type ColorKey = keyof typeof colors;
+
 let currentThemeId = DEFAULT_THEME;
+let transientPreviewThemeId: string | null = null;
+let cssThemeId: string | null = null;
+let cssThemeDocument: unknown = null;
+
+const THEME_CSS_VARIABLES: Array<[ColorKey, string]> = [
+  ["bg", "--gloom-bg"],
+  ["panel", "--gloom-panel"],
+  ["border", "--gloom-border"],
+  ["borderFocused", "--gloom-border-focused"],
+  ["text", "--gloom-text"],
+  ["textDim", "--gloom-text-dim"],
+  ["textBright", "--gloom-text-bright"],
+  ["textMuted", "--gloom-text-muted"],
+  ["positive", "--gloom-positive"],
+  ["negative", "--gloom-negative"],
+  ["neutral", "--gloom-neutral"],
+  ["warning", "--gloom-warning"],
+  ["header", "--gloom-header"],
+  ["headerText", "--gloom-header-text"],
+  ["selected", "--gloom-selected"],
+  ["selectedText", "--gloom-selected-text"],
+  ["commandBg", "--gloom-command-bg"],
+  ["commandBorder", "--gloom-command-border"],
+];
 
 export function getCurrentThemeId(): string {
   return currentThemeId;
@@ -16,14 +42,34 @@ export function applyTheme(id: string): void {
   currentThemeId = id;
   // Mutate in-place so every existing import sees the new values
   Object.assign(colors, theme);
+  syncThemeCssVariables();
 }
 
-export function syncTheme(id: string): void {
-  if (currentThemeId === id) return;
+export function previewTheme(id: string): void {
+  transientPreviewThemeId = id;
   applyTheme(id);
 }
 
-export type ColorKey = keyof typeof colors;
+export function clearTransientThemePreview(): void {
+  transientPreviewThemeId = null;
+}
+
+export function syncTheme(id: string): void {
+  if (
+    transientPreviewThemeId
+    && currentThemeId === transientPreviewThemeId
+    && id !== transientPreviewThemeId
+  ) {
+    syncThemeCssVariables();
+    return;
+  }
+  transientPreviewThemeId = null;
+  if (currentThemeId === id) {
+    syncThemeCssVariables();
+    return;
+  }
+  applyTheme(id);
+}
 
 export { blendHex } from "./color-utils";
 
@@ -47,6 +93,21 @@ export function getComparisonSeriesColor(index: number): string {
 /** Returns a hover background color derived from bg and selected */
 export function hoverBg(): string {
   return blendHex(colors.bg, colors.selected, 0.5);
+}
+
+function syncThemeCssVariables(): void {
+  const documentLike = (globalThis as {
+    document?: { documentElement?: { style?: { setProperty: (name: string, value: string) => void } } };
+  }).document;
+  const style = documentLike?.documentElement?.style;
+  if (!style) return;
+  if (cssThemeId === currentThemeId && cssThemeDocument === documentLike) return;
+  cssThemeId = currentThemeId;
+  cssThemeDocument = documentLike;
+  for (const [key, name] of THEME_CSS_VARIABLES) {
+    style.setProperty(name, colors[key]);
+  }
+  style.setProperty("--gloom-hover-bg", hoverBg());
 }
 
 export function commandBarBg(): string {

--- a/src/theme/theme-context.tsx
+++ b/src/theme/theme-context.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { colors, getCurrentThemeId, syncTheme } from "./colors";
+import type { Theme } from "./themes";
+
+type ThemeColors = Omit<Theme, "name" | "description">;
+
+interface ThemeContextValue {
+  themeId: string;
+  colors: ThemeColors;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ themeId, children }: { themeId: string; children: ReactNode }) {
+  syncTheme(themeId);
+  const value = useMemo(() => ({ themeId, colors }), [themeId]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useThemeId(): string {
+  return useContext(ThemeContext)?.themeId ?? getCurrentThemeId();
+}
+
+export function useThemeColors(): ThemeColors {
+  return useContext(ThemeContext)?.colors ?? colors;
+}

--- a/src/types/desktop-window.ts
+++ b/src/types/desktop-window.ts
@@ -15,10 +15,15 @@ export interface DesktopDockPreviewState {
   edge: "left" | "right" | "top" | "bottom" | null;
 }
 
+export interface DesktopThemePreviewState {
+  theme: string | null;
+}
+
 export interface DesktopWindowBridge {
   kind: "main" | "detached";
   paneId?: string;
   syncMainState?(snapshot: DesktopSharedStateSnapshot): Promise<void>;
+  syncThemePreview?(preview: DesktopThemePreviewState): Promise<void>;
   replaceDetachedPaneState?(paneId: string, paneState: PaneRuntimeState): Promise<void>;
   popOutPane?(paneId: string): Promise<void>;
   dockDetachedPane?(paneId: string): Promise<void>;
@@ -26,4 +31,5 @@ export interface DesktopWindowBridge {
   focusDetachedPane?(paneId: string): Promise<void>;
   subscribeState(listener: (snapshot: DesktopSharedStateSnapshot) => void): () => void;
   subscribeDockPreview?(listener: (preview: DesktopDockPreviewState) => void): () => void;
+  subscribeThemePreview?(listener: (preview: DesktopThemePreviewState) => void): () => void;
 }


### PR DESCRIPTION
Moves theme repaint subscriptions into a dedicated theme context so non-theme selectors do not repaint during previews.

Replaces the command bar theme flow with a small debounced picker that keeps keyboard navigation local while still previewing and committing themes correctly.

Adds lightweight detached-window preview sync without sending full desktop snapshots, and updates visible desktop/table/chart surfaces to repaint from live theme colors.

Also fixes chart palette invalidation so ticker chart gradients update immediately after theme changes.