### PR TITLE
Fix native pane body sizing

### DIFF
--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -9,7 +9,7 @@ import { colors, floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../.
 import { useThemeColors } from "../../theme/theme-context";
 import { hasPaneFooterContent, PaneFooterBar, PaneFooterProvider } from "./pane-footer";
 import { PaneContent } from "./pane-content";
-import { getPaneBodyWidth, NATIVE_PANE_BODY_LAYOUT_PROPS } from "./pane-sizing";
+import { getNativePaneBodyWidth, getPaneBodyWidth, NATIVE_PANE_BODY_LAYOUT_PROPS } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX, TITLEBAR_TRAFFIC_LIGHT_WIDTH } from "./titlebar-overlay";
 import {
@@ -52,7 +52,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     ? getPaneDisplayTitle(titleState, instance, paneDef)
     : "Detached Pane";
   const focused = windowFocused;
-  const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(width)) : getPaneBodyWidth(width);
+  const bodyWidth = nativePaneChrome ? getNativePaneBodyWidth(width) : getPaneBodyWidth(width);
 
   const focusPane = useCallback(() => {
     setWindowFocused(true);

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -3,7 +3,12 @@ import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import { getPaneBodyHeight, NATIVE_PANE_BODY_LAYOUT_PROPS, shouldReservePaneFooter } from "./pane-sizing";
+import {
+  getNativePaneBodyHeight,
+  getPaneBodyHeight,
+  NATIVE_PANE_BODY_LAYOUT_PROPS,
+  shouldReservePaneFooter,
+} from "./pane-sizing";
 
 interface FloatingPaneWrapperProps {
   paneId?: string;
@@ -77,7 +82,9 @@ export function FloatingPaneWrapper({
   const bg = floatingPaneBg(focused);
   const showFooter = hasPaneFooterContent(footer);
   const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
-  const bodyHeight = getPaneBodyHeight(height, reserveFooter);
+  const bodyHeight = nativePaneChrome
+    ? getNativePaneBodyHeight(height, reserveFooter)
+    : getPaneBodyHeight(height, reserveFooter);
   const bodyLayoutProps = nativePaneChrome
     ? NATIVE_PANE_BODY_LAYOUT_PROPS
     : { height: bodyHeight };

--- a/src/components/layout/pane-sizing.ts
+++ b/src/components/layout/pane-sizing.ts
@@ -20,3 +20,15 @@ export function getPaneBodyHeight(height: number, reserveFooter = true): number 
 export function getPaneBodyWidth(width: number): number {
   return Math.max(1, Math.floor(width));
 }
+
+export function getNativePaneBodyHeight(height: number, reserveFooter = true): number {
+  const preciseHeight = Number.isFinite(height) ? height : 1;
+  return Math.max(
+    1,
+    preciseHeight - PANE_HEADER_ROWS - (reserveFooter ? PANE_FOOTER_ROWS : 0),
+  );
+}
+
+export function getNativePaneBodyWidth(width: number): number {
+  return Math.max(1, Number.isFinite(width) ? width : 1);
+}

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -3,7 +3,12 @@ import type { ReactNode } from "react";
 import { colors, paneBg } from "../../theme/colors";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import { getPaneBodyHeight, NATIVE_PANE_BODY_LAYOUT_PROPS, shouldReservePaneFooter } from "./pane-sizing";
+import {
+  getNativePaneBodyHeight,
+  getPaneBodyHeight,
+  NATIVE_PANE_BODY_LAYOUT_PROPS,
+  shouldReservePaneFooter,
+} from "./pane-sizing";
 
 interface PaneWrapperProps {
   paneId?: string;
@@ -22,6 +27,23 @@ interface PaneWrapperProps {
   onActionMouseDown?: (event: any) => void;
   footer?: CombinedPaneFooter | null;
   children: ReactNode;
+}
+
+function resolvePaneBodyHeight(
+  height: number,
+  hasTitle: boolean,
+  reserveFooter: boolean,
+  nativePaneChrome: boolean | undefined,
+): number {
+  if (nativePaneChrome) {
+    return hasTitle
+      ? getNativePaneBodyHeight(height, reserveFooter)
+      : Math.max(1, height);
+  }
+
+  return hasTitle
+    ? getPaneBodyHeight(height, reserveFooter)
+    : Math.max(1, Math.floor(height));
 }
 
 export function PaneWrapper({
@@ -47,7 +69,7 @@ export function PaneWrapper({
   const showFooter = hasPaneFooterContent(footer);
   const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
   const bodyHeight = typeof height === "number"
-    ? title ? getPaneBodyHeight(height, reserveFooter) : Math.max(1, Math.floor(height))
+    ? resolvePaneBodyHeight(height, !!title, reserveFooter, nativePaneChrome)
     : undefined;
   const bodyLayoutProps = nativePaneChrome
     ? NATIVE_PANE_BODY_LAYOUT_PROPS

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -50,7 +50,13 @@ import { FloatingPaneWrapper } from "./floating-pane";
 import { PaneContent } from "./pane-content";
 import { PaneWrapper } from "./pane";
 import { hasPaneFooterContent, PaneFooterProvider } from "./pane-footer";
-import { getPaneBodyHeight, getPaneBodyWidth, shouldReservePaneFooter } from "./pane-sizing";
+import {
+  getNativePaneBodyHeight,
+  getNativePaneBodyWidth,
+  getPaneBodyHeight,
+  getPaneBodyWidth,
+  shouldReservePaneFooter,
+} from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX } from "./titlebar-overlay";
 import { capturePaneScreenshotPngBase64 } from "../../utils/dom-screenshot";
@@ -1621,7 +1627,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         if (!pane) return null;
         const focused = focusedPaneId === leaf.instanceId && (!overlayOpen || menuState?.paneId === leaf.instanceId);
         const showActions = focused || hoveredPaneId === leaf.instanceId || menuState?.paneId === leaf.instanceId;
-        const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(leaf.rect.width)) : getPaneBodyWidth(leaf.rect.width);
+        const bodyWidth = nativePaneChrome ? getNativePaneBodyWidth(leaf.rect.width) : getPaneBodyWidth(leaf.rect.width);
         return (
           <Box
             key={`dock:${leaf.instanceId}`}
@@ -1634,7 +1640,9 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
             <PaneFooterProvider>
               {(footer) => {
                 const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
-                const bodyHeight = getPaneBodyHeight(leaf.rect.height, reserveFooter);
+                const bodyHeight = nativePaneChrome
+                  ? getNativePaneBodyHeight(leaf.rect.height, reserveFooter)
+                  : getPaneBodyHeight(leaf.rect.height, reserveFooter);
                 return (
                   <PaneWrapper
                     paneId={leaf.instanceId}
@@ -1674,12 +1682,14 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
           : rect;
         const focused = focusedPaneId === pane.instance.instanceId && (!overlayOpen || menuState?.paneId === pane.instance.instanceId);
         const showActions = focused || hoveredPaneId === pane.instance.instanceId || menuState?.paneId === pane.instance.instanceId;
-        const bodyWidth = nativePaneChrome ? Math.max(1, Math.floor(preview.width)) : getPaneBodyWidth(preview.width);
+        const bodyWidth = nativePaneChrome ? getNativePaneBodyWidth(preview.width) : getPaneBodyWidth(preview.width);
         return (
           <PaneFooterProvider key={`float:${pane.instance.instanceId}`}>
             {(footer) => {
               const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
-              const bodyHeight = getPaneBodyHeight(preview.height, reserveFooter);
+              const bodyHeight = nativePaneChrome
+                ? getNativePaneBodyHeight(preview.height, reserveFooter)
+                : getPaneBodyHeight(preview.height, reserveFooter);
               return (
                 <FloatingPaneWrapper
                   paneId={pane.instance.instanceId}


### PR DESCRIPTION
## Summary
- keep native desktop pane body dimensions on a pixel-precision path
- stop passing floored terminal cell dimensions into docked, floating, and detached pane bodies
- leave terminal pane sizing on the existing floored cell path

## Root cause
Desktop pane layout was already using precise geometry, but the shared pane shell still floored body width and height before rendering pane content. Datatables inherited that floored body size and could leave a row-sized gap at the bottom while resizing.

## Validation
- bunx biome check src/components/layout/pane-sizing.ts src/components/layout/shell.tsx src/components/layout/pane.tsx src/components/layout/floating-pane.tsx src/components/layout/detached-pane-shell.tsx
- bun test src/components/layout/shell.test.tsx src/components/layout/pane-content.test.tsx
- bun run desktop:view:build
- bun run build
- git diff --check