### PR TITLE
Add HLC chart bars

### DIFF
--- a/src/components/chart/chart-data.ts
+++ b/src/components/chart/chart-data.ts
@@ -43,6 +43,10 @@ function getRequestedRenderMode(mode?: ChartRenderMode, compact = false): ChartR
   return mode ?? "area";
 }
 
+function isOhlcProjectionMode(mode: ChartRenderMode): boolean {
+  return mode === "candles" || mode === "ohlc" || mode === "hlc";
+}
+
 export function resolveRenderMode(
   mode: ChartRenderMode | undefined,
   chartWidth: number,
@@ -64,6 +68,7 @@ export function resolveRenderMode(
       else if (chartWidth < 40) effectiveMode = "ohlc";
       break;
     case "ohlc":
+    case "hlc":
       if (chartWidth < 28) effectiveMode = "line";
       break;
   }
@@ -328,11 +333,11 @@ export function projectChartData(
 ): ChartProjection {
   const { requestedMode, effectiveMode, fallbackMode } = resolveRenderMode(mode, targetWidth, compact);
   const ohlcBucketWidth = options.ohlcBucketWidth ?? targetWidth;
-  const projectionWidth = effectiveMode === "candles" || effectiveMode === "ohlc"
+  const projectionWidth = isOhlcProjectionMode(effectiveMode)
     ? Math.max(Math.floor(ohlcBucketWidth / 2), 1)
     : targetWidth;
 
-  const projectedPoints = effectiveMode === "candles" || effectiveMode === "ohlc"
+  const projectedPoints = isOhlcProjectionMode(effectiveMode)
     ? bucketOhlcSeries(points, projectionWidth, options)
     : projectCloseSeries(points, projectionWidth);
 

--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -278,15 +278,41 @@ function getBarHalfWidth(pointCount: number, bufWidth: number): number {
   return Math.floor(barW / 2);
 }
 
+function isOhlcLikeMode(mode: ChartRenderMode): boolean {
+  return mode === "ohlc" || mode === "hlc";
+}
+
+function isHighLowMode(mode: ChartRenderMode): boolean {
+  return mode === "candles" || isOhlcLikeMode(mode);
+}
+
+function getOhlcTickLength(pointCount: number, bufWidth: number): number {
+  if (pointCount <= 1) return 4;
+  const spacing = bufWidth / pointCount;
+  return Math.min(Math.max(Math.round(spacing * 0.45), 3), 5);
+}
+
+function getOhlcStemWidth(pointCount: number, bufWidth: number): number {
+  if (pointCount <= 1) return 3;
+  const spacing = bufWidth / pointCount;
+  return Math.min(Math.max(Math.round(spacing * 0.2), 2), 3);
+}
+
+function getOhlcHorizontalPad(pointCount: number, bufWidth: number): number {
+  const tickLen = getOhlcTickLength(pointCount, bufWidth);
+  const stemWidth = getOhlcStemWidth(pointCount, bufWidth);
+  return Math.max(tickLen - 1, Math.ceil((stemWidth - 1) / 2), 0);
+}
+
 function getDotX(index: number, pointCount: number, width: number, mode: ChartRenderMode): number {
   switch (mode) {
     case "candles": {
       const pad = getCandleHalfWidth(pointCount, width);
       return getSeriesPosition(index, pointCount, width, pad, pad);
     }
-    case "ohlc": {
-      const tickLen = Math.max(getCandleHalfWidth(pointCount, width), 2);
-      const pad = Math.max(tickLen - 1, 0);
+    case "ohlc":
+    case "hlc": {
+      const pad = getOhlcHorizontalPad(pointCount, width);
       return getSeriesPosition(index, pointCount, width, pad, pad);
     }
     default:
@@ -415,12 +441,16 @@ function drawOhlcChart(
   palette: ResolvedChartPalette,
   min: number,
   max: number,
+  mode: Extract<ChartRenderMode, "ohlc" | "hlc">,
 ) {
-  const tickLen = Math.max(getCandleHalfWidth(points.length, buf.width), 2);
+  const tickLen = getOhlcTickLength(points.length, buf.width);
+  const stemWidth = getOhlcStemWidth(points.length, buf.width);
+  const stemLeft = Math.floor((stemWidth - 1) / 2);
+  const stemRight = Math.ceil((stemWidth - 1) / 2);
 
   for (let i = 0; i < points.length; i++) {
     const point = points[i]!;
-    const x = getDotX(i, points.length, buf.width, "ohlc");
+    const x = getDotX(i, points.length, buf.width, mode);
     const highY = getScaledY(point.high, min, max, chartTop, chartBottom);
     const lowY = getScaledY(point.low, min, max, chartTop, chartBottom);
     const openY = getScaledY(point.open, min, max, chartTop, chartBottom);
@@ -428,14 +458,15 @@ function drawOhlcChart(
     const isUp = point.close >= point.open;
     const color = isUp ? palette.candleUp : palette.candleDown;
 
-    // Vertical line
-    drawLine(buf, x, highY, x, lowY, color, LAYER_DATA);
-
-    // Open tick extends left
-    for (let dx = 0; dx < tickLen; dx++) {
-      setPixel(buf, x - dx, openY, color, LAYER_DATA);
+    for (let dx = -stemLeft; dx <= stemRight; dx++) {
+      drawLine(buf, x + dx, highY, x + dx, lowY, color, LAYER_DATA);
     }
-    // Close tick extends right
+
+    if (mode === "ohlc") {
+      for (let dx = 0; dx < tickLen; dx++) {
+        setPixel(buf, x - dx, openY, color, LAYER_DATA);
+      }
+    }
     for (let dx = 0; dx < tickLen; dx++) {
       setPixel(buf, x + dx, closeY, color, LAYER_DATA);
     }
@@ -1222,10 +1253,10 @@ export function buildChartScene(
   if (points.length === 0) return null;
 
   const dimensions = normalizeRenderDimensions(opts);
-  const dataMin = opts.mode === "candles" || opts.mode === "ohlc"
+  const dataMin = isHighLowMode(opts.mode)
     ? Math.min(...points.map((point) => point.low))
     : Math.min(...points.map((point) => point.close));
-  const dataMax = opts.mode === "candles" || opts.mode === "ohlc"
+  const dataMax = isHighLowMode(opts.mode)
     ? Math.max(...points.map((point) => point.high))
     : Math.max(...points.map((point) => point.close));
   const indicatorValues = getIndicatorOverlayValues(opts.indicators);
@@ -1394,7 +1425,10 @@ export function renderChart(
       drawCandlestickChart(buf, points, 0, chartDotBottom, palette, min, max);
       break;
     case "ohlc":
-      drawOhlcChart(buf, points, 0, chartDotBottom, palette, min, max);
+      drawOhlcChart(buf, points, 0, chartDotBottom, palette, min, max, "ohlc");
+      break;
+    case "hlc":
+      drawOhlcChart(buf, points, 0, chartDotBottom, palette, min, max, "hlc");
       break;
   }
 
@@ -1406,7 +1440,7 @@ export function renderChart(
       volDotBottom,
       palette.volumeUp,
       palette.volumeDown,
-      mode === "candles" || mode === "ohlc" ? "openClose" : "previousClose",
+      isHighLowMode(mode) ? "openClose" : "previousClose",
       mode,
     );
   }

--- a/src/components/chart/chart-types.ts
+++ b/src/components/chart/chart-types.ts
@@ -2,14 +2,14 @@ import type { PricePoint } from "../../types/financials";
 
 export type TimeRange = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y" | "5Y" | "ALL";
 export type ChartResolution = "auto" | "1m" | "5m" | "15m" | "30m" | "45m" | "1h" | "1d" | "1wk" | "1mo";
-export type ChartRenderMode = "area" | "line" | "candles" | "ohlc";
+export type ChartRenderMode = "area" | "line" | "candles" | "ohlc" | "hlc";
 export type ChartAxisMode = "price" | "percent";
 export type ChartRendererPreference = "auto" | "kitty" | "braille";
 export type ResolvedChartRenderer = "kitty" | "braille";
 export type ComparisonChartRenderMode = "area" | "line";
 
 export const TIME_RANGES: TimeRange[] = ["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
-export const CHART_RENDER_MODES: ChartRenderMode[] = ["area", "line", "candles", "ohlc"];
+export const CHART_RENDER_MODES: ChartRenderMode[] = ["area", "line", "candles", "ohlc", "hlc"];
 export const CHART_RENDERER_PREFERENCES: ChartRendererPreference[] = ["auto", "kitty", "braille"];
 export const COMPARISON_RENDER_MODES: ComparisonChartRenderMode[] = ["area", "line"];
 

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -183,6 +183,8 @@ describe("resolveRenderMode", () => {
     expect(resolveRenderMode("candles", 28)).toMatchObject({ effectiveMode: "ohlc", fallbackMode: "ohlc" });
     expect(resolveRenderMode("candles", 39)).toMatchObject({ effectiveMode: "ohlc", fallbackMode: "ohlc" });
     expect(resolveRenderMode("candles", 40)).toMatchObject({ effectiveMode: "candles", fallbackMode: null });
+    expect(resolveRenderMode("hlc", 27)).toMatchObject({ effectiveMode: "line", fallbackMode: "line" });
+    expect(resolveRenderMode("hlc", 28)).toMatchObject({ effectiveMode: "hlc", fallbackMode: null });
   });
 
   test("forces compact charts back to area mode", () => {
@@ -192,7 +194,7 @@ describe("resolveRenderMode", () => {
     expect(projection.fallbackMode).toBeNull();
   });
 
-  test("uses fewer projected buckets for candles and ohlc to preserve spacing", () => {
+  test("uses fewer projected buckets for candles and ohlc-style bars to preserve spacing", () => {
     const denseSeries = Array.from({ length: 100 }, (_, i) => ({
       date: new Date(2024, 0, i + 1),
       open: 100 + i,
@@ -204,6 +206,7 @@ describe("resolveRenderMode", () => {
 
     expect(projectChartData(denseSeries, 80, "candles", false).points).toHaveLength(34);
     expect(projectChartData(denseSeries, 80, "ohlc", false).points).toHaveLength(34);
+    expect(projectChartData(denseSeries, 80, "hlc", false).points).toHaveLength(34);
     expect(projectChartData(denseSeries, 80, "line", false).points).toHaveLength(80);
   });
 
@@ -528,6 +531,7 @@ describe("renderChart", () => {
       { mode: "line", width: 12, cursorX: 4 },
       { mode: "candles", width: 40, cursorX: 13 },
       { mode: "ohlc", width: 28, cursorX: 9 },
+      { mode: "hlc", width: 28, cursorX: 9 },
     ];
 
     for (const testCase of cases) {
@@ -553,6 +557,7 @@ describe("renderChart", () => {
       { mode: "area", width: 12, height: 6, cursorX: 5, cursorY: 4 },
       { mode: "candles", width: 40, height: 6, cursorX: 13, cursorY: 3 },
       { mode: "ohlc", width: 28, height: 6, cursorX: 9, cursorY: 1 },
+      { mode: "hlc", width: 28, height: 6, cursorX: 9, cursorY: 1 },
     ];
 
     for (const testCase of cases) {
@@ -638,12 +643,26 @@ describe("renderChart", () => {
         width: 28,
         height: 6,
         lines: [
-          "⠁  ⠁  ⠁  ⢸  ⠁  ⠁  ⡄  ⠁  ⠁  ⠁",
-          " ⢰       ⢸⠒⠂    ⠐⠒⡇         ",
-          "⠁⢸⠒⠂  ⠁ ⠒⢺  ⠁  ⠁  ⡇  ⠁  ⠁ ⡆⠁",
-          "⠤⢼ ⡀  ⡀  ⠸  ⡀  ⡀  ⡇  ⡀  ⡀ ⡏⠉",
-          " ⠸                ⡧⠤    ⠠⠤⡇ ",
-          "⡀  ⡀  ⡀  ⡀  ⡀  ⡀  ⡇  ⡀  ⡀ ⠃⡀",
+          "⠁  ⠁  ⠁  ⢸⣿ ⠁  ⠁ ⣤⡄  ⠁  ⠁  ⠁",
+          " ⢰⣶      ⢸⣿⠒⠂  ⠐⠒⣿⡇         ",
+          "⠁⢸⣿⠒⠂ ⠁ ⠒⢺⣿ ⠁  ⠁ ⣿⡇  ⠁  ⠁⣶⡆⠁",
+          "⠤⢼⣿⡀  ⡀  ⠸⠿ ⡀  ⡀ ⣿⡇  ⡀  ⡀⣿⡏⠉",
+          " ⠸⠿              ⣿⡧⠤   ⠠⠤⣿⡇ ",
+          "⡀  ⡀  ⡀  ⡀  ⡀  ⡀ ⣿⡇  ⡀  ⡀⠛⠃⡀",
+        ],
+        timeLabels: "Jan 2    3        4    Jan 5",
+      },
+      {
+        mode: "hlc",
+        width: 28,
+        height: 6,
+        lines: [
+          "⠁  ⠁  ⠁  ⢸⣿ ⠁  ⠁ ⣤⡄  ⠁  ⠁  ⠁",
+          " ⢰⣶      ⢸⣿⠒⠂    ⣿⡇         ",
+          "⠁⢸⣿⠒⠂ ⠁  ⢸⣿ ⠁  ⠁ ⣿⡇  ⠁  ⠁⣶⡆⠁",
+          "⡀⢸⣿⡀  ⡀  ⠸⠿ ⡀  ⡀ ⣿⡇  ⡀  ⡀⣿⡏⠉",
+          " ⠸⠿              ⣿⡧⠤     ⣿⡇ ",
+          "⡀  ⡀  ⡀  ⡀  ⡀  ⡀ ⣿⡇  ⡀  ⡀⠛⠃⡀",
         ],
         timeLabels: "Jan 2    3        4    Jan 5",
       },

--- a/src/components/chart/native/chart-rasterizer.ts
+++ b/src/components/chart/native/chart-rasterizer.ts
@@ -247,16 +247,39 @@ function projectX(index: number, count: number, left: number, right: number): nu
   return lerp(left, right, index / (count - 1));
 }
 
+function isOhlcLikeMode(mode: ChartRenderMode): boolean {
+  return mode === "ohlc" || mode === "hlc";
+}
+
+function isHighLowMode(mode: ChartRenderMode): boolean {
+  return mode === "candles" || isOhlcLikeMode(mode);
+}
+
+function getNativeBarMetrics(count: number, width: number, mode: Extract<ChartRenderMode, "candles" | "ohlc" | "hlc">) {
+  const spacing = width / Math.max(count, 1);
+  if (mode === "candles") {
+    return {
+      bodyWidth: clamp(spacing * 0.58, 2, Math.max(spacing - 1, 2)),
+      tickLength: 0,
+      stemThickness: 1.2,
+    };
+  }
+
+  return {
+    bodyWidth: 0,
+    tickLength: clamp(spacing * 0.5, 3, Math.max(spacing * 0.62, 3)),
+    stemThickness: clamp(spacing * 0.12, 2, 3.2),
+  };
+}
+
 function projectChartX(index: number, count: number, width: number, mode: ChartRenderMode): number {
-  if (mode !== "candles" && mode !== "ohlc") {
+  if (!isHighLowMode(mode)) {
     return projectX(index, count, 0, Math.max(width - 1, 0));
   }
 
-  const spacing = width / Math.max(count, 1);
-  const bodyWidth = clamp(spacing * 0.58, 2, Math.max(spacing - 1, 2));
-  const tickLength = clamp(spacing * 0.34, 2, Math.max(spacing * 0.48, 2));
-  const horizontalPad = mode === "ohlc"
-    ? Math.ceil(Math.max(tickLength - 1, 0))
+  const { bodyWidth, tickLength, stemThickness } = getNativeBarMetrics(count, width, mode);
+  const horizontalPad = isOhlcLikeMode(mode)
+    ? Math.ceil(Math.max(tickLength - 1, stemThickness / 2, 0))
     : Math.ceil(bodyWidth / 2);
   return projectX(index, count, horizontalPad, Math.max(width - 1 - horizontalPad, horizontalPad));
 }
@@ -332,13 +355,11 @@ function drawCandles(
   scene: ChartScene,
   top: number,
   bottom: number,
-  mode: Extract<ChartRenderMode, "candles" | "ohlc">,
+  mode: Extract<ChartRenderMode, "candles" | "ohlc" | "hlc">,
 ) {
-  const spacing = width / Math.max(scene.points.length, 1);
-  const bodyWidth = clamp(spacing * 0.58, 2, Math.max(spacing - 1, 2));
-  const tickLength = clamp(spacing * 0.34, 2, Math.max(spacing * 0.48, 2));
-  const horizontalPad = mode === "ohlc"
-    ? Math.ceil(Math.max(tickLength - 1, 0))
+  const { bodyWidth, tickLength, stemThickness } = getNativeBarMetrics(scene.points.length, width, mode);
+  const horizontalPad = isOhlcLikeMode(mode)
+    ? Math.ceil(Math.max(tickLength - 1, stemThickness / 2, 0))
     : Math.ceil(bodyWidth / 2);
   const plotLeft = horizontalPad;
   const plotRight = Math.max(width - 1 - horizontalPad, plotLeft);
@@ -355,10 +376,12 @@ function drawCandles(
     const wickColor = parseHex(isUp ? scene.colors.wickUp : scene.colors.wickDown, 0.92);
     const bodyColor = parseHex(isUp ? scene.colors.candleUp : scene.colors.candleDown, 1);
 
-    if (mode === "ohlc") {
-      drawLine(data, width, height, x, highY, x, lowY, wickColor, 1.2);
-      drawLine(data, width, height, x - tickLength, openY, x, openY, bodyColor, 1.4);
-      drawLine(data, width, height, x, closeY, x + tickLength, closeY, bodyColor, 1.4);
+    if (isOhlcLikeMode(mode)) {
+      drawLine(data, width, height, x, highY, x, lowY, wickColor, stemThickness);
+      if (mode === "ohlc") {
+        drawLine(data, width, height, x - tickLength, openY, x, openY, bodyColor, Math.max(stemThickness, 1.4));
+      }
+      drawLine(data, width, height, x, closeY, x + tickLength, closeY, bodyColor, Math.max(stemThickness, 1.4));
       continue;
     }
 
@@ -395,7 +418,7 @@ function drawVolume(
     if (heightRatio <= 0) continue;
     const x = projectX(index, scene.points.length, 0, width - 1);
     const barTop = lerp(bottom, top, heightRatio);
-    const isUp = scene.mode === "candles" || scene.mode === "ohlc"
+    const isUp = isHighLowMode(scene.mode)
       ? point.close >= point.open
       : index === 0 || point.close >= scene.points[index - 1]!.close;
     const color = parseHex(isUp ? scene.colors.volumeUp : scene.colors.volumeDown, 0.6);
@@ -485,6 +508,9 @@ export function renderNativeChartBase(scene: ChartScene, pixelWidth: number, pix
         break;
       case "ohlc":
         drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "ohlc");
+        break;
+      case "hlc":
+        drawCandles(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom, "hlc");
         break;
     }
 

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -135,6 +135,7 @@ const MODE_CHIPS: Record<ChartRenderMode, string> = {
   line: "L",
   candles: "C",
   ohlc: "O",
+  hlc: "H",
 };
 
 const MODE_LABELS: Record<ChartRenderMode, string> = {
@@ -142,6 +143,7 @@ const MODE_LABELS: Record<ChartRenderMode, string> = {
   line: "LINE",
   candles: "CANDLES",
   ohlc: "OHLC",
+  hlc: "HLC",
 };
 
 const AXIS_MEASURE_PALETTE = resolveChartPalette({
@@ -3412,7 +3414,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
 
   const hasHistory = chartWindow.points.length > 0;
   const requestedMode = projection.requestedMode;
-  const showOhlcSummary = projection.effectiveMode === "candles" || projection.effectiveMode === "ohlc";
+  const showOhlcSummary = projection.effectiveMode === "candles" || projection.effectiveMode === "ohlc" || projection.effectiveMode === "hlc";
   const hasDisplayCursor = displayCursorX !== null && displayCursorY !== null;
   const activePoint = showOhlcSummary ? (selectionScene?.activePoint ?? null) : null;
   const visiblePriceRange = selectionScene
@@ -3552,26 +3554,33 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       priceRange: visiblePriceRange,
     });
 
+    const parts: PaneFooterSegment["parts"] = [
+      ...(projection.effectiveMode === "hlc"
+        ? []
+        : [
+            { text: "O", tone: "label" as const },
+            { text: formatPrice(activePoint.open), tone: "value" as const },
+          ]),
+      { text: "H", tone: "label" },
+      { text: formatPrice(activePoint.high), tone: "value" },
+      { text: "L", tone: "label" },
+      { text: formatPrice(activePoint.low), tone: "value" },
+      { text: "C", tone: "label" },
+      { text: formatPrice(activePoint.close), tone: "value" },
+      { text: "V", tone: "label" },
+      { text: formatCompact(activePoint.volume), tone: "value" },
+    ];
+
     return [{
-      id: "ohlc",
-      parts: [
-        { text: "O", tone: "label" },
-        { text: formatPrice(activePoint.open), tone: "value" },
-        { text: "H", tone: "label" },
-        { text: formatPrice(activePoint.high), tone: "value" },
-        { text: "L", tone: "label" },
-        { text: formatPrice(activePoint.low), tone: "value" },
-        { text: "C", tone: "label" },
-        { text: formatPrice(activePoint.close), tone: "value" },
-        { text: "V", tone: "label" },
-        { text: formatCompact(activePoint.volume), tone: "value" },
-      ],
+      id: projection.effectiveMode === "hlc" ? "hlc" : "ohlc",
+      parts,
     }];
   }, [
     activePoint,
     chartAssetCategory,
     chartCurrency,
     compact,
+    projection.effectiveMode,
     showOhlcSummary,
     visiblePriceRange,
   ]);

--- a/src/data/config-store-node.ts
+++ b/src/data/config-store-node.ts
@@ -266,7 +266,8 @@ function isChartPreferences(value: unknown): value is ChartPreferences {
   return (defaultRenderMode === "area"
     || defaultRenderMode === "line"
     || defaultRenderMode === "candles"
-    || defaultRenderMode === "ohlc")
+    || defaultRenderMode === "ohlc"
+    || defaultRenderMode === "hlc")
     && (renderer === "auto" || renderer === "kitty" || renderer === "braille");
 }
 
@@ -278,6 +279,7 @@ function sanitizeChartPreferences(value: unknown, fallback: ChartPreferences): C
     || candidate.defaultRenderMode === "line"
     || candidate.defaultRenderMode === "candles"
     || candidate.defaultRenderMode === "ohlc"
+    || candidate.defaultRenderMode === "hlc"
     ? candidate.defaultRenderMode
     : fallback.defaultRenderMode;
   const renderer = candidate.renderer === "auto"

--- a/src/data/config-store.test.ts
+++ b/src/data/config-store.test.ts
@@ -219,7 +219,7 @@ describe("loadConfig", () => {
     await writeConfigJson(dataDir, createSavedConfig({
       configVersion: 7,
       chartPreferences: {
-        defaultRenderMode: "line",
+        defaultRenderMode: "hlc",
         renderer: "nope",
       },
     }));
@@ -227,7 +227,7 @@ describe("loadConfig", () => {
     const config = await loadConfig(dataDir);
 
     expect(config.chartPreferences).toEqual({
-      defaultRenderMode: "line",
+      defaultRenderMode: "hlc",
       renderer: "auto",
     });
     expect(config.pluginConfig).toEqual({});

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,7 +2,7 @@ import type { Portfolio, Watchlist } from "./ticker";
 
 export const CURRENT_CONFIG_VERSION = 15;
 
-export type DefaultChartRenderMode = "area" | "line" | "candles" | "ohlc";
+export type DefaultChartRenderMode = "area" | "line" | "candles" | "ohlc" | "hlc";
 export type ChartRendererPreference = "auto" | "kitty" | "braille";
 
 export interface ChartPreferences {


### PR DESCRIPTION
Adds HLC as a chart mode alongside OHLC, including persisted chart preferences and mode cycling.

Widens OHLC/HLC stems and ticks in both terminal and native chart renderers so bar charts are easier to read.

Updates chart projection and footer summary behavior so HLC shows high, low, close, and volume without the opening print.

Fixes #177
