### PR TITLE
Simplify ticker detail navigation

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -326,8 +326,8 @@ ctx.openPaneSettings("my-pane:1");     // Open settings for a specific pane
 ctx.showPane("my-pane");               // Show a hidden pane
 ctx.hidePane("my-pane");               // Hide a pane
 ctx.focusPane("my-pane");              // Move focus to a pane
-ctx.pinTicker("AAPL");                 // Pin a ticker to its own detail pane
-ctx.pinTicker("AAPL", { floating: true, paneType: "ticker-detail" });
+ctx.pinTicker("AAPL");                 // Open or focus a fixed detail pane for AAPL
+ctx.pinTicker("AAPL", { floating: true, paneType: "ticker-detail", forceNewPane: true });
 ctx.createPaneFromTemplate("quote-monitor-new", { symbol: "AAPL" });
 ```
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -96,7 +96,8 @@ import {
 } from "./components/command-bar/workflow-ops";
 import { getPaneTemplateDisplayLabel } from "./components/command-bar/pane-template-display";
 import {
-  resolveTickerNavigationDetailPane,
+  findFixedTickerPaneForSymbol,
+  resolveTickerNavigationReplacementPane,
   shouldFocusTickerNavigationTarget,
 } from "./plugins/ticker-navigation";
 import { debugLog } from "./utils/debug-log";
@@ -1109,6 +1110,16 @@ function AppInner({
     dispatch({ type: "SET_ACTIVE_PANEL", panel: resolvePanelForPane(paneId, layout) });
     dispatch({ type: "FOCUS_PANE", paneId });
   }, [dispatch, resolvePanelForPane, state.config.layout]);
+  const focusVisiblePane = (paneId: string, layout: LayoutConfig = state.config.layout) => {
+    const nextLayout = layout.floating.some((entry) => entry.instanceId === paneId)
+      ? bringToFront(layout, paneId)
+      : layout;
+
+    if (nextLayout !== state.config.layout) {
+      persistLayout(nextLayout, { pushHistory: false });
+    }
+    activatePane(paneId, nextLayout);
+  };
   const placePaneInstance = useCallback((
     instance: PaneInstanceConfig,
     paneDef: NonNullable<ReturnType<typeof pluginRegistry.panes.get>>,
@@ -1341,20 +1352,20 @@ function AppInner({
       return;
     }
 
-    const layout = state.config.layout.floating.some((entry) => entry.instanceId === instanceId)
-      ? bringToFront(state.config.layout, instanceId)
-      : state.config.layout;
-
-    if (layout !== state.config.layout) {
-      persistLayout(layout, { pushHistory: false });
-    }
-    activatePane(instanceId, layout);
+    focusVisiblePane(instanceId);
   };
   pluginRegistry.pinTickerFn = (symbol, options) => {
     if (isDetachedWindow) return;
     const paneType = options?.paneType ?? "ticker-detail";
     const paneDef = pluginRegistry.panes.get(paneType);
     if (!paneDef) return;
+    const existing = options?.forceNewPane
+      ? null
+      : findFixedTickerPaneForSymbol(state.config.layout, paneType, symbol);
+    if (existing) {
+      focusVisiblePane(existing.instanceId);
+      return;
+    }
     const instance = buildPaneInstance(paneType, {
       title: symbol,
       binding: { kind: "fixed", symbol },
@@ -1383,52 +1394,43 @@ function AppInner({
     const sourcePaneId = options?.sourcePaneId ?? stateRef.current.focusedPaneId;
     (async () => {
       try {
-      // Resolve or create the ticker in the local database
-      const resolved = await resolveTickerSearch({
-        query: rawSymbol,
-        activeTicker: null,
-        tickers: stateRef.current.tickers,
-        dataProvider,
-      });
+        // Resolve or create the ticker in the local database
+        const resolved = await resolveTickerSearch({
+          query: rawSymbol,
+          activeTicker: null,
+          tickers: stateRef.current.tickers,
+          dataProvider,
+        });
 
-      let symbol = rawSymbol;
-      if (resolved?.kind === "local") {
-        symbol = resolved.symbol;
-      } else if (resolved?.kind === "provider" && resolved.result) {
-        const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolved.result);
-        symbol = ticker.metadata.ticker;
-        dispatch({ type: "UPDATE_TICKER", ticker });
-        if (created) {
-          pluginRegistry.events.emit("ticker:added", { symbol, ticker });
+        let symbol = rawSymbol;
+        if (resolved?.kind === "local") {
+          symbol = resolved.symbol;
+        } else if (resolved?.kind === "provider" && resolved.result) {
+          const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolved.result);
+          symbol = ticker.metadata.ticker;
+          dispatch({ type: "UPDATE_TICKER", ticker });
+          if (created) {
+            pluginRegistry.events.emit("ticker:added", { symbol, ticker });
+          }
         }
-      }
 
-      // Active panel resolution — navigate the initiating or linked detail pane:
-      // 1. If the source pane IS a ticker-detail, retarget it directly
-      // 2. If a ticker-detail follows the source pane, retarget that
-      // 3. Any follow-mode ticker-detail in the layout
-      // 4. Any ticker-detail in the layout
-      // 5. Fall back to pinning a new pane
-      const currentState = stateRef.current;
-      const currentLayout = currentState.config.layout;
-      const detailPane = resolveTickerNavigationDetailPane(currentLayout, sourcePaneId);
-      const focusIfStillOwned = (paneId: string, layout: LayoutConfig) => {
-        if (!shouldFocusTickerNavigationTarget({
-          sourcePaneId,
-          currentFocusedPaneId: stateRef.current.focusedPaneId,
-          targetPaneId: paneId,
-        })) {
-          return;
-        }
-        activatePane(paneId, layout);
-      };
+        // Only actions that originate from a ticker detail replace that exact pane.
+        // Everything else opens or focuses a fixed ticker detail for the symbol.
+        const currentState = stateRef.current;
+        const currentLayout = currentState.config.layout;
+        const detailPane = resolveTickerNavigationReplacementPane(currentLayout, sourcePaneId);
+        const focusIfStillOwned = (paneId: string, layout: LayoutConfig) => {
+          if (!shouldFocusTickerNavigationTarget({
+            sourcePaneId,
+            currentFocusedPaneId: stateRef.current.focusedPaneId,
+            targetPaneId: paneId,
+          })) {
+            return;
+          }
+          activatePane(paneId, layout);
+        };
 
-      if (detailPane) {
-        if (detailPane.binding?.kind === "follow") {
-          const sourceId = detailPane.binding.sourceInstanceId;
-          dispatch({ type: "UPDATE_PANE_STATE", paneId: sourceId, patch: { cursorSymbol: symbol } });
-          focusIfStillOwned(detailPane.instanceId, currentLayout);
-        } else {
+        if (detailPane) {
           const nextLayout = {
             ...currentLayout,
             instances: currentLayout.instances.map((instance) => (
@@ -1439,14 +1441,13 @@ function AppInner({
           };
           persistLayout(nextLayout);
           focusIfStillOwned(detailPane.instanceId, nextLayout);
+        } else if (shouldFocusTickerNavigationTarget({
+          sourcePaneId,
+          currentFocusedPaneId: stateRef.current.focusedPaneId,
+          targetPaneId: null,
+        })) {
+          pluginRegistry.pinTicker(symbol, { floating: false });
         }
-      } else if (shouldFocusTickerNavigationTarget({
-        sourcePaneId,
-        currentFocusedPaneId: stateRef.current.focusedPaneId,
-        targetPaneId: null,
-      })) {
-        pluginRegistry.pinTicker(symbol, { floating: false });
-      }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         pluginRegistry.notify({ body: `Failed to navigate to ${rawSymbol}: ${message}`, type: "error" });

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -845,8 +845,12 @@ export function CommandBar({
     dispatch({ type: "FOCUS_PANE", paneId: targetPane.instanceId });
   }, [dispatch]);
 
-  const openFixedTickerPane = useCallback((symbol: string) => {
-    pluginRegistry.pinTicker(symbol, { floating: true, paneType: "ticker-detail" });
+  const openFixedTickerPane = useCallback((symbol: string, options?: { forceNewPane?: boolean }) => {
+    pluginRegistry.pinTicker(symbol, {
+      floating: true,
+      paneType: "ticker-detail",
+      forceNewPane: options?.forceNewPane,
+    });
   }, [pluginRegistry]);
 
   const commitTheme = useCallback((themeId: string) => {
@@ -872,7 +876,7 @@ export function CommandBar({
       ? findPaneInstance(currentState.config.layout, currentState.focusedPaneId)
       : null;
     if (options?.forceNewPane) {
-      openFixedTickerPane(symbol);
+      openFixedTickerPane(symbol, { forceNewPane: true });
       return;
     }
 

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -20,7 +20,7 @@ import {
 import type { BrokerAdapter } from "../types/broker";
 import type { PluginCapability } from "../capabilities";
 import type { DataProvider } from "../types/data-provider";
-import type { AppNotificationRequest, BrokerInstanceUpdateOptions } from "../types/plugin";
+import type { AppNotificationRequest, BrokerInstanceUpdateOptions, PinTickerOptions } from "../types/plugin";
 
 export interface PluginRuntimeAccess {
   getMarketData(): DataProvider | null;
@@ -30,7 +30,7 @@ export interface PluginRuntimeAccess {
   updateBrokerInstance(instanceId: string, values: Record<string, unknown>, options?: BrokerInstanceUpdateOptions): Promise<void>;
   syncBrokerInstance(instanceId: string): Promise<void>;
   removeBrokerInstance(instanceId: string): Promise<void>;
-  pinTicker(symbol: string, options?: { floating?: boolean; paneType?: string }): void;
+  pinTicker(symbol: string, options?: PinTickerOptions): void;
   navigateTicker(symbol: string, options?: { sourcePaneId?: string | null }): void;
   selectTicker(symbol: string, paneId?: string): void;
   switchTab(tabId: string, paneId?: string): void;

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -26,6 +26,7 @@ import type {
   PaneSettingsDef,
   PaneTemplateCreateOptions,
   PaneTemplateDef,
+  PinTickerOptions,
   PluginPaneSettingsState,
   PluginResumeState,
   TickerAction,
@@ -140,7 +141,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   createPaneFromTemplateAsyncFn: ((templateId: string, options?: PaneTemplateCreateOptions) => Promise<void>) = async () => {};
   hidePaneFn: ((paneId: string) => void) = () => {};
   focusPaneFn: ((paneId: string) => void) = () => {};
-  pinTickerFn: ((symbol: string, options?: { floating?: boolean; paneType?: string }) => void) = () => {};
+  pinTickerFn: ((symbol: string, options?: PinTickerOptions) => void) = () => {};
   navigateTickerFn: ((symbol: string, options?: { sourcePaneId?: string | null }) => void) = () => {};
   getMarketData = () => this.marketData;
   getCapability = (capabilityId: string) => this.capabilities.get(capabilityId)?.capability ?? null;
@@ -151,7 +152,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   );
   syncBrokerInstance = (instanceId: string) => this.syncBrokerInstanceFn(instanceId);
   removeBrokerInstance = (instanceId: string) => this.removeBrokerInstanceFn(instanceId);
-  pinTicker = (symbol: string, options?: { floating?: boolean; paneType?: string }) => {
+  pinTicker = (symbol: string, options?: PinTickerOptions) => {
     this.pinTickerFn(symbol, options);
   };
   navigateTicker = (symbol: string, options?: { sourcePaneId?: string | null }) => {

--- a/src/plugins/ticker-navigation.test.ts
+++ b/src/plugins/ticker-navigation.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { createPaneInstance, type LayoutConfig, type PaneInstanceConfig } from "../types/config";
 import {
-  resolveTickerNavigationDetailPane,
+  findFixedTickerPaneForSymbol,
+  resolveTickerNavigationReplacementPane,
   shouldFocusTickerNavigationTarget,
 } from "./ticker-navigation";
 
@@ -20,8 +21,8 @@ function createLayout(instances: PaneInstanceConfig[]): LayoutConfig {
   };
 }
 
-describe("resolveTickerNavigationDetailPane", () => {
-  test("prefers the detail pane following the pane that opened ticker navigation", () => {
+describe("resolveTickerNavigationReplacementPane", () => {
+  test("only replaces the ticker detail pane that opened ticker navigation", () => {
     const layout = createLayout([
       createPaneInstance("portfolio-list", {
         instanceId: "portfolio-list:main",
@@ -42,8 +43,37 @@ describe("resolveTickerNavigationDetailPane", () => {
     ]);
 
     expect(
-      resolveTickerNavigationDetailPane(layout, "comparison-chart:main")?.instanceId,
-    ).toBe("ticker-detail:compare");
+      resolveTickerNavigationReplacementPane(layout, "comparison-chart:main")?.instanceId,
+    ).toBeUndefined();
+    expect(
+      resolveTickerNavigationReplacementPane(layout, "ticker-detail:portfolio")?.instanceId,
+    ).toBe("ticker-detail:portfolio");
+  });
+});
+
+describe("findFixedTickerPaneForSymbol", () => {
+  test("finds only a visible fixed pane for the requested symbol", () => {
+    const layout = createLayout([
+      createPaneInstance("portfolio-list", {
+        instanceId: "portfolio-list:main",
+        binding: { kind: "none" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:follow",
+        binding: { kind: "follow", sourceInstanceId: "portfolio-list:main" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:aapl",
+        binding: { kind: "fixed", symbol: "AAPL" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:msft",
+        binding: { kind: "fixed", symbol: "MSFT" },
+      }),
+    ]);
+
+    expect(findFixedTickerPaneForSymbol(layout, "ticker-detail", "AAPL")?.instanceId).toBe("ticker-detail:aapl");
+    expect(findFixedTickerPaneForSymbol(layout, "ticker-detail", "NVDA")).toBeNull();
   });
 });
 

--- a/src/plugins/ticker-navigation.ts
+++ b/src/plugins/ticker-navigation.ts
@@ -1,33 +1,27 @@
 import { findPaneInstance, type LayoutConfig, type PaneInstanceConfig } from "../types/config";
 import { isPaneInLayout } from "./pane-manager";
 
-export function resolveTickerNavigationDetailPane(
+export function resolveTickerNavigationReplacementPane(
   layout: LayoutConfig,
   sourcePaneId: string | null,
 ): PaneInstanceConfig | null {
   const sourceInstance = sourcePaneId ? findPaneInstance(layout, sourcePaneId) : null;
+  return sourceInstance?.paneId === "ticker-detail" && isPaneInLayout(layout, sourceInstance.instanceId)
+    ? sourceInstance
+    : null;
+}
 
-  return (
-    sourceInstance?.paneId === "ticker-detail" && isPaneInLayout(layout, sourceInstance.instanceId)
-      ? sourceInstance
-      : null
-  )
-    ?? layout.instances.find((instance) =>
-      instance.paneId === "ticker-detail"
-      && instance.binding?.kind === "follow"
-      && instance.binding.sourceInstanceId === sourcePaneId
-      && isPaneInLayout(layout, instance.instanceId)
-    )
-    ?? layout.instances.find((instance) =>
-      instance.paneId === "ticker-detail"
-      && instance.binding?.kind === "follow"
-      && isPaneInLayout(layout, instance.instanceId)
-    )
-    ?? layout.instances.find((instance) =>
-      instance.paneId === "ticker-detail"
-      && isPaneInLayout(layout, instance.instanceId)
-    )
-    ?? null;
+export function findFixedTickerPaneForSymbol(
+  layout: LayoutConfig,
+  paneId: string,
+  symbol: string,
+): PaneInstanceConfig | null {
+  return layout.instances.find((instance) =>
+    instance.paneId === paneId
+    && instance.binding?.kind === "fixed"
+    && instance.binding.symbol === symbol
+    && isPaneInLayout(layout, instance.instanceId)
+  ) ?? null;
 }
 
 export function shouldFocusTickerNavigationTarget({

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -406,6 +406,12 @@ export interface BrokerInstanceUpdateOptions {
   replaceConfig?: boolean;
 }
 
+export interface PinTickerOptions {
+  floating?: boolean;
+  paneType?: string;
+  forceNewPane?: boolean;
+}
+
 export interface GloomPluginContext {
   registerPane(pane: PaneDef): void;
   registerPaneTemplate(template: PaneTemplateDef): void;
@@ -448,7 +454,7 @@ export interface GloomPluginContext {
   createPaneFromTemplate(templateId: string, options?: PaneTemplateCreateOptions): void;
   hidePane(paneId: string): void;
   focusPane(paneId: string): void;
-  pinTicker(symbol: string, options?: { floating?: boolean; paneType?: string }): void;
+  pinTicker(symbol: string, options?: PinTickerOptions): void;
   navigateTicker(symbol: string, options?: { sourcePaneId?: string | null }): void;
   openPaneSettings(paneId?: string): void;
 

--- a/src/ui/context-menu.tsx
+++ b/src/ui/context-menu.tsx
@@ -127,7 +127,7 @@ function selectedTextMenuItems(text: string, registry: PluginRegistry | null, co
       contextMenuDivider("selected-text:ticker-divider"),
       {
         id: "selected-text:open-ticker",
-        label: "Open as Ticker",
+        label: "Open Ticker Detail",
         onSelect: () => registry?.navigateTicker(symbol),
       },
       {
@@ -224,13 +224,13 @@ export function tickerContextMenuItems({
   const items: ContextMenuItem[] = [
     {
       id: "ticker:open",
-      label: `Open ${symbol}`,
+      label: `Open ${symbol} Detail`,
       onSelect: () => (openTicker ? openTicker(symbol) : registry?.navigateTicker(symbol)),
     },
     {
       id: "ticker:pin-floating",
-      label: `Pin ${symbol} in Floating Detail`,
-      onSelect: () => registry?.pinTicker(symbol, { floating: true, paneType: "ticker-detail" }),
+      label: `Open ${symbol} in New Floating Detail`,
+      onSelect: () => registry?.pinTicker(symbol, { floating: true, paneType: "ticker-detail", forceNewPane: true }),
     },
     {
       id: "ticker:copy-symbol",


### PR DESCRIPTION
This simplifies ticker detail navigation so ticker opens outside a detail pane focus an existing fixed detail for that symbol or create one, while actions originating inside a ticker detail replace only that exact pane.

It removes the old layout-wide replacement heuristic that could retarget linked or unrelated detail panes, keeps explicit new floating detail creation available, and updates context-menu wording plus plugin docs to make the behavior clearer.
