### PR TITLE
Fix command bar ticker search

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -986,6 +986,25 @@ describe("CommandBar", () => {
     expect(frame).toContain("Security Description");
   });
 
+  test("T without an active ticker opens ticker search on enter", async () => {
+    testSetup = await testRender(<CommandBarHarness query="T" />, {
+      width: 100,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("Description");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Back");
+    expect(frame).toContain("Security Description");
+  });
+
   test("QQ with an active ticker shows ghost completion and tab inserts the symbol", async () => {
     testSetup = await testRender(<CommandBarHarness query="QQ" live selectedTicker="AAPL" showQueryState />, {
       width: 100,
@@ -1134,6 +1153,121 @@ describe("CommandBar", () => {
     expect(frame).toContain("AAOI");
   });
 
+  test("keeps exact T ticker matches above noisy provider matches", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="T AMD"
+        extraTickers={[
+          makeTicker("AMDL", "GraniteShares 2x Long AMD Daily"),
+          makeTicker("AMUU", "Direxion Daily AMD Bull 2X ETF"),
+        ]}
+        dataProvider={makeDataProvider(async () => [
+          { providerId: "yahoo", symbol: "DES", name: "AMD-themed synthetic listing", exchange: "ASX", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "DES2", name: "AMD-themed secondary listing", exchange: "LSE", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "AMD", name: "Advanced Micro Devices", exchange: "NASDAQ", type: "EQUITY" },
+        ])}
+      />,
+      { width: 100, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+    const frame = await waitForFrameToContain("DES2");
+    const resultLines = frame
+      .split("\n")
+      .filter((line) => /\b(AMD|DES2?|DES)\b/.test(line) && /\b(NASDAQ|ASX|LSE)\b/.test(line));
+
+    expect(resultLines[0]).toContain("AMD");
+    expect(resultLines[0]).toContain("NASDAQ");
+  });
+
+  test("loads exact provider matches for plain ticker-shaped root queries", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="amd"
+        extraTickers={[
+          makeTicker("AMDL", "GraniteShares 2x Long AMD Daily"),
+          makeTicker("AMUU", "Direxion Daily AMD Bull 2X ETF"),
+        ]}
+        dataProvider={makeDataProvider(async () => [
+          { providerId: "yahoo", symbol: "DES", name: "AMD-themed synthetic listing", exchange: "ASX", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "AMD", name: "Advanced Micro Devices", exchange: "NASDAQ", type: "EQUITY" },
+        ])}
+      />,
+      { width: 100, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+    const frame = await waitForFrameToContain("DES");
+    const resultLines = frame
+      .split("\n")
+      .filter((line) => /\b(AMD|AMDL|AMUU|DES)\b/.test(line) && /\b(NASDAQ|ASX)\b/.test(line));
+
+    expect(resultLines[0]).toContain("AMD");
+    expect(resultLines[0]).toContain("NASDAQ");
+  });
+
+  test("keeps pane matches visible alongside plain ticker provider results", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="opti"
+        dataProvider={makeDataProvider(async () => [
+          { providerId: "yahoo", symbol: "OPTI", name: "Optimi Health Corp", exchange: "CSE", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "OPTI", name: "Optimi Health Corp", exchange: "NEO", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "OPTI", name: "Optimi Health Corp", exchange: "LSE", type: "EQUITY" },
+        ])}
+        configurePluginRegistry={(pluginRegistry) => {
+          const paneTemplates = pluginRegistry.paneTemplates as Map<string, any>;
+          paneTemplates.set("options-pane", {
+            id: "options-pane",
+            paneId: "options",
+            label: "Options",
+            description: "Options chain for the selected ticker",
+            shortcut: { prefix: "OMON", argPlaceholder: "ticker", argKind: "ticker" },
+            canCreate: (context: any, options?: PaneTemplateCreateOptions) => (
+              context.activeTicker !== null || !!options?.arg
+            ),
+          });
+        }}
+      />,
+      { width: 100, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+    const frame = await waitForFrameToContain("OPTI");
+    expect(frame).toContain("Options");
+    expect(frame).toContain("OMON");
+  });
+
+  test("clears stale provider rows after a plain ticker root search is cleared", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query=""
+        live
+        dataProvider={makeDataProvider(async () => [
+          { providerId: "yahoo", symbol: "OPTI", name: "Optimi Health Corp", exchange: "CSE", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "OPTI", name: "Optimi Health Corp", exchange: "NEO", type: "EQUITY" },
+          { providerId: "yahoo", symbol: "OPTI", name: "Optimi Health Corp", exchange: "LSE", type: "EQUITY" },
+        ])}
+      />,
+      { width: 100, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      await testSetup!.mockInput.typeText("opti");
+      await testSetup!.renderOnce();
+    });
+
+    await waitForFrameToContain("OPTI");
+    await emitKeypress(testSetup, { name: "u", ctrl: true });
+    await renderFrames(2);
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Search");
+    expect(frame).toContain("Tickers");
+    expect(frame).not.toContain("OPTI");
+  });
+
   test("DES MSFT opens an exact ticker directly", async () => {
     const pinned: string[] = [];
 
@@ -1158,6 +1292,33 @@ describe("CommandBar", () => {
     });
 
     expect(pinned).toEqual(["MSFT"]);
+  });
+
+  test("T AMD opens an exact ticker directly", async () => {
+    const pinned: string[] = [];
+
+    testSetup = await testRender(
+      <CommandBarHarness
+        query="T AMD"
+        extraTickers={[makeTicker("AMD", "Advanced Micro Devices")]}
+        configurePluginRegistry={(pluginRegistry) => {
+          pluginRegistry.pinTicker = (symbol) => {
+            pinned.push(symbol);
+          };
+        }}
+      />,
+      { width: 100, height: 20 },
+    );
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(pinned).toEqual(["AMD"]);
   });
 
   test("AW AAPL uses the active watchlist target by default", async () => {
@@ -2026,6 +2187,66 @@ describe("CommandBar", () => {
     });
 
     expect(created).toEqual([{ templateId: "news-top-pane", options: undefined }]);
+  });
+
+  test("surfaces ticker-required pane templates by name without an active ticker", async () => {
+    testSetup = await testRender(<CommandBarHarness
+      query="Options"
+      extraTickers={[makeTicker("^RUT", "Chicago Board Options Exchange Russell 2000")]}
+      configurePluginRegistry={(pluginRegistry) => {
+        const paneTemplates = pluginRegistry.paneTemplates as Map<string, any>;
+        paneTemplates.set("options-pane", {
+          id: "options-pane",
+          paneId: "options",
+          label: "Options",
+          description: "Options chain for the selected ticker",
+          keywords: ["options", "chain", "calls", "puts"],
+          shortcut: { prefix: "OMON", argPlaceholder: "ticker", argKind: "ticker" },
+          canCreate: (context: any, options?: PaneTemplateCreateOptions) => (
+            context.activeTicker !== null || !!options?.arg
+          ),
+        });
+      }}
+    />, {
+      width: 100,
+      height: 18,
+    });
+
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Options");
+    expect(frame).toContain("OMON");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Back");
+    expect(frame).toContain("Ticker");
+  });
+
+  test("ranks exact ticker symbols before longer ticker prefixes in root search", async () => {
+    testSetup = await testRender(<CommandBarHarness
+      query="amd"
+      extraTickers={[
+        makeTicker("AMDL", "GraniteShares 2x Long AMD Daily ETF"),
+        makeTicker("AMD", "Advanced Micro Devices"),
+      ]}
+    />, {
+      width: 100,
+      height: 18,
+    });
+
+    await testSetup.renderOnce();
+
+    const tickerLines = testSetup.captureCharFrame()
+      .split("\n")
+      .filter((line) => /\bAMD\b|\bAMDL\b/.test(line));
+    expect(tickerLines[0]).toMatch(/\bAMD\b/);
+    expect(tickerLines[0]).not.toMatch(/\bAMDL\b/);
   });
 
   test("opens plugin command wizards inline inside the command bar", async () => {

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -185,6 +185,37 @@ const NATIVE_COMMAND_BAR_PADDING_X_PX = 14;
 const NATIVE_COMMAND_BAR_PADDING_Y_PX = 14;
 const QUICK_LOOK_TICKER_SEARCH_OPTIONS = { includeOptionContracts: false } as const;
 
+function normalizeCommandTickerSearchText(value: string): string {
+  return value.trim().toUpperCase().replace(/[^A-Z0-9]+/g, "");
+}
+
+function isLikelyPlainTickerSearch(query: string): boolean {
+  const trimmed = query.trim();
+  if (!trimmed || /\s/.test(trimmed)) return false;
+  if (!/^[A-Za-z0-9.^=\-/]+$/.test(trimmed)) return false;
+
+  const compact = normalizeCommandTickerSearchText(trimmed);
+  if (compact.length < 2) return false;
+  if (compact.length <= 6) return true;
+  return /[.^=\-/]/.test(trimmed) && compact.length <= 10;
+}
+
+function isExactTickerResultMatch(item: ResultItem, query: string): boolean {
+  if (item.kind !== "ticker" && item.kind !== "search") return false;
+  const normalizedQuery = normalizeCommandTickerSearchText(query);
+  if (!normalizedQuery) return false;
+  return normalizeCommandTickerSearchText(item.label) === normalizedQuery;
+}
+
+function getPaneTemplateArgKind(template: PaneTemplateDef): string | undefined {
+  return template.shortcut?.argKind ?? template.shortcut?.argPlaceholder;
+}
+
+function canPromptForPaneTemplateArg(template: PaneTemplateDef): boolean {
+  const argKind = getPaneTemplateArgKind(template);
+  return argKind === "ticker" || argKind === "ticker-list" || argKind === "tickers";
+}
+
 function getDefaultConfigBackupPath(): string {
   const home = typeof process !== "undefined" ? process.env.HOME : undefined;
   return `${home || "~"}/gloomberb-config-backup.json`;
@@ -563,9 +594,10 @@ const CommandBarListBody = memo(function CommandBarListBody({
 
         const isSelected = row.globalIdx === visibleListState.selectedIdx;
         const isHovered = row.globalIdx === visibleListState.hoveredIdx && !isSelected;
+        const itemRowKey = `item:${row.globalIdx}:${row.item.id}:${row.item.category}:${row.item.label}:${row.item.right || ""}`;
         return (
           <CommandBarListItemRow
-            key={row.item.id}
+            key={itemRowKey}
             item={row.item}
             globalIdx={row.globalIdx}
             isSelected={isSelected}
@@ -2446,7 +2478,7 @@ export function CommandBar({
       const argPlaceholder = template.shortcut?.argPlaceholder;
       return template.wizard.some((step) => step.type === "textarea" || step.key !== argPlaceholder);
     }
-    if (template.shortcut?.argPlaceholder === "ticker" || template.shortcut?.argPlaceholder === "tickers") {
+    if (canPromptForPaneTemplateArg(template)) {
       return !arg?.trim();
     }
     return false;
@@ -2632,6 +2664,57 @@ export function CommandBar({
       }]
   ), [mapTickerSearchCandidateToResultItem]);
 
+  const mergeTickerSearchResultItems = useCallback((
+    query: string,
+    preferredItems: ResultItem[],
+    fallbackItems: ResultItem[],
+  ): ResultItem[] => {
+    const merged: ResultItem[] = [];
+    const seen = new Set<string>();
+    const addItem = (item: ResultItem) => {
+      if (item.kind === "info") return;
+      const key = `${item.label.trim().toUpperCase()}:${(item.right || "").trim().toUpperCase()}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      merged.push(item);
+    };
+    preferredItems.forEach(addItem);
+    fallbackItems.forEach(addItem);
+    if (merged.length === 0) return fallbackItems;
+
+    return rankTickerSearchItems(merged, query)
+      .map((item) => isExactTickerResultMatch(item, query) && item.category !== "Saved"
+        ? { ...item, category: "Exact Match" }
+        : item);
+  }, []);
+
+  const mergePlainRootTickerResults = useCallback((
+    query: string,
+    providerItems: ResultItem[],
+    rootItems: ResultItem[],
+  ): ResultItem[] => {
+    const merged: ResultItem[] = [];
+    const seen = new Set<string>();
+    const addItem = (item: ResultItem, options?: { skipInfo?: boolean }) => {
+      if (options?.skipInfo && item.kind === "info") return;
+      const key = (item.kind === "ticker" || item.kind === "search")
+        ? `${item.kind}:${item.label.trim().toUpperCase()}:${(item.right || "").trim().toUpperCase()}`
+        : `${item.kind}:${item.id}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      merged.push(item);
+    };
+
+    providerItems
+      .filter((item) => item.category === "Exact Match" || isExactTickerResultMatch(item, query))
+      .forEach((item) => addItem(item, { skipInfo: true }));
+    rootItems.forEach((item) => addItem(item));
+    providerItems
+      .filter((item) => item.category !== "Exact Match" && !isExactTickerResultMatch(item, query))
+      .forEach((item) => addItem(item, { skipInfo: true }));
+    return merged.length > 0 ? merged : rootItems;
+  }, []);
+
   const buildTickerSearchCacheKey = useCallback((
     query: string,
     brokerId?: string | null,
@@ -2718,7 +2801,10 @@ export function CommandBar({
     activeCollectionId,
   }), [activeCollectionId, activeTickerSymbol, state.config, state.focusedPaneId]);
 
-  const getAvailablePaneTemplates = useCallback((options?: PaneTemplateCreateOptions): PaneTemplateDef[] => {
+  const getAvailablePaneTemplates = useCallback((
+    options?: PaneTemplateCreateOptions,
+    availability?: { includePromptableTickerTemplates?: boolean },
+  ): PaneTemplateDef[] => {
     const disabledPlugins = new Set(state.config.disabledPlugins || []);
     const context = getPaneTemplateContext();
     return [...pluginRegistry.paneTemplates.values()]
@@ -2727,7 +2813,12 @@ export function CommandBar({
         if (pluginId && disabledPlugins.has(pluginId)) return false;
         if (!template.canCreate) return true;
         try {
-          return template.canCreate(context, options);
+          const canCreate = template.canCreate(context, options);
+          if (canCreate) return true;
+          return !!availability?.includePromptableTickerTemplates
+            && !options?.arg
+            && !context.activeTicker
+            && canPromptForPaneTemplateArg(template);
         } catch (error) {
           commandBarLog.error("Pane template canCreate failed", {
             templateId: template.id,
@@ -2751,13 +2842,13 @@ export function CommandBar({
       const prefix = template.shortcut?.prefix?.toUpperCase();
       if (!prefix) return false;
       const arg = trimmed.slice(prefix.length).trim();
-      const argKind = template.shortcut?.argKind ?? template.shortcut?.argPlaceholder;
+      const argKind = getPaneTemplateArgKind(template);
       if (upper !== prefix && (!argKind || !upper.startsWith(`${prefix} `))) return false;
       if (!template.canCreate) return true;
       try {
         const canCreate = template.canCreate(context, arg ? { arg } : undefined);
         if (canCreate) return true;
-        if (!arg && !context.activeTicker && (argKind === "ticker" || argKind === "ticker-list")) {
+        if (!arg && !context.activeTicker && canPromptForPaneTemplateArg(template)) {
           return true;
         }
         return false;
@@ -2837,8 +2928,11 @@ export function CommandBar({
   const paneShortcutItems = useCallback((options?: {
     filterQuery?: string;
     createOptions?: PaneTemplateCreateOptions;
+    includePromptableTickerTemplates?: boolean;
   }): ResultItem[] => {
-    const items = getAvailablePaneTemplates(options?.createOptions)
+    const items = getAvailablePaneTemplates(options?.createOptions, {
+      includePromptableTickerTemplates: options?.includePromptableTickerTemplates,
+    })
       .filter((template) => template.shortcut)
       .map((template) => createPaneTemplateItem(template, {
         category: "Panes",
@@ -3217,6 +3311,7 @@ export function CommandBar({
 
   useEffect(() => {
     if (tickerSearchRouteQuery == null) {
+      searchRequestIdRef.current += 1;
       setTickerSearchPending(false);
       setTickerSearchResults([]);
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
@@ -3225,6 +3320,7 @@ export function CommandBar({
 
     const searchQuery = tickerSearchRouteQuery.trim();
     if (!searchQuery) {
+      searchRequestIdRef.current += 1;
       setTickerSearchPending(false);
       setTickerSearchResults([]);
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
@@ -3239,7 +3335,7 @@ export function CommandBar({
       activePortfolio?.brokerInstanceId,
     );
     setTickerSearchResults(cachedCandidates
-      ? buildTickerSearchResultItems(cachedCandidates, searchQuery)
+      ? mergeTickerSearchResultItems(searchQuery, localItems, buildTickerSearchResultItems(cachedCandidates, searchQuery))
       : localItems);
     const requestId = ++searchRequestIdRef.current;
     const searchDelay = skipTickerSearchDebounceRef.current ? 0 : 200;
@@ -3266,7 +3362,11 @@ export function CommandBar({
           activePortfolio?.brokerId,
           activePortfolio?.brokerInstanceId,
         );
-        setTickerSearchResults(buildTickerSearchResultItems(combined, searchQuery));
+        setTickerSearchResults(mergeTickerSearchResultItems(
+          searchQuery,
+          localTickerSearchResultItems(searchQuery, { limit: 6 }),
+          buildTickerSearchResultItems(combined, searchQuery),
+        ));
       } catch {
         if (requestId !== searchRequestIdRef.current) return;
         const nextItems: ResultItem[] = [{
@@ -3295,6 +3395,7 @@ export function CommandBar({
     buildTickerSearchResultItems,
     localTickerSearchResultItems,
     mapTickerSearchCandidateToResultItem,
+    mergeTickerSearchResultItems,
     readTickerSearchCache,
     tickerSearchRouteQuery,
     writeTickerSearchCache,
@@ -3559,8 +3660,8 @@ export function CommandBar({
           label: "Type a ticker symbol",
           detail: "Open security details after resolving a ticker",
           category: "Search",
-          kind: "info",
-          action: () => {},
+          kind: "command",
+          action: () => openModeRoute("ticker-search", ""),
         });
       } else if (match.arg) {
         items.push(...localTickerSearchResultItems(match.arg, { limit: 6 }));
@@ -3610,7 +3711,7 @@ export function CommandBar({
       const allItems = [
         ...tickerItems,
         ...commandItems,
-        ...paneShortcutItems(),
+        ...paneShortcutItems({ includePromptableTickerTemplates: true }),
         ...nonShortcutPaneTemplateItems(),
         ...tickerActionItems(),
         ...pluginCommandItems(),
@@ -3644,6 +3745,18 @@ export function CommandBar({
     tickerActionItems,
   ]);
 
+  const rootPlainTickerSearchArg = useMemo(() => {
+    if (activeMatch || rootShortcutIntent.kind !== "none" || !isLikelyPlainTickerSearch(rootQuery)) return null;
+    const normalizedQuery = normalizeCommandTickerSearchText(rootQuery);
+    const hasExactNonTickerResult = rootResultModel.items.some((item) => (
+      item.kind !== "ticker"
+      && item.kind !== "search"
+      && normalizeCommandTickerSearchText(item.label) === normalizedQuery
+    ));
+    return hasExactNonTickerResult ? null : rootQuery.trim();
+  }, [activeMatch, rootQuery, rootResultModel.items, rootShortcutIntent.kind]);
+  const rootTickerSearchArg = rootSecurityDescriptionArg ?? rootPlainTickerSearchArg;
+
   useEffect(() => {
     if (currentRoute) return;
 
@@ -3668,6 +3781,7 @@ export function CommandBar({
 
   useEffect(() => {
     if (currentRoute) {
+      rootSearchRequestIdRef.current += 1;
       setRootSearching(false);
       setRootProviderResults(null);
       setRootProviderResultsQuery(null);
@@ -3676,7 +3790,8 @@ export function CommandBar({
       return;
     }
 
-    if (!rootSecurityDescriptionArg) {
+    if (!rootTickerSearchArg) {
+      rootSearchRequestIdRef.current += 1;
       setRootSearching(false);
       setRootProviderResults(null);
       setRootProviderResultsQuery(null);
@@ -3685,7 +3800,7 @@ export function CommandBar({
       return;
     }
 
-    const searchQuery = rootSecurityDescriptionArg;
+    const searchQuery = rootTickerSearchArg;
     if (rootSearchTimerRef.current) clearTimeout(rootSearchTimerRef.current);
     if (rootLastSearchedQueryRef.current === searchQuery) {
       return;
@@ -3699,7 +3814,10 @@ export function CommandBar({
       activeSearchPortfolio?.brokerId,
       activeSearchPortfolio?.brokerInstanceId,
     );
-    setRootProviderResults(cachedCandidates ? buildTickerSearchResultItems(cachedCandidates, searchQuery) : null);
+    const localItems = localTickerSearchResultItems(searchQuery, { limit: 6 });
+    setRootProviderResults(cachedCandidates
+      ? mergeTickerSearchResultItems(searchQuery, localItems, buildTickerSearchResultItems(cachedCandidates, searchQuery))
+      : null);
     setRootProviderResultsQuery(cachedCandidates ? searchQuery : null);
 
     const requestId = ++rootSearchRequestIdRef.current;
@@ -3723,7 +3841,11 @@ export function CommandBar({
           activeSearchPortfolio?.brokerId,
           activeSearchPortfolio?.brokerInstanceId,
         );
-        setRootProviderResults(buildTickerSearchResultItems(combined, searchQuery));
+        setRootProviderResults(mergeTickerSearchResultItems(
+          searchQuery,
+          localTickerSearchResultItems(searchQuery, { limit: 6 }),
+          buildTickerSearchResultItems(combined, searchQuery),
+        ));
         setRootProviderResultsQuery(searchQuery);
       } catch {
         if (requestId !== rootSearchRequestIdRef.current) return;
@@ -3751,20 +3873,46 @@ export function CommandBar({
     buildTickerSearchResultItems,
     currentRoute,
     dataProvider,
+    localTickerSearchResultItems,
+    mergeTickerSearchResultItems,
     readTickerSearchCache,
-    rootSecurityDescriptionArg,
+    rootTickerSearchArg,
     state.config.portfolios,
     state.tickers,
     writeTickerSearchCache,
   ]);
 
   const rootResults = useMemo(() => {
-    if (rootSecurityDescriptionArg && rootProviderResultsQuery === rootSecurityDescriptionArg && rootProviderResults) {
+    if (rootTickerSearchArg && rootProviderResultsQuery === rootTickerSearchArg && rootProviderResults) {
+      if (rootPlainTickerSearchArg) {
+        return mergePlainRootTickerResults(rootPlainTickerSearchArg, rootProviderResults, rootResultModel.items);
+      }
       return rootProviderResults;
     }
     return rootResultModel.items;
-  }, [rootProviderResults, rootProviderResultsQuery, rootResultModel.items, rootSecurityDescriptionArg]);
+  }, [
+    mergePlainRootTickerResults,
+    rootPlainTickerSearchArg,
+    rootProviderResults,
+    rootProviderResultsQuery,
+    rootResultModel.items,
+    rootTickerSearchArg,
+  ]);
   const orderedRootResults = useMemo(() => orderListResults(rootResults), [rootResults]);
+  const activeRootProviderResultsKey = useMemo(() => {
+    if (!rootTickerSearchArg || rootProviderResultsQuery !== rootTickerSearchArg || !rootProviderResults) return null;
+    return [
+      rootTickerSearchArg,
+      ...rootProviderResults.map((item) => `${item.id}:${item.category}:${item.label}:${item.right || ""}`),
+    ].join("\n");
+  }, [rootProviderResults, rootProviderResultsQuery, rootTickerSearchArg]);
+
+  useEffect(() => {
+    if (!activeRootProviderResultsKey) return;
+    setRootSelectedIdx(0);
+    setRootHoveredIdx(null);
+    nativeListScrollRef.current?.scrollTo(0);
+  }, [activeRootProviderResultsKey]);
 
   const rootGhostCompletion = !currentRoute && rootShortcutIntent.kind === "inferred-complete"
     ? rootShortcutIntent.completionQuery
@@ -3776,7 +3924,7 @@ export function CommandBar({
     if (currentRoute || rootShortcutIntent.kind === "none") return null;
 
     if (rootShortcutIntent.source === "pane-template") {
-      const argKind = rootShortcutIntent.template.shortcut?.argKind ?? rootShortcutIntent.template.shortcut?.argPlaceholder;
+      const argKind = getPaneTemplateArgKind(rootShortcutIntent.template);
       if (argKind === "ticker") {
         const symbol = normalizeTickerInput(activeTickerSymbol, rootShortcutIntent.argText);
         if (symbol) {
@@ -3809,8 +3957,8 @@ export function CommandBar({
       const symbol = normalizeTickerInput(activeTickerSymbol, rootShortcutIntent.argText);
       if (symbol) {
         return rootShortcutIntent.kind === "inferred-complete"
-          ? `Shortcut: DES ${symbol} · Tab to accept`
-          : `Shortcut: DES ${symbol}`;
+          ? `Shortcut: ${rootShortcutIntent.prefix} ${symbol} · Tab to accept`
+          : `Shortcut: ${rootShortcutIntent.prefix} ${symbol}`;
       }
       return "Shortcut: Description";
     }
@@ -3865,7 +4013,7 @@ export function CommandBar({
       return true;
     }
     if (intent.source === "pane-template") {
-      const argKind = intent.template.shortcut?.argKind ?? intent.template.shortcut?.argPlaceholder;
+      const argKind = getPaneTemplateArgKind(intent.template);
       if (argKind === "ticker") {
         openModeRoute("ticker-search", intent.argText, {
           action: "pane-template",
@@ -3959,7 +4107,7 @@ export function CommandBar({
       }
       return {
         id: `security-description:${match.arg}`,
-        label: `DES ${match.arg.toUpperCase()}`,
+        label: `${match.prefix} ${match.arg.toUpperCase()}`,
         detail: "Open security details or resolve the ticker",
         category: "Search",
         kind: "command",
@@ -5221,8 +5369,18 @@ export function CommandBar({
       Math.max(7, estimateWorkflowBodyRows(currentRoute)),
     )
     : baseBodyHeight;
-  const bodyHeight = currentRoute?.kind === "workflow" ? workflowBodyHeight : baseBodyHeight;
-  const listBodyHeight = baseBodyHeight;
+  const shouldUseCompactListHeight = nativePaneChrome
+    && visibleListState != null
+    && !themePickerActive
+    && !showCustomMultiSelectPicker;
+  const listBodyHeight = shouldUseCompactListHeight
+    ? Math.min(baseBodyHeight, Math.max(1, nativeListRows.length))
+    : baseBodyHeight;
+  const bodyHeight = currentRoute?.kind === "workflow"
+    ? workflowBodyHeight
+    : shouldUseCompactListHeight
+      ? listBodyHeight
+      : baseBodyHeight;
   const nativePanelPaddingColumns = nativePaneChrome
     ? Math.ceil((NATIVE_COMMAND_BAR_PADDING_X_PX * 2) / Math.max(1, cellWidthPx))
     : 0;
@@ -5233,7 +5391,7 @@ export function CommandBar({
     || currentRoute?.kind === "confirm"
     || showCustomMultiSelectPicker)
     ? 1
-    : 3;
+    : currentRoute ? 3 : 2;
   const barHeight = nativePaneChrome
     ? bodyHeight + nativeBodyChromeRows + nativePanelPaddingRows
     : bodyHeight + 7;

--- a/src/components/command-bar/command-registry.ts
+++ b/src/components/command-bar/command-registry.ts
@@ -10,6 +10,7 @@ export interface CommandContext {
 export interface Command {
   id: string;
   prefix: string;        // e.g., "DES", "AW", "RP"
+  aliases?: string[];
   label: string;
   description: string;
   hasArg?: boolean;       // true if prefix takes an argument (e.g., "DES AMD")
@@ -24,6 +25,7 @@ export const commands: Command[] = [
   {
     id: "security-description",
     prefix: "DES",
+    aliases: ["T"],
     label: "Description",
     description: "Open security details for a ticker",
     hasArg: true,
@@ -239,19 +241,27 @@ export const commands: Command[] = [
 ];
 
 /** Find a command whose prefix matches the start of the input */
-export function matchPrefix(input: string, commandList: Command[] = commands): { command: Command; arg: string } | null {
+export function matchPrefix(input: string, commandList: Command[] = commands): { command: Command; arg: string; prefix: string } | null {
   const upper = input.toUpperCase().trim();
   if (!upper) return null;
 
   // Sort by prefix length descending so longer prefixes match first (e.g., "AW" before "A")
-  const sorted = [...commandList].sort((a, b) => b.prefix.length - a.prefix.length);
+  const sorted = commandList
+    .flatMap((command) => getCommandPrefixes(command).map((prefix) => ({ command, prefix })))
+    .sort((a, b) => b.prefix.length - a.prefix.length);
 
-  for (const cmd of sorted) {
-    if (upper.startsWith(cmd.prefix + " ") || upper === cmd.prefix) {
-      const arg = input.slice(cmd.prefix.length).trim();
-      return { command: cmd, arg };
+  for (const { command, prefix } of sorted) {
+    if (upper.startsWith(`${prefix} `) || upper === prefix) {
+      const arg = input.slice(prefix.length).trim();
+      return { command, arg, prefix };
     }
   }
 
   return null;
+}
+
+export function getCommandPrefixes(command: Command): string[] {
+  return [command.prefix, ...(command.aliases ?? [])]
+    .map((prefix) => prefix.trim().toUpperCase())
+    .filter(Boolean);
 }

--- a/src/components/command-bar/root-shortcuts.ts
+++ b/src/components/command-bar/root-shortcuts.ts
@@ -1,5 +1,5 @@
 import type { CommandDef, PaneTemplateDef } from "../../types/plugin";
-import type { Command } from "./command-registry";
+import { getCommandPrefixes, type Command } from "./command-registry";
 import { getPaneTemplateDisplayLabel } from "./pane-template-display";
 
 type RootShortcutArgKind = "text" | "ticker" | "ticker-list";
@@ -83,16 +83,15 @@ function buildShortcutCandidates(
 ): ShortcutParseCandidate[] {
   return [
     ...commands
-      .filter((command) => command.prefix.trim().length > 0)
-      .map((command) => ({
-        prefix: normalizeShortcutPrefix(command.prefix),
+      .flatMap((command) => getCommandPrefixes(command).map((prefix) => ({
+        prefix: normalizeShortcutPrefix(prefix),
         label: command.label,
         description: command.description,
         argKind: getCommandShortcutArgKind(command),
         argPlaceholder: command.argPlaceholder,
         source: "command" as const,
         command,
-      })),
+      }))),
     ...pluginCommands
       .filter((command) => command.shortcut?.trim().length)
       .map((command) => ({

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -11,6 +11,7 @@ describe("command bar view model helpers", () => {
   test("resolves prefix-driven modes", () => {
     expect(resolveCommandBarMode("")).toMatchObject({ kind: "default", badge: "BROWSE" });
     expect(resolveCommandBarMode("DES NVDA")).toMatchObject({ kind: "search", badge: "DES" });
+    expect(resolveCommandBarMode("T NVDA")).toMatchObject({ kind: "search", badge: "T" });
     expect(resolveCommandBarMode("TH ")).toMatchObject({ kind: "themes", badge: "THEMES" });
     expect(resolveCommandBarMode("PL notes")).toMatchObject({ kind: "plugins", badge: "PLUGINS" });
     expect(resolveCommandBarMode("LAY ")).toMatchObject({ kind: "layout", badge: "LAYOUT" });

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -47,7 +47,7 @@ export function resolveCommandBarMode(query: string, commandList?: Command[]): C
 
   switch (match.command.id) {
     case "security-description":
-      return { kind: "search", badge: "DES", hint: "Open security details for a ticker" };
+      return { kind: "search", badge: match.prefix, hint: "Open security details for a ticker" };
     case "theme":
       return { kind: "themes", badge: "THEMES", hint: "Preview with arrows, Enter to save, Esc to revert" };
     case "plugins":
@@ -128,6 +128,7 @@ export function truncateText(text: string, width: number): string {
 
 function getCategoryPriority(category: string): number {
   const normalized = category.trim().toLowerCase();
+  if (normalized === "exact match") return -50;
   if (normalized === "saved") return -40;
   if (normalized === "primary listing") return -30;
   if (normalized === "other listings") return -20;

--- a/src/utils/fuzzy-search.ts
+++ b/src/utils/fuzzy-search.ts
@@ -5,7 +5,18 @@ export function fuzzyMatch(query: string, target: string): { match: boolean; sco
   const t = target.toLowerCase();
 
   if (q.length === 0) return { match: true, score: 0 };
-  if (t.startsWith(q)) return { match: true, score: 1000 - q.length }; // exact prefix match
+  if (t === q) return { match: true, score: 2500 - q.length };
+
+  const tokens = t.split(/\s+/).filter(Boolean);
+  const exactTokenIndex = tokens.findIndex((token) => token === q);
+  if (exactTokenIndex >= 0) return { match: true, score: 2200 - q.length - exactTokenIndex };
+
+  const prefixTokenIndex = tokens.findIndex((token) => token.startsWith(q));
+  if (prefixTokenIndex >= 0) {
+    const token = tokens[prefixTokenIndex]!;
+    return { match: true, score: 1000 - q.length - prefixTokenIndex - (token.length - q.length) };
+  }
+
   if (t.includes(q)) return { match: true, score: 500 - q.length }; // substring match
 
   let qi = 0;

--- a/src/utils/ticker-search.test.ts
+++ b/src/utils/ticker-search.test.ts
@@ -82,7 +82,7 @@ describe("ticker-search utilities", () => {
       ]),
     });
 
-    expect(results.map((item) => item.id)).toEqual(["goto:AAPL", "search:APP"]);
+    expect(results.map((item) => item.id)).toEqual(["goto:AAPL", "search:APP:NASDAQ:TEST"]);
     expect(findExactTickerSearchMatch(results, "AAPL")?.id).toBe("goto:AAPL");
   });
 
@@ -97,7 +97,7 @@ describe("ticker-search utilities", () => {
       ]),
     });
 
-    expect(results.map((item) => item.id)).toEqual(["goto:AAPL", "search:APLE"]);
+    expect(results.map((item) => item.id)).toEqual(["goto:AAPL", "search:APLE:NASDAQ:TEST"]);
     expect(results[0]).toMatchObject({
       id: "goto:AAPL",
       detail: "Apple Inc",

--- a/src/utils/ticker-search.ts
+++ b/src/utils/ticker-search.ts
@@ -140,7 +140,7 @@ export function createProviderTickerSearchCandidates(
     const symbol = getSearchResultSymbol(result);
     const saved = localTickers.has(symbol);
     return [{
-      id: `search:${result.symbol}`,
+      id: buildProviderCandidateId(result, symbol),
       label: symbol,
       symbol,
       detail: [result.name, result.brokerLabel, result.type].filter(Boolean).join(" | "),
@@ -357,6 +357,7 @@ export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "
         item,
         index,
         normalizedSymbol: normalizeSearchText(item.symbol || item.label),
+        symbolMatchRank: scoreSymbolMatchRank(intent, item),
         textScore,
         score: textScore + priorityScore + (textScore > 0 && saved ? 900 : 0),
       };
@@ -375,6 +376,7 @@ export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "
       return !matchedLocalSymbols.has(normalizedSymbol);
     })
     .sort((a, b) => {
+      if (b.symbolMatchRank !== a.symbolMatchRank) return b.symbolMatchRank - a.symbolMatchRank;
       if (b.score !== a.score) return b.score - a.score;
       const aSaved = isSavedSearchItem(a.item);
       const bSaved = isSavedSearchItem(b.item);
@@ -461,6 +463,16 @@ function buildProviderSearchResultKey(result: InstrumentSearchResult): string {
     normalizeSearchText(result.primaryExchange || ""),
     normalizeSearchText(result.currency || ""),
   ].join("|");
+}
+
+function buildProviderCandidateId(result: InstrumentSearchResult, symbol: string): string {
+  return [
+    "search",
+    normalizeTickerSymbol(symbol),
+    normalizeSearchText(result.exchange || result.primaryExchange || result.type || ""),
+    normalizeSearchText(result.currency || ""),
+    normalizeSearchText(result.providerId || ""),
+  ].filter(Boolean).join(":");
 }
 
 function getProviderHintRichness(result: InstrumentSearchResult): number {
@@ -726,6 +738,41 @@ function scoreSearchAlias(intent: SearchQueryIntent, alias: string): number {
   }
 
   return score;
+}
+
+function scoreSymbolMatchRank(
+  intent: SearchQueryIntent,
+  item: Pick<TickerSearchRankableItem, "label"> & Partial<TickerSearchRankableItem>,
+): number {
+  if (!intent.normalizedQuery && !intent.compactQuery) return 0;
+  const displaySymbol = normalizeSearchText(item.symbol || item.label);
+  const compactDisplaySymbol = compactSearchText(item.symbol || item.label);
+
+  if (
+    displaySymbol === intent.normalizedQuery
+    || (intent.compactQuery && compactDisplaySymbol === intent.compactQuery)
+  ) {
+    return 3;
+  }
+
+  const aliases = getItemSearchAliases(item);
+  if (aliases.some((alias) => {
+    const normalizedAlias = normalizeSearchText(alias);
+    const compactAlias = compactSearchText(alias);
+    return normalizedAlias === intent.normalizedQuery
+      || (intent.compactQuery && compactAlias === intent.compactQuery);
+  })) {
+    return 2;
+  }
+
+  if (
+    displaySymbol.startsWith(intent.normalizedQuery)
+    || (intent.compactQuery && compactDisplaySymbol.startsWith(intent.compactQuery))
+  ) {
+    return 1;
+  }
+
+  return 0;
 }
 
 function scoreAssetPreference(intent: SearchQueryIntent, instrumentClass?: TickerSearchInstrumentClass): number {


### PR DESCRIPTION
## Summary
- restore `T` as a ticker-search prefix and keep exact ticker matches ahead of noisy saved/provider rows
- keep pane matches such as Options and Holders visible alongside plain ticker-shaped searches
- clear stale provider result rows and compact the native command-bar result list height

## Testing
- `bun test src/components/command-bar/command-bar.test.tsx src/components/command-bar/view-model.test.ts src/utils/ticker-search.test.ts`
- `bun run build`
- `bun run desktop:view:build`
- `git diff --check`
- tmux smoke checks for `amd`, `t amd`, `options`, `holders`, `opti`, and clearing `opti`

Fixes #327