### PR TITLE
Add chat presence notifications and unread state

### DIFF
--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { AppNotificationRequest, PluginPersistence } from "../../types/plugin";
 import type { PersistedResourceValue } from "../../types/persistence";
-import { apiClient, type ChatChannel, type ChatMessage } from "../../utils/api-client";
+import { apiClient, type ChatChannel, type ChatMessage, type ChatNotification } from "../../utils/api-client";
 import { ChatController } from "./chat-controller";
 
 const TRANSCRIPT_KIND = "channel-transcript";
@@ -12,6 +12,12 @@ const originalConnectChannel = apiClient.connectChannel.bind(apiClient);
 const originalGetSession = apiClient.getSession.bind(apiClient);
 const originalGetMessages = apiClient.getMessages.bind(apiClient);
 const originalGetChannels = apiClient.getChannels.bind(apiClient);
+const originalGetChatPresence = apiClient.getChatPresence.bind(apiClient);
+const originalGetChatState = apiClient.getChatState.bind(apiClient);
+const originalUpdateChatChannelState = apiClient.updateChatChannelState.bind(apiClient);
+const originalMarkChatNotificationsDelivered = apiClient.markChatNotificationsDelivered.bind(apiClient);
+const originalSubscribeChatNotifications = apiClient.subscribeChatNotifications.bind(apiClient);
+const originalSubscribeChatPresence = apiClient.subscribeChatPresence.bind(apiClient);
 
 const SERVER_CHAT_CHANNELS: ChatChannel[] = [
   { id: "everyone", name: "everyone", created_at: "2026-03-26T12:10:05.684Z" },
@@ -100,6 +106,30 @@ class TrackingPersistence extends MemoryPersistence {
   }
 }
 
