### PR TITLE
Fix comparison chart h/l navigation

### DIFF
--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -873,7 +873,6 @@ function ComparisonStockChartView({
   ]);
   const axisSectionWidth = axisWidth + axisRightPadding;
   const chartWidth = Math.max(width - axisSectionWidth - axisGap, minChartWidth);
-  const maxCursorX = chartWidth - 1;
   const seriesDates = useMemo(() => getUniqueSortedSeriesDates(series), [series]);
   const visibleDateWindow = useMemo(() => buildVisibleDateWindow(seriesDates, viewState.panOffset, viewState.zoomLevel), [seriesDates, viewState.panOffset, viewState.zoomLevel]);
   const activePreset = resolveVisibleActivePreset(seriesDates, {
@@ -1004,6 +1003,16 @@ function ComparisonStockChartView({
         ? current
         : { ...current, cursorX: next.cursorX, cursorY: next.cursorY }
     ));
+  };
+
+  const selectSymbolByOffset = (offset: number) => {
+    setViewState((current) => {
+      const currentIndex = Math.max(symbols.indexOf(current.selectedSymbol ?? symbols[0] ?? ""), 0);
+      return {
+        ...current,
+        selectedSymbol: symbols[clamp(currentIndex + offset, 0, symbols.length - 1)] ?? current.selectedSymbol,
+      };
+    });
   };
 
   useEffect(() => {
@@ -1425,22 +1434,6 @@ function ComparisonStockChartView({
       case "t":
         onEditTickers?.();
         return;
-      case "h":
-        mouseCrosshairDisabledRef.current = false;
-        cursorMotionKindRef.current = "discrete";
-        setViewState((current) => ({
-          ...current,
-          cursorX: current.cursorX === null ? maxCursorX : Math.max(current.cursorX - 1, 0),
-        }));
-        return;
-      case "l":
-        mouseCrosshairDisabledRef.current = false;
-        cursorMotionKindRef.current = "discrete";
-        setViewState((current) => ({
-          ...current,
-          cursorX: current.cursorX === null ? 0 : Math.min(current.cursorX + 1, maxCursorX),
-        }));
-        return;
       case "escape":
         mouseCrosshairDisabledRef.current = true;
         updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
@@ -1451,42 +1444,20 @@ function ComparisonStockChartView({
         if (viewState.selectedSymbol) onOpenSymbol(viewState.selectedSymbol);
         return;
       case "left":
-        setViewState((current) => {
-          const currentIndex = Math.max(symbols.indexOf(current.selectedSymbol ?? symbols[0] ?? ""), 0);
-          return {
-            ...current,
-            selectedSymbol: symbols[Math.max(currentIndex - 1, 0)] ?? current.selectedSymbol,
-          };
-        });
+      case "h":
+        selectSymbolByOffset(-1);
         return;
       case "right":
-        setViewState((current) => {
-          const currentIndex = Math.max(symbols.indexOf(current.selectedSymbol ?? symbols[0] ?? ""), 0);
-          return {
-            ...current,
-            selectedSymbol: symbols[Math.min(currentIndex + 1, symbols.length - 1)] ?? current.selectedSymbol,
-          };
-        });
+      case "l":
+        selectSymbolByOffset(1);
         return;
       case "up":
       case "k":
-        setViewState((current) => {
-          const currentIndex = Math.max(symbols.indexOf(current.selectedSymbol ?? symbols[0] ?? ""), 0);
-          return {
-            ...current,
-            selectedSymbol: symbols[Math.max(currentIndex - legendColumns, 0)] ?? current.selectedSymbol,
-          };
-        });
+        selectSymbolByOffset(-legendColumns);
         return;
       case "down":
       case "j":
-        setViewState((current) => {
-          const currentIndex = Math.max(symbols.indexOf(current.selectedSymbol ?? symbols[0] ?? ""), 0);
-          return {
-            ...current,
-            selectedSymbol: symbols[Math.min(currentIndex + legendColumns, symbols.length - 1)] ?? current.selectedSymbol,
-          };
-        });
+        selectSymbolByOffset(legendColumns);
         return;
     }
 

--- a/src/plugins/builtin/comparison-chart.test.tsx
+++ b/src/plugins/builtin/comparison-chart.test.tsx
@@ -346,7 +346,7 @@ describe("comparisonChartPlugin", () => {
     expect(frame).toContain("AUTO");
   });
 
-  test("moves legend selection with the keyboard and opens the selected ticker on Enter", async () => {
+  test("moves legend selection with arrow and h/l keys, then opens the selected ticker on Enter", async () => {
     const spy = { selected: [] as string[], focused: [] as string[] };
     const provider = createProvider({
       AAPL: [100, 102, 104],
@@ -378,6 +378,8 @@ describe("comparisonChartPlugin", () => {
 
     await flushFrames();
     await pressComparisonInput(() => testSetup!.mockInput.pressArrow("right"));
+    await pressComparisonInput(() => testSetup!.mockInput.pressKey("l"));
+    await pressComparisonInput(() => testSetup!.mockInput.pressKey("h"));
     await pressComparisonInput(() => testSetup!.mockInput.pressEnter());
 
     expect(spy.selected).toEqual(["MSFT"]);


### PR DESCRIPTION
Updates the comparison chart keyboard handler so h/l move ticker legend selection just like left/right arrows, while j/k continue moving by legend rows.
Removes the old h/l crosshair-only path that prevented selecting neighboring tickers from the keyboard.
Adds a focused regression for keyboard selection before opening the selected ticker.

Fixes #324.
