### PR TITLE
Persist layout pane state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import {
   AppProvider,
   getFocusedCollectionId,
   getFocusedTickerSymbol,
+  syncConfigActiveLayoutState,
   useAppDispatch,
   useAppSelector,
   useAppStateRef,
@@ -348,11 +349,13 @@ function AppInner({
       if (!ensured) return null;
       if (ensured.layout !== state.config.layout) {
         dispatch({ type: "PUSH_LAYOUT_HISTORY" });
-        const layouts = state.config.layouts.map((savedLayout, index) => (
-          index === state.config.activeLayoutIndex ? { ...savedLayout, layout: ensured.layout } : savedLayout
-        ));
         dispatch({ type: "UPDATE_LAYOUT", layout: ensured.layout });
-        scheduleConfigSave({ ...state.config, layout: ensured.layout, layouts });
+        scheduleConfigSave(syncConfigActiveLayoutState(
+          { ...state.config, layout: ensured.layout },
+          state.paneState,
+          state.focusedPaneId,
+          state.activePanel,
+        ));
       }
       return ensured.instance.instanceId;
     })();
@@ -1078,14 +1081,16 @@ function AppInner({
   const persistLayout = (layout: LayoutConfig, options?: { pushHistory?: boolean }) => {
     const currentState = stateRef.current;
     const normalizedLayout = normalizePaneLayout(layout);
-    const layouts = currentState.config.layouts.map((savedLayout, index) => (
-      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout: normalizedLayout } : savedLayout
-    ));
     if (options?.pushHistory !== false) {
       dispatch({ type: "PUSH_LAYOUT_HISTORY" });
     }
     dispatch({ type: "UPDATE_LAYOUT", layout: normalizedLayout });
-    scheduleConfigSave({ ...currentState.config, layout: normalizedLayout, layouts });
+    scheduleConfigSave(syncConfigActiveLayoutState(
+      { ...currentState.config, layout: normalizedLayout },
+      currentState.paneState,
+      currentState.focusedPaneId,
+      currentState.activePanel,
+    ));
   };
   const resolvePanelForPane = useCallback((paneId: string, layout: LayoutConfig = state.config.layout): "left" | "right" => {
     const instanceId = resolvePaneTarget(paneId, layout);

--- a/src/components/chart/chart-pane-settings.ts
+++ b/src/components/chart/chart-pane-settings.ts
@@ -4,6 +4,7 @@ import {
   useAppStateRef,
   usePaneInstance,
   usePaneInstanceId,
+  syncConfigActiveLayoutState,
 } from "../../state/app-context";
 import { scheduleConfigSave } from "../../state/config-save-scheduler";
 import type { ChartResolution, TimeRange } from "./chart-types";
@@ -24,10 +25,12 @@ export function usePersistChartControlSelection(rangePresetKey: string): (
       [rangePresetKey]: range,
       chartResolution: resolution,
     });
-    const layouts = currentState.config.layouts.map((savedLayout, index) => (
-      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
-    ));
-    const nextConfig = { ...currentState.config, layout, layouts };
+    const nextConfig = syncConfigActiveLayoutState(
+      { ...currentState.config, layout },
+      currentState.paneState,
+      currentState.focusedPaneId,
+      currentState.activePanel,
+    );
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     scheduleConfigSave(nextConfig);
   };

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -6,7 +6,6 @@ import { useShortcut } from "../../react/input";
 import { useAppDispatch, useAppSelector, usePaneInstance, usePaneInstanceId, usePaneSettingValue, usePaneTicker } from "../../state/app-context";
 import { usePaneFooter, type PaneFooterSegment, type PaneHint } from "../layout/pane-footer";
 import { ShortcutHint } from "../ui";
-import { saveConfig } from "../../data/config-store";
 import { getSharedMarketData } from "../../plugins/registry";
 import { colors } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
@@ -1449,6 +1448,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const preferredRenderer = config.chartPreferences.renderer;
   const [storedRangePreset] = usePaneSettingValue("chartRangePreset", DEFAULT_TICKER_CHART_RANGE_PRESET);
   const [storedResolution] = usePaneSettingValue<ChartResolution>("chartResolution", DEFAULT_TICKER_CHART_RESOLUTION);
+  const [storedRenderMode, setStoredRenderMode] = usePaneSettingValue<ChartRenderMode>("chartRenderMode", defaultRenderMode);
   const persistChartControls = usePersistChartControlSelection("chartRangePreset");
   const [viewState, setViewState] = useState<StockChartViewportState>({
     presetRange: compact ? "1Y" : storedRangePreset,
@@ -1458,7 +1458,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     zoomLevel: 1,
     cursorX: null,
     cursorY: null,
-    renderMode: defaultRenderMode,
+    renderMode: storedRenderMode,
   });
   // Read indicator config from the chart caller, falling back to legacy pane settings.
   const indicatorConfig: IndicatorConfig = indicatorConfigOverride ?? ((pane?.settings?.indicators as IndicatorConfig) ?? EMPTY_INDICATOR_CONFIG);
@@ -1683,6 +1683,12 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     });
     updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
   }, [compact, selectionSupportMap, storedRangePreset, storedResolution]);
+  useEffect(() => {
+    if (compact) return;
+    setViewState((current) => (
+      current.renderMode === storedRenderMode ? current : { ...current, renderMode: storedRenderMode }
+    ));
+  }, [compact, storedRenderMode]);
   const effectiveResolution: ChartResolution = !compact
     && requestedResolution !== "auto"
     && resolutionSupport !== null
@@ -2545,18 +2551,11 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     };
   }, [preferredRenderer, renderer]);
 
-  const persistDefaultRenderMode = (nextMode: ChartRenderMode) => {
-    if (nextMode === defaultRenderMode) return;
-    const nextConfig = {
-      ...config,
-      chartPreferences: {
-        ...config.chartPreferences,
-        defaultRenderMode: nextMode,
-      },
-    };
-    dispatch({ type: "SET_CONFIG", config: nextConfig });
-    saveConfig(nextConfig).catch(() => {});
-  };
+  const persistRenderMode = useCallback((nextMode: ChartRenderMode) => {
+    if (!compact && nextMode !== storedRenderMode) {
+      setStoredRenderMode(nextMode);
+    }
+  }, [compact, setStoredRenderMode, storedRenderMode]);
 
   const expandBufferRange = (action: PendingExpansionAction): boolean => {
     if (compact) return false;
@@ -2658,7 +2657,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   };
 
   const setRenderMode = (mode: ChartRenderMode) => {
-    persistDefaultRenderMode(mode);
+    persistRenderMode(mode);
     setViewState((current) => ({ ...current, renderMode: mode }));
   };
 
@@ -2872,7 +2871,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
           const activeMode = current.renderMode ?? "area";
           const index = CHART_RENDER_MODES.indexOf(activeMode);
           const nextMode = CHART_RENDER_MODES[(index + 1) % CHART_RENDER_MODES.length]!;
-          persistDefaultRenderMode(nextMode);
+          persistRenderMode(nextMode);
           return { ...current, renderMode: nextMode };
         });
         return;
@@ -3463,7 +3462,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         const activeMode = current.renderMode ?? "area";
         const index = CHART_RENDER_MODES.indexOf(activeMode);
         const nextMode = CHART_RENDER_MODES[(index + 1) % CHART_RENDER_MODES.length]!;
-        persistDefaultRenderMode(nextMode);
+        persistRenderMode(nextMode);
         return { ...current, renderMode: nextMode };
       });
     };
@@ -3535,6 +3534,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     footerHints,
     history,
     navigableDateWindow,
+    persistRenderMode,
     resolutionChips,
     selectedResolution,
     selectionSupportMap,

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -24,16 +24,18 @@ import {
 } from "../../theme/colors";
 import {
   getFocusedCollectionId,
+  syncConfigActiveLayoutState,
   useAppDispatch,
   useAppSelector,
   useFocusedTicker,
   type AppState,
 } from "../../state/app-context";
+import { scheduleConfigSave } from "../../state/config-save-scheduler";
 import { fuzzyFilter } from "../../utils/fuzzy-search";
 import { commands, matchPrefix, type Command } from "./command-registry";
 import { useThemeColors } from "../../theme/theme-context";
 import { ThemePicker, type ThemePickerHandle } from "./theme-picker";
