### PR TITLE
Add multi-channel chat panes

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -8,6 +8,7 @@ import { cloneLayout, createDefaultConfig, type AppConfig } from "../../types/co
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRecord } from "../../types/ticker";
 import type { PluginRegistry } from "../../plugins/registry";
+import type { PaneTemplateCreateOptions } from "../../types/plugin";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -161,7 +162,7 @@ function makePluginRegistry(hasPaneSettings: (paneId: string) => boolean = () =>
         paneId: "chat",
         label: "New Chat Pane",
         description: "Open another floating chat window",
-        shortcut: { prefix: "CHAT" },
+        shortcut: { prefix: "CHAT", argPlaceholder: "channel", argKind: "text" },
       }],
       ["quote-monitor-pane", {
         id: "quote-monitor-pane",
@@ -272,6 +273,7 @@ function CommandBarHarness({
     ...createInitialState(config),
     commandBarOpen: true,
     commandBarQuery: query,
+    focusedPaneId: "portfolio-list:main",
     tickers: new Map(tickers.map((ticker) => [ticker.metadata.ticker, ticker])),
     config: { ...config, disabledPlugins },
     paneState: selectedTicker
@@ -333,7 +335,7 @@ describe("CommandBar", () => {
   });
 
   test("runs check for updates from the command bar", async () => {
-    const calls = [];
+    const calls: number[] = [];
 
     testSetup = await testRender(<CommandBarHarness query="check for updates" live onCheckForUpdates={() => { calls.push(Date.now()); }} />, {
       width: 80,
@@ -956,7 +958,7 @@ describe("CommandBar", () => {
   });
 
   test("typing a shorthand and pressing enter executes the inferred quote monitor shortcut", async () => {
-    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query=""
@@ -987,6 +989,39 @@ describe("CommandBar", () => {
         arg: "AAPL",
         symbol: "AAPL",
         ticker: makeTicker("AAPL", "Apple Inc."),
+      },
+    }]);
+  });
+
+  test("typing a chat channel shortcut opens that channel directly", async () => {
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query=""
+      live
+      configurePluginRegistry={(pluginRegistry) => {
+        pluginRegistry.createPaneFromTemplateAsyncFn = async (templateId, options) => {
+          created.push({ templateId, options });
+        };
+      }}
+    />, {
+      width: 100,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("CHAT help");
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(created).toEqual([{
+      templateId: "new-chat-pane",
+      options: {
+        arg: "help",
       },
     }]);
   });
@@ -1904,7 +1939,7 @@ describe("CommandBar", () => {
   });
 
   test("does not treat no-argument shortcut prefixes as typed pane names", async () => {
-    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query="Top News"
@@ -2090,7 +2125,7 @@ describe("CommandBar", () => {
   });
 
   test("QQ MSFT executes directly without opening a secondary workflow", async () => {
-    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query="QQ MSFT"
@@ -2123,7 +2158,7 @@ describe("CommandBar", () => {
   });
 
   test("CMP AAPL,MSFT creates the comparison chart directly", async () => {
-    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query="CMP AAPL,MSFT"
@@ -2202,7 +2237,7 @@ describe("CommandBar", () => {
   });
 
   test("CMP with one resolved ticker opens inline completion instead of creating a one-symbol chart", async () => {
-    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query="CMP AMD"
@@ -2246,7 +2281,7 @@ describe("CommandBar", () => {
   });
 
   test("AI <prompt> opens the inline workflow and prefills the textarea prompt", async () => {
-    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query="AI quality compounders"
@@ -2302,7 +2337,7 @@ describe("CommandBar", () => {
   });
 
   test("submits typed AI screener prompts from the textarea field", async () => {
-    const created: Array<{ templateId: string; options?: Record<string, unknown> }> = [];
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query="AI"
@@ -2749,7 +2784,7 @@ describe("CommandBar", () => {
         query="auth login"
         live
         configurePluginRegistry={(pluginRegistry) => {
-          pluginRegistry.commands.set("auth-login", {
+          (pluginRegistry.commands as Map<string, any>).set("auth-login", {
             id: "auth-login",
             label: "Auth Login",
             description: "Log in to your account",
@@ -2789,7 +2824,7 @@ describe("CommandBar", () => {
         query="workspace"
         live
         configurePluginRegistry={(pluginRegistry) => {
-          pluginRegistry.commands.set("new-workspace", {
+          (pluginRegistry.commands as Map<string, any>).set("new-workspace", {
             id: "new-workspace",
             label: "Workspace",
             description: "Create a workspace",
@@ -2799,7 +2834,7 @@ describe("CommandBar", () => {
             wizard: [
               { key: "name", label: "Name", type: "text", placeholder: "Research" },
             ],
-            execute: async (values) => {
+            execute: async (values?: Record<string, string>) => {
               submitted.push(values);
             },
           } as any);

--- a/src/components/layout/pane-title.ts
+++ b/src/components/layout/pane-title.ts
@@ -8,7 +8,10 @@ export function getPaneDisplayTitle(
   paneDef: PaneDef,
 ): string {
   if (instance.paneId === "chat") {
-    return instance.title ?? "#everyone";
+    const channelId = typeof instance.settings?.channelId === "string" && instance.settings.channelId.trim()
+      ? instance.settings.channelId.trim()
+      : "everyone";
+    return instance.title ?? `#${channelId}`;
   }
 
   if (instance.paneId === "ticker-detail") {

--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { AppNotificationRequest, PluginPersistence } from "../../types/plugin";
 import type { PersistedResourceValue } from "../../types/persistence";
-import { apiClient, type ChatMessage } from "../../utils/api-client";
+import { apiClient, type ChatChannel, type ChatMessage } from "../../utils/api-client";
 import { ChatController } from "./chat-controller";
 
 const TRANSCRIPT_KIND = "channel-transcript";
@@ -11,6 +11,14 @@ const TRANSCRIPT_SCHEMA_VERSION = 2;
 const originalConnectChannel = apiClient.connectChannel.bind(apiClient);
 const originalGetSession = apiClient.getSession.bind(apiClient);
 const originalGetMessages = apiClient.getMessages.bind(apiClient);
+const originalGetChannels = apiClient.getChannels.bind(apiClient);
+
+const SERVER_CHAT_CHANNELS: ChatChannel[] = [
+  { id: "everyone", name: "everyone", created_at: "2026-03-26T12:10:05.684Z" },
+  { id: "equities", name: "equities", created_at: "2026-05-09T00:00:00.000Z" },
+  { id: "options", name: "options", created_at: "2026-05-09T00:00:00.000Z" },
+  { id: "help", name: "help", created_at: "2026-05-09T00:00:00.000Z" },
+];
 
 async function flushMicrotasks() {
   await Promise.resolve();
@@ -98,6 +106,7 @@ afterEach(() => {
   apiClient.connectChannel = originalConnectChannel;
   apiClient.getSession = originalGetSession;
   apiClient.getMessages = originalGetMessages;
+  apiClient.getChannels = originalGetChannels;
 });
 
 describe("ChatController", () => {
@@ -139,6 +148,27 @@ describe("ChatController", () => {
     expect(snapshot.draft).toBe("cached draft");
     expect(snapshot.replyToId).toBe("m1");
     expect(snapshot.messages.map((entry) => entry.id)).toEqual(["m1"]);
+  });
+
+  test("starts without client-seeded channels and hydrates the server channel list", async () => {
+    const controller = new ChatController();
+    apiClient.getChannels = async () => SERVER_CHAT_CHANNELS;
+
+    expect(controller.getSnapshot().channels).toEqual([]);
+
+    await controller.refreshChannels();
+
+    expect(controller.getSnapshot().channels).toEqual(SERVER_CHAT_CHANNELS);
+  });
+
+  test("rejects unknown shortcut channels after the server list loads", async () => {
+    const controller = new ChatController();
+    apiClient.getChannels = async () => SERVER_CHAT_CHANNELS;
+
+    await expect(controller.resolveRequiredChannelId("help")).resolves.toBe("help");
+    await expect(controller.resolveRequiredChannelId("made-up")).rejects.toThrow(
+      'Unknown chat channel "#made-up".',
+    );
   });
 
   test("hydrates a cached verified user into the api client for offline use", async () => {
@@ -410,6 +440,58 @@ describe("ChatController", () => {
     })?.value).toEqual({
       messages: [message],
     });
+  });
+
+  test("keeps per-channel drafts and transcripts isolated", () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const everyoneMessage: ChatMessage = {
+      id: "m1",
+      channelId: "everyone",
+      content: "general",
+      replyToId: null,
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u1", username: "vince", displayName: "Vince" },
+    };
+    const optionsMessage: ChatMessage = {
+      id: "m2",
+      channelId: "options",
+      content: "options note",
+      replyToId: null,
+      createdAt: "2026-03-28T00:01:00.000Z",
+      user: { id: "u2", username: "bob", displayName: "Bob" },
+    };
+
+    persistence.setState("channel:everyone", {
+      draft: "general draft",
+      replyToId: null,
+      lastCursor: "m1",
+      lastViewedMessageId: "m1",
+    }, { schemaVersion: 1 });
+    persistence.setState("channel:options", {
+      draft: "options draft",
+      replyToId: null,
+      lastCursor: "m2",
+      lastViewedMessageId: "m2",
+    }, { schemaVersion: 1 });
+    persistence.setResource(TRANSCRIPT_KIND, "everyone", { messages: [everyoneMessage] }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+    persistence.setResource(TRANSCRIPT_KIND, "options", { messages: [optionsMessage] }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+
+    controller.attachPersistence(persistence);
+    controller.setChannelDraft("options", "updated options");
+
+    expect(controller.getSnapshot().messages.map((entry) => entry.content)).toEqual(["general"]);
+    expect(controller.getSnapshot().draft).toBe("general draft");
+    expect(controller.getSnapshot("options").messages.map((entry) => entry.content)).toEqual(["options note"]);
+    expect(controller.getSnapshot("options").draft).toBe("updated options");
   });
 
   test("stores the latest message id as the incremental cursor", async () => {

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -1,10 +1,10 @@
 import type { AppNotificationRequest, PluginPersistence, PluginResumeState } from "../../types/plugin";
-import { apiClient, type ChatMessage, type PersistedAuthUser } from "../../utils/api-client";
+import { apiClient, type ChatChannel, type ChatMessage, type PersistedAuthUser } from "../../utils/api-client";
 import { debugLog } from "../../utils/debug-log";
 import { toTimestampMillis } from "../../utils/timestamp";
 
 const SESSION_STATE_KEY = "session";
-const CHANNEL_STATE_KEY = "channel:everyone";
+const DEFAULT_CHAT_CHANNEL_ID = "everyone";
 const TRANSCRIPT_KIND = "channel-transcript";
 const TRANSCRIPT_SOURCE = "server";
 const MESSAGE_PAGE_SIZE = 50;
@@ -42,6 +42,9 @@ interface PersistedTranscript {
 }
 
 export interface ChatControllerSnapshot {
+  channelId: string;
+  channels: ChatChannel[];
+  channelsLoading: boolean;
   loading: boolean;
   loadingOlderMessages: boolean;
   hasOlderMessages: boolean;
@@ -54,6 +57,74 @@ export interface ChatControllerSnapshot {
 }
 
 type ChatConnection = { send: (content: string, replyToId?: string) => Promise<ChatMessage>; close: () => void };
+
+interface ChannelRuntimeState {
+  hydrated: boolean;
+  messagesLoading: boolean;
+  olderMessagesLoading: boolean;
+  refreshMessagesPromise: Promise<void> | null;
+  loadOlderMessagesPromise: Promise<void> | null;
+  reachedOldestMessage: boolean;
+  messages: ChatMessage[];
+  pendingMessages: ChatMessage[];
+  draft: string;
+  replyToId: string | null;
+  lastCursor: string | null;
+  lastViewedMessageId: string | null;
+  wsConnection: ChatConnection | null;
+  wsConnected: boolean;
+  draftSyncTimer: ReturnType<typeof setTimeout> | null;
+  openViewCount: number;
+}
+
+interface ChannelListenerEntry {
+  channelId: string;
+  listener: (snapshot: ChatControllerSnapshot) => void;
+}
+
+function channelStateKey(channelId: string): string {
+  return `channel:${channelId}`;
+}
+
+function normalizeChannelId(channelId: string | null | undefined): string {
+  const normalized = channelId?.trim();
+  return normalized || DEFAULT_CHAT_CHANNEL_ID;
+}
+
+function createEmptyChannelState(): ChannelRuntimeState {
+  return {
+    hydrated: false,
+    messagesLoading: false,
+    olderMessagesLoading: false,
+    refreshMessagesPromise: null,
+    loadOlderMessagesPromise: null,
+    reachedOldestMessage: false,
+    messages: [],
+    pendingMessages: [],
+    draft: "",
+    replyToId: null,
+    lastCursor: null,
+    lastViewedMessageId: null,
+    wsConnection: null,
+    wsConnected: false,
+    draftSyncTimer: null,
+    openViewCount: 0,
+  };
+}
+
+function normalizeChannels(channels: ChatChannel[]): ChatChannel[] {
+  const byId = new Map<string, ChatChannel>();
+  for (const channel of channels) {
+    const id = channel.id.trim();
+    if (!id) continue;
+    byId.set(id, {
+      ...channel,
+      id,
+      name: channel.name.trim() || id,
+    });
+  }
+  return [...byId.values()];
+}
 
 function normalizeUsername(username: string | null | undefined): string | null {
   const trimmed = username?.trim();
@@ -112,27 +183,20 @@ export class ChatController {
   private appActive = true;
   private hydrated = false;
   private sessionChecked = false;
-  private messagesLoading = false;
-  private olderMessagesLoading = false;
-  private refreshMessagesPromise: Promise<void> | null = null;
-  private loadOlderMessagesPromise: Promise<void> | null = null;
-  private reachedOldestMessage = false;
   private user: { id: string; username: string; emailVerified: boolean } | null = null;
-  private messages: ChatMessage[] = [];
-  private pendingMessages: ChatMessage[] = [];
-  private draft = "";
-  private replyToId: string | null = null;
-  private lastCursor: string | null = null;
-  private lastViewedMessageId: string | null = null;
-  private wsConnection: ChatConnection | null = null;
-  private wsConnected = false;
+  private channels: ChatChannel[] = [];
+  private channelsLoading = false;
+  private channelsPromise: Promise<void> | null = null;
+  private channelStates = new Map<string, ChannelRuntimeState>();
   private verificationPollTimer: ReturnType<typeof setInterval> | null = null;
   private safetyRefreshTimer: ReturnType<typeof setInterval> | null = null;
-  private draftSyncTimer: ReturnType<typeof setTimeout> | null = null;
-  private openViewCount = 0;
   private pendingMessageSeq = 0;
   private notifyFn: (notification: AppNotificationRequest) => void = () => {};
-  private listeners = new Set<(snapshot: ChatControllerSnapshot) => void>();
+  private listeners = new Set<ChannelListenerEntry>();
+
+  private get wsConnection(): ChatConnection | null {
+    return this.ensureChannelState(DEFAULT_CHAT_CHANNEL_ID).wsConnection;
+  }
 
   attachPersistence(persistence: PluginPersistence, resume?: PluginResumeState): void {
     this.persistence = persistence;
@@ -166,50 +230,140 @@ export class ChatController {
       }
       : null;
     this.sessionChecked = true;
+    this.ensureChannelState(DEFAULT_CHAT_CHANNEL_ID);
+    this.syncVerificationPolling();
+  }
 
-    const channel = this.resume?.getState<PersistedChannelState>(CHANNEL_STATE_KEY, {
+  subscribe(listener: (snapshot: ChatControllerSnapshot) => void): () => void;
+  subscribe(channelId: string, listener: (snapshot: ChatControllerSnapshot) => void): () => void;
+  subscribe(
+    channelIdOrListener: string | ((snapshot: ChatControllerSnapshot) => void),
+    maybeListener?: (snapshot: ChatControllerSnapshot) => void,
+  ): () => void {
+    const channelId = typeof channelIdOrListener === "string"
+      ? normalizeChannelId(channelIdOrListener)
+      : DEFAULT_CHAT_CHANNEL_ID;
+    const listener = typeof channelIdOrListener === "function" ? channelIdOrListener : maybeListener;
+    if (!listener) return () => {};
+    const entry = { channelId, listener };
+    this.listeners.add(entry);
+    listener(this.getSnapshot(channelId));
+    return () => {
+      this.listeners.delete(entry);
+    };
+  }
+
+  getSnapshot(channelId = DEFAULT_CHAT_CHANNEL_ID): ChatControllerSnapshot {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
+    return {
+      channelId: normalizedChannelId,
+      channels: this.channels,
+      channelsLoading: this.channelsLoading,
+      loading: !this.sessionChecked || channel.messagesLoading,
+      loadingOlderMessages: channel.olderMessagesLoading,
+      hasOlderMessages: channel.messages.length > 0 && !channel.reachedOldestMessage,
+      hasSavedSession: !!apiClient.getSessionToken(),
+      user: this.user,
+      messages: this.getVisibleMessages(normalizedChannelId),
+      draft: channel.draft,
+      replyToId: channel.replyToId,
+      unreadMentionCount: this.getUnreadMentionCount(normalizedChannelId),
+    };
+  }
+
+  getChannels(): ChatChannel[] {
+    return this.channels;
+  }
+
+  async refreshChannels(): Promise<void> {
+    if (this.channelsPromise) return this.channelsPromise;
+    this.channelsLoading = true;
+    this.emit();
+
+    const request = apiClient.getChannels()
+      .then((channels) => {
+        this.channels = normalizeChannels(channels);
+      })
+      .catch(() => {
+        // Keep the last backend-provided list if the refresh fails.
+      })
+      .finally(() => {
+        this.channelsLoading = false;
+        this.channelsPromise = null;
+        this.emit();
+      });
+
+    this.channelsPromise = request;
+    return request;
+  }
+
+  async resolveRequiredChannelId(channelId: string): Promise<string> {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    if (this.isKnownChannelId(normalizedChannelId)) {
+      return normalizedChannelId;
+    }
+    await this.refreshChannels();
+    if (this.isKnownChannelId(normalizedChannelId)) {
+      return normalizedChannelId;
+    }
+    throw new Error(`Unknown chat channel "#${normalizedChannelId}".`);
+  }
+
+  async resolvePreferredChannelId(channelId: string | null | undefined): Promise<string> {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    if (this.isKnownChannelId(normalizedChannelId)) {
+      return normalizedChannelId;
+    }
+    await this.refreshChannels();
+    if (this.isKnownChannelId(normalizedChannelId)) {
+      return normalizedChannelId;
+    }
+    if (this.isKnownChannelId(DEFAULT_CHAT_CHANNEL_ID)) {
+      return DEFAULT_CHAT_CHANNEL_ID;
+    }
+    return this.channels[0]?.id ?? DEFAULT_CHAT_CHANNEL_ID;
+  }
+
+  private isKnownChannelId(channelId: string): boolean {
+    return this.channels.some((channel) => channel.id === channelId);
+  }
+
+  private ensureChannelState(channelId: string): ChannelRuntimeState {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const existing = this.channelStates.get(normalizedChannelId);
+    if (existing) return existing;
+
+    const channel = createEmptyChannelState();
+    this.channelStates.set(normalizedChannelId, channel);
+    this.hydrateChannelState(normalizedChannelId, channel);
+    return channel;
+  }
+
+  private hydrateChannelState(channelId: string, channel: ChannelRuntimeState): void {
+    if (channel.hydrated || !this.persistence) return;
+    channel.hydrated = true;
+
+    const persistedChannel = this.resume?.getState<PersistedChannelState>(channelStateKey(channelId), {
       schemaVersion: CHANNEL_SCHEMA_VERSION,
-    }) ?? this.persistence.getState<PersistedChannelState>(CHANNEL_STATE_KEY, {
+    }) ?? this.persistence.getState<PersistedChannelState>(channelStateKey(channelId), {
       schemaVersion: CHANNEL_SCHEMA_VERSION,
     });
-    this.draft = channel?.draft ?? "";
-    this.replyToId = channel?.replyToId ?? null;
-    const persistedCursor = channel?.lastCursor ?? null;
-    const persistedViewedMessageId = channel?.lastViewedMessageId ?? null;
+    channel.draft = persistedChannel?.draft ?? "";
+    channel.replyToId = persistedChannel?.replyToId ?? null;
+    const persistedCursor = persistedChannel?.lastCursor ?? null;
+    const persistedViewedMessageId = persistedChannel?.lastViewedMessageId ?? null;
 
-    const transcript = this.persistence.getResource<PersistedTranscript>(TRANSCRIPT_KIND, "everyone", {
+    const transcript = this.persistence.getResource<PersistedTranscript>(TRANSCRIPT_KIND, channelId, {
       sourceKey: TRANSCRIPT_SOURCE,
       schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
       allowExpired: true,
     });
-    this.messages = transcript?.value.messages ?? [];
-    this.lastCursor = resolveHydratedCursor(this.messages, persistedCursor);
-    this.lastViewedMessageId = this.user?.id && apiClient.getSessionToken()
-      ? persistedViewedMessageId ?? getLatestMessageId(this.messages)
+    channel.messages = transcript?.value.messages ?? [];
+    channel.lastCursor = resolveHydratedCursor(channel.messages, persistedCursor);
+    channel.lastViewedMessageId = this.user?.id && apiClient.getSessionToken()
+      ? persistedViewedMessageId ?? getLatestMessageId(channel.messages)
       : null;
-    this.syncVerificationPolling();
-  }
-
-  subscribe(listener: (snapshot: ChatControllerSnapshot) => void): () => void {
-    this.listeners.add(listener);
-    listener(this.getSnapshot());
-    return () => {
-      this.listeners.delete(listener);
-    };
-  }
-
-  getSnapshot(): ChatControllerSnapshot {
-    return {
-      loading: !this.sessionChecked || this.messagesLoading,
-      loadingOlderMessages: this.olderMessagesLoading,
-      hasOlderMessages: this.messages.length > 0 && !this.reachedOldestMessage,
-      hasSavedSession: !!apiClient.getSessionToken(),
-      user: this.user,
-      messages: this.getVisibleMessages(),
-      draft: this.draft,
-      replyToId: this.replyToId,
-      unreadMentionCount: this.getUnreadMentionCount(),
-    };
   }
 
   async refreshSession(): Promise<void> {
@@ -217,13 +371,13 @@ export class ChatController {
     if (!token) {
       this.stopVerificationPolling();
       this.stopSafetyRefresh();
-      this.wsConnection?.close();
-      this.wsConnection = null;
-      this.wsConnected = false;
+      this.closeAllConnections();
       this.user = null;
       this.sessionChecked = true;
-      this.pendingMessages = [];
-      this.lastViewedMessageId = null;
+      for (const channel of this.channelStates.values()) {
+        channel.pendingMessages = [];
+        channel.lastViewedMessageId = null;
+      }
       this.persistSession();
       this.emit();
       return;
@@ -233,14 +387,14 @@ export class ChatController {
     if (!session) {
       this.stopVerificationPolling();
       this.stopSafetyRefresh();
-      this.wsConnection?.close();
-      this.wsConnection = null;
-      this.wsConnected = false;
+      this.closeAllConnections();
       apiClient.setSessionToken(null);
       this.user = null;
       this.sessionChecked = true;
-      this.pendingMessages = [];
-      this.lastViewedMessageId = null;
+      for (const channel of this.channelStates.values()) {
+        channel.pendingMessages = [];
+        channel.lastViewedMessageId = null;
+      }
       this.persistSession();
       this.emit();
       return;
@@ -251,8 +405,10 @@ export class ChatController {
     this.user = nextUser;
     const nextIdentity = `${nextUser.id}:${normalizeUsername(nextUser.username) ?? ""}`;
     if (previousIdentity && previousIdentity !== nextIdentity) {
-      this.lastViewedMessageId = this.messages[this.messages.length - 1]?.id ?? null;
-      this.persistChannelState();
+      for (const [channelId, channel] of this.channelStates) {
+        channel.lastViewedMessageId = channel.messages[channel.messages.length - 1]?.id ?? null;
+        this.persistChannelState(channelId);
+      }
     }
     this.sessionChecked = true;
     this.persistSession();
@@ -260,100 +416,127 @@ export class ChatController {
 
     if (nextUser?.emailVerified) {
       this.stopVerificationPolling();
-      this.ensureConnection();
+      this.ensureOpenChannelConnections();
       return;
     }
 
     this.syncVerificationPolling();
     this.stopSafetyRefresh();
-    this.wsConnection?.close();
-    this.wsConnection = null;
-    this.wsConnected = false;
+    this.closeAllConnections();
   }
 
   async refreshMessages(): Promise<void> {
-    return this.runMessagesRefresh({ showLoading: true });
+    return this.refreshChannelMessages(DEFAULT_CHAT_CHANNEL_ID);
   }
 
-  private async runMessagesRefresh(options: { showLoading: boolean }): Promise<void> {
-    if (this.refreshMessagesPromise) return this.refreshMessagesPromise;
+  async refreshChannelMessages(channelId: string): Promise<void> {
+    return this.runMessagesRefresh(normalizeChannelId(channelId), { showLoading: true });
+  }
+
+  private async runMessagesRefresh(channelId: string, options: { showLoading: boolean }): Promise<void> {
+    const channel = this.ensureChannelState(channelId);
+    if (channel.refreshMessagesPromise) return channel.refreshMessagesPromise;
 
     if (options.showLoading) {
-      this.messagesLoading = true;
-      this.emit();
+      channel.messagesLoading = true;
+      this.emit(channelId);
     }
 
-    const request = this.fetchMessages()
+    const request = this.fetchMessages(channelId)
       .catch(() => {
-        this.persistChannelState();
+        this.persistChannelState(channelId);
       })
       .finally(() => {
         if (options.showLoading) {
-          this.messagesLoading = false;
+          channel.messagesLoading = false;
         }
-        this.refreshMessagesPromise = null;
-        this.emit();
+        channel.refreshMessagesPromise = null;
+        this.emit(channelId);
       });
 
-    this.refreshMessagesPromise = request;
+    channel.refreshMessagesPromise = request;
     return request;
   }
 
   async loadOlderMessages(): Promise<void> {
-    if (this.loadOlderMessagesPromise) return this.loadOlderMessagesPromise;
-    const before = this.messages[0]?.id ?? null;
-    if (!before || this.reachedOldestMessage) return;
+    return this.loadOlderChannelMessages(DEFAULT_CHAT_CHANNEL_ID);
+  }
 
-    this.olderMessagesLoading = true;
-    this.emit();
+  async loadOlderChannelMessages(channelId: string): Promise<void> {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
+    if (channel.loadOlderMessagesPromise) return channel.loadOlderMessagesPromise;
+    const before = channel.messages[0]?.id ?? null;
+    if (!before || channel.reachedOldestMessage) return;
 
-    const request = this.fetchOlderMessages(before)
+    channel.olderMessagesLoading = true;
+    this.emit(normalizedChannelId);
+
+    const request = this.fetchOlderMessages(normalizedChannelId, before)
       .catch(() => {
-        this.persistChannelState();
+        this.persistChannelState(normalizedChannelId);
       })
       .finally(() => {
-        this.olderMessagesLoading = false;
-        this.loadOlderMessagesPromise = null;
-        this.emit();
+        channel.olderMessagesLoading = false;
+        channel.loadOlderMessagesPromise = null;
+        this.emit(normalizedChannelId);
       });
 
-    this.loadOlderMessagesPromise = request;
+    channel.loadOlderMessagesPromise = request;
     return request;
   }
 
   setDraft(draft: string): void {
-    if (draft === this.draft) return;
-    this.draft = draft;
-    this.scheduleDraftSync();
+    this.setChannelDraft(DEFAULT_CHAT_CHANNEL_ID, draft);
+  }
+
+  setChannelDraft(channelId: string, draft: string): void {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
+    if (draft === channel.draft) return;
+    channel.draft = draft;
+    this.scheduleDraftSync(normalizedChannelId);
   }
 
   setReplyToId(replyToId: string | null): void {
-    this.replyToId = replyToId;
-    this.persistChannelState();
-    this.emit();
+    this.setChannelReplyToId(DEFAULT_CHAT_CHANNEL_ID, replyToId);
+  }
+
+  setChannelReplyToId(channelId: string, replyToId: string | null): void {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
+    channel.replyToId = replyToId;
+    this.persistChannelState(normalizedChannelId);
+    this.emit(normalizedChannelId);
   }
 
   attachView(): () => void {
-    this.openViewCount += 1;
-    if (this.markViewedThroughLatestMessage()) {
-      this.emit();
+    return this.attachChannelView(DEFAULT_CHAT_CHANNEL_ID);
+  }
+
+  attachChannelView(channelId: string): () => void {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
+    channel.openViewCount += 1;
+    if (this.markViewedThroughLatestMessage(normalizedChannelId)) {
+      this.emit(normalizedChannelId);
     }
     return () => {
-      this.openViewCount = Math.max(0, this.openViewCount - 1);
-      this.flushDraftSync();
+      channel.openViewCount = Math.max(0, channel.openViewCount - 1);
+      this.flushDraftSync(normalizedChannelId);
     };
   }
 
   clearSession(): void {
     this.stopVerificationPolling();
     this.stopSafetyRefresh();
-    this.wsConnection?.close();
-    this.wsConnection = null;
-    this.wsConnected = false;
+    this.closeAllConnections();
     this.user = null;
     this.sessionChecked = false;
-    this.pendingMessages = [];
-    this.lastViewedMessageId = null;
+    for (const channel of this.channelStates.values()) {
+      channel.pendingMessages = [];
+      channel.lastViewedMessageId = null;
+    }
     this.emit();
   }
 
@@ -370,17 +553,20 @@ export class ChatController {
   reset(clearSession = false): void {
     this.stopVerificationPolling();
     this.stopSafetyRefresh();
-    this.wsConnection?.close();
-    this.wsConnection = null;
-    this.wsConnected = false;
-    this.messages = [];
-    this.pendingMessages = [];
-    this.draft = "";
-    this.replyToId = null;
-    this.lastCursor = null;
-    this.lastViewedMessageId = null;
-    this.reachedOldestMessage = false;
-    this.openViewCount = 0;
+    this.closeAllConnections();
+    for (const [channelId, channel] of this.channelStates) {
+      this.clearDraftSyncTimer(channel);
+      channel.messages = [];
+      channel.pendingMessages = [];
+      channel.draft = "";
+      channel.replyToId = null;
+      channel.lastCursor = null;
+      channel.lastViewedMessageId = null;
+      channel.reachedOldestMessage = false;
+      channel.openViewCount = 0;
+      this.persistence?.deleteResource(TRANSCRIPT_KIND, channelId, { sourceKey: TRANSCRIPT_SOURCE });
+      this.persistChannelState(channelId);
+    }
     if (clearSession) {
       this.user = null;
       apiClient.setSessionToken(null);
@@ -388,92 +574,101 @@ export class ChatController {
     } else {
       this.persistSession();
     }
-    this.persistence?.deleteResource(TRANSCRIPT_KIND, "everyone", { sourceKey: TRANSCRIPT_SOURCE });
-    this.persistChannelState();
     this.emit();
   }
 
   dispose(): void {
     chatLog.info("dispose controller", {
       listeners: this.listeners.size,
-      hasConnection: !!this.wsConnection,
+      connections: [...this.channelStates.values()].filter((channel) => !!channel.wsConnection).length,
     });
-    this.flushDraftSync();
+    for (const [channelId] of this.channelStates) {
+      this.flushDraftSync(channelId);
+    }
     this.stopVerificationPolling();
     this.stopSafetyRefresh();
-    this.wsConnection?.close();
-    this.wsConnection = null;
-    this.wsConnected = false;
-    this.messagesLoading = false;
-    this.olderMessagesLoading = false;
-    this.refreshMessagesPromise = null;
-    this.loadOlderMessagesPromise = null;
-    this.openViewCount = 0;
+    this.closeAllConnections();
+    for (const channel of this.channelStates.values()) {
+      channel.messagesLoading = false;
+      channel.olderMessagesLoading = false;
+      channel.refreshMessagesPromise = null;
+      channel.loadOlderMessagesPromise = null;
+      channel.openViewCount = 0;
+    }
     this.notifyFn = () => {};
     this.listeners.clear();
   }
 
   send(content: string, replyToId?: string): void {
+    this.sendToChannel(DEFAULT_CHAT_CHANNEL_ID, content, replyToId);
+  }
+
+  sendToChannel(channelId: string, content: string, replyToId?: string): void {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
     if (!this.user?.emailVerified || !apiClient.getSessionToken()) return;
-    if (!this.wsConnection && this.user?.emailVerified && apiClient.getSessionToken()) {
-      this.ensureConnection();
+    if (!channel.wsConnection && this.user?.emailVerified && apiClient.getSessionToken()) {
+      this.ensureConnection(normalizedChannelId);
     }
-    const connection = this.wsConnection;
+    const connection = channel.wsConnection;
     if (!connection) {
       this.notifyFn({ body: "Unable to send message right now.", type: "error" });
       return;
     }
 
-    const pendingMessage = this.createPendingMessage(content, replyToId);
-    this.pendingMessages = [...this.pendingMessages, pendingMessage];
-    this.draft = "";
-    this.replyToId = null;
-    this.persistChannelState();
-    this.emit();
+    const pendingMessage = this.createPendingMessage(normalizedChannelId, content, replyToId);
+    channel.pendingMessages = [...channel.pendingMessages, pendingMessage];
+    channel.draft = "";
+    channel.replyToId = null;
+    this.persistChannelState(normalizedChannelId);
+    this.emit(normalizedChannelId);
 
     void connection.send(content, replyToId).then((message) => {
-      this.pendingMessages = this.pendingMessages.filter((entry) => entry.id !== pendingMessage.id);
-      this.mergeMessages([message]);
+      channel.pendingMessages = channel.pendingMessages.filter((entry) => entry.id !== pendingMessage.id);
+      this.mergeMessages(normalizedChannelId, [message]);
     }).catch((error) => {
       const errorMessage = error instanceof Error && error.message ? error.message : "Failed to send message.";
-      this.pendingMessages = this.pendingMessages.map((entry) => (
+      channel.pendingMessages = channel.pendingMessages.map((entry) => (
         entry.id === pendingMessage.id
           ? { ...entry, clientStatus: "failed", clientError: errorMessage }
           : entry
       ));
-      this.emit();
+      this.emit(normalizedChannelId);
       this.notifyFn({ body: errorMessage, type: "error" });
     });
   }
 
-  ensureConnection(): void {
+  ensureConnection(channelId = DEFAULT_CHAT_CHANNEL_ID): void {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
     if (!this.user?.emailVerified || !apiClient.getSessionToken()) {
       this.stopSafetyRefresh();
       return;
     }
     this.startSafetyRefresh();
-    if (this.wsConnected) return;
-    this.wsConnected = true;
+    if (channel.wsConnected) return;
+    channel.wsConnected = true;
 
-    void this.refreshMessages().catch(() => {});
+    void this.refreshChannelMessages(normalizedChannelId).catch(() => {});
 
-    this.wsConnection = apiClient.connectChannel(
-      "everyone",
+    channel.wsConnection = apiClient.connectChannel(
+      normalizedChannelId,
       (message) => {
-        if (this.messages.some((entry) => entry.id === message.id)) return;
-        this.mergeMessages([message]);
+        if (channel.messages.some((entry) => entry.id === message.id)) return;
+        this.mergeMessages(normalizedChannelId, [message]);
       },
       () => {
-        this.wsConnected = false;
+        channel.wsConnected = false;
       },
     );
   }
 
-  private emit(): void {
-    const snapshot = this.getSnapshot();
-    for (const listener of this.listeners) {
+  private emit(channelId?: string): void {
+    for (const entry of this.listeners) {
+      if (channelId && entry.channelId !== channelId) continue;
+      const snapshot = this.getSnapshot(entry.channelId);
       try {
-        listener(snapshot);
+        entry.listener(snapshot);
       } catch {
         // ignore subscriber errors
       }
@@ -504,7 +699,9 @@ export class ChatController {
         this.stopSafetyRefresh();
         return;
       }
-      void this.runMessagesRefresh({ showLoading: false }).catch(() => {});
+      for (const channelId of this.getSafetyRefreshChannelIds()) {
+        void this.runMessagesRefresh(channelId, { showLoading: false }).catch(() => {});
+      }
     }, SAFETY_REFRESH_MS);
     this.safetyRefreshTimer.unref?.();
   }
@@ -515,85 +712,126 @@ export class ChatController {
     this.safetyRefreshTimer = null;
   }
 
-  private async fetchMessages(): Promise<void> {
-    const legacyTimestampCursor = isLegacyTimestampCursor(this.lastCursor);
-    const hasIncrementalCursor = !!this.lastCursor;
-
-    try {
-      const messages = await apiClient.getMessages("everyone", {
-        limit: MESSAGE_PAGE_SIZE,
-        after: this.lastCursor ?? undefined,
-      });
-      if (!hasIncrementalCursor && messages.length < MESSAGE_PAGE_SIZE) {
-        this.reachedOldestMessage = true;
-      }
-      if (messages.length > 0) {
-        this.mergeMessages(messages);
-        return;
-      }
-      if (legacyTimestampCursor) {
-        const fullRefresh = await apiClient.getMessages("everyone", { limit: MESSAGE_PAGE_SIZE });
-        if (fullRefresh.length < MESSAGE_PAGE_SIZE) {
-          this.reachedOldestMessage = true;
-        }
-        if (fullRefresh.length > 0) {
-          this.mergeMessages(fullRefresh);
-          return;
-        }
-        this.lastCursor = null;
-      }
-      this.persistChannelState();
-      return;
-    } catch {
-      const messages = await apiClient.getMessages("everyone", { limit: MESSAGE_PAGE_SIZE });
-      if (messages.length < MESSAGE_PAGE_SIZE) {
-        this.reachedOldestMessage = true;
-      }
-      if (messages.length > 0) {
-        this.mergeMessages(messages);
-        return;
-      }
-      this.persistChannelState();
+  private closeAllConnections(): void {
+    for (const channel of this.channelStates.values()) {
+      channel.wsConnection?.close();
+      channel.wsConnection = null;
+      channel.wsConnected = false;
     }
   }
 
-  private async fetchOlderMessages(before: string): Promise<void> {
-    const messages = await apiClient.getMessages("everyone", {
+  private ensureOpenChannelConnections(): void {
+    const channelIds = new Set<string>([DEFAULT_CHAT_CHANNEL_ID]);
+    for (const [channelId, channel] of this.channelStates) {
+      if (channel.openViewCount > 0 || channel.wsConnection) {
+        channelIds.add(channelId);
+      }
+    }
+    for (const channelId of channelIds) {
+      this.ensureConnection(channelId);
+    }
+  }
+
+  private getSafetyRefreshChannelIds(): string[] {
+    const active = [...this.channelStates.entries()]
+      .filter(([, channel]) => channel.openViewCount > 0 || channel.wsConnection)
+      .map(([channelId]) => channelId);
+    return active.length > 0 ? active : [DEFAULT_CHAT_CHANNEL_ID];
+  }
+
+  private async fetchMessages(channelId: string): Promise<void> {
+    const channel = this.ensureChannelState(channelId);
+    const legacyTimestampCursor = isLegacyTimestampCursor(channel.lastCursor);
+    const hasIncrementalCursor = !!channel.lastCursor;
+
+    try {
+      const messages = await apiClient.getMessages(channelId, {
+        limit: MESSAGE_PAGE_SIZE,
+        after: channel.lastCursor ?? undefined,
+      });
+      if (!hasIncrementalCursor && messages.length < MESSAGE_PAGE_SIZE) {
+        channel.reachedOldestMessage = true;
+      }
+      if (messages.length > 0) {
+        this.mergeMessages(channelId, messages);
+        return;
+      }
+      if (legacyTimestampCursor) {
+        const fullRefresh = await apiClient.getMessages(channelId, { limit: MESSAGE_PAGE_SIZE });
+        if (fullRefresh.length < MESSAGE_PAGE_SIZE) {
+          channel.reachedOldestMessage = true;
+        }
+        if (fullRefresh.length > 0) {
+          this.mergeMessages(channelId, fullRefresh);
+          return;
+        }
+        channel.lastCursor = null;
+      }
+      this.persistChannelState(channelId);
+      return;
+    } catch {
+      const messages = await apiClient.getMessages(channelId, { limit: MESSAGE_PAGE_SIZE });
+      if (messages.length < MESSAGE_PAGE_SIZE) {
+        channel.reachedOldestMessage = true;
+      }
+      if (messages.length > 0) {
+        this.mergeMessages(channelId, messages);
+        return;
+      }
+      this.persistChannelState(channelId);
+    }
+  }
+
+  private async fetchOlderMessages(channelId: string, before: string): Promise<void> {
+    const channel = this.ensureChannelState(channelId);
+    const messages = await apiClient.getMessages(channelId, {
       limit: MESSAGE_PAGE_SIZE,
       before,
     });
     if (messages.length < MESSAGE_PAGE_SIZE) {
-      this.reachedOldestMessage = true;
+      channel.reachedOldestMessage = true;
     }
     if (messages.length === 0) {
-      this.persistChannelState();
+      this.persistChannelState(channelId);
       return;
     }
-    this.mergeMessages(messages, { notifyMentions: false });
+    this.mergeMessages(channelId, messages, { notifyMentions: false });
   }
 
-  private mergeMessages(messages: ChatMessage[], options?: { notifyMentions?: boolean }): void {
-    this.reconcilePendingMessages(messages);
+  private mergeMessages(
+    channelIdOrMessages: string | ChatMessage[],
+    maybeMessages?: ChatMessage[] | { notifyMentions?: boolean },
+    maybeOptions?: { notifyMentions?: boolean },
+  ): void {
+    const channelId = Array.isArray(channelIdOrMessages) ? DEFAULT_CHAT_CHANNEL_ID : channelIdOrMessages;
+    const messages = Array.isArray(channelIdOrMessages)
+      ? channelIdOrMessages
+      : (maybeMessages as ChatMessage[] | undefined) ?? [];
+    const options = Array.isArray(channelIdOrMessages)
+      ? maybeMessages as { notifyMentions?: boolean } | undefined
+      : maybeOptions;
+    const channel = this.ensureChannelState(channelId);
+    this.reconcilePendingMessages(channelId, messages);
     const merged = new Map<string, ChatMessage>();
     const incoming = new Map<string, ChatMessage>();
-    for (const message of this.messages) merged.set(message.id, message);
+    for (const message of channel.messages) merged.set(message.id, message);
     for (const message of messages) {
       if (!merged.has(message.id)) {
         incoming.set(message.id, message);
       }
       merged.set(message.id, message);
     }
-    this.messages = [...merged.values()]
+    channel.messages = [...merged.values()]
       .sort(compareMessages);
-    this.lastCursor = this.messages[this.messages.length - 1]?.id ?? this.lastCursor;
-    if (this.openViewCount > 0) {
-      this.markViewedThroughLatestMessage(false);
+    channel.lastCursor = channel.messages[channel.messages.length - 1]?.id ?? channel.lastCursor;
+    if (channel.openViewCount > 0) {
+      this.markViewedThroughLatestMessage(channelId, false);
     }
     if (options?.notifyMentions !== false) {
-      this.trackUnreadMentions([...incoming.values()]);
+      this.trackUnreadMentions(channelId, [...incoming.values()]);
     }
-    this.persistTranscript();
-    this.emit();
+    this.persistTranscript(channelId);
+    this.emit(channelId);
   }
 
   private persistSession(): void {
@@ -609,67 +847,73 @@ export class ChatController {
     });
   }
 
-  private persistChannelState(): void {
-    this.clearDraftSyncTimer();
-    this.writeChannelState();
+  private persistChannelState(channelId: string): void {
+    const channel = this.ensureChannelState(channelId);
+    this.clearDraftSyncTimer(channel);
+    this.writeChannelState(channelId);
   }
 
-  private writeChannelState(): void {
+  private writeChannelState(channelId: string): void {
+    const channel = this.ensureChannelState(channelId);
     const value = {
-      draft: this.draft,
-      replyToId: this.replyToId,
-      lastCursor: this.lastCursor,
-      lastViewedMessageId: this.lastViewedMessageId,
+      draft: channel.draft,
+      replyToId: channel.replyToId,
+      lastCursor: channel.lastCursor,
+      lastViewedMessageId: channel.lastViewedMessageId,
     } satisfies PersistedChannelState;
-    this.resume?.setState(CHANNEL_STATE_KEY, value, {
+    this.resume?.setState(channelStateKey(channelId), value, {
       schemaVersion: CHANNEL_SCHEMA_VERSION,
     });
-    this.persistence?.setState(CHANNEL_STATE_KEY, value, {
+    this.persistence?.setState(channelStateKey(channelId), value, {
       schemaVersion: CHANNEL_SCHEMA_VERSION,
     });
   }
 
-  private scheduleDraftSync(): void {
-    this.clearDraftSyncTimer();
-    this.draftSyncTimer = setTimeout(() => {
-      this.draftSyncTimer = null;
-      this.writeChannelState();
-      this.emit();
+  private scheduleDraftSync(channelId: string): void {
+    const channel = this.ensureChannelState(channelId);
+    this.clearDraftSyncTimer(channel);
+    channel.draftSyncTimer = setTimeout(() => {
+      channel.draftSyncTimer = null;
+      this.writeChannelState(channelId);
+      this.emit(channelId);
     }, DRAFT_SYNC_DEBOUNCE_MS);
-    this.draftSyncTimer.unref?.();
+    channel.draftSyncTimer.unref?.();
   }
 
-  private clearDraftSyncTimer(): void {
-    if (!this.draftSyncTimer) return;
-    clearTimeout(this.draftSyncTimer);
-    this.draftSyncTimer = null;
+  private clearDraftSyncTimer(channel: ChannelRuntimeState): void {
+    if (!channel.draftSyncTimer) return;
+    clearTimeout(channel.draftSyncTimer);
+    channel.draftSyncTimer = null;
   }
 
-  private flushDraftSync(): void {
-    if (!this.draftSyncTimer) return;
-    this.clearDraftSyncTimer();
-    this.writeChannelState();
+  private flushDraftSync(channelId: string): void {
+    const channel = this.ensureChannelState(channelId);
+    if (!channel.draftSyncTimer) return;
+    this.clearDraftSyncTimer(channel);
+    this.writeChannelState(channelId);
   }
 
-  private persistTranscript(): void {
-    if (this.messages.length === 0) {
-      this.persistence?.deleteResource(TRANSCRIPT_KIND, "everyone", { sourceKey: TRANSCRIPT_SOURCE });
-      this.persistChannelState();
+  private persistTranscript(channelId: string): void {
+    const channel = this.ensureChannelState(channelId);
+    if (channel.messages.length === 0) {
+      this.persistence?.deleteResource(TRANSCRIPT_KIND, channelId, { sourceKey: TRANSCRIPT_SOURCE });
+      this.persistChannelState(channelId);
       return;
     }
 
-    this.persistence?.setResource(TRANSCRIPT_KIND, "everyone", {
-      messages: this.messages.slice(-MAX_CACHED_MESSAGES),
+    this.persistence?.setResource(TRANSCRIPT_KIND, channelId, {
+      messages: channel.messages.slice(-MAX_CACHED_MESSAGES),
     } satisfies PersistedTranscript, {
       sourceKey: TRANSCRIPT_SOURCE,
       schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
       cachePolicy: TRANSCRIPT_CACHE_POLICY,
     });
-    this.persistChannelState();
+    this.persistChannelState(channelId);
   }
 
-  private trackUnreadMentions(messages: ChatMessage[]): void {
-    if (this.openViewCount > 0) {
+  private trackUnreadMentions(channelId: string, messages: ChatMessage[]): void {
+    const channel = this.ensureChannelState(channelId);
+    if (channel.openViewCount > 0) {
       return;
     }
 
@@ -687,25 +931,26 @@ export class ChatController {
     }
     this.notifyFn({
       title: "Gloomberb chat",
-      body: `${freshMentions.length} new mentions in #everyone.`,
+      body: `${freshMentions.length} new mentions in #${channelId}.`,
       type: "info",
       desktop: "when-inactive",
     });
   }
 
-  private getUnreadMentionCount(): number {
-    return this.getUnreadMentionMessages().length;
+  private getUnreadMentionCount(channelId: string): number {
+    return this.getUnreadMentionMessages(channelId).length;
   }
 
-  private getUnreadMentionMessages(): ChatMessage[] {
-    if (!this.lastViewedMessageId) {
-      return this.getMentionMessages(this.messages);
+  private getUnreadMentionMessages(channelId: string): ChatMessage[] {
+    const channel = this.ensureChannelState(channelId);
+    if (!channel.lastViewedMessageId) {
+      return this.getMentionMessages(channel.messages);
     }
 
-    const viewedIndex = this.messages.findIndex((message) => message.id === this.lastViewedMessageId);
+    const viewedIndex = channel.messages.findIndex((message) => message.id === channel.lastViewedMessageId);
     const unseenMessages = viewedIndex >= 0
-      ? this.messages.slice(viewedIndex + 1)
-      : this.messages;
+      ? channel.messages.slice(viewedIndex + 1)
+      : channel.messages;
     return this.getMentionMessages(unseenMessages);
   }
 
@@ -718,31 +963,33 @@ export class ChatController {
     ));
   }
 
-  private markViewedThroughLatestMessage(persist = true): boolean {
-    const latestMessageId = this.messages[this.messages.length - 1]?.id ?? null;
-    if (this.lastViewedMessageId === latestMessageId) {
+  private markViewedThroughLatestMessage(channelId: string, persist = true): boolean {
+    const channel = this.ensureChannelState(channelId);
+    const latestMessageId = channel.messages[channel.messages.length - 1]?.id ?? null;
+    if (channel.lastViewedMessageId === latestMessageId) {
       return false;
     }
-    this.lastViewedMessageId = latestMessageId;
+    channel.lastViewedMessageId = latestMessageId;
     if (persist) {
-      this.persistChannelState();
+      this.persistChannelState(channelId);
     }
     return true;
   }
 
-  private getVisibleMessages(): ChatMessage[] {
-    return [...this.messages, ...this.pendingMessages]
+  private getVisibleMessages(channelId: string): ChatMessage[] {
+    const channel = this.ensureChannelState(channelId);
+    return [...channel.messages, ...channel.pendingMessages]
       .sort(compareMessages);
   }
 
-  private createPendingMessage(content: string, replyToId?: string): ChatMessage {
+  private createPendingMessage(channelId: string, content: string, replyToId?: string): ChatMessage {
     const replyToMessage = replyToId
-      ? this.getVisibleMessages().find((message) => message.id === replyToId) ?? null
+      ? this.getVisibleMessages(channelId).find((message) => message.id === replyToId) ?? null
       : null;
     const pendingId = `local:${Date.now()}:${this.pendingMessageSeq += 1}`;
     return {
       id: pendingId,
-      channelId: "everyone",
+      channelId,
       content,
       replyToId: replyToId ?? null,
       createdAt: new Date().toISOString(),
@@ -762,10 +1009,11 @@ export class ChatController {
     };
   }
 
-  private reconcilePendingMessages(messages: ChatMessage[]): void {
-    if (this.pendingMessages.length === 0 || messages.length === 0) return;
+  private reconcilePendingMessages(channelId: string, messages: ChatMessage[]): void {
+    const channel = this.ensureChannelState(channelId);
+    if (channel.pendingMessages.length === 0 || messages.length === 0) return;
 
-    const remaining = [...this.pendingMessages];
+    const remaining = [...channel.pendingMessages];
     for (const incoming of messages) {
       const incomingMs = toTimestampMillis(incoming.createdAt);
       const pendingIndex = remaining.findIndex((pending) => (
@@ -778,7 +1026,7 @@ export class ChatController {
         remaining.splice(pendingIndex, 1);
       }
     }
-    this.pendingMessages = remaining;
+    channel.pendingMessages = remaining;
   }
 }
 

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -1,27 +1,42 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, useState } from "react";
+import { act, useCallback, useMemo, useRef, useState } from "react";
 import { PaneFooterBar, PaneFooterProvider } from "../../components/layout/pane-footer";
 import { testRender } from "../../renderers/opentui/test-utils";
-import { AppContext, createInitialState } from "../../state/app-context";
-import { createTestPluginRuntime } from "../../test-support/plugin-runtime";
+import { AppContext, appReducer, createInitialState, PaneInstanceProvider } from "../../state/app-context";
+import { createConfigBackedTestPluginRuntime, createTestPluginRuntime } from "../../test-support/plugin-runtime";
 import { colors } from "../../theme/colors";
-import { createDefaultConfig } from "../../types/config";
+import { createDefaultConfig, findPaneInstance, type PaneInstanceConfig } from "../../types/config";
 import type { PersistedResourceValue } from "../../types/persistence";
 import type { PluginPersistence } from "../../types/plugin";
 import { Box } from "../../ui";
-import { apiClient, type ChatMessage } from "../../utils/api-client";
+import { apiClient, type ChatChannel, type ChatMessage } from "../../utils/api-client";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
 import { setSharedMarketDataForTests, setSharedRegistryForTests } from "../registry";
-import { ChatContent, ChatStatusWidget, getSelectedMessageScrollTop, gloomberbCloudPlugin } from "./chat";
-import { ChatController } from "./chat-controller";
+import { ChatContent, ChatStatusWidget, getScrollTopForElementIntoView, getSelectedMessageScrollTop, gloomberbCloudPlugin } from "./chat";
+import { chatController, ChatController } from "./chat-controller";
 
 const TRANSCRIPT_KIND = "channel-transcript";
 const TRANSCRIPT_KEY = "everyone";
 const TRANSCRIPT_SOURCE = "server";
 const TRANSCRIPT_SCHEMA_VERSION = 2;
 const originalConnectChannel = apiClient.connectChannel.bind(apiClient);
+const originalGetChannels = apiClient.getChannels.bind(apiClient);
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+const TEST_CHAT_CHANNELS: ChatChannel[] = [
+  { id: "everyone", name: "everyone", created_at: "2026-03-26T12:10:05.684Z" },
+  { id: "equities", name: "equities", created_at: "2026-05-09T00:00:00.000Z" },
+  { id: "options", name: "options", created_at: "2026-05-09T00:00:00.000Z" },
+  { id: "macro", name: "macro", created_at: "2026-05-09T00:00:00.000Z" },
+  { id: "crypto", name: "crypto", created_at: "2026-05-09T00:00:00.000Z" },
+  { id: "energy", name: "energy", created_at: "2026-05-09T00:00:00.000Z" },
+  { id: "help", name: "help", created_at: "2026-05-09T00:00:00.000Z" },
+];
+
+function installServerChannels(controller: ChatController, channels = TEST_CHAT_CHANNELS): void {
+  (controller as any).channels = channels;
+}
 
 class MemoryPersistence implements PluginPersistence {
   private readonly state = new Map<string, { schemaVersion: number; value: unknown }>();
@@ -237,6 +252,7 @@ afterEach(async () => {
   setSharedRegistryForTests(undefined);
   setSharedMarketDataForTests(undefined);
   apiClient.connectChannel = originalConnectChannel;
+  apiClient.getChannels = originalGetChannels;
   apiClient.setSessionToken(null);
 
   if (testSetup) {
@@ -354,6 +370,341 @@ describe("ChatContent", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Type a message...");
     expect(frame).not.toContain("click a message");
+  });
+
+  test("shows the channel sidebar on wide panes and hides it on narrow panes", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+    const renderChannelPane = (width: number) => (
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+          <ChatContent
+            controller={controller}
+            width={width}
+            height={12}
+            focused
+            channelId="options"
+            onChannelChange={() => {}}
+          />
+        </PluginRenderProvider>
+      </AppContext>
+    );
+
+    await act(async () => {
+      testSetup = await testRender(renderChannelPane(90), {
+        width: 90,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("options");
+
+    await act(async () => {
+      testSetup?.renderer.destroy();
+      testSetup = await testRender(renderChannelPane(60), {
+        width: 60,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).not.toContain("options");
+  });
+
+  test("selects a sidebar channel from a single text click", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+
+    function ChannelPane() {
+      const [channelId, setChannelId] = useState("equities");
+      return (
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={90}
+              height={12}
+              focused
+              channelId={channelId}
+              onChannelChange={setChannelId}
+            />
+          </PluginRenderProvider>
+        </AppContext>
+      );
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<ChannelPane />, {
+        width: 90,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("#equities");
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("options"));
+    const col = lines[row]?.indexOf("options") ?? -1;
+
+    expect(row).toBeGreaterThanOrEqual(0);
+    expect(col).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(col + 1, row);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(testSetup.captureCharFrame()).toContain("#options");
+  });
+
+  test("uses arrows to move between channel sidebar and chat content", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+
+    function ChannelPane() {
+      const [channelId, setChannelId] = useState("equities");
+      return (
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={90}
+              height={12}
+              focused
+              channelId={channelId}
+              onChannelChange={setChannelId}
+            />
+          </PluginRenderProvider>
+        </AppContext>
+      );
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<ChannelPane />, {
+        width: 90,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("#equities");
+    const getActiveChannelBackgrounds = () => {
+      const activeLine = testSetup!.captureSpans().lines.find((line) => lineText(line).includes("#equities"));
+      expect(activeLine).toBeDefined();
+      return activeLine!.spans.map((span) => span.bg.toInts().join(","));
+    };
+    const getContentBackgrounds = () => {
+      const contentLine = testSetup!.captureSpans().lines.find((line) => lineText(line).includes("No messages yet"));
+      expect(contentLine).toBeDefined();
+      return contentLine!.spans.map((span) => span.bg.toInts().join(","));
+    };
+    const contentFocusedBackgrounds = getActiveChannelBackgrounds();
+    const rightFocusedBackgrounds = getContentBackgrounds();
+
+    await emitKeypress({ name: "down", sequence: "\u001b[B" });
+    expect(testSetup.captureCharFrame()).toContain("#equities");
+
+    await emitKeypress({ name: "left", sequence: "\u001b[D" });
+    await flushFrame();
+    expect(getActiveChannelBackgrounds()).not.toEqual(contentFocusedBackgrounds);
+    expect(getContentBackgrounds()).not.toEqual(rightFocusedBackgrounds);
+    await emitKeypress({ name: "down", sequence: "\u001b[B" });
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("#options");
+
+    await emitKeypress({ name: "up", sequence: "\u001b[A" });
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("#equities");
+
+    await emitKeypress({ name: "right", sequence: "\u001b[C" });
+    await flushFrame();
+    expect(getActiveChannelBackgrounds()).toEqual(contentFocusedBackgrounds);
+    expect(getContentBackgrounds()).toEqual(rightFocusedBackgrounds);
+    await emitKeypress({ name: "down", sequence: "\u001b[B" });
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("#equities");
+  });
+
+  test("keeps the channel sidebar visible while a channel loads", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    const getSnapshot = controller.getSnapshot.bind(controller);
+    controller.getSnapshot = ((channelId?: string) => ({
+      ...getSnapshot(channelId),
+      loading: true,
+      messages: [],
+    })) as typeof controller.getSnapshot;
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+
+    await act(async () => {
+      testSetup = await testRender(
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={90}
+              height={12}
+              focused
+              channelId="options"
+              onChannelChange={() => {}}
+            />
+          </PluginRenderProvider>
+        </AppContext>,
+        {
+          width: 90,
+          height: 12,
+        },
+      );
+    });
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("#options");
+    expect(frame).toContain("Loading...");
+  });
+
+  test("persists a pane channel selection without the last-visited write reverting it", async () => {
+    const registeredPanes: Array<{ id: string; component: (props: any) => JSX.Element }> = [];
+    gloomberbCloudPlugin.setup({
+      persistence: new MemoryPersistence(),
+      resume: {
+        getState: () => null,
+        setState: () => {},
+        deleteState: () => {},
+      },
+      registerPane: (pane: { id: string; component: (props: any) => JSX.Element }) => {
+        registeredPanes.push(pane);
+      },
+      registerPaneTemplate: () => {},
+      registerDetailTab: () => {},
+      registerShortcut: () => {},
+      registerCommand: () => {},
+      showPane: () => {},
+      hidePane: () => {},
+      notify: () => {},
+    } as any);
+    const ChatPaneComponent = registeredPanes.find((pane) => pane.id === "chat")?.component;
+    expect(ChatPaneComponent).toBeDefined();
+    const ResolvedChatPaneComponent = ChatPaneComponent!;
+
+    const originalRefreshChannels = chatController.refreshChannels;
+    const originalRefreshSession = chatController.refreshSession;
+    const originalRefreshChannelMessages = chatController.refreshChannelMessages;
+    installServerChannels(chatController);
+    chatController.refreshChannels = async () => {};
+    chatController.refreshSession = async () => {};
+    chatController.refreshChannelMessages = async () => {};
+
+    const paneInstanceId = "chat:test";
+    const chatInstance: PaneInstanceConfig = {
+      instanceId: paneInstanceId,
+      paneId: "chat",
+      settings: { channelId: "equities" },
+    };
+    const layout = {
+      dockRoot: { kind: "pane" as const, instanceId: paneInstanceId },
+      floating: [],
+      detached: [],
+      instances: [chatInstance],
+    };
+    const initialState = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+    initialState.focusedPaneId = paneInstanceId;
+    initialState.config = {
+      ...initialState.config,
+      layout,
+      layouts: [{ name: "Test", layout }],
+      pluginConfig: {
+        "gloomberb-cloud": {
+          lastChatChannelId: "equities",
+        },
+      },
+    };
+    let latestState = initialState;
+
+    function ChatPaneHarness() {
+      const [state, setState] = useState(initialState);
+      const stateRef = useRef(state);
+      stateRef.current = state;
+      latestState = state;
+      const dispatch = useCallback((action: any) => {
+        setState((current) => {
+          const next = appReducer(current, action);
+          latestState = next;
+          return next;
+        });
+      }, []);
+      const runtime = useMemo(() => createConfigBackedTestPluginRuntime({
+        getConfig: () => stateRef.current.config,
+        setConfig: (config) => dispatch({ type: "SET_CONFIG", config }),
+      }), [dispatch]);
+
+      return (
+        <AppContext value={{ state, dispatch }}>
+          <PaneInstanceProvider paneId={paneInstanceId}>
+            <PluginRenderProvider pluginId="gloomberb-cloud" runtime={runtime}>
+              <ResolvedChatPaneComponent
+                width={90}
+                height={12}
+                focused
+                close={() => {}}
+              />
+            </PluginRenderProvider>
+          </PaneInstanceProvider>
+        </AppContext>
+      );
+    }
+
+    try {
+      await act(async () => {
+        testSetup = await testRender(<ChatPaneHarness />, {
+          width: 90,
+          height: 12,
+        });
+      });
+
+      await flushFrame();
+      const lines = testSetup.captureCharFrame().split("\n");
+      const row = lines.findIndex((line) => line.includes("options"));
+      const col = lines[row]?.indexOf("options") ?? -1;
+
+      expect(row).toBeGreaterThanOrEqual(0);
+      expect(col).toBeGreaterThanOrEqual(0);
+
+      await act(async () => {
+        await testSetup!.mockMouse.click(col + 1, row);
+        await testSetup!.renderOnce();
+        await testSetup!.renderOnce();
+      });
+      await flushFrame();
+
+      expect(findPaneInstance(latestState.config.layout, paneInstanceId)?.settings?.channelId).toBe("options");
+      expect(latestState.config.pluginConfig["gloomberb-cloud"]?.lastChatChannelId).toBe("options");
+      expect(testSetup.captureCharFrame()).toContain("#options");
+    } finally {
+      chatController.refreshChannels = originalRefreshChannels;
+      chatController.refreshSession = originalRefreshSession;
+      chatController.refreshChannelMessages = originalRefreshChannelMessages;
+      installServerChannels(chatController, []);
+      chatController.dispose();
+    }
   });
 
   test("uses the full message row width when the reply action is hidden", async () => {
@@ -635,6 +986,29 @@ describe("ChatContent", () => {
     });
 
     expect(nextScrollTop).toBe(13);
+  });
+
+  test("keeps a selected desktop message inside the scroll viewport", () => {
+    expect(getScrollTopForElementIntoView({
+      scrollTop: 120,
+      viewportHeight: 60,
+      elementTop: 170,
+      elementHeight: 24,
+    })).toBe(134);
+
+    expect(getScrollTopForElementIntoView({
+      scrollTop: 120,
+      viewportHeight: 60,
+      elementTop: 92,
+      elementHeight: 18,
+    })).toBe(92);
+
+    expect(getScrollTopForElementIntoView({
+      scrollTop: 120,
+      viewportHeight: 60,
+      elementTop: 132,
+      elementHeight: 18,
+    })).toBe(120);
   });
 
   test("up arrow still moves within a multi-line draft before handing off to message selection", async () => {
@@ -1517,5 +1891,49 @@ describe("ChatContent", () => {
       "confirmPassword",
       "_validate",
     ]);
+  });
+
+  test("new chat pane opens directly on the last visited channel", async () => {
+    const originalRefreshChannels = chatController.refreshChannels;
+    installServerChannels(chatController);
+    chatController.refreshChannels = async () => {};
+    const chatTemplate = gloomberbCloudPlugin.paneTemplates?.find((template) => template.id === "new-chat-pane");
+    try {
+      expect(chatTemplate?.wizard).toBeUndefined();
+      expect(chatTemplate?.shortcut).toMatchObject({
+        prefix: "CHAT",
+        argPlaceholder: "channel",
+        argKind: "text",
+      });
+      const created = await Promise.resolve(chatTemplate?.createInstance?.({
+        config: {
+          pluginConfig: {
+            "gloomberb-cloud": {
+              lastChatChannelId: "options",
+            },
+          },
+        },
+      }));
+      expect(created).toMatchObject({
+        settings: { channelId: "options" },
+        placement: "floating",
+      });
+      const createdFromShortcut = await Promise.resolve(chatTemplate?.createInstance?.({
+        config: {
+          pluginConfig: {
+            "gloomberb-cloud": {
+              lastChatChannelId: "options",
+            },
+          },
+        },
+      }, { arg: "#HELP" }));
+      expect(createdFromShortcut).toMatchObject({
+        settings: { channelId: "help" },
+        placement: "floating",
+      });
+    } finally {
+      chatController.refreshChannels = originalRefreshChannels;
+      installServerChannels(chatController, []);
+    }
   });
 });

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -1,17 +1,21 @@
 import { Box, ScrollBox, Span, Text, useUiCapabilities } from "../../ui";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { memo, useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useShortcut } from "../../react/input";
 import { TextAttributes, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
-import { useAppDispatch, useAppSelector } from "../../state/app-context";
-import { useInlineTickers } from "../../state/use-inline-tickers";
-import { getMessageComposerBlockHeight, MessageComposer } from "../../components/ui";
+import { useAppDispatch, useAppSelector, useAppStateRef, usePaneInstance, usePaneInstanceId } from "../../state/app-context";
+import { useInlineTickers, type InlineTickerCatalogEntry } from "../../state/use-inline-tickers";
+import { ExternalLinkText, getMessageComposerBlockHeight, MessageComposer } from "../../components/ui";
 import { TickerBadgeText } from "../../components/ticker-badge-text";
-import { colors, hoverBg } from "../../theme/colors";
-import { apiClient, type ChatMessage } from "../../utils/api-client";
+import { TickerBadge } from "../../components/ticker-badge";
+import { blendHex, colors, hoverBg } from "../../theme/colors";
+import { apiClient, type ChatChannel, type ChatMessage } from "../../utils/api-client";
 import { formatTimeAgo } from "../../utils/format";
+import { tokenizeInlineContent } from "../../utils/inline-content-tokenizer";
 import { getSharedRegistry } from "../../plugins/registry";
 import { usePluginAppActions } from "../../plugins/plugin-runtime";
+import { setPaneSetting } from "../../pane-settings";
+import { scheduleConfigSave } from "../../state/config-save-scheduler";
 import { chatController, type ChatController } from "./chat-controller";
 import { createGloomberbCloudCapabilities, createGloomberbCloudProvider } from "../../sources/gloomberb-cloud";
 import { InlineAuthActions } from "./cloud-auth-actions";
@@ -22,16 +26,25 @@ interface ChatContentProps {
   height: number;
   focused: boolean;
   close?: () => void;
+  channelId?: string;
+  onChannelChange?: (channelId: string) => void;
   controller?: Pick<
     ChatController,
     | "attachView"
+    | "attachChannelView"
     | "getSnapshot"
+    | "refreshChannels"
     | "loadOlderMessages"
+    | "loadOlderChannelMessages"
     | "refreshMessages"
+    | "refreshChannelMessages"
     | "refreshSession"
     | "send"
+    | "sendToChannel"
     | "setDraft"
+    | "setChannelDraft"
     | "setReplyToId"
+    | "setChannelReplyToId"
     | "subscribe"
   >;
 }
@@ -42,10 +55,16 @@ interface ChatStatusWidgetProps {
 
 const MESSAGE_GROUP_THRESHOLD_MS = 5 * 60 * 1000;
 const CHAT_COMPOSER_MAX_ROWS = 5;
-const NATIVE_CHAT_COMPOSER_TOP_GAP_PX = 12;
 const MESSAGE_ACTION_WIDTH = 9;
 const COMPOSER_ACTION_WIDTH = 10;
 const MESSAGE_SELECTION_BOTTOM_INSET = 1;
+const DESKTOP_MESSAGE_RIGHT_PADDING = 2;
+const CHANNEL_SIDEBAR_MIN_WIDTH = 18;
+const CHANNEL_SIDEBAR_MAX_WIDTH = 24;
+const CHANNEL_SIDEBAR_BREAKPOINT = 72;
+const DEFAULT_CHAT_CHANNEL_ID = "everyone";
+const LAST_VISITED_CHAT_CHANNEL_KEY = "lastChatChannelId";
+const CHAT_CHANNEL_MOUSE_HANDLED = "__gloomberbChatChannelHandled";
 
 function isGroupedWithPrevious(messages: ChatMessage[], index: number) {
   if (index === 0) return false;
@@ -117,9 +136,125 @@ function getMessageTopOffset(messages: ChatMessage[], index: number, width: numb
   return offset;
 }
 
-function scrollToBottom(scrollBox: ScrollBoxRenderable | null) {
+function hasPixelScrollMetrics(scrollBox: ScrollBoxRenderable | null) {
+  return !!scrollBox?.scrollToPixels && typeof scrollBox.scrollHeightPx === "number" && !!scrollBox.viewportPx;
+}
+
+function getScrollTop(scrollBox: ScrollBoxRenderable, preferPixels: boolean) {
+  return preferPixels && typeof scrollBox.scrollTopPx === "number" ? scrollBox.scrollTopPx : scrollBox.scrollTop;
+}
+
+function getScrollHeight(scrollBox: ScrollBoxRenderable, preferPixels: boolean) {
+  return preferPixels && typeof scrollBox.scrollHeightPx === "number" ? scrollBox.scrollHeightPx : scrollBox.scrollHeight;
+}
+
+function getViewportHeight(scrollBox: ScrollBoxRenderable, preferPixels: boolean) {
+  return preferPixels && scrollBox.viewportPx ? scrollBox.viewportPx.height : scrollBox.viewport?.height ?? 0;
+}
+
+function scrollToPosition(scrollBox: ScrollBoxRenderable, target: number, preferPixels: boolean) {
+  if (preferPixels && scrollBox.scrollToPixels) {
+    scrollBox.scrollToPixels(target);
+    return;
+  }
+  scrollBox.scrollTo(target);
+}
+
+function scrollToBottom(scrollBox: ScrollBoxRenderable | null, preferPixels = false) {
   if (!scrollBox) return;
-  scrollBox.scrollTo(Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height));
+  const exactPixels = preferPixels && hasPixelScrollMetrics(scrollBox);
+  scrollToPosition(
+    scrollBox,
+    Math.max(0, getScrollHeight(scrollBox, exactPixels) - getViewportHeight(scrollBox, exactPixels)),
+    exactPixels,
+  );
+}
+
+function runAfterLayout(callback: () => void) {
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(callback);
+    return;
+  }
+  queueMicrotask(callback);
+}
+
+export function getScrollTopForElementIntoView({
+  scrollTop,
+  viewportHeight,
+  elementTop,
+  elementHeight,
+  bottomInset = 0,
+}: {
+  scrollTop: number;
+  viewportHeight: number;
+  elementTop: number;
+  elementHeight: number;
+  bottomInset?: number;
+}) {
+  const visibleHeight = Math.max(viewportHeight - bottomInset, 1);
+  const elementBottom = elementTop + elementHeight;
+  if (elementTop < scrollTop || elementHeight >= visibleHeight) return elementTop;
+  if (elementBottom > scrollTop + visibleHeight) return elementBottom - visibleHeight;
+  return scrollTop;
+}
+
+function scrollElementIntoScrollBoxView(scrollBox: ScrollBoxRenderable | null, node: unknown) {
+  const nodeRect = (node as { getBoundingClientRect?: () => { x?: number; y?: number; top?: number; width?: number; height?: number } } | null)
+    ?.getBoundingClientRect?.();
+  const scrollRect = scrollBox?.getBoundingClientRect?.() as { x?: number; y?: number; top?: number; width?: number; height?: number } | undefined;
+  if (
+    scrollBox &&
+    nodeRect &&
+    scrollRect &&
+    scrollBox.scrollToPixels &&
+    typeof scrollBox.scrollTopPx === "number" &&
+    scrollBox.viewportPx
+  ) {
+    const nodeY = nodeRect.y ?? nodeRect.top ?? 0;
+    const scrollY = scrollRect.y ?? scrollRect.top ?? 0;
+    const elementTop = scrollBox.scrollTopPx + nodeY - scrollY;
+    const nextScrollTop = getScrollTopForElementIntoView({
+      scrollTop: scrollBox.scrollTopPx,
+      viewportHeight: scrollBox.viewportPx.height,
+      elementTop,
+      elementHeight: Math.max(nodeRect.height ?? 0, 1),
+    });
+    if (nextScrollTop !== scrollBox.scrollTopPx) {
+      scrollBox.scrollToPixels(nextScrollTop);
+    }
+    return true;
+  }
+
+  const scrollIntoView = (node as { scrollIntoView?: (options?: unknown) => void } | null)?.scrollIntoView;
+  if (typeof scrollIntoView !== "function") return false;
+  scrollIntoView.call(node, { block: "nearest", inline: "nearest" });
+  return true;
+}
+
+function normalizeChannelId(channelId: string | null | undefined) {
+  const trimmed = channelId?.trim();
+  return trimmed || DEFAULT_CHAT_CHANNEL_ID;
+}
+
+function normalizeShortcutChannelId(channelId: string | null | undefined) {
+  const trimmed = channelId?.trim().replace(/^#+/, "");
+  return normalizeChannelId(trimmed?.toLowerCase());
+}
+
+function getLastVisitedChatChannelId(config: { pluginConfig: Record<string, Record<string, unknown>> }) {
+  return normalizeChannelId(config.pluginConfig["gloomberb-cloud"]?.[LAST_VISITED_CHAT_CHANNEL_KEY] as string | undefined);
+}
+
+function formatChannelLabel(channel: ChatChannel | undefined, fallbackId: string) {
+  return channel?.name?.trim() || fallbackId;
+}
+
+function truncateChannelLabel(label: string, width: number) {
+  if (width <= 0) return "";
+  if (label.length <= width) return label;
+  if (width <= 1) return label.slice(0, width);
+  if (width <= 3) return label.slice(0, width);
+  return `${label.slice(0, width - 3)}...`;
 }
 
 export function getSelectedMessageScrollTop({
@@ -213,17 +348,548 @@ function ChatActionChip({
   );
 }
 
+interface ChatMessageRenderState {
+  isSelected: boolean;
+  isHovered: boolean;
+  grouped: boolean;
+  showReplyAction: boolean;
+  bgColor: string | undefined;
+  selectedTextColor: string;
+  replyMetaColor: string;
+  replyAuthorColor: string;
+  headerStatus: string;
+  headerStatusColor: string;
+  authorColor: string;
+  authorAttributes: number;
+  bodyColor: string;
+}
+
+function getChatMessageRenderState({
+  msg,
+  index,
+  messages,
+  selectedIdx,
+  hoveredIdx,
+  canSend,
+}: {
+  msg: ChatMessage;
+  index: number;
+  messages: ChatMessage[];
+  selectedIdx: number;
+  hoveredIdx: number | null;
+  canSend: boolean;
+}): ChatMessageRenderState {
+  const isSelected = index === selectedIdx;
+  const isHovered = index === hoveredIdx && !isSelected;
+  const grouped = isGroupedWithPrevious(messages, index);
+  const isSending = msg.clientStatus === "sending";
+  const hasFailed = msg.clientStatus === "failed";
+  const selectedTextColor = hasFailed ? colors.negative : colors.selectedText;
+  const headerStatus = isSending ? "sending..." : hasFailed ? "failed" : formatTimeAgo(msg.createdAt);
+
+  return {
+    isSelected,
+    isHovered,
+    grouped,
+    showReplyAction: canSend && (isSelected || hoveredIdx === index),
+    bgColor: isSelected ? colors.selected : isHovered ? hoverBg() : undefined,
+    selectedTextColor,
+    replyMetaColor: isSelected ? selectedTextColor : colors.textMuted,
+    replyAuthorColor: isSelected ? selectedTextColor : colors.textDim,
+    headerStatus,
+    headerStatusColor: isSelected
+      ? selectedTextColor
+      : isSending
+        ? colors.textDim
+        : hasFailed
+          ? colors.negative
+          : colors.textMuted,
+    authorColor: isSelected ? selectedTextColor : hasFailed ? colors.negative : colors.positive,
+    authorAttributes: (isSending ? TextAttributes.DIM : 0) | TextAttributes.BOLD,
+    bodyColor: isSelected ? selectedTextColor : hasFailed ? colors.negative : isSending ? colors.textDim : colors.text,
+  };
+}
+
+function ResponsiveTickerBadgeText({
+  text,
+  catalog,
+  textColor,
+  openTicker,
+}: {
+  text: string;
+  catalog: Record<string, InlineTickerCatalogEntry>;
+  textColor: string;
+  openTicker: (symbol: string) => void;
+}) {
+  const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
+  const tokens = useMemo(() => tokenizeInlineContent(text), [text]);
+
+  return (
+    <Box
+      flexDirection="row"
+      flexWrap="wrap"
+      flexGrow={1}
+      style={{ minWidth: 0, width: "100%" }}
+    >
+      {tokens.map((token, index) => {
+        if (token.kind === "text") {
+          if (!token.value) return null;
+          return (
+            <Text
+              key={`text:${index}`}
+              fg={textColor}
+              wrapText
+              style={{
+                minWidth: 0,
+                whiteSpace: "pre-wrap",
+                overflowWrap: "anywhere",
+              }}
+            >
+              {token.value}
+            </Text>
+          );
+        }
+
+        if (token.kind === "link") {
+          return (
+            <ExternalLinkText
+              key={`link:${index}`}
+              url={token.url}
+              label={token.value}
+              color={textColor}
+            />
+          );
+        }
+
+        const entry = catalog[token.symbol];
+        if (!entry || entry.status === "missing") {
+          return <Text key={`raw:${index}`} fg={textColor}>{token.value}</Text>;
+        }
+
+        return (
+          <TickerBadge
+            key={`badge:${index}:${token.symbol}`}
+            symbol={token.symbol}
+            status={entry.status}
+            quote={entry.quote}
+            hovered={hoveredSymbol === token.symbol}
+            onHoverStart={() => setHoveredSymbol(token.symbol)}
+            onHoverEnd={() => {
+              setHoveredSymbol((current) => (current === token.symbol ? null : current));
+            }}
+            onOpen={openTicker}
+          />
+        );
+      })}
+    </Box>
+  );
+}
+
+interface ChatMessageBaseProps {
+  msg: ChatMessage;
+  index: number;
+  messages: ChatMessage[];
+  selectedIdx: number;
+  hoveredIdx: number | null;
+  canSend: boolean;
+  catalog: Record<string, InlineTickerCatalogEntry>;
+  openTicker: (symbol: string) => void;
+  beginReplyTo: (index: number, options?: { deferFocus?: boolean }) => void;
+  jumpToMessage: (messageId: string) => void;
+}
+
+interface TerminalChatMessageProps extends ChatMessageBaseProps {
+  contentWidth: number;
+  messageBodyWidth: number;
+  setHoveredIdx: (updater: (current: number | null) => number | null) => void;
+}
+
+function TerminalChatMessage({
+  msg,
+  index,
+  messages,
+  selectedIdx,
+  hoveredIdx,
+  canSend,
+  contentWidth,
+  messageBodyWidth,
+  catalog,
+  openTicker,
+  beginReplyTo,
+  jumpToMessage,
+  setHoveredIdx,
+}: TerminalChatMessageProps) {
+  const state = getChatMessageRenderState({ msg, index, messages, selectedIdx, hoveredIdx, canSend });
+  const bodyLines = getMessageBodyLines(msg, contentWidth);
+  const showInlineReplyAction = !state.grouped && state.showReplyAction;
+  const showGroupedReplyAction = state.grouped && state.showReplyAction;
+  const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));
+  const clearHovered = () => setHoveredIdx((current) => (current === index ? null : current));
+  const messageRowProps = {
+    width: contentWidth,
+    backgroundColor: state.bgColor,
+    onMouseMove: setHovered,
+    onMouseOut: clearHovered,
+  };
+
+  return (
+    <Box key={msg.id} width={contentWidth} flexDirection="column">
+      {msg.replyTo && (
+        <Box
+          {...messageRowProps}
+          flexDirection="row"
+          height={1}
+          paddingLeft={2}
+          onMouseDown={() => {
+            if (msg.replyToId) jumpToMessage(msg.replyToId);
+          }}
+        >
+          <Text fg={state.replyMetaColor}>reply </Text>
+          <Text fg={state.replyAuthorColor}>{msg.replyTo.user.username}: </Text>
+          <Text fg={state.replyMetaColor}>
+            {formatInlinePreview(
+              msg.replyTo.content,
+              Math.max(messageBodyWidth - `reply ${msg.replyTo.user.username}: `.length, 0),
+            )}
+          </Text>
+        </Box>
+      )}
+      {!state.grouped && (
+        <Box
+          {...messageRowProps}
+          flexDirection="row"
+          height={1}
+          paddingLeft={1}
+        >
+          <Text fg={state.authorColor} attributes={state.authorAttributes}>
+            {msg.user.username ?? "anon"}
+          </Text>
+          <Text fg={state.headerStatusColor}> {state.headerStatus}</Text>
+          {showInlineReplyAction && (
+            <>
+              <Text fg={state.headerStatusColor}> </Text>
+              <Box width={MESSAGE_ACTION_WIDTH} height={1}>
+                <ChatActionChip
+                  label="Reply"
+                  width={MESSAGE_ACTION_WIDTH}
+                  emphasized={state.isSelected}
+                  onPress={() => beginReplyTo(index)}
+                />
+              </Box>
+            </>
+          )}
+        </Box>
+      )}
+      {bodyLines.map((line, lineIndex) => (
+        <Box
+          key={`${msg.id}:body:${lineIndex}`}
+          {...messageRowProps}
+          paddingLeft={3}
+          height={1}
+          flexDirection="row"
+          position={state.grouped ? "relative" : undefined}
+        >
+          <Box width={messageBodyWidth} height={1}>
+            <TickerBadgeText
+              text={line}
+              lineWidth={messageBodyWidth}
+              catalog={catalog}
+              textColor={state.bodyColor}
+              openTicker={openTicker}
+            />
+          </Box>
+          {lineIndex === 0 && showGroupedReplyAction && (
+            <Box position="absolute" top={0} right={0} width={MESSAGE_ACTION_WIDTH} height={1}>
+              <ChatActionChip
+                label="Reply"
+                width={MESSAGE_ACTION_WIDTH}
+                emphasized={state.isSelected}
+                onPress={() => beginReplyTo(index)}
+              />
+            </Box>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+const DesktopChatMessage = memo(function DesktopChatMessage({
+  msg,
+  index,
+  messages,
+  selectedIdx,
+  hoveredIdx,
+  canSend,
+  catalog,
+  openTicker,
+  beginReplyTo,
+  jumpToMessage,
+  registerMessageElement,
+}: ChatMessageBaseProps & {
+  registerMessageElement: (messageId: string, node: unknown | null) => void;
+}) {
+  const state = getChatMessageRenderState({ msg, index, messages, selectedIdx, hoveredIdx, canSend });
+  const showInlineReplyAction = !state.grouped && canSend;
+  const showGroupedReplyAction = state.grouped && canSend;
+  const rowProps = {
+    width: "100%",
+    paddingRight: DESKTOP_MESSAGE_RIGHT_PADDING,
+    backgroundColor: state.bgColor,
+    "data-gloom-role": "chat-message-row",
+    "data-selected": state.isSelected ? "true" : "false",
+    style: { minWidth: 0 },
+  };
+
+  return (
+    <Box
+      key={msg.id}
+      ref={(node: unknown | null) => registerMessageElement(msg.id, node)}
+      width="100%"
+      flexDirection="column"
+      data-gloom-role="chat-message"
+      data-gloom-chat-message-id={msg.id}
+      data-selected={state.isSelected ? "true" : "false"}
+      style={{ "--chat-hover-bg": hoverBg(), minWidth: 0 }}
+    >
+      {msg.replyTo && (
+        <Box
+          {...rowProps}
+          flexDirection="row"
+          paddingLeft={2}
+          onMouseDown={() => {
+            if (msg.replyToId) jumpToMessage(msg.replyToId);
+          }}
+          style={{ minWidth: 0, alignItems: "flex-start", cursor: "pointer" }}
+        >
+          <Text
+            fg={state.replyMetaColor}
+            wrapText
+            style={{
+              minWidth: 0,
+              width: "100%",
+              display: "-webkit-box",
+              WebkitBoxOrient: "vertical",
+              WebkitLineClamp: 2,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "normal",
+              overflowWrap: "anywhere",
+            }}
+          >
+            <Span fg={state.replyMetaColor}>reply </Span>
+            <Span fg={state.replyAuthorColor}>{msg.replyTo.user.username}: </Span>
+            <Span fg={state.replyMetaColor}>{normalizeInlinePreview(msg.replyTo.content)}</Span>
+          </Text>
+        </Box>
+      )}
+      {!state.grouped && (
+        <Box
+          {...rowProps}
+          flexDirection="row"
+          height={1}
+          paddingLeft={1}
+        >
+          <Text fg={state.authorColor} attributes={state.authorAttributes}>
+            {msg.user.username ?? "anon"}
+          </Text>
+          <Text fg={state.headerStatusColor}> {state.headerStatus}</Text>
+          {showInlineReplyAction && (
+            <>
+              <Text fg={state.headerStatusColor}> </Text>
+              <Box
+                width={MESSAGE_ACTION_WIDTH}
+                height={1}
+                data-gloom-role="chat-message-reply-action"
+              >
+                <ChatActionChip
+                  label="Reply"
+                  width={MESSAGE_ACTION_WIDTH}
+                  emphasized={state.isSelected}
+                  onPress={() => beginReplyTo(index)}
+                />
+              </Box>
+            </>
+          )}
+        </Box>
+      )}
+      <Box
+        {...rowProps}
+        paddingLeft={3}
+        flexDirection="row"
+        position={state.grouped ? "relative" : undefined}
+        style={{ minWidth: 0, alignItems: "flex-start" }}
+      >
+        <Box flexGrow={1} style={{ minWidth: 0 }}>
+          <ResponsiveTickerBadgeText
+            text={msg.content}
+            catalog={catalog}
+            textColor={state.bodyColor}
+            openTicker={openTicker}
+          />
+        </Box>
+        {showGroupedReplyAction && (
+          <Box
+            position="absolute"
+            top={0}
+            right={0}
+            width={MESSAGE_ACTION_WIDTH}
+            height={1}
+            data-gloom-role="chat-message-reply-action"
+          >
+            <ChatActionChip
+              label="Reply"
+              width={MESSAGE_ACTION_WIDTH}
+              emphasized={state.isSelected}
+              onPress={() => beginReplyTo(index)}
+            />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+});
+
+function ChannelSidebar({
+  channels,
+  activeChannelId,
+  width,
+  height,
+  focused,
+  keyboardFocused,
+  loading,
+  onSelect,
+  onFocusRequest,
+}: {
+  channels: ChatChannel[];
+  activeChannelId: string;
+  width: number;
+  height: number;
+  focused: boolean;
+  keyboardFocused: boolean;
+  loading: boolean;
+  onSelect?: (channelId: string) => void;
+  onFocusRequest?: () => void;
+}) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const borderWidth = nativePaneChrome ? 0 : width > 1 ? 1 : 0;
+  const listWidth = Math.max(width - borderWidth, 1);
+  const labelWidth = Math.max(listWidth - 3, 1);
+  const dividerColor = focused ? colors.borderFocused : colors.border;
+  const sidebarBg = keyboardFocused ? blendHex(colors.panel, colors.borderFocused, 0.18) : colors.panel;
+  const activeBg = keyboardFocused
+    ? blendHex(colors.selected, colors.borderFocused, 0.32)
+    : blendHex(colors.panel, colors.selected, 0.35);
+  const [hoveredChannelId, setHoveredChannelId] = useState<string | null>(null);
+  const sidebarBorder = borderWidth > 0
+    ? (
+      <Box width={1} height={height} flexDirection="column">
+        {Array.from({ length: height }, (_, index) => (
+          <Text key={index} fg={dividerColor} selectable={false}>│</Text>
+        ))}
+      </Box>
+    )
+    : null;
+
+  return (
+    <Box
+      width={width}
+      height={height}
+      flexDirection="row"
+      position="relative"
+    >
+      <Box
+        width={listWidth}
+        height={height}
+        flexDirection="column"
+        backgroundColor={sidebarBg}
+      >
+        {channels.map((channel) => {
+          const active = channel.id === activeChannelId;
+          const hovered = hoveredChannelId === channel.id && !active;
+          const fg = active ? colors.selectedText : keyboardFocused ? colors.text : colors.textDim;
+          const bg = active ? activeBg : hovered ? hoverBg() : sidebarBg;
+          const label = formatChannelLabel(channel, channel.id);
+          const selectChannel = (event: any) => {
+            if (event) {
+              event.preventDefault?.();
+              event.stopPropagation?.();
+              if (event[CHAT_CHANNEL_MOUSE_HANDLED]) return;
+              event[CHAT_CHANNEL_MOUSE_HANDLED] = true;
+            }
+            onFocusRequest?.();
+            onSelect?.(channel.id);
+          };
+          return (
+            <Box
+              key={channel.id}
+              height={1}
+              width={listWidth}
+              flexDirection="row"
+              backgroundColor={bg}
+              onMouseDown={selectChannel}
+              onMouseMove={() => setHoveredChannelId((current) => (current === channel.id ? current : channel.id))}
+              onMouseOut={() => setHoveredChannelId((current) => (current === channel.id ? null : current))}
+              style={{ cursor: "pointer" }}
+            >
+              <Text fg={fg} selectable={false} onMouseDown={selectChannel}> </Text>
+              <Text fg={fg} selectable={false} onMouseDown={selectChannel}>{active ? "#" : " "}</Text>
+              <Text fg={fg} selectable={false} onMouseDown={selectChannel}>{truncateChannelLabel(label, labelWidth)}</Text>
+              <Box flexGrow={1} onMouseDown={selectChannel} />
+            </Box>
+          );
+        })}
+        <Box flexGrow={1} />
+        {loading && focused && (
+          <Box height={1} width={listWidth} flexDirection="row">
+            <Text fg={colors.textDim}> syncing</Text>
+          </Box>
+        )}
+      </Box>
+      {sidebarBorder}
+      {nativePaneChrome && (
+        <Box
+          position="absolute"
+          top={0}
+          right={0}
+          width={1}
+          height={height}
+          style={{
+            width: 1,
+            height: "100%",
+            backgroundColor: dividerColor,
+            pointerEvents: "none",
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
 export function ChatContent({
   width,
   height,
   focused,
   close,
+  channelId: rawChannelId,
+  onChannelChange,
   controller = chatController,
 }: ChatContentProps) {
   const dispatch = useAppDispatch();
-  const initialSnapshot = controller.getSnapshot();
+  const channelId = normalizeChannelId(rawChannelId);
+  const channelIdRef = useRef(channelId);
+  channelIdRef.current = channelId;
+  const initialSnapshot = controller.getSnapshot(channelId);
   const { nativePaneChrome } = useUiCapabilities();
-  const contentWidth = Math.max(width - 2, 1);
+  const [channels, setChannels] = useState<ChatChannel[]>(initialSnapshot.channels);
+  const [channelsLoading, setChannelsLoading] = useState(initialSnapshot.channelsLoading);
+  const showChannelSidebar = channels.length > 1 && width >= CHANNEL_SIDEBAR_BREAKPOINT && height >= 8;
+  const channelSidebarWidth = showChannelSidebar
+    ? Math.min(CHANNEL_SIDEBAR_MAX_WIDTH, Math.max(CHANNEL_SIDEBAR_MIN_WIDTH, Math.floor(width * 0.24)))
+    : 0;
+  const compactChannelHeaderHeight = nativePaneChrome && !showChannelSidebar && channels.length > 1 ? 1 : 0;
+  const chatWidth = Math.max(width - channelSidebarWidth, 1);
+  const contentWidth = Math.max(chatWidth - 2, 1);
   const composerPrefixWidth = nativePaneChrome ? 0 : 3;
   const composerTextWidth = Math.max(contentWidth - composerPrefixWidth, 1);
   const inputValueRef = useRef(initialSnapshot.draft);
@@ -237,12 +903,19 @@ export function ChatContent({
   const [composerRows, setComposerRows] = useState(() => estimateComposerHeight(initialSnapshot.draft, composerTextWidth));
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [sidebarFocused, setSidebarFocusedState] = useState(false);
+  const sidebarFocusedRef = useRef(false);
+  const setSidebarFocused = useCallback((nextFocused: boolean) => {
+    sidebarFocusedRef.current = nextFocused;
+    setSidebarFocusedState((current) => (current === nextFocused ? current : nextFocused));
+  }, []);
   const [followMessages, setFollowMessages] = useState(true);
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(() => (
     initialSnapshot.replyToId ? initialSnapshot.messages.find((message) => message.id === initialSnapshot.replyToId) ?? null : null
   ));
   const inputRef = useRef<TextareaRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const messageElementsRef = useRef(new Map<string, unknown>());
   const applyingExternalDraftRef = useRef(false);
   const prependAnchorRef = useRef<{
     oldestMessageId: string | null;
@@ -251,7 +924,7 @@ export function ChatContent({
     selectedMessageId: string | null;
   } | null>(null);
   const canSend = !!user?.emailVerified;
-  const nativeComposerTopGap = nativePaneChrome && canSend ? NATIVE_CHAT_COMPOSER_TOP_GAP_PX : 0;
+  const useDefaultControllerChannel = channelId === DEFAULT_CHAT_CHANNEL_ID && !onChannelChange;
   const messageBodyWidth = Math.max(contentWidth - 4, 1);
   const composerHeight = canSend
     ? nativePaneChrome
@@ -266,16 +939,51 @@ export function ChatContent({
   }, [composerTextWidth]);
 
   useEffect(() => {
-    return controller.attachView();
-  }, [controller]);
+    return useDefaultControllerChannel ? controller.attachView() : controller.attachChannelView(channelId);
+  }, [channelId, controller, useDefaultControllerChannel]);
 
   useEffect(() => {
     updateComposerRows(inputValueRef.current);
   }, [updateComposerRows]);
 
   useEffect(() => {
-    const unsubscribe = controller.subscribe((snapshot) => {
+    void controller.refreshChannels().catch(() => {});
+    void controller.refreshSession().catch(() => {});
+  }, [controller]);
+
+  useEffect(() => {
+    setSelectedIdx(-1);
+    setFollowMessages(true);
+    prependAnchorRef.current = null;
+    const snapshot = controller.getSnapshot(channelId);
+    setMessages(snapshot.messages);
+    setChannels(snapshot.channels);
+    setChannelsLoading(snapshot.channelsLoading);
+    setHasSavedSession(snapshot.hasSavedSession);
+    setUser(snapshot.user);
+    setLoading(snapshot.loading);
+    setLoadingOlderMessages(snapshot.loadingOlderMessages);
+    setHasOlderMessages(snapshot.hasOlderMessages);
+    inputValueRef.current = snapshot.draft;
+    updateComposerRows(snapshot.draft);
+    const textarea = inputRef.current;
+    if (textarea && textarea.editBuffer.getText() !== snapshot.draft) {
+      applyingExternalDraftRef.current = true;
+      textarea.setText(snapshot.draft);
+      applyingExternalDraftRef.current = false;
+    }
+    setReplyTo(snapshot.replyToId
+      ? snapshot.messages.find((message) => message.id === snapshot.replyToId) ?? null
+      : null);
+
+    const unsubscribe = useDefaultControllerChannel
+      ? controller.subscribe(handleSnapshot)
+      : controller.subscribe(channelId, handleSnapshot);
+
+    function handleSnapshot(snapshot: ReturnType<ChatController["getSnapshot"]>) {
       setMessages(snapshot.messages);
+      setChannels(snapshot.channels);
+      setChannelsLoading(snapshot.channelsLoading);
       setHasSavedSession(snapshot.hasSavedSession);
       setUser(snapshot.user);
       setLoading(snapshot.loading);
@@ -294,23 +1002,33 @@ export function ChatContent({
       setReplyTo(snapshot.replyToId
         ? snapshot.messages.find((message) => message.id === snapshot.replyToId) ?? null
         : null);
-    });
+    }
 
-    void controller.refreshSession().catch(() => {});
-    void controller.refreshMessages().catch(() => {});
+    void (useDefaultControllerChannel ? controller.refreshMessages() : controller.refreshChannelMessages(channelId)).catch(() => {});
     return unsubscribe;
-  }, [controller, updateComposerRows]);
+  }, [channelId, controller, updateComposerRows, useDefaultControllerChannel]);
 
-  const { catalog, openTicker } = useInlineTickers(messages.map((message) => message.content));
+  const messageContents = useMemo(() => messages.map((message) => message.content), [messages]);
+  const { catalog, openTicker } = useInlineTickers(messageContents);
 
   const replyToRef = useRef(replyTo);
   replyToRef.current = replyTo;
+  const pendingJumpMessageIdRef = useRef<string | null>(null);
+
+  const registerMessageElement = useCallback((messageId: string, node: unknown | null) => {
+    if (node) {
+      messageElementsRef.current.set(messageId, node);
+    } else {
+      messageElementsRef.current.delete(messageId);
+    }
+  }, []);
 
   const focusInput = useCallback(() => {
+    setSidebarFocused(false);
     setInputFocused(true);
     dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
-    inputRef.current?.focus();
-  }, [dispatch]);
+    inputRef.current?.focus?.();
+  }, [dispatch, setSidebarFocused]);
 
   const focusComposer = useCallback(() => {
     setSelectedIdx(-1);
@@ -325,8 +1043,12 @@ export function ChatContent({
 
   const clearReplyTarget = useCallback(() => {
     setReplyTo(null);
-    controller.setReplyToId(null);
-  }, [controller]);
+    if (useDefaultControllerChannel) {
+      controller.setReplyToId(null);
+    } else {
+      controller.setChannelReplyToId(channelId, null);
+    }
+  }, [channelId, controller, useDefaultControllerChannel]);
 
   const beginReplyTo = useCallback((index: number, options?: { deferFocus?: boolean }) => {
     if (!canSend || index < 0 || index >= messages.length) return;
@@ -335,13 +1057,17 @@ export function ChatContent({
     setSelectedIdx(index);
     setFollowMessages(index === messages.length - 1);
     setReplyTo(nextReplyTo);
-    controller.setReplyToId(nextReplyTo.id);
+    if (useDefaultControllerChannel) {
+      controller.setReplyToId(nextReplyTo.id);
+    } else {
+      controller.setChannelReplyToId(channelId, nextReplyTo.id);
+    }
     if (options?.deferFocus) {
       queueMicrotask(() => focusInput());
     } else {
       focusInput();
     }
-  }, [canSend, controller, focusInput, messages]);
+  }, [canSend, channelId, controller, focusInput, messages, useDefaultControllerChannel]);
 
   const returnToComposer = useCallback(() => {
     setSelectedIdx(-1);
@@ -384,32 +1110,144 @@ export function ChatContent({
   const sendMessage = useCallback(() => {
     const content = inputValueRef.current.trim();
     if (!content) return;
-    controller.send(content, replyToRef.current?.id);
+    if (useDefaultControllerChannel) {
+      controller.send(content, replyToRef.current?.id);
+    } else {
+      controller.sendToChannel(channelId, content, replyToRef.current?.id);
+    }
     setSelectedIdx(-1);
     setFollowMessages(true);
-  }, [controller]);
+  }, [channelId, controller, useDefaultControllerChannel]);
 
   const requestOlderMessages = useCallback(() => {
     const scrollBox = scrollRef.current;
     if (!scrollBox || loadingOlderMessages || !hasOlderMessages || messages.length === 0) return;
+    const exactPixels = nativePaneChrome === true && hasPixelScrollMetrics(scrollBox);
 
     prependAnchorRef.current = {
       oldestMessageId: messages[0]?.id ?? null,
-      scrollHeight: scrollBox.scrollHeight,
-      scrollTop: scrollBox.scrollTop,
+      scrollHeight: getScrollHeight(scrollBox, exactPixels),
+      scrollTop: getScrollTop(scrollBox, exactPixels),
       selectedMessageId: selectedIdx >= 0 ? messages[selectedIdx]?.id ?? null : null,
     };
     setFollowMessages(false);
-    void controller.loadOlderMessages().catch(() => {
+    const request = useDefaultControllerChannel
+      ? controller.loadOlderMessages()
+      : controller.loadOlderChannelMessages(channelId);
+    void request.catch(() => {
       prependAnchorRef.current = null;
     });
-  }, [controller, hasOlderMessages, loadingOlderMessages, messages, selectedIdx]);
+  }, [channelId, controller, hasOlderMessages, loadingOlderMessages, messages, nativePaneChrome, selectedIdx, useDefaultControllerChannel]);
 
   const requestOlderMessagesIfNeeded = useCallback(() => {
     const scrollBox = scrollRef.current;
     if (!scrollBox || scrollBox.scrollTop > 1) return;
     requestOlderMessages();
   }, [requestOlderMessages]);
+
+  const scrollToLoadedMessage = useCallback((messageId: string) => {
+    const targetIndex = messages.findIndex((message) => message.id === messageId);
+    if (targetIndex < 0) return false;
+
+    setSelectedIdx(targetIndex);
+    setFollowMessages(false);
+    prependAnchorRef.current = null;
+    runAfterLayout(() => {
+      if (nativePaneChrome && scrollElementIntoScrollBoxView(scrollRef.current, messageElementsRef.current.get(messageId))) return;
+      const scrollBox = scrollRef.current;
+      if (!scrollBox) return;
+      scrollBox.scrollTo(getMessageTopOffset(messages, targetIndex, contentWidth));
+    });
+    return true;
+  }, [contentWidth, messages, nativePaneChrome]);
+
+  const jumpToMessage = useCallback((messageId: string) => {
+    if (scrollToLoadedMessage(messageId)) return;
+    pendingJumpMessageIdRef.current = messageId;
+    if (hasOlderMessages && !loadingOlderMessages) {
+      requestOlderMessages();
+    } else {
+      pendingJumpMessageIdRef.current = null;
+    }
+  }, [hasOlderMessages, loadingOlderMessages, requestOlderMessages, scrollToLoadedMessage]);
+
+  useEffect(() => {
+    const pendingId = pendingJumpMessageIdRef.current;
+    if (!pendingId) return;
+    if (scrollToLoadedMessage(pendingId)) {
+      pendingJumpMessageIdRef.current = null;
+      prependAnchorRef.current = null;
+      return;
+    }
+    if (hasOlderMessages && !loadingOlderMessages) {
+      requestOlderMessages();
+    } else {
+      pendingJumpMessageIdRef.current = null;
+    }
+  }, [hasOlderMessages, loadingOlderMessages, messages, requestOlderMessages, scrollToLoadedMessage]);
+
+  const changeChannel = useCallback((nextChannelId: string) => {
+    const normalized = normalizeChannelId(nextChannelId);
+    if (normalized === channelIdRef.current) return;
+    channelIdRef.current = normalized;
+    setSelectedIdx(-1);
+    setFollowMessages(true);
+    onChannelChange?.(normalized);
+  }, [onChannelChange]);
+
+  useEffect(() => {
+    if (!onChannelChange || channelsLoading || channels.length === 0) return;
+    if (channels.some((channel) => channel.id === channelId)) return;
+    const fallbackChannelId = channels.find((channel) => channel.id === DEFAULT_CHAT_CHANNEL_ID)?.id
+      ?? channels[0]?.id;
+    if (fallbackChannelId) {
+      changeChannel(fallbackChannelId);
+    }
+  }, [changeChannel, channelId, channels, channelsLoading, onChannelChange]);
+
+  const cycleChannel = useCallback((direction: 1 | -1) => {
+    if (channels.length <= 1 || !onChannelChange) return false;
+    const currentIndex = Math.max(0, channels.findIndex((channel) => channel.id === channelIdRef.current));
+    const nextIndex = (currentIndex + direction + channels.length) % channels.length;
+    const nextChannel = channels[nextIndex];
+    if (!nextChannel) return false;
+    changeChannel(nextChannel.id);
+    return true;
+  }, [changeChannel, channels, onChannelChange]);
+
+  const focusChannelSidebar = useCallback(() => {
+    if (!showChannelSidebar || !onChannelChange) return false;
+    if (inputFocused) {
+      blurInput();
+    }
+    setSelectedIdx(-1);
+    setSidebarFocused(true);
+    return true;
+  }, [blurInput, inputFocused, onChannelChange, setSidebarFocused, showChannelSidebar]);
+
+  const focusChatContent = useCallback(() => {
+    if (!showChannelSidebar) return false;
+    setSidebarFocused(false);
+    return true;
+  }, [setSidebarFocused, showChannelSidebar]);
+
+  const moveSidebarChannelSelection = useCallback((direction: "up" | "down") => {
+    if (!showChannelSidebar || channels.length <= 1 || !onChannelChange) return false;
+    const currentIndex = channels.findIndex((channel) => channel.id === channelIdRef.current);
+    const baseIndex = currentIndex >= 0 ? currentIndex : 0;
+    const nextIndex = direction === "down"
+      ? Math.min(baseIndex + 1, channels.length - 1)
+      : Math.max(baseIndex - 1, 0);
+    const nextChannel = channels[nextIndex];
+    if (!nextChannel || nextIndex === baseIndex) return true;
+    changeChannel(nextChannel.id);
+    return true;
+  }, [changeChannel, channels, onChannelChange, showChannelSidebar]);
+
+  useEffect(() => {
+    if (focused && showChannelSidebar) return;
+    setSidebarFocused(false);
+  }, [focused, setSidebarFocused, showChannelSidebar]);
 
   useEffect(() => {
     if (!canSend && inputFocused) {
@@ -425,7 +1263,7 @@ export function ChatContent({
 
   useEffect(() => {
     if (focused && inputFocused) {
-      inputRef.current?.focus();
+      inputRef.current?.focus?.();
     }
   }, [focused, inputFocused]);
 
@@ -433,8 +1271,12 @@ export function ChatContent({
     if (applyingExternalDraftRef.current) return;
     inputValueRef.current = draft;
     updateComposerRows(draft);
-    controller.setDraft(draft);
-  }, [controller, updateComposerRows]);
+    if (useDefaultControllerChannel) {
+      controller.setDraft(draft);
+    } else {
+      controller.setChannelDraft(channelId, draft);
+    }
+  }, [channelId, controller, updateComposerRows, useDefaultControllerChannel]);
 
   useEffect(() => {
     const textarea = inputRef.current;
@@ -460,6 +1302,39 @@ export function ChatContent({
     if (!focused) return;
     const isEnterKey = event.name === "return" || event.name === "enter";
 
+    if (sidebarFocusedRef.current && showChannelSidebar) {
+      if (event.name === "left") {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        return;
+      }
+
+      if (event.name === "right") {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        focusChatContent();
+        return;
+      }
+
+      if (event.name === "up" || event.name === "down") {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        moveSidebarChannelSelection(event.name);
+        return;
+      }
+    }
+
+    if (
+      event.name === "left" &&
+      showChannelSidebar &&
+      (!inputFocused || inputValueRef.current.length === 0) &&
+      focusChannelSidebar()
+    ) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      return;
+    }
+
     if (inputFocused) {
       if (event.name === "escape") {
         event.preventDefault?.();
@@ -482,6 +1357,17 @@ export function ChatContent({
         }
       }
 
+      return;
+    }
+
+    if ((event.name === "]" || event.sequence === "]") && cycleChannel(1)) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      return;
+    }
+    if ((event.name === "[" || event.sequence === "[") && cycleChannel(-1)) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
       return;
     }
 
@@ -551,28 +1437,10 @@ export function ChatContent({
       event.stopPropagation?.();
       setSelectedIdx(messages.length - 1);
       setFollowMessages(true);
-      queueMicrotask(() => scrollToBottom(scrollRef.current));
+      queueMicrotask(() => scrollToBottom(scrollRef.current, nativePaneChrome));
       return;
     }
-  }, [
-    beginReplyTo,
-    blurInput,
-    canSend,
-    clearReplyTarget,
-    focusComposer,
-    focused,
-    inputFocused,
-    hasOlderMessages,
-    loadingOlderMessages,
-    messages.length,
-    moveMessageSelection,
-    replyTo,
-    requestOlderMessages,
-    requestOlderMessagesIfNeeded,
-    returnToComposer,
-    selectedIdx,
-    shouldLeaveComposerForSelection,
-  ]);
+  });
 
   const inputMetaHeight = canSend && replyTo ? 1 : 0;
   const composerBlockHeight = canSend
@@ -581,8 +1449,8 @@ export function ChatContent({
   const inputAreaHeight = canSend ? composerBlockHeight + inputMetaHeight : 2;
   const topSeparatorHeight = nativePaneChrome ? 0 : 1;
   const footerSeparatorHeight = !nativePaneChrome && !canSend ? 1 : 0;
-  const messageAreaHeight = Math.max(1, height - topSeparatorHeight - footerSeparatorHeight - inputAreaHeight);
-  const composerWidth = nativePaneChrome ? width : contentWidth;
+  const messageAreaHeight = Math.max(1, height - compactChannelHeaderHeight - topSeparatorHeight - footerSeparatorHeight - inputAreaHeight);
+  const composerWidth = nativePaneChrome ? chatWidth : contentWidth;
 
   useEffect(() => {
     if (selectedIdx < messages.length) return;
@@ -591,8 +1459,8 @@ export function ChatContent({
 
   useEffect(() => {
     if (!stickyTranscript) return;
-    queueMicrotask(() => scrollToBottom(scrollRef.current));
-  }, [contentWidth, height, messages, messageAreaHeight, stickyTranscript]);
+    queueMicrotask(() => scrollToBottom(scrollRef.current, nativePaneChrome));
+  }, [contentWidth, height, messages, messageAreaHeight, nativePaneChrome, stickyTranscript]);
 
   useEffect(() => {
     const anchor = prependAnchorRef.current;
@@ -602,14 +1470,19 @@ export function ChatContent({
       const currentAnchor = prependAnchorRef.current;
       const scrollBox = scrollRef.current;
       if (!currentAnchor || !scrollBox) return;
+      if (pendingJumpMessageIdRef.current) {
+        prependAnchorRef.current = null;
+        return;
+      }
 
       const previousOldestIndex = currentAnchor.oldestMessageId
         ? messages.findIndex((message) => message.id === currentAnchor.oldestMessageId)
         : -1;
-      const addedRows = previousOldestIndex > 0
+      const exactPixels = nativePaneChrome === true && hasPixelScrollMetrics(scrollBox);
+      const addedRows = !exactPixels && previousOldestIndex > 0
         ? getMessageTopOffset(messages, previousOldestIndex, contentWidth)
-        : Math.max(0, scrollBox.scrollHeight - currentAnchor.scrollHeight);
-      scrollBox.scrollTo(currentAnchor.scrollTop + addedRows);
+        : Math.max(0, getScrollHeight(scrollBox, exactPixels) - currentAnchor.scrollHeight);
+      scrollToPosition(scrollBox, currentAnchor.scrollTop + addedRows, exactPixels);
       if (currentAnchor.selectedMessageId) {
         const selectedMessageIndex = messages.findIndex((message) => message.id === currentAnchor.selectedMessageId);
         if (selectedMessageIndex >= 0) {
@@ -618,29 +1491,34 @@ export function ChatContent({
       }
       prependAnchorRef.current = null;
     });
-  }, [contentWidth, loadingOlderMessages, messages]);
+  }, [contentWidth, loadingOlderMessages, messages, nativePaneChrome]);
 
   useEffect(() => {
     if (!focused || !stickyTranscript) return;
-    queueMicrotask(() => scrollToBottom(scrollRef.current));
-  }, [focused, stickyTranscript]);
+    queueMicrotask(() => scrollToBottom(scrollRef.current, nativePaneChrome));
+  }, [focused, nativePaneChrome, stickyTranscript]);
 
   useEffect(() => {
     const sb = scrollRef.current;
     if (!sb) return;
     if (!selectionActive) return;
+    if (nativePaneChrome) {
+      const selectedMessageId = messages[selectedIdx]?.id ?? "";
+      runAfterLayout(() => scrollElementIntoScrollBoxView(scrollRef.current, messageElementsRef.current.get(selectedMessageId)));
+      return;
+    }
     const top = getMessageTopOffset(messages, selectedIdx, contentWidth);
     const rowHeight = estimateMessageHeight(messages[selectedIdx]!, contentWidth, isGroupedWithPrevious(messages, selectedIdx));
     const nextScrollTop = getSelectedMessageScrollTop({
       scrollTop: sb.scrollTop,
-      viewportHeight: sb.viewport.height,
+      viewportHeight: sb.viewport?.height ?? 0,
       top,
       rowHeight,
     });
     if (nextScrollTop !== sb.scrollTop) {
       sb.scrollTo(nextScrollTop);
     }
-  }, [contentWidth, messages, selectedIdx, selectionActive]);
+  }, [contentWidth, messages, nativePaneChrome, selectedIdx, selectionActive]);
 
   const replyPreview = replyTo
     ? formatInlinePreview(
@@ -649,17 +1527,44 @@ export function ChatContent({
     )
     : "";
   const inputPlaceholder = replyTo ? `Reply to @${replyTo.user.username}...` : "Type a message...";
-
-  if (loading && messages.length === 0) {
-    return (
-      <Box flexGrow={1} alignItems="center" justifyContent="center">
-        <Text fg={colors.textDim}>Loading...</Text>
-      </Box>
-    );
-  }
+  const activeChannel = channels.find((channel) => channel.id === channelId);
+  const activeChannelLabel = formatChannelLabel(activeChannel, channelId);
+  const chatContentBg = focused && showChannelSidebar && !sidebarFocused
+    ? blendHex(colors.bg, colors.borderFocused, 0.08)
+    : undefined;
 
   return (
-    <Box flexDirection="column" width={width} height={height}>
+    <Box flexDirection="row" width={width} height={height}>
+      {showChannelSidebar && (
+        <ChannelSidebar
+          channels={channels}
+          activeChannelId={channelId}
+          width={channelSidebarWidth}
+          height={height}
+          focused={focused}
+          keyboardFocused={sidebarFocused}
+          loading={channelsLoading}
+          onSelect={changeChannel}
+          onFocusRequest={() => setSidebarFocused(true)}
+        />
+      )}
+
+      <Box
+        flexDirection="column"
+        width={chatWidth}
+        height={height}
+        backgroundColor={chatContentBg}
+        onMouseDown={() => setSidebarFocused(false)}
+      >
+      {compactChannelHeaderHeight > 0 && (
+        <Box height={1} width={contentWidth} flexDirection="row">
+          <Text fg={colors.textDim}>#</Text>
+          <Text fg={colors.positive} attributes={TextAttributes.BOLD}>
+            {truncateChannelLabel(activeChannelLabel, Math.max(contentWidth - 1, 1))}
+          </Text>
+        </Box>
+      )}
+
       {!nativePaneChrome && (
         <Box height={1} width={contentWidth}>
           <Text fg={colors.border}>{"-".repeat(contentWidth)}</Text>
@@ -668,155 +1573,64 @@ export function ChatContent({
 
       <ScrollBox
         ref={scrollRef}
-        height={messageAreaHeight}
+        height={nativePaneChrome ? undefined : messageAreaHeight}
+        flexGrow={nativePaneChrome ? 1 : undefined}
         scrollY
         focusable={false}
         stickyScroll={stickyTranscript}
         stickyStart="bottom"
         onMouseScroll={() => queueMicrotask(requestOlderMessagesIfNeeded)}
-        style={nativeComposerTopGap > 0 ? { paddingBottom: nativeComposerTopGap } : undefined}
+        style={nativePaneChrome ? { minHeight: 0 } : undefined}
       >
         {loadingOlderMessages && (
           <Box alignItems="center" justifyContent="center" height={1} width={contentWidth}>
             <Text fg={colors.textDim}>Loading earlier messages...</Text>
           </Box>
         )}
-        {messages.length === 0 && (
+        {loading && messages.length === 0 ? (
+          <Box alignItems="center" justifyContent="center" flexGrow={1}>
+            <Text fg={colors.textDim}>Loading...</Text>
+          </Box>
+        ) : messages.length === 0 && (
           <Box alignItems="center" justifyContent="center" flexGrow={1}>
             <Text fg={colors.textDim}>No messages yet. Be the first to say something!</Text>
           </Box>
         )}
-        {messages.map((msg, index) => {
-          const isSelected = index === selectedIdx;
-          const isHovered = index === hoveredIdx && !isSelected;
-          const showReplyAction = canSend && (isSelected || hoveredIdx === index);
-          const bgColor = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
-          const grouped = isGroupedWithPrevious(messages, index);
-          const isSending = msg.clientStatus === "sending";
-          const hasFailed = msg.clientStatus === "failed";
-          const selectedTextColor = hasFailed ? colors.negative : colors.selectedText;
-          const replyMetaColor = isSelected ? selectedTextColor : colors.textMuted;
-          const replyAuthorColor = isSelected ? selectedTextColor : colors.textDim;
-          const headerStatus = isSending ? "sending..." : hasFailed ? "failed" : formatTimeAgo(msg.createdAt);
-          const headerStatusColor = isSelected
-            ? selectedTextColor
-            : isSending
-              ? colors.textDim
-              : hasFailed
-                ? colors.negative
-                : colors.textMuted;
-          const authorColor = isSelected ? selectedTextColor : hasFailed ? colors.negative : colors.positive;
-          const authorAttributes = (isSending ? TextAttributes.DIM : 0) | TextAttributes.BOLD;
-          const bodyColor = isSelected ? selectedTextColor : hasFailed ? colors.negative : isSending ? colors.textDim : colors.text;
-          const bodyLines = getMessageBodyLines(msg, contentWidth);
-          const showInlineReplyAction = !grouped && (nativePaneChrome ? canSend : showReplyAction);
-          const showGroupedReplyAction = grouped && (nativePaneChrome ? canSend : showReplyAction);
-          const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));
-          const clearHovered = () => setHoveredIdx((current) => (current === index ? null : current));
-          const messageRowProps = {
-            width: contentWidth,
-            backgroundColor: bgColor,
-            "data-gloom-role": nativePaneChrome ? "chat-message-row" : undefined,
-            "data-selected": nativePaneChrome ? (isSelected ? "true" : "false") : undefined,
-            onMouseMove: nativePaneChrome ? undefined : setHovered,
-            onMouseOut: nativePaneChrome ? undefined : clearHovered,
-          };
-          return (
-            <Box
+        {messages.map((msg, index) => (
+          nativePaneChrome ? (
+            <DesktopChatMessage
               key={msg.id}
-              width={contentWidth}
-              flexDirection="column"
-              data-gloom-role={nativePaneChrome ? "chat-message" : undefined}
-              data-selected={nativePaneChrome ? (isSelected ? "true" : "false") : undefined}
-              style={nativePaneChrome ? { "--chat-hover-bg": hoverBg() } : undefined}
-            >
-              {msg.replyTo && (
-                <Box
-                  {...messageRowProps}
-                  flexDirection="row"
-                  height={1}
-                  paddingLeft={2}
-                >
-                  <Text fg={replyMetaColor}>reply </Text>
-                  <Text fg={replyAuthorColor}>{msg.replyTo.user.username}: </Text>
-                  <Text fg={replyMetaColor}>
-                    {formatInlinePreview(
-                      msg.replyTo.content,
-                      Math.max(messageBodyWidth - `reply ${msg.replyTo.user.username}: `.length, 0),
-                    )}
-                  </Text>
-                </Box>
-              )}
-              {!grouped && (
-                <Box
-                  {...messageRowProps}
-                  flexDirection="row"
-                  height={1}
-                  paddingLeft={1}
-                >
-                  <Text fg={authorColor} attributes={authorAttributes}>
-                    {msg.user.username ?? "anon"}
-                  </Text>
-                  <Text fg={headerStatusColor}> {headerStatus}</Text>
-                  {showInlineReplyAction && (
-                    <>
-                      <Text fg={headerStatusColor}> </Text>
-                      <Box
-                        width={MESSAGE_ACTION_WIDTH}
-                        height={1}
-                        data-gloom-role={nativePaneChrome ? "chat-message-reply-action" : undefined}
-                      >
-                        <ChatActionChip
-                          label="Reply"
-                          width={MESSAGE_ACTION_WIDTH}
-                          emphasized={isSelected}
-                          onPress={() => beginReplyTo(index)}
-                        />
-                      </Box>
-                    </>
-                  )}
-                </Box>
-              )}
-              {bodyLines.map((line, lineIndex) => (
-                <Box
-                  key={`${msg.id}:body:${lineIndex}`}
-                  {...messageRowProps}
-                  paddingLeft={3}
-                  height={1}
-                  flexDirection="row"
-                  position={grouped ? "relative" : undefined}
-                >
-                  <Box width={messageBodyWidth} height={1}>
-                    <TickerBadgeText
-                      text={line}
-                      lineWidth={messageBodyWidth}
-                      catalog={catalog}
-                      textColor={bodyColor}
-                      openTicker={openTicker}
-                    />
-                  </Box>
-                  {lineIndex === 0 && showGroupedReplyAction && (
-                    <Box
-                      position="absolute"
-                      top={0}
-                      right={0}
-                      width={MESSAGE_ACTION_WIDTH}
-                      height={1}
-                      data-gloom-role={nativePaneChrome ? "chat-message-reply-action" : undefined}
-                    >
-                      <ChatActionChip
-                        label="Reply"
-                        width={MESSAGE_ACTION_WIDTH}
-                        emphasized={isSelected}
-                        onPress={() => beginReplyTo(index)}
-                      />
-                    </Box>
-                  )}
-                </Box>
-              ))}
-            </Box>
-          );
-        })}
+              msg={msg}
+              index={index}
+              messages={messages}
+              selectedIdx={selectedIdx}
+              hoveredIdx={hoveredIdx}
+              canSend={canSend}
+              catalog={catalog}
+              openTicker={openTicker}
+              beginReplyTo={beginReplyTo}
+              jumpToMessage={jumpToMessage}
+              registerMessageElement={registerMessageElement}
+            />
+          ) : (
+            <TerminalChatMessage
+              key={msg.id}
+              msg={msg}
+              index={index}
+              messages={messages}
+              selectedIdx={selectedIdx}
+              hoveredIdx={hoveredIdx}
+              canSend={canSend}
+              contentWidth={contentWidth}
+              messageBodyWidth={messageBodyWidth}
+              catalog={catalog}
+              openTicker={openTicker}
+              beginReplyTo={beginReplyTo}
+              jumpToMessage={jumpToMessage}
+              setHoveredIdx={setHoveredIdx}
+            />
+          )
+        ))}
       </ScrollBox>
 
       {!nativePaneChrome && !canSend && (
@@ -887,17 +1701,79 @@ export function ChatContent({
           )}
         </Box>
       )}
+      </Box>
     </Box>
   );
 }
 
 function ChatPane({ focused, width, height, close }: PaneProps) {
+  const dispatch = useAppDispatch();
+  const stateRef = useAppStateRef();
+  const paneId = usePaneInstanceId();
+  const pane = usePaneInstance();
+  const rawPaneChannelId = typeof pane?.settings?.channelId === "string" ? pane.settings.channelId : null;
+  const lastVisitedChannelId = useAppSelector((state) => (
+    (state.config.pluginConfig["gloomberb-cloud"]?.[LAST_VISITED_CHAT_CHANNEL_KEY] as string | undefined) ??
+    DEFAULT_CHAT_CHANNEL_ID
+  ));
+  const initialChannelIdRef = useRef(normalizeChannelId(rawPaneChannelId ?? lastVisitedChannelId));
+  const persistedChannelId = normalizeChannelId(rawPaneChannelId ?? initialChannelIdRef.current);
+  const persistChannelId = useCallback((nextChannelId: string) => {
+    const currentState = stateRef.current;
+    const layout = setPaneSetting(currentState.config.layout, paneId, "channelId", nextChannelId);
+    const layouts = currentState.config.layouts.map((savedLayout, index) => (
+      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
+    ));
+    const pluginConfig = {
+      ...currentState.config.pluginConfig,
+      "gloomberb-cloud": {
+        ...(currentState.config.pluginConfig["gloomberb-cloud"] ?? {}),
+        [LAST_VISITED_CHAT_CHANNEL_KEY]: nextChannelId,
+      },
+    };
+    const nextConfig = {
+      ...currentState.config,
+      layout,
+      layouts,
+      pluginConfig,
+    };
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    scheduleConfigSave(nextConfig);
+  }, [dispatch, paneId, stateRef]);
+  const [channelId, setLocalChannelId] = useState(initialChannelIdRef.current);
+  const pendingChannelIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (rawPaneChannelId) return;
+    persistChannelId(initialChannelIdRef.current);
+  }, [persistChannelId, rawPaneChannelId]);
+
+  useEffect(() => {
+    const normalizedPersisted = normalizeChannelId(persistedChannelId);
+    if (pendingChannelIdRef.current) {
+      if (pendingChannelIdRef.current === normalizedPersisted) {
+        pendingChannelIdRef.current = null;
+      }
+      return;
+    }
+    setLocalChannelId((current) => (current === normalizedPersisted ? current : normalizedPersisted));
+  }, [persistedChannelId]);
+
+  const setChannelId = useCallback((nextChannelId: string) => {
+    const normalized = normalizeChannelId(nextChannelId);
+    pendingChannelIdRef.current = normalized;
+    setLocalChannelId((current) => (current === normalized ? current : normalized));
+    persistChannelId(normalized);
+  }, [persistChannelId]);
+
   return (
     <ChatContent
       width={width}
       height={height}
       focused={focused}
       close={close}
+      channelId={channelId}
+      onChannelChange={setChannelId}
     />
   );
 }
@@ -977,8 +1853,16 @@ export const gloomberbCloudPlugin: GloomPlugin = {
       label: "New Chat Pane",
       description: "Open another floating chat window",
       keywords: ["new", "chat", "pane", "message"],
-      shortcut: { prefix: "CHAT" },
-      createInstance: () => ({ placement: "floating" }),
+      shortcut: { prefix: "CHAT", argPlaceholder: "channel", argKind: "text" },
+      createInstance: async (context, options) => {
+        const channelId = options?.arg
+          ? await chatController.resolveRequiredChannelId(normalizeShortcutChannelId(options.arg))
+          : await chatController.resolvePreferredChannelId(getLastVisitedChatChannelId(context.config));
+        return {
+          placement: "floating",
+          settings: { channelId },
+        };
+      },
     },
   ],
 

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -940,6 +940,13 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         const element = getElement();
         if (element) element.scrollTop = Math.max(0, value) * WEB_CELL_HEIGHT;
       },
+      get scrollTopPx() {
+        return Math.max(0, getElement()?.scrollTop ?? 0);
+      },
+      set scrollTopPx(value: number) {
+        const element = getElement();
+        if (element) element.scrollTop = Math.max(0, value);
+      },
       get scrollLeft() {
         return toCellX(getElement()?.scrollLeft ?? 0);
       },
@@ -947,17 +954,37 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         const element = getElement();
         if (element) element.scrollLeft = Math.max(0, value) * WEB_CELL_WIDTH;
       },
+      get scrollLeftPx() {
+        return Math.max(0, getElement()?.scrollLeft ?? 0);
+      },
+      set scrollLeftPx(value: number) {
+        const element = getElement();
+        if (element) element.scrollLeft = Math.max(0, value);
+      },
       get scrollHeight() {
         return toCellY(getElement()?.scrollHeight ?? 0);
       },
       get scrollWidth() {
         return toCellX(getElement()?.scrollWidth ?? 0);
       },
+      get scrollHeightPx() {
+        return Math.max(0, getElement()?.scrollHeight ?? 0);
+      },
+      get scrollWidthPx() {
+        return Math.max(0, getElement()?.scrollWidth ?? 0);
+      },
       get viewport() {
         const element = getElement();
         return {
           width: toCellX(element?.clientWidth ?? 0),
           height: toCellY(element?.clientHeight ?? 0),
+        };
+      },
+      get viewportPx() {
+        const element = getElement();
+        return {
+          width: Math.max(0, element?.clientWidth ?? 0),
+          height: Math.max(0, element?.clientHeight ?? 0),
         };
       },
       getBoundingClientRect() {
@@ -984,6 +1011,21 @@ const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unknown> & {
         element.scrollTo({
           left: Math.max(0, target.x ?? toCellX(element.scrollLeft)) * WEB_CELL_WIDTH,
           top: Math.max(0, target.y ?? toCellY(element.scrollTop)) * WEB_CELL_HEIGHT,
+        });
+      },
+      scrollToPixels(target: number | { x?: number; y?: number }, y?: number) {
+        const element = getElement();
+        if (!element) return;
+        if (typeof target === "number") {
+          element.scrollTop = Math.max(0, target);
+          if (typeof y === "number") {
+            element.scrollLeft = Math.max(0, y);
+          }
+          return;
+        }
+        element.scrollTo({
+          left: Math.max(0, target.x ?? element.scrollLeft),
+          top: Math.max(0, target.y ?? element.scrollTop),
         });
       },
     }), [horizontalScrollBar, verticalScrollBar]);

--- a/src/state/use-inline-tickers.ts
+++ b/src/state/use-inline-tickers.ts
@@ -33,7 +33,7 @@ export function useInlineTickers(texts: readonly string[]): {
   const tickers = useAppSelector((state) => state.tickers);
   const financials = useAppSelector((state) => state.financials);
   const registry = getSharedRegistry();
-  const [, setRefreshVersion] = useState(0);
+  const [refreshVersion, setRefreshVersion] = useState(0);
   const textsKey = texts.join("\u0000");
   const symbols = useMemo(() => normalizeSymbols(texts), [textsKey]);
   const symbolsKey = symbols.join("|");
@@ -168,15 +168,18 @@ export function useInlineTickers(texts: readonly string[]): {
     registry?.pinTicker(symbol, { floating: true, paneType: "ticker-detail" });
   }, [registry]);
 
-  const catalog: Record<string, InlineTickerCatalogEntry> = {};
-  for (const symbol of symbols) {
-    const ticker = tickers.get(symbol) ?? null;
-    const quote = financials.get(symbol)?.quote ?? null;
-    const status: InlineTickerStatus = ticker
-      ? (quote ? "ready" : quoteMissingSymbols.has(symbol) ? "missing" : "loading")
-      : (missingSymbols.has(symbol) ? "missing" : "loading");
-    catalog[symbol] = { status, ticker, quote };
-  }
+  const catalog = useMemo(() => {
+    const entries: Record<string, InlineTickerCatalogEntry> = {};
+    for (const symbol of symbols) {
+      const ticker = tickers.get(symbol) ?? null;
+      const quote = financials.get(symbol)?.quote ?? null;
+      const status: InlineTickerStatus = ticker
+        ? (quote ? "ready" : quoteMissingSymbols.has(symbol) ? "missing" : "loading")
+        : (missingSymbols.has(symbol) ? "missing" : "loading");
+      entries[symbol] = { status, ticker, quote };
+    }
+    return entries;
+  }, [financials, refreshVersion, symbols, tickers]);
 
   return { catalog, openTicker };
 }

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -98,13 +98,19 @@ export interface ScrollBoxRenderable {
   scrollTop: number;
   scrollLeft?: number;
   scrollHeight: number;
+  scrollTopPx?: number;
+  scrollLeftPx?: number;
+  scrollHeightPx?: number;
+  scrollWidthPx?: number;
   viewport?: { width: number; height: number };
+  viewportPx?: { width: number; height: number };
   visible?: boolean;
   parent?: unknown;
   getBoundingClientRect?: () => { x: number; y: number; width: number; height: number };
   horizontalScrollBar?: { visible: boolean };
   verticalScrollBar?: { visible: boolean };
   scrollTo(target: number | { x?: number; y?: number }, y?: number): void;
+  scrollToPixels?(target: number | { x?: number; y?: number }, y?: number): void;
 }
 
 export interface InputRenderable {

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -54,7 +54,6 @@ export interface ChatMessage {
 export interface ChatChannel {
   id: string;
   name: string;
-  description: string | null;
   created_at: string;
 }
 
@@ -467,7 +466,7 @@ class GloomApiClient {
     throw new Error(message);
   }
 
-  private extractSessionCookie(res: Response): void {
+  private extractSessionCookie(res: CloudApiResponse): void {
     const setCookie = res.headers.getSetCookie?.() ?? [];
     const fallbackHeader = res.headers.get("set-cookie");
     if (fallbackHeader) {


### PR DESCRIPTION
Adds server-provided multi-channel chat panes with per-channel drafts, transcripts, unread state, and pane titles.
Adds a responsive channel sidebar with mouse selection, keyboard focus movement, visible focus state, and desktop-friendly message scrolling.
Supports direct `CHAT <channel>` shortcuts and opens new chat panes on the last visited channel without a setup form.
Tightens desktop chat rendering around links, ticker badges, selected-message visibility, and right-side message padding.
