### PR TITLE
Fix command bar shortcut precedence

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1594,7 +1594,7 @@ function AppInner({
         }
       }
     }
-  });
+  }, { phase: "before" });
 
   if (desktopWindowBridge?.kind === "detached" && desktopWindowBridge.paneId) {
     return (

--- a/src/components/data-table-view.test.tsx
+++ b/src/components/data-table-view.test.tsx
@@ -130,7 +130,16 @@ async function renderSettled() {
   });
 }
 
-async function emitKeypress(event: { name?: string; sequence?: string; defaultPrevented?: boolean; propagationStopped?: boolean }) {
+async function emitKeypress(event: {
+  name?: string;
+  sequence?: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+  option?: boolean;
+  defaultPrevented?: boolean;
+  propagationStopped?: boolean;
+}) {
   await act(async () => {
     testSetup!.renderer.keyInput.emit("keypress", {
       ctrl: false,
@@ -157,6 +166,10 @@ describe("DataTableView", () => {
     expect(testSetup.captureCharFrame()).toContain("selected=First row");
 
     await emitKeypress({ name: "j", sequence: "j" });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).toContain("selected=Second row");
+
+    await emitKeypress({ name: "k", sequence: "k", meta: true });
     await renderSettled();
     expect(testSetup.captureCharFrame()).toContain("selected=Second row");
 

--- a/src/components/data-table-view.tsx
+++ b/src/components/data-table-view.tsx
@@ -194,13 +194,13 @@ export function DataTableView<
     if (onRootKeyDown?.(event)) return;
     if (tableProps.items.length === 0) return;
 
-    if (isNextTableRowKey(event.name)) {
+    if (isNextTableRowKey(event)) {
       stopTableKey(event);
       selectByOffset(1);
       return;
     }
 
-    if (isPreviousTableRowKey(event.name)) {
+    if (isPreviousTableRowKey(event)) {
       stopTableKey(event);
       selectByOffset(-1);
       return;

--- a/src/components/feed-data-table-stack-view.tsx
+++ b/src/components/feed-data-table-stack-view.tsx
@@ -3,6 +3,7 @@ import { TextAttributes, type ScrollBoxRenderable } from "../ui";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { colors } from "../theme/colors";
 import { formatTimeAgo } from "../utils/format";
+import { isPlainKey } from "../utils/keyboard";
 import { toTimestampMillis } from "../utils/timestamp";
 import { DataTableStackView } from "./data-table-stack-view";
 import {
@@ -245,13 +246,13 @@ export function FeedDataTableStackView({
     preventDefault?: () => void;
     stopPropagation?: () => void;
   }) => {
-    if (event.name === "j" || event.name === "down") {
+    if (isPlainKey(event, "j", "down")) {
       event.stopPropagation?.();
       event.preventDefault?.();
       scrollDetailBy(1);
       return true;
     }
-    if (event.name === "k" || event.name === "up") {
+    if (isPlainKey(event, "k", "up")) {
       event.stopPropagation?.();
       event.preventDefault?.();
       scrollDetailBy(-1);

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -12,6 +12,7 @@ import { resolveBrokerConfigFields, type BrokerAdapter, type BrokerConfigField }
 import { buildBrokerProfileConfig, validateBrokerProfileValues } from "../../brokers/profile-form";
 import { createBrokerInstanceId } from "../../utils/broker-instances";
 import { isBackNavigationKey, isPlainEscape } from "../../utils/back-navigation";
+import { isPlainKey } from "../../utils/keyboard";
 import { detectShortcutPlatform, formatPrimaryShortcut, getShortcutDisplayMode } from "../../utils/shortcut-labels";
 import { syncBrokerInstance } from "../../brokers/sync-broker-instance";
 import { debugLog } from "../../utils/debug-log";
@@ -528,24 +529,24 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
 
     // --- Step-specific controls ---
     if (step === "theme") {
-      if (event.name === "up" || event.name === "k") {
+      if (isPlainKey(event, "up", "k")) {
         setThemeIdx((i) => Math.max(0, i - 1));
-      } else if (event.name === "down" || event.name === "j") {
+      } else if (isPlainKey(event, "down", "j")) {
         setThemeIdx((i) => Math.min(themeIds.length - 1, i + 1));
       }
     } else if (step === "portfolio" && portfolioSub === "choose") {
-      if (event.name === "up" || event.name === "k") {
+      if (isPlainKey(event, "up", "k")) {
         setPortfolioOptionIdx((i) => Math.max(0, i - 1));
-      } else if (event.name === "down" || event.name === "j") {
+      } else if (isPlainKey(event, "down", "j")) {
         setPortfolioOptionIdx((i) => Math.min(portfolioChoices.length - 1, i + 1));
       }
     } else if (step === "portfolio" && portfolioSub === "broker-fields" && selectedBrokerId) {
       const currentField = activeBrokerFields[brokerFieldIdx];
       if (currentField?.type === "select") {
         const optionCount = currentField.options?.length ?? 0;
-        if (event.name === "up" || event.name === "k") {
+        if (isPlainKey(event, "up", "k")) {
           setBrokerSelectIdx((index) => Math.max(0, index - 1));
-        } else if (event.name === "down" || event.name === "j") {
+        } else if (isPlainKey(event, "down", "j")) {
           setBrokerSelectIdx((index) => Math.min(optionCount - 1, index + 1));
         }
       }

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -10,6 +10,7 @@ import type {
 } from "../types/plugin";
 import type { PluginRegistry } from "../plugins/registry";
 import { blendHex, colors } from "../theme/colors";
+import { isPlainKey } from "../utils/keyboard";
 import { Button, DialogFrame, ListView, MultiSelectDialogContent, TextField } from "./ui";
 import { NativeSelect, openNativeSelect, type NativeSelectElement } from "./ui/native-select";
 
@@ -333,8 +334,8 @@ function useSelectFieldDialogController({
 
   useDialogKeyboard((event) => {
     event.stopPropagation();
-    if (event.name === "up" || event.name === "k") setSelectedIndex((index) => Math.max(0, index - 1));
-    else if (event.name === "down" || event.name === "j") setSelectedIndex((index) => Math.min(field.options.length - 1, index + 1));
+    if (isPlainKey(event, "up", "k")) setSelectedIndex((index) => Math.max(0, index - 1));
+    else if (isPlainKey(event, "down", "j")) setSelectedIndex((index) => Math.min(field.options.length - 1, index + 1));
     else if (event.name === "escape") dismiss();
     else if (event.name === "enter" || event.name === "return" || isSpaceKey(event)) {
       const option = field.options[selectedIndex];
@@ -716,8 +717,8 @@ export function PaneSettingsDialogContent({
 
   useDialogKeyboard((event) => {
     event.stopPropagation();
-    if (event.name === "up" || event.name === "k") setSelectedIndex((index) => Math.max(0, index - 1));
-    else if (event.name === "down" || event.name === "j") setSelectedIndex((index) => Math.min(fields.length - 1, index + 1));
+    if (isPlainKey(event, "up", "k")) setSelectedIndex((index) => Math.max(0, index - 1));
+    else if (isPlainKey(event, "down", "j")) setSelectedIndex((index) => Math.min(fields.length - 1, index + 1));
     else if (event.name === "escape") dismiss();
     else if (event.name === "enter" || event.name === "return" || isSpaceKey(event)) {
       void openFieldEditor(fields[selectedIndex]).catch(() => {});

--- a/src/components/pane-template-wizard.tsx
+++ b/src/components/pane-template-wizard.tsx
@@ -4,6 +4,7 @@ import { type InputRenderable, type TextareaRenderable } from "../ui";
 import { type AlertContext, type PromptContext, useDialogKeyboard } from "../ui/dialog";
 import type { WizardStep } from "../types/plugin";
 import { colors } from "../theme/colors";
+import { isPlainKey } from "../utils/keyboard";
 import { DialogFrame, ListView, TextField } from "./ui";
 
 export function PaneTemplateInfoStep({
@@ -165,9 +166,9 @@ export function PaneTemplateSelectStep({
 
   useDialogKeyboard((event) => {
     event.stopPropagation();
-    if (event.name === "up" || event.name === "k") {
+    if (isPlainKey(event, "up", "k")) {
       setSelectedIndex((index) => Math.max(0, index - 1));
-    } else if (event.name === "down" || event.name === "j") {
+    } else if (isPlainKey(event, "down", "j")) {
       setSelectedIndex((index) => Math.min(options.length - 1, index + 1));
     } else if (event.name === "return" || event.name === "enter") {
       resolve(options[selectedIndex]?.value ?? "");

--- a/src/components/price-selector-dialog.tsx
+++ b/src/components/price-selector-dialog.tsx
@@ -8,6 +8,7 @@ import { colors } from "../theme/colors";
 import { formatMarketPrice } from "../utils/market-format";
 import { DialogFrame, ListView, NumberField } from "./ui";
 import { padTo } from "../utils/format";
+import { isPlainKey } from "../utils/keyboard";
 
 interface PricePreset {
   label: string;
@@ -98,9 +99,9 @@ export function PriceSelectorDialog({
     }
 
     if (mode === "list") {
-      if (event.name === "up" || event.name === "k") {
+      if (isPlainKey(event, "up", "k")) {
         setIndex((current) => Math.max(0, current - 1));
-      } else if (event.name === "down" || event.name === "j") {
+      } else if (isPlainKey(event, "down", "j")) {
         if (index < presets.length - 1) {
           setIndex((current) => current + 1);
         } else {

--- a/src/components/table-view-shared.tsx
+++ b/src/components/table-view-shared.tsx
@@ -7,6 +7,7 @@ import {
   type RefObject,
 } from "react";
 import { Box, type ScrollBoxRenderable } from "../ui";
+import { isPlainKeyboardEvent } from "../utils/keyboard";
 
 function listenToScrollBarChange(
   scrollBar: ScrollBoxRenderable["verticalScrollBar"],
@@ -28,6 +29,8 @@ export interface TableViewKeyEvent {
   name?: string;
   ctrl?: boolean;
   meta?: boolean;
+  super?: boolean;
+  alt?: boolean;
   option?: boolean;
   shift?: boolean;
   readonly defaultPrevented?: boolean;
@@ -74,11 +77,23 @@ export function isTableActivationKey(name: string | undefined): boolean {
   return name === "enter" || name === "return";
 }
 
-export function isNextTableRowKey(name: string | undefined): boolean {
+function getTableKeyName(event: TableViewKeyEvent | string | undefined): string | undefined {
+  return typeof event === "string" ? event : event?.name;
+}
+
+function isPlainTableKey(event: TableViewKeyEvent | string | undefined): boolean {
+  return typeof event !== "object" || isPlainKeyboardEvent(event);
+}
+
+export function isNextTableRowKey(event: TableViewKeyEvent | string | undefined): boolean {
+  const name = getTableKeyName(event);
+  if (!isPlainTableKey(event)) return false;
   return name === "j" || name === "down";
 }
 
-export function isPreviousTableRowKey(name: string | undefined): boolean {
+export function isPreviousTableRowKey(event: TableViewKeyEvent | string | undefined): boolean {
+  const name = getTableKeyName(event);
+  if (!isPlainTableKey(event)) return false;
   return name === "k" || name === "up";
 }
 

--- a/src/components/ticker-list-table-view.tsx
+++ b/src/components/ticker-list-table-view.tsx
@@ -168,13 +168,13 @@ export function TickerListTableView({
     if (onRootKeyDown?.(event)) return;
     if (tableProps.tickers.length === 0) return;
 
-    if (isNextTableRowKey(event.name)) {
+    if (isNextTableRowKey(event)) {
       stopTableKey(event);
       selectByOffset(1);
       return;
     }
 
-    if (isPreviousTableRowKey(event.name)) {
+    if (isPreviousTableRowKey(event)) {
       stopTableKey(event);
       selectByOffset(-1);
       return;

--- a/src/components/ui/choice-dialog.tsx
+++ b/src/components/ui/choice-dialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Box, Text } from "../../ui";
 import { type PromptContext, useDialogKeyboard } from "../../ui/dialog";
 import { colors } from "../../theme/colors";
+import { isPlainKey } from "../../utils/keyboard";
 import { DialogFrame } from "./frame";
 import { ListView, type ListViewItem } from "./list-view";
 
@@ -58,9 +59,9 @@ export function ChoiceDialog({
 
   useDialogKeyboard((event) => {
     event.stopPropagation();
-    if (event.name === "up" || event.name === "k") {
+    if (isPlainKey(event, "up", "k")) {
       setIndex((current) => clampChoiceIndex(current - 1, choices.length));
-    } else if (event.name === "down" || event.name === "j") {
+    } else if (isPlainKey(event, "down", "j")) {
       setIndex((current) => clampChoiceIndex(current + 1, choices.length));
     } else if (event.name === "enter" || event.name === "return") {
       activateChoice(selectedChoice);

--- a/src/components/ui/multi-select-dialog.tsx
+++ b/src/components/ui/multi-select-dialog.tsx
@@ -5,6 +5,7 @@ import { type AlertContext, useDialog, useDialogKeyboard } from "../../ui/dialog
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { colors } from "../../theme/colors";
 import { isDetailBackNavigationKey } from "../../utils/back-navigation";
+import { isPlainKey } from "../../utils/keyboard";
 import { ToggleList } from "../toggle-list";
 import { Button } from "./button";
 import { DialogFrame } from "./frame";
@@ -176,10 +177,10 @@ export function MultiSelectDialogContent({
 
   useDialogKeyboard((event) => {
     event.stopPropagation();
-    if (event.name === "up" || event.name === "k") {
+    if (isPlainKey(event, "up", "k")) {
       const nextIndex = Math.max(0, selectedIndex - 1);
       setSelectedOptionId(displayOptions[nextIndex]?.value ?? selectedOptionId);
-    } else if (event.name === "down" || event.name === "j") {
+    } else if (isPlainKey(event, "down", "j")) {
       const nextIndex = Math.min(displayOptions.length - 1, selectedIndex + 1);
       setSelectedOptionId(displayOptions[nextIndex]?.value ?? selectedOptionId);
     } else if (isSpaceKey(event)) {

--- a/src/plugins/builtin/broker-manager/index.tsx
+++ b/src/plugins/builtin/broker-manager/index.tsx
@@ -32,6 +32,7 @@ import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import type { BrokerAccount } from "../../../types/trading";
 import { useDialog, type PromptContext } from "../../../ui/dialog";
 import { formatCurrency } from "../../../utils/format";
+import { isPlainKey } from "../../../utils/keyboard";
 import { usePluginAppActions, usePluginBrokerActions } from "../../plugin-runtime";
 import {
   buildBrokerProfileRows,
@@ -442,13 +443,13 @@ export function BrokersPane({ focused, width, height }: PaneProps) {
         saveEdit().catch(() => {});
         return;
       }
-      if (event.name === "up" || event.name === "k") {
+      if (isPlainKey(event, "up", "k")) {
         event.stopPropagation();
         const index = editKeys.indexOf(activeEditKey);
         setActiveEditKey(editKeys[Math.max(0, index - 1)] ?? "label");
         return;
       }
-      if (event.name === "down" || event.name === "j" || event.name === "tab") {
+      if (isPlainKey(event, "down", "j", "tab")) {
         event.stopPropagation();
         const index = editKeys.indexOf(activeEditKey);
         setActiveEditKey(editKeys[Math.min(editKeys.length - 1, index + 1)] ?? "label");

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -964,6 +964,34 @@ describe("ChatContent", () => {
     expect(frame).toContain("Reply to @user2...");
   });
 
+  test("modified k does not move message selection", async () => {
+    const controller = createController({
+      messages: [makeMessage(1), makeMessage(2)],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 72,
+        height: 12,
+      }), {
+        width: 72,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    await emitKeypress({ name: "up", sequence: "\u001b[A" });
+    await emitKeypress({ name: "k", sequence: "k", meta: true });
+    await emitKeypress({ name: "return", sequence: "\r" });
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("replying to @user2");
+    expect(frame).toContain("Reply to @user2...");
+    expect(frame).not.toContain("replying to @user1");
+  });
+
   test("shows the reply action next to the selected message timestamp", async () => {
     const controller = createController({
       messages: [makeMessage(1), makeMessage(2)],

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -12,6 +12,7 @@ import { blendHex, colors, hoverBg } from "../../theme/colors";
 import { apiClient, type ChatChannel, type ChatMessage } from "../../utils/api-client";
 import { formatTimeAgo } from "../../utils/format";
 import { tokenizeInlineContent } from "../../utils/inline-content-tokenizer";
+import { isPlainKey } from "../../utils/keyboard";
 import { getSharedRegistry } from "../../plugins/registry";
 import { usePluginAppActions } from "../../plugins/plugin-runtime";
 import { setPaneSetting } from "../../pane-settings";
@@ -1432,20 +1433,20 @@ export function ChatContent({
     const isEnterKey = event.name === "return" || event.name === "enter";
 
     if (sidebarFocusedRef.current && showChannelSidebar) {
-      if (event.name === "left") {
+      if (isPlainKey(event, "left")) {
         event.preventDefault?.();
         event.stopPropagation?.();
         return;
       }
 
-      if (event.name === "right") {
+      if (isPlainKey(event, "right")) {
         event.preventDefault?.();
         event.stopPropagation?.();
         focusChatContent();
         return;
       }
 
-      if (event.name === "up" || event.name === "down") {
+      if (isPlainKey(event, "up", "down")) {
         event.preventDefault?.();
         event.stopPropagation?.();
         moveSidebarChannelSelection(event.name);
@@ -1454,7 +1455,7 @@ export function ChatContent({
     }
 
     if (
-      event.name === "left" &&
+      isPlainKey(event, "left") &&
       showChannelSidebar &&
       (!inputFocused || inputValueRef.current.length === 0) &&
       focusChannelSidebar()
@@ -1476,7 +1477,7 @@ export function ChatContent({
         return;
       }
 
-      if ((event.name === "up" || event.name === "down") && shouldLeaveComposerForSelection(event.name)) {
+      if (isPlainKey(event, "up", "down") && shouldLeaveComposerForSelection(event.name)) {
         const moved = moveMessageSelection(event.name);
         if (moved) {
           event.preventDefault?.();
@@ -1489,12 +1490,12 @@ export function ChatContent({
       return;
     }
 
-    if ((event.name === "]" || event.sequence === "]") && cycleChannel(1)) {
+    if (isPlainKey(event, "]") && cycleChannel(1)) {
       event.preventDefault?.();
       event.stopPropagation?.();
       return;
     }
-    if ((event.name === "[" || event.sequence === "[") && cycleChannel(-1)) {
+    if (isPlainKey(event, "[") && cycleChannel(-1)) {
       event.preventDefault?.();
       event.stopPropagation?.();
       return;
@@ -1507,7 +1508,7 @@ export function ChatContent({
       return;
     }
 
-    if ((isEnterKey || event.name === "i") && canSend) {
+    if ((isEnterKey || isPlainKey(event, "i")) && canSend) {
       event.preventDefault?.();
       event.stopPropagation?.();
       queueMicrotask(() => focusComposer());
@@ -1524,7 +1525,7 @@ export function ChatContent({
       return;
     }
 
-    if (event.name === "j" || event.name === "down") {
+    if (isPlainKey(event, "j", "down")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       if (selectedIdx === messages.length - 1) {
@@ -1534,7 +1535,7 @@ export function ChatContent({
       moveMessageSelection("down");
       return;
     }
-    if (event.name === "k" || event.name === "up") {
+    if (isPlainKey(event, "k", "up")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       if (selectedIdx === 0 && hasOlderMessages && !loadingOlderMessages) {
@@ -1545,14 +1546,14 @@ export function ChatContent({
       return;
     }
 
-    if (canSend && event.name === "r" && selectedIdx >= 0 && selectedIdx < messages.length) {
+    if (canSend && isPlainKey(event, "r") && selectedIdx >= 0 && selectedIdx < messages.length) {
       event.preventDefault?.();
       event.stopPropagation?.();
       beginReplyTo(selectedIdx, { deferFocus: true });
       return;
     }
 
-    if (event.name === "g" && !event.shift) {
+    if (isPlainKey(event, "g")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       setSelectedIdx(0);

--- a/src/plugins/builtin/debug.tsx
+++ b/src/plugins/builtin/debug.tsx
@@ -7,6 +7,7 @@ import { usePaneFooter } from "../../components";
 import { usePluginAppActions } from "../plugin-runtime";
 import { colors, hoverBg } from "../../theme/colors";
 import { debugLog, type LogEntry, type LogLevel } from "../../utils/debug-log";
+import { isPlainKey } from "../../utils/keyboard";
 import { wrapTextLines } from "../../utils/text-wrap";
 import { writeFileSync } from "fs";
 import { join } from "path";
@@ -154,12 +155,12 @@ function DebugPane({ focused, width, height }: PaneProps) {
     }
 
     // Navigation
-    if (event.name === "j" || event.name === "down") {
+    if (isPlainKey(event, "j", "down")) {
       setAutoScroll(false);
       setSelectedIdx((prev) => Math.min(prev + 1, entries.length - 1));
       return;
     }
-    if (event.name === "k" || event.name === "up") {
+    if (isPlainKey(event, "k", "up")) {
       setAutoScroll(false);
       setSelectedIdx((prev) => Math.max(prev - 1, 0));
       return;

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -12,6 +12,7 @@ import { resolveFredMapping } from "./fred-series-map";
 import { resolveChartPalette } from "../../../components/chart/chart-renderer";
 import type { ProjectedChartPoint } from "../../../components/chart/chart-data";
 import { apiClient, type CloudFredObservationPayload, type CloudFredSeriesInfoPayload } from "../../../utils/api-client";
+import { isPlainKey } from "../../../utils/keyboard";
 
 const CACHE_TTL_MS = 15 * 60 * 1000;
 
@@ -202,11 +203,11 @@ function EconDetailView({ event, width, height, focused }: EconDetailViewProps) 
 
   useShortcut((ev) => {
     if (!focused) return;
-    if (ev.name === "j" || ev.name === "down") {
+    if (isPlainKey(ev, "j", "down")) {
       ev.stopPropagation?.();
       ev.preventDefault?.();
       scrollDetailBy(1);
-    } else if (ev.name === "k" || ev.name === "up") {
+    } else if (isPlainKey(ev, "k", "up")) {
       ev.stopPropagation?.();
       ev.preventDefault?.();
       scrollDetailBy(-1);

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -14,6 +14,7 @@ import { blendHex, colors, priceColor } from "../../../theme/colors";
 import type { HolderData, HolderRecord } from "../../../types/financials";
 import type { GloomPlugin } from "../../../types/plugin";
 import { formatCompact, formatPercent, formatPercentRaw, padTo } from "../../../utils/format";
+import { isPlainKey } from "../../../utils/keyboard";
 import { useAssetData, usePluginPaneState } from "../../plugin-runtime";
 import { createTickerSurfacePaneTemplate } from "../ticker-surface";
 
@@ -810,7 +811,7 @@ function HoldersView({ focused, width, height }: { focused: boolean; width: numb
 
   useShortcut((event) => {
     if (!focused || viewMode !== "chart") return;
-    if (event.name === "j" || event.name === "down") {
+    if (isPlainKey(event, "j", "down")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       const nextIdx = Math.min((selectedIdx >= 0 ? selectedIdx : 0) + 1, sortedRows.length - 1);
@@ -818,7 +819,7 @@ function HoldersView({ focused, width, height }: { focused: boolean; width: numb
       if (nextRow) setSelectedId(nextRow.id);
       return;
     }
-    if (event.name === "k" || event.name === "up") {
+    if (isPlainKey(event, "k", "up")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       const nextIdx = Math.max((selectedIdx >= 0 ? selectedIdx : 0) - 1, 0);

--- a/src/plugins/builtin/news-wire/news-detail-view.tsx
+++ b/src/plugins/builtin/news-wire/news-detail-view.tsx
@@ -8,6 +8,7 @@ import { TickerBadge } from "../../../components/ticker-badge";
 import { ExternalLink, ExternalLinkText } from "../../../components/ui";
 import { collectNewsDisplayTickers } from "../../../news/ticker-symbols";
 import { useInlineTickers } from "../../../state/use-inline-tickers";
+import { isPlainKey } from "../../../utils/keyboard";
 import { wrapTextLines } from "../../../utils/text-wrap";
 
 function hasStoryItems(article: MarketNewsItem | null): boolean {
@@ -196,13 +197,13 @@ export function NewsDetailView({ item, focused, width, showTitle = true }: {
 
   useShortcut((event) => {
     if (!focused) return;
-    if (event.name === "j" || event.name === "down") {
+    if (isPlainKey(event, "j", "down")) {
       event.stopPropagation?.();
       event.preventDefault?.();
       scrollBy(1);
       return;
     }
-    if (event.name === "k" || event.name === "up") {
+    if (isPlainKey(event, "k", "up")) {
       event.stopPropagation?.();
       event.preventDefault?.();
       scrollBy(-1);

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -7,6 +7,7 @@ import { usePaneTicker } from "../../state/app-context";
 import { blendHex, colors, hoverBg } from "../../theme/colors";
 import { blendForContrast, contrastRatio, higherContrast } from "../../theme/color-utils";
 import { formatCompact, formatNumber } from "../../utils/format";
+import { isPlainKey } from "../../utils/keyboard";
 import { formatMarketPrice } from "../../utils/market-format";
 import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../market-data/hooks";
@@ -227,7 +228,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       return true;
     }
 
-    if (event.name === "j" || event.name === "down") {
+    if (isPlainKey(event, "j", "down")) {
       if (strikes.length === 0) return true;
       event.preventDefault?.();
       event.stopPropagation?.();
@@ -236,7 +237,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       setStrikeIdx((i) => Math.min(i + 1, strikes.length - 1));
       return true;
     }
-    if (event.name === "k" || event.name === "up") {
+    if (isPlainKey(event, "k", "up")) {
       if (strikes.length === 0) return true;
       event.preventDefault?.();
       event.stopPropagation?.();

--- a/src/plugins/ibkr/trading-pane.tsx
+++ b/src/plugins/ibkr/trading-pane.tsx
@@ -16,6 +16,7 @@ import { colors, priceColor } from "../../theme/colors";
 import type { PaneProps } from "../../types/plugin";
 import type { Quote } from "../../types/financials";
 import { formatCurrency, padTo } from "../../utils/format";
+import { isPlainKey } from "../../utils/keyboard";
 import { formatMarketPrice, formatMarketQuantity } from "../../utils/market-format";
 import { getBrokerInstance } from "../../utils/broker-instances";
 import { usePluginPaneActions } from "../plugin-runtime";
@@ -295,13 +296,13 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     if (!focused) return;
     event.stopPropagation?.();
 
-    if (event.name === "j" || event.name === "down") {
+    if (isPlainKey(event, "j", "down")) {
       const nextIndex = Math.min(tradeState.selectedOpenOrderIndex + 1, Math.max(0, gatewaySnapshot.openOrders.length - 1));
       updateTradingPaneState({ selectedOpenOrderIndex: nextIndex });
       return;
     }
 
-    if (event.name === "k" || event.name === "up") {
+    if (isPlainKey(event, "k", "up")) {
       const nextIndex = Math.max(0, tradeState.selectedOpenOrderIndex - 1);
       updateTradingPaneState({ selectedOpenOrderIndex: nextIndex });
       return;

--- a/src/utils/keyboard.ts
+++ b/src/utils/keyboard.ts
@@ -1,0 +1,31 @@
+export interface KeyboardModifierEventLike {
+  ctrl?: boolean;
+  meta?: boolean;
+  super?: boolean;
+  alt?: boolean;
+  option?: boolean;
+  shift?: boolean;
+  name?: string;
+}
+
+export function hasKeyboardModifier(event: KeyboardModifierEventLike): boolean {
+  return !!(
+    event.ctrl
+    || event.meta
+    || event.super
+    || event.alt
+    || event.option
+    || event.shift
+  );
+}
+
+export function isPlainKeyboardEvent(event: KeyboardModifierEventLike): boolean {
+  return !hasKeyboardModifier(event);
+}
+
+export function isPlainKey(
+  event: KeyboardModifierEventLike,
+  ...names: string[]
+): boolean {
+  return isPlainKeyboardEvent(event) && names.includes(event.name ?? "");
+}


### PR DESCRIPTION
This makes the command bar shortcut run before pane-level keyboard handlers, so Cmd+K opens it even when focus is in chat or other navigable surfaces. It adds shared plain-key modifier handling and applies it to chat, tables, dialogs, detail panes, and plugin surfaces so modified navigation keys are not consumed as j/k movement. It also adds focused regressions for chat and shared table navigation.