### PR TITLE
Add validated ticker quick-add for portfolios and watchlists

### DIFF
--- a/src/components/table-view-shared.tsx
+++ b/src/components/table-view-shared.tsx
@@ -56,7 +56,8 @@ export function TableViewFrame({
   return (
     <Box
       flexDirection="column"
-      flexGrow={1}
+      flexGrow={height == null ? 1 : undefined}
+      flexShrink={height == null ? undefined : 0}
       width={width}
       height={height}
       backgroundColor={backgroundColor}

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -5,6 +5,7 @@ import { join } from "path";
 import { act, useReducer } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { AppPersistence } from "../../data/app-persistence";
+import { TickerRepository } from "../../data/ticker-repository";
 import { AppContext, appReducer, createInitialState, PaneInstanceProvider, type AppAction } from "../../state/app-context";
 import { AssetDataRouter } from "../../sources/provider-router";
 import { cloneLayout, createDefaultConfig, type AppConfig, type BrokerInstanceConfig } from "../../types/config";
@@ -14,6 +15,7 @@ import type { TickerRecord } from "../../types/ticker";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { createTestPluginRuntime } from "../../test-support/plugin-runtime";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
+import { PluginRegistry, setSharedMarketDataForTests, setSharedRegistryForTests } from "../registry";
 import type { BrokerAdapter } from "../../types/broker";
 import { portfolioListPlugin } from "./portfolio-list";
 
@@ -24,6 +26,7 @@ let harnessDispatch: React.Dispatch<AppAction> | null = null;
 let sharedCoordinator: MarketDataCoordinator | null = null;
 let harnessState: ReturnType<typeof createInitialState> | null = null;
 const tempPaths: string[] = [];
+const tempPersistences: AppPersistence[] = [];
 
 const PortfolioPane = portfolioListPlugin.panes![0]!.component as (props: {
   paneId: string;
@@ -154,6 +157,75 @@ function createPortfolioConfigWithColumns(
   }
   return config;
 }
+
+function createManualCollectionConfig(collectionId: string): AppConfig {
+  const config = createDefaultConfig("/tmp/gloomberb-portfolio-list");
+  const layout = {
+    dockRoot: { kind: "pane" as const, instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "portfolio-list",
+      binding: { kind: "none" as const },
+      params: { collectionId },
+    }],
+    floating: [],
+  };
+
+  return {
+    ...config,
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  };
+}
+
+function installQuickAddRegistry(provider: DataProvider): PluginRegistry {
+  const persistence = new AppPersistence(createTempDbPath("quick-add"));
+  tempPersistences.push(persistence);
+  const registry = new PluginRegistry(provider, new TickerRepository(persistence.tickers), persistence);
+  registry.getConfigFn = () => harnessState?.config ?? createDefaultConfig("/tmp/gloomberb-portfolio-list");
+  return registry;
+}
+
+function createQuickAddProvider(match = true): DataProvider {
+  return {
+    id: "quick-add-test",
+    name: "Quick Add Test",
+    async getTickerFinancials() {
+      return {
+        annualStatements: [],
+        quarterlyStatements: [],
+        priceHistory: [],
+        quote: makeQuote({ symbol: "MSFT", price: 420, change: 5.2, changePercent: 1.25, name: "Microsoft" }),
+      };
+    },
+    async getQuote(symbol) {
+      if (match && symbol === "MSFT") {
+        return makeQuote({ symbol: "MSFT", price: 420, change: 5.2, changePercent: 1.25, name: "Microsoft" });
+      }
+      throw new Error(`No quote for ${symbol}`);
+    },
+    async getExchangeRate() {
+      return 1;
+    },
+    async search(query) {
+      if (!match || query !== "MSFT") return [];
+      return [{
+        symbol: "MSFT",
+        name: "Microsoft",
+        exchange: "NASDAQ",
+        currency: "USD",
+        type: "STK",
+      }];
+    },
+    async getArticleSummary() {
+      return null;
+    },
+    async getPriceHistory() {
+      return [];
+    },
+  };
+}
+
 function createPortfolioState(
   config: AppConfig,
   collectionId: string,
@@ -193,6 +265,7 @@ function PortfolioHarness({
   exchangeRates,
   stateMutator,
   runtime = createTestPluginRuntime(),
+  paneHeight = 24,
 }: {
   config: AppConfig;
   collectionId: string;
@@ -203,6 +276,7 @@ function PortfolioHarness({
   exchangeRates?: Map<string, number>;
   stateMutator?: (state: ReturnType<typeof createInitialState>) => void;
   runtime?: PluginRuntimeAccess;
+  paneHeight?: number;
 }) {
   const initialState = createPortfolioState(config, collectionId, expanded, {
     ticker,
@@ -224,7 +298,7 @@ function PortfolioHarness({
             paneType="portfolio-list"
             focused
             width={100}
-            height={24}
+            height={paneHeight}
           />
         </PluginRenderProvider>
       </PaneInstanceProvider>
@@ -249,7 +323,12 @@ afterEach(async () => {
   harnessDispatch = null;
   sharedCoordinator = null;
   setSharedMarketDataCoordinator(null);
+  setSharedMarketDataForTests(undefined);
+  setSharedRegistryForTests(undefined);
   harnessState = null;
+  for (const persistence of tempPersistences.splice(0)) {
+    persistence.close();
+  }
   for (const path of tempPaths.splice(0)) {
     if (existsSync(path)) rmSync(path, { force: true });
   }
@@ -289,6 +368,151 @@ describe("PortfolioListPane cash and margin UI", () => {
       await testSetup!.renderOnce();
     });
     expect(pinned).toEqual([{ symbol: "AAPL", options: { floating: true, paneType: "ticker-detail" } }]);
+  });
+
+  test("quick-add validates and adds an exact watchlist ticker", async () => {
+    const config = createManualCollectionConfig("watchlist");
+    const notifications: Array<{ type?: string; body: string }> = [];
+    installQuickAddRegistry(createQuickAddProvider(true));
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="watchlist"
+        ticker={makeTicker({ portfolios: [], watchlists: [], positions: [] })}
+        runtime={createTestPluginRuntime({
+          notify: (notification) => notifications.push(notification),
+        })}
+        paneHeight={12}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+    await act(async () => {
+      testSetup!.mockInput.pressKey("n");
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await testSetup!.mockInput.typeText("MSFT");
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 360));
+    });
+    await flushFrame();
+
+    const previewFrame = testSetup.captureCharFrame();
+    expect(previewFrame).toContain("420");
+    expect(previewFrame).not.toMatch(/MSFT\s+420/);
+    expect(previewFrame).toContain("+1.25%");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(harnessState?.tickers.get("MSFT")?.metadata.watchlists).toEqual(["watchlist"]);
+    expect(notifications.at(-1)).toMatchObject({
+      type: "success",
+      body: "Added MSFT to Watchlist.",
+    });
+  });
+
+  test("quick-add adds an exact ticker to a manual portfolio", async () => {
+    const config = createManualCollectionConfig("main");
+    const notifications: Array<{ type?: string; body: string }> = [];
+    installQuickAddRegistry(createQuickAddProvider(true));
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="main"
+        ticker={makeTicker({ portfolios: [], watchlists: [], positions: [] })}
+        runtime={createTestPluginRuntime({
+          notify: (notification) => notifications.push(notification),
+        })}
+        paneHeight={12}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+    await act(async () => {
+      testSetup!.mockInput.pressKey("n");
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await testSetup!.mockInput.typeText("MSFT");
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 360));
+    });
+    await flushFrame();
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(harnessState?.tickers.get("MSFT")?.metadata.portfolios).toEqual(["main"]);
+    expect(notifications.at(-1)).toMatchObject({
+      type: "success",
+      body: "Added MSFT to Main Portfolio.",
+    });
+  });
+
+  test("quick-add rejects unresolved ticker input", async () => {
+    const config = createManualCollectionConfig("watchlist");
+    const notifications: Array<{ type?: string; body: string }> = [];
+    installQuickAddRegistry(createQuickAddProvider(false));
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="watchlist"
+        ticker={makeTicker({ portfolios: [], watchlists: [], positions: [] })}
+        runtime={createTestPluginRuntime({
+          notify: (notification) => notifications.push(notification),
+        })}
+        paneHeight={12}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+    await act(async () => {
+      testSetup!.mockInput.pressKey("n");
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await testSetup!.mockInput.typeText("NOPE");
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 360));
+    });
+    await flushFrame();
+
+    expect(testSetup.captureCharFrame()).toContain("No exact ticker match");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(harnessState?.tickers.has("NOPE")).toBe(false);
+    expect(notifications.at(-1)).toMatchObject({
+      type: "error",
+      body: "No exact ticker match",
+    });
   });
 
   test("keeps non-broker portfolios unchanged", async () => {

--- a/src/plugins/builtin/portfolio-list/cli/commands.ts
+++ b/src/plugins/builtin/portfolio-list/cli/commands.ts
@@ -23,6 +23,7 @@ import type { CliCommandContext, CliCommandDef } from "../../../../types/plugin"
 import type { TickerRecord } from "../../../../types/ticker";
 import {
   addTickerToPortfolio,
+  addTickerToWatchlist,
   createManualPortfolio,
   deleteManualPortfolio,
   findPortfolio,
@@ -415,7 +416,7 @@ async function deleteWatchlist(name: string, ctx: CliCommandContext) {
   persistence.close();
 }
 
-async function addTickerToWatchlist(watchlistName: string, symbol: string, ctx: CliCommandContext) {
+async function addTickerToWatchlistCommand(watchlistName: string, symbol: string, ctx: CliCommandContext) {
   const { config, store, dataProvider, persistence } = await ctx.initMarketData();
   const watchlist = findWatchlist(config, watchlistName);
   if (!watchlist) {
@@ -424,19 +425,14 @@ async function addTickerToWatchlist(watchlistName: string, symbol: string, ctx: 
 
   try {
     const ticker = await resolveTickerForCli(symbol, store, dataProvider);
-    if (ticker.metadata.watchlists.includes(watchlist.id)) {
+    const result = addTickerToWatchlist(ticker, watchlist.id);
+    if (!result.changed) {
       console.log(cliStyles.warning(`${ticker.metadata.ticker} is already in "${watchlist.name}".`));
       persistence.close();
       return;
     }
 
-    const nextTicker: TickerRecord = {
-      ...ticker,
-      metadata: {
-        ...ticker.metadata,
-        watchlists: [...ticker.metadata.watchlists, watchlist.id],
-      },
-    };
+    const nextTicker = result.ticker;
     await store.saveTicker(nextTicker);
     console.log(cliStyles.success(`Added ${nextTicker.metadata.ticker} to "${watchlist.name}".`));
     if (nextTicker.metadata.name) {
@@ -644,7 +640,7 @@ export const watchlistCliCommand: CliCommandDef = {
       const symbol = args.at(-1);
       const name = args.slice(1, -1).join(" ");
       if (!name || !symbol) ctx.fail("Usage: gloomberb watchlist add <watchlist> <ticker>");
-      await addTickerToWatchlist(name!, symbol!, ctx);
+      await addTickerToWatchlistCommand(name!, symbol!, ctx);
       return;
     }
 

--- a/src/plugins/builtin/portfolio-list/mutations.ts
+++ b/src/plugins/builtin/portfolio-list/mutations.ts
@@ -121,6 +121,23 @@ export function addTickerToPortfolio(
   };
 }
 
+export function addTickerToWatchlist(
+  ticker: TickerRecord,
+  watchlistId: string,
+): { changed: boolean; ticker: TickerRecord } {
+  if (ticker.metadata.watchlists.includes(watchlistId)) {
+    return { changed: false, ticker };
+  }
+
+  return {
+    changed: true,
+    ticker: replaceTickerMetadata(ticker, {
+      ...ticker.metadata,
+      watchlists: [...ticker.metadata.watchlists, watchlistId],
+    }),
+  };
+}
+
 export function removeTickerFromPortfolio(
   ticker: TickerRecord,
   portfolioId: string,

--- a/src/plugins/builtin/portfolio-list/pane.tsx
+++ b/src/plugins/builtin/portfolio-list/pane.tsx
@@ -46,6 +46,8 @@ import { getMostRecentQuoteUpdate } from "../../../utils/quote-time";
 import { priceColor } from "../../../theme/colors";
 import { PortfolioTickerTable, type QuoteFlashDirection } from "./table";
 import { useThrottledCursorSymbol } from "./use-throttled-cursor-symbol";
+import { isManualPortfolio } from "./mutations";
+import { QuickAddTickerInput, type QuickAddCollectionKind } from "./quick-add";
 
 const VISIBLE_FINANCIAL_REFRESH_COOLDOWN_MS = 5 * 60_000;
 const VISIBLE_FINANCIAL_WARMUP_DELAY_MS = 350;
@@ -209,6 +211,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   const [now, setNow] = useState(Date.now());
   const [flashSymbols, setFlashSymbols] = useState<Map<string, QuoteFlashDirection>>(new Map());
   const [streamWindow, setStreamWindow] = useState({ start: 0, end: 24 });
+  const [quickAddFocused, setQuickAddFocused] = useState(false);
 
   const previousPricesRef = useRef<Map<string, number>>(new Map());
   const mountedRef = useRef(true);
@@ -235,6 +238,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   );
   const activeCollectionId = resolveActiveCollectionId(currentCollectionId, visibleCollections);
   const isPortfolioTab = getCollectionTypeFromConfig(config, activeCollectionId) === "portfolio";
+  const activeCollectionEntry = visibleCollections.find((collection) => collection.id === activeCollectionId) ?? null;
   const currentPortfolio = useMemo(() => (
     isPortfolioTab
       ? config.portfolios.find((portfolio) => portfolio.id === activeCollectionId) ?? null
@@ -334,6 +338,9 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     flushCursorSymbol(ticker.metadata.ticker);
     openTickerFloating(ticker.metadata.ticker);
   }, [flushCursorSymbol, openTickerFloating]);
+  const handleTickerAdded = useCallback((symbol: string) => {
+    setCursorSymbol(symbol, { immediate: true });
+  }, [setCursorSymbol]);
 
   const handleTableKeyDown = useCallback((event: DataTableKeyEvent) => {
     if (!focused) return;
@@ -555,6 +562,30 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       : [],
   }), [cashDrawerExpanded, setCashDrawerExpanded, showCashDrawer, summaryFooterInfo]);
 
+  const quickAddCollectionKind = useMemo<QuickAddCollectionKind | null>(() => {
+    if (!activeCollectionId) return null;
+    const collectionType = getCollectionTypeFromConfig(config, activeCollectionId);
+    if (collectionType === "watchlist") return "watchlist";
+    if (collectionType === "portfolio" && currentPortfolio && isManualPortfolio(currentPortfolio)) {
+      return "portfolio";
+    }
+    return null;
+  }, [activeCollectionId, config, currentPortfolio]);
+  const showQuickAdd = !!(activeCollectionId && activeCollectionEntry && quickAddCollectionKind);
+  const quickAddHeight = showQuickAdd ? 1 : 0;
+  const tableHeight = Math.max(1, height - headerHeight - drawerHeight - quickAddHeight);
+  const quickAddRow = activeCollectionId && activeCollectionEntry && quickAddCollectionKind ? (
+    <QuickAddTickerInput
+      collectionId={activeCollectionId}
+      collectionKind={quickAddCollectionKind}
+      collectionName={activeCollectionEntry.name}
+      focused={focused}
+      width={width}
+      onAdded={handleTickerAdded}
+      onFocusChange={setQuickAddFocused}
+    />
+  ) : null;
+
   return (
     <Box flexDirection="column" width={width} height={height}>
       <Box flexDirection="column" height={headerHeight}>
@@ -575,7 +606,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
 
       <PortfolioTickerTable
         columns={columns}
-        focused={focused}
+        focused={focused && !quickAddFocused}
         sortColumnId={activeSort.columnId}
         sortDirection={activeSort.direction}
         onHeaderClick={handleHeaderClick}
@@ -590,7 +621,10 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
         visibleRangeBuffer={3}
         resetScrollKey={activeCollectionId}
         onRowActivate={handleRowActivate}
+        rootHeight={tableHeight}
       />
+
+      {quickAddRow}
 
       {showCashDrawer && accountState && (
         <Box height={drawerHeight} paddingX={1}>

--- a/src/plugins/builtin/portfolio-list/quick-add.tsx
+++ b/src/plugins/builtin/portfolio-list/quick-add.tsx
@@ -1,0 +1,422 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Input, Text, type InputRenderable } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { useAppDispatch, useAppSelector } from "../../../state/app-context";
+import { getSharedRegistry } from "../../registry";
+import { usePluginAppActions } from "../../plugin-runtime";
+import { colors, priceColor } from "../../../theme/colors";
+import { formatPercentRaw } from "../../../utils/format";
+import { formatMarketPrice } from "../../../utils/market-format";
+import { resolveTickerSearch, upsertTickerFromSearchResult, type ResolvedTickerSearch } from "../../../utils/ticker-search";
+import type { Quote } from "../../../types/financials";
+import type { TickerRecord } from "../../../types/ticker";
+import { addTickerToPortfolio, addTickerToWatchlist } from "./mutations";
+
+const QUICK_ADD_DEBOUNCE_MS = 300;
+const QUICK_ADD_MAX_QUERY_LENGTH = 32;
+const QUICK_ADD_SYMBOL_RE = /^[A-Z0-9][A-Z0-9.\-\s]*$/;
+
+export type QuickAddCollectionKind = "portfolio" | "watchlist";
+
+interface ResolvedQuickAdd {
+  query: string;
+  symbol: string;
+  resolved: ResolvedTickerSearch;
+  ticker: TickerRecord | null;
+  quote: Quote | null;
+}
+
+type QuickAddValidation =
+  | { status: "idle"; query: "" }
+  | { status: "checking"; query: string }
+  | (ResolvedQuickAdd & { status: "ready" | "duplicate" })
+  | { status: "missing" | "error"; query: string; message: string };
+
+const IDLE_VALIDATION: QuickAddValidation = { status: "idle", query: "" };
+
+function normalizeQuickAddQuery(value: string): string {
+  return value.replace(/^\s*\$/, "").trim().toUpperCase().replace(/\s+/g, " ");
+}
+
+function isPlausibleTickerQuery(query: string): boolean {
+  return query.length > 0
+    && query.length <= QUICK_ADD_MAX_QUERY_LENGTH
+    && QUICK_ADD_SYMBOL_RE.test(query);
+}
+
+function tickerBelongsToCollection(
+  ticker: TickerRecord | null,
+  collectionKind: QuickAddCollectionKind,
+  collectionId: string,
+): boolean {
+  if (!ticker) return false;
+  return collectionKind === "portfolio"
+    ? ticker.metadata.portfolios.includes(collectionId)
+    : ticker.metadata.watchlists.includes(collectionId);
+}
+
+function quoteContextFromResolved(resolved: ResolvedTickerSearch) {
+  const instrument = resolved.kind === "provider"
+    ? resolved.result.brokerContract
+    : resolved.ticker.metadata.broker_contracts?.[0];
+  return instrument
+    ? {
+        brokerId: instrument.brokerId,
+        brokerInstanceId: instrument.brokerInstanceId,
+        instrument,
+      }
+    : undefined;
+}
+
+function exchangeFromResolved(resolved: ResolvedTickerSearch): string | undefined {
+  return resolved.kind === "provider"
+    ? resolved.result.exchange
+    : resolved.ticker.metadata.exchange;
+}
+
+function tickerNameFromValidation(validation: Extract<QuickAddValidation, { status: "ready" | "duplicate" }>): string {
+  if (validation.ticker?.metadata.name) return validation.ticker.metadata.name;
+  return validation.resolved.kind === "provider" ? validation.resolved.result.name : "";
+}
+
+function QuickAddPreview({
+  validation,
+  collectionKind,
+  submitting,
+}: {
+  validation: QuickAddValidation;
+  collectionKind: QuickAddCollectionKind;
+  submitting: boolean;
+}) {
+  if (submitting) {
+    return <Text fg={colors.textDim}>adding...</Text>;
+  }
+
+  if (validation.status === "idle") {
+    return <Text fg={colors.textMuted}> </Text>;
+  }
+
+  if (validation.status === "checking") {
+    return <Text fg={colors.textDim}>{`${validation.query} checking...`}</Text>;
+  }
+
+  if (validation.status === "missing" || validation.status === "error") {
+    return <Text fg={colors.textMuted}>{validation.message}</Text>;
+  }
+
+  if (validation.status === "duplicate") {
+    return <Text fg={colors.textMuted}>{`${validation.symbol} already in ${collectionKind}`}</Text>;
+  }
+
+  const quote = validation.quote;
+  const assetCategory = validation.ticker?.metadata.assetCategory
+    ?? (validation.resolved.kind === "provider" ? validation.resolved.result.type : undefined);
+  const priceText = quote?.price != null
+    ? formatMarketPrice(quote.price, { assetCategory, maxWidth: 12 })
+    : "-";
+  const changeValue = quote?.changePercent;
+  const name = tickerNameFromValidation(validation);
+  const showSymbol = normalizeQuickAddQuery(validation.symbol) !== validation.query;
+  const symbolPrefix = showSymbol ? `${validation.symbol} ` : "";
+
+  return (
+    <Box flexDirection="row" overflow="hidden">
+      <Text fg={colors.textDim}>{`${symbolPrefix}${priceText} `}</Text>
+      <Text fg={changeValue == null ? colors.textDim : priceColor(changeValue)}>
+        {formatPercentRaw(changeValue)}
+      </Text>
+      {name ? <Text fg={colors.textMuted}>{`  ${name}`}</Text> : null}
+    </Box>
+  );
+}
+
+export function QuickAddTickerInput({
+  collectionId,
+  collectionKind,
+  collectionName,
+  focused,
+  width,
+  onAdded,
+  onFocusChange,
+}: {
+  collectionId: string;
+  collectionKind: QuickAddCollectionKind;
+  collectionName: string;
+  focused: boolean;
+  width: number;
+  onAdded: (symbol: string) => void;
+  onFocusChange?: (focused: boolean) => void;
+}) {
+  const dispatch = useAppDispatch();
+  const { notify } = usePluginAppActions();
+  const tickers = useAppSelector((state) => state.tickers);
+  const financials = useAppSelector((state) => state.financials);
+  const inputRef = useRef<InputRenderable | null>(null);
+  const validationSeqRef = useRef(0);
+  const [inputFocused, setInputFocused] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [validation, setValidation] = useState<QuickAddValidation>(IDLE_VALIDATION);
+  const [submitting, setSubmitting] = useState(false);
+
+  const focusInput = useCallback(() => {
+    if (!focused) return;
+    setInputFocused(true);
+    queueMicrotask(() => inputRef.current?.focus?.());
+  }, [focused]);
+
+  const blurInput = useCallback(() => {
+    setInputFocused(false);
+  }, []);
+
+  const resetInput = useCallback(() => {
+    setInputValue("");
+    setValidation(IDLE_VALIDATION);
+  }, []);
+
+  useEffect(() => {
+    onFocusChange?.(inputFocused && focused);
+  }, [focused, inputFocused, onFocusChange]);
+
+  useEffect(() => {
+    if (inputFocused && focused) {
+      dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+      return () => dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+    }
+  }, [dispatch, focused, inputFocused]);
+
+  useEffect(() => {
+    if (!focused && inputFocused) {
+      blurInput();
+    }
+  }, [blurInput, focused, inputFocused]);
+
+  const validateQuery = useCallback(async (query: string): Promise<QuickAddValidation> => {
+    if (!query) return IDLE_VALIDATION;
+    if (!isPlausibleTickerQuery(query)) {
+      return { status: "missing", query, message: "Use a ticker symbol" };
+    }
+
+    const registry = getSharedRegistry();
+    if (!registry) {
+      return { status: "error", query, message: "Ticker lookup unavailable" };
+    }
+
+    try {
+      const resolved = await resolveTickerSearch({
+        query,
+        activeTicker: null,
+        tickers,
+        dataProvider: registry.marketData,
+      });
+      if (!resolved) {
+        return { status: "missing", query, message: "No exact ticker match" };
+      }
+
+      const symbol = resolved.symbol;
+      const ticker = resolved.kind === "local" ? resolved.ticker : (tickers.get(symbol) ?? null);
+      const cachedQuote = financials.get(symbol)?.quote ?? null;
+      let quote = cachedQuote;
+      if (!quote) {
+        try {
+          quote = await registry.marketData.getQuote(
+            symbol,
+            exchangeFromResolved(resolved),
+            quoteContextFromResolved(resolved),
+          );
+        } catch {
+          quote = null;
+        }
+      }
+
+      return {
+        status: tickerBelongsToCollection(ticker, collectionKind, collectionId) ? "duplicate" : "ready",
+        query,
+        symbol,
+        resolved,
+        ticker,
+        quote,
+      };
+    } catch {
+      return { status: "error", query, message: "Ticker lookup failed" };
+    }
+  }, [collectionId, collectionKind, financials, tickers]);
+
+  useEffect(() => {
+    const query = normalizeQuickAddQuery(inputValue);
+    validationSeqRef.current += 1;
+    const seq = validationSeqRef.current;
+
+    if (!query) {
+      setValidation(IDLE_VALIDATION);
+      return;
+    }
+
+    if (!isPlausibleTickerQuery(query)) {
+      setValidation({ status: "missing", query, message: "Use a ticker symbol" });
+      return;
+    }
+
+    setValidation({ status: "checking", query });
+    const timeoutId = setTimeout(() => {
+      void validateQuery(query).then((result) => {
+        if (validationSeqRef.current === seq) {
+          setValidation(result);
+        }
+      });
+    }, QUICK_ADD_DEBOUNCE_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [inputValue, validateQuery]);
+
+  const submitInput = useCallback(async (submittedValue?: string) => {
+    const query = normalizeQuickAddQuery(submittedValue ?? inputValue);
+    if (!query || submitting) return;
+
+    setSubmitting(true);
+    try {
+      const currentValidation = (
+        validation.query === query
+        && (validation.status === "ready" || validation.status === "duplicate")
+      )
+        ? validation
+        : await validateQuery(query);
+      setValidation(currentValidation);
+
+      if (currentValidation.status === "duplicate") {
+        notify({ type: "info", body: `${currentValidation.symbol} is already in ${collectionName}.` });
+        return;
+      }
+      if (currentValidation.status !== "ready") {
+        notify({ type: "error", body: currentValidation.status === "idle" ? "Ticker symbol is required." : currentValidation.message });
+        return;
+      }
+
+      const registry = getSharedRegistry();
+      if (!registry) {
+        notify({ type: "error", body: "Ticker lookup unavailable." });
+        return;
+      }
+
+      let ticker: TickerRecord;
+      let created = false;
+      if (currentValidation.resolved.kind === "local") {
+        ticker = currentValidation.resolved.ticker;
+      } else {
+        const result = await upsertTickerFromSearchResult(registry.tickerRepository, currentValidation.resolved.result);
+        ticker = result.ticker;
+        created = result.created;
+      }
+
+      const result = collectionKind === "portfolio"
+        ? addTickerToPortfolio(ticker, collectionId)
+        : addTickerToWatchlist(ticker, collectionId);
+
+      if (!result.changed) {
+        notify({ type: "info", body: `${ticker.metadata.ticker} is already in ${collectionName}.` });
+        return;
+      }
+
+      await registry.tickerRepository.saveTicker(result.ticker);
+      dispatch({ type: "UPDATE_TICKER", ticker: result.ticker });
+      if (created) {
+        registry.events.emit("ticker:added", {
+          symbol: result.ticker.metadata.ticker,
+          ticker: result.ticker,
+        });
+      }
+
+      onAdded(result.ticker.metadata.ticker);
+      notify({ type: "success", body: `Added ${result.ticker.metadata.ticker} to ${collectionName}.` });
+      resetInput();
+      queueMicrotask(() => inputRef.current?.focus?.());
+    } catch {
+      setValidation({ status: "error", query, message: "Ticker add failed" });
+      notify({ type: "error", body: `Failed to add ${query}.` });
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    collectionId,
+    collectionKind,
+    collectionName,
+    dispatch,
+    inputValue,
+    notify,
+    onAdded,
+    resetInput,
+    submitting,
+    validateQuery,
+    validation,
+  ]);
+
+  useShortcut((event) => {
+    if (!focused) return;
+
+    if (inputFocused) {
+      if (event.name === "escape") {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        resetInput();
+        blurInput();
+      }
+      return;
+    }
+
+    if (event.name === "n" && !event.ctrl && !event.meta && !event.super) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusInput();
+    }
+  });
+
+  const inputWidth = useMemo(() => {
+    const queryWidth = normalizeQuickAddQuery(inputValue).length;
+    if (queryWidth > 0) {
+      return Math.max(4, Math.min(18, queryWidth + 1));
+    }
+    return Math.max(6, Math.min(10, Math.floor(width * 0.18)));
+  }, [inputValue, width]);
+  const previewWidth = Math.max(8, width - inputWidth - 7);
+
+  return (
+    <Box
+      height={1}
+      width="100%"
+      flexDirection="row"
+      flexShrink={0}
+      paddingX={1}
+      backgroundColor={colors.panel}
+      onMouseDown={(event: { preventDefault?: () => void }) => {
+        event.preventDefault?.();
+        focusInput();
+      }}
+    >
+      <Text fg={inputFocused ? colors.text : colors.textDim}>+</Text>
+      <Box width={1} />
+      <Box width={inputWidth}>
+        <Input
+          ref={inputRef}
+          value={inputValue}
+          focused={inputFocused && focused}
+          placeholder="ticker"
+          placeholderColor={colors.textMuted}
+          textColor={colors.text}
+          backgroundColor={colors.panel}
+          onInput={(value: string) => setInputValue(value.toUpperCase())}
+          onChange={(value: string) => setInputValue(value.toUpperCase())}
+          onSubmit={(value: string) => void submitInput(value)}
+          onFocus={() => setInputFocused(true)}
+          onBlur={blurInput}
+        />
+      </Box>
+      <Box width={1} />
+      <Box width={previewWidth} overflow="hidden">
+        <QuickAddPreview
+          validation={validation}
+          collectionKind={collectionKind}
+          submitting={submitting}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/portfolio-list/table.tsx
+++ b/src/plugins/builtin/portfolio-list/table.tsx
@@ -62,6 +62,7 @@ export function PortfolioTickerTable({
   visibleRangeBuffer,
   resetScrollKey,
   onRowActivate,
+  rootHeight,
 }: {
   columns: ColumnConfig[];
   focused?: boolean;
@@ -80,6 +81,7 @@ export function PortfolioTickerTable({
   visibleRangeBuffer?: number;
   resetScrollKey?: unknown;
   onRowActivate?: (ticker: TickerRecord) => void;
+  rootHeight?: number;
 }) {
   const cellCacheRef = useRef(createRowValueCache<string, ReturnType<typeof getColumnValue>>(5000));
   const resolveCell = useCallback(
@@ -112,6 +114,7 @@ export function PortfolioTickerTable({
       visibleRangeBuffer={visibleRangeBuffer}
       resetScrollKey={resetScrollKey}
       onRowActivate={onRowActivate}
+      rootHeight={rootHeight}
     />
   );
 }


### PR DESCRIPTION
Adds a bottom quick-add input to manual portfolios and watchlists so users can type a ticker directly from the collection pane.

The input validates exact ticker matches before submit, previews current quote and percent change inline, rejects unresolved symbols, and avoids duplicating the typed symbol in the preview.

It reuses the shared portfolio/watchlist membership mutation path so CLI and pane behavior stay consistent.
