### PR TITLE
Use server chat notification events

### DIFF
--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -586,6 +586,54 @@ describe("ChatController", () => {
     });
   });
 
+  test("hydrates missing transcript cache without marking history unread", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const history: ChatMessage = {
+      id: "m1",
+      channelId: "everyone",
+      content: "already seen",
+      replyToId: null,
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u2", username: "bob", displayName: "Bob" },
+    };
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    persistence.setState("channel:everyone", {
+      draft: "",
+      replyToId: null,
+      lastCursor: "m1",
+      lastViewedMessageId: "m1",
+    }, { schemaVersion: 1 });
+
+    controller.setNotifier((notification) => {
+      notifications.push(notification);
+    });
+    controller.attachPersistence(persistence);
+
+    const calls: Array<{ channelId: string; opts?: { after?: string; before?: string; limit?: number } }> = [];
+    apiClient.getMessages = async (channelId, opts) => {
+      calls.push({ channelId, opts });
+      return opts?.after ? [] : [history];
+    };
+
+    await controller.refreshMessages();
+
+    expect(calls).toEqual([{
+      channelId: "everyone",
+      opts: { limit: 50, after: undefined },
+    }]);
+    expect(controller.getSnapshot().messages).toEqual([history]);
+    expect(controller.getSnapshot().channelStates.find((entry) => entry.channelId === "everyone")).toMatchObject({
+      unreadCount: 0,
+    });
+    expect(notifications).toEqual([]);
+  });
+
   test("backfills from cached transcript when persisted cursor is ahead of the cache", async () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
@@ -744,7 +792,7 @@ describe("ChatController", () => {
     expect(notifications).toEqual([{ body: "server offline", type: "error" }]);
   });
 
-  test("tracks unread mentions and emits an app notification while chat is closed", () => {
+  test("tracks unread mentions from fetched messages without issuing local notifications", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
     const notifications: AppNotificationRequest[] = [];
@@ -770,19 +818,14 @@ describe("ChatController", () => {
     (controller as any).mergeMessages([message]);
 
     expect(controller.getSnapshot().unreadMentionCount).toBe(1);
-    expect(notifications).toEqual([{
-      title: "Gloomberb chat",
-      body: "@bob mentioned you: hey @Vince can you take a look?",
-      type: "info",
-      desktop: "when-inactive",
-    }]);
+    expect(notifications).toEqual([]);
     expect(persistence.getState<{ lastCursor: string | null; lastViewedMessageId: string | null }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
       lastCursor: "m1",
       lastViewedMessageId: null,
     });
   });
 
-  test("keeps emitting mention notifications while the app is backgrounded", () => {
+  test("displays server-issued mention notifications while the app is backgrounded", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
     const notifications: AppNotificationRequest[] = [];
@@ -806,10 +849,18 @@ describe("ChatController", () => {
     controller.attachPersistence(persistence);
     controller.setAppActive(false);
 
-    (controller as any).mergeMessages([message]);
+    (controller as any).handleChatNotification({
+      id: "n1",
+      type: "mention",
+      channelId: "everyone",
+      messageId: "m1",
+      createdAt: "2026-03-28T00:00:00.000Z",
+      message,
+    } satisfies ChatNotification);
 
     expect(notifications).toEqual([{
       title: "Gloomberb chat",
+      subtitle: "#everyone",
       body: "@bob mentioned you: hey @vince",
       type: "info",
       desktop: "when-inactive",
@@ -846,12 +897,7 @@ describe("ChatController", () => {
     const detachView = controller.attachView();
 
     expect(controller.getSnapshot().unreadMentionCount).toBe(0);
-    expect(notifications).toEqual([{
-      title: "Gloomberb chat",
-      body: "@bob mentioned you: hey @vince",
-      type: "info",
-      desktop: "when-inactive",
-    }]);
+    expect(notifications).toEqual([]);
     expect(persistence.getState<{ lastViewedMessageId: string | null }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
       lastViewedMessageId: "m1",
     });
@@ -1043,6 +1089,46 @@ describe("ChatController", () => {
     expect(notifications).toHaveLength(1);
   });
 
+  test("displays server-issued channel notifications", () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const message: ChatMessage = {
+      id: "m1",
+      channelId: "options",
+      content: "new option flow",
+      replyToId: null,
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u2", username: "bob", displayName: "Bob" },
+    };
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    controller.setNotifier((entry) => {
+      notifications.push(entry);
+    });
+    controller.attachPersistence(persistence);
+
+    (controller as any).handleChatNotification({
+      id: "n1",
+      type: "channel",
+      channelId: "options",
+      messageId: "m1",
+      createdAt: "2026-03-28T00:00:00.000Z",
+      message,
+    } satisfies ChatNotification);
+
+    expect(notifications).toEqual([{
+      title: "Gloomberb chat",
+      subtitle: "#options",
+      body: "#options @bob: new option flow",
+      type: "info",
+      desktop: "when-inactive",
+    }]);
+  });
+
   test("tracks unread channel messages and clears them when the channel opens", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
@@ -1075,7 +1161,7 @@ describe("ChatController", () => {
     detachView();
   });
 
-  test("reply notifications fire even when channel notifications are disabled", () => {
+  test("server reply notifications fire even when channel notifications are disabled", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
     const notifications: AppNotificationRequest[] = [];
@@ -1098,7 +1184,14 @@ describe("ChatController", () => {
     });
     controller.attachPersistence(persistence);
 
-    (controller as any).mergeMessages("options", [message]);
+    (controller as any).handleChatNotification({
+      id: "n1",
+      type: "reply",
+      channelId: "options",
+      messageId: "m2",
+      createdAt: "2026-03-28T00:00:00.000Z",
+      message,
+    } satisfies ChatNotification);
 
     expect(notifications).toEqual([{
       title: "Gloomberb chat",

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -66,6 +66,7 @@ export interface ChatControllerSnapshot {
 }
 
 type ChatConnection = { send: (content: string, replyToId?: string) => Promise<ChatMessage>; close: () => void };
+type MergeMessagesOptions = { countUnread?: boolean };
 
 interface ChannelRuntimeState {
   hydrated: boolean;
@@ -373,7 +374,7 @@ export class ChatController {
       channel.lastViewedMessageId = entry.lastReadMessageId ?? channel.lastViewedMessageId;
     }
     for (const notification of state.notifications) {
-      this.handleChatNotification(notification);
+      this.handleChatNotification(notification, { countUnread: false });
     }
     this.ensureOpenChannelConnections();
     this.emit();
@@ -908,6 +909,8 @@ export class ChatController {
     const channel = this.ensureChannelState(channelId);
     const legacyTimestampCursor = isLegacyTimestampCursor(channel.lastCursor);
     const hasIncrementalCursor = !!channel.lastCursor;
+    const hadMessages = channel.messages.length > 0;
+    const countIncrementalUnread = hadMessages && hasIncrementalCursor && !legacyTimestampCursor;
 
     try {
       const messages = await apiClient.getMessages(channelId, {
@@ -918,7 +921,7 @@ export class ChatController {
         channel.reachedOldestMessage = true;
       }
       if (messages.length > 0) {
-        this.mergeMessages(channelId, messages);
+        this.mergeMessages(channelId, messages, { countUnread: countIncrementalUnread });
         return;
       }
       if (legacyTimestampCursor) {
@@ -927,7 +930,7 @@ export class ChatController {
           channel.reachedOldestMessage = true;
         }
         if (fullRefresh.length > 0) {
-          this.mergeMessages(channelId, fullRefresh);
+          this.mergeMessages(channelId, fullRefresh, { countUnread: false });
           return;
         }
         channel.lastCursor = null;
@@ -940,7 +943,7 @@ export class ChatController {
         channel.reachedOldestMessage = true;
       }
       if (messages.length > 0) {
-        this.mergeMessages(channelId, messages);
+        this.mergeMessages(channelId, messages, { countUnread: false });
         return;
       }
       this.persistChannelState(channelId);
@@ -960,20 +963,20 @@ export class ChatController {
       this.persistChannelState(channelId);
       return;
     }
-    this.mergeMessages(channelId, messages, { notifyMentions: false });
+    this.mergeMessages(channelId, messages, { countUnread: false });
   }
 
   private mergeMessages(
     channelIdOrMessages: string | ChatMessage[],
-    maybeMessages?: ChatMessage[] | { notifyMentions?: boolean },
-    maybeOptions?: { notifyMentions?: boolean },
+    maybeMessages?: ChatMessage[] | MergeMessagesOptions,
+    maybeOptions?: MergeMessagesOptions,
   ): void {
     const channelId = Array.isArray(channelIdOrMessages) ? DEFAULT_CHAT_CHANNEL_ID : channelIdOrMessages;
     const messages = Array.isArray(channelIdOrMessages)
       ? channelIdOrMessages
       : (maybeMessages as ChatMessage[] | undefined) ?? [];
     const options = Array.isArray(channelIdOrMessages)
-      ? maybeMessages as { notifyMentions?: boolean } | undefined
+      ? maybeMessages as MergeMessagesOptions | undefined
       : maybeOptions;
     const channel = this.ensureChannelState(channelId);
     this.reconcilePendingMessages(channelId, messages);
@@ -992,11 +995,8 @@ export class ChatController {
     const freshIncoming = [...incoming.values()].filter((message) => message.user.id !== this.user?.id);
     if (channel.openViewCount > 0) {
       this.markViewedThroughLatestMessage(channelId, false);
-    } else if (freshIncoming.length > 0) {
+    } else if (freshIncoming.length > 0 && options?.countUnread !== false) {
       channel.unreadCount += freshIncoming.length;
-    }
-    if (options?.notifyMentions !== false) {
-      this.trackIncomingNotifications(channelId, freshIncoming);
     }
     this.persistTranscript(channelId);
     this.emit(channelId);
@@ -1079,89 +1079,27 @@ export class ChatController {
     this.persistChannelState(channelId);
   }
 
-  private trackIncomingNotifications(channelId: string, messages: ChatMessage[]): void {
-    const channel = this.ensureChannelState(channelId);
-    if (channel.openViewCount > 0) {
-      return;
-    }
-
-    const mentions: ChatMessage[] = [];
-    for (const message of messages) {
-      if (this.isReplyToCurrentUser(message)) {
-        this.notifyReplyMessage(channelId, message);
-        continue;
-      }
-      if (this.isMentionForCurrentUser(message)) {
-        mentions.push(message);
-        continue;
-      }
-      if (channel.notificationsEnabled) {
-        this.notifyChannelMessage(channelId, message);
-      }
-    }
-
-    const freshMentions = mentions.filter((message) => !this.notifiedMessageIds.has(message.id));
-    if (freshMentions.length === 0) return;
-    for (const message of freshMentions) {
-      this.notifiedMessageIds.add(message.id);
-    }
-
-    if (freshMentions.length === 1) {
-      this.notifyFn({
-        title: "Gloomberb chat",
-        body: formatMentionToast(freshMentions[0]!),
-        type: "info",
-        desktop: "when-inactive",
-      });
-      return;
-    }
-    this.notifyFn({
-      title: "Gloomberb chat",
-      body: `${freshMentions.length} new mentions in #${channelId}.`,
-      type: "info",
-      desktop: "when-inactive",
-    });
-  }
-
-  private handleChatNotification(notification: ChatNotification): void {
-    if (notification.type === "reply") {
-      this.notifyReplyMessage(notification.channelId, notification.message);
+  private handleChatNotification(notification: ChatNotification, options: { countUnread?: boolean } = {}): void {
+    this.mergeMessages(notification.channelId, [notification.message], { countUnread: options.countUnread });
+    const channel = this.ensureChannelState(notification.channelId);
+    if (channel.openViewCount === 0) {
+      this.notifyServerMessage(notification);
     }
     void apiClient.markChatNotificationsDelivered([notification.id]).catch(() => {});
   }
 
-  private isReplyToCurrentUser(message: ChatMessage): boolean {
-    return !!this.user?.id
-      && message.user.id !== this.user.id
-      && message.replyTo?.user.id === this.user.id;
-  }
-
-  private isMentionForCurrentUser(message: ChatMessage): boolean {
-    const normalizedUsername = normalizeUsername(this.user?.username);
-    return !!normalizedUsername
-      && message.user.id !== this.user?.id
-      && messageMentionsUsername(message.content, normalizedUsername);
-  }
-
-  private notifyReplyMessage(channelId: string, message: ChatMessage): void {
-    if (this.notifiedMessageIds.has(message.id)) return;
-    this.notifiedMessageIds.add(message.id);
+  private notifyServerMessage(notification: ChatNotification): void {
+    if (this.notifiedMessageIds.has(notification.messageId)) return;
+    this.notifiedMessageIds.add(notification.messageId);
+    const body = notification.type === "reply"
+      ? formatReplyToast(notification.message)
+      : notification.type === "mention"
+        ? formatMentionToast(notification.message)
+        : formatChannelToast(notification.channelId, notification.message);
     this.notifyFn({
       title: "Gloomberb chat",
-      subtitle: `#${channelId}`,
-      body: formatReplyToast(message),
-      type: "info",
-      desktop: "when-inactive",
-    });
-  }
-
-  private notifyChannelMessage(channelId: string, message: ChatMessage): void {
-    if (this.notifiedMessageIds.has(message.id)) return;
-    this.notifiedMessageIds.add(message.id);
-    this.notifyFn({
-      title: "Gloomberb chat",
-      subtitle: `#${channelId}`,
-      body: formatChannelToast(channelId, message),
+      subtitle: `#${notification.channelId}`,
+      body,
       type: "info",
       desktop: "when-inactive",
     });

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -68,7 +68,7 @@ export interface ChatChannelState {
 
 export interface ChatNotification {
   id: string;
-  type: "reply";
+  type: "reply" | "mention" | "channel";
   channelId: string;
   messageId: string;
   createdAt: string;


### PR DESCRIPTION
## Summary
- display chat notifications only from server-issued notification events
- keep transcript refreshes from creating local notification side effects
- cover missing desktop transcript hydration and server-issued mention/channel notifications

## Checks
- bun test src/plugins/builtin/chat-controller.test.ts src/utils/api-client.test.ts
- bun run desktop:view:build