### PR TITLE
Theme correlation heatmap and shared UI colors

### DIFF
--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1152,9 +1152,18 @@ function resolveSelectionCursor(
   };
 }
 
-const INDICATOR_COLORS = [
-  "#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8",
-];
+function getIndicatorColor(index: number): string {
+  const indicatorColors = [
+    colors.negative,
+    colors.positive,
+    colors.borderFocused,
+    colors.warning,
+    colors.textBright,
+    colors.neutral,
+    colors.textMuted,
+  ];
+  return indicatorColors[((index % indicatorColors.length) + indicatorColors.length) % indicatorColors.length]!;
+}
 
 function getIndicatorWarmupPeriod(config: IndicatorConfig): number {
   const periods = [
@@ -1270,7 +1279,7 @@ function computeIndicatorOverlays(
   config: IndicatorConfig,
 ): ChartIndicatorOverlays {
   let colorIdx = 0;
-  const nextColor = () => INDICATOR_COLORS[colorIdx++ % INDICATOR_COLORS.length]!;
+  const nextColor = () => getIndicatorColor(colorIdx++);
 
   const smaLines = (config.sma ?? []).map((period) => ({
     period,

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -18,6 +18,8 @@ import {
   commandBarSelectedText,
   commandBarSubtleText,
   commandBarText,
+  blendHex,
+  colors,
   getCurrentThemeId,
   previewTheme,
 } from "../../theme/colors";
@@ -5679,7 +5681,7 @@ export function CommandBar({
         data-gloom-role="command-bar-panel"
         style={nativePaneChrome ? {
           borderRadius: 8,
-          boxShadow: "0 14px 32px rgba(0,0,0,0.18)",
+          boxShadow: `0 14px 32px ${blendHex(commandBarBg(), colors.bg, 0.18)}`,
           overflow: "hidden",
           padding: `${NATIVE_COMMAND_BAR_PADDING_Y_PX}px ${NATIVE_COMMAND_BAR_PADDING_X_PX}px`,
         } : undefined}

--- a/src/components/layout/pane-footer.tsx
+++ b/src/components/layout/pane-footer.tsx
@@ -393,7 +393,7 @@ export function PaneFooterBar({
           "--pane-footer-border-color": empty ? "transparent" : topBorderColor,
           borderTop: `1px solid ${empty ? "transparent" : topBorderColor}`,
           backgroundColor: nativeBackgroundColor,
-          boxShadow: empty ? "none" : "inset 0 1px 0 rgba(255,255,255,0.03)",
+          boxShadow: empty ? "none" : `inset 0 1px 0 ${blendHex(nativeBackgroundColor, colors.textBright, 0.03)}`,
         }}
       >
         <FooterContent

--- a/src/components/layout/pane-header.tsx
+++ b/src/components/layout/pane-header.tsx
@@ -1,6 +1,6 @@
 import { Box, Span, Text, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
-import { colors, floatingPaneTitleBg, paneTitleBg, paneTitleText } from "../../theme/colors";
+import { blendHex, colors, floatingPaneTitleBg, paneTitleBg, paneTitleText } from "../../theme/colors";
 
 const PANE_HEADER_HEIGHT = 1;
 const PANE_HEADER_GRIP = ":: ";
@@ -127,7 +127,9 @@ export function PaneHeader({
         style={{
           borderBottom: `1px solid ${focused ? colors.borderFocused : colors.border}`,
           paddingInline: 6,
-          boxShadow: focused ? "inset 0 -1px 0 rgba(84, 201, 159, 0.18)" : "inset 0 -1px 0 rgba(255,255,255,0.04)",
+          boxShadow: focused
+            ? `inset 0 -1px 0 ${blendHex(paneTitleBg(focused), colors.borderFocused, 0.18)}`
+            : `inset 0 -1px 0 ${blendHex(paneTitleBg(focused), colors.textBright, 0.04)}`,
         }}
       >
         <Text fg={focused ? colors.borderFocused : colors.textMuted} selectable={false} data-gloom-role="pane-grip">

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,6 +1,6 @@
 import { Box, Span, Text, TextAttributes, contextMenuDivider, useContextMenu, useUiCapabilities } from "../../ui";
 import { useCallback, useEffect, useState } from "react";
-import { colors, hoverBg } from "../../theme/colors";
+import { blendHex, colors, hoverBg } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
 import { useAppDispatch, useAppSelector, useFocusedTicker } from "../../state/app-context";
 import {
@@ -251,7 +251,7 @@ function NativeStatusBar({
       }}
       style={{
         borderTop: `1px solid ${colors.border}`,
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.03)",
+        boxShadow: `inset 0 1px 0 ${blendHex(colors.panel, colors.textBright, 0.03)}`,
         paddingInline: 8,
       }}
     >

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -167,7 +167,9 @@ function DesktopSwitch({
       style={{
         border: `1px solid ${checked ? colors.borderFocused : colors.border}`,
         borderRadius: 999,
-        boxShadow: checked ? "inset 0 1px 0 rgba(255,255,255,0.10)" : "inset 0 1px 0 rgba(255,255,255,0.05)",
+        boxShadow: checked
+          ? `inset 0 1px 0 ${blendHex(colors.selected, colors.textBright, 0.1)}`
+          : `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.05)}`,
         cursor: "pointer",
         paddingInline: 2,
       }}
@@ -178,7 +180,7 @@ function DesktopSwitch({
         backgroundColor={checked ? colors.selectedText : colors.textMuted}
         style={{
           borderRadius: 999,
-          boxShadow: "0 1px 2px rgba(0, 0, 0, 0.35)",
+          boxShadow: `0 1px 2px ${blendHex(colors.panel, colors.bg, 0.35)}`,
         }}
       />
     </Box>

--- a/src/components/toggle-list.tsx
+++ b/src/components/toggle-list.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useUiHost } from "../ui";
 import { TextAttributes } from "../ui";
-import { colors } from "../theme/colors";
+import { blendHex, colors } from "../theme/colors";
 import { ListView, type ListRowState, type ListViewItem } from "./ui/list-view";
 
 export interface ToggleListItem {
@@ -76,8 +76,8 @@ function DesktopToggleRow({
           border: `1px solid ${checkboxBorder}`,
           borderRadius: 4,
           boxShadow: enabled
-            ? "inset 0 1px 0 rgba(255,255,255,0.28)"
-            : "inset 0 1px 0 rgba(255,255,255,0.05)",
+            ? `inset 0 1px 0 ${blendHex(colors.borderFocused, colors.textBright, 0.28)}`
+            : `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.05)}`,
         }}
       >
         {enabled && (

--- a/src/components/ui/native-select.tsx
+++ b/src/components/ui/native-select.tsx
@@ -2,7 +2,7 @@
 
 import { type CSSProperties } from "react";
 import { Box } from "../../ui";
-import { colors } from "../../theme/colors";
+import { blendHex, colors } from "../../theme/colors";
 
 export type NativeSelectElement = HTMLSelectElement & { showPicker?: () => void };
 
@@ -51,11 +51,11 @@ export function NativeSelect({
     width,
     height: 28,
     color: colors.text,
-    backgroundColor: "rgba(255, 255, 255, 0.06)",
+    backgroundColor: blendHex(colors.panel, colors.textBright, 0.06),
     border: `1px solid ${colors.border}`,
     borderRadius: 6,
     padding: "0 8px",
-    boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+    boxShadow: `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.05)}`,
     cursor: "pointer",
     font: "inherit",
     letterSpacing: 0,

--- a/src/plugins/builtin/broker-manager/index.tsx
+++ b/src/plugins/builtin/broker-manager/index.tsx
@@ -47,7 +47,7 @@ type BrokerColumn = DataTableColumn & { id: BrokerColumnId };
 function stateColor(state: BrokerDisplayState): string {
   switch (state) {
     case "connected": return colors.positive;
-    case "connecting": return "#e5c07b";
+    case "connecting": return colors.warning;
     case "error": return colors.negative;
     case "disabled": return colors.textMuted;
     case "unavailable": return colors.negative;

--- a/src/plugins/builtin/correlation/colors.test.ts
+++ b/src/plugins/builtin/correlation/colors.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { applyTheme } from "../../../theme/colors";
+import { contrastRatio } from "../../../theme/color-utils";
+import { DEFAULT_THEME, themes } from "../../../theme/themes";
+import { resolveCorrelationHeatmapCellColors } from "./colors";
+
+const CORRELATION_VALUES = [-1, -0.75, -0.5, -0.25, 0, 0.13, 0.24, 0.39, 0.49, 0.75, 1] as const;
+const CELL_TEXT_MIN_CONTRAST = 4.5;
+const MUTED_TEXT_MIN_CONTRAST = 3.6;
+
+afterEach(() => {
+  applyTheme(DEFAULT_THEME);
+});
+
+describe("correlation heatmap colors", () => {
+  test("keeps populated cells readable in every theme", () => {
+    for (const themeId of Object.keys(themes)) {
+      applyTheme(themeId);
+      for (const correlation of CORRELATION_VALUES) {
+        const cell = resolveCorrelationHeatmapCellColors(correlation);
+        expect(
+          contrastRatio(cell.foreground, cell.background),
+          `${themeId} correlation ${correlation}`,
+        ).toBeGreaterThanOrEqual(CELL_TEXT_MIN_CONTRAST);
+      }
+    }
+  });
+
+  test("keeps empty cells readable in every theme", () => {
+    for (const themeId of Object.keys(themes)) {
+      applyTheme(themeId);
+      const cell = resolveCorrelationHeatmapCellColors(null);
+      expect(
+        contrastRatio(cell.foreground, cell.background),
+        `${themeId} empty cell`,
+      ).toBeGreaterThanOrEqual(MUTED_TEXT_MIN_CONTRAST);
+    }
+  });
+});

--- a/src/plugins/builtin/correlation/colors.ts
+++ b/src/plugins/builtin/correlation/colors.ts
@@ -1,0 +1,87 @@
+import { colors } from "../../../theme/colors";
+import { blendHex, contrastRatio } from "../../../theme/color-utils";
+
+const HEATMAP_BASE_BLEND = 0.35;
+const HEATMAP_TEXT_MIN_CONTRAST = 4.5;
+const HEATMAP_MUTED_MIN_CONTRAST = 3.6;
+const HEATMAP_TINT_STEPS = [0.56, 0.5, 0.44, 0.38, 0.32, 0.28, 0.24, 0.2, 0.16, 0.12] as const;
+
+export interface CorrelationHeatmapCellColors {
+  background: string;
+  foreground: string;
+}
+
+function highestContrast(candidates: readonly string[], background: string): string {
+  return candidates.reduce((best, candidate) => (
+    contrastRatio(candidate, background) > contrastRatio(best, background) ? candidate : best
+  ));
+}
+
+function textCandidates(): string[] {
+  return [
+    colors.text,
+    colors.textDim,
+    colors.textBright,
+    colors.textMuted,
+    colors.selectedText,
+    colors.headerText,
+    colors.bg,
+    colors.panel,
+    colors.header,
+    colors.commandBg,
+  ];
+}
+
+function heatmapBaseBackground(): string {
+  return blendHex(colors.panel, colors.bg, HEATMAP_BASE_BLEND);
+}
+
+function heatmapSemanticColor(correlation: number): string {
+  const clamped = Math.max(-1, Math.min(1, correlation));
+  return clamped < 0
+    ? blendHex(colors.negative, colors.warning, clamped + 1)
+    : blendHex(colors.warning, colors.positive, clamped);
+}
+
+function heatmapTintSteps(targetStrength: number): number[] {
+  const steps = HEATMAP_TINT_STEPS.filter((step) => step <= targetStrength);
+  return steps[0] === targetStrength ? steps : [targetStrength, ...steps];
+}
+
+function readableForeground(background: string): string {
+  return highestContrast(textCandidates(), background);
+}
+
+export function resolveCorrelationHeatmapCellColors(correlation: number | null): CorrelationHeatmapCellColors {
+  const baseBackground = heatmapBaseBackground();
+
+  if (correlation === null) {
+    const muted = colors.textMuted;
+    return {
+      background: baseBackground,
+      foreground: contrastRatio(muted, baseBackground) >= HEATMAP_MUTED_MIN_CONTRAST
+        ? muted
+        : readableForeground(baseBackground),
+    };
+  }
+
+  const clamped = Math.max(-1, Math.min(1, correlation));
+  const semanticColor = heatmapSemanticColor(clamped);
+  const targetStrength = 0.3 + Math.abs(clamped) * 0.26;
+  let fallback: CorrelationHeatmapCellColors | null = null;
+
+  for (const tintStrength of heatmapTintSteps(targetStrength)) {
+    const background = blendHex(baseBackground, semanticColor, tintStrength);
+    const foreground = readableForeground(background);
+    const cellColors = { background, foreground };
+    fallback = cellColors;
+    if (contrastRatio(foreground, background) >= HEATMAP_TEXT_MIN_CONTRAST) {
+      return cellColors;
+    }
+  }
+
+  return fallback ?? {
+    background: baseBackground,
+    foreground: readableForeground(baseBackground),
+  };
+}

--- a/src/plugins/builtin/correlation/index.test.tsx
+++ b/src/plugins/builtin/correlation/index.test.tsx
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, type ReactElement } from "react";
+import { Box } from "../../../ui";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import {
+  AppContext,
+  createInitialState,
+  PaneInstanceProvider,
+} from "../../../state/app-context";
+import { cloneLayout, createDefaultConfig } from "../../../types/config";
+import type { TickerRecord } from "../../../types/ticker";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../plugin-runtime";
+import { correlationPlugin } from ".";
+
+const TEST_PANE_ID = "correlation:test";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function makeTicker(symbol: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      broker_contracts: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function CorrelationHarness({ runtime }: { runtime: PluginRuntimeAccess }) {
+  const layout = {
+    dockRoot: { kind: "pane" as const, instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "correlation",
+      settings: {
+        rangePreset: "1Y",
+        symbols: ["AAPL", "MSFT"],
+        symbolsText: "AAPL, MSFT",
+      },
+    }],
+    floating: [],
+    detached: [],
+  };
+  const config = {
+    ...createDefaultConfig("/tmp/gloomberb-correlation-test"),
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  };
+  const state = createInitialState(config);
+  state.focusedPaneId = TEST_PANE_ID;
+  state.tickers = new Map([
+    ["AAPL", makeTicker("AAPL")],
+    ["MSFT", makeTicker("MSFT")],
+  ]);
+
+  const CorrelationPane = correlationPlugin.panes?.[0]?.component as (props: {
+    paneId: string;
+    paneType: string;
+    focused: boolean;
+    width: number;
+    height: number;
+  }) => ReactElement;
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <PluginRenderProvider pluginId="correlation" runtime={runtime}>
+          <Box width={60} height={8}>
+            <CorrelationPane
+              paneId={TEST_PANE_ID}
+              paneType="correlation"
+              focused
+              width={60}
+              height={8}
+            />
+          </Box>
+        </PluginRenderProvider>
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+      await Promise.resolve();
+    });
+  }
+  testSetup = undefined;
+});
+
+describe("correlationPlugin", () => {
+  test("opens tickers from row and column labels", async () => {
+    const opened: Array<{ symbol: string; options: { floating?: boolean; paneType?: string } | undefined }> = [];
+    const runtime = createTestPluginRuntime({
+      pinTicker: (symbol, options) => opened.push({ symbol, options }),
+      navigateTicker: () => {
+        throw new Error("known correlation tickers should open directly");
+      },
+    });
+
+    await act(async () => {
+      testSetup = await testRender(<CorrelationHarness runtime={runtime} />, {
+        width: 60,
+        height: 8,
+      });
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    const lines = testSetup!.captureCharFrame().split("\n");
+    const headerY = lines.findIndex((line) => line.includes("AAPL") && line.includes("MSFT"));
+    const headerCol = lines[headerY]?.indexOf("AAPL") ?? -1;
+    expect(headerY).toBeGreaterThanOrEqual(0);
+    expect(headerCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(headerCol + 1, headerY);
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    const rowY = lines.findIndex((line, index) => index > headerY && line.includes("MSFT"));
+    const rowCol = lines[rowY]?.indexOf("MSFT") ?? -1;
+    expect(rowY).toBeGreaterThanOrEqual(0);
+    expect(rowCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(rowCol + 1, rowY);
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    expect(opened).toEqual([
+      { symbol: "AAPL", options: { floating: true, paneType: "ticker-detail" } },
+      { symbol: "MSFT", options: { floating: true, paneType: "ticker-detail" } },
+    ]);
+  });
+});

--- a/src/plugins/builtin/correlation/index.tsx
+++ b/src/plugins/builtin/correlation/index.tsx
@@ -1,9 +1,9 @@
 import { Box, ScrollBox, Text } from "../../../ui";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { TextAttributes } from "../../../ui";
 import { usePaneFooter } from "../../../components";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
-import { colors } from "../../../theme/colors";
+import { colors, hoverBg } from "../../../theme/colors";
 import { usePluginTickerActions } from "../../plugin-runtime";
 import { useAppSelector, usePaneInstance } from "../../../state/app-context";
 import { useChartQueries } from "../../../market-data/hooks";
@@ -15,7 +15,6 @@ import {
   computeDatedReturns,
   correlateDatedReturns,
   formatCorrelation,
-  correlationColor,
   type CorrelationResult,
   type DatedReturn,
 } from "./compute";
@@ -26,6 +25,7 @@ import {
   getCorrelationPaneSettings,
   type CorrelationRangePreset,
 } from "./settings";
+import { resolveCorrelationHeatmapCellColors } from "./colors";
 
 const ROW_HEADER_WIDTH = 7;
 const MATRIX_CELL_WIDTH = 10;
@@ -142,10 +142,63 @@ function buildCorrelationPaneTitle(symbols: string[], rangePreset: CorrelationRa
   return `${symbols.slice(0, 2).join(" · ")} +${symbols.length - 2} ${rangePreset}`;
 }
 
+function handleSymbolMouseDown(event: {
+  preventDefault?: () => void;
+  stopPropagation?: () => void;
+}, openSymbol: () => void): void {
+  event.preventDefault?.();
+  event.stopPropagation?.();
+  openSymbol();
+}
+
+function SymbolLabelCell({
+  symbol,
+  width,
+  color,
+  align = "flex-start",
+  hovered,
+  onHover,
+  onLeave,
+  onOpen,
+}: {
+  symbol: string;
+  width: number;
+  color: string;
+  align?: "flex-start" | "flex-end";
+  hovered: boolean;
+  onHover: (symbol: string) => void;
+  onLeave: (symbol: string) => void;
+  onOpen: (symbol: string) => void;
+}) {
+  const openSymbol = useCallback(() => onOpen(symbol), [onOpen, symbol]);
+  return (
+    <Box
+      width={width}
+      flexShrink={0}
+      justifyContent={align}
+      paddingRight={align === "flex-end" ? 1 : undefined}
+      overflow="hidden"
+      backgroundColor={hovered ? hoverBg() : undefined}
+      style={{ cursor: "pointer" }}
+      onMouseMove={() => onHover(symbol)}
+      onMouseOut={() => onLeave(symbol)}
+      onMouseDown={(event: any) => handleSymbolMouseDown(event, openSymbol)}
+    >
+      <Text
+        fg={hovered ? colors.textBright : color}
+        attributes={TextAttributes.BOLD | TextAttributes.UNDERLINE}
+      >
+        {displaySymbol(symbol)}
+      </Text>
+    </Box>
+  );
+}
+
 function CorrelationMatrixPane({ width, height }: PaneProps) {
   const pane = usePaneInstance();
-  const { navigateTicker } = usePluginTickerActions();
+  const { navigateTicker, pinTicker } = usePluginTickerActions();
   const tickers = useAppSelector((state) => state.tickers);
+  const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
   const settings = useMemo(() => getCorrelationPaneSettings(pane?.settings), [pane?.settings]);
 
   const instruments = useMemo(() => {
@@ -234,6 +287,18 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
     ],
   }), [settings.rangePreset, settings.symbolsError, statusSummary, symbols.length]);
 
+  const openSymbol = useCallback((symbol: string) => {
+    if (tickers.has(symbol)) {
+      pinTicker(symbol, { floating: true, paneType: "ticker-detail" });
+      return;
+    }
+    navigateTicker(symbol);
+  }, [navigateTicker, pinTicker, tickers]);
+
+  const clearHoveredSymbol = useCallback((symbol: string) => {
+    setHoveredSymbol((current) => (current === symbol ? null : current));
+  }, []);
+
   if (settings.symbolsError) {
     return (
       <Box flexDirection="column" width={width} height={height} paddingX={2} paddingY={1}>
@@ -265,11 +330,17 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
       <Box flexDirection="row" paddingX={1} height={1} backgroundColor={headerBg}>
         <Box width={rowHeaderWidth} flexShrink={0} />
         {symbols.map((sym) => (
-          <Box key={sym} width={cellWidth} justifyContent="flex-end" paddingRight={1} overflow="hidden">
-            <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-              {displaySymbol(sym)}
-            </Text>
-          </Box>
+          <SymbolLabelCell
+            key={sym}
+            symbol={sym}
+            width={cellWidth}
+            align="flex-end"
+            color={colors.textDim}
+            hovered={hoveredSymbol === sym}
+            onHover={setHoveredSymbol}
+            onLeave={clearHoveredSymbol}
+            onOpen={openSymbol}
+          />
         ))}
       </Box>
 
@@ -283,14 +354,16 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
                 width={rowHeaderWidth}
                 flexShrink={0}
                 overflow="hidden"
-                onMouseDown={() => navigateTicker(rowSym)}
               >
-                <Text
-                  fg={rowHeaderColor(seriesBySymbol.get(rowSym)?.status ?? "loading")}
-                  attributes={TextAttributes.BOLD | TextAttributes.UNDERLINE}
-                >
-                  {displaySymbol(rowSym)}
-                </Text>
+                <SymbolLabelCell
+                  symbol={rowSym}
+                  width={rowHeaderWidth}
+                  color={rowHeaderColor(seriesBySymbol.get(rowSym)?.status ?? "loading")}
+                  hovered={hoveredSymbol === rowSym}
+                  onHover={setHoveredSymbol}
+                  onLeave={clearHoveredSymbol}
+                  onOpen={openSymbol}
+                />
               </Box>
               {/* Cells */}
               {symbols.map((colSym) => {
@@ -301,9 +374,7 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
                 } else {
                   r = matrix.results.get(pairKey(rowSym, colSym))?.correlation ?? null;
                 }
-                const cellColor = isDiag
-                  ? colors.textDim
-                  : correlationColor(r, colors.positive, colors.negative, colors.textMuted);
+                const cellColors = resolveCorrelationHeatmapCellColors(r);
                 const text = isDiag ? " 1.00" : formatCorrelation(r);
                 return (
                   <Box
@@ -311,9 +382,9 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
                     width={cellWidth}
                     justifyContent="flex-end"
                     paddingRight={1}
-                    backgroundColor={isDiag ? headerBg : undefined}
+                    backgroundColor={cellColors.background}
                   >
-                    <Text fg={cellColor}>{text}</Text>
+                    <Text fg={cellColors.foreground}>{text}</Text>
                   </Box>
                 );
               })}

--- a/src/plugins/builtin/debug.tsx
+++ b/src/plugins/builtin/debug.tsx
@@ -37,7 +37,7 @@ function levelColor(level: LogLevel): string {
   switch (level) {
     case "debug": return colors.textDim;
     case "info": return colors.positive;
-    case "warn": return "#e5c07b";
+    case "warn": return colors.warning;
     case "error": return colors.negative;
   }
 }

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
 import { blendHex, colors, priceColor } from "../../../theme/colors";
+import { higherContrast } from "../../../theme/color-utils";
 import type { HolderData, HolderRecord } from "../../../types/financials";
 import type { GloomPlugin } from "../../../types/plugin";
 import { formatCompact, formatPercent, formatPercentRaw, padTo } from "../../../utils/format";
@@ -445,6 +446,14 @@ function desktopTileColor(row: HolderRow): string {
   return blendHex(colors.panel, row.changePercent > 0 ? colors.positive : colors.negative, intensity);
 }
 
+function tileTextColor(backgroundColor: string): string {
+  return higherContrast(
+    higherContrast(colors.text, colors.textBright, backgroundColor),
+    colors.selectedText,
+    backgroundColor,
+  );
+}
+
 function Tile({ tile, selected, currency, marketCap, onSelect }: {
   tile: TileLayout;
   selected: boolean;
@@ -455,7 +464,8 @@ function Tile({ tile, selected, currency, marketCap, onSelect }: {
   const renderWidth = Math.max(1, tile.width - (tile.width > 2 ? 1 : 0));
   const renderHeight = Math.max(1, tile.height - (tile.height > 2 ? 1 : 0));
   const innerWidth = Math.max(1, renderWidth - 1);
-  const textColor = "#ffffff";
+  const backgroundColor = selected ? colors.selected : tileColor(tile.row);
+  const textColor = tileTextColor(backgroundColor);
   const attributes = selected ? TextAttributes.BOLD : TextAttributes.NONE;
   const label = tile.row.name;
   const amount = tile.row.value != null
@@ -471,7 +481,7 @@ function Tile({ tile, selected, currency, marketCap, onSelect }: {
       top={tile.y}
       width={renderWidth}
       height={renderHeight}
-      backgroundColor={selected ? colors.selected : tileColor(tile.row)}
+      backgroundColor={backgroundColor}
       onMouseDown={(event: PreventableMouseEvent) => {
         event.preventDefault();
         onSelect();
@@ -516,6 +526,7 @@ function DesktopTile({ tile, chartWidth, chartHeight, selected, hovered, currenc
   const canShowLabel = tile.width >= 4 && tile.height >= 1.4;
   const isTiny = tile.width < 5 || tile.height < 2;
   const backgroundColor = desktopTileColor(tile.row);
+  const textColor = tileTextColor(backgroundColor);
   const style: CSSProperties = {
     position: "absolute",
     left: `calc(${pct(tile.x, chartWidth)} + 1px)`,
@@ -531,14 +542,14 @@ function DesktopTile({ tile, chartWidth, chartHeight, selected, hovered, currenc
       ? `1px solid ${colors.textBright}`
       : hovered
         ? `1px solid ${blendHex(colors.textBright, backgroundColor, 0.55)}`
-        : "1px solid rgba(255,255,255,0.11)",
+        : `1px solid ${blendHex(backgroundColor, colors.textBright, 0.11)}`,
     boxShadow: selected
-      ? "inset 0 0 0 1px rgba(255,255,255,0.55)"
+      ? `inset 0 0 0 1px ${blendHex(backgroundColor, colors.textBright, 0.55)}`
       : hovered
-        ? "inset 0 0 0 1px rgba(255,255,255,0.18)"
+        ? `inset 0 0 0 1px ${blendHex(backgroundColor, colors.textBright, 0.18)}`
         : "none",
     backgroundColor,
-    color: "#ffffff",
+    color: textColor,
     display: "flex",
     flexDirection: "column",
     alignItems: "stretch",
@@ -557,7 +568,7 @@ function DesktopTile({ tile, chartWidth, chartHeight, selected, hovered, currenc
     whiteSpace: "nowrap",
     lineHeight: 1.1,
     letterSpacing: 0,
-    textShadow: "0 1px 1px rgba(0,0,0,0.35)",
+    textShadow: `0 1px 1px ${blendHex(backgroundColor, colors.bg, 0.35)}`,
   };
 
   return (
@@ -573,7 +584,7 @@ function DesktopTile({ tile, chartWidth, chartHeight, selected, hovered, currenc
     >
       {canShowLabel && (
         <Text
-          fg="#ffffff"
+          fg={textColor}
           attributes={selected ? TextAttributes.BOLD : TextAttributes.NONE}
           style={{
             ...textStyle,
@@ -586,10 +597,10 @@ function DesktopTile({ tile, chartWidth, chartHeight, selected, hovered, currenc
       )}
       {canShowDetails && (
         <>
-          <Text fg="#ffffff" style={{ ...textStyle, fontSize: 12, fontWeight: 600 }}>{amount}</Text>
-          <Text fg="#ffffff" style={{ ...textStyle, fontSize: 12, fontWeight: 600 }}>{ownership ?? change}</Text>
+          <Text fg={textColor} style={{ ...textStyle, fontSize: 12, fontWeight: 600 }}>{amount}</Text>
+          <Text fg={textColor} style={{ ...textStyle, fontSize: 12, fontWeight: 600 }}>{ownership ?? change}</Text>
           {ownership && canShowChange && (
-            <Text fg="#ffffff" style={{ ...textStyle, fontSize: 12, fontWeight: 600 }}>{change}</Text>
+            <Text fg={textColor} style={{ ...textStyle, fontSize: 12, fontWeight: 600 }}>{change}</Text>
           )}
         </>
       )}

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -5,7 +5,7 @@ import type { GloomPlugin } from "../../types/plugin";
 import type { OptionContract, OptionsChain } from "../../types/financials";
 import { usePaneTicker } from "../../state/app-context";
 import { blendHex, colors, hoverBg } from "../../theme/colors";
-import { blendForContrast, contrastRatio, higherContrast } from "../../theme/color-utils";
+import { blendForContrast, contrastRatio } from "../../theme/color-utils";
 import { formatCompact, formatNumber } from "../../utils/format";
 import { formatMarketPrice } from "../../utils/market-format";
 import { formatExpDate, resolveOptionsTarget } from "../../utils/options";
@@ -47,15 +47,6 @@ type OptionsViewProps = {
 type OptionColorRole = "call" | "put" | "price" | "activity" | "iv" | "strike";
 
 const OPTION_TEXT_MIN_CONTRAST = 4.5;
-
-const OPTION_BASE_COLORS: Record<OptionColorRole, string> = {
-  call: "#5ed69a",
-  put: "#ff9c7a",
-  price: "#dfc05b",
-  activity: "#35a7d6",
-  iv: "#8bd878",
-  strike: "#8fb7ff",
-};
 
 const OPTION_COLUMNS: Array<Omit<OptionColumn, "headerColor">> = [
   { id: "callOpenInterest", label: "C OI", width: 6, align: "right" },
@@ -404,14 +395,13 @@ function mostReadableColor(surface: string, candidates: readonly string[]): stri
 }
 
 export function optionRoleColor(role: OptionColorRole, surface: string): string {
-  const preferred = OPTION_BASE_COLORS[role];
-  const themeColor = optionRoleThemeColor(role);
+  const preferred = optionRoleThemeColor(role);
   const fallback = mostReadableColor(surface, [
     preferred,
-    themeColor,
     colors.text,
     colors.textBright,
-    higherContrast("#ffffff", "#000000", surface),
+    colors.selectedText,
+    colors.neutral,
   ]);
   return blendForContrast(preferred, surface, fallback, OPTION_TEXT_MIN_CONTRAST);
 }
@@ -421,7 +411,8 @@ export function optionMutedColor(surface: string): string {
     colors.textDim,
     colors.text,
     colors.textBright,
-    higherContrast("#ffffff", "#000000", surface),
+    colors.selectedText,
+    colors.neutral,
   ]);
   return blendForContrast(colors.textDim, surface, fallback, OPTION_TEXT_MIN_CONTRAST);
 }

--- a/src/renderers/electrobun/view/desktop-controls.tsx
+++ b/src/renderers/electrobun/view/desktop-controls.tsx
@@ -40,8 +40,8 @@ function controlBorderColor(focused = false, active = false): string {
 
 function controlShadow(active = false): string {
   return active
-    ? "0 0 0 1px rgba(84, 201, 159, 0.18), inset 0 1px 0 rgba(255,255,255,0.06)"
-    : "inset 0 1px 0 rgba(255,255,255,0.04)";
+    ? `0 0 0 1px ${blendHex(colors.bg, colors.borderFocused, 0.18)}, inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.06)}`
+    : `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.04)}`;
 }
 
 function buttonPalette(props: Pick<ButtonProps, "variant" | "active" | "disabled">) {
@@ -76,7 +76,7 @@ function buttonPalette(props: Pick<ButtonProps, "variant" | "active" | "disabled
     case "ghost":
       return {
         fg: colors.textDim,
-        bg: "rgba(0, 0, 0, 0)",
+        bg: "transparent",
         border: panelBorder(),
       };
     case "secondary":
@@ -339,7 +339,7 @@ function listRowStyle(selected: boolean): CSSProperties {
   return {
     borderRadius: CONTROL_RADIUS,
     border: `1px solid ${selected ? colors.borderFocused : "transparent"}`,
-    boxShadow: selected ? "inset 0 1px 0 rgba(255,255,255,0.06)" : undefined,
+    boxShadow: selected ? `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.06)}` : undefined,
     cursor: "pointer",
   };
 }

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -1,5 +1,5 @@
 @keyframes gloom-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-html, body, #root { width: 100%; height: 100%; min-height: 100%; overflow: hidden; background: #000; }
+html, body, #root { width: 100%; height: 100%; min-height: 100%; overflow: hidden; background: var(--gloom-bg); }
 #root:focus { outline: none; }
 body {
   --cell-w: 8px;
@@ -8,7 +8,7 @@ body {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 12px;
   line-height: var(--cell-h);
-  color: #d8dde3;
+  color: var(--gloom-text);
   cursor: default;
   user-select: none;
   color-scheme: dark;
@@ -62,26 +62,26 @@ button, [data-gloom-interactive="true"] { cursor: pointer; }
   border: 0;
   border-radius: 6px;
   overflow: hidden;
-  box-shadow: 0 18px 38px rgba(0, 0, 0, .46);
+  box-shadow: 0 18px 38px color-mix(in srgb, var(--gloom-bg) 46%, transparent);
 }
 [data-gloom-role="pane-window"][data-floating="true"]::after {
   content: "";
   position: absolute;
   inset: 0;
-  border: 1px solid var(--pane-border-color, #3a4148);
+  border: 1px solid var(--pane-border-color, var(--gloom-border));
   border-radius: inherit;
   pointer-events: none;
   z-index: 100;
 }
 [data-gloom-role="pane-window"][data-floating="true"][data-focused="true"] {
-  box-shadow: 0 18px 40px rgba(0, 0, 0, .5);
+  box-shadow: 0 18px 40px color-mix(in srgb, var(--gloom-bg) 50%, transparent);
 }
 [data-gloom-role="pane-window"][data-floating="false"] {
   border: 0;
   border-radius: 0;
 }
 [data-gloom-role="pane-window"][data-floating="false"][data-focused="true"] {
-  box-shadow: inset 0 0 0 1px var(--pane-border-color, #54c99f);
+  box-shadow: inset 0 0 0 1px var(--pane-border-color, var(--gloom-border-focused));
 }
 [data-gloom-role="pane-header"] {
   align-items: center;
@@ -125,7 +125,7 @@ body.gloom-dragging {
   min-height: var(--cell-h);
   max-height: var(--cell-h);
   align-items: center;
-  border-top: 1px solid color-mix(in srgb, #3a4148 72%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--gloom-border) 72%, transparent);
   font-size: 11.5px;
 }
 [data-gloom-role="status-bar"] span {
@@ -137,7 +137,7 @@ body.gloom-dragging {
   min-height: var(--cell-h);
   max-height: var(--cell-h);
   align-items: center;
-  border-top: 1px solid color-mix(in srgb, var(--pane-footer-border-color, #3a4148) 72%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--pane-footer-border-color, var(--gloom-border)) 72%, transparent);
   font-size: 11.5px;
   overflow: hidden;
 }
@@ -153,7 +153,7 @@ body.gloom-dragging {
   border-radius: 4px;
 }
 [data-gloom-role="pane-hint"]:hover {
-  background: rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--gloom-text-bright) 8%, transparent);
 }
 [data-gloom-role="pane-action"],
 [data-gloom-role="pane-close"] {
@@ -162,7 +162,7 @@ body.gloom-dragging {
 }
 [data-gloom-role="pane-action"]:hover,
 [data-gloom-role="pane-close"]:hover {
-  background: rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--gloom-text-bright) 8%, transparent);
 }
 [data-gloom-role="resize-handle"] {
   cursor: nwse-resize;
@@ -191,7 +191,7 @@ body.gloom-dragging {
   cursor: pointer;
 }
 [data-gloom-role="tab-close"]:hover {
-  background: rgba(255,255,255,.1);
+  background: color-mix(in srgb, var(--gloom-text-bright) 10%, transparent);
 }
 [data-gloom-scrollbar-x],
 [data-gloom-scrollbar-y] {
@@ -199,7 +199,7 @@ body.gloom-dragging {
   scrollbar-width: thin;
 }
 [data-gloom-scrollbar-active="true"] {
-  scrollbar-color: rgba(216,221,227,.26) transparent;
+  scrollbar-color: color-mix(in srgb, var(--gloom-text) 26%, transparent) transparent;
 }
 [data-gloom-scrollbar-x]::-webkit-scrollbar,
 [data-gloom-scrollbar-y]::-webkit-scrollbar {
@@ -227,7 +227,7 @@ body.gloom-dragging {
 }
 [data-gloom-scrollbar-active="true"]::-webkit-scrollbar-thumb,
 [data-gloom-scrollbar-active="true"]::-webkit-scrollbar-thumb:hover {
-  background: rgba(216,221,227,.24);
+  background: color-mix(in srgb, var(--gloom-text) 24%, transparent);
   background-clip: content-box;
 }
 [data-gloom-scrollbar-x]::-webkit-scrollbar-corner,
@@ -284,8 +284,8 @@ body.gloom-dragging {
   top: 50%;
   height: 1px;
 }
-.gloom-loading, .gloom-fatal { padding: 24px; color: #d8dde3; }
-.gloom-fatal pre { white-space: pre-wrap; color: #ffb4a8; }
+.gloom-loading, .gloom-fatal { padding: 24px; color: var(--gloom-text); }
+.gloom-fatal pre { white-space: pre-wrap; color: var(--gloom-negative); }
 .gloom-toast-viewport {
   position: fixed;
   right: 16px;
@@ -300,7 +300,7 @@ body.gloom-dragging {
   max-width: 420px;
   padding: 10px 12px;
   border: 1px solid;
-  box-shadow: 0 12px 24px rgba(0,0,0,.28);
+  box-shadow: 0 12px 24px color-mix(in srgb, var(--gloom-bg) 28%, transparent);
 }
 .gloom-toast-action {
   margin-top: 8px;
@@ -313,17 +313,19 @@ body.gloom-dragging {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0,0,0,.64);
+  background: color-mix(in srgb, var(--gloom-bg) 64%, transparent);
   z-index: 9999;
 }
 .gloom-dialog {
   max-width: min(920px, calc(100vw - 48px));
   max-height: calc(100vh - 48px);
   overflow: auto;
-  border: 1px solid #3a4148;
+  border: 1px solid var(--gloom-border);
   border-radius: 6px;
-  background: #101417;
-  color: #d8dde3;
+  background: var(--gloom-panel);
+  color: var(--gloom-text);
   padding: 0;
-  box-shadow: 0 18px 48px rgba(0,0,0,.46), inset 0 1px 0 rgba(255,255,255,.05);
+  box-shadow:
+    0 18px 48px color-mix(in srgb, var(--gloom-bg) 46%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--gloom-text-bright) 5%, transparent);
 }

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -129,7 +129,7 @@ function commonStyle(props: Record<string, unknown>): CSSProperties {
     marginBottom: cellInset(props.marginBottom ?? props.marginY ?? props.margin, "y"),
     gap: typeof props.gap === "number" ? `${props.gap * gapUnit}px` : props.gap as CSSProperties["gap"],
     overflow: props.overflow as CSSProperties["overflow"],
-    border: props.border ? `1px solid ${typeof props.borderColor === "string" ? props.borderColor : "#3a4148"}` : undefined,
+    border: props.border ? `1px solid ${typeof props.borderColor === "string" ? props.borderColor : "var(--gloom-border)"}` : undefined,
     boxSizing: "border-box",
     minInlineSize: zeroMinInlineSize ? 0 : undefined,
     minBlockSize: zeroMinBlockSize ? 0 : undefined,
@@ -551,7 +551,7 @@ function ChartCrosshair({
           height: 7,
           borderRadius: 7,
           border: `1px solid ${crosshair.color}`,
-          backgroundColor: "rgba(255, 255, 255, 0.16)",
+          backgroundColor: `color-mix(in srgb, ${crosshair.color} 16%, transparent)`,
           boxSizing: "border-box",
           transform: "translate(-50%, -50%)",
           pointerEvents: "none",
@@ -610,7 +610,7 @@ function textInputStyle(props: Record<string, unknown>, multiline: boolean): CSS
     resize: "none",
     border: "none",
     outline: "none",
-    color: typeof textColor === "string" ? textColor : "#d8dde3",
+    color: typeof textColor === "string" ? textColor : "var(--gloom-text)",
     backgroundColor: typeof backgroundColor === "string" ? backgroundColor : "transparent",
     whiteSpace: multiline && props.wrapText ? "pre-wrap" : "pre",
     overflow: multiline ? "auto" : "hidden",
@@ -1209,7 +1209,9 @@ function WebTabs({
 
   const resolveTabBackground = (active: boolean, hovered: boolean) => {
     if (active && variant === "pill") {
-      return hovered ? "rgba(84, 201, 159, 0.24)" : palette.activeBg;
+      return hovered
+        ? `color-mix(in srgb, ${palette.activeBg} 76%, ${palette.hoverBg})`
+        : palette.activeBg;
     }
     return hovered ? palette.hoverBg : "transparent";
   };

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { resetTerminalInputState } from "../../utils/terminal-input-reset";
 import type { KeyEventLike } from "../../react/input";
 import type { NativeRendererHost, RendererHost } from "../../ui/host";
+import { colors } from "../../theme/colors";
 
 export { useKeyboard, useRenderer, useTerminalDimensions };
 export type { CliRenderer };
@@ -54,7 +55,7 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
 
   const renderer = await createCliRenderer({
     exitOnCtrlC: true,
-    backgroundColor: "#000000",
+    backgroundColor: colors.bg,
     enableMouseMovement: true,
   });
   const root = createRoot(renderer);

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -66,7 +66,7 @@ export async function startOpenTuiApp(): Promise<void> {
             <OpenTuiDialogHostProvider
               size="medium"
               dialogOptions={{ style: { backgroundColor: colors.bg, borderColor: colors.borderFocused, borderStyle: "single", paddingX: 2, paddingY: 1 } }}
-              backdropColor="#000000"
+              backdropColor={colors.bg}
               backdropOpacity={0.8}
             >
               <App

--- a/src/renderers/opentui/test-utils.tsx
+++ b/src/renderers/opentui/test-utils.tsx
@@ -4,6 +4,7 @@ import { testRender as openTuiTestRender } from "@opentui/react/test-utils";
 import { createRoot as openTuiCreateRoot, useRenderer } from "@opentui/react";
 import { UiHostProvider, type NativeRendererHost, type RendererHost } from "../../ui";
 import { ToastHostProvider } from "../../ui/toast";
+import { colors } from "../../theme/colors";
 import { OpenTuiInputHostProvider } from "./input-host";
 import { openTuiUiHost } from "./ui-host";
 import { OpenTuiDialogHostProvider } from "./dialog-host";
@@ -14,8 +15,8 @@ export function TestDialogProvider({ children }: { children: ReactNode }) {
     <DialogProvider
       dialogOptions={{
         style: {
-          backgroundColor: "#000000",
-          borderColor: "#ffffff",
+          backgroundColor: colors.bg,
+          borderColor: colors.borderFocused,
           borderStyle: "single",
         },
       }}
@@ -54,9 +55,9 @@ export function OpenTuiTestProviders({ children }: { children: ReactNode }) {
       <OpenTuiInputHostProvider>
         <ToastHostProvider host={openTuiToastHost}>
           <OpenTuiDialogHostProvider
-            backgroundColor="#000000"
-            containerBorderColor="#555555"
-            focusedBorderColor="#9cdcfe"
+            backgroundColor={colors.bg}
+            containerBorderColor={colors.border}
+            focusedBorderColor={colors.borderFocused}
           >
             {children}
           </OpenTuiDialogHostProvider>

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -73,21 +73,20 @@ export function syncTheme(id: string): void {
 
 export { blendHex } from "./color-utils";
 
-const COMPARISON_SERIES_COLORS = [
-  "#5bc0eb",
-  "#f6ae2d",
-  "#f26419",
-  "#6f2dbd",
-  "#00a896",
-  "#ef476f",
-  "#118ab2",
-  "#8ac926",
-  "#ff7f51",
-  "#4361ee",
-] as const;
-
 export function getComparisonSeriesColor(index: number): string {
-  return COMPARISON_SERIES_COLORS[((index % COMPARISON_SERIES_COLORS.length) + COMPARISON_SERIES_COLORS.length) % COMPARISON_SERIES_COLORS.length]!;
+  const seriesColors = [
+    colors.borderFocused,
+    colors.warning,
+    colors.positive,
+    colors.negative,
+    colors.textBright,
+    colors.neutral,
+    blendHex(colors.borderFocused, colors.positive, 0.45),
+    blendHex(colors.warning, colors.negative, 0.35),
+    blendHex(colors.textBright, colors.positive, 0.35),
+    blendHex(colors.borderFocused, colors.negative, 0.35),
+  ];
+  return seriesColors[((index % seriesColors.length) + seriesColors.length) % seriesColors.length]!;
 }
 
 /** Returns a hover background color derived from bg and selected */


### PR DESCRIPTION
This makes the CORR matrix heatmap theme-aware and keeps values readable across light and dark themes. Symbol row and column labels now use the ticker-opening path so clicking either axis opens a floating ticker detail pane. It also removes remaining hardcoded UI colors from related chart, table, native desktop, and OpenTUI surfaces in favor of theme roles.