### PR TITLE
Fix pane activation from command bar Enter

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -10,6 +10,7 @@ import type { DataProvider } from "../../types/data-provider";
 import type { TickerRecord } from "../../types/ticker";
 import type { PluginRegistry } from "../../plugins/registry";
 import type { PaneTemplateCreateOptions } from "../../types/plugin";
+import { useShortcut } from "../../react/input";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -236,6 +237,15 @@ function ThemeProbe() {
   return <text>{`theme:${useThemeId()}`}</text>;
 }
 
+function UnhandledEnterProbe({ onEnter }: { onEnter: () => void }) {
+  useShortcut((event) => {
+    if (event.name === "enter" || event.name === "return") {
+      onEnter();
+    }
+  });
+  return null;
+}
+
 function CommandBarHarness({
   query,
   disabledPlugins = [],
@@ -251,6 +261,7 @@ function CommandBarHarness({
   hasPaneSettings,
   onCheckForUpdates,
   onAction,
+  onUnhandledEnter,
 }: {
   query: string;
   disabledPlugins?: string[];
@@ -266,6 +277,7 @@ function CommandBarHarness({
   hasPaneSettings?: (paneId: string) => boolean;
   onCheckForUpdates?: () => void | Promise<void>;
   onAction?: (action: AppAction) => void;
+  onUnhandledEnter?: () => void;
 }) {
   let config = {
     ...createDefaultConfig("/tmp/gloomberb-test"),
@@ -330,6 +342,7 @@ function CommandBarHarness({
               onCheckForUpdates={onCheckForUpdates}
             />
           )}
+          {onUnhandledEnter && <UnhandledEnterProbe onEnter={onUnhandledEnter} />}
         </TestDialogProvider>
       </AppContext>
     </ThemeProvider>
@@ -1040,6 +1053,38 @@ describe("CommandBar", () => {
         ticker: makeTicker("AAPL", "Apple Inc."),
       },
     }]);
+  });
+
+  test("consumes enter before focused pane shortcuts when executing a pane shortcut", async () => {
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
+    let leakedEnterCount = 0;
+
+    testSetup = await testRender(<CommandBarHarness
+      query="PF"
+      live
+      onUnhandledEnter={() => {
+        leakedEnterCount += 1;
+      }}
+      configurePluginRegistry={(pluginRegistry) => {
+        pluginRegistry.createPaneFromTemplateAsyncFn = async (templateId, options) => {
+          created.push({ templateId, options });
+        };
+      }}
+    />, {
+      width: 100,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(created).toEqual([{ templateId: "new-portfolio-pane", options: undefined }]);
+    expect(leakedEnterCount).toBe(0);
   });
 
   test("typing a chat channel shortcut opens that channel directly", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -2,8 +2,7 @@ import { Box, Input, ScrollBox, Text, Textarea, useUiCapabilities } from "../../
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { TextAttributes, type InputRenderable, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
-import { useNativeRenderer } from "../../ui";
-import { useViewport } from "../../react/input";
+import { useShortcut, useViewport } from "../../react/input";
 import { Button, NumberField, Spinner, TextField } from "../ui";
 import { NativeSelect, openNativeSelect, type NativeSelectElement } from "../ui/native-select";
 import { ToggleList } from "../toggle-list";
@@ -661,7 +660,6 @@ export function CommandBar({
   const stateRef = useRef(state);
   stateRef.current = state;
   const { symbol: activeTickerSymbol, ticker: activeTickerData, financials: activeFinancials } = useFocusedTicker();
-  const renderer = useNativeRenderer();
   const { width: termWidth, height: termHeight } = useViewport();
   const { nativePaneChrome, cellWidthPx = 8, cellHeightPx = 18 } = useUiCapabilities();
   const availableCommands = useMemo(
@@ -4842,343 +4840,277 @@ export function CommandBar({
     }
   }, [currentRoute, pluginRegistry, updateTopRoute, updateWorkflowValue]);
 
-  useEffect(() => {
-    const keyInput = renderer.keyInput as typeof renderer.keyInput & {
-      onInternal?: (event: "keypress", handler: (event: {
-        name: string;
-        sequence?: string;
-        ctrl?: boolean;
-        option?: boolean;
-        meta?: boolean;
-        shift?: boolean;
-        stopPropagation: () => void;
-        preventDefault: () => void;
-      }) => void) => void;
-      offInternal?: (event: "keypress", handler: (event: {
-        name: string;
-        sequence?: string;
-        ctrl?: boolean;
-        option?: boolean;
-        meta?: boolean;
-        shift?: boolean;
-        stopPropagation: () => void;
-        preventDefault: () => void;
-      }) => void) => void;
-    };
-    if (!keyInput) return undefined;
-    const handleKeyPress = (event: {
-      name: string;
-      sequence?: string;
-      ctrl?: boolean;
-      option?: boolean;
-      meta?: boolean;
-      shift?: boolean;
-      stopPropagation: () => void;
-      preventDefault: () => void;
-    }) => {
-      if (event.name === "escape" || event.name === "`") {
-        event.stopPropagation();
-        event.preventDefault();
-        dismissCommandBar();
-        return;
-      }
+  useShortcut((event) => {
+    if (event.name === "escape" || event.name === "`") {
+      event.stopPropagation();
+      event.preventDefault();
+      dismissCommandBar();
+      return;
+    }
 
-      if (currentRoute?.kind === "confirm") {
-        if (isPlainBackspace(event)) {
-          event.stopPropagation();
-          event.preventDefault();
-          popRoute();
-          return;
-        }
-        if (event.name === "return" || event.name === "enter" || event.name === "y") {
-          event.stopPropagation();
-          event.preventDefault();
-          void confirmCurrentRoute();
-          return;
-        }
-        if (event.name === "n") {
-          event.stopPropagation();
-          event.preventDefault();
-          popRoute();
-        }
-        return;
-      }
-
-      if (
-        currentRoute
-        && (currentRoute.kind === "mode"
-          || currentRoute.kind === "picker"
-          || currentRoute.kind === "pane-settings")
-        && isPlainBackspace(event)
-        && currentRoute.query.length === 0
-      ) {
+    if (currentRoute?.kind === "confirm") {
+      if (isPlainBackspace(event)) {
         event.stopPropagation();
         event.preventDefault();
         popRoute();
         return;
       }
-
-      if (currentRoute?.kind === "workflow") {
-        const visibleFields = getVisibleWorkflowFields(currentRoute.fields, currentRoute.values);
-        const activeField = visibleFields.find((field) => field.id === currentRoute.activeFieldId) ?? visibleFields[0];
-        const activeTextarea = activeField?.type === "textarea";
-
-        if (isPlainBackspace(event)) {
-          const activeValue = activeField
-            ? getWorkflowFieldStringValue(activeField, currentRoute.values[activeField.id])
-            : "";
-          if (!activeField || !isWorkflowTextField(activeField) || activeValue.length === 0) {
-            event.stopPropagation();
-            event.preventDefault();
-            popRoute();
-            return;
-          }
-        }
-
-        if (event.name === "tab") {
-          event.stopPropagation();
-          event.preventDefault();
-          moveWorkflowFocus(event.shift ? -1 : 1);
-          return;
-        }
-
-        if (activeTextarea && event.ctrl && event.name === "s") {
-          event.stopPropagation();
-          event.preventDefault();
-          void submitWorkflowRoute(currentRoute);
-          return;
-        }
-
-        if (activeTextarea && (event.name === "up" || event.name === "down" || (event.ctrl && (event.name === "p" || event.name === "n")))) {
-          return;
-        }
-
-        if (event.name === "up" || (event.ctrl && event.name === "p")) {
-          event.stopPropagation();
-          event.preventDefault();
-          moveWorkflowFocus(-1);
-          return;
-        }
-
-        if (event.name === "down" || (event.ctrl && event.name === "n")) {
-          event.stopPropagation();
-          event.preventDefault();
-          moveWorkflowFocus(1);
-          return;
-        }
-
-        if (event.name === "space" && activeField?.type === "toggle") {
-          event.stopPropagation();
-          event.preventDefault();
-          updateWorkflowValue(activeField.id, !coerceFieldBoolean(currentRoute.values[activeField.id]));
-          return;
-        }
-
-        if (
-          event.name === "return"
-          || event.name === "enter"
-          || (nativePaneChrome && event.name === "space" && activeField?.type === "select")
-        ) {
-          if (!activeField) return;
-          if (activeField.type === "select" || activeField.type === "multi-select" || activeField.type === "ordered-multi-select" || activeField.type === "toggle") {
-            event.stopPropagation();
-            event.preventDefault();
-            if (nativePaneChrome && activeField.type === "select") {
-              openNativeSelect(workflowNativeSelectRefs.current.get(activeField.id));
-              return;
-            }
-            openWorkflowFieldPicker(currentRoute, activeField);
-            return;
-          }
-        }
-
-        return;
-      }
-
-      if (currentRoute?.kind === "picker") {
-        if (event.name === "up" || (event.ctrl && event.name === "p")) {
-          event.stopPropagation();
-          event.preventDefault();
-          moveListSelection(-1);
-          return;
-        }
-        if (event.name === "down" || (event.ctrl && event.name === "n")) {
-          event.stopPropagation();
-          event.preventDefault();
-          moveListSelection(1);
-          return;
-        }
-        if (currentRoute.pickerId === "field-multi-select" && (event.name === "space" || event.sequence === " ")) {
-          event.stopPropagation();
-          event.preventDefault();
-          const listState = visibleListStateRef.current;
-          const selected = listState?.results[listState.selectedIdx];
-          if (!selected) return;
-          handleMultiSelectToggle(selected.id);
-          return;
-        }
-        if (currentRoute.pickerId === "field-multi-select" && event.name === "[") {
-          event.stopPropagation();
-          event.preventDefault();
-          handleMultiSelectMove("up");
-          return;
-        }
-        if (currentRoute.pickerId === "field-multi-select" && event.name === "]") {
-          event.stopPropagation();
-          event.preventDefault();
-          handleMultiSelectMove("down");
-          return;
-        }
-        if (event.name === "return" || event.name === "enter") {
-          event.stopPropagation();
-          event.preventDefault();
-          if (currentRoute.pickerId === "field-multi-select") {
-            commitMultiSelectPicker();
-            return;
-          }
-          activateListSelection();
-        }
-        return;
-      }
-
-      if (currentRoute?.kind === "pane-settings") {
-        if (event.name === "up" || (event.ctrl && event.name === "p")) {
-          event.stopPropagation();
-          event.preventDefault();
-          moveListSelection(-1);
-          return;
-        }
-        if (event.name === "down" || (event.ctrl && event.name === "n")) {
-          event.stopPropagation();
-          event.preventDefault();
-          moveListSelection(1);
-          return;
-        }
-        if (event.name === "return" || event.name === "enter" || event.name === "space") {
-          event.stopPropagation();
-          event.preventDefault();
-          activateListSelection();
-        }
-        return;
-      }
-
-      if (themePickerActive) {
-        if (event.name === "up" || (event.ctrl && event.name === "p")) {
-          event.stopPropagation();
-          event.preventDefault();
-          themePickerRef.current?.move(-1);
-          return;
-        }
-        if (event.name === "down" || (event.ctrl && event.name === "n")) {
-          event.stopPropagation();
-          event.preventDefault();
-          themePickerRef.current?.move(1);
-          return;
-        }
-        if (event.name === "return" || event.name === "enter") {
-          event.stopPropagation();
-          event.preventDefault();
-          themePickerRef.current?.commit();
-          return;
-        }
-      }
-
-      const activeListState = visibleListStateRef.current;
-      if (!activeListState) return;
-
-      if (!currentRoute && event.name === "tab") {
-        if (acceptRootShortcutTab()) {
-          event.stopPropagation();
-          event.preventDefault();
-          return;
-        }
-      }
-
-      if (event.name === "down" || (event.ctrl && event.name === "n")) {
+      if (event.name === "return" || event.name === "enter" || event.name === "y") {
         event.stopPropagation();
         event.preventDefault();
-        moveListSelection(1);
+        void confirmCurrentRoute();
+        return;
+      }
+      if (event.name === "n") {
+        event.stopPropagation();
+        event.preventDefault();
+        popRoute();
+      }
+      return;
+    }
+
+    if (
+      currentRoute
+      && (currentRoute.kind === "mode"
+        || currentRoute.kind === "picker"
+        || currentRoute.kind === "pane-settings")
+      && isPlainBackspace(event)
+      && currentRoute.query.length === 0
+    ) {
+      event.stopPropagation();
+      event.preventDefault();
+      popRoute();
+      return;
+    }
+
+    if (currentRoute?.kind === "workflow") {
+      const visibleFields = getVisibleWorkflowFields(currentRoute.fields, currentRoute.values);
+      const activeField = visibleFields.find((field) => field.id === currentRoute.activeFieldId) ?? visibleFields[0];
+      const activeTextarea = activeField?.type === "textarea";
+
+      if (isPlainBackspace(event)) {
+        const activeValue = activeField
+          ? getWorkflowFieldStringValue(activeField, currentRoute.values[activeField.id])
+          : "";
+        if (!activeField || !isWorkflowTextField(activeField) || activeValue.length === 0) {
+          event.stopPropagation();
+          event.preventDefault();
+          popRoute();
+          return;
+        }
+      }
+
+      if (event.name === "tab") {
+        event.stopPropagation();
+        event.preventDefault();
+        moveWorkflowFocus(event.shift ? -1 : 1);
+        return;
+      }
+
+      if (activeTextarea && event.ctrl && event.name === "s") {
+        event.stopPropagation();
+        event.preventDefault();
+        void submitWorkflowRoute(currentRoute);
+        return;
+      }
+
+      if (activeTextarea && (event.name === "up" || event.name === "down" || (event.ctrl && (event.name === "p" || event.name === "n")))) {
         return;
       }
 
       if (event.name === "up" || (event.ctrl && event.name === "p")) {
         event.stopPropagation();
         event.preventDefault();
+        moveWorkflowFocus(-1);
+        return;
+      }
+
+      if (event.name === "down" || (event.ctrl && event.name === "n")) {
+        event.stopPropagation();
+        event.preventDefault();
+        moveWorkflowFocus(1);
+        return;
+      }
+
+      if (event.name === "space" && activeField?.type === "toggle") {
+        event.stopPropagation();
+        event.preventDefault();
+        updateWorkflowValue(activeField.id, !coerceFieldBoolean(currentRoute.values[activeField.id]));
+        return;
+      }
+
+      if (
+        event.name === "return"
+        || event.name === "enter"
+        || (nativePaneChrome && event.name === "space" && activeField?.type === "select")
+      ) {
+        if (!activeField) return;
+        if (activeField.type === "select" || activeField.type === "multi-select" || activeField.type === "ordered-multi-select" || activeField.type === "toggle") {
+          event.stopPropagation();
+          event.preventDefault();
+          if (nativePaneChrome && activeField.type === "select") {
+            openNativeSelect(workflowNativeSelectRefs.current.get(activeField.id));
+            return;
+          }
+          openWorkflowFieldPicker(currentRoute, activeField);
+          return;
+        }
+      }
+
+      return;
+    }
+
+    if (currentRoute?.kind === "picker") {
+      if (event.name === "up" || (event.ctrl && event.name === "p")) {
+        event.stopPropagation();
+        event.preventDefault();
         moveListSelection(-1);
         return;
       }
-
-      if ((event.meta && (event.name === "backspace" || event.name === "delete")) || (event.ctrl && event.name === "u")) {
+      if (event.name === "down" || (event.ctrl && event.name === "n")) {
         event.stopPropagation();
         event.preventDefault();
-        setActiveListQuery("");
+        moveListSelection(1);
         return;
       }
-
-      if ((event.ctrl && event.name === "w") || (event.meta && (event.name === "h" || event.name === "u"))) {
+      if (currentRoute.pickerId === "field-multi-select" && (event.name === "space" || event.sequence === " ")) {
         event.stopPropagation();
         event.preventDefault();
-        const trimmed = activeListState.query.replace(/\s+$/, "");
-        const nextQuery = trimmed.replace(/[^\s]+$/, "").replace(/\s+$/, "");
-        setActiveListQuery(nextQuery);
+        const listState = visibleListStateRef.current;
+        const selected = listState?.results[listState.selectedIdx];
+        if (!selected) return;
+        handleMultiSelectToggle(selected.id);
         return;
       }
-
-      const pluginToggleMode = (currentRoute?.kind === "mode" && currentRoute.screen === "plugins")
-        || (!currentRoute && rootModeInfo.kind === "plugins");
-      if (pluginToggleMode && event.name === "space") {
+      if (currentRoute.pickerId === "field-multi-select" && event.name === "[") {
         event.stopPropagation();
         event.preventDefault();
-        const selected = activeListState.results[activeListState.selectedIdx];
-        if (selected?.pluginToggle) {
-          void selected.pluginToggle();
-        }
+        handleMultiSelectMove("up");
         return;
       }
-
+      if (currentRoute.pickerId === "field-multi-select" && event.name === "]") {
+        event.stopPropagation();
+        event.preventDefault();
+        handleMultiSelectMove("down");
+        return;
+      }
       if (event.name === "return" || event.name === "enter") {
         event.stopPropagation();
         event.preventDefault();
-        if (event.shift) {
-          activateListSelection({ secondary: true });
+        if (currentRoute.pickerId === "field-multi-select") {
+          commitMultiSelectPicker();
           return;
         }
         activateListSelection();
       }
-    };
-
-    if (keyInput.onInternal) {
-      keyInput.onInternal("keypress", handleKeyPress);
-    } else {
-      keyInput.on("keypress", handleKeyPress);
+      return;
     }
-    return () => {
-      if (keyInput.offInternal) {
-        keyInput.offInternal("keypress", handleKeyPress);
-      } else {
-        keyInput.off("keypress", handleKeyPress);
+
+    if (currentRoute?.kind === "pane-settings") {
+      if (event.name === "up" || (event.ctrl && event.name === "p")) {
+        event.stopPropagation();
+        event.preventDefault();
+        moveListSelection(-1);
+        return;
       }
-    };
-  }, [
-    activateListSelection,
-    acceptRootShortcutTab,
-    commitMultiSelectPicker,
-    confirmCurrentRoute,
-    currentRoute,
-    dismissCommandBar,
-    handleMultiSelectMove,
-    handleMultiSelectToggle,
-    moveListSelection,
-    moveWorkflowFocus,
-    nativePaneChrome,
-    openWorkflowFieldPicker,
-    popRoute,
-    renderer,
-    rootModeInfo.kind,
-    setActiveListQuery,
-    themePickerActive,
-    updateWorkflowValue,
-  ]);
+      if (event.name === "down" || (event.ctrl && event.name === "n")) {
+        event.stopPropagation();
+        event.preventDefault();
+        moveListSelection(1);
+        return;
+      }
+      if (event.name === "return" || event.name === "enter" || event.name === "space") {
+        event.stopPropagation();
+        event.preventDefault();
+        activateListSelection();
+      }
+      return;
+    }
+
+    if (themePickerActive) {
+      if (event.name === "up" || (event.ctrl && event.name === "p")) {
+        event.stopPropagation();
+        event.preventDefault();
+        themePickerRef.current?.move(-1);
+        return;
+      }
+      if (event.name === "down" || (event.ctrl && event.name === "n")) {
+        event.stopPropagation();
+        event.preventDefault();
+        themePickerRef.current?.move(1);
+        return;
+      }
+      if (event.name === "return" || event.name === "enter") {
+        event.stopPropagation();
+        event.preventDefault();
+        themePickerRef.current?.commit();
+        return;
+      }
+    }
+
+    const activeListState = visibleListStateRef.current;
+    if (!activeListState) return;
+
+    if (!currentRoute && event.name === "tab") {
+      if (acceptRootShortcutTab()) {
+        event.stopPropagation();
+        event.preventDefault();
+        return;
+      }
+    }
+
+    if (event.name === "down" || (event.ctrl && event.name === "n")) {
+      event.stopPropagation();
+      event.preventDefault();
+      moveListSelection(1);
+      return;
+    }
+
+    if (event.name === "up" || (event.ctrl && event.name === "p")) {
+      event.stopPropagation();
+      event.preventDefault();
+      moveListSelection(-1);
+      return;
+    }
+
+    if ((event.meta && (event.name === "backspace" || event.name === "delete")) || (event.ctrl && event.name === "u")) {
+      event.stopPropagation();
+      event.preventDefault();
+      setActiveListQuery("");
+      return;
+    }
+
+    if ((event.ctrl && event.name === "w") || (event.meta && (event.name === "h" || event.name === "u"))) {
+      event.stopPropagation();
+      event.preventDefault();
+      const trimmed = activeListState.query.replace(/\s+$/, "");
+      const nextQuery = trimmed.replace(/[^\s]+$/, "").replace(/\s+$/, "");
+      setActiveListQuery(nextQuery);
+      return;
+    }
+
+    const pluginToggleMode = (currentRoute?.kind === "mode" && currentRoute.screen === "plugins")
+      || (!currentRoute && rootModeInfo.kind === "plugins");
+    if (pluginToggleMode && event.name === "space") {
+      event.stopPropagation();
+      event.preventDefault();
+      const selected = activeListState.results[activeListState.selectedIdx];
+      if (selected?.pluginToggle) {
+        void selected.pluginToggle();
+      }
+      return;
+    }
+
+    if (event.name === "return" || event.name === "enter") {
+      event.stopPropagation();
+      event.preventDefault();
+      if (event.shift) {
+        activateListSelection({ secondary: true });
+        return;
+      }
+      activateListSelection();
+    }
+  }, { phase: "before" });
 
   const barWidth = nativePaneChrome
     ? Math.max(46, Math.min(78, termWidth - 10, Math.floor(termWidth * 0.64)))

--- a/src/components/data-table-view.test.tsx
+++ b/src/components/data-table-view.test.tsx
@@ -130,7 +130,7 @@ async function renderSettled() {
   });
 }
 
-async function emitKeypress(event: { name?: string; sequence?: string }) {
+async function emitKeypress(event: { name?: string; sequence?: string; defaultPrevented?: boolean; propagationStopped?: boolean }) {
   await act(async () => {
     testSetup!.renderer.keyInput.emit("keypress", {
       ctrl: false,
@@ -139,6 +139,8 @@ async function emitKeypress(event: { name?: string; sequence?: string }) {
       shift: false,
       eventType: "press",
       repeated: false,
+      defaultPrevented: false,
+      propagationStopped: false,
       preventDefault: () => {},
       stopPropagation: () => {},
       ...event,
@@ -166,6 +168,14 @@ describe("DataTableView", () => {
     await emitKeypress({ name: "enter", sequence: "\r" });
     await renderSettled();
     expect(testSetup.captureCharFrame()).toContain("activated=First row");
+
+    await emitKeypress({ name: "j", sequence: "j" });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).toContain("selected=Second row activated=First row");
+
+    await emitKeypress({ name: "enter", sequence: "\r", defaultPrevented: true });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).toContain("selected=Second row activated=First row");
   });
 
   test("keeps keyboard navigation usable without external row selection", async () => {

--- a/src/components/data-table-view.tsx
+++ b/src/components/data-table-view.tsx
@@ -188,6 +188,7 @@ export function DataTableView<
   }, [activateIndex, effectiveSelectedIndex, navigableIndices]);
 
   useShortcut((event) => {
+    if (event.defaultPrevented || event.propagationStopped) return;
     if (!focused || !keyboardNavigation) return;
 
     if (onRootKeyDown?.(event)) return;

--- a/src/components/table-view-shared.tsx
+++ b/src/components/table-view-shared.tsx
@@ -30,6 +30,8 @@ export interface TableViewKeyEvent {
   meta?: boolean;
   option?: boolean;
   shift?: boolean;
+  readonly defaultPrevented?: boolean;
+  readonly propagationStopped?: boolean;
   preventDefault?: () => void;
   stopPropagation?: () => void;
 }

--- a/src/components/ticker-list-table-view.tsx
+++ b/src/components/ticker-list-table-view.tsx
@@ -162,6 +162,7 @@ export function TickerListTableView({
   }, [activateIndex, selectedIndex, tableProps.tickers.length]);
 
   useShortcut((event) => {
+    if (event.defaultPrevented || event.propagationStopped) return;
     if (!focused || !keyboardNavigation) return;
 
     if (onRootKeyDown?.(event)) return;


### PR DESCRIPTION
Fixes a leaked Enter keypress from the command bar that could be seen by the newly focused pane after launching shortcuts like WEI.
The command bar now consumes activation through the shared shortcut pipeline before pane shortcuts run, and shared table wrappers ignore already-consumed key events.
This keeps datatable panes focused on their selected first row without immediately opening ticker details.
