### PR TITLE
Expose nested command actions in root search

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -9,7 +9,7 @@ import { cloneLayout, createDefaultConfig, type AppConfig } from "../../types/co
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRecord } from "../../types/ticker";
 import type { PluginRegistry } from "../../plugins/registry";
-import type { PaneTemplateCreateOptions } from "../../types/plugin";
+import type { PaneSettingField, PaneTemplateCreateOptions } from "../../types/plugin";
 import { useShortcut } from "../../react/input";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
@@ -231,6 +231,40 @@ function makePluginRegistry(hasPaneSettings: (paneId: string) => boolean = () =>
     removeBrokerInstanceFn: async () => {},
     getConfigFn: () => createDefaultConfig("/tmp/gloomberb-test"),
   } as unknown as PluginRegistry;
+}
+
+function makeQuoteMonitorPaneSettingsDescriptor(
+  pluginRegistry: PluginRegistry,
+  fields: PaneSettingField[],
+  settings: Record<string, unknown> = {},
+) {
+  const config = createDefaultConfig("/tmp/gloomberb-test");
+  const pane = {
+    instanceId: "quote-monitor:main",
+    paneId: "quote-monitor",
+    title: "Quote Monitor",
+    settings,
+  };
+  return {
+    paneId: "quote-monitor:main",
+    pane,
+    paneDef: pluginRegistry.panes.get("quote-monitor")!,
+    settingsDef: {
+      title: "Quote Monitor Settings",
+      fields,
+    },
+    context: {
+      config,
+      layout: cloneLayout(config.layout),
+      paneId: "quote-monitor:main",
+      paneType: "quote-monitor",
+      pane,
+      settings,
+      paneState: {},
+      activeTicker: "AAPL",
+      activeCollectionId: "main",
+    },
+  } as any;
 }
 
 function ThemeProbe() {
@@ -2103,6 +2137,32 @@ describe("CommandBar", () => {
     expect(frame).toContain("Current Layout");
   });
 
+  test("runs layout actions directly from root search", async () => {
+    const actions: AppAction[] = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query="undo layout change"
+      live
+      configureConfig={layoutModeConfig}
+      configureState={layoutModeState}
+      onAction={(action) => actions.push(action)}
+    />, {
+      width: 90,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+
+    expect(testSetup.captureCharFrame()).toContain("Undo Layout Change");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions.some((action) => action.type === "UNDO_LAYOUT")).toBe(true);
+  });
+
   test("renders filtered saved layouts with textual previews", async () => {
     testSetup = await testRender(<CommandBarHarness
       query="LAY Research"
@@ -2735,41 +2795,12 @@ describe("CommandBar", () => {
       })}
       hasPaneSettings={(paneId) => paneId === "quote-monitor:main"}
       configurePluginRegistry={(pluginRegistry) => {
-        pluginRegistry.resolvePaneSettings = () => ({
-          paneId: "quote-monitor:main",
-          pane: {
-            instanceId: "quote-monitor:main",
-            paneId: "quote-monitor",
-            title: "Quote Monitor",
-            settings: {},
-          },
-          paneDef: pluginRegistry.panes.get("quote-monitor")!,
-          settingsDef: {
-            title: "Quote Monitor Settings",
-            fields: [{
-              key: "symbol",
-              label: "Symbol",
-              type: "text",
-              description: "Ticker symbol to track",
-            }],
-          },
-          context: {
-            config: createDefaultConfig("/tmp/gloomberb-test"),
-            layout: cloneLayout(createDefaultConfig("/tmp/gloomberb-test").layout),
-            paneId: "quote-monitor:main",
-            paneType: "quote-monitor",
-            pane: {
-              instanceId: "quote-monitor:main",
-              paneId: "quote-monitor",
-              title: "Quote Monitor",
-              settings: {},
-            },
-            settings: {},
-            paneState: {},
-            activeTicker: "AAPL",
-            activeCollectionId: "main",
-          },
-        }) as any;
+        pluginRegistry.resolvePaneSettings = () => makeQuoteMonitorPaneSettingsDescriptor(pluginRegistry, [{
+          key: "symbol",
+          label: "Symbol",
+          type: "text",
+          description: "Ticker symbol to track",
+        }]);
         pluginRegistry.applyPaneSettingValueFn = async (paneId, field, value) => {
           appliedValues.push({ paneId, key: field.key, value });
         };
@@ -2816,6 +2847,64 @@ describe("CommandBar", () => {
     }]);
   });
 
+  test("opens focused pane settings directly from root search", async () => {
+    const appliedValues: Array<{ paneId: string; key: string; value: unknown }> = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query="ticker symbol"
+      configureState={(state) => ({
+        ...state,
+        focusedPaneId: "quote-monitor:main",
+      })}
+      hasPaneSettings={(paneId) => paneId === "quote-monitor:main"}
+      configurePluginRegistry={(pluginRegistry) => {
+        pluginRegistry.resolvePaneSettings = () => makeQuoteMonitorPaneSettingsDescriptor(pluginRegistry, [{
+          key: "symbol",
+          label: "Symbol",
+          type: "text",
+          description: "Ticker symbol to track",
+        }]);
+        pluginRegistry.applyPaneSettingValueFn = async (paneId, field, value) => {
+          appliedValues.push({ paneId, key: field.key, value });
+        };
+      }}
+    />, {
+      width: 100,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Quote Monitor Settings");
+    expect(frame).toContain("Symbol");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Apply");
+    expect(frame).toContain("Symbol");
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("MSFT");
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(appliedValues).toEqual([{
+      paneId: "quote-monitor:main",
+      key: "symbol",
+      value: "MSFT",
+    }]);
+  });
+
   test("uses backspace as back only when a pane-settings route query is empty", async () => {
     testSetup = await testRender(<CommandBarHarness
       query="PS"
@@ -2825,41 +2914,12 @@ describe("CommandBar", () => {
       })}
       hasPaneSettings={(paneId) => paneId === "quote-monitor:main"}
       configurePluginRegistry={(pluginRegistry) => {
-        pluginRegistry.resolvePaneSettings = () => ({
-          paneId: "quote-monitor:main",
-          pane: {
-            instanceId: "quote-monitor:main",
-            paneId: "quote-monitor",
-            title: "Quote Monitor",
-            settings: {},
-          },
-          paneDef: pluginRegistry.panes.get("quote-monitor")!,
-          settingsDef: {
-            title: "Quote Monitor Settings",
-            fields: [{
-              key: "symbol",
-              label: "Symbol",
-              type: "text",
-              description: "Ticker symbol to track",
-            }],
-          },
-          context: {
-            config: createDefaultConfig("/tmp/gloomberb-test"),
-            layout: cloneLayout(createDefaultConfig("/tmp/gloomberb-test").layout),
-            paneId: "quote-monitor:main",
-            paneType: "quote-monitor",
-            pane: {
-              instanceId: "quote-monitor:main",
-              paneId: "quote-monitor",
-              title: "Quote Monitor",
-              settings: {},
-            },
-            settings: {},
-            paneState: {},
-            activeTicker: "AAPL",
-            activeCollectionId: "main",
-          },
-        }) as any;
+        pluginRegistry.resolvePaneSettings = () => makeQuoteMonitorPaneSettingsDescriptor(pluginRegistry, [{
+          key: "symbol",
+          label: "Symbol",
+          type: "text",
+          description: "Ticker symbol to track",
+        }]);
       }}
     />, {
       width: 100,
@@ -2915,48 +2975,17 @@ describe("CommandBar", () => {
       })}
       hasPaneSettings={(paneId) => paneId === "quote-monitor:main"}
       configurePluginRegistry={(pluginRegistry) => {
-        pluginRegistry.resolvePaneSettings = () => ({
-          paneId: "quote-monitor:main",
-          pane: {
-            instanceId: "quote-monitor:main",
-            paneId: "quote-monitor",
-            title: "Quote Monitor",
-            settings: {},
-          },
-          paneDef: pluginRegistry.panes.get("quote-monitor")!,
-          settingsDef: {
-            title: "Quote Monitor Settings",
-            fields: [{
-              key: "columns",
-              label: "Columns",
-              type: "ordered-multi-select",
-              description: "Visible columns",
-              options: [
-                { value: "volume", label: "AAA", description: "Volume column" },
-                { value: "spread", label: "BBB", description: "Spread column" },
-                { value: "beta", label: "CCC", description: "Beta column" },
-              ],
-            }],
-          },
-          context: {
-            config: createDefaultConfig("/tmp/gloomberb-test"),
-            layout: cloneLayout(createDefaultConfig("/tmp/gloomberb-test").layout),
-            paneId: "quote-monitor:main",
-            paneType: "quote-monitor",
-            pane: {
-              instanceId: "quote-monitor:main",
-              paneId: "quote-monitor",
-              title: "Quote Monitor",
-              settings: {},
-            },
-            settings: {
-              columns: ["volume", "spread"],
-            },
-            paneState: {},
-            activeTicker: "AAPL",
-            activeCollectionId: "main",
-          },
-        }) as any;
+        pluginRegistry.resolvePaneSettings = () => makeQuoteMonitorPaneSettingsDescriptor(pluginRegistry, [{
+          key: "columns",
+          label: "Columns",
+          type: "ordered-multi-select",
+          description: "Visible columns",
+          options: [
+            { value: "volume", label: "AAA", description: "Volume column" },
+            { value: "spread", label: "BBB", description: "Spread column" },
+            { value: "beta", label: "CCC", description: "Beta column" },
+          ],
+        }], { columns: ["volume", "spread"] });
       }}
     />, {
       width: 100,

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -2205,6 +2205,94 @@ export function CommandBar({
     }
   }, []);
 
+  const activatePaneSettingField = useCallback((
+    paneId: string,
+    field: PaneSettingField,
+    currentValue: unknown,
+    options?: { keepRouteOpen?: boolean },
+  ) => {
+    const normalized = normalizePaneSettingField(paneId, field, currentValue);
+    if (normalized.mode === "toggle") {
+      if (options?.keepRouteOpen) {
+        updateTopRoute((route) => route.kind === "pane-settings"
+          ? { ...route, pendingFieldKey: field.key, error: null }
+          : route);
+      }
+      void pluginRegistry.applyPaneSettingValueFn(paneId, field, !normalized.value)
+        .then(() => {
+          if (options?.keepRouteOpen) {
+            updateTopRoute((route) => route.kind === "pane-settings"
+              ? { ...route, pendingFieldKey: null, error: null }
+              : route);
+          } else {
+            closeAll({ revertThemePreview: false });
+          }
+        })
+        .catch((error) => {
+          if (options?.keepRouteOpen) {
+            updateTopRoute((route) => route.kind === "pane-settings"
+              ? {
+                ...route,
+                pendingFieldKey: null,
+                error: error instanceof Error ? error.message : "Could not apply that setting.",
+              }
+              : route);
+            return;
+          }
+          notify(error instanceof Error ? error.message : "Could not apply that setting.", { type: "error" });
+        });
+      return;
+    }
+    if (normalized.mode === "workflow" && normalized.route) {
+      openWorkflowRoute(normalized.route);
+      return;
+    }
+    if (normalized.mode === "picker") {
+      openPickerRoute(normalized.route);
+    }
+  }, [
+    closeAll,
+    normalizePaneSettingField,
+    notify,
+    openPickerRoute,
+    openWorkflowRoute,
+    pluginRegistry,
+    updateTopRoute,
+  ]);
+
+  const buildPaneSettingItems = useCallback((
+    paneId: string | null,
+    query: string,
+    options?: { keepRouteOpen?: boolean },
+  ): ResultItem[] => {
+    if (!paneId) return [];
+    const descriptor = pluginRegistry.resolvePaneSettings(paneId);
+    if (!descriptor) return [];
+
+    const category = descriptor.settingsDef.title || "Pane Settings";
+    const paneLabel = descriptor.pane.title || descriptor.paneDef.name || descriptor.pane.paneId;
+    const items = descriptor.settingsDef.fields.map((field): ResultItem => {
+      const currentValue = descriptor.context.settings[field.key];
+      return {
+        id: `pane-setting:${field.key}`,
+        label: field.label,
+        detail: summarizePaneSettingValue(field, currentValue),
+        category,
+        kind: "action",
+        right: field.type,
+        searchText: `${category} ${paneLabel} ${field.label} ${field.description || ""} ${field.type}`,
+        action: () => activatePaneSettingField(descriptor.paneId, field, currentValue, options),
+      };
+    });
+
+    return query
+      ? fuzzyFilter(items, query, (item) => `${item.label} ${item.detail} ${item.right || ""} ${item.searchText || ""}`)
+      : items;
+  }, [
+    activatePaneSettingField,
+    pluginRegistry,
+  ]);
+
   function readWorkflowTextareaValue(fieldId: string, fallback = ""): string {
     const ref = getInputRef(workflowInputRefs.current, fieldId).current;
     const nextValue = (ref as TextareaRenderable | null)?.editBuffer?.getText?.();
@@ -3720,6 +3808,8 @@ export function CommandBar({
       const allItems = [
         ...tickerItems,
         ...commandItems,
+        ...buildLayoutItems("", { confirmDangerousActions: true }),
+        ...buildPaneSettingItems(state.focusedPaneId, rootQuery),
         ...paneShortcutItems({ includePromptableTickerTemplates: true }),
         ...nonShortcutPaneTemplateItems(),
         ...tickerActionItems(),
@@ -3735,6 +3825,7 @@ export function CommandBar({
     activeTickerSymbol,
     availableCommands,
     buildLayoutItems,
+    buildPaneSettingItems,
     buildPluginItems,
     createQuickLookLocalTickerCandidates,
     createPluginCommandItem,
@@ -4319,21 +4410,7 @@ export function CommandBar({
     if (currentRoute.kind === "pane-settings") {
       const descriptor = pluginRegistry.resolvePaneSettings(currentRoute.paneId);
       if (!descriptor) return null;
-      const items = descriptor.settingsDef.fields.map((field) => {
-        const currentValue = descriptor.context.settings[field.key];
-        return {
-          id: `pane-setting:${field.key}`,
-          label: field.label,
-          detail: summarizePaneSettingValue(field, currentValue),
-          category: descriptor.settingsDef.title || "Pane Settings",
-          kind: "action" as const,
-          right: field.type,
-          action: () => {},
-        };
-      });
-      const filtered = currentRoute.query
-        ? fuzzyFilter(items, currentRoute.query, (item) => `${item.label} ${item.detail} ${item.right || ""}`)
-        : items;
+      const filtered = buildPaneSettingItems(currentRoute.paneId, currentRoute.query, { keepRouteOpen: true });
       return {
         kind: "pane-settings",
         title: descriptor.settingsDef.title || "Pane Settings",
@@ -4358,6 +4435,7 @@ export function CommandBar({
     activeTickerData,
     activeTickerSymbol,
     buildLayoutItems,
+    buildPaneSettingItems,
     buildPluginItems,
     closeAll,
     createPaneTemplateItem,
@@ -4805,40 +4883,7 @@ export function CommandBar({
     }
 
     if (currentRoute?.kind === "pane-settings") {
-      const descriptor = pluginRegistry.resolvePaneSettings(currentRoute.paneId);
-      if (!descriptor) return;
-      const selectedField = descriptor.settingsDef.fields.find((field) => `pane-setting:${field.key}` === selected.id);
-      if (!selectedField) return;
-      const currentValue = descriptor.context.settings[selectedField.key];
-      const normalized = normalizePaneSettingField(currentRoute.paneId, selectedField, currentValue);
-      if (normalized.mode === "toggle") {
-        updateTopRoute((route) => route.kind === "pane-settings"
-          ? { ...route, pendingFieldKey: selectedField.key, error: null }
-          : route);
-        void pluginRegistry.applyPaneSettingValueFn(currentRoute.paneId, selectedField, !normalized.value)
-          .then(() => {
-            updateTopRoute((route) => route.kind === "pane-settings"
-              ? { ...route, pendingFieldKey: null, error: null }
-              : route);
-          })
-          .catch((error) => {
-            updateTopRoute((route) => route.kind === "pane-settings"
-              ? {
-                ...route,
-                pendingFieldKey: null,
-                error: error instanceof Error ? error.message : "Could not apply that setting.",
-              }
-              : route);
-          });
-        return;
-      }
-      if (normalized.mode === "workflow" && normalized.route) {
-        openWorkflowRoute(normalized.route);
-        return;
-      }
-      if (normalized.mode === "picker") {
-        openPickerRoute(normalized.route);
-      }
+      void selected.action();
       return;
     }
 
@@ -4846,10 +4891,7 @@ export function CommandBar({
   }, [
     closeAll,
     currentRoute,
-    normalizePaneSettingField,
     openInlineConfirm,
-    openPickerRoute,
-    openWorkflowRoute,
     persistLayoutChange,
     pluginRegistry,
     resolveImmediateRootSelection,


### PR DESCRIPTION
Fixes #171.

Root command search now includes layout actions and focused pane settings, so known actions like undoing layout changes or editing a focused pane setting can be found without opening a parent command group first.

Plugin toggles and theme choices stay behind their dedicated modes, while direct results reuse the same layout confirmation and pane-setting edit paths as the nested routes.