+beforeEach(() => {
+  apiClient.getChatPresence = async () => ({ onlineCount: 0 });
+  apiClient.getChatState = async () => ({
+    channels: SERVER_CHAT_CHANNELS,
+    onlineCount: 0,
+    channelStates: SERVER_CHAT_CHANNELS.map((channel) => ({
+      channelId: channel.id,
+      notificationsEnabled: false,
+      lastReadMessageId: null,
+      unreadCount: 0,
+    })),
+    notifications: [],
+  });
+  apiClient.updateChatChannelState = async (channelId, body) => ({
+    channelId,
+    notificationsEnabled: body.notificationsEnabled ?? false,
+    lastReadMessageId: body.readThroughMessageId ?? null,
+    unreadCount: 0,
+  });
+  apiClient.markChatNotificationsDelivered = async () => ({ delivered: 1 });
+  apiClient.subscribeChatNotifications = () => () => {};
+  apiClient.subscribeChatPresence = () => () => {};
+});
+
 afterEach(() => {
   apiClient.dispose();
   apiClient.setSessionToken(null);
@@ -107,6 +137,12 @@ afterEach(() => {
   apiClient.getSession = originalGetSession;
   apiClient.getMessages = originalGetMessages;
   apiClient.getChannels = originalGetChannels;
+  apiClient.getChatPresence = originalGetChatPresence;
+  apiClient.getChatState = originalGetChatState;
+  apiClient.updateChatChannelState = originalUpdateChatChannelState;
+  apiClient.markChatNotificationsDelivered = originalMarkChatNotificationsDelivered;
+  apiClient.subscribeChatNotifications = originalSubscribeChatNotifications;
+  apiClient.subscribeChatPresence = originalSubscribeChatPresence;
 });
 
 describe("ChatController", () => {
@@ -280,6 +316,7 @@ describe("ChatController", () => {
     const controller = new ChatController();
 
     apiClient.setSessionToken("token-123");
+    (controller as any).sessionToken = "token-123";
     (controller as any).user = { id: "u1", username: "vince", emailVerified: false };
 
     controller.setAppActive(false);
@@ -297,6 +334,7 @@ describe("ChatController", () => {
     let closed = false;
 
     apiClient.setSessionToken("token-123");
+    (controller as any).sessionToken = "token-123";
     (controller as any).user = { id: "u1", username: "vince", emailVerified: false };
     (controller as any).syncVerificationPolling();
     expect((controller as any).verificationPollTimer).not.toBeNull();
@@ -853,6 +891,222 @@ describe("ChatController", () => {
     });
 
     detachView();
+  });
+
+  test("loads server chat state, pending reply notifications, and acks delivery", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const deliveredIds: string[][] = [];
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    apiClient.getSession = async () => ({
+      id: "u1",
+      name: "Vince",
+      email: "vince@example.com",
+      username: "vince",
+      emailVerified: true,
+      image: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    apiClient.getChatState = async () => ({
+      channels: SERVER_CHAT_CHANNELS,
+      onlineCount: 7,
+      channelStates: [{
+        channelId: "options",
+        notificationsEnabled: true,
+        lastReadMessageId: "m1",
+        unreadCount: 3,
+      }],
+      notifications: [{
+        id: "n1",
+        type: "reply",
+        channelId: "options",
+        messageId: "m2",
+        createdAt: "2026-03-28T00:02:00.000Z",
+        message: {
+          id: "m2",
+          channelId: "options",
+          content: "answering you",
+          replyToId: "m1",
+          createdAt: "2026-03-28T00:02:00.000Z",
+          user: { id: "u2", username: "bob", displayName: "Bob" },
+          replyTo: { content: "question", user: { id: "u1", username: "vince" } },
+        },
+      }],
+    });
+    apiClient.markChatNotificationsDelivered = async (ids) => {
+      deliveredIds.push(ids);
+      return { delivered: ids.length };
+    };
+    apiClient.connectChannel = () => ({
+      send: async () => {
+        throw new Error("not implemented");
+      },
+      close: () => {},
+    });
+
+    controller.setNotifier((notification) => {
+      notifications.push(notification);
+    });
+    controller.attachPersistence(persistence);
+
+    await controller.refreshSession();
+
+    expect(controller.getSnapshot("options").onlineCount).toBe(7);
+    expect(controller.getSnapshot("options").channelStates.find((entry) => entry.channelId === "options")).toMatchObject({
+      notificationsEnabled: true,
+      unreadCount: 3,
+    });
+    expect(notifications).toEqual([{
+      title: "Gloomberb chat",
+      subtitle: "#options",
+      body: "@bob replied to you: answering you",
+      type: "info",
+      desktop: "when-inactive",
+    }]);
+    expect(deliveredIds).toEqual([["n1"]]);
+  });
+
+  test("toggles channel notifications optimistically and keeps the channel connected", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const connectedChannels: string[] = [];
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    apiClient.updateChatChannelState = async (channelId, body) => ({
+      channelId,
+      notificationsEnabled: body.notificationsEnabled === true,
+      lastReadMessageId: null,
+      unreadCount: 0,
+    });
+    apiClient.connectChannel = (channelId) => {
+      connectedChannels.push(channelId);
+      return {
+        send: async () => {
+          throw new Error("not implemented");
+        },
+        close: () => {},
+      };
+    };
+
+    controller.attachPersistence(persistence);
+    controller.setChannelNotificationsEnabled("options", true);
+    await flushMicrotasks();
+
+    expect(controller.getSnapshot("options").channelStates.find((entry) => entry.channelId === "options")).toMatchObject({
+      notificationsEnabled: true,
+    });
+    expect(connectedChannels).toContain("options");
+  });
+
+  test("dedupes reply notifications by message id", () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const notification: ChatNotification = {
+      id: "n1",
+      type: "reply",
+      channelId: "everyone",
+      messageId: "m2",
+      createdAt: "2026-03-28T00:02:00.000Z",
+      message: {
+        id: "m2",
+        channelId: "everyone",
+        content: "same reply",
+        replyToId: "m1",
+        createdAt: "2026-03-28T00:02:00.000Z",
+        user: { id: "u2", username: "bob", displayName: "Bob" },
+        replyTo: { content: "question", user: { id: "u1", username: "vince" } },
+      },
+    };
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    controller.setNotifier((entry) => {
+      notifications.push(entry);
+    });
+    controller.attachPersistence(persistence);
+
+    (controller as any).handleChatNotification(notification);
+    (controller as any).handleChatNotification({ ...notification, id: "n2" });
+
+    expect(notifications).toHaveLength(1);
+  });
+
+  test("tracks unread channel messages and clears them when the channel opens", () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const message: ChatMessage = {
+      id: "m1",
+      channelId: "options",
+      content: "new option flow",
+      replyToId: null,
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u2", username: "bob", displayName: "Bob" },
+    };
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    controller.attachPersistence(persistence);
+
+    (controller as any).mergeMessages("options", [message]);
+
+    expect(controller.getSnapshot("options").channelStates.find((entry) => entry.channelId === "options")).toMatchObject({
+      unreadCount: 1,
+    });
+
+    const detachView = controller.attachChannelView("options");
+
+    expect(controller.getSnapshot("options").channelStates.find((entry) => entry.channelId === "options")).toMatchObject({
+      unreadCount: 0,
+    });
+    detachView();
+  });
+
+  test("reply notifications fire even when channel notifications are disabled", () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const message: ChatMessage = {
+      id: "m2",
+      channelId: "options",
+      content: "reply without channel notify",
+      replyToId: "m1",
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u2", username: "bob", displayName: "Bob" },
+      replyTo: { content: "question", user: { id: "u1", username: "vince" } },
+    };
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    controller.setNotifier((notification) => {
+      notifications.push(notification);
+    });
+    controller.attachPersistence(persistence);
+
+    (controller as any).mergeMessages("options", [message]);
+
+    expect(notifications).toEqual([{
+      title: "Gloomberb chat",
+      subtitle: "#options",
+      body: "@bob replied to you: reply without channel notify",
+      type: "info",
+      desktop: "when-inactive",
+    }]);
   });
 
   test("recovers from a legacy timestamp cursor by falling back to a full transcript fetch", async () => {

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -1,5 +1,12 @@
 import type { AppNotificationRequest, PluginPersistence, PluginResumeState } from "../../types/plugin";
-import { apiClient, type ChatChannel, type ChatMessage, type PersistedAuthUser } from "../../utils/api-client";
+import {
+  apiClient,
+  type ChatChannel,
+  type ChatChannelState,
+  type ChatMessage,
+  type ChatNotification,
+  type PersistedAuthUser,
+} from "../../utils/api-client";
 import { debugLog } from "../../utils/debug-log";
 import { toTimestampMillis } from "../../utils/timestamp";
 
@@ -44,11 +51,13 @@ interface PersistedTranscript {
 export interface ChatControllerSnapshot {
   channelId: string;
   channels: ChatChannel[];
+  channelStates: ChatChannelState[];
   channelsLoading: boolean;
   loading: boolean;
   loadingOlderMessages: boolean;
   hasOlderMessages: boolean;
   hasSavedSession: boolean;
+  onlineCount: number;
   user: { id: string; username: string; emailVerified: boolean } | null;
   messages: ChatMessage[];
   draft: string;
@@ -71,6 +80,8 @@ interface ChannelRuntimeState {
   replyToId: string | null;
   lastCursor: string | null;
   lastViewedMessageId: string | null;
+  notificationsEnabled: boolean;
+  unreadCount: number;
   wsConnection: ChatConnection | null;
   wsConnected: boolean;
   draftSyncTimer: ReturnType<typeof setTimeout> | null;
@@ -105,6 +116,8 @@ function createEmptyChannelState(): ChannelRuntimeState {
     replyToId: null,
     lastCursor: null,
     lastViewedMessageId: null,
+    notificationsEnabled: false,
+    unreadCount: 0,
     wsConnection: null,
     wsConnected: false,
     draftSyncTimer: null,
@@ -152,6 +165,23 @@ function formatMentionToast(message: ChatMessage): string {
   return `@${author} mentioned you: ${snippet}`;
 }
 
+function formatReplyToast(message: ChatMessage): string {
+  const author = message.user.username || "Someone";
+  const normalized = message.content.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return `@${author} replied to you.`;
+  }
+  const snippet = normalized.length > 72 ? `${normalized.slice(0, 69)}...` : normalized;
+  return `@${author} replied to you: ${snippet}`;
+}
+
+function formatChannelToast(channelId: string, message: ChatMessage): string {
+  const author = message.user.username || "Someone";
+  const normalized = message.content.replace(/\s+/g, " ").trim();
+  const snippet = normalized.length > 72 ? `${normalized.slice(0, 69)}...` : normalized;
+  return snippet ? `#${channelId} @${author}: ${snippet}` : `#${channelId} @${author} sent a message.`;
+}
+
 function isLegacyTimestampCursor(cursor: string | null): boolean {
   return !!cursor && ISO_TIMESTAMP_CURSOR.test(cursor);
 }
@@ -182,9 +212,11 @@ export class ChatController {
   private resume: PluginResumeState | null = null;
   private appActive = true;
   private hydrated = false;
+  private sessionToken: string | null = null;
   private sessionChecked = false;
   private user: { id: string; username: string; emailVerified: boolean } | null = null;
   private channels: ChatChannel[] = [];
+  private onlineCount = 0;
   private channelsLoading = false;
   private channelsPromise: Promise<void> | null = null;
   private channelStates = new Map<string, ChannelRuntimeState>();
@@ -193,6 +225,9 @@ export class ChatController {
   private pendingMessageSeq = 0;
   private notifyFn: (notification: AppNotificationRequest) => void = () => {};
   private listeners = new Set<ChannelListenerEntry>();
+  private chatNotificationUnsubscribe: (() => void) | null = null;
+  private chatPresenceUnsubscribe: (() => void) | null = null;
+  private notifiedMessageIds = new Set<string>();
 
   private get wsConnection(): ChatConnection | null {
     return this.ensureChannelState(DEFAULT_CHAT_CHANNEL_ID).wsConnection;
@@ -217,7 +252,8 @@ export class ChatController {
     }) ?? this.persistence.getState<PersistedSessionState>(SESSION_STATE_KEY, {
       schemaVersion: SESSION_SCHEMA_VERSION,
     });
-    apiClient.setSessionToken(session?.sessionToken ?? null);
+    this.sessionToken = session?.sessionToken ?? null;
+    apiClient.setSessionToken(this.sessionToken);
     // WebSocket tokens are short-lived connection credentials. Reusing a persisted
     // one can trap reconnects on an expired token even while the session cookie is valid.
     apiClient.setWebSocketToken(null);
@@ -259,11 +295,13 @@ export class ChatController {
     return {
       channelId: normalizedChannelId,
       channels: this.channels,
+      channelStates: this.getChannelStateSnapshots(),
       channelsLoading: this.channelsLoading,
       loading: !this.sessionChecked || channel.messagesLoading,
       loadingOlderMessages: channel.olderMessagesLoading,
       hasOlderMessages: channel.messages.length > 0 && !channel.reachedOldestMessage,
-      hasSavedSession: !!apiClient.getSessionToken(),
+      hasSavedSession: !!this.sessionToken,
+      onlineCount: this.onlineCount,
       user: this.user,
       messages: this.getVisibleMessages(normalizedChannelId),
       draft: channel.draft,
@@ -274,6 +312,22 @@ export class ChatController {
 
   getChannels(): ChatChannel[] {
     return this.channels;
+  }
+
+  private getChannelStateSnapshots(): ChatChannelState[] {
+    const channelIds = new Set<string>([
+      ...this.channels.map((channel) => channel.id),
+      ...this.channelStates.keys(),
+    ]);
+    return [...channelIds].map((channelId) => {
+      const channel = this.ensureChannelState(channelId);
+      return {
+        channelId,
+        notificationsEnabled: channel.notificationsEnabled,
+        lastReadMessageId: channel.lastViewedMessageId,
+        unreadCount: channel.unreadCount,
+      };
+    });
   }
 
   async refreshChannels(): Promise<void> {
@@ -296,6 +350,33 @@ export class ChatController {
 
     this.channelsPromise = request;
     return request;
+  }
+
+  async refreshPresence(): Promise<void> {
+    const presence = await apiClient.getChatPresence();
+    this.onlineCount = presence.onlineCount;
+    this.emit();
+  }
+
+  async refreshChatState(): Promise<void> {
+    if (!this.user?.emailVerified || !this.sessionToken) {
+      await this.refreshPresence();
+      return;
+    }
+    const state = await apiClient.getChatState();
+    this.channels = normalizeChannels(state.channels);
+    this.onlineCount = state.onlineCount;
+    for (const entry of state.channelStates) {
+      const channel = this.ensureChannelState(entry.channelId);
+      channel.notificationsEnabled = entry.notificationsEnabled;
+      channel.unreadCount = entry.unreadCount;
+      channel.lastViewedMessageId = entry.lastReadMessageId ?? channel.lastViewedMessageId;
+    }
+    for (const notification of state.notifications) {
+      this.handleChatNotification(notification);
+    }
+    this.ensureOpenChannelConnections();
+    this.emit();
   }
 
   async resolveRequiredChannelId(channelId: string): Promise<string> {
@@ -361,22 +442,26 @@ export class ChatController {
     });
     channel.messages = transcript?.value.messages ?? [];
     channel.lastCursor = resolveHydratedCursor(channel.messages, persistedCursor);
-    channel.lastViewedMessageId = this.user?.id && apiClient.getSessionToken()
+    channel.lastViewedMessageId = this.user?.id && this.sessionToken
       ? persistedViewedMessageId ?? getLatestMessageId(channel.messages)
       : null;
   }
 
   async refreshSession(): Promise<void> {
     const token = apiClient.getSessionToken();
+    this.sessionToken = token;
     if (!token) {
       this.stopVerificationPolling();
       this.stopSafetyRefresh();
+      this.stopRealtimeSubscriptions();
       this.closeAllConnections();
       this.user = null;
       this.sessionChecked = true;
       for (const channel of this.channelStates.values()) {
         channel.pendingMessages = [];
         channel.lastViewedMessageId = null;
+        channel.unreadCount = 0;
+        channel.notificationsEnabled = false;
       }
       this.persistSession();
       this.emit();
@@ -387,13 +472,17 @@ export class ChatController {
     if (!session) {
       this.stopVerificationPolling();
       this.stopSafetyRefresh();
+      this.stopRealtimeSubscriptions();
       this.closeAllConnections();
       apiClient.setSessionToken(null);
+      this.sessionToken = null;
       this.user = null;
       this.sessionChecked = true;
       for (const channel of this.channelStates.values()) {
         channel.pendingMessages = [];
         channel.lastViewedMessageId = null;
+        channel.unreadCount = 0;
+        channel.notificationsEnabled = false;
       }
       this.persistSession();
       this.emit();
@@ -402,6 +491,7 @@ export class ChatController {
 
     const previousIdentity = `${this.user?.id ?? ""}:${normalizeUsername(this.user?.username) ?? ""}`;
     const nextUser = { id: session.id, username: session.username ?? session.name, emailVerified: !!session.emailVerified };
+    this.sessionToken = apiClient.getSessionToken();
     this.user = nextUser;
     const nextIdentity = `${nextUser.id}:${normalizeUsername(nextUser.username) ?? ""}`;
     if (previousIdentity && previousIdentity !== nextIdentity) {
@@ -416,12 +506,15 @@ export class ChatController {
 
     if (nextUser?.emailVerified) {
       this.stopVerificationPolling();
+      this.ensureRealtimeSubscriptions();
+      await this.refreshChatState().catch(() => {});
       this.ensureOpenChannelConnections();
       return;
     }
 
     this.syncVerificationPolling();
     this.stopSafetyRefresh();
+    this.stopRealtimeSubscriptions();
     this.closeAllConnections();
   }
 
@@ -510,6 +603,33 @@ export class ChatController {
     this.emit(normalizedChannelId);
   }
 
+  setChannelNotificationsEnabled(channelId: string, enabled: boolean): void {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
+    if (channel.notificationsEnabled === enabled) return;
+
+    const previous = channel.notificationsEnabled;
+    channel.notificationsEnabled = enabled;
+    this.emit();
+    this.ensureOpenChannelConnections();
+
+    void apiClient.updateChatChannelState(normalizedChannelId, {
+      notificationsEnabled: enabled,
+    }).then((nextState) => {
+      this.applyChannelState(nextState);
+      this.ensureOpenChannelConnections();
+      this.emit();
+    }).catch((error) => {
+      channel.notificationsEnabled = previous;
+      this.ensureOpenChannelConnections();
+      this.emit();
+      this.notifyFn({
+        body: error instanceof Error ? error.message : "Failed to update channel notifications.",
+        type: "error",
+      });
+    });
+  }
+
   attachView(): () => void {
     return this.attachChannelView(DEFAULT_CHAT_CHANNEL_ID);
   }
@@ -530,12 +650,16 @@ export class ChatController {
   clearSession(): void {
     this.stopVerificationPolling();
     this.stopSafetyRefresh();
+    this.stopRealtimeSubscriptions();
     this.closeAllConnections();
+    this.sessionToken = null;
     this.user = null;
     this.sessionChecked = false;
     for (const channel of this.channelStates.values()) {
       channel.pendingMessages = [];
       channel.lastViewedMessageId = null;
+      channel.unreadCount = 0;
+      channel.notificationsEnabled = false;
     }
     this.emit();
   }
@@ -548,11 +672,13 @@ export class ChatController {
       return;
     }
     this.syncVerificationPolling();
+    void this.refreshChatState().catch(() => {});
   }
 
   reset(clearSession = false): void {
     this.stopVerificationPolling();
     this.stopSafetyRefresh();
+    this.stopRealtimeSubscriptions();
     this.closeAllConnections();
     for (const [channelId, channel] of this.channelStates) {
       this.clearDraftSyncTimer(channel);
@@ -562,12 +688,15 @@ export class ChatController {
       channel.replyToId = null;
       channel.lastCursor = null;
       channel.lastViewedMessageId = null;
+      channel.unreadCount = 0;
+      channel.notificationsEnabled = false;
       channel.reachedOldestMessage = false;
       channel.openViewCount = 0;
       this.persistence?.deleteResource(TRANSCRIPT_KIND, channelId, { sourceKey: TRANSCRIPT_SOURCE });
       this.persistChannelState(channelId);
     }
     if (clearSession) {
+      this.sessionToken = null;
       this.user = null;
       apiClient.setSessionToken(null);
       this.persistence?.deleteState(SESSION_STATE_KEY);
@@ -587,6 +716,7 @@ export class ChatController {
     }
     this.stopVerificationPolling();
     this.stopSafetyRefresh();
+    this.stopRealtimeSubscriptions();
     this.closeAllConnections();
     for (const channel of this.channelStates.values()) {
       channel.messagesLoading = false;
@@ -597,6 +727,7 @@ export class ChatController {
     }
     this.notifyFn = () => {};
     this.listeners.clear();
+    this.notifiedMessageIds.clear();
   }
 
   send(content: string, replyToId?: string): void {
@@ -606,8 +737,8 @@ export class ChatController {
   sendToChannel(channelId: string, content: string, replyToId?: string): void {
     const normalizedChannelId = normalizeChannelId(channelId);
     const channel = this.ensureChannelState(normalizedChannelId);
-    if (!this.user?.emailVerified || !apiClient.getSessionToken()) return;
-    if (!channel.wsConnection && this.user?.emailVerified && apiClient.getSessionToken()) {
+    if (!this.user?.emailVerified || !this.sessionToken) return;
+    if (!channel.wsConnection && this.user?.emailVerified && this.sessionToken) {
       this.ensureConnection(normalizedChannelId);
     }
     const connection = channel.wsConnection;
@@ -641,7 +772,7 @@ export class ChatController {
   ensureConnection(channelId = DEFAULT_CHAT_CHANNEL_ID): void {
     const normalizedChannelId = normalizeChannelId(channelId);
     const channel = this.ensureChannelState(normalizedChannelId);
-    if (!this.user?.emailVerified || !apiClient.getSessionToken()) {
+    if (!this.user?.emailVerified || !this.sessionToken) {
       this.stopSafetyRefresh();
       return;
     }
@@ -675,8 +806,15 @@ export class ChatController {
     }
   }
 
+  private applyChannelState(state: ChatChannelState): void {
+    const channel = this.ensureChannelState(state.channelId);
+    channel.notificationsEnabled = state.notificationsEnabled;
+    channel.unreadCount = state.unreadCount;
+    channel.lastViewedMessageId = state.lastReadMessageId ?? channel.lastViewedMessageId;
+  }
+
   private syncVerificationPolling(): void {
-    if (!this.appActive || !apiClient.getSessionToken() || !this.user || this.user.emailVerified) {
+    if (!this.appActive || !this.sessionToken || !this.user || this.user.emailVerified) {
       this.stopVerificationPolling();
       return;
     }
@@ -684,6 +822,27 @@ export class ChatController {
     this.verificationPollTimer = setInterval(() => {
       void this.refreshSession().catch(() => {});
     }, VERIFICATION_POLL_MS);
+  }
+
+  private ensureRealtimeSubscriptions(): void {
+    if (!this.chatNotificationUnsubscribe) {
+      this.chatNotificationUnsubscribe = apiClient.subscribeChatNotifications((notification) => {
+        this.handleChatNotification(notification);
+      });
+    }
+    if (!this.chatPresenceUnsubscribe) {
+      this.chatPresenceUnsubscribe = apiClient.subscribeChatPresence((onlineCount) => {
+        this.onlineCount = onlineCount;
+        this.emit();
+      });
+    }
+  }
+
+  private stopRealtimeSubscriptions(): void {
+    this.chatNotificationUnsubscribe?.();
+    this.chatNotificationUnsubscribe = null;
+    this.chatPresenceUnsubscribe?.();
+    this.chatPresenceUnsubscribe = null;
   }
 
   private stopVerificationPolling(): void {
@@ -695,7 +854,7 @@ export class ChatController {
   private startSafetyRefresh(): void {
     if (this.safetyRefreshTimer) return;
     this.safetyRefreshTimer = setInterval(() => {
-      if (!this.user?.emailVerified || !apiClient.getSessionToken()) {
+      if (!this.user?.emailVerified || !this.sessionToken) {
         this.stopSafetyRefresh();
         return;
       }
@@ -723,9 +882,15 @@ export class ChatController {
   private ensureOpenChannelConnections(): void {
     const channelIds = new Set<string>([DEFAULT_CHAT_CHANNEL_ID]);
     for (const [channelId, channel] of this.channelStates) {
-      if (channel.openViewCount > 0 || channel.wsConnection) {
+      if (channel.openViewCount > 0 || channel.notificationsEnabled) {
         channelIds.add(channelId);
       }
+    }
+    for (const [channelId, channel] of this.channelStates) {
+      if (channelIds.has(channelId) || !channel.wsConnection || channel.openViewCount > 0) continue;
+      channel.wsConnection.close();
+      channel.wsConnection = null;
+      channel.wsConnected = false;
     }
     for (const channelId of channelIds) {
       this.ensureConnection(channelId);
@@ -734,7 +899,7 @@ export class ChatController {
 
   private getSafetyRefreshChannelIds(): string[] {
     const active = [...this.channelStates.entries()]
-      .filter(([, channel]) => channel.openViewCount > 0 || channel.wsConnection)
+      .filter(([, channel]) => channel.openViewCount > 0 || channel.notificationsEnabled || channel.wsConnection)
       .map(([channelId]) => channelId);
     return active.length > 0 ? active : [DEFAULT_CHAT_CHANNEL_ID];
   }
@@ -824,11 +989,14 @@ export class ChatController {
     channel.messages = [...merged.values()]
       .sort(compareMessages);
     channel.lastCursor = channel.messages[channel.messages.length - 1]?.id ?? channel.lastCursor;
+    const freshIncoming = [...incoming.values()].filter((message) => message.user.id !== this.user?.id);
     if (channel.openViewCount > 0) {
       this.markViewedThroughLatestMessage(channelId, false);
+    } else if (freshIncoming.length > 0) {
+      channel.unreadCount += freshIncoming.length;
     }
     if (options?.notifyMentions !== false) {
-      this.trackUnreadMentions(channelId, [...incoming.values()]);
+      this.trackIncomingNotifications(channelId, freshIncoming);
     }
     this.persistTranscript(channelId);
     this.emit(channelId);
@@ -836,7 +1004,7 @@ export class ChatController {
 
   private persistSession(): void {
     const value = {
-      sessionToken: apiClient.getSessionToken(),
+      sessionToken: this.sessionToken,
       user: this.user,
     } satisfies PersistedSessionState;
     this.resume?.setState(SESSION_STATE_KEY, value, {
@@ -911,14 +1079,32 @@ export class ChatController {
     this.persistChannelState(channelId);
   }
 
-  private trackUnreadMentions(channelId: string, messages: ChatMessage[]): void {
+  private trackIncomingNotifications(channelId: string, messages: ChatMessage[]): void {
     const channel = this.ensureChannelState(channelId);
     if (channel.openViewCount > 0) {
       return;
     }
 
-    const freshMentions = this.getMentionMessages(messages);
+    const mentions: ChatMessage[] = [];
+    for (const message of messages) {
+      if (this.isReplyToCurrentUser(message)) {
+        this.notifyReplyMessage(channelId, message);
+        continue;
+      }
+      if (this.isMentionForCurrentUser(message)) {
+        mentions.push(message);
+        continue;
+      }
+      if (channel.notificationsEnabled) {
+        this.notifyChannelMessage(channelId, message);
+      }
+    }
+
+    const freshMentions = mentions.filter((message) => !this.notifiedMessageIds.has(message.id));
     if (freshMentions.length === 0) return;
+    for (const message of freshMentions) {
+      this.notifiedMessageIds.add(message.id);
+    }
 
     if (freshMentions.length === 1) {
       this.notifyFn({
@@ -932,6 +1118,50 @@ export class ChatController {
     this.notifyFn({
       title: "Gloomberb chat",
       body: `${freshMentions.length} new mentions in #${channelId}.`,
+      type: "info",
+      desktop: "when-inactive",
+    });
+  }
+
+  private handleChatNotification(notification: ChatNotification): void {
+    if (notification.type === "reply") {
+      this.notifyReplyMessage(notification.channelId, notification.message);
+    }
+    void apiClient.markChatNotificationsDelivered([notification.id]).catch(() => {});
+  }
+
+  private isReplyToCurrentUser(message: ChatMessage): boolean {
+    return !!this.user?.id
+      && message.user.id !== this.user.id
+      && message.replyTo?.user.id === this.user.id;
+  }
+
+  private isMentionForCurrentUser(message: ChatMessage): boolean {
+    const normalizedUsername = normalizeUsername(this.user?.username);
+    return !!normalizedUsername
+      && message.user.id !== this.user?.id
+      && messageMentionsUsername(message.content, normalizedUsername);
+  }
+
+  private notifyReplyMessage(channelId: string, message: ChatMessage): void {
+    if (this.notifiedMessageIds.has(message.id)) return;
+    this.notifiedMessageIds.add(message.id);
+    this.notifyFn({
+      title: "Gloomberb chat",
+      subtitle: `#${channelId}`,
+      body: formatReplyToast(message),
+      type: "info",
+      desktop: "when-inactive",
+    });
+  }
+
+  private notifyChannelMessage(channelId: string, message: ChatMessage): void {
+    if (this.notifiedMessageIds.has(message.id)) return;
+    this.notifiedMessageIds.add(message.id);
+    this.notifyFn({
+      title: "Gloomberb chat",
+      subtitle: `#${channelId}`,
+      body: formatChannelToast(channelId, message),
       type: "info",
       desktop: "when-inactive",
     });
@@ -966,12 +1196,22 @@ export class ChatController {
   private markViewedThroughLatestMessage(channelId: string, persist = true): boolean {
     const channel = this.ensureChannelState(channelId);
     const latestMessageId = channel.messages[channel.messages.length - 1]?.id ?? null;
-    if (channel.lastViewedMessageId === latestMessageId) {
+    const previousUnreadCount = channel.unreadCount;
+    if (channel.lastViewedMessageId === latestMessageId && previousUnreadCount === 0) {
       return false;
     }
     channel.lastViewedMessageId = latestMessageId;
+    channel.unreadCount = 0;
     if (persist) {
       this.persistChannelState(channelId);
+    }
+    if (latestMessageId && this.user?.emailVerified && this.sessionToken) {
+      void apiClient.updateChatChannelState(channelId, {
+        readThroughMessageId: latestMessageId,
+      }).then((state) => {
+        this.applyChannelState(state);
+        this.emit();
+      }).catch(() => {});
     }
     return true;
   }
@@ -1001,7 +1241,7 @@ export class ChatController {
       replyTo: replyToMessage
         ? {
           content: replyToMessage.content,
-          user: { username: replyToMessage.user.username },
+          user: { id: replyToMessage.user.id, username: replyToMessage.user.username },
         }
         : null,
       clientStatus: "sending",

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, useCallback, useMemo, useRef, useState } from "react";
 import { PaneFooterBar, PaneFooterProvider } from "../../components/layout/pane-footer";
 import { testRender } from "../../renderers/opentui/test-utils";
@@ -8,7 +8,7 @@ import { colors } from "../../theme/colors";
 import { createDefaultConfig, findPaneInstance, type PaneInstanceConfig } from "../../types/config";
 import type { PersistedResourceValue } from "../../types/persistence";
 import type { PluginPersistence } from "../../types/plugin";
-import { Box } from "../../ui";
+import { Box, TextAttributes } from "../../ui";
 import { apiClient, type ChatChannel, type ChatMessage } from "../../utils/api-client";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
 import { setSharedMarketDataForTests, setSharedRegistryForTests } from "../registry";
@@ -21,6 +21,8 @@ const TRANSCRIPT_SOURCE = "server";
 const TRANSCRIPT_SCHEMA_VERSION = 2;
 const originalConnectChannel = apiClient.connectChannel.bind(apiClient);
 const originalGetChannels = apiClient.getChannels.bind(apiClient);
+const originalGetChatPresence = apiClient.getChatPresence.bind(apiClient);
+const originalUpdateChatChannelState = apiClient.updateChatChannelState.bind(apiClient);
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -150,6 +152,8 @@ function createController(options: {
   controller.attachPersistence(persistence);
   controller.refreshSession = async () => {};
   controller.refreshMessages = async () => {};
+  controller.refreshPresence = async () => {};
+  controller.refreshChatState = async () => {};
   return controller;
 }
 
@@ -248,11 +252,23 @@ function hexToRgbaInts(hex: string) {
   ].join(",");
 }
 
+beforeEach(() => {
+  apiClient.getChatPresence = async () => ({ onlineCount: 0 });
+  apiClient.updateChatChannelState = async (channelId, body) => ({
+    channelId,
+    notificationsEnabled: body.notificationsEnabled ?? false,
+    lastReadMessageId: body.readThroughMessageId ?? null,
+    unreadCount: 0,
+  });
+});
+
 afterEach(async () => {
   setSharedRegistryForTests(undefined);
   setSharedMarketDataForTests(undefined);
   apiClient.connectChannel = originalConnectChannel;
   apiClient.getChannels = originalGetChannels;
+  apiClient.getChatPresence = originalGetChatPresence;
+  apiClient.updateChatChannelState = originalUpdateChatChannelState;
   apiClient.setSessionToken(null);
 
   if (testSetup) {
@@ -466,6 +482,136 @@ describe("ChatContent", () => {
     await flushFrame();
 
     expect(testSetup.captureCharFrame()).toContain("#options");
+  });
+
+  test("renders unread sidebar channels in bold and clears them when opened", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    const optionsState = (controller as any).ensureChannelState("options");
+    optionsState.unreadCount = 2;
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+
+    function ChannelPane() {
+      const [channelId, setChannelId] = useState("equities");
+      return (
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={90}
+              height={12}
+              focused
+              channelId={channelId}
+              onChannelChange={setChannelId}
+            />
+          </PluginRenderProvider>
+        </AppContext>
+      );
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<ChannelPane />, {
+        width: 90,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+    const unreadLine = testSetup.captureSpans().lines.find((line) => lineText(line).includes("options"));
+    const unreadSpan = unreadLine?.spans.find((span) => span.text.includes("options"));
+    expect((unreadSpan?.attributes ?? 0) & TextAttributes.BOLD).toBe(TextAttributes.BOLD);
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("options"));
+    const col = lines[row]?.indexOf("options") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(col + 1, row);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    const readLine = testSetup.captureSpans().lines.find((line) => lineText(line).includes("#options"));
+    const readSpan = readLine?.spans.find((span) => span.text.includes("options"));
+    expect((readSpan?.attributes ?? 0) & TextAttributes.BOLD).toBe(0);
+  });
+
+  test("toggles sidebar channel notifications without selecting the channel", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    const toggles: Array<{ channelId: string; enabled: boolean }> = [];
+    controller.setChannelNotificationsEnabled = (channelId: string, enabled: boolean) => {
+      toggles.push({ channelId, enabled });
+    };
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+
+    function ChannelPane() {
+      const [channelId, setChannelId] = useState("equities");
+      return (
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={90}
+              height={12}
+              focused
+              channelId={channelId}
+              onChannelChange={setChannelId}
+            />
+          </PluginRenderProvider>
+        </AppContext>
+      );
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<ChannelPane />, {
+        width: 90,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+    const frame = testSetup.captureCharFrame();
+    const lines = frame.split("\n");
+    const row = lines.findIndex((line) => line.includes("options"));
+    const col = lines[row]?.lastIndexOf("·") ?? -1;
+    expect(row).toBeGreaterThanOrEqual(0);
+    expect(col).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(col, row);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(toggles).toEqual([{ channelId: "options", enabled: true }]);
+    expect(testSetup.captureCharFrame()).toContain("#equities");
+    expect(testSetup.captureCharFrame()).not.toContain("#options");
+  });
+
+  test("shows the sidebar online count footer", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    (controller as any).onlineCount = 6;
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, { width: 90, height: 12 }), {
+        width: 90,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    expect(testSetup.captureCharFrame()).toContain("● 6 online");
   });
 
   test("uses arrows to move between channel sidebar and chat content", async () => {

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -891,7 +891,6 @@ export function ChatContent({
   const channelSidebarWidth = showChannelSidebar
     ? Math.min(CHANNEL_SIDEBAR_MAX_WIDTH, Math.max(CHANNEL_SIDEBAR_MIN_WIDTH, Math.floor(width * 0.24)))
     : 0;
-  const compactChannelHeaderHeight = nativePaneChrome && !showChannelSidebar && channels.length > 1 ? 1 : 0;
   const chatWidth = Math.max(width - channelSidebarWidth, 1);
   const contentWidth = Math.max(chatWidth - 2, 1);
   const composerPrefixWidth = nativePaneChrome ? 0 : 3;
@@ -1453,7 +1452,7 @@ export function ChatContent({
   const inputAreaHeight = canSend ? composerBlockHeight + inputMetaHeight : 2;
   const topSeparatorHeight = nativePaneChrome ? 0 : 1;
   const footerSeparatorHeight = !nativePaneChrome && !canSend ? 1 : 0;
-  const messageAreaHeight = Math.max(1, height - compactChannelHeaderHeight - topSeparatorHeight - footerSeparatorHeight - inputAreaHeight);
+  const messageAreaHeight = Math.max(1, height - topSeparatorHeight - footerSeparatorHeight - inputAreaHeight);
   const composerWidth = nativePaneChrome ? chatWidth : contentWidth;
 
   useEffect(() => {
@@ -1531,8 +1530,6 @@ export function ChatContent({
     )
     : "";
   const inputPlaceholder = replyTo ? `Reply to @${replyTo.user.username}...` : "Type a message...";
-  const activeChannel = channels.find((channel) => channel.id === channelId);
-  const activeChannelLabel = formatChannelLabel(activeChannel, channelId);
   const chatContentBg = focused && showChannelSidebar && !sidebarFocused
     ? blendHex(colors.bg, colors.borderFocused, 0.08)
     : undefined;
@@ -1570,15 +1567,6 @@ export function ChatContent({
         onMouseDown={() => setSidebarFocused(false)}
         style={nativeFillStyle}
       >
-      {compactChannelHeaderHeight > 0 && (
-        <Box height={1} width={contentWidth} flexDirection="row">
-          <Text fg={colors.textDim}>#</Text>
-          <Text fg={colors.positive} attributes={TextAttributes.BOLD}>
-            {truncateChannelLabel(activeChannelLabel, Math.max(contentWidth - 1, 1))}
-          </Text>
-        </Box>
-      )}
-
       {!nativePaneChrome && (
         <Box height={1} width={contentWidth}>
           <Text fg={colors.border}>{"-".repeat(contentWidth)}</Text>

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -34,6 +34,8 @@ interface ChatContentProps {
     | "attachChannelView"
     | "getSnapshot"
     | "refreshChannels"
+    | "refreshChatState"
+    | "refreshPresence"
     | "loadOlderMessages"
     | "loadOlderChannelMessages"
     | "refreshMessages"
@@ -43,6 +45,7 @@ interface ChatContentProps {
     | "sendToChannel"
     | "setDraft"
     | "setChannelDraft"
+    | "setChannelNotificationsEnabled"
     | "setReplyToId"
     | "setChannelReplyToId"
     | "subscribe"
@@ -752,35 +755,45 @@ const DesktopChatMessage = memo(function DesktopChatMessage({
 
 function ChannelSidebar({
   channels,
+  channelStates,
   activeChannelId,
+  onlineCount,
   width,
   height,
   focused,
   keyboardFocused,
   loading,
+  canManageNotifications,
   onSelect,
   onFocusRequest,
+  onToggleNotifications,
 }: {
   channels: ChatChannel[];
+  channelStates: ReturnType<ChatController["getSnapshot"]>["channelStates"];
   activeChannelId: string;
+  onlineCount: number;
   width: number;
   height: number;
   focused: boolean;
   keyboardFocused: boolean;
   loading: boolean;
+  canManageNotifications: boolean;
   onSelect?: (channelId: string) => void;
   onFocusRequest?: () => void;
+  onToggleNotifications?: (channelId: string, enabled: boolean) => void;
 }) {
   const { nativePaneChrome } = useUiCapabilities();
   const borderWidth = nativePaneChrome ? 0 : width > 1 ? 1 : 0;
   const listWidth = Math.max(width - borderWidth, 1);
-  const labelWidth = Math.max(listWidth - 3, 1);
+  const notificationWidth = canManageNotifications ? 2 : 0;
+  const labelWidth = Math.max(listWidth - 3 - notificationWidth, 1);
   const dividerColor = focused ? colors.borderFocused : colors.border;
   const sidebarBg = keyboardFocused ? blendHex(colors.panel, colors.borderFocused, 0.18) : colors.panel;
   const activeBg = keyboardFocused
     ? blendHex(colors.selected, colors.borderFocused, 0.32)
     : blendHex(colors.panel, colors.selected, 0.35);
   const [hoveredChannelId, setHoveredChannelId] = useState<string | null>(null);
+  const channelStateById = useMemo(() => new Map(channelStates.map((state) => [state.channelId, state])), [channelStates]);
   const sidebarLayoutHeight = nativePaneChrome ? "100%" : height;
   const nativeFillStyle = nativePaneChrome ? { minHeight: 0 } : undefined;
   const sidebarBorder = borderWidth > 0
@@ -810,6 +823,9 @@ function ChannelSidebar({
       >
         {channels.map((channel) => {
           const active = channel.id === activeChannelId;
+          const channelState = channelStateById.get(channel.id);
+          const notificationsEnabled = channelState?.notificationsEnabled === true;
+          const unread = (channelState?.unreadCount ?? 0) > 0;
           const hovered = hoveredChannelId === channel.id && !active;
           const fg = active ? colors.selectedText : keyboardFocused ? colors.text : colors.textDim;
           const bg = active ? activeBg : hovered ? hoverBg() : sidebarBg;
@@ -824,6 +840,14 @@ function ChannelSidebar({
             onFocusRequest?.();
             onSelect?.(channel.id);
           };
+          const toggleNotifications = (event: any) => {
+            event?.preventDefault?.();
+            event?.stopPropagation?.();
+            if (event) {
+              event[CHAT_CHANNEL_MOUSE_HANDLED] = true;
+            }
+            onToggleNotifications?.(channel.id, !notificationsEnabled);
+          };
           return (
             <Box
               key={channel.id}
@@ -837,9 +861,27 @@ function ChannelSidebar({
               style={{ cursor: "pointer" }}
             >
               <Text fg={fg} selectable={false} onMouseDown={selectChannel}> </Text>
-              <Text fg={fg} selectable={false} onMouseDown={selectChannel}>{active ? "#" : " "}</Text>
-              <Text fg={fg} selectable={false} onMouseDown={selectChannel}>{truncateChannelLabel(label, labelWidth)}</Text>
+              <Text fg={fg} attributes={unread ? TextAttributes.BOLD : 0} selectable={false} onMouseDown={selectChannel}>{active ? "#" : " "}</Text>
+              <Text fg={fg} attributes={unread ? TextAttributes.BOLD : 0} selectable={false} onMouseDown={selectChannel}>{truncateChannelLabel(label, labelWidth)}</Text>
               <Box flexGrow={1} onMouseDown={selectChannel} />
+              {canManageNotifications && (
+                <Box
+                  width={notificationWidth}
+                  height={1}
+                  alignItems="center"
+                  justifyContent="center"
+                  onMouseDown={toggleNotifications}
+                  style={{ cursor: "pointer" }}
+                >
+                  <Text
+                    fg={notificationsEnabled ? colors.positive : colors.textMuted}
+                    selectable={false}
+                    onMouseDown={toggleNotifications}
+                  >
+                    {notificationsEnabled ? "◖)" : "◖·"}
+                  </Text>
+                </Box>
+              )}
             </Box>
           );
         })}
@@ -849,6 +891,10 @@ function ChannelSidebar({
             <Text fg={colors.textDim}> syncing</Text>
           </Box>
         )}
+        <Box height={1} width={listWidth} flexDirection="row">
+          <Text fg={colors.positive}>●</Text>
+          <Text fg={colors.textDim}>{` ${truncateChannelLabel(`${onlineCount} online`, Math.max(listWidth - 2, 1))}`}</Text>
+        </Box>
       </Box>
       {sidebarBorder}
       {nativePaneChrome && (
@@ -897,6 +943,8 @@ export function ChatContent({
   const composerTextWidth = Math.max(contentWidth - composerPrefixWidth, 1);
   const inputValueRef = useRef(initialSnapshot.draft);
   const [messages, setMessages] = useState<ChatMessage[]>(initialSnapshot.messages);
+  const [channelStates, setChannelStates] = useState(initialSnapshot.channelStates);
+  const [onlineCount, setOnlineCount] = useState(initialSnapshot.onlineCount);
   const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
   const [user, setUser] = useState<{ id: string; username: string; emailVerified: boolean } | null>(initialSnapshot.user);
   const [loading, setLoading] = useState(initialSnapshot.loading);
@@ -951,6 +999,7 @@ export function ChatContent({
 
   useEffect(() => {
     void controller.refreshChannels().catch(() => {});
+    void controller.refreshPresence().catch(() => {});
     void controller.refreshSession().catch(() => {});
   }, [controller]);
 
@@ -961,6 +1010,8 @@ export function ChatContent({
     const snapshot = controller.getSnapshot(channelId);
     setMessages(snapshot.messages);
     setChannels(snapshot.channels);
+    setChannelStates(snapshot.channelStates);
+    setOnlineCount(snapshot.onlineCount);
     setChannelsLoading(snapshot.channelsLoading);
     setHasSavedSession(snapshot.hasSavedSession);
     setUser(snapshot.user);
@@ -986,6 +1037,8 @@ export function ChatContent({
     function handleSnapshot(snapshot: ReturnType<ChatController["getSnapshot"]>) {
       setMessages(snapshot.messages);
       setChannels(snapshot.channels);
+      setChannelStates(snapshot.channelStates);
+      setOnlineCount(snapshot.onlineCount);
       setChannelsLoading(snapshot.channelsLoading);
       setHasSavedSession(snapshot.hasSavedSession);
       setUser(snapshot.user);
@@ -1131,7 +1184,7 @@ export function ChatContent({
       oldestMessageId: messages[0]?.id ?? null,
       scrollHeight: getScrollHeight(scrollBox, exactPixels),
       scrollTop: getScrollTop(scrollBox, exactPixels),
-      selectedMessageId: selectedIdx >= 0 ? messages[selectedIdx]?.id ?? null : null,
+      selectedMessageId: selectedIdx >= 0 ? messages[selectedIdx]?.id ?? null : messages[0]?.id ?? null,
     };
     setFollowMessages(false);
     const request = useDefaultControllerChannel
@@ -1469,30 +1522,32 @@ export function ChatContent({
     const anchor = prependAnchorRef.current;
     if (!anchor || loadingOlderMessages) return;
 
-    queueMicrotask(() => {
-      const currentAnchor = prependAnchorRef.current;
-      const scrollBox = scrollRef.current;
-      if (!currentAnchor || !scrollBox) return;
-      if (pendingJumpMessageIdRef.current) {
-        prependAnchorRef.current = null;
-        return;
-      }
-
-      const previousOldestIndex = currentAnchor.oldestMessageId
-        ? messages.findIndex((message) => message.id === currentAnchor.oldestMessageId)
-        : -1;
-      const exactPixels = nativePaneChrome === true && hasPixelScrollMetrics(scrollBox);
-      const addedRows = !exactPixels && previousOldestIndex > 0
-        ? getMessageTopOffset(messages, previousOldestIndex, contentWidth)
-        : Math.max(0, getScrollHeight(scrollBox, exactPixels) - currentAnchor.scrollHeight);
-      scrollToPosition(scrollBox, currentAnchor.scrollTop + addedRows, exactPixels);
-      if (currentAnchor.selectedMessageId) {
-        const selectedMessageIndex = messages.findIndex((message) => message.id === currentAnchor.selectedMessageId);
-        if (selectedMessageIndex >= 0) {
-          setSelectedIdx(selectedMessageIndex);
-        }
-      }
+    const currentAnchor = anchor;
+    const scrollBox = scrollRef.current;
+    if (!scrollBox) return;
+    if (pendingJumpMessageIdRef.current) {
       prependAnchorRef.current = null;
+      return;
+    }
+
+    const previousOldestIndex = currentAnchor.oldestMessageId
+      ? messages.findIndex((message) => message.id === currentAnchor.oldestMessageId)
+      : -1;
+    const exactPixels = nativePaneChrome === true && hasPixelScrollMetrics(scrollBox);
+    const addedRows = !exactPixels && previousOldestIndex > 0
+      ? getMessageTopOffset(messages, previousOldestIndex, contentWidth)
+      : Math.max(0, getScrollHeight(scrollBox, exactPixels) - currentAnchor.scrollHeight);
+    scrollToPosition(scrollBox, currentAnchor.scrollTop + addedRows, exactPixels);
+    if (currentAnchor.selectedMessageId) {
+      const selectedMessageIndex = messages.findIndex((message) => message.id === currentAnchor.selectedMessageId);
+      if (selectedMessageIndex >= 0) {
+        setSelectedIdx(selectedMessageIndex);
+      }
+    }
+    queueMicrotask(() => {
+      if (prependAnchorRef.current === currentAnchor) {
+        prependAnchorRef.current = null;
+      }
     });
   }, [contentWidth, loadingOlderMessages, messages, nativePaneChrome]);
 
@@ -1505,6 +1560,7 @@ export function ChatContent({
     const sb = scrollRef.current;
     if (!sb) return;
     if (!selectionActive) return;
+    if (prependAnchorRef.current) return;
     if (nativePaneChrome) {
       const selectedMessageId = messages[selectedIdx]?.id ?? "";
       runAfterLayout(() => scrollElementIntoScrollBoxView(scrollRef.current, messageElementsRef.current.get(selectedMessageId)));
@@ -1547,14 +1603,20 @@ export function ChatContent({
       {showChannelSidebar && (
         <ChannelSidebar
           channels={channels}
+          channelStates={channelStates}
           activeChannelId={channelId}
+          onlineCount={onlineCount}
           width={channelSidebarWidth}
           height={height}
           focused={focused}
           keyboardFocused={sidebarFocused}
           loading={channelsLoading}
+          canManageNotifications={!!user?.emailVerified}
           onSelect={changeChannel}
           onFocusRequest={() => setSidebarFocused(true)}
+          onToggleNotifications={(nextChannelId, enabled) => {
+            controller.setChannelNotificationsEnabled(nextChannelId, enabled);
+          }}
         />
       )}
 

--- a/src/utils/api-client.test.ts
+++ b/src/utils/api-client.test.ts
@@ -282,6 +282,134 @@ describe("apiClient chat timestamps", () => {
     expect(seenCreatedAts).toEqual(["2026-04-08T07:28:27.625Z"]);
     channel.close();
   });
+
+  test("fetches chat state and normalizes pending notification timestamps", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = mockFetch(async (input: Request | string | URL) => {
+      requestedUrl = String(input);
+      return createResponse({
+        channels: [{ id: "everyone", name: "everyone", created_at: "2026-04-08T07:00:00.000Z" }],
+        onlineCount: 2,
+        channelStates: [{
+          channelId: "everyone",
+          notificationsEnabled: true,
+          lastReadMessageId: "m1",
+          unreadCount: 1,
+        }],
+        notifications: [{
+          id: "n1",
+          type: "reply",
+          channelId: "everyone",
+          messageId: "m2",
+          createdAt: "2026-04-08 07:30:00.000",
+          message: {
+            id: "m2",
+            channelId: "everyone",
+            content: "reply",
+            replyToId: "m1",
+            createdAt: "2026-04-08 07:29:00.000",
+            user: { id: "u2", username: "bob", displayName: "Bob" },
+            replyTo: { content: "parent", user: { id: "u1", username: "vince" } },
+          },
+        }],
+      });
+    });
+
+    const state = await apiClient.getChatState();
+
+    expect(new URL(requestedUrl).pathname).toBe("/chat/state");
+    expect(state.onlineCount).toBe(2);
+    expect(state.notifications[0]?.createdAt).toBe("2026-04-08T07:30:00.000Z");
+    expect(state.notifications[0]?.message.createdAt).toBe("2026-04-08T07:29:00.000Z");
+  });
+
+  test("updates chat channel state and marks notifications delivered", async () => {
+    const requests: Array<{ path: string; method: string; body: unknown }> = [];
+    const responses = [
+      createResponse({
+        channelId: "everyone",
+        notificationsEnabled: true,
+        lastReadMessageId: "m2",
+        unreadCount: 0,
+      }),
+      createResponse({ delivered: 2 }),
+      createResponse({ onlineCount: 4 }),
+    ];
+    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
+      requests.push({
+        path: new URL(String(input)).pathname,
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return responses.shift() as Response;
+    });
+
+    await apiClient.updateChatChannelState("everyone", {
+      notificationsEnabled: true,
+      readThroughMessageId: "m2",
+    });
+    await apiClient.markChatNotificationsDelivered(["n1", "n2"]);
+    const presence = await apiClient.getChatPresence();
+
+    expect(requests).toEqual([
+      {
+        path: "/chat/channels/everyone/state",
+        method: "PATCH",
+        body: { notificationsEnabled: true, readThroughMessageId: "m2" },
+      },
+      {
+        path: "/chat/notifications/delivered",
+        method: "POST",
+        body: { notificationIds: ["n1", "n2"] },
+      },
+      {
+        path: "/chat/presence",
+        method: "GET",
+        body: null,
+      },
+    ]);
+    expect(presence).toEqual({ onlineCount: 4 });
+  });
+
+  test("emits websocket chat presence and notification events", async () => {
+    const seenPresence: number[] = [];
+    const seenNotifications: string[] = [];
+    const unsubscribePresence = apiClient.subscribeChatPresence((onlineCount) => {
+      seenPresence.push(onlineCount);
+    });
+    const unsubscribeNotifications = apiClient.subscribeChatNotifications((notification) => {
+      seenNotifications.push(`${notification.id}:${notification.message.createdAt}`);
+    });
+
+    await (apiClient as any).handleSocketMessage(JSON.stringify({
+      type: "chat.presence",
+      onlineCount: 5,
+    }));
+    await (apiClient as any).handleSocketMessage(JSON.stringify({
+      type: "chat.notification",
+      data: {
+        id: "n1",
+        type: "reply",
+        channelId: "everyone",
+        messageId: "m2",
+        createdAt: "2026-04-08 07:30:00.000",
+        message: {
+          id: "m2",
+          channelId: "everyone",
+          content: "reply",
+          replyToId: "m1",
+          createdAt: "2026-04-08 07:29:00.000",
+          user: { id: "u2", username: "bob", displayName: "Bob" },
+          replyTo: { content: "parent", user: { id: "u1", username: "vince" } },
+        },
+      },
+    }));
+
+    expect(seenPresence).toEqual([5]);
+    expect(seenNotifications).toEqual(["n1:2026-04-08T07:29:00.000Z"]);
+    unsubscribePresence();
+    unsubscribeNotifications();
+  });
 });
 
 describe("apiClient cloud news", () => {

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -48,7 +48,7 @@ export interface ChatMessage {
   replyToId: string | null;
   createdAt: string;
   user: { id: string; username: string; displayName: string };
-  replyTo?: { content: string; user: { username: string } } | null;
+  replyTo?: { content: string; user: { id?: string; username: string } } | null;
   clientStatus?: "sending" | "failed";
   clientError?: string | null;
 }
@@ -57,6 +57,29 @@ export interface ChatChannel {
   id: string;
   name: string;
   created_at: string;
+}
+
+export interface ChatChannelState {
+  channelId: string;
+  notificationsEnabled: boolean;
+  lastReadMessageId: string | null;
+  unreadCount: number;
+}
+
+export interface ChatNotification {
+  id: string;
+  type: "reply";
+  channelId: string;
+  messageId: string;
+  createdAt: string;
+  message: ChatMessage;
+}
+
+export interface ChatStateResponse {
+  channels: ChatChannel[];
+  onlineCount: number;
+  channelStates: ChatChannelState[];
+  notifications: ChatNotification[];
 }
 
 export interface AuthUser {
@@ -352,6 +375,21 @@ function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
   return messages.map((message) => normalizeChatMessage(message));
 }
 
+function normalizeChatNotification(notification: ChatNotification): ChatNotification {
+  return {
+    ...notification,
+    createdAt: normalizeTimestamp(notification.createdAt),
+    message: normalizeChatMessage(notification.message),
+  };
+}
+
+function normalizeChatState(response: ChatStateResponse): ChatStateResponse {
+  return {
+    ...response,
+    notifications: response.notifications.map(normalizeChatNotification),
+  };
+}
+
 function normalizeTweet(tweet: CloudTweetPayload): CloudTweetPayload {
   return {
     ...tweet,
@@ -370,6 +408,8 @@ function normalizeTweetSearchResponse(response: CloudTweetSearchResponse): Cloud
 }
 
 type ChannelListener = (message: ChatMessage) => void;
+type ChatNotificationListener = (notification: ChatNotification) => void;
+type ChatPresenceListener = (onlineCount: number) => void;
 type QuoteListener = (target: QuoteStreamTarget, quote: CloudQuotePayload) => void;
 type SessionCookieName = (typeof SESSION_COOKIE_NAMES)[number];
 
@@ -408,6 +448,8 @@ class GloomApiClient {
   private reconnectDelayMs = 1000;
 
   private readonly channelListeners = new Map<string, Set<ChannelListener>>();
+  private readonly chatNotificationListeners = new Set<ChatNotificationListener>();
+  private readonly chatPresenceListeners = new Set<ChatPresenceListener>();
   private readonly quoteListeners = new Map<string, Set<QuoteListener>>();
   private readonly quoteTargets = new Map<string, QuoteStreamTarget>();
   private readonly pendingQuoteSubscribes = new Map<string, QuoteStreamTarget>();
@@ -650,7 +692,12 @@ class GloomApiClient {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
     if (payload && typeof payload === "object" && "type" in (payload as Record<string, unknown>)) {
       const type = (payload as Record<string, unknown>).type;
-      if (type === "market.subscribe" || type === "market.unsubscribe" || type === "chat.subscribe") {
+      if (
+        type === "market.subscribe"
+        || type === "market.unsubscribe"
+        || type === "chat.subscribe"
+        || type === "chat.unsubscribe"
+      ) {
         cloudApiLog.info("send websocket message", payload);
       }
     }
@@ -773,6 +820,21 @@ class GloomApiClient {
       return;
     }
 
+    if (parsed?.type === "chat.notification" && parsed.data) {
+      const notification = normalizeChatNotification(parsed.data as ChatNotification);
+      for (const listener of this.chatNotificationListeners) {
+        listener(notification);
+      }
+      return;
+    }
+
+    if (parsed?.type === "chat.presence" && typeof parsed.onlineCount === "number") {
+      for (const listener of this.chatPresenceListeners) {
+        listener(parsed.onlineCount);
+      }
+      return;
+    }
+
     if (parsed?.type === "market.quote" && parsed.quote && typeof parsed.symbol === "string") {
       const key = marketKey(parsed.symbol, parsed.exchange);
       const target = this.quoteTargets.get(key) ?? {
@@ -853,6 +915,32 @@ class GloomApiClient {
     return this.request<ChatChannel[]>("/chat/channels");
   }
 
+  async getChatPresence(): Promise<{ onlineCount: number }> {
+    return this.request<{ onlineCount: number }>("/chat/presence");
+  }
+
+  async getChatState(): Promise<ChatStateResponse> {
+    const state = await this.request<ChatStateResponse>("/chat/state");
+    return normalizeChatState(state);
+  }
+
+  async updateChatChannelState(
+    channelId: string,
+    body: { notificationsEnabled?: boolean; readThroughMessageId?: string },
+  ): Promise<ChatChannelState> {
+    return this.request<ChatChannelState>(`/chat/channels/${channelId}/state`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+  }
+
+  async markChatNotificationsDelivered(notificationIds: string[]): Promise<{ delivered: number }> {
+    return this.request<{ delivered: number }>("/chat/notifications/delivered", {
+      method: "POST",
+      body: JSON.stringify({ notificationIds }),
+    });
+  }
+
   async getMessages(
     channelId: string,
     opts?: { after?: string; before?: string; limit?: number },
@@ -914,11 +1002,26 @@ class GloomApiClient {
         current.delete(onMessage);
         if (current.size === 0) {
           this.channelListeners.delete(channelId);
+          this.sendSocketMessage({ type: "chat.unsubscribe", channelId });
         }
         if (!this.shouldKeepSocketOpen()) {
           this.teardownSocket();
         }
       },
+    };
+  }
+
+  subscribeChatNotifications(listener: ChatNotificationListener): () => void {
+    this.chatNotificationListeners.add(listener);
+    return () => {
+      this.chatNotificationListeners.delete(listener);
+    };
+  }
+
+  subscribeChatPresence(listener: ChatPresenceListener): () => void {
+    this.chatPresenceListeners.add(listener);
+    return () => {
+      this.chatPresenceListeners.delete(listener);
     };
   }
 
@@ -997,6 +1100,8 @@ class GloomApiClient {
       channelTargets: this.channelListeners.size,
     });
     this.channelListeners.clear();
+    this.chatNotificationListeners.clear();
+    this.chatPresenceListeners.clear();
     this.quoteListeners.clear();
     this.quoteTargets.clear();
     this.pendingQuoteSubscribes.clear();


### PR DESCRIPTION
## Summary
- add client chat state APIs for presence, channel notification state, unread state, and durable reply notifications
- keep notification-enabled channels connected while chat is closed and de-dupe reply/channel notifications
- show unread channel labels, per-channel notification toggles, and online count in the chat sidebar
- includes the existing compact native chat header cleanup already on this branch

## Backend
- Platform backend support was already committed and deployed separately, including the old-client reply/channel hotfix.

## Tests
- bun test src/utils/api-client.test.ts src/plugins/builtin/chat-controller.test.ts src/plugins/builtin/chat.test.tsx
- git diff --check