### PR TITLE
Fix chat scroll and news story details

### DIFF
--- a/src/news/aggregator.test.ts
+++ b/src/news/aggregator.test.ts
@@ -312,4 +312,45 @@ describe("NewsService", () => {
     expect(detail?.items?.map((item) => item.id)).toEqual(["item-2", "item-1"]);
     expect(state.articles[0]?.items?.map((item) => item.id)).toEqual(["item-2", "item-1"]);
   });
+
+  it("keeps story detail identity when a duplicate feed item wins ranking", async () => {
+    const url = "https://detail.example.com/duplicate-story";
+    const cloudArticle = makeItem({
+      id: "story-1",
+      url,
+      importance: 60,
+      publishedAt: new Date("2026-04-01T10:00:00.000Z"),
+      items: [],
+    });
+    const feedDuplicate = makeItem({
+      id: "rss-1",
+      url,
+      importance: 95,
+      publishedAt: new Date("2026-04-01T10:05:00.000Z"),
+    });
+    const detailArticle = makeItem({
+      ...cloudArticle,
+      items: [{
+        id: "item-1",
+        sourceKey: "wire-a",
+        sourceName: "Wire A",
+        title: "Original",
+        url: "https://detail.example.com/original",
+        publishedAt: new Date("2026-04-01T10:00:00.000Z"),
+      }],
+    });
+
+    agg.register({ ...makeStorySource("cloud", [cloudArticle], detailArticle), priority: 10 });
+    agg.register({ ...makeSource("rss", [feedDuplicate]), priority: 2000 });
+
+    const initial = await agg.load({ feed: "top", limit: 10 });
+
+    expect(initial.articles[0]?.id).toBe("story-1");
+    expect(initial.articles[0]?.importance).toBe(95);
+
+    await agg.loadStory(initial.articles[0]!.id);
+    const state = agg.getQueryState({ feed: "top", limit: 10 });
+
+    expect(state.articles[0]?.items?.map((item) => item.id)).toEqual(["item-1"]);
+  });
 });

--- a/src/news/aggregator.ts
+++ b/src/news/aggregator.ts
@@ -12,6 +12,9 @@ const MAX_ARTICLES = 500;
 const DEFAULT_POLL_INTERVAL_MS = 2 * 60 * 1000;
 const DEFAULT_GLOBAL_QUERY: NewsQuery = { feed: "latest", limit: MAX_ARTICLES };
 const FEEDS = new Set<NewsFeed>(["latest", "top", "breaking", "ticker", "sector", "topic"]);
+const DETAIL_CAPABLE_ARTICLE = Symbol("detail-capable-news-article");
+
+type DetailCapableArticle = NewsArticle & { [DETAIL_CAPABLE_ARTICLE]?: true };
 
 function normalizeTicker(ticker: string | undefined): string {
   return ticker ? normalizeSymbol(ticker) : "";
@@ -101,6 +104,57 @@ function sortByPublishedAt(items: NewsArticle[]): NewsArticle[] {
   return [...items].sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
 }
 
+function hasStoryItems(item: NewsArticle | null | undefined): boolean {
+  return (item?.items?.length ?? 0) > 0;
+}
+
+function markDetailCapableArticle(source: NewsCapability, item: NewsArticle): NewsArticle {
+  if (!source.provider.fetchNewsStory) return item;
+  Object.defineProperty(item, DETAIL_CAPABLE_ARTICLE, {
+    value: true,
+    configurable: true,
+  });
+  return item;
+}
+
+function isDetailCapableArticle(item: NewsArticle): boolean {
+  return (item as DetailCapableArticle)[DETAIL_CAPABLE_ARTICLE] === true;
+}
+
+function shouldReplaceDuplicate(existing: NewsArticle, item: NewsArticle): boolean {
+  return (
+    item.importance > existing.importance ||
+    (item.importance === existing.importance && item.publishedAt > existing.publishedAt)
+  );
+}
+
+function selectDetailArticle(
+  existing: NewsArticle,
+  item: NewsArticle,
+  winner: NewsArticle,
+): NewsArticle | null {
+  if (isDetailCapableArticle(winner)) return winner;
+  if (isDetailCapableArticle(item)) return item;
+  if (isDetailCapableArticle(existing)) return existing;
+  if (hasStoryItems(winner)) return winner;
+  if (hasStoryItems(item)) return item;
+  if (hasStoryItems(existing)) return existing;
+  return null;
+}
+
+function mergeDuplicateArticle(existing: NewsArticle, item: NewsArticle): NewsArticle {
+  const winner = shouldReplaceDuplicate(existing, item)
+    ? { ...existing, ...item }
+    : existing;
+  const detailArticle = selectDetailArticle(existing, item, winner);
+  if (!detailArticle || detailArticle.id === winner.id) return winner;
+  return {
+    ...winner,
+    id: detailArticle.id,
+    items: hasStoryItems(detailArticle) ? detailArticle.items : winner.items,
+  };
+}
+
 function dedupeArticles(items: NewsArticle[]): NewsArticle[] {
   const byKey = new Map<string, NewsArticle>();
   for (const item of items) {
@@ -110,12 +164,7 @@ function dedupeArticles(items: NewsArticle[]): NewsArticle[] {
       byKey.set(key, item);
       continue;
     }
-    if (
-      item.importance > existing.importance ||
-      (item.importance === existing.importance && item.publishedAt > existing.publishedAt)
-    ) {
-      byKey.set(key, { ...existing, ...item });
-    }
+    byKey.set(key, mergeDuplicateArticle(existing, item));
   }
   return sortByPublishedAt([...byKey.values()]).slice(0, MAX_ARTICLES);
 }
@@ -382,7 +431,8 @@ export class NewsService {
     let firstEmpty: SourceFetchResult | null = null;
     for (const source of sources) {
       try {
-        const articles = await source.provider.fetchNews(query);
+        const articles = (await source.provider.fetchNews(query))
+          .map((article) => markDetailCapableArticle(source, article));
         const result = { articles, sourceIds: [newsCapabilitySourceId(source)] };
         if (articles.length > 0) return result;
         firstEmpty ??= result;
@@ -397,7 +447,8 @@ export class NewsService {
     const settled = await Promise.allSettled(
       sources.map(async (source) => ({
         source,
-        articles: await source.provider.fetchNews(query),
+        articles: (await source.provider.fetchNews(query))
+          .map((article) => markDetailCapableArticle(source, article)),
       })),
     );
     const articles: NewsArticle[] = [];
@@ -418,7 +469,8 @@ export class NewsService {
     let changed = false;
     for (const query of queries) {
       if (source.isEnabled?.() === false || news.supports?.(query) === false) continue;
-      const cached = news.getCachedNews?.(query) ?? [];
+      const cached = (news.getCachedNews?.(query) ?? [])
+        .map((article) => markDetailCapableArticle(source, article));
       if (cached.length === 0) continue;
       const key = buildNewsQueryKey(query);
       const current = this.queryStates.get(key) ?? createIdleState();

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -1622,7 +1622,7 @@ describe("ChatContent", () => {
     expect(frame).not.toContain("message 1");
   });
 
-  test("repins the transcript to the latest message when a following chat pane regains focus", async () => {
+  test("preserves a manually scrolled transcript across focus and snapshot refreshes", async () => {
     const controller = createController({
       messages: [
         makeMessage(1),
@@ -1680,13 +1680,90 @@ describe("ChatContent", () => {
 
     await act(async () => {
       setFocused?.(true);
+      (controller as any).emit("everyone");
       await testSetup!.renderOnce();
     });
     await flushFrame();
 
-    const refocusedFrame = testSetup.captureCharFrame();
-    expect(refocusedFrame).toContain("message 8");
-    expect(refocusedFrame).not.toContain("message 2");
+    const refreshedFrame = testSetup.captureCharFrame();
+    expect(refreshedFrame).toContain("message 2");
+    expect(refreshedFrame).not.toContain("message 8");
+  });
+
+  test("opens a newly selected channel at the latest message", async () => {
+    const controller = createController({
+      messages: Array.from({ length: 8 }, (_, index) => makeMessage(index + 1)),
+    });
+    installServerChannels(controller, TEST_CHAT_CHANNELS.slice(0, 2));
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+
+    const equitiesMessages = Array.from({ length: 8 }, (_, index) => ({
+      ...makeMessage(index + 1),
+      id: `o${index + 1}`,
+      channelId: "equities",
+      content: `equities message ${index + 1}`,
+    }));
+    const equitiesState = (controller as any).ensureChannelState("equities");
+    equitiesState.messages = equitiesMessages;
+    equitiesState.lastCursor = "o8";
+
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat-channel-scroll"));
+
+    function ChannelPane() {
+      const [channelId, setChannelId] = useState("everyone");
+      return (
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={90}
+              height={13}
+              focused
+              channelId={channelId}
+              onChannelChange={setChannelId}
+            />
+          </PluginRenderProvider>
+        </AppContext>
+      );
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<ChannelPane />, {
+        width: 90,
+        height: 13,
+      });
+    });
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("message 8");
+
+    await act(async () => {
+      await testSetup!.mockMouse.scroll(24, 4, "up");
+      await testSetup!.mockMouse.scroll(24, 4, "up");
+      await testSetup!.mockMouse.scroll(24, 4, "up");
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("message 2");
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("equities"));
+    const col = lines[row]?.indexOf("equities") ?? -1;
+    expect(row).toBeGreaterThanOrEqual(0);
+    expect(col).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(col + 1, row);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    const channelFrame = testSetup.captureCharFrame();
+    expect(channelFrame).toContain("equities message 8");
+    expect(channelFrame).not.toContain("equities message 1");
   });
 
   test("keeps the bottom reachable after narrowing the chat pane", async () => {

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -75,6 +75,7 @@ const DESKTOP_CHAT_INPUT_TOP_MARGIN_PX = 6;
 const DEFAULT_CHAT_CHANNEL_ID = "everyone";
 const LAST_VISITED_CHAT_CHANNEL_KEY = "lastChatChannelId";
 const CHAT_CHANNEL_MOUSE_HANDLED = "__gloomberbChatChannelHandled";
+const SCROLL_BOTTOM_THRESHOLD_PX = 2;
 
 function isGroupedWithPrevious(messages: ChatMessage[], index: number) {
   if (index === 0) return false;
@@ -178,6 +179,15 @@ function scrollToBottom(scrollBox: ScrollBoxRenderable | null, preferPixels = fa
     Math.max(0, getScrollHeight(scrollBox, exactPixels) - getViewportHeight(scrollBox, exactPixels)),
     exactPixels,
   );
+}
+
+function isScrolledToBottom(scrollBox: ScrollBoxRenderable | null, preferPixels = false) {
+  if (!scrollBox) return true;
+  const exactPixels = preferPixels && hasPixelScrollMetrics(scrollBox);
+  const scrollTop = getScrollTop(scrollBox, exactPixels);
+  const maxScrollTop = Math.max(0, getScrollHeight(scrollBox, exactPixels) - getViewportHeight(scrollBox, exactPixels));
+  const threshold = exactPixels ? SCROLL_BOTTOM_THRESHOLD_PX : 0;
+  return maxScrollTop - scrollTop <= threshold;
 }
 
 function runAfterLayout(callback: () => void) {
@@ -1058,6 +1068,7 @@ export function ChatContent({
     : 0;
   const selectionActive = selectedIdx >= 0 && selectedIdx < messages.length;
   const stickyTranscript = followMessages && !selectionActive;
+  const latestMessageId = messages[messages.length - 1]?.id ?? null;
   const updateComposerRows = useCallback((draft: string) => {
     const nextRows = estimateComposerHeight(draft, composerTextWidth);
     setComposerRows((current) => (current === nextRows ? current : nextRows));
@@ -1274,6 +1285,23 @@ export function ChatContent({
     if (!scrollBox || scrollBox.scrollTop > 1) return;
     requestOlderMessages();
   }, [requestOlderMessages]);
+
+  const handleTranscriptScrollActivity = useCallback((event?: { scroll?: { direction?: "up" | "down" | "left" | "right" } }) => {
+    const direction = event?.scroll?.direction;
+    runAfterLayout(() => {
+      requestOlderMessagesIfNeeded();
+
+      const scrollBox = scrollRef.current;
+      if (!scrollBox) return;
+      const atBottom = isScrolledToBottom(scrollBox, nativePaneChrome);
+      if (direction === "up" && !atBottom) {
+        setFollowMessages(false);
+        return;
+      }
+
+      setFollowMessages(atBottom);
+    });
+  }, [nativePaneChrome, requestOlderMessagesIfNeeded]);
 
   const scrollToLoadedMessage = useCallback((messageId: string) => {
     const targetIndex = messages.findIndex((message) => message.id === messageId);
@@ -1590,7 +1618,7 @@ export function ChatContent({
   useEffect(() => {
     if (!stickyTranscript) return;
     queueMicrotask(() => scrollToBottom(scrollRef.current, nativePaneChrome));
-  }, [contentWidth, height, messages, messageAreaHeight, nativePaneChrome, stickyTranscript]);
+  }, [channelId, contentWidth, height, latestMessageId, messageAreaHeight, nativePaneChrome, stickyTranscript]);
 
   useEffect(() => {
     const anchor = prependAnchorRef.current;
@@ -1717,7 +1745,7 @@ export function ChatContent({
         focusable={false}
         stickyScroll={stickyTranscript}
         stickyStart="bottom"
-        onMouseScroll={() => queueMicrotask(requestOlderMessagesIfNeeded)}
+        onMouseScroll={handleTranscriptScrollActivity}
         style={nativePaneChrome ? { minHeight: 0 } : undefined}
       >
         {loadingOlderMessages && (

--- a/src/plugins/builtin/news-wire/index.tsx
+++ b/src/plugins/builtin/news-wire/index.tsx
@@ -39,7 +39,7 @@ const TopPane = createNewsPresetPane({
   paneKey: "top",
   title: "Top News",
   query: NEWS_QUERY_PRESETS.top,
-  columns: ["rank", "time", "source", "title", "tickers", "importance"],
+  columns: ["rank", "time", "title", "tickers", "importance"],
   defaultSort: { columnId: "importance", direction: "desc" },
   emptyStateTitle: "No top stories yet",
   emptyStateHint: "Try refreshing later as new headlines are ranked.",

--- a/src/plugins/builtin/news-wire/news-preset-pane.tsx
+++ b/src/plugins/builtin/news-wire/news-preset-pane.tsx
@@ -45,6 +45,9 @@ export function NewsPresetPane({
     `${paneKey}:sort`,
     defaultSort,
   );
+  const effectiveSortPreference = columns.includes(sortPreference.columnId)
+    ? sortPreference
+    : defaultSort;
   const loadNewsStory = useLoadNewsStory();
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles, loadNewsStory);
   const { readArticleIds, markArticleRead } = useNewsReadState();
@@ -79,7 +82,7 @@ export function NewsPresetPane({
       readArticleIds={readArticleIds}
       selectedArticleId={selectedArticleId}
       setSelectedArticleId={setSelectedArticleId}
-      sortPreference={sortPreference}
+      sortPreference={effectiveSortPreference}
       setSortPreference={setSortPreference}
       onOpenArticle={openArticle}
       onArticleRead={markArticleRead}

--- a/src/plugins/builtin/news-wire/persisted-articles.ts
+++ b/src/plugins/builtin/news-wire/persisted-articles.ts
@@ -65,8 +65,14 @@ function samePersistedArticles(left: PersistedNewsArticle[], right: PersistedNew
   if (left.length !== right.length) return false;
   return left.every((article, index) => {
     const other = right[index];
-    return other?.id === article.id && other.publishedAt === article.publishedAt;
+    return other?.id === article.id &&
+      other.publishedAt === article.publishedAt &&
+      storyItemsSignature(other.items) === storyItemsSignature(article.items);
   });
+}
+
+function storyItemsSignature(items: PersistedNewsStoryItem[] | undefined): string {
+  return items?.map((item) => `${item.id}:${item.publishedAt}`).join("|") ?? "";
 }
 
 export function usePersistedNewsArticles(key: string, articles: MarketNewsItem[]): MarketNewsItem[] {


### PR DESCRIPTION
Preserves manual chat transcript position through focus and snapshot refreshes, while newly selected channels still open at the latest message.

Keeps news story detail IDs and source items attached when duplicate feed items win ranking, and persists story item changes so details refresh correctly.

Removes the source column from Top News and falls back to the default sort when saved sort state points at a removed column.