### PR TITLE
Fix desktop pane bottom layout

### DIFF
--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -9,7 +9,7 @@ import { colors, floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../.
 import { useThemeColors } from "../../theme/theme-context";
 import { hasPaneFooterContent, PaneFooterBar, PaneFooterProvider } from "./pane-footer";
 import { PaneContent } from "./pane-content";
-import { getPaneBodyWidth } from "./pane-sizing";
+import { getPaneBodyWidth, NATIVE_PANE_BODY_LAYOUT_PROPS } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX, TITLEBAR_TRAFFIC_LIGHT_WIDTH } from "./titlebar-overlay";
 import {
@@ -132,6 +132,9 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
         const bodyHeight = Math.max(1, height - headerHeightRows - footerHeightRows);
         const background = floatingPaneBg(focused);
         const titleBackground = floatingPaneTitleBg(focused);
+        const bodyLayoutProps = nativePaneChrome
+          ? NATIVE_PANE_BODY_LAYOUT_PROPS
+          : { height: bodyHeight };
 
         return (
           <Box
@@ -182,7 +185,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
                 )}
               </Box>
             </Box>
-            <Box height={bodyHeight} overflow="hidden" backgroundColor={background}>
+            <Box {...bodyLayoutProps} overflow="hidden" backgroundColor={background}>
               <PaneContent
                 component={paneDef.component}
                 paneId={instance.instanceId}

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import { getPaneBodyHeight, shouldReservePaneFooter } from "./pane-sizing";
+import { getPaneBodyHeight, NATIVE_PANE_BODY_LAYOUT_PROPS, shouldReservePaneFooter } from "./pane-sizing";
 
 interface FloatingPaneWrapperProps {
   paneId?: string;
@@ -78,6 +78,9 @@ export function FloatingPaneWrapper({
   const showFooter = hasPaneFooterContent(footer);
   const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
   const bodyHeight = getPaneBodyHeight(height, reserveFooter);
+  const bodyLayoutProps = nativePaneChrome
+    ? NATIVE_PANE_BODY_LAYOUT_PROPS
+    : { height: bodyHeight };
 
   return (
     <Box
@@ -115,7 +118,7 @@ export function FloatingPaneWrapper({
       />
 
       {/* Content */}
-      <Box height={bodyHeight} overflow="hidden" backgroundColor={bg}>
+      <Box {...bodyLayoutProps} overflow="hidden" backgroundColor={bg}>
         {children}
       </Box>
 

--- a/src/components/layout/pane-sizing.ts
+++ b/src/components/layout/pane-sizing.ts
@@ -2,6 +2,12 @@
 const PANE_HEADER_ROWS = 1;
 const PANE_FOOTER_ROWS = 1;
 
+export const NATIVE_PANE_BODY_LAYOUT_PROPS = {
+  flexGrow: 1,
+  flexBasis: 0,
+  minHeight: 0,
+} as const;
+
 export function shouldReservePaneFooter(nativePaneChrome: boolean | undefined, showFooter: boolean): boolean {
   return !nativePaneChrome || showFooter;
 }

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { colors, paneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import { getPaneBodyHeight, shouldReservePaneFooter } from "./pane-sizing";
+import { getPaneBodyHeight, NATIVE_PANE_BODY_LAYOUT_PROPS, shouldReservePaneFooter } from "./pane-sizing";
 
 interface PaneWrapperProps {
   paneId?: string;
@@ -49,6 +49,13 @@ export function PaneWrapper({
   const bodyHeight = typeof height === "number"
     ? title ? getPaneBodyHeight(height, reserveFooter) : Math.max(1, Math.floor(height))
     : undefined;
+  const bodyLayoutProps = nativePaneChrome
+    ? NATIVE_PANE_BODY_LAYOUT_PROPS
+    : {
+        height: bodyHeight,
+        flexGrow: bodyHeight == null ? 1 : 0,
+        flexBasis: bodyHeight == null ? 0 : undefined,
+      };
 
   return (
     <Box
@@ -82,9 +89,7 @@ export function PaneWrapper({
         />
       )}
       <Box
-        height={bodyHeight}
-        flexGrow={bodyHeight == null ? 1 : 0}
-        flexBasis={bodyHeight == null ? 0 : undefined}
+        {...bodyLayoutProps}
         overflow="hidden"
         backgroundColor={bg}
       >

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -781,6 +781,8 @@ function ChannelSidebar({
     ? blendHex(colors.selected, colors.borderFocused, 0.32)
     : blendHex(colors.panel, colors.selected, 0.35);
   const [hoveredChannelId, setHoveredChannelId] = useState<string | null>(null);
+  const sidebarLayoutHeight = nativePaneChrome ? "100%" : height;
+  const nativeFillStyle = nativePaneChrome ? { minHeight: 0 } : undefined;
   const sidebarBorder = borderWidth > 0
     ? (
       <Box width={1} height={height} flexDirection="column">
@@ -794,15 +796,17 @@ function ChannelSidebar({
   return (
     <Box
       width={width}
-      height={height}
+      height={sidebarLayoutHeight}
       flexDirection="row"
       position="relative"
+      style={nativeFillStyle}
     >
       <Box
         width={listWidth}
-        height={height}
+        height={sidebarLayoutHeight}
         flexDirection="column"
         backgroundColor={sidebarBg}
+        style={nativeFillStyle}
       >
         {channels.map((channel) => {
           const active = channel.id === activeChannelId;
@@ -853,7 +857,7 @@ function ChannelSidebar({
           top={0}
           right={0}
           width={1}
-          height={height}
+          height={sidebarLayoutHeight}
           style={{
             width: 1,
             height: "100%",
@@ -1532,9 +1536,17 @@ export function ChatContent({
   const chatContentBg = focused && showChannelSidebar && !sidebarFocused
     ? blendHex(colors.bg, colors.borderFocused, 0.08)
     : undefined;
+  const chatLayoutHeight = nativePaneChrome ? "100%" : height;
+  const nativeFillStyle = nativePaneChrome ? { minHeight: 0 } : undefined;
 
   return (
-    <Box flexDirection="row" width={width} height={height}>
+    <Box
+      flexDirection="row"
+      width={width}
+      height={chatLayoutHeight}
+      flexGrow={nativePaneChrome ? 1 : undefined}
+      style={nativeFillStyle}
+    >
       {showChannelSidebar && (
         <ChannelSidebar
           channels={channels}
@@ -1552,9 +1564,11 @@ export function ChatContent({
       <Box
         flexDirection="column"
         width={chatWidth}
-        height={height}
+        height={chatLayoutHeight}
+        flexGrow={nativePaneChrome ? 1 : undefined}
         backgroundColor={chatContentBg}
         onMouseDown={() => setSidebarFocused(false)}
+        style={nativeFillStyle}
       >
       {compactChannelHeaderHeight > 0 && (
         <Box height={1} width={contentWidth} flexDirection="row">

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -120,6 +120,8 @@ body.gloom-dragging {
   pointer-events: auto;
 }
 [data-gloom-role="status-bar"] {
+  flex: 0 0 var(--cell-h);
+  height: var(--cell-h);
   min-height: var(--cell-h);
   max-height: var(--cell-h);
   align-items: center;
@@ -130,6 +132,8 @@ body.gloom-dragging {
   line-height: var(--cell-h);
 }
 [data-gloom-role="pane-footer"] {
+  flex: 0 0 var(--cell-h);
+  height: var(--cell-h);
   min-height: var(--cell-h);
   max-height: var(--cell-h);
   align-items: center;


### PR DESCRIPTION
Fixes desktop pane surfaces that were still sizing body/footer areas from floored terminal-cell heights.

The shared pane wrappers now let native Electrobun bodies flex-fill between fixed chrome while preserving terminal row math for non-native rendering. Chat content, the composer area, and the channel sidebar now fill the real pane height so resizing no longer leaves bottom gaps or stretched status/footer bars.