-import { exportConfig, importConfig, resetAllData, saveConfig } from "../../data/config-store";
+import { exportConfig, importConfig, resetAllData } from "../../data/config-store";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRepository } from "../../data/ticker-repository";
 import type { PluginRegistry } from "../../plugins/registry";
@@ -618,6 +620,7 @@ export function CommandBar({
   const tickers = useAppSelector((state) => state.tickers);
   const financials = useAppSelector((state) => state.financials);
   const focusedPaneId = useAppSelector((state) => state.focusedPaneId);
+  const activePanel = useAppSelector((state) => state.activePanel);
   const layoutHistory = useAppSelector((state) => state.layoutHistory);
   const recentTickers = useAppSelector((state) => state.recentTickers);
   const commandBarOpen = useAppSelector((state) => state.commandBarOpen);
@@ -633,6 +636,7 @@ export function CommandBar({
     tickers,
     financials,
     focusedPaneId,
+    activePanel,
     layoutHistory,
     recentTickers,
     commandBarOpen,
@@ -643,6 +647,7 @@ export function CommandBar({
     updateCheckInProgress,
     updateNotice,
   }) as AppState, [
+    activePanel,
     commandBarLaunchRequest,
     commandBarOpen,
     commandBarQuery,
@@ -660,6 +665,15 @@ export function CommandBar({
   ]);
   const stateRef = useRef(state);
   stateRef.current = state;
+  const persistConfig = useCallback((nextConfig: AppState["config"]) => {
+    const currentState = stateRef.current;
+    scheduleConfigSave(syncConfigActiveLayoutState(
+      nextConfig,
+      currentState.paneState,
+      currentState.focusedPaneId,
+      currentState.activePanel,
+    ));
+  }, []);
   const { symbol: activeTickerSymbol, ticker: activeTickerData, financials: activeFinancials } = useFocusedTicker();
   const renderer = useNativeRenderer();
   const { width: termWidth, height: termHeight } = useViewport();
@@ -833,15 +847,7 @@ export function CommandBar({
           : instance
       )),
     };
-    const nextConfig = {
-      ...currentState.config,
-      layout: nextLayout,
-      layouts: currentState.config.layouts.map((savedLayout, index) => (
-        index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout: nextLayout } : savedLayout
-      )),
-    };
     dispatch({ type: "UPDATE_LAYOUT", layout: nextLayout });
-    void saveConfig(nextConfig);
     dispatch({ type: "FOCUS_PANE", paneId: targetPane.instanceId });
   }, [dispatch]);
 
@@ -1165,9 +1171,9 @@ export function CommandBar({
     );
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     setActiveCollection(portfolio.id);
-    await saveConfig(nextConfig);
+    persistConfig(nextConfig);
     notify(`Created portfolio "${portfolio.name}".`, { type: "success" });
-  }, [dispatch, notify, setActiveCollection]);
+  }, [dispatch, notify, persistConfig, setActiveCollection]);
 
   const createWatchlist = useCallback(async (name: string) => {
     const currentState = stateRef.current;
@@ -1184,9 +1190,9 @@ export function CommandBar({
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     setActiveCollection(id);
-    await saveConfig(nextConfig);
+    persistConfig(nextConfig);
     notify(`Created watchlist "${trimmedName}".`, { type: "success" });
-  }, [dispatch, notify, setActiveCollection]);
+  }, [dispatch, notify, persistConfig, setActiveCollection]);
 
   const deleteWatchlist = useCallback(async (watchlistId: string) => {
     const currentState = stateRef.current;
@@ -1204,9 +1210,9 @@ export function CommandBar({
       const fallback = nextConfig.portfolios[0]?.id || nextConfig.watchlists[0]?.id || "";
       if (fallback) setActiveCollection(fallback);
     }
-    await saveConfig(nextConfig);
+    persistConfig(nextConfig);
     notify(`Deleted "${watchlist.name}".`, { type: "success" });
-  }, [activeCollectionId, dispatch, notify, setActiveCollection]);
+  }, [activeCollectionId, dispatch, notify, persistConfig, setActiveCollection]);
 
   const deletePortfolio = useCallback(async (portfolioId: string) => {
     const currentState = stateRef.current;
@@ -1234,9 +1240,9 @@ export function CommandBar({
       const fallback = nextConfig.portfolios[0]?.id || nextConfig.watchlists[0]?.id || "";
       if (fallback) setActiveCollection(fallback);
     }
-    await saveConfig(nextConfig);
+    persistConfig(nextConfig);
     notify(`Deleted "${portfolio.name}".`, { type: "success" });
-  }, [activeCollectionId, dispatch, notify, setActiveCollection, tickerRepository]);
+  }, [activeCollectionId, dispatch, notify, persistConfig, setActiveCollection, tickerRepository]);
 
   const setPortfolioPositionFromWorkflow = useCallback(async (values: Record<string, CommandBarFieldValue>) => {
     const currentState = stateRef.current;
@@ -1499,6 +1505,7 @@ export function CommandBar({
       const enabled = !disabledPlugins.includes(plugin.id);
       const toggleAction = () => {
         dispatch({ type: "TOGGLE_PLUGIN", pluginId: plugin.id });
+        const currentState = stateRef.current;
         const nextDisabled = enabled
           ? [...disabledPlugins, plugin.id]
           : disabledPlugins.filter((entry) => entry !== plugin.id);
@@ -1507,7 +1514,7 @@ export function CommandBar({
             pluginRegistry.hidePane(paneId);
           }
         }
-        void saveConfig({ ...state.config, disabledPlugins: nextDisabled });
+        persistConfig({ ...currentState.config, disabledPlugins: nextDisabled });
       };
       return {
         id: `plugin:${plugin.id}`,
@@ -1520,7 +1527,7 @@ export function CommandBar({
         action: toggleAction,
       };
     });
-  }, [dispatch, pluginRegistry, state.config]);
+  }, [dispatch, persistConfig, pluginRegistry, state.config]);
 
   const buildLayoutItems = useCallback((
     query: string,
@@ -3128,7 +3135,7 @@ export function CommandBar({
           },
         };
         dispatch({ type: "SET_CONFIG", config: nextConfig });
-        void saveConfig(nextConfig);
+        persistConfig(nextConfig);
         closeAll({ revertThemePreview: false });
         return;
       }
@@ -5669,15 +5676,15 @@ export function CommandBar({
               paletteText={paletteText}
               panelBg={panelBg}
               onPreview={applyThemePreview}
-              onCommit={(themeId) => {
-                const nextConfig = {
-                  ...stateRef.current.config,
-                  theme: themeId,
-                };
-                commitTheme(themeId);
-                void saveConfig(nextConfig);
-                closeAll({ revertThemePreview: false });
-              }}
+	              onCommit={(themeId) => {
+	                const nextConfig = {
+	                  ...stateRef.current.config,
+	                  theme: themeId,
+	                };
+	                commitTheme(themeId);
+	                persistConfig(nextConfig);
+	                closeAll({ revertThemePreview: false });
+	              }}
             />
           )}
 

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -33,6 +33,7 @@ import { removePaneInstances, type LayoutConfig } from "../../types/config";
 import { contextMenuDivider, type ContextMenuItem } from "../../types/context-menu";
 import {
   resolveTickerForPane,
+  syncConfigActiveLayoutState,
   useAppDispatch,
   useAppSelector,
 } from "../../state/app-context";
@@ -794,6 +795,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   const config = useAppSelector((state) => state.config);
   const paneState = useAppSelector((state) => state.paneState);
   const focusedPaneId = useAppSelector(selectFocusedPaneId);
+  const activePanel = useAppSelector((state) => state.activePanel);
   const commandBarOpen = useAppSelector(selectCommandBarOpen);
   const inputCaptured = useAppSelector((state) => state.inputCaptured);
   const statusBarVisible = useAppSelector(selectStatusBarVisible);
@@ -876,15 +878,17 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
   );
 
   const persistLayout = useCallback((nextLayout: LayoutConfig, options?: { pushHistory?: boolean }) => {
-    const layouts = config.layouts.map((savedLayout, index) => (
-      index === config.activeLayoutIndex ? { ...savedLayout, layout: nextLayout } : savedLayout
-    ));
     if (options?.pushHistory !== false) {
       dispatch({ type: "PUSH_LAYOUT_HISTORY" });
     }
     dispatch({ type: "UPDATE_LAYOUT", layout: nextLayout });
-    scheduleConfigSave({ ...config, layout: nextLayout, layouts });
-  }, [config, dispatch]);
+    scheduleConfigSave(syncConfigActiveLayoutState(
+      { ...config, layout: nextLayout },
+      paneState,
+      focusedPaneId,
+      activePanel,
+    ));
+  }, [activePanel, config, dispatch, focusedPaneId, paneState]);
 
   const closeFocusedPane = useCallback(() => {
     if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) return false;

--- a/src/core/state/app-state.ts
+++ b/src/core/state/app-state.ts
@@ -169,11 +169,33 @@ function defaultPaneStateForInstance(config: AppConfig, instance: PaneInstanceCo
   return {};
 }
 
-function reconcilePaneState(config: AppConfig, previous: Record<string, PaneRuntimeState>): Record<string, PaneRuntimeState> {
+function cloneRuntimeValue<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => cloneRuntimeValue(entry)) as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneRuntimeValue(entry)]),
+    ) as T;
+  }
+  return value;
+}
+
+export function clonePaneStateMap(previous: Record<string, Record<string, unknown>>): Record<string, PaneRuntimeState> {
+  return Object.fromEntries(
+    Object.entries(previous).map(([paneId, paneState]) => [paneId, cloneRuntimeValue(paneState) as PaneRuntimeState]),
+  );
+}
+
+function reconcilePaneState(
+  config: AppConfig,
+  previous: Record<string, PaneRuntimeState>,
+  layout: LayoutConfig = config.layout,
+): Record<string, PaneRuntimeState> {
   const next: Record<string, PaneRuntimeState> = {};
-  for (const instance of config.layout.instances) {
+  for (const instance of layout.instances) {
     const defaults = defaultPaneStateForInstance(config, instance);
-    const paneState = { ...defaults, ...(previous[instance.instanceId] ?? {}) };
+    const paneState = { ...defaults, ...cloneRuntimeValue(previous[instance.instanceId] ?? {}) };
     if (
       instance.paneId === "portfolio-list"
       && !isKnownCollection(config, paneState.collectionId as string | undefined)
@@ -286,10 +308,56 @@ function nextRecentTickers(current: string[], symbol: string | null): string[] {
   return next;
 }
 
-function syncLayouts(layouts: SavedLayout[], activeLayoutIndex: number, layout: LayoutConfig): SavedLayout[] {
-  return layouts.map((savedLayout, index) => (
-    index === activeLayoutIndex ? { ...savedLayout, layout: cloneLayout(layout) } : savedLayout
-  ));
+function cloneSavedLayout(entry: SavedLayout): SavedLayout {
+  return {
+    ...entry,
+    layout: cloneLayout(entry.layout),
+    paneState: entry.paneState ? clonePaneStateMap(entry.paneState) : entry.paneState,
+  };
+}
+
+function buildSavedLayoutSnapshot(
+  entry: SavedLayout | undefined,
+  layout: LayoutConfig,
+  paneState: Record<string, PaneRuntimeState>,
+  focusedPaneId: string | null,
+  activePanel: "left" | "right",
+): SavedLayout {
+  return {
+    ...(entry ?? { name: "Default" }),
+    layout: cloneLayout(layout),
+    paneState: clonePaneStateMap(paneState),
+    focusedPaneId,
+    activePanel,
+  };
+}
+
+export function syncConfigActiveLayoutState(
+  config: AppConfig,
+  paneState: Record<string, PaneRuntimeState>,
+  focusedPaneId: string | null,
+  activePanel: "left" | "right",
+): AppConfig {
+  const activeLayoutIndex = config.activeLayoutIndex >= 0 && config.activeLayoutIndex < config.layouts.length
+    ? config.activeLayoutIndex
+    : 0;
+  const layouts = config.layouts.length > 0
+    ? config.layouts.map((savedLayout, index) => (
+      index === activeLayoutIndex
+        ? buildSavedLayoutSnapshot(savedLayout, config.layout, reconcilePaneState(config, paneState), focusedPaneId, activePanel)
+        : cloneSavedLayout(savedLayout)
+    ))
+    : [buildSavedLayoutSnapshot(undefined, config.layout, reconcilePaneState(config, paneState), focusedPaneId, activePanel)];
+  return {
+    ...config,
+    layouts,
+    activeLayoutIndex,
+  };
+}
+
+function getActiveSavedPaneState(config: AppConfig): Record<string, PaneRuntimeState> | null {
+  const paneState = config.layouts[config.activeLayoutIndex]?.paneState;
+  return paneState ? clonePaneStateMap(paneState) : null;
 }
 
 const PANEL_RESOLUTION_BOUNDS = { x: 0, y: 0, width: 120, height: 40 };
@@ -393,9 +461,7 @@ function bringFloatingToFront(layout: LayoutConfig, paneId: string): LayoutConfi
 
 function focusPaneState(state: AppState, paneId: string): AppState {
   const layout = bringFloatingToFront(state.config.layout, paneId);
-  const config = layout !== state.config.layout
-    ? { ...state.config, layout, layouts: syncLayouts(state.config.layouts, state.config.activeLayoutIndex, layout) }
-    : state.config;
+  const config = layout !== state.config.layout ? { ...state.config, layout } : state.config;
   const recentTickers = nextRecentTickers(
     state.recentTickers,
     resolveTickerForPane(state, paneId),
@@ -409,41 +475,44 @@ function focusPaneState(state: AppState, paneId: string): AppState {
   }
   return {
     ...state,
-    config,
+    config: syncConfigActiveLayoutState(config, state.paneState, paneId, state.activePanel),
     focusedPaneId: paneId,
     recentTickers,
   };
 }
 
-function bringFocusedFloatingPaneToFront(config: AppConfig, focusedPaneId: string | null): AppConfig {
-  if (!focusedPaneId) return config;
-  const layout = bringFloatingToFront(config.layout, focusedPaneId);
-  if (layout === config.layout) return config;
-  return {
-    ...config,
-    layout,
-    layouts: syncLayouts(config.layouts, config.activeLayoutIndex, layout),
-  };
-}
-
-function withFocusedPane(state: AppState, config: AppConfig): AppState {
+function withFocusedPane(
+  state: AppState,
+  config: AppConfig,
+  options: {
+    paneState?: Record<string, PaneRuntimeState>;
+    focusedPaneId?: string | null;
+    activePanel?: "left" | "right";
+  } = {},
+): AppState {
   const normalizedLayout = normalizePaneLayout(config.layout);
   const nextConfig = normalizedLayout === config.layout
     ? config
     : {
       ...config,
       layout: normalizedLayout,
-      layouts: syncLayouts(config.layouts, config.activeLayoutIndex, normalizedLayout),
-    };
-  const nextPaneState = reconcilePaneState(nextConfig, state.paneState);
-  const focusedPaneId = resolveFocusedPaneId(nextConfig.layout, state.focusedPaneId);
-  const focusedConfig = bringFocusedFloatingPaneToFront(nextConfig, focusedPaneId);
+  };
+  const activePanel = options.activePanel ?? state.activePanel;
+  const nextPaneState = reconcilePaneState(nextConfig, options.paneState ?? state.paneState);
+  const requestedFocusedPaneId = Object.prototype.hasOwnProperty.call(options, "focusedPaneId")
+    ? (options.focusedPaneId ?? null)
+    : state.focusedPaneId;
+  const focusedPaneId = resolveFocusedPaneId(nextConfig.layout, requestedFocusedPaneId);
+  const focusedLayout = focusedPaneId ? bringFloatingToFront(nextConfig.layout, focusedPaneId) : nextConfig.layout;
+  const focusedConfig = focusedLayout === nextConfig.layout ? nextConfig : { ...nextConfig, layout: focusedLayout };
+  const syncedConfig = syncConfigActiveLayoutState(focusedConfig, nextPaneState, focusedPaneId, activePanel);
   return {
     ...state,
-    config: focusedConfig,
+    config: syncedConfig,
     paneState: nextPaneState,
-    brokerAccounts: reconcileBrokerAccounts(focusedConfig, state.brokerAccounts),
+    brokerAccounts: reconcileBrokerAccounts(syncedConfig, state.brokerAccounts),
     focusedPaneId,
+    activePanel,
   };
 }
 
@@ -465,7 +534,16 @@ function hydrateDesktopSnapshot(state: AppState, snapshot: DesktopSharedStateSna
 export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case "SET_CONFIG":
-      return withFocusedPane({ ...state, themePreview: null, layoutHistory: {} }, action.config);
+      return withFocusedPane(
+        { ...state, themePreview: null, layoutHistory: {} },
+        action.config,
+        {
+          paneState: {
+            ...state.paneState,
+            ...(getActiveSavedPaneState(action.config) ?? {}),
+          },
+        },
+      );
 
     case "SET_TICKERS":
       return { ...state, tickers: action.tickers };
@@ -488,15 +566,13 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           : currentState;
       }
       const layout = clearTickerBindings(state.config.layout, action.symbol);
-      const layouts = syncLayouts(state.config.layouts, state.config.activeLayoutIndex, layout);
-      return {
+      return withFocusedPane({
         ...state,
         tickers,
         financials,
         paneState,
         recentTickers: state.recentTickers.filter((symbol) => symbol !== action.symbol),
-        config: { ...state.config, layout, layouts },
-      };
+      }, { ...state.config, layout }, { paneState });
     }
 
     case "SET_FINANCIALS": {
@@ -526,11 +602,10 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case "SET_ACTIVE_PANEL": {
       const firstPane = getPanelFocusTarget(state.config.layout, action.panel);
-      return {
-        ...state,
+      return withFocusedPane(state, state.config, {
         activePanel: action.panel,
         focusedPaneId: firstPane ?? state.focusedPaneId,
-      };
+      });
     }
 
     case "TOGGLE_COMMAND_BAR":
@@ -658,14 +733,12 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const target = entry.past[entry.past.length - 1]!;
       entry.past = entry.past.slice(0, -1);
       entry.future = [cloneLayout(state.config.layout), ...entry.future].slice(0, MAX_LAYOUT_HISTORY);
-      const layouts = syncLayouts(state.config.layouts, currentIndex, target);
       return withFocusedPane({
         ...state,
         layoutHistory: setHistoryForIndex(state.layoutHistory, currentIndex, entry),
       }, {
         ...state.config,
         layout: cloneLayout(target),
-        layouts,
       });
     }
 
@@ -676,54 +749,76 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const target = entry.future[0]!;
       entry.future = entry.future.slice(1);
       entry.past = [...entry.past, cloneLayout(state.config.layout)].slice(-MAX_LAYOUT_HISTORY);
-      const layouts = syncLayouts(state.config.layouts, currentIndex, target);
       return withFocusedPane({
         ...state,
         layoutHistory: setHistoryForIndex(state.layoutHistory, currentIndex, entry),
       }, {
         ...state.config,
         layout: cloneLayout(target),
-        layouts,
       });
     }
 
     case "UPDATE_LAYOUT": {
-      const layouts = syncLayouts(state.config.layouts, state.config.activeLayoutIndex, action.layout);
-      return withFocusedPane(state, { ...state.config, layout: action.layout, layouts });
+      return withFocusedPane(state, { ...state.config, layout: action.layout });
     }
 
     case "SWITCH_LAYOUT": {
       if (action.index < 0 || action.index >= state.config.layouts.length) return state;
-      const layouts = syncLayouts(state.config.layouts, state.config.activeLayoutIndex, state.config.layout);
-      const target = layouts[action.index]!;
+      if (action.index === state.config.activeLayoutIndex) return state;
+      const currentConfig = syncConfigActiveLayoutState(
+        state.config,
+        state.paneState,
+        state.focusedPaneId,
+        state.activePanel,
+      );
+      const target = currentConfig.layouts[action.index]!;
       return withFocusedPane(state, {
-        ...state.config,
+        ...currentConfig,
         layout: cloneLayout(target.layout),
-        layouts,
         activeLayoutIndex: action.index,
+      }, {
+        paneState: target.paneState ? clonePaneStateMap(target.paneState) : {},
+        focusedPaneId: target.focusedPaneId ?? null,
+        activePanel: target.activePanel ?? state.activePanel,
       });
     }
 
     case "NEW_LAYOUT": {
+      const currentConfig = syncConfigActiveLayoutState(
+        state.config,
+        state.paneState,
+        state.focusedPaneId,
+        state.activePanel,
+      );
       const newLayout: SavedLayout = {
         name: action.name,
         layout: cloneLayout(DEFAULT_LAYOUT),
+        paneState: {},
       };
-      const layouts = [...syncLayouts(state.config.layouts, state.config.activeLayoutIndex, state.config.layout), newLayout];
+      const layouts = [...currentConfig.layouts, newLayout];
       return withFocusedPane({
         ...state,
         layoutHistory: setHistoryForIndex(state.layoutHistory, layouts.length - 1, { past: [], future: [] }),
       }, {
-        ...state.config,
+        ...currentConfig,
         layout: cloneLayout(newLayout.layout),
         layouts,
         activeLayoutIndex: layouts.length - 1,
+      }, {
+        paneState: {},
+        focusedPaneId: null,
       });
     }
 
     case "DELETE_LAYOUT": {
       if (state.config.layouts.length <= 1) return state;
-      const layouts = state.config.layouts.filter((_, index) => index !== action.index);
+      const currentConfig = syncConfigActiveLayoutState(
+        state.config,
+        state.paneState,
+        state.focusedPaneId,
+        state.activePanel,
+      );
+      const layouts = currentConfig.layouts.filter((_, index) => index !== action.index);
       const nextActiveLayoutIndex = action.index <= state.config.activeLayoutIndex
         ? Math.max(0, state.config.activeLayoutIndex - 1)
         : state.config.activeLayoutIndex;
@@ -732,20 +827,30 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         ...state,
         layoutHistory: removeHistoryIndex(state.layoutHistory, action.index),
       }, {
-        ...state.config,
+        ...currentConfig,
         layout: cloneLayout(nextLayout.layout),
         layouts,
         activeLayoutIndex: nextActiveLayoutIndex,
+      }, {
+        paneState: nextLayout.paneState ? clonePaneStateMap(nextLayout.paneState) : {},
+        focusedPaneId: nextLayout.focusedPaneId ?? null,
+        activePanel: nextLayout.activePanel ?? state.activePanel,
       });
     }
 
     case "RENAME_LAYOUT": {
       if (action.index < 0 || action.index >= state.config.layouts.length) return state;
+      const currentConfig = syncConfigActiveLayoutState(
+        state.config,
+        state.paneState,
+        state.focusedPaneId,
+        state.activePanel,
+      );
       return {
         ...state,
         config: {
-          ...state.config,
-          layouts: state.config.layouts.map((savedLayout, index) => (
+          ...currentConfig,
+          layouts: currentConfig.layouts.map((savedLayout, index) => (
             index === action.index ? { ...savedLayout, name: action.name } : savedLayout
           )),
         },
@@ -754,20 +859,30 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case "DUPLICATE_LAYOUT": {
       if (action.index < 0 || action.index >= state.config.layouts.length) return state;
-      const source = state.config.layouts[action.index]!;
+      const currentConfig = syncConfigActiveLayoutState(
+        state.config,
+        state.paneState,
+        state.focusedPaneId,
+        state.activePanel,
+      );
+      const source = currentConfig.layouts[action.index]!;
       const duplicate: SavedLayout = {
+        ...cloneSavedLayout(source),
         name: `${source.name} Copy`,
-        layout: cloneLayout(source.layout),
       };
-      const layouts = [...syncLayouts(state.config.layouts, state.config.activeLayoutIndex, state.config.layout), duplicate];
+      const layouts = [...currentConfig.layouts, duplicate];
       return withFocusedPane({
         ...state,
         layoutHistory: setHistoryForIndex(state.layoutHistory, layouts.length - 1, { past: [], future: [] }),
       }, {
-        ...state.config,
+        ...currentConfig,
         layout: cloneLayout(duplicate.layout),
         layouts,
         activeLayoutIndex: layouts.length - 1,
+      }, {
+        paneState: duplicate.paneState ? clonePaneStateMap(duplicate.paneState) : {},
+        focusedPaneId: duplicate.focusedPaneId ?? state.focusedPaneId,
+        activePanel: duplicate.activePanel ?? state.activePanel,
       });
     }
 
@@ -802,12 +917,14 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const recentTickers = Object.prototype.hasOwnProperty.call(action.patch, "cursorSymbol")
         ? nextRecentTickers(state.recentTickers, typeof nextState.cursorSymbol === "string" ? nextState.cursorSymbol : null)
         : state.recentTickers;
+      const paneState = {
+        ...state.paneState,
+        [action.paneId]: nextState,
+      };
       return {
         ...state,
-        paneState: {
-          ...state.paneState,
-          [action.paneId]: nextState,
-        },
+        config: syncConfigActiveLayoutState(state.config, paneState, state.focusedPaneId, state.activePanel),
+        paneState,
         recentTickers,
       };
     }
@@ -819,21 +936,23 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       if (Object.is(currentPluginValues[action.key], action.value)) {
         return state;
       }
-      return {
-        ...state,
-        paneState: {
-          ...state.paneState,
-          [action.paneId]: {
-            ...current,
-            pluginState: {
-              ...currentPluginState,
-              [action.pluginId]: {
-                ...currentPluginValues,
-                [action.key]: action.value,
-              },
+      const paneState = {
+        ...state.paneState,
+        [action.paneId]: {
+          ...current,
+          pluginState: {
+            ...currentPluginState,
+            [action.pluginId]: {
+              ...currentPluginValues,
+              [action.key]: action.value,
             },
           },
         },
+      };
+      return {
+        ...state,
+        config: syncConfigActiveLayoutState(state.config, paneState, state.focusedPaneId, state.activePanel),
+        paneState,
       };
     }
 
@@ -843,20 +962,31 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 }
 
 export function createInitialState(config: AppConfig, sessionSnapshot: AppSessionSnapshot | null = null): AppState {
-  const paneState = reconcilePaneState(config, sessionSnapshot?.paneState ?? {});
+  const activeSavedLayout = config.layouts[config.activeLayoutIndex];
+  const savedPaneState = activeSavedLayout?.paneState ? clonePaneStateMap(activeSavedLayout.paneState) : {};
+  const sessionPaneState = sessionSnapshot?.paneState ? clonePaneStateMap(sessionSnapshot.paneState) : {};
+  const paneState = reconcilePaneState(config, { ...sessionPaneState, ...savedPaneState });
   const defaultFocusedPaneId = getTopFloatingPaneId(config.layout) ?? getPaneOrder(config.layout)[0] ?? null;
-  const focusedPaneId = sessionSnapshot?.focusedPaneId
-    && config.layout.instances.some((instance) => instance.instanceId === sessionSnapshot.focusedPaneId)
-    ? sessionSnapshot.focusedPaneId
+  const requestedFocusedPaneId = activeSavedLayout?.focusedPaneId ?? sessionSnapshot?.focusedPaneId ?? null;
+  const focusedPaneId = requestedFocusedPaneId
+    && config.layout.instances.some((instance) => instance.instanceId === requestedFocusedPaneId)
+    ? requestedFocusedPaneId
     : defaultFocusedPaneId;
-  const focusedConfig = bringFocusedFloatingPaneToFront(config, focusedPaneId);
+  const activePanel = activeSavedLayout?.activePanel ?? (sessionSnapshot?.activePanel === "right" ? "right" : "left");
+  const focusedLayout = focusedPaneId ? bringFloatingToFront(config.layout, focusedPaneId) : config.layout;
+  const focusedConfig = syncConfigActiveLayoutState(
+    focusedLayout === config.layout ? config : { ...config, layout: focusedLayout },
+    paneState,
+    focusedPaneId,
+    activePanel,
+  );
   return {
     config: focusedConfig,
     tickers: new Map(),
     financials: new Map(),
     exchangeRates: new Map([["USD", 1]]),
     brokerAccounts: {},
-    activePanel: sessionSnapshot?.activePanel === "right" ? "right" : "left",
+    activePanel,
     focusedPaneId,
     paneState,
     recentTickers: config.recentTickers,

--- a/src/data/config-store-node.ts
+++ b/src/data/config-store-node.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { dirname, join } from "path";
 import type {
   AppConfig,
@@ -89,7 +89,9 @@ function normalizeConfig(saved: Record<string, unknown>, dataDir: string): { con
   const activeLayoutIndex = sanitizeActiveLayoutIndex(saved.activeLayoutIndex, layouts.length);
   const layout = cloneLayout(layouts[activeLayoutIndex]?.layout ?? directLayout);
   const syncedLayouts = layouts.map((entry, index) => (
-    index === activeLayoutIndex ? { ...entry, layout: cloneLayout(layout) } : entry
+    index === activeLayoutIndex
+      ? { ...entry, layout: cloneLayout(layout), paneState: sanitizeSavedPaneState(entry.paneState, layout) }
+      : entry
   ));
 
   const disabledPlugins = sanitizeDisabledPlugins(saved, defaults.disabledPlugins, {
@@ -138,7 +140,9 @@ export async function saveConfig(config: AppConfig): Promise<void> {
   const activeLayoutIndex = sanitizeActiveLayoutIndex(config.activeLayoutIndex, config.layouts.length || 1);
   const layout = sanitizeLayout(config.layout, createDefaultConfig(config.dataDir).layout);
   const layouts = sanitizeSavedLayouts(config.layouts, layout).map((entry, index) => (
-    index === activeLayoutIndex ? { ...entry, layout: cloneLayout(layout) } : entry
+    index === activeLayoutIndex
+      ? { ...entry, layout: cloneLayout(layout), paneState: sanitizeSavedPaneState(entry.paneState, layout) }
+      : entry
   ));
 
   const persisted: AppConfig = {
@@ -158,7 +162,14 @@ export async function saveConfig(config: AppConfig): Promise<void> {
     recentTickers: sanitizeStringArray(config.recentTickers, []),
   };
 
-  await writeFile(configPath, JSON.stringify(persisted, null, 2), "utf-8");
+  const tempPath = `${configPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await writeFile(tempPath, JSON.stringify(persisted, null, 2), "utf-8");
+    await rename(tempPath, configPath);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => {});
+    throw error;
+  }
 }
 
 export async function initDataDir(dataDir: string): Promise<AppConfig> {
@@ -236,6 +247,41 @@ function sanitizeDisabledSources(saved: Record<string, unknown>, fallback: strin
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeSerializableValue(value: unknown): unknown {
+  if (value == null) return value;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => sanitizeSerializableValue(entry))
+      .filter((entry) => entry !== undefined);
+  }
+  if (isPlainRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .map(([key, entry]) => [key, sanitizeSerializableValue(entry)])
+        .filter(([, entry]) => entry !== undefined),
+    );
+  }
+  return undefined;
+}
+
+function sanitizeSavedPaneState(
+  value: unknown,
+  layout: LayoutConfig,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!isPlainRecord(value)) return undefined;
+  const validPaneIds = new Set(layout.instances.map((instance) => instance.instanceId));
+  const paneState = Object.fromEntries(
+    Object.entries(value)
+      .filter(([paneId, entry]) => validPaneIds.has(paneId) && isPlainRecord(entry))
+      .map(([paneId, entry]) => [paneId, sanitizeSerializableValue(entry)])
+      .filter((entry): entry is [string, Record<string, unknown>] => isPlainRecord(entry[1])),
+  );
+  return paneState;
 }
 
 function isPluginConfigMap(value: unknown): value is Record<string, Record<string, unknown>> {
@@ -374,10 +420,21 @@ function sanitizeSavedLayouts(value: unknown, fallbackLayout: LayoutConfig): Sav
       && typeof entry === "object"
       && typeof (entry as SavedLayout).name === "string",
     )
-    .map((entry) => ({
-      name: entry.name,
-      layout: sanitizeLayout(entry.layout, fallbackLayout),
-    }));
+    .map((entry) => {
+      const layout = sanitizeLayout(entry.layout, fallbackLayout);
+      return {
+        id: typeof entry.id === "string" ? entry.id : undefined,
+        name: entry.name,
+        layout,
+        paneState: sanitizeSavedPaneState((entry as { paneState?: unknown }).paneState, layout),
+        focusedPaneId: typeof entry.focusedPaneId === "string" || entry.focusedPaneId === null
+          ? entry.focusedPaneId
+          : undefined,
+        activePanel: entry.activePanel === "right" || entry.activePanel === "left"
+          ? entry.activePanel
+          : undefined,
+      };
+    });
 
   return layouts.length > 0 ? layouts : [{ name: "Default", layout: cloneLayout(fallbackLayout) }];
 }

--- a/src/data/config-store.test.ts
+++ b/src/data/config-store.test.ts
@@ -342,6 +342,40 @@ describe("loadConfig", () => {
     });
   });
 
+  test("preserves saved layout pane state and focus metadata", async () => {
+    const dataDir = await createTempConfigDir();
+    await writeConfigJson(dataDir, createSavedConfig({
+      layouts: [{
+        name: "Chart",
+        layout: DEFAULT_LAYOUT,
+        paneState: {
+          "ticker-detail:main": { activeTabId: "chart" },
+          "missing:pane": { activeTabId: "overview" },
+        },
+        focusedPaneId: "ticker-detail:main",
+        activePanel: "right",
+      }],
+    }));
+
+    const config = await loadConfig(dataDir);
+
+    expect(config.layouts[0]?.paneState).toEqual({
+      "ticker-detail:main": { activeTabId: "chart" },
+    });
+    expect(config.layouts[0]?.focusedPaneId).toBe("ticker-detail:main");
+    expect(config.layouts[0]?.activePanel).toBe("right");
+
+    await saveConfig(config);
+    const persisted = JSON.parse(await readFile(join(dataDir, "config.json"), "utf-8")) as {
+      layouts: Array<{ paneState?: Record<string, unknown>; focusedPaneId?: string | null; activePanel?: string }>;
+    };
+    expect(persisted.layouts[0]?.paneState).toEqual({
+      "ticker-detail:main": { activeTabId: "chart" },
+    });
+    expect(persisted.layouts[0]?.focusedPaneId).toBe("ticker-detail:main");
+    expect(persisted.layouts[0]?.activePanel).toBe("right");
+  });
+
   test("migrates legacy main portfolio panes to the portfolio default columns", async () => {
     const dataDir = await createTempConfigDir();
     const legacyColumnIds = DEFAULT_COLUMNS.map((column) => column.id);

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -3,7 +3,7 @@ import { memo, useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useShortcut } from "../../react/input";
 import { TextAttributes, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
 import type { GloomPlugin, PaneProps } from "../../types/plugin";
-import { useAppDispatch, useAppSelector, useAppStateRef, usePaneInstance, usePaneInstanceId } from "../../state/app-context";
+import { syncConfigActiveLayoutState, useAppDispatch, useAppSelector, useAppStateRef, usePaneInstance, usePaneInstanceId } from "../../state/app-context";
 import { useInlineTickers, type InlineTickerCatalogEntry } from "../../state/use-inline-tickers";
 import { ExternalLinkText, getMessageComposerBlockHeight, MessageComposer } from "../../components/ui";
 import { TickerBadgeText } from "../../components/ticker-badge-text";
@@ -1869,9 +1869,6 @@ function ChatPane({ focused, width, height, close }: PaneProps) {
   const persistChannelId = useCallback((nextChannelId: string) => {
     const currentState = stateRef.current;
     const layout = setPaneSetting(currentState.config.layout, paneId, "channelId", nextChannelId);
-    const layouts = currentState.config.layouts.map((savedLayout, index) => (
-      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
-    ));
     const pluginConfig = {
       ...currentState.config.pluginConfig,
       "gloomberb-cloud": {
@@ -1882,11 +1879,16 @@ function ChatPane({ focused, width, height, close }: PaneProps) {
     const nextConfig = {
       ...currentState.config,
       layout,
-      layouts,
       pluginConfig,
     };
-    dispatch({ type: "SET_CONFIG", config: nextConfig });
-    scheduleConfigSave(nextConfig);
+    const syncedConfig = syncConfigActiveLayoutState(
+      nextConfig,
+      currentState.paneState,
+      currentState.focusedPaneId,
+      currentState.activePanel,
+    );
+    dispatch({ type: "SET_CONFIG", config: syncedConfig });
+    scheduleConfigSave(syncedConfig);
   }, [dispatch, paneId, stateRef]);
   const [channelId, setLocalChannelId] = useState(initialChannelIdRef.current);
   const pendingChannelIdRef = useRef<string | null>(null);

--- a/src/plugins/builtin/layout-manager.tsx
+++ b/src/plugins/builtin/layout-manager.tsx
@@ -1,4 +1,3 @@
-import { saveConfig } from "../../data/config-store";
 import { findPaneInstance, type LayoutConfig } from "../../types/config";
 import type { AppNotificationRequest, GloomPlugin, GloomPluginContext } from "../../types/plugin";
 import type { AppAction } from "../../state/app-context";
@@ -30,15 +29,10 @@ export function clearLayoutManagerDispatch() {
   getStateRef = null;
 }
 
-function persistLayout(ctx: Pick<GloomPluginContext, "getConfig">, layout: LayoutConfig) {
+function persistLayout(_ctx: Pick<GloomPluginContext, "getConfig">, layout: LayoutConfig) {
   if (!dispatchRef) return;
   dispatchRef({ type: "PUSH_LAYOUT_HISTORY" });
   dispatchRef({ type: "UPDATE_LAYOUT", layout });
-  const config = ctx.getConfig();
-  const layouts = config.layouts.map((savedLayout, index) => (
-    index === config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
-  ));
-  saveConfig({ ...config, layout, layouts }).catch(() => {});
 }
 
 function getFocusedPane(layout: LayoutConfig, focusedPaneId: string | null) {

--- a/src/plugins/builtin/ticker-detail.test.tsx
+++ b/src/plugins/builtin/ticker-detail.test.tsx
@@ -820,7 +820,7 @@ describe("TickerDetailPane", () => {
     expect(frame).toContain("+25.00%");
   });
 
-  test("falls back to Overview when a hidden active tab becomes unavailable", async () => {
+  test("renders an Overview fallback without overwriting a temporarily unavailable active tab", async () => {
     const gatewayConfig = createDetailConfig("AAPL", [createGatewayInstance()]);
     const noGatewayConfig = createDetailConfig("AAPL");
     setSharedRegistryForTests(makeRegistry());
@@ -844,7 +844,7 @@ describe("TickerDetailPane", () => {
     await flushFrame();
 
     const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("active:overview");
+    expect(frame).toContain("active:ibkr-trade");
     expect(frame).not.toContain("Trade");
   });
 

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -154,12 +154,6 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
     });
   }, [resolvedTabId, visibleTabIds]);
 
-  useEffect(() => {
-    if (resolvedTabId !== activeTabId) {
-      setActiveTabId(resolvedTabId);
-    }
-  }, [activeTabId, resolvedTabId, setActiveTabId]);
-
   const handleKeyboard = useCallback((event: { name?: string }) => {
     const currentState = stateRef.current;
     if (!currentState.focused || currentState.pluginCaptured) return;

--- a/src/renderers/electrobun/bun/desktop-workspace.ts
+++ b/src/renderers/electrobun/bun/desktop-workspace.ts
@@ -1,13 +1,15 @@
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
-import type { PaneRuntimeState } from "../../../core/state/app-state";
+import { clonePaneStateMap, syncConfigActiveLayoutState, type PaneRuntimeState } from "../../../core/state/app-state";
 import { cloneLayout, type AppConfig } from "../../../types/config";
 import type { DesktopSharedStateSnapshot } from "../../../types/desktop-window";
 import { detachPaneToFrame, dockPane, insertAtRootEdge, removePane } from "../../../plugins/pane-manager";
 
-function clonePaneStateMap(state: Record<string, PaneRuntimeState>): Record<string, PaneRuntimeState> {
-  return Object.fromEntries(
-    Object.entries(state).map(([paneId, paneState]) => [paneId, { ...paneState }]),
-  );
+function cloneSavedLayouts(config: AppConfig): AppConfig["layouts"] {
+  return config.layouts.map((entry) => ({
+    ...entry,
+    layout: cloneLayout(entry.layout),
+    paneState: entry.paneState ? clonePaneStateMap(entry.paneState) : entry.paneState,
+  }));
 }
 
 function filterPaneState(
@@ -18,17 +20,6 @@ function filterPaneState(
   return Object.fromEntries(
     Object.entries(paneState).filter(([paneId]) => validPaneIds.has(paneId)),
   );
-}
-
-function syncActiveLayout(config: AppConfig): AppConfig {
-  return {
-    ...config,
-    layouts: config.layouts.map((entry, index) => (
-      index === config.activeLayoutIndex
-        ? { ...entry, layout: cloneLayout(config.layout) }
-        : entry
-    )),
-  };
 }
 
 export interface DesktopWorkspace {
@@ -55,22 +46,37 @@ export function createDesktopWorkspace(
   config: AppConfig,
   sessionSnapshot: AppSessionSnapshot | null,
 ): DesktopWorkspace {
+  const savedPaneState = config.layouts[config.activeLayoutIndex]?.paneState ?? {};
+  const initialPaneState = filterPaneState(config.layout, clonePaneStateMap({
+    ...(sessionSnapshot?.paneState ?? {}),
+    ...savedPaneState,
+  }));
+  const initialFocusedPaneId = config.layouts[config.activeLayoutIndex]?.focusedPaneId
+    ?? sessionSnapshot?.focusedPaneId
+    ?? null;
+  const initialActivePanel = config.layouts[config.activeLayoutIndex]?.activePanel
+    ?? (sessionSnapshot?.activePanel === "right" ? "right" : "left");
   let sharedState: DesktopSharedStateSnapshot = {
-    config: syncActiveLayout(config),
-    paneState: filterPaneState(config.layout, clonePaneStateMap(sessionSnapshot?.paneState ?? {})),
-    focusedPaneId: sessionSnapshot?.focusedPaneId ?? null,
-    activePanel: sessionSnapshot?.activePanel === "right" ? "right" : "left",
+    config: syncConfigActiveLayoutState(config, initialPaneState, initialFocusedPaneId, initialActivePanel),
+    paneState: initialPaneState,
+    focusedPaneId: initialFocusedPaneId,
+    activePanel: initialActivePanel,
     statusBarVisible: sessionSnapshot?.statusBarVisible !== false,
   };
 
   const updateConfig = (nextConfig: AppConfig, options?: { layoutChanged?: boolean }) => {
-    const syncedConfig = syncActiveLayout(nextConfig);
+    const syncedConfig = syncConfigActiveLayoutState(
+      nextConfig,
+      sharedState.paneState,
+      sharedState.focusedPaneId,
+      sharedState.activePanel,
+    );
     sharedState = {
       ...sharedState,
       config: {
         ...syncedConfig,
         layout: cloneLayout(syncedConfig.layout),
-        layouts: syncedConfig.layouts.map((entry) => ({ ...entry, layout: cloneLayout(entry.layout) })),
+        layouts: cloneSavedLayouts(syncedConfig),
       },
       paneState: filterPaneState(syncedConfig.layout, sharedState.paneState),
       layoutChanged: options?.layoutChanged,
@@ -82,7 +88,7 @@ export function createDesktopWorkspace(
     config: {
       ...sharedState.config,
       layout: cloneLayout(sharedState.config.layout),
-      layouts: sharedState.config.layouts.map((entry) => ({ ...entry, layout: cloneLayout(entry.layout) })),
+      layouts: cloneSavedLayouts(sharedState.config),
     },
     paneState: clonePaneStateMap(sharedState.paneState),
     focusedPaneId: sharedState.focusedPaneId,
@@ -94,12 +100,17 @@ export function createDesktopWorkspace(
   return {
     getSnapshot,
     syncMainState(snapshot) {
-      const syncedConfig = syncActiveLayout(snapshot.config);
+      const syncedConfig = syncConfigActiveLayoutState(
+        snapshot.config,
+        snapshot.paneState,
+        snapshot.focusedPaneId,
+        snapshot.activePanel,
+      );
       sharedState = {
         config: {
           ...syncedConfig,
           layout: cloneLayout(syncedConfig.layout),
-          layouts: syncedConfig.layouts.map((entry) => ({ ...entry, layout: cloneLayout(entry.layout) })),
+          layouts: cloneSavedLayouts(syncedConfig),
         },
         paneState: filterPaneState(syncedConfig.layout, clonePaneStateMap(snapshot.paneState)),
         focusedPaneId: snapshot.focusedPaneId,
@@ -113,12 +124,19 @@ export function createDesktopWorkspace(
       return updateConfig(config, options);
     },
     replaceDetachedPaneState(paneId, paneState) {
+      const nextPaneState = filterPaneState(sharedState.config.layout, {
+        ...sharedState.paneState,
+        [paneId]: { ...paneState },
+      });
       sharedState = {
         ...sharedState,
-        paneState: filterPaneState(sharedState.config.layout, {
-          ...sharedState.paneState,
-          [paneId]: { ...paneState },
-        }),
+        config: syncConfigActiveLayoutState(
+          sharedState.config,
+          nextPaneState,
+          sharedState.focusedPaneId,
+          sharedState.activePanel,
+        ),
+        paneState: nextPaneState,
       };
       return getSnapshot();
     },

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -10,9 +10,9 @@ import {
 import { createAppServices, type AppServices } from "../../../core/app-services";
 import { getDataDir, initDataDir, saveConfig, resetAllData, exportConfig, importConfig, setConfigStoreHost } from "../../../data/config-store";
 import * as nodeConfigStoreHost from "../../../data/config-store-node";
-import { cloneLayout, findPaneInstance, type AppConfig } from "../../../types/config";
+import { findPaneInstance, type AppConfig } from "../../../types/config";
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
-import type { PaneRuntimeState } from "../../../core/state/app-state";
+import { syncConfigActiveLayoutState, type PaneRuntimeState } from "../../../core/state/app-state";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState } from "../../../types/desktop-window";
 import type { ReleaseInfo, UpdateCheckResult, UpdateProgress } from "../../../updater";
 import { buildSoundCommand } from "../../../notifications/app-notifier";
@@ -140,13 +140,13 @@ function scopeClientId(rpc: DesktopRpc, id: string): string {
   return `${getRpcWindowKey(rpc) ?? "window"}:${id}`;
 }
 
-function syncActiveLayout(config: AppConfig): AppConfig {
-  return {
-    ...config,
-    layouts: config.layouts.map((entry, index) => (
-      index === config.activeLayoutIndex ? { ...entry, layout: cloneLayout(config.layout) } : entry
-    )),
-  };
+function syncActiveLayout(
+  config: AppConfig,
+  paneState: Record<string, PaneRuntimeState> = config.layouts[config.activeLayoutIndex]?.paneState ?? {},
+  focusedPaneId: string | null = config.layouts[config.activeLayoutIndex]?.focusedPaneId ?? null,
+  activePanel: "left" | "right" = config.layouts[config.activeLayoutIndex]?.activePanel ?? "left",
+): AppConfig {
+  return syncConfigActiveLayoutState(config, paneState, focusedPaneId, activePanel);
 }
 
 function normalizeInitWindowTarget(
@@ -670,7 +670,7 @@ async function commitDesktopSnapshot(
   snapshot: DesktopSharedStateSnapshot,
   options: { persistConfig?: boolean; reconcileWindows?: boolean } = {},
 ): Promise<DesktopSharedStateSnapshot> {
-  const nextConfig = syncActiveLayout(snapshot.config);
+  const nextConfig = syncActiveLayout(snapshot.config, snapshot.paneState, snapshot.focusedPaneId, snapshot.activePanel);
   setCurrentConfig(nextConfig);
   desktopWorkspace = requireDesktopWorkspace();
   desktopWorkspace.replaceConfig(nextConfig, { layoutChanged: snapshot.layoutChanged });

--- a/src/state/app-context.test.ts
+++ b/src/state/app-context.test.ts
@@ -329,6 +329,64 @@ describe("pane state updates", () => {
 
     expect(next).toBe(initial);
   });
+
+  test("keeps pane runtime state scoped to each saved layout", () => {
+    let state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    const originalLayoutIndex = state.config.activeLayoutIndex;
+
+    state = appReducer(state, {
+      type: "UPDATE_PANE_STATE",
+      paneId: "ticker-detail:main",
+      patch: { activeTabId: "chart" },
+    });
+    state = appReducer(state, { type: "DUPLICATE_LAYOUT", index: originalLayoutIndex });
+    const duplicateLayoutIndex = state.config.activeLayoutIndex;
+
+    state = appReducer(state, {
+      type: "UPDATE_PANE_STATE",
+      paneId: "ticker-detail:main",
+      patch: { activeTabId: "financials" },
+    });
+
+    expect(state.config.layouts[duplicateLayoutIndex]?.paneState?.["ticker-detail:main"]?.activeTabId).toBe("financials");
+
+    state = appReducer(state, { type: "SWITCH_LAYOUT", index: originalLayoutIndex });
+    expect(state.paneState["ticker-detail:main"]?.activeTabId).toBe("chart");
+    expect(state.config.layouts[originalLayoutIndex]?.paneState?.["ticker-detail:main"]?.activeTabId).toBe("chart");
+
+    state = appReducer(state, { type: "SWITCH_LAYOUT", index: duplicateLayoutIndex });
+    expect(state.paneState["ticker-detail:main"]?.activeTabId).toBe("financials");
+  });
+
+  test("hydrates saved layout pane state before legacy session pane state", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    config.layouts[config.activeLayoutIndex] = {
+      ...config.layouts[config.activeLayoutIndex]!,
+      paneState: {
+        "ticker-detail:main": { activeTabId: "chart" },
+      },
+      focusedPaneId: "ticker-detail:main",
+      activePanel: "right",
+    };
+    const sessionSnapshot: AppSessionSnapshot = {
+      paneState: {
+        "ticker-detail:main": { activeTabId: "overview" },
+      },
+      focusedPaneId: "portfolio-list:main",
+      activePanel: "left",
+      statusBarVisible: true,
+      openPaneIds: ["portfolio-list:main", "ticker-detail:main"],
+      hydrationTargets: [],
+      exchangeCurrencies: ["USD"],
+      savedAt: Date.now(),
+    };
+
+    const state = createInitialState(config, sessionSnapshot);
+
+    expect(state.paneState["ticker-detail:main"]?.activeTabId).toBe("chart");
+    expect(state.focusedPaneId).toBe("ticker-detail:main");
+    expect(state.activePanel).toBe("right");
+  });
 });
 
 describe("quote merging", () => {
@@ -487,6 +545,61 @@ describe("quote merging", () => {
 });
 
 describe("layout focus fallback", () => {
+  test("switching to an old layout without focused metadata uses that layout's top floating pane", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const targetLayout = {
+      ...cloneLayout(config.layout),
+      dockRoot: null,
+      floating: [
+        { instanceId: "chat:main", x: 4, y: 2, width: 36, height: 10, zIndex: 70 },
+        { instanceId: "ticker-detail:main", x: 12, y: 4, width: 36, height: 10, zIndex: 95 },
+      ],
+    };
+    config.layouts = [
+      { name: "Current", layout: cloneLayout(config.layout), paneState: {} },
+      { name: "Floating", layout: cloneLayout(targetLayout), paneState: {} },
+    ];
+    config.activeLayoutIndex = 0;
+
+    let state = createInitialState(config);
+    state = appReducer(state, { type: "FOCUS_PANE", paneId: "chat:main" });
+    state = appReducer(state, { type: "SWITCH_LAYOUT", index: 1 });
+
+    const chatEntry = state.config.layout.floating.find((entry) => entry.instanceId === "chat:main");
+    const tickerEntry = state.config.layout.floating.find((entry) => entry.instanceId === "ticker-detail:main");
+    expect(state.focusedPaneId).toBe("ticker-detail:main");
+    expect((tickerEntry?.zIndex ?? 0) > (chatEntry?.zIndex ?? 0)).toBe(true);
+  });
+
+  test("switching layouts raises the saved focused floating pane above stale z-order", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const targetLayout = {
+      ...cloneLayout(config.layout),
+      dockRoot: null,
+      floating: [
+        { instanceId: "chat:main", x: 4, y: 2, width: 36, height: 10, zIndex: 70 },
+        { instanceId: "ticker-detail:main", x: 12, y: 4, width: 36, height: 10, zIndex: 95 },
+      ],
+    };
+    config.layouts = [
+      { name: "Current", layout: cloneLayout(config.layout), paneState: {} },
+      {
+        name: "Floating",
+        layout: cloneLayout(targetLayout),
+        paneState: {},
+        focusedPaneId: "chat:main",
+      },
+    ];
+    config.activeLayoutIndex = 0;
+
+    const state = appReducer(createInitialState(config), { type: "SWITCH_LAYOUT", index: 1 });
+
+    const chatEntry = state.config.layout.floating.find((entry) => entry.instanceId === "chat:main");
+    const tickerEntry = state.config.layout.floating.find((entry) => entry.instanceId === "ticker-detail:main");
+    expect(state.focusedPaneId).toBe("chat:main");
+    expect((chatEntry?.zIndex ?? 0) > (tickerEntry?.zIndex ?? 0)).toBe(true);
+  });
+
   test("starts with the top floating pane focused when no session pane is active", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     const layout = {

--- a/src/state/app-context.tsx
+++ b/src/state/app-context.tsx
@@ -37,6 +37,7 @@ import {
   type PaneRuntimeState,
   resolveCollectionForPane,
   resolveTickerForPane,
+  syncConfigActiveLayoutState,
 } from "../core/state/app-state";
 import type { AppAction, AppState } from "../core/state/app-state";
 import { scheduleConfigSave } from "./config-save-scheduler";
@@ -50,6 +51,7 @@ export {
   getPaneState,
   resolveCollectionForPane,
   resolveFinancialsForPane,
+  syncConfigActiveLayoutState,
   resolveTickerFileForPane,
   resolveTickerForPane,
 } from "../core/state/app-state";
@@ -283,10 +285,12 @@ export function usePaneSettingValue<T>(
       ? (nextValue as (previousValue: T) => T)(currentValue)
       : nextValue;
     const layout = setPaneSetting(currentState.config.layout, scopedPaneId, key, resolved);
-    const layouts = currentState.config.layouts.map((savedLayout, index) => (
-      index === currentState.config.activeLayoutIndex ? { ...savedLayout, layout } : savedLayout
-    ));
-    const nextConfig = { ...currentState.config, layout, layouts };
+    const nextConfig = syncConfigActiveLayoutState(
+      { ...currentState.config, layout },
+      currentState.paneState,
+      currentState.focusedPaneId,
+      currentState.activePanel,
+    );
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     scheduleConfigSave(nextConfig);
   }, [dispatch, fallback, key, scopedPaneId, stateRef]);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -108,8 +108,12 @@ export interface LayoutConfig {
 }
 
 export interface SavedLayout {
+  id?: string;
   name: string;
   layout: LayoutConfig;
+  paneState?: Record<string, Record<string, unknown>>;
+  focusedPaneId?: string | null;
+  activePanel?: "left" | "right";
 }
 
 export interface AppConfig {
@@ -585,8 +589,8 @@ export function createDefaultConfig(dataDir: string): AppConfig {
     watchlists: [{ id: "watchlist", name: "Watchlist" }],
     layout,
     layouts: [
-      { name: "Home", layout: cloneLayout(layout) },
-      { name: "Monitor", layout: cloneLayout(DEFAULT_MONITOR_LAYOUT) },
+      { name: "Home", layout: cloneLayout(layout), paneState: {} },
+      { name: "Monitor", layout: cloneLayout(DEFAULT_MONITOR_LAYOUT), paneState: {} },
     ],
     activeLayoutIndex: 0,
     brokerInstances: [],


### PR DESCRIPTION
Persist pane runtime state, focus, and active panel inside each saved layout so layout switches and app restarts restore ticker tabs, chart controls, selected collections, plugin state, and z-order independently per layout.

Chart render mode now saves per pane/layout instead of mutating the global default, and temporarily unavailable ticker-detail tabs no longer overwrite the stored active tab.

Config saves now sanitize saved pane state, write atomically, and route active-layout snapshots through the shared persistence path to avoid stale overwrites.

Fixes #326.
