### PR TITLE
Fix comparison chart startup churn

### DIFF
--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -7,12 +7,12 @@ import { useChartQueries } from "../../market-data/hooks";
 import { buildChartKey } from "../../market-data/selectors";
 import { useAppSelector, usePaneSettingValue } from "../../state/app-context";
 import { usePaneFooter, type PaneHint } from "../layout/pane-footer";
-import { blendHex, colors, getComparisonSeriesColor, priceColor } from "../../theme/colors";
+import { blendHex, colors, getComparisonSeriesColor } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
 import type { BrokerContractRef } from "../../types/instrument";
 import type { PricePoint } from "../../types/financials";
 import { formatPercentRaw } from "../../utils/format";
-import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../utils/market-format";
+import { formatMarketPriceWithCurrency } from "../../utils/market-format";
 import { getSharedMarketData } from "../../plugins/registry";
 import {
   applyComparisonZoomAroundAnchor,
@@ -30,7 +30,6 @@ import {
 import {
   buildVisibleDateWindow,
   clearActivePreset,
-  formatVisibleSpanLabel,
   needsCanonicalPresetViewportReset,
   resolveChartBodyState,
   resolveCanonicalPresetViewport,
@@ -96,7 +95,7 @@ import {
   resolveNativeSurfaceVisibleRect,
   type NativeSurfaceRenderableNode,
 } from "./native/surface-visibility";
-import { formatDateShort, resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
+import { resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
 import { TimeAxisLabel } from "./time-axis-label";
 import { PriceAxisLabels } from "./price-axis-labels";
 
@@ -445,6 +444,23 @@ function clipText(text: string, width: number): string {
   return `${text.slice(0, width - 3)}...`;
 }
 
+function formatLegendSummary(
+  symbol: string,
+  rawValue: number | null,
+  baseValue: number | null,
+  currency: string,
+  priceRange: number | undefined,
+): string {
+  if (rawValue === null) return `${symbol} waiting`;
+  const price = formatMarketPriceWithCurrency(rawValue, currency, {
+    minimumFractionDigits: 2,
+    precisionOffset: 1,
+    priceRange,
+  });
+  if (baseValue === null || baseValue === 0) return `${symbol} ${price}`;
+  return `${symbol} ${price} ${formatPercentRaw(((rawValue - baseValue) / baseValue) * 100)}`;
+}
+
 function getInitialComparisonMode(mode: string | undefined): ComparisonChartRenderMode {
   return mode === "line" ? "line" : "area";
 }
@@ -555,6 +571,7 @@ function ComparisonStockChartView({
   const mouseCrosshairDisabledRef = useRef(false);
   const cursorMotionKindRef = useRef<ChartCursorMotionKind>("discrete");
   const animationFrameRef = useRef<number | null>(null);
+  const lastAppliedStoredSelectionKeyRef = useRef<string | null>(null);
   const pendingCanonicalResetRef = useRef(1);
   const appliedCanonicalResetRef = useRef(0);
   const pendingExpansionRef = useRef<PendingExpansionAction>(null);
@@ -564,7 +581,7 @@ function ComparisonStockChartView({
   const axisRightPadding = 1;
   const minimumAxisWidth = axisMode === "percent" ? 5 : 4;
   const axisGap = axisSectionWidthBudget > 0 ? 1 : 0;
-  const headerRows = 1;
+  const headerRows = 0;
   const controlRows = 2;
   const timeAxisRows = 1;
   const helpRows = 0;
@@ -591,13 +608,35 @@ function ComparisonStockChartView({
     ));
   };
 
-  const capabilityKey = useMemo(() => symbolSources.map((source) => [
-    source.symbol,
-    source.exchange,
-    source.brokerId ?? "",
-    source.brokerInstanceId ?? "",
-    source.instrument?.conId ?? "",
-  ].join(":")).join("|"), [symbolSources]);
+  const marketDataProvider = getSharedMarketData();
+  const capabilityDescriptor = useMemo(() => {
+    const sources = symbolSources.map((source) => ({
+      symbol: source.symbol,
+      exchange: source.exchange,
+      brokerId: source.brokerId,
+      brokerInstanceId: source.brokerInstanceId,
+      instrument: source.instrument,
+    }));
+    return {
+      key: sources.map((source) => [
+        source.symbol,
+        source.exchange,
+        source.brokerId ?? "",
+        source.brokerInstanceId ?? "",
+        source.instrument?.conId ?? "",
+        source.instrument?.localSymbol ?? "",
+        source.instrument?.symbol ?? "",
+      ].join(":")).join("|"),
+      sources,
+    };
+  }, [symbolSources]);
+  const effectiveResolutionSupport = useMemo<ChartResolutionSupport[]>(() => (
+    resolutionSupport ?? DEFAULT_VISIBLE_MANUAL_CHART_RESOLUTIONS.map((resolution) => ({ resolution, maxRange: "ALL" as const }))
+  ), [resolutionSupport]);
+  const selectionSupportMap = useMemo(
+    () => buildChartResolutionSupportMap(effectiveResolutionSupport),
+    [effectiveResolutionSupport],
+  );
 
   useEffect(() => {
     if (symbols.includes(viewState.selectedSymbol ?? "")) return;
@@ -608,21 +647,25 @@ function ComparisonStockChartView({
   }, [symbols, viewState.selectedSymbol]);
 
   useEffect(() => {
+    const storedSelectionKey = `${storedRangePreset}:${storedResolution}`;
+    if (lastAppliedStoredSelectionKeyRef.current === storedSelectionKey) return;
+
+    lastAppliedStoredSelectionKeyRef.current = storedSelectionKey;
     pendingCanonicalResetRef.current += 1;
     setViewState((current) => (
       storedResolution === "auto"
-        ? resolveStoredChartSelection(current, storedRangePreset, storedResolution, supportMap)
+        ? resolveStoredChartSelection(current, storedRangePreset, storedResolution, selectionSupportMap)
         : resolvePresetSelection(
           {
             ...current,
             resolution: storedResolution,
           },
           storedRangePreset,
-          getSupportMaxRange(supportMap, storedResolution),
+          getSupportMaxRange(selectionSupportMap, storedResolution),
         )
     ));
     updateDisplayCursorTarget(EMPTY_DISPLAY_CURSOR, "discrete");
-  }, [storedRangePreset, storedResolution, supportMap]);
+  }, [selectionSupportMap, storedRangePreset, storedResolution]);
 
   const commitDisplayCursor = (next: DisplayCursorState) => {
     displayCursorRef.current = next;
@@ -705,15 +748,15 @@ function ComparisonStockChartView({
   ), [nativeSurfaceManager]);
 
   useEffect(() => {
-    const provider = getSharedMarketData();
-    if ((!provider?.getChartResolutionSupport && !provider?.getChartResolutionCapabilities) || symbolSources.length === 0) {
+    const provider = marketDataProvider;
+    if ((!provider?.getChartResolutionSupport && !provider?.getChartResolutionCapabilities) || capabilityDescriptor.sources.length === 0) {
       setResolutionSupport(null);
       return;
     }
 
     let cancelled = false;
     setResolutionSupport(null);
-    Promise.all(symbolSources.map(async (source) => {
+    Promise.all(capabilityDescriptor.sources.map(async (source) => {
       try {
         const support = provider.getChartResolutionSupport
           ? await provider.getChartResolutionSupport(
@@ -757,11 +800,7 @@ function ComparisonStockChartView({
     return () => {
       cancelled = true;
     };
-  }, [capabilityKey, symbolSources]);
-
-  const effectiveResolutionSupport = useMemo<ChartResolutionSupport[]>(() => (
-    resolutionSupport ?? DEFAULT_VISIBLE_MANUAL_CHART_RESOLUTIONS.map((resolution) => ({ resolution, maxRange: "ALL" as const }))
-  ), [resolutionSupport]);
+  }, [capabilityDescriptor.key, marketDataProvider]);
   const availableManualResolutions = resolutionSupport?.map((entry) => entry.resolution) ?? DEFAULT_VISIBLE_MANUAL_CHART_RESOLUTIONS;
   const effectiveResolution: ChartResolution = viewState.resolution !== "auto"
     && resolutionSupport !== null
@@ -1629,18 +1668,9 @@ function ComparisonStockChartView({
   const hasChartData = series.some((entry) => entry.points.length > 0);
   const hasDisplayCursor = displayCursorX !== null && displayCursorY !== null;
   const cursorScene = hasDisplayCursor ? displayScene : staticScene;
-  const selectedSeries = hasChartData ? (cursorScene?.selectedSeries ?? staticResult.selectedSeries) : null;
-  const selectedPoint = hasChartData ? (cursorScene?.selectedPoint ?? staticResult.selectedPoint) : null;
-  const selectedRawValue = selectedPoint?.rawValue ?? selectedSeries?.latestRawValue ?? null;
-  const selectedBaseValue = selectedSeries?.baseValue ?? null;
-  const selectedChange = selectedRawValue !== null && selectedBaseValue !== null
-    ? selectedRawValue - selectedBaseValue
+  const legendActiveIndex = hasChartData
+    ? cursorScene?.activeIdx ?? staticScene?.activeIdx ?? null
     : null;
-  const selectedChangePct = selectedChange !== null && selectedBaseValue
-    ? (selectedChange / selectedBaseValue) * 100
-    : null;
-  const selectedCurrency = selectedSeries?.currency ?? "USD";
-  const displayDate = cursorScene?.activeDate ?? staticResult.activeDate;
   const visiblePriceRange = result.priceRange ?? staticResult.priceRange ?? undefined;
   const axisLabels = new Map(staticResult.axisLabels.map((entry) => [entry.row, entry.label]));
   const cursorRow = useCanvasChart ? cursorScene?.cursorRow ?? null : result.cursorRow;
@@ -1652,10 +1682,6 @@ function ComparisonStockChartView({
       visiblePriceRange,
     )
     : null;
-  const visibleLabel = formatVisibleSpanLabel({
-    start: visibleWindow.dates[0] ?? null,
-    end: visibleWindow.dates[visibleWindow.dates.length - 1] ?? null,
-  });
   const cursorTimeAxisColumn = hasDisplayCursor ? displayScene?.cursorColumn ?? null : null;
   const cursorTimeAxisDate = hasDisplayCursor ? displayScene?.activeDate ?? null : null;
 
@@ -1852,32 +1878,6 @@ function ComparisonStockChartView({
       flexGrow={1}
       onMouseScroll={hasChartData && !isBlockingBody && !bodyMessage ? handlePlotScroll : undefined}
     >
-      <Box flexDirection="row" gap={2} height={1}>
-        <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
-          {viewState.selectedSymbol ?? "Compare"} - {getChartResolutionLabel(effectiveResolution)}
-        </Text>
-        <Text fg={colors.textDim}>{visibleLabel}</Text>
-        <Text fg={selectedChange !== null ? priceColor(selectedChange) : colors.textDim}>
-          {selectedRawValue !== null
-            ? formatMarketPriceWithCurrency(selectedRawValue, selectedCurrency, {
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })
-            : "—"}
-        </Text>
-        <Text fg={selectedChange !== null ? priceColor(selectedChange) : colors.textDim}>
-          {selectedChange !== null && selectedChangePct !== null
-            ? `${formatSignedMarketPrice(selectedChange, {
-              minimumFractionDigits: 2,
-              precisionOffset: 1,
-              priceRange: visiblePriceRange,
-            })} (${formatPercentRaw(selectedChangePct)})`
-            : "Waiting for data"}
-        </Text>
-        {displayDate && <Text fg={colors.textDim}>{formatDateShort(displayDate)}</Text>}
-      </Box>
-
       <Box flexDirection="row" height={1}>
         <Box flexDirection="row" gap={1}>
           {TIME_RANGES.map((range, index) => (
@@ -1964,19 +1964,11 @@ function ComparisonStockChartView({
                 {legendRow.map((symbol) => {
                   const item = projection.series.find((entry) => entry.symbol === symbol) ?? null;
                   const isSelected = viewState.selectedSymbol === symbol;
-                  const latestRaw = item?.latestRawValue ?? null;
-                  const latestChange = latestRaw !== null && item?.baseValue != null ? latestRaw - item.baseValue : null;
-                  const latestChangePct = latestChange !== null && item?.baseValue
-                    ? (latestChange / item.baseValue) * 100
-                    : null;
+                  const activeRaw = legendActiveIndex !== null
+                    ? item?.points[legendActiveIndex]?.rawValue ?? null
+                    : item?.latestRawValue ?? null;
                   const currency = item?.currency ?? "USD";
-                  const summary = latestRaw !== null && latestChangePct !== null
-                    ? `${symbol} ${formatMarketPriceWithCurrency(latestRaw, currency, {
-                      minimumFractionDigits: 2,
-                      precisionOffset: 1,
-                      priceRange: visiblePriceRange,
-                    })} ${formatPercentRaw(latestChangePct)}`
-                    : `${symbol} waiting`;
+                  const summary = formatLegendSummary(symbol, activeRaw, item?.baseValue ?? null, currency, visiblePriceRange);
 
                   return (
                     <Box

--- a/src/plugins/builtin/comparison-chart.test.tsx
+++ b/src/plugins/builtin/comparison-chart.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, type ReactElement } from "react";
+import { act, useState, type ReactElement } from "react";
 import { createTestRenderer } from "@opentui/core/testing";
 import { createOpenTuiTestRoot as createRoot } from "../../renderers/opentui/test-utils";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
@@ -301,7 +301,6 @@ describe("comparisonChartPlugin", () => {
     expect(frame).toContain("1:1D");
     expect(frame).toContain("2:1W");
     expect(frame).toContain("1D");
-    expect(frame).toContain("view:");
     expect(frame).toContain("[t]ickers");
     expect(frame).toContain("[m]ode");
     expect(frame).toContain("[r]es");
@@ -310,6 +309,119 @@ describe("comparisonChartPlugin", () => {
     expect(frame).not.toContain("wheel pan");
     expect(frame).not.toContain("wheel zoom");
     expect(frame).not.toContain("side by side");
+  });
+
+  test("updates every legend value from the crosshair position", async () => {
+    const provider = createProvider({
+      AAPL: [100, 102, 104],
+      MSFT: [200, 202, 204],
+    }, {
+      AAPL: "USD",
+      MSFT: "USD",
+    });
+    setSharedMarketDataForTests(provider);
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedRegistryForTests(createRegistrySpy({ selected: [], focused: [] }));
+
+    await mountComparisonHarness({
+      axisMode: "percent",
+      symbols: ["AAPL", "MSFT"],
+      symbolsText: "AAPL, MSFT",
+    }, [
+      makeTicker("AAPL", "USD"),
+      makeTicker("MSFT", "USD"),
+    ], [
+      ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104])],
+      ["MSFT", makeFinancials("MSFT", "USD", [200, 202, 204])],
+    ]);
+
+    await flushFrames();
+
+    let frame = testSetup!.captureCharFrame();
+    expect(frame).not.toContain("AAPL - 1D");
+    expect(frame).toContain("AAPL $104.00 +4.00%");
+    expect(frame).toContain("MSFT $204.00 +2.00%");
+
+    await act(async () => {
+      await testSetup!.mockMouse.moveTo(2, 4);
+      await testSetup!.renderOnce();
+    });
+    await flushFrames();
+
+    frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("AAPL $100.00 0.00%");
+    expect(frame).toContain("MSFT $200.00 0.00%");
+  });
+
+  test("does not refetch resolution support when only comparison prices update", async () => {
+    let supportCalls = 0;
+    const provider = createProvider({
+      AAPL: [100, 102, 104],
+      MSFT: [200, 202, 204],
+    }, {
+      AAPL: "USD",
+      MSFT: "USD",
+    });
+    provider.getChartResolutionCapabilities = async () => {
+      supportCalls += 1;
+      return ["5m", "15m", "1h", "1d", "1wk", "1mo"];
+    };
+    setSharedMarketDataForTests(provider);
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedRegistryForTests(createRegistrySpy({ selected: [], focused: [] }));
+
+    const settings = {
+      axisMode: "percent",
+      symbols: ["AAPL", "MSFT"],
+      symbolsText: "AAPL, MSFT",
+    };
+    const tickers = [
+      makeTicker("AAPL", "USD"),
+      makeTicker("MSFT", "USD"),
+    ];
+    const spy = { selected: [] as string[], focused: [] as string[] };
+    const runtime = createRuntimeSpy(spy);
+    let updateFinancials: ((rows: Array<[string, TickerFinancials]>) => void) | null = null;
+    function PriceUpdateHarness({ initialFinancials }: { initialFinancials: Array<[string, TickerFinancials]> }) {
+      const [rows, setRows] = useState(initialFinancials);
+      updateFinancials = setRows;
+      return createComparisonHarness(settings, tickers, rows, runtime);
+    }
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 20 });
+    root = createRoot(testSetup.renderer);
+    await act(async () => {
+      root!.render(
+        <PriceUpdateHarness
+          initialFinancials={[
+            ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104])],
+            ["MSFT", makeFinancials("MSFT", "USD", [200, 202, 204])],
+          ]}
+        />,
+      );
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await testSetup!.renderOnce();
+    });
+    await flushFrames();
+
+    expect(supportCalls).toBe(2);
+
+    await act(async () => {
+      updateFinancials!([
+        ["AAPL", makeFinancials("AAPL", "USD", [101, 103, 105])],
+        ["MSFT", makeFinancials("MSFT", "USD", [201, 203, 205])],
+      ]);
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await testSetup!.renderOnce();
+    });
+    await flushFrames();
+
+    expect(supportCalls).toBe(2);
   });
 
   test("keeps controls visible when comparison history is empty", async () => {


### PR DESCRIPTION
Fixes #329.

This stabilizes the comparison chart startup path by fetching chart-resolution support only when the compared instruments change, instead of resetting support whenever quote or financial data updates.
It also removes the single-symbol top readout from the comparison chart and makes each bottom legend value follow the active crosshair position, so all compared tickers update together.