### PR TITLE
Fix Ask AI desktop layout

### DIFF
--- a/src/components/markdown-text.tsx
+++ b/src/components/markdown-text.tsx
@@ -87,9 +87,32 @@ function parseLine(line: string): ParsedLine {
   return { segments: parseInlineMarkdown(line) };
 }
 
-function SegmentSpan({ segment }: { segment: StyledSegment }) {
+function wrappedTextStyle() {
+  return {
+    minWidth: 0,
+    whiteSpace: "pre-wrap",
+    overflowWrap: "anywhere",
+  } as const;
+}
+
+function wrappedInlineTextStyle() {
+  return {
+    ...wrappedTextStyle(),
+    display: "inline",
+  } as const;
+}
+
+function SegmentSpan({ segment, wrap = false }: { segment: StyledSegment; wrap?: boolean }) {
+  const wrapProps = wrap
+    ? {
+        wrapText: true,
+        wrapMode: "word",
+        style: wrappedInlineTextStyle(),
+      }
+    : {};
+
   if (segment.code) {
-    return <Span fg={colors.textDim}>{segment.text}</Span>;
+    return <Span fg={colors.textDim} {...wrapProps}>{segment.text}</Span>;
   }
   const attrs =
     (segment.bold ? TextAttributes.BOLD : 0) |
@@ -99,6 +122,7 @@ function SegmentSpan({ segment }: { segment: StyledSegment }) {
     <Span
       fg={segment.color ?? undefined}
       attributes={attrs || undefined}
+      {...wrapProps}
     >
       {segment.text}
     </Span>
@@ -124,6 +148,15 @@ function MarkdownLine({
 }) {
   const indent = parsed.indent ?? 0;
   const indentStr = indent > 0 ? " ".repeat(indent) : "";
+  const shouldWrap = lineWidth != null;
+  const textWrapProps = shouldWrap
+    ? {
+        width: lineWidth,
+        wrapText: true,
+        wrapMode: "word",
+        style: wrappedTextStyle(),
+      }
+    : {};
 
   // Check if any segment contains ticker symbols
   const fullText = parsed.segments.map((s) => s.text).join("");
@@ -133,10 +166,10 @@ function MarkdownLine({
   if (!hasTickers) {
     // Simple case: no tickers, render as styled text
     return (
-      <Text fg={textColor}>
+      <Text fg={textColor} {...textWrapProps}>
         {indentStr}
         {parsed.segments.map((segment, i) => (
-          <SegmentSpan key={i} segment={segment} />
+          <SegmentSpan key={i} segment={segment} wrap={shouldWrap} />
         ))}
       </Text>
     );
@@ -153,16 +186,28 @@ function MarkdownLine({
           if (token.kind === "text") {
             if (!token.value) return null;
             return (
-              <Text key={`${segIdx}:${tokIdx}`} fg={textColor}>
-                <SegmentSpan segment={{ ...segment, text: token.value }} />
+              <Text
+                key={`${segIdx}:${tokIdx}`}
+                fg={textColor}
+                {...(shouldWrap
+                  ? { wrapText: true, wrapMode: "word", style: wrappedTextStyle() }
+                  : {})}
+              >
+                <SegmentSpan segment={{ ...segment, text: token.value }} wrap={shouldWrap} />
               </Text>
             );
           }
           const entry = catalog[token.symbol];
           if (!entry || entry.status === "missing") {
             return (
-              <Text key={`${segIdx}:${tokIdx}`} fg={textColor}>
-                <SegmentSpan segment={{ ...segment, text: token.value }} />
+              <Text
+                key={`${segIdx}:${tokIdx}`}
+                fg={textColor}
+                {...(shouldWrap
+                  ? { wrapText: true, wrapMode: "word", style: wrappedTextStyle() }
+                  : {})}
+              >
+                <SegmentSpan segment={{ ...segment, text: token.value }} wrap={shouldWrap} />
               </Text>
             );
           }

--- a/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
+++ b/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
@@ -300,13 +300,32 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
     nativePaneChrome,
     terminalBottomInset: terminalFooterClearance,
   });
-  const chatHeight = Math.max(height - composerBlockHeight, 0);
+  const chatHeight = nativePaneChrome ? undefined : Math.max(height - composerBlockHeight, 0);
+  const layoutHeight = nativePaneChrome ? "100%" : height;
+  const nativeFillStyle = nativePaneChrome ? { minHeight: 0 } : undefined;
 
   return (
-    <Box flexDirection="column" paddingX={nativePaneChrome ? 0 : 1} height={height} overflow="hidden">
-      {chatHeight > 0 && (
-        <ScrollBox ref={scrollRef} height={chatHeight} scrollY>
-          <Box flexDirection="column" paddingX={nativePaneChrome ? 1 : 0}>
+    <Box
+      flexDirection="column"
+      paddingX={nativePaneChrome ? 0 : 1}
+      height={layoutHeight}
+      flexGrow={nativePaneChrome ? 1 : undefined}
+      overflow="hidden"
+      style={nativeFillStyle}
+    >
+      {(nativePaneChrome || (chatHeight ?? 0) > 0) && (
+        <ScrollBox
+          ref={scrollRef}
+          height={nativePaneChrome ? undefined : chatHeight}
+          flexGrow={nativePaneChrome ? 1 : undefined}
+          scrollY
+          style={nativeFillStyle}
+        >
+          <Box
+            flexDirection="column"
+            paddingX={nativePaneChrome ? 1 : 0}
+            style={nativeFillStyle}
+          >
             {messages.length === 0 ? (
               <Box paddingTop={1}>
                 <Text fg={colors.textDim}>
@@ -354,7 +373,7 @@ export function AskAiDetailTab({ width, height, focused, onCapture }: DetailTabP
         placeholder="Ask a question..."
         terminalPrefix=" > "
         terminalBottomInset={terminalFooterClearance}
-        width={nativePaneChrome ? width : contentWidth}
+        width={nativePaneChrome ? "100%" : contentWidth}
         height={composerHeight}
         onFocusRequest={focusInput}
         onInput={(value) => setInputValue(value)}


### PR DESCRIPTION
## Summary
- wrap Ask AI markdown text to the available pane width on desktop
- keep the desktop Ask AI composer inside the pane body above the footer/status area
- clean generated build output from the worktree before publishing

## Root cause
Plain markdown lines did not pass wrap props through the styled text path, and the native Ask AI pane still used row-height sizing where the desktop body is flex-based.

## Validation
- git diff --check
- bun run desktop:view:build
- bun run build