### PR TITLE
Add portfolio sparklines and quote monitor grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a shortcut or command n
 | Shortcut | Function |
 |----------|----------|
 | `DES <ticker>` | Security details for a ticker |
-| `QQ <ticker>` | Ticker quote |
+| `QQ <tickers>` | Ticker quote monitor |
 | `PM <query>` | Polymarket and Kalshi prediction data |
 | `TOP` | Ranked market stories |
 | `MOST` | Top gainers, losers, most active, and trending tickers |

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -471,7 +471,7 @@ describe("renderChart", () => {
       cellHeightPx,
     });
 
-    expect(overlay.labelText).toBe("$214.03 ");
+    expect(overlay.labelText).toBe("$214.03");
     expect(overlay.topPercent).toBeCloseTo((cursorPixelY / (height * cellHeightPx - 1)) * 100, 5);
   });
 

--- a/src/components/chart/price-axis-labels.tsx
+++ b/src/components/chart/price-axis-labels.tsx
@@ -25,7 +25,6 @@ function clamp(value: number, min: number, max: number): number {
 
 export function buildCursorPriceAxisOverlay({
   axisWidth,
-  axisSectionWidth,
   height,
   cursorPixelY,
   cursorLabel,
@@ -40,7 +39,7 @@ export function buildCursorPriceAxisOverlay({
 }): CursorPriceAxisOverlay {
   const labelText = cursorLabel === null
     ? null
-    : formatAxisCell(cursorLabel, axisWidth).padEnd(axisSectionWidth);
+    : formatAxisCell(cursorLabel, axisWidth).trimStart();
   const pixelHeight = Math.max(height * cellHeightPx, 1);
   let topPercent: number | null = null;
 
@@ -73,6 +72,20 @@ export function PriceAxisLabels({
     cellHeightPx,
   }), [axisSectionWidth, axisWidth, cellHeightPx, cursorLabel, cursorPixelY, height]);
   const usePixelOverlay = fractionalViewport && overlay.labelText !== null && overlay.topPercent !== null;
+  const axisPaddingWidth = Math.max(0, axisSectionWidth - axisWidth);
+  const axisLabelJustify = fractionalViewport ? "flex-start" : "flex-end";
+  const renderAxisLabel = (label: string | null, fg: string) => (
+    fractionalViewport ? (
+      <Box flexDirection="row" width={axisSectionWidth} height={1}>
+        <Box flexDirection="row" width={axisWidth} justifyContent={axisLabelJustify} overflow="hidden">
+          {label ? <Text fg={fg}>{formatAxisCell(label, axisWidth).trimStart()}</Text> : null}
+        </Box>
+        {axisPaddingWidth > 0 ? <Box width={axisPaddingWidth} /> : null}
+      </Box>
+    ) : (
+      <Text fg={fg}>{formatAxisCell(label, axisWidth).padEnd(axisSectionWidth)}</Text>
+    )
+  );
 
   return (
     <Box
@@ -86,16 +99,16 @@ export function PriceAxisLabels({
         const isCursorRow = !usePixelOverlay && cursorLabel !== null && cursorRow === row;
         const label = isCursorRow ? cursorLabel : (axisLabels.get(row) ?? null);
         return (
-          <Text key={row} fg={isCursorRow ? cursorColor : colors.textDim}>
-            {formatAxisCell(label, axisWidth).padEnd(axisSectionWidth)}
-          </Text>
+          <Box key={row} height={1}>
+            {renderAxisLabel(label, isCursorRow ? cursorColor : colors.textDim)}
+          </Box>
         );
       })}
       {usePixelOverlay ? (
-        <Text
+        <Box
           width={axisSectionWidth}
-          fg={cursorColor}
           bg={colors.bg}
+          flexDirection="row"
           style={{
             position: "absolute",
             left: 0,
@@ -106,8 +119,11 @@ export function PriceAxisLabels({
             zIndex: 1,
           }}
         >
-          {overlay.labelText}
-        </Text>
+          <Box flexDirection="row" width={axisWidth} justifyContent={axisLabelJustify} overflow="hidden">
+            <Text fg={cursorColor}>{overlay.labelText}</Text>
+          </Box>
+          {axisPaddingWidth > 0 ? <Box width={axisPaddingWidth} /> : null}
+        </Box>
       ) : null}
     </Box>
   );

--- a/src/components/chart/stock-chart-renderer-switch.test.tsx
+++ b/src/components/chart/stock-chart-renderer-switch.test.tsx
@@ -382,7 +382,7 @@ describe("StockChart renderer switching", () => {
     const manager = getNativeSurfaceManager(testSetup.renderer as never) as unknown as {
       surfaces: Map<string, { snapshot: { rect: { height: number } } }>;
     };
-    expect(manager.surfaces.get("chart-surface:ticker-detail:test:full:base")?.snapshot.rect.height).toBe(11);
+    expect(manager.surfaces.get("chart-surface:ticker-detail:test:full:base")?.snapshot.rect.height).toBe(12);
   });
 
   test("moves candle OHLC summary into the pane footer", async () => {

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1449,7 +1449,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
 }: ResolvedStockChartProps) {
   const themeColors = useThemeColors();
   const renderer = useNativeRenderer();
-  const { canvasCharts, cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1 } = useUiCapabilities();
+  const { canvasCharts, cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1, fractionalViewport = false } = useUiCapabilities();
   const dispatch = useAppDispatch();
   const config = useAppSelector((state) => state.config);
   const paneId = usePaneInstanceId();
@@ -1741,9 +1741,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const axisSectionWidthBudget = compact
     ? axisMode === "percent" ? 11 : 8
     : axisMode === "percent" ? 11 : 10;
-  const axisRightPadding = 1;
+  const axisRightPadding = compact || fractionalViewport ? 0 : 1;
   const minimumAxisWidth = axisMode === "percent" ? 5 : 4;
-  const axisGap = axisSectionWidthBudget > 0 ? 1 : 0;
+  const axisGap = axisSectionWidthBudget > 0 ? fractionalViewport ? 0.5 : 1 : 0;
   const minChartWidth = compact ? 12 : 20;
   const measurementChartWidth = Math.max(width - axisSectionWidthBudget - axisGap, minChartWidth);
   const headerRows = compact ? 0 : 2;
@@ -1751,7 +1751,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const timeAxisRow = 1;
   // Native/canvas surfaces can cover the last physical row after pixel rounding;
   // keep the text x-axis one row clear of the pane footer.
-  const nativeSurfaceGuardRow = !compact && (useCanvasChart || effectiveRenderer === "kitty") ? 1 : 0;
+  const nativeSurfaceGuardRow = !compact && fractionalViewport && (useCanvasChart || effectiveRenderer === "kitty") ? 1 : 0;
   const volumeHeight = showVolume && !compact ? 3 : 0;
   const chartHeight = Math.max(height - headerRows - helpRow - timeAxisRow - nativeSurfaceGuardRow, 4);
   const chartCurrency = currencyOverride ?? financials?.quote?.currency ?? ticker?.metadata.currency ?? "USD";
@@ -2377,7 +2377,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         colors: AXIS_MEASURE_PALETTE,
         timeAxisDates: measuredTimeAxisDates,
       });
-      const cursorSamples = measuredScene
+      const cursorSamples = !compact && measuredScene
         ? [
           formatCursorAxisValue(
             measuredScene.min,
@@ -2418,6 +2418,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     chartHeight,
     compact,
     displayedDateWindow,
+    fractionalViewport,
     history,
     historyOverride,
     minChartWidth,
@@ -4080,7 +4081,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
           </Box>
         ) : (
           <Box flexDirection="row" gap={1}>
-            <Text fg={colors.textDim}>mode:{MODE_LABELS[requestedMode]}</Text>
             {projection.fallbackMode && (
               <Text fg={colors.textDim}>auto:{MODE_LABELS[projection.fallbackMode]}</Text>
             )}

--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -170,8 +170,9 @@ function makePluginRegistry(hasPaneSettings: (paneId: string) => boolean = () =>
         id: "quote-monitor-pane",
         paneId: "quote-monitor",
         label: "Quote Monitor",
-        description: "Open a compact quote monitor for the selected ticker",
-        shortcut: { prefix: "QQ", argPlaceholder: "ticker" },
+        description: "Open a compact quote monitor for one or more tickers",
+        shortcut: { prefix: "QQ", argPlaceholder: "tickers", argKind: "ticker-list" },
+        wizard: [{ key: "tickers", label: "Quote Tickers", type: "text" }],
       }],
       ["new-ibkr-trading-pane", {
         id: "new-ibkr-trading-pane",
@@ -1013,7 +1014,7 @@ describe("CommandBar", () => {
     expect(frame).not.toContain("Back");
   });
 
-  test("QQ without an active ticker opens inline ticker search on enter", async () => {
+  test("QQ without an active ticker opens inline ticker-list entry on enter", async () => {
     testSetup = await testRender(<CommandBarHarness query="QQ" />, {
       width: 100,
       height: 20,
@@ -1030,7 +1031,7 @@ describe("CommandBar", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Back");
-    expect(frame).toContain("Security Description");
+    expect(frame).toContain("Quote Tickers");
   });
 
   test("T without an active ticker opens ticker search on enter", async () => {
@@ -1102,8 +1103,7 @@ describe("CommandBar", () => {
       templateId: "quote-monitor-pane",
       options: {
         arg: "AAPL",
-        symbol: "AAPL",
-        ticker: makeTicker("AAPL", "Apple Inc."),
+        symbols: ["AAPL"],
       },
     }]);
   });
@@ -2525,8 +2525,39 @@ describe("CommandBar", () => {
       templateId: "quote-monitor-pane",
       options: {
         arg: "MSFT",
-        symbol: "MSFT",
-        ticker: makeTicker("MSFT", "Microsoft Corp."),
+        symbols: ["MSFT"],
+      },
+    }]);
+  });
+
+  test("QQ AAPL,MSFT creates a multi-symbol quote monitor directly", async () => {
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query="QQ AAPL,MSFT"
+      selectedTicker="AAPL"
+      configurePluginRegistry={(pluginRegistry) => {
+        pluginRegistry.createPaneFromTemplateAsyncFn = async (templateId, options) => {
+          created.push({ templateId, options });
+        };
+      }}
+    />, {
+      width: 100,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(created).toEqual([{
+      templateId: "quote-monitor-pane",
+      options: {
+        arg: "AAPL,MSFT",
+        symbols: ["AAPL", "MSFT"],
       },
     }]);
   });

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -4042,9 +4042,9 @@ export function CommandBar({
         }
         const inferred = normalizeTickerInput(activeTickerSymbol, undefined);
         if (inferred) {
-          return `Shortcut: ${rootShortcutIntent.label} · inferred ${inferred} · Tab to accept`;
+          return `Shortcut: ${rootShortcutIntent.label} for ${inferred} · Tab to accept`;
         }
-        return `Shortcut: ${rootShortcutIntent.label} · Enter tickers to compare`;
+        return `Shortcut: ${rootShortcutIntent.label} · Enter tickers`;
       }
       return `Shortcut: ${rootShortcutIntent.label}`;
     }

--- a/src/components/command-bar/workflow-ops.ts
+++ b/src/components/command-bar/workflow-ops.ts
@@ -16,6 +16,7 @@ import {
   COMPARISON_CHART_PANE_ID,
   MIN_COMPARISON_CHART_SYMBOLS,
 } from "../../plugins/builtin/comparison-chart";
+import { buildQuoteMonitorPaneTitle } from "../../plugins/builtin/ticker-detail/settings";
 import { getPaneTemplateDisplayLabel } from "./pane-template-display";
 
 export interface SharedWorkflowDeps {
@@ -366,43 +367,21 @@ export async function applyPaneSettingFieldValue(
     return;
   }
 
-  if (descriptor.pane.paneId === "quote-monitor" && field.key === "symbol") {
+  if (descriptor.pane.paneId === "quote-monitor" && (field.key === "symbol" || field.key === "symbolsText")) {
     const rawQuery = typeof value === "string" ? value.trim() : "";
-    const resolvedTicker = await resolveTickerSearch({
-      query: rawQuery,
-      activeTicker: null,
-      tickers: state.tickers,
-      dataProvider: deps.dataProvider,
-    });
-    if (!resolvedTicker) {
-      throw new Error(`No ticker match found for "${rawQuery}".`);
-    }
-
-    const symbol = resolvedTicker.kind === "local"
-      ? resolvedTicker.ticker.metadata.ticker
-      : resolvedTicker.symbol;
-
-    if (resolvedTicker.kind === "provider") {
-      const { ticker, created } = await upsertTickerFromSearchResult(
-        deps.tickerRepository,
-        resolvedTicker.result,
-      );
-      deps.dispatch({ type: "UPDATE_TICKER", ticker });
-      if (created) {
-        deps.pluginRegistry.events.emit("ticker:added", {
-          symbol: ticker.metadata.ticker,
-          ticker,
-        });
-      }
-    }
+    const symbols = await resolveTickerListInput(rawQuery, null, deps);
+    const primarySymbol = symbols[0]!;
+    const symbolsText = formatTickerListInput(symbols);
 
     const nextLayout = updatePaneInstance(state.config.layout, targetId, (instance) => ({
       ...instance,
-      title: symbol,
-      binding: { kind: "fixed", symbol },
+      title: buildQuoteMonitorPaneTitle(symbols),
+      binding: { kind: "fixed", symbol: primarySymbol },
       settings: {
         ...(instance.settings ?? {}),
-        symbol,
+        symbol: primarySymbol,
+        symbols,
+        symbolsText,
       },
     }));
     deps.persistLayout(nextLayout, { pushHistory: shouldPushHistory });
@@ -433,7 +412,7 @@ export async function applyPaneSettingFieldValue(
   }
 
   let nextSettings: Record<string, unknown> = {
-    ...descriptor.context.settings,
+    ...(descriptor.rawSettings ?? descriptor.context.settings),
     [field.key]: value,
   };
 

--- a/src/components/price-sparkline-view.tsx
+++ b/src/components/price-sparkline-view.tsx
@@ -1,0 +1,463 @@
+import { useMemo } from "react";
+import {
+  Box,
+  ChartSurface,
+  Text,
+  useNativeRenderer,
+  useUiCapabilities,
+  useUiHost,
+  type BitmapSurface,
+} from "../ui";
+import { colors } from "../theme/colors";
+import { useThemeColors } from "../theme/theme-context";
+import type { PricePoint } from "../types/financials";
+import { computeBitmapSize } from "./chart/native/chart-rasterizer";
+import { renderPriceSparkline } from "./price-sparkline";
+
+export const PRICE_SPARKLINE_COLUMN_ID = "sparkline";
+export const PRICE_SPARKLINE_PERIOD_LABEL = "1M";
+
+const SPARKLINE_HEIGHT = 1;
+const SPARKLINE_FALLBACK_POINTS = 22;
+export type PriceSparklineTrend = "positive" | "negative" | "neutral";
+export type PriceSparklinePeriod = "1D" | "1W" | "1M" | "1Y";
+
+const PERIOD_WINDOW_DAYS: Record<PriceSparklinePeriod, number> = {
+  "1D": 1,
+  "1W": 7,
+  "1M": 30,
+  "1Y": 365,
+};
+
+const PERIOD_FALLBACK_POINTS: Record<PriceSparklinePeriod, number> = {
+  "1D": 2,
+  "1W": 7,
+  "1M": SPARKLINE_FALLBACK_POINTS,
+  "1Y": 252,
+};
+
+interface SparklineSample {
+  x: number;
+  y: number;
+}
+
+interface SparklineBitmapOptions {
+  area?: boolean;
+}
+
+function closeValue(point: PricePoint): number | null {
+  return Number.isFinite(point.close) ? point.close : null;
+}
+
+function getPointTime(point: PricePoint): number {
+  const value = point.date as Date | string | number | null | undefined;
+  if (value instanceof Date) return value.getTime();
+  if (value == null) return Number.NaN;
+  return new Date(value).getTime();
+}
+
+function resolveSparklineHistory(priceHistory: PricePoint[], period: PriceSparklinePeriod = "1M"): PricePoint[] {
+  const validHistory = priceHistory.filter((point) => Number.isFinite(getPointTime(point)));
+  const latest = validHistory.at(-1);
+  if (!latest) return [];
+
+  const latestTime = getPointTime(latest);
+  if (Number.isFinite(latestTime)) {
+    const cutoffTime = latestTime - PERIOD_WINDOW_DAYS[period] * 86_400_000;
+    const windowHistory = validHistory.filter((point) => getPointTime(point) >= cutoffTime);
+    if (windowHistory.length >= 2) return windowHistory;
+  }
+
+  return validHistory.slice(-PERIOD_FALLBACK_POINTS[period]);
+}
+
+function sparklineValues(priceHistory: PricePoint[]): number[] {
+  return priceHistory
+    .map(closeValue)
+    .filter((value): value is number => value != null);
+}
+
+function sparklineColor(values: number[], trend?: PriceSparklineTrend): string {
+  if (trend === "positive") return colors.positive;
+  if (trend === "negative") return colors.negative;
+  if (trend === "neutral") return colors.textMuted;
+
+  const first = values[0];
+  const last = values.at(-1);
+  if (first == null || last == null) return colors.textMuted;
+  return last >= first ? colors.positive : colors.negative;
+}
+
+function buildSamples(values: number[], width: number, height: number, padding: number): SparklineSample[] {
+  if (values.length < 2) return [];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const left = padding;
+  const right = Math.max(left, width - padding);
+  const top = padding;
+  const bottom = Math.max(top, height - padding);
+  return values.map((value, index) => ({
+    x: left + (index / Math.max(values.length - 1, 1)) * (right - left),
+    y: bottom - ((value - min) / range) * (bottom - top),
+  }));
+}
+
+function svgPath(samples: SparklineSample[]): string {
+  return samples
+    .map((sample, index) => `${index === 0 ? "M" : "L"}${sample.x.toFixed(2)} ${sample.y.toFixed(2)}`)
+    .join(" ");
+}
+
+function svgAreaPath(samples: SparklineSample[], baseline: number): string {
+  const linePath = svgPath(samples);
+  if (!linePath || samples.length === 0) return "";
+  const first = samples[0]!;
+  const last = samples[samples.length - 1]!;
+  return `${linePath} L${last.x.toFixed(2)} ${baseline.toFixed(2)} L${first.x.toFixed(2)} ${baseline.toFixed(2)} Z`;
+}
+
+function parseHex(hex: string, alpha = 1) {
+  const normalized = hex.replace("#", "");
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+    a: Math.round(Math.max(0, Math.min(1, alpha)) * 255),
+  };
+}
+
+function colorWithAlpha(color: string, alpha: number): string {
+  if (!/^#[0-9a-f]{6}$/i.test(color)) return color;
+  const parsed = parseHex(color, alpha);
+  return `rgba(${parsed.r}, ${parsed.g}, ${parsed.b}, ${Math.max(0, Math.min(1, alpha))})`;
+}
+
+function blendPixel(
+  pixels: Uint8Array,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+  color: ReturnType<typeof parseHex>,
+  opacity: number,
+) {
+  if (x < 0 || y < 0 || x >= width || y >= height || opacity <= 0) return;
+  const alpha = Math.max(0, Math.min(1, (color.a / 255) * opacity));
+  const offset = (y * width + x) * 4;
+  const dstAlpha = pixels[offset + 3]! / 255;
+  const outAlpha = alpha + dstAlpha * (1 - alpha);
+  if (outAlpha <= 0) return;
+
+  const dstFactor = dstAlpha * (1 - alpha);
+  pixels[offset] = Math.round((color.r * alpha + pixels[offset]! * dstFactor) / outAlpha);
+  pixels[offset + 1] = Math.round((color.g * alpha + pixels[offset + 1]! * dstFactor) / outAlpha);
+  pixels[offset + 2] = Math.round((color.b * alpha + pixels[offset + 2]! * dstFactor) / outAlpha);
+  pixels[offset + 3] = Math.round(outAlpha * 255);
+}
+
+function drawSegment(
+  pixels: Uint8Array,
+  width: number,
+  height: number,
+  start: SparklineSample,
+  end: SparklineSample,
+  color: ReturnType<typeof parseHex>,
+  thickness: number,
+) {
+  const half = thickness / 2;
+  const minX = Math.floor(Math.min(start.x, end.x) - half - 1);
+  const maxX = Math.ceil(Math.max(start.x, end.x) + half + 1);
+  const minY = Math.floor(Math.min(start.y, end.y) - half - 1);
+  const maxY = Math.ceil(Math.max(start.y, end.y) + half + 1);
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const lengthSq = dx * dx + dy * dy || 1;
+
+  for (let y = minY; y <= maxY; y++) {
+    for (let x = minX; x <= maxX; x++) {
+      const px = x + 0.5;
+      const py = y + 0.5;
+      const t = Math.max(0, Math.min(1, ((px - start.x) * dx + (py - start.y) * dy) / lengthSq));
+      const nearestX = start.x + dx * t;
+      const nearestY = start.y + dy * t;
+      const distance = Math.hypot(px - nearestX, py - nearestY);
+      const coverage = Math.max(0, Math.min(1, half + 0.9 - distance));
+      blendPixel(pixels, width, height, x, y, color, coverage);
+    }
+  }
+}
+
+function drawAreaFill(
+  pixels: Uint8Array,
+  width: number,
+  height: number,
+  samples: SparklineSample[],
+  baseline: number,
+  color: ReturnType<typeof parseHex>,
+) {
+  if (samples.length < 2) return;
+
+  const first = samples[0]!;
+  const last = samples[samples.length - 1]!;
+  const startX = Math.max(0, Math.floor(first.x));
+  const endX = Math.min(width - 1, Math.ceil(last.x));
+  let segmentIndex = 0;
+
+  for (let x = startX; x <= endX; x++) {
+    const centerX = x + 0.5;
+    while (segmentIndex < samples.length - 2 && samples[segmentIndex + 1]!.x < centerX) {
+      segmentIndex++;
+    }
+
+    const start = samples[segmentIndex]!;
+    const end = samples[segmentIndex + 1]!;
+    const dx = end.x - start.x;
+    const t = dx === 0 ? 0 : Math.max(0, Math.min(1, (centerX - start.x) / dx));
+    const lineY = start.y + (end.y - start.y) * t;
+    const top = Math.max(0, Math.ceil(Math.min(lineY, baseline)));
+    const bottom = Math.min(height - 1, Math.floor(Math.max(lineY, baseline)));
+    const distance = Math.max(1, bottom - top);
+
+    for (let y = top; y <= bottom; y++) {
+      const fade = 1 - ((y - top) / distance) * 0.55;
+      blendPixel(pixels, width, height, x, y, color, fade);
+    }
+  }
+}
+
+function renderSparklineBitmap(
+  values: number[],
+  width: number,
+  height: number,
+  color: string,
+  options: SparklineBitmapOptions = {},
+): BitmapSurface | null {
+  if (values.length < 2 || width <= 0 || height <= 0) return null;
+  const pixels = new Uint8Array(width * height * 4);
+  const padding = options.area ? Math.max(1, Math.round(height * 0.06)) : Math.max(1, Math.round(height * 0.18));
+  const samples = buildSamples(values, width - 1, height - 1, padding);
+  const fillColor = parseHex(color, 0.18);
+  const glowColor = parseHex(color, options.area ? 0.06 : 0.18);
+  const lineColor = parseHex(color, 0.96);
+
+  if (options.area) {
+    drawAreaFill(pixels, width, height, samples, height - 1, fillColor);
+  }
+  for (let index = 0; index < samples.length - 1; index++) {
+    drawSegment(
+      pixels,
+      width,
+      height,
+      samples[index]!,
+      samples[index + 1]!,
+      glowColor,
+      options.area ? Math.max(1.2, height * 0.08) : Math.max(2, height * 0.24),
+    );
+  }
+  for (let index = 0; index < samples.length - 1; index++) {
+    drawSegment(
+      pixels,
+      width,
+      height,
+      samples[index]!,
+      samples[index + 1]!,
+      lineColor,
+      options.area ? Math.max(1.1, height * 0.055) : Math.max(1.25, height * 0.1),
+    );
+  }
+
+  return { width, height, pixels };
+}
+
+function DesktopPriceSparkline({
+  values,
+  width,
+  height,
+  color,
+}: {
+  values: number[];
+  width: number;
+  height: number;
+  color: string;
+}) {
+  const svgWidth = Math.max(24, width * 8);
+  const svgHeight = Math.max(18, height * 18);
+  const path = svgPath(buildSamples(values, svgWidth, svgHeight, 2));
+  if (!path) return <Text fg={colors.textMuted}>{" "}</Text>;
+
+  return (
+    <Box width={width} height={height} justifyContent="center" overflow="hidden">
+      <svg
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        width="100%"
+        height="100%"
+        aria-hidden="true"
+        focusable="false"
+        style={{ display: "block" }}
+      >
+        <path
+          d={path}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.7"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+    </Box>
+  );
+}
+
+function TerminalPriceSparkline({
+  priceHistory,
+  values,
+  width,
+  height,
+  color,
+  area = false,
+}: {
+  priceHistory: PricePoint[];
+  values: number[];
+  width: number;
+  height: number;
+  color: string;
+  area?: boolean;
+}) {
+  const { nativeCharts, cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1 } = useUiCapabilities();
+  const nativeRenderer = useNativeRenderer();
+  const rendererResolution = nativeRenderer.resolution;
+  const rendererTerminalWidth = nativeRenderer.terminalWidth;
+  const rendererTerminalHeight = nativeRenderer.terminalHeight;
+  const bitmap = useMemo(() => {
+    if (!nativeCharts || values.length < 2) return null;
+    const scale = Math.max(1, pixelRatio);
+    const bitmapSize = rendererResolution && rendererTerminalWidth > 0 && rendererTerminalHeight > 0
+      ? computeBitmapSize(
+        { x: 0, y: 0, width, height },
+        rendererResolution,
+        rendererTerminalWidth,
+        rendererTerminalHeight,
+      )
+      : {
+          pixelWidth: Math.max(1, Math.round(width * cellWidthPx * scale)),
+          pixelHeight: Math.max(1, Math.round(height * cellHeightPx * scale)),
+        };
+    return renderSparklineBitmap(values, bitmapSize.pixelWidth, bitmapSize.pixelHeight, color, { area });
+  }, [
+    area,
+    cellHeightPx,
+    cellWidthPx,
+    color,
+    height,
+    nativeCharts,
+    pixelRatio,
+    rendererResolution,
+    rendererTerminalHeight,
+    rendererTerminalWidth,
+    values,
+    width,
+  ]);
+  const fallback = useMemo(
+    () => renderPriceSparkline(priceHistory, { width, height, maxPoints: priceHistory.length }),
+    [height, priceHistory, width],
+  );
+
+  return (
+    <ChartSurface width={width} height={height} flexDirection="column" bitmaps={bitmap ? [bitmap] : null}>
+      {fallback ? <Text content={fallback} /> : null}
+    </ChartSurface>
+  );
+}
+
+export function PriceSparkline({
+  priceHistory,
+  width,
+  trend,
+  period = "1M",
+  height = SPARKLINE_HEIGHT,
+  area = false,
+}: {
+  priceHistory: PricePoint[] | undefined;
+  width: number;
+  trend?: PriceSparklineTrend;
+  period?: PriceSparklinePeriod;
+  height?: number;
+  area?: boolean;
+}) {
+  useThemeColors();
+  const sparklineHistory = useMemo(() => resolveSparklineHistory(priceHistory ?? [], period), [period, priceHistory]);
+  const values = useMemo(() => sparklineValues(sparklineHistory), [sparklineHistory]);
+  if (values.length < 2) {
+    return <Text fg={colors.textMuted}>{" "}</Text>;
+  }
+
+  const color = sparklineColor(values, trend);
+  return useUiHost().kind === "desktop-web"
+    ? <DesktopPriceSparkline values={values} width={width} height={height} color={color} />
+    : <TerminalPriceSparkline priceHistory={sparklineHistory} values={values} width={width} height={height} color={color} area={area} />;
+}
+
+export function PriceAreaSparklineBackground({
+  priceHistory,
+  trend,
+  period = "1M",
+}: {
+  priceHistory: PricePoint[] | undefined;
+  trend?: PriceSparklineTrend;
+  period?: PriceSparklinePeriod;
+}) {
+  useThemeColors();
+  const uiHost = useUiHost();
+  const sparklineHistory = useMemo(() => resolveSparklineHistory(priceHistory ?? [], period), [period, priceHistory]);
+  const values = useMemo(() => sparklineValues(sparklineHistory), [sparklineHistory]);
+  if (uiHost.kind !== "desktop-web" || values.length < 2) return null;
+
+  const color = sparklineColor(values, trend);
+  const baseline = 100;
+  const samples = buildSamples(values, 100, baseline, 0);
+  const linePath = svgPath(samples);
+  const areaPath = svgAreaPath(samples, baseline);
+  if (!linePath || !areaPath) return null;
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      focusable="false"
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        display: "block",
+        pointerEvents: "none",
+      }}
+    >
+      <path d={areaPath} fill={colorWithAlpha(color, 0.08)} />
+      <path
+        d={linePath}
+        fill="none"
+        stroke={colorWithAlpha(color, 0.46)}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+export function resolvePriceSparklineRange(
+  priceHistory: PricePoint[] | undefined,
+  period: PriceSparklinePeriod = "1M",
+): { min: number; max: number } | null {
+  const values = sparklineValues(resolveSparklineHistory(priceHistory ?? [], period));
+  if (values.length < 2) return null;
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values),
+  };
+}

--- a/src/components/price-sparkline.ts
+++ b/src/components/price-sparkline.ts
@@ -1,0 +1,46 @@
+import type { PricePoint } from "../types/financials";
+import { colors } from "../theme/colors";
+import { renderChart, resolveChartPalette, type StyledContent } from "./chart/chart-renderer";
+import type { ProjectedChartPoint } from "./chart/chart-data";
+
+function coercePointDate(value: PricePoint["date"]): Date {
+  return value instanceof Date ? value : new Date(value as Date | string | number);
+}
+
+export function renderPriceSparkline(
+  priceHistory: PricePoint[],
+  options: { width?: number; height?: number; maxPoints?: number } = {},
+): StyledContent | null {
+  if (priceHistory.length < 2) return null;
+
+  const width = Math.max(4, Math.floor(options.width ?? 10));
+  const height = Math.max(1, Math.floor(options.height ?? 1));
+  const maxPoints = Math.max(1, Math.floor(options.maxPoints ?? Math.max(20, width * 2)));
+  const pointsWindow = priceHistory.slice(-maxPoints);
+  const points: ProjectedChartPoint[] = pointsWindow.map((pt) => ({
+    date: coercePointDate(pt.date),
+    open: pt.open ?? pt.close,
+    high: pt.high ?? pt.close,
+    low: pt.low ?? pt.close,
+    close: pt.close,
+    volume: pt.volume ?? 0,
+  }));
+
+  const first = pointsWindow[0]?.close ?? 0;
+  const last = pointsWindow[pointsWindow.length - 1]?.close ?? 0;
+  const trend = last > first ? "positive" : last < first ? "negative" : "neutral";
+  const palette = resolveChartPalette(colors, trend);
+
+  const result = renderChart(points, {
+    width,
+    height,
+    showVolume: false,
+    volumeHeight: 0,
+    cursorX: null,
+    cursorY: null,
+    mode: "line",
+    colors: palette,
+  });
+
+  return result.lines[0] ?? null;
+}

--- a/src/components/ticker-list-table.tsx
+++ b/src/components/ticker-list-table.tsx
@@ -18,8 +18,7 @@ import type { ColumnConfig } from "../types/config";
 import type { TickerFinancials, PricePoint } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
 import { padTo } from "../utils/format";
-import { renderChart, resolveChartPalette, type StyledContent } from "./chart/chart-renderer";
-import type { ProjectedChartPoint } from "./chart/chart-data";
+import { PRICE_SPARKLINE_COLUMN_ID, PriceSparkline } from "./price-sparkline-view";
 import { tableContentWidthProps, useMeasuredTableContentWidth } from "./ui/table-layout";
 import { useViewport } from "../react/input";
 import { measurePerf } from "../utils/perf-marks";
@@ -88,7 +87,6 @@ export interface TickerListTableProps {
   onRowActivate?: (ticker: TickerRecord) => void;
   emptyTitle?: string;
   emptyHint?: string;
-  showSparklines?: boolean;
   virtualize?: boolean;
   overscan?: number;
 }
@@ -155,38 +153,6 @@ const TickerListHeader = memo(function TickerListHeader({
   );
 });
 
-function renderSparkline(priceHistory: PricePoint[]): StyledContent | null {
-  if (priceHistory.length < 5) return null;
-
-  const last20 = priceHistory.slice(-20);
-  const points: ProjectedChartPoint[] = last20.map((pt) => ({
-    date: pt.date,
-    open: pt.open ?? pt.close,
-    high: pt.high ?? pt.close,
-    low: pt.low ?? pt.close,
-    close: pt.close,
-    volume: pt.volume ?? 0,
-  }));
-
-  const first = last20[0]?.close ?? 0;
-  const last = last20[last20.length - 1]?.close ?? 0;
-  const trend = last >= first ? "positive" : "negative";
-  const palette = resolveChartPalette(colors, trend);
-
-  const result = renderChart(points, {
-    width: 10,
-    height: 1,
-    showVolume: false,
-    volumeHeight: 0,
-    cursorX: null,
-    cursorY: null,
-    mode: "line",
-    colors: palette,
-  });
-
-  return result.lines[0] ?? null;
-}
-
 const TickerListRow = memo(function TickerListRow({
   columns,
   ticker,
@@ -201,7 +167,6 @@ const TickerListRow = memo(function TickerListRow({
   onRowActivate,
   onRowContextMenu,
   openContextMenuOnMouseDown,
-  showSparklines,
   priceHistory,
   contentWidth,
 }: {
@@ -218,17 +183,12 @@ const TickerListRow = memo(function TickerListRow({
   onRowActivate?: (ticker: TickerRecord) => void;
   onRowContextMenu: (ticker: TickerRecord, financials: TickerFinancials | undefined, event: unknown) => void;
   openContextMenuOnMouseDown: boolean;
-  showSparklines?: boolean;
   priceHistory?: PricePoint[];
   contentWidth: number;
 }) {
   useThemeColors();
   const lastActivatedAtRef = useRef<number | null>(null);
   const rowBg = isSelected ? colors.selected : isHovered ? hoverBg() : colors.bg;
-
-  const sparkline = showSparklines && priceHistory && priceHistory.length >= 5
-    ? renderSparkline(priceHistory)
-    : null;
 
   return (
     <Box
@@ -268,6 +228,14 @@ const TickerListRow = memo(function TickerListRow({
       }}
     >
       {columns.map((column) => {
+        if (column.id === PRICE_SPARKLINE_COLUMN_ID) {
+          return (
+            <Box key={column.id} width={column.width + 1} overflow="hidden">
+              <PriceSparkline priceHistory={priceHistory} width={column.width} />
+            </Box>
+          );
+        }
+
         const { text, color } = resolveCell(column, ticker, financials);
         const baseFg = color || (isSelected ? colors.selectedText : colors.text);
         const shouldFlash = flashDirection != null && FLASHABLE_QUOTE_COLUMN_IDS.has(column.id);
@@ -283,11 +251,6 @@ const TickerListRow = memo(function TickerListRow({
           </Box>
         );
       })}
-      {sparkline && (
-        <Box width={12}>
-          <Text content={sparkline} />
-        </Box>
-      )}
     </Box>
   );
 }, (previous, next) => (
@@ -304,7 +267,6 @@ const TickerListRow = memo(function TickerListRow({
   && previous.onRowActivate === next.onRowActivate
   && previous.onRowContextMenu === next.onRowContextMenu
   && previous.openContextMenuOnMouseDown === next.openContextMenuOnMouseDown
-  && previous.showSparklines === next.showSparklines
   && previous.priceHistory === next.priceHistory
   && previous.contentWidth === next.contentWidth
 ));
@@ -329,7 +291,6 @@ export function TickerListTable({
   onRowActivate,
   emptyTitle = "No tickers.",
   emptyHint = "Press Ctrl+P to add one.",
-  showSparklines,
   virtualize = true,
   overscan = 4,
 }: TickerListTableProps) {
@@ -347,8 +308,8 @@ export function TickerListTable({
   hoveredIdxRef.current = hoveredIdx;
   const safeFlashSymbols = flashSymbols ?? EMPTY_FLASH_SYMBOLS;
   const tableWidth = useMemo(
-    () => columns.reduce((sum, column) => sum + column.width + 1, 2) + (showSparklines ? 12 : 0),
-    [columns, showSparklines],
+    () => columns.reduce((sum, column) => sum + column.width + 1, 2),
+    [columns],
   );
   const { contentWidth, measureContentWidth } = useMeasuredTableContentWidth(
     tableWidth,
@@ -492,7 +453,6 @@ export function TickerListTable({
                 onRowActivate={onRowActivate}
                 onRowContextMenu={handleRowContextMenu}
                 openContextMenuOnMouseDown={nativeContextMenu !== true}
-                showSparklines={showSparklines}
                 priceHistory={financialsMap.get(ticker.metadata.ticker)?.priceHistory}
                 contentWidth={contentWidth}
               />

--- a/src/data/config-store-node.ts
+++ b/src/data/config-store-node.ts
@@ -20,6 +20,15 @@ import { isLayoutConfig, sanitizeLayout } from "./config-layout";
 
 const configLog = debugLog.createLogger("config");
 const LEGACY_MAIN_PORTFOLIO_COLUMN_IDS = DEFAULT_COLUMNS.map((column) => column.id);
+const PRE_SPARKLINE_PORTFOLIO_COLUMN_IDS = [
+  ...DEFAULT_COLUMNS.map((column) => column.id),
+  "shares",
+  "avg_cost",
+  "cost_basis",
+  "mkt_value",
+  "pnl",
+  "pnl_pct",
+];
 const BUILTIN_SOURCE_IDS = new Set(["yahoo", "gloomberb-cloud"]);
 const BUILTIN_PLUGIN_GROUP_ALIASES: Record<string, string> = {
   "comparison-chart": "market-overview",
@@ -390,24 +399,31 @@ function hasExactColumnIds(value: unknown, expected: string[]): boolean {
     && value.every((entry, index) => entry === expected[index]);
 }
 
+function shouldMigratePortfolioColumnIds(value: unknown): boolean {
+  return hasExactColumnIds(value, LEGACY_MAIN_PORTFOLIO_COLUMN_IDS)
+    || hasExactColumnIds(value, PRE_SPARKLINE_PORTFOLIO_COLUMN_IDS);
+}
+
 function migrateLegacyPortfolioDefaultColumns(layout: LayoutConfig, enabled: boolean): LayoutConfig {
   if (!enabled) return layout;
 
-  const instanceIndex = layout.instances.findIndex((instance) =>
-    instance.instanceId === "portfolio-list:main"
-    && instance.paneId === "portfolio-list"
-    && hasExactColumnIds(instance.settings?.columnIds, LEGACY_MAIN_PORTFOLIO_COLUMN_IDS)
-  );
-  if (instanceIndex < 0) return layout;
+  const instanceIndices = layout.instances.flatMap((instance, index) => (
+    instance.paneId === "portfolio-list" && shouldMigratePortfolioColumnIds(instance.settings?.columnIds)
+      ? [index]
+      : []
+  ));
+  if (instanceIndices.length === 0) return layout;
 
   const nextLayout = cloneLayout(layout);
-  nextLayout.instances[instanceIndex] = {
-    ...nextLayout.instances[instanceIndex]!,
-    settings: {
-      ...(nextLayout.instances[instanceIndex]?.settings ?? {}),
-      columnIds: [...DEFAULT_PORTFOLIO_COLUMN_IDS],
-    },
-  };
+  for (const instanceIndex of instanceIndices) {
+    nextLayout.instances[instanceIndex] = {
+      ...nextLayout.instances[instanceIndex]!,
+      settings: {
+        ...(nextLayout.instances[instanceIndex]?.settings ?? {}),
+        columnIds: [...DEFAULT_PORTFOLIO_COLUMN_IDS],
+      },
+    };
+  }
   return nextLayout;
 }
 

--- a/src/plugins/builtin/ai/settings.ts
+++ b/src/plugins/builtin/ai/settings.ts
@@ -60,6 +60,9 @@ export function resolveVisibleAiScreenerColumns(columnIds: string[]): ColumnConf
 export function buildAiScreenerPaneSettingsDef(settings: AiScreenerPaneSettings): PaneSettingsDef {
   return {
     title: "AI Screener Settings",
+    values: {
+      columnIds: [...settings.columnIds],
+    },
     fields: [
       {
         key: "columnIds",

--- a/src/plugins/builtin/help.test.tsx
+++ b/src/plugins/builtin/help.test.tsx
@@ -81,7 +81,7 @@ describe("HelpPane", () => {
           paneId: "ticker-detail",
           label: "Quote Monitor",
           description: "Open ticker detail",
-          shortcut: { prefix: "QQ", argPlaceholder: "ticker" },
+          shortcut: { prefix: "QQ", argPlaceholder: "tickers", argKind: "ticker-list" },
         },
       ]]),
       shortcuts: new Map([[
@@ -110,7 +110,7 @@ describe("HelpPane", () => {
     const frame = testSetup!.captureCharFrame();
     expect(frame).toMatch(/AW\s+<ticker>/);
     expect(frame).toMatch(/SA\s+<symbol condition price>/);
-    expect(frame).toMatch(/QQ\s+<ticker>/);
+    expect(frame).toMatch(/QQ\s+<tickers>/);
     expect(frame).toContain("Add Alert (Alerts)");
     expect(frame).toContain("Shift+C");
     expect(frame).toContain("Toggle chat (Gloomberb Cloud)");

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -390,7 +390,7 @@ describe("PortfolioListPane cash and margin UI", () => {
 
     await flushFrame();
     await act(async () => {
-      testSetup!.mockInput.pressKey("n");
+      testSetup!.mockInput.pressKey("a");
       await testSetup!.renderOnce();
     });
     await act(async () => {
@@ -539,6 +539,43 @@ describe("PortfolioListPane cash and margin UI", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).not.toContain("Cash & Margin");
+  });
+
+  test("renders one-month sparkline column when price history is loaded", async () => {
+    const config = createPortfolioConfigWithColumns(
+      "broker:ibkr-flex:DU12345",
+      ["ticker", "price", "sparkline"],
+      [createBrokerInstance("flex")],
+    );
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="broker:ibkr-flex:DU12345"
+        stateMutator={(state) => {
+          state.financials = new Map([[
+            "AAPL",
+            {
+              annualStatements: [],
+              quarterlyStatements: [],
+              quote: makeQuote(),
+              priceHistory: [118, 121, 119, 124, 127, 126, 130].map((close, index) => ({
+                date: `2026-03-${20 + index}T00:00:00Z` as unknown as Date,
+                close,
+              })),
+            },
+          ]]);
+        }}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("1M");
+    const row = frame.split("\n").find((line) => line.includes("AAPL")) ?? "";
+    expect(row).toMatch(/[\u2800-\u28ff]/);
   });
 
   test("keeps native price and avg cost while converting market value and pnl to base currency", async () => {

--- a/src/plugins/builtin/portfolio-list/metrics.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.ts
@@ -8,6 +8,7 @@ import { convertCurrency, formatCompact, formatNumber, formatPercentRaw } from "
 import { formatMarketCost, formatMarketPrice, formatMarketQuantity, formatSignedMarketPrice, type MarketFormatOptions } from "../../../utils/market-format";
 import { getActiveQuoteDisplay, marketStateDot, type ActiveQuoteDisplay } from "../../../utils/market-status";
 import { formatOptionTicker } from "../../../utils/options";
+import { PRICE_SPARKLINE_COLUMN_ID } from "../../../components/price-sparkline-view";
 
 export interface ColumnContext {
   activeTab?: string;
@@ -293,6 +294,8 @@ export function getColumnValue(
       return { text: "—" };
     case "latency":
       return { text: formatQuoteAgeWithSource(quote, ctx.now) };
+    case PRICE_SPARKLINE_COLUMN_ID:
+      return { text: "" };
     default:
       return { text: "—" };
   }
@@ -387,6 +390,14 @@ export function getSortValue(
       return null;
     case "latency":
       return quote?.lastUpdated != null ? ctx.now - (clampQuoteTimestamp(quote.lastUpdated, ctx.now) ?? ctx.now) : null;
+    case PRICE_SPARKLINE_COLUMN_ID: {
+      const values = (financials?.priceHistory ?? [])
+        .map((point) => point.close)
+        .filter((value) => Number.isFinite(value));
+      const first = values[0];
+      const last = values.at(-1);
+      return first != null && last != null && first !== 0 ? ((last - first) / Math.abs(first)) * 100 : null;
+    }
     default:
       return null;
   }

--- a/src/plugins/builtin/portfolio-list/quick-add.tsx
+++ b/src/plugins/builtin/portfolio-list/quick-add.tsx
@@ -362,12 +362,12 @@ export function QuickAddTickerInput({
       return;
     }
 
-    if (event.name === "n" && !event.ctrl && !event.meta && !event.super) {
+    if ((event.name === "a" || event.name === "n") && !event.ctrl && !event.meta && !event.super) {
       event.preventDefault?.();
       event.stopPropagation?.();
       focusInput();
     }
-  });
+  }, { phase: "before" });
 
   const inputWidth = useMemo(() => {
     const queryWidth = normalizeQuickAddQuery(inputValue).length;

--- a/src/plugins/builtin/portfolio-list/settings.ts
+++ b/src/plugins/builtin/portfolio-list/settings.ts
@@ -1,5 +1,6 @@
 import type { PaneSettingOption, PaneSettingsDef, PaneTemplateContext } from "../../../types/plugin";
 import { DEFAULT_COLUMNS, DEFAULT_PORTFOLIO_COLUMN_IDS, type AppConfig, type ColumnConfig } from "../../../types/config";
+import { PRICE_SPARKLINE_COLUMN_ID, PRICE_SPARKLINE_PERIOD_LABEL } from "../../../components/price-sparkline-view";
 
 export type CollectionScope = "all" | "portfolios" | "watchlists" | "custom";
 
@@ -9,7 +10,6 @@ export interface PortfolioPaneSettings {
   visibleCollectionIds: string[];
   hideHeader: boolean;
   hideCash: boolean;
-  showSparklines?: boolean;
 }
 
 export interface CollectionEntry {
@@ -20,6 +20,7 @@ export interface CollectionEntry {
 
 export const PORTFOLIO_COLUMN_DEFS: ColumnConfig[] = [
   ...DEFAULT_COLUMNS,
+  { id: PRICE_SPARKLINE_COLUMN_ID, label: PRICE_SPARKLINE_PERIOD_LABEL, width: 6, align: "left" },
   { id: "bid", label: "BID", width: 10, align: "right", format: "currency" },
   { id: "ask", label: "ASK", width: 10, align: "right", format: "currency" },
   { id: "spread", label: "SPREAD", width: 10, align: "right", format: "currency" },
@@ -93,6 +94,13 @@ function resolveCollectionOptions(entries: CollectionEntry[]): PaneSettingOption
   }));
 }
 
+function describeColumnOption(column: ColumnConfig): string {
+  if (column.id === PRICE_SPARKLINE_COLUMN_ID) return "One-month price sparkline.";
+  return PORTFOLIO_ONLY_COLUMN_IDS.has(column.id)
+    ? "Visible only when this pane is showing a portfolio."
+    : "Visible for watchlists and portfolios.";
+}
+
 export function getPortfolioPaneSettings(settings: Record<string, unknown> | undefined): PortfolioPaneSettings {
   const columnIds = Array.isArray(settings?.columnIds)
     ? settings.columnIds.filter((value): value is string => typeof value === "string")
@@ -107,7 +115,6 @@ export function getPortfolioPaneSettings(settings: Record<string, unknown> | und
     visibleCollectionIds,
     hideHeader: settings?.hideHeader === true,
     hideCash: settings?.hideCash === true,
-    showSparklines: settings?.showSparklines === true,
   };
 }
 
@@ -115,6 +122,7 @@ export function cleanPortfolioPaneSettings(settings: Record<string, unknown>): R
   const nextSettings = { ...settings };
   delete nextSettings.hideTabs;
   delete nextSettings.lockedCollectionId;
+  delete nextSettings.showSparklines;
   if (nextSettings.collectionScope !== "custom") {
     delete nextSettings.visibleCollectionIds;
   }
@@ -175,7 +183,10 @@ export function resolveVisibleColumns(columnIds: string[], isPortfolioTab: boole
     return resolved;
   }
 
-  return DEFAULT_COLUMNS.filter((column) => isPortfolioTab || !PORTFOLIO_ONLY_COLUMN_IDS.has(column.id));
+  return DEFAULT_PORTFOLIO_COLUMN_IDS
+    .map((columnId) => PORTFOLIO_COLUMNS_BY_ID.get(columnId))
+    .filter((column): column is ColumnConfig => column != null)
+    .filter((column) => isPortfolioTab || !PORTFOLIO_ONLY_COLUMN_IDS.has(column.id));
 }
 
 export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: PortfolioPaneSettings): PaneSettingsDef {
@@ -190,9 +201,7 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
       options: PORTFOLIO_COLUMN_DEFS.map((column) => ({
         value: column.id,
         label: column.label,
-        description: PORTFOLIO_ONLY_COLUMN_IDS.has(column.id)
-          ? "Visible only when this pane is showing a portfolio."
-          : "Visible for watchlists and portfolios.",
+        description: describeColumnOption(column),
       })),
     },
     {
@@ -222,14 +231,13 @@ export function buildPortfolioPaneSettingsDef(config: AppConfig, settings: Portf
     label: "Hide Cash Positions",
     type: "toggle",
   });
-  fields.push({
-    key: "showSparklines",
-    label: "Sparklines",
-    type: "toggle",
-  });
-
   return {
     title: "Portfolio Pane Settings",
+    values: {
+      ...settings,
+      columnIds: [...settings.columnIds],
+      visibleCollectionIds: [...settings.visibleCollectionIds],
+    },
     fields,
   };
 }

--- a/src/plugins/builtin/portfolio-list/table.tsx
+++ b/src/plugins/builtin/portfolio-list/table.tsx
@@ -56,7 +56,6 @@ export function PortfolioTickerTable({
   financialsMap,
   columnContext,
   flashSymbols,
-  showSparklines,
   onRootKeyDown,
   onVisibleRangeChange,
   visibleRangeBuffer,
@@ -75,7 +74,6 @@ export function PortfolioTickerTable({
   financialsMap: Map<string, TickerFinancials>;
   columnContext: ColumnContext;
   flashSymbols: Map<string, QuoteFlashDirection>;
-  showSparklines?: boolean;
   onRootKeyDown?: (event: DataTableKeyEvent) => boolean | void;
   onVisibleRangeChange?: (range: TickerListVisibleRange) => void;
   visibleRangeBuffer?: number;
@@ -108,7 +106,6 @@ export function PortfolioTickerTable({
       sortColumnId={sortColumnId}
       sortDirection={sortDirection}
       onHeaderClick={onHeaderClick}
-      showSparklines={showSparklines}
       onRootKeyDown={onRootKeyDown}
       onVisibleRangeChange={onVisibleRangeChange}
       visibleRangeBuffer={visibleRangeBuffer}

--- a/src/plugins/builtin/quote-monitor.test.tsx
+++ b/src/plugins/builtin/quote-monitor.test.tsx
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
 import type { TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { createDefaultConfig } from "../../types/config";
 import { AppContext, createInitialState, PaneInstanceProvider } from "../../state/app-context";
 import { QuoteMonitorPane } from "./ticker-detail";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
+import type { PinTickerOptions } from "../../types/plugin";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -15,7 +18,91 @@ afterEach(() => {
   }
 });
 
-function createQuoteMonitorHarness() {
+interface PinTickerCall {
+  symbol: string;
+  options?: PinTickerOptions;
+}
+
+function makeRuntime(options: {
+  pinCalls?: PinTickerCall[];
+  settingsCalls?: Array<string | undefined>;
+} = {}): PluginRuntimeAccess {
+  return {
+    getMarketData: () => null,
+    getCapability: () => null,
+    getBrokerAdapter: () => null,
+    connectBrokerInstance: async () => {},
+    updateBrokerInstance: async () => {},
+    syncBrokerInstance: async () => {},
+    removeBrokerInstance: async () => {},
+    pinTicker: (symbol, pinOptions) => {
+      options.pinCalls?.push({ symbol, options: pinOptions });
+    },
+    navigateTicker: () => {},
+    selectTicker: () => {},
+    switchTab: () => {},
+    switchPanel: () => {},
+    openCommandBar: () => {},
+    showPane: () => {},
+    hidePane: () => {},
+    openPaneSettings: (paneId) => {
+      options.settingsCalls?.push(paneId);
+    },
+    openPluginCommandWorkflow: () => {},
+    notify: () => {},
+    subscribeResumeState: () => () => {},
+    getResumeState: () => null,
+    setResumeState: () => {},
+    deleteResumeState: () => {},
+    getConfigState: () => null,
+    setConfigState: async () => {},
+    setConfigStates: async () => {},
+    deleteConfigState: async () => {},
+    getConfigStateKeys: () => [],
+  };
+}
+
+function makeTicker(symbol: string, name: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function makeFinancials(symbol: string, price: number, change: number, changePercent: number): TickerFinancials {
+  return {
+    quote: {
+      symbol,
+      price,
+      currency: "USD",
+      change,
+      changePercent,
+      lastUpdated: Date.now(),
+    },
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: Array.from({ length: 12 }, (_, index) => ({
+      date: new Date(Date.UTC(2026, 0, index + 1)),
+      close: price - 6 + index,
+    })),
+  };
+}
+
+function createQuoteMonitorHarness(options: {
+  symbols?: string[];
+  pinCalls?: PinTickerCall[];
+  settingsCalls?: Array<string | undefined>;
+} = {}) {
+  const symbols = options.symbols ?? ["MSFT"];
   const config = createDefaultConfig("/tmp/gloomberb-test");
   (config.layout as typeof config.layout & { docked: Array<{ instanceId: string; columnIndex: number; order: number }> }).docked = [
     { instanceId: "ticker-detail:main", columnIndex: 0, order: 0 },
@@ -24,47 +111,36 @@ function createQuoteMonitorHarness() {
   config.layout.instances.push({
     instanceId: "quote-monitor:test",
     paneId: "quote-monitor",
-    title: "MSFT",
-    binding: { kind: "fixed", symbol: "MSFT" },
+    title: symbols.join(" · "),
+    binding: { kind: "fixed", symbol: symbols[0]! },
+    settings: {
+      symbol: symbols[0]!,
+      symbols,
+      symbolsText: symbols.join(", "),
+    },
   });
 
   const state = createInitialState(config);
 
-  const ticker: TickerRecord = {
-    metadata: {
-      ticker: "MSFT",
-      exchange: "NASDAQ",
-      currency: "USD",
-      name: "Microsoft",
-      portfolios: [],
-      watchlists: [],
-      positions: [],
-      custom: {},
-      tags: [],
-    },
-  };
-
-  const financials: TickerFinancials = {
-    quote: {
-      symbol: "MSFT",
-      price: 356.15,
-      currency: "USD",
-      change: -9.82,
-      changePercent: -2.68,
-      lastUpdated: Date.now(),
-    },
-    annualStatements: [],
-    quarterlyStatements: [],
-    priceHistory: [],
-  };
-
-  state.tickers = new Map([["MSFT", ticker]]);
-  state.financials = new Map([["MSFT", financials]]);
+  const tickers = [
+    makeTicker("MSFT", "Microsoft"),
+    makeTicker("AAPL", "Apple"),
+  ];
+  state.tickers = new Map(tickers.map((ticker) => [ticker.metadata.ticker, ticker]));
+  state.financials = new Map([
+    ["MSFT", makeFinancials("MSFT", 356.15, -9.82, -2.68)],
+    ["AAPL", makeFinancials("AAPL", 202.12, 3.05, 1.53)],
+  ]);
 
   return (
     <AppContext value={{ state, dispatch: () => {} }}>
       <PaneInstanceProvider paneId="quote-monitor:test">
-        <QuoteMonitorPane paneId="quote-monitor:test" paneType="quote-monitor" focused width={72} height={7} />
+        <PluginRenderProvider pluginId="ticker-detail" runtime={makeRuntime({
+          pinCalls: options.pinCalls,
+          settingsCalls: options.settingsCalls,
+        })}>
+          <QuoteMonitorPane paneId="quote-monitor:test" paneType="quote-monitor" focused width={72} height={7} />
+        </PluginRenderProvider>
       </PaneInstanceProvider>
     </AppContext>
   );
@@ -84,6 +160,63 @@ describe("QuoteMonitorPane", () => {
     expect(frame).toContain("$356.15");
     expect(frame).toContain("-2.68%");
     expect(frame).toContain("-9.82");
+    expect(frame).toMatch(/[⠁-⣿]/);
   });
 
+  test("renders multiple configured tickers", async () => {
+    testSetup = await testRender(createQuoteMonitorHarness({ symbols: ["MSFT", "AAPL"] }), {
+      width: 72,
+      height: 8,
+    });
+
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("MSFT");
+    expect(frame).toContain("AAPL");
+    expect(frame).toContain("$356.15");
+    expect(frame).toContain("$202.12");
+  });
+
+  test("opens a ticker detail pane on the second card click", async () => {
+    const pinCalls: PinTickerCall[] = [];
+    testSetup = await testRender(createQuoteMonitorHarness({ pinCalls }), {
+      width: 72,
+      height: 7,
+    });
+
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    const row = frame.split("\n").findIndex((line) => line.includes("MSFT"));
+    expect(row).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(3, row);
+      await testSetup!.renderOnce();
+      await testSetup!.mockMouse.click(3, row);
+      await testSetup!.renderOnce();
+    });
+
+    expect(pinCalls).toEqual([{
+      symbol: "MSFT",
+      options: { paneType: "ticker-detail", floating: true },
+    }]);
+  });
+
+  test("opens pane settings when t is pressed", async () => {
+    const settingsCalls: Array<string | undefined> = [];
+    testSetup = await testRender(createQuoteMonitorHarness({ settingsCalls }), {
+      width: 72,
+      height: 7,
+    });
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      testSetup!.mockInput.pressKey("t");
+      await testSetup!.renderOnce();
+    });
+
+    expect(settingsCalls).toEqual(["quote-monitor:test"]);
+  });
 });

--- a/src/plugins/builtin/ticker-detail/chart-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/chart-tab.tsx
@@ -1,4 +1,4 @@
-import { Box } from "../../../ui";
+import { Box, useUiCapabilities } from "../../../ui";
 import { useViewport } from "../../../react/input";
 import { useCallback, useMemo } from "react";
 import { ChartIndicatorSelector } from "../../../components/chart/chart-indicator-selector";
@@ -39,11 +39,12 @@ export function ChartTab({
   financials: TickerFinancials | null;
 }) {
   const { width: termWidth, height: termHeight } = useViewport();
+  const { fractionalViewport = false } = useUiCapabilities();
   const [rawIndicatorSelection] = usePluginConfigState<unknown>(CHART_INDICATORS_PLUGIN_CONFIG_KEY, null);
   const [indicatorSelectionVersion] = usePluginConfigState<unknown>(CHART_INDICATORS_PLUGIN_CONFIG_VERSION_KEY, null);
   const setPluginConfigStates = useSetPluginConfigStates();
 
-  const chartWidth = Math.max((width || Math.floor(termWidth * 0.55)) - 2, 30);
+  const chartWidth = Math.max((width || Math.floor(termWidth * 0.55)) - (fractionalViewport ? 1 : 2), 30);
   const chartHeight = Math.max(height ?? termHeight - 8, 10);
   const hasStoredIndicatorSelection = Array.isArray(rawIndicatorSelection);
   const selectedIndicatorIds = useMemo(

--- a/src/plugins/builtin/ticker-detail/index.tsx
+++ b/src/plugins/builtin/ticker-detail/index.tsx
@@ -4,9 +4,11 @@ import { TickerDetailPane } from "./pane";
 import { QuoteMonitorPane } from "./quote-monitor";
 import {
   buildQuoteMonitorSettingsDef,
+  buildQuoteMonitorPaneTitle,
   buildTickerDetailSettingsDef,
   getTickerDetailPaneSettings,
 } from "./settings";
+import { formatTickerListInput } from "../../../utils/ticker-list";
 
 export { FinancialsTab } from "./financials-tab";
 export { QuoteMonitorPane } from "./quote-monitor";
@@ -34,7 +36,7 @@ export const tickerDetailPlugin: GloomPlugin = {
       component: QuoteMonitorPane,
       defaultPosition: "right",
       defaultMode: "floating",
-      defaultFloatingSize: { width: 64, height: 8 },
+      defaultFloatingSize: { width: 72, height: 10 },
       settings: buildQuoteMonitorSettingsDef(),
     },
   ],
@@ -59,17 +61,36 @@ export const tickerDetailPlugin: GloomPlugin = {
       id: "quote-monitor-pane",
       paneId: "quote-monitor",
       label: "Quote Monitor",
-      description: "Open a compact quote monitor for the selected ticker",
+      description: "Open a compact quote monitor for one or more tickers",
       keywords: ["quote", "monitor", "price", "ticker", "pane"],
-      shortcut: { prefix: "QQ", argPlaceholder: "ticker", argKind: "ticker" },
-      canCreate: (context, options) => (options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg)) !== null,
+      shortcut: { prefix: "QQ", argPlaceholder: "tickers", argKind: "ticker-list" },
+      wizard: [
+        {
+          key: "tickers",
+          label: "Quote Tickers",
+          placeholder: "AAPL, MSFT, NVDA",
+          body: ["Enter one or more ticker symbols separated by commas."],
+          type: "text",
+        },
+      ],
+      canCreate: (context, options) => (
+        (options?.symbols?.length ?? 0) > 0
+        || normalizeTickerInput(context.activeTicker, options?.arg) !== null
+      ),
       createInstance: (context, options) => {
-        const ticker = options?.symbol ?? normalizeTickerInput(context.activeTicker, options?.arg);
-        return ticker
+        const symbols = options?.symbols?.length
+          ? options.symbols
+          : [normalizeTickerInput(context.activeTicker, options?.arg)].filter((symbol): symbol is string => !!symbol);
+        const primarySymbol = symbols[0];
+        return primarySymbol
           ? {
-            title: ticker,
-            binding: { kind: "fixed", symbol: ticker },
-            settings: { symbol: ticker },
+            title: buildQuoteMonitorPaneTitle(symbols),
+            binding: { kind: "fixed", symbol: primarySymbol },
+            settings: {
+              symbol: primarySymbol,
+              symbols,
+              symbolsText: formatTickerListInput(symbols),
+            },
             placement: "floating",
           }
           : null;

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -1,4 +1,4 @@
-import { Box, ScrollBox, Text } from "../../../ui";
+import { Box, ScrollBox, Text, useUiCapabilities } from "../../../ui";
 import { TextAttributes } from "../../../ui";
 import { useViewport } from "../../../react/input";
 import { useFxRatesMap } from "../../../market-data/hooks";
@@ -32,7 +32,6 @@ const STAT_COLUMN_GAP = 2;
 const STAT_LABEL_WIDTH = 12;
 const BOOK_LABEL_WIDTH = 4;
 const RANGE_ENDPOINT_WIDTH = 11;
-const RANGE_MAX_WIDTH = 42;
 const POSITION_COLUMN_GAP = 1;
 
 function CompactRangeBar({
@@ -71,21 +70,23 @@ function CompactRangeBar({
   return (
     <Box flexDirection="column" width={width} flexShrink={0}>
       <Box flexDirection="row" height={1}>
-        <Text fg={colors.textDim}>{padTo(label, labelWidth)}</Text>
+        <Box width={labelWidth} overflow="hidden">
+          <Text fg={colors.textDim}>{label}</Text>
+        </Box>
         <Text fg={markerColor}>{pctLabel}</Text>
       </Box>
       <Box flexDirection="row" height={1}>
-        <Text fg={colors.textDim}>
-          {padTo(lowText, endpointWidth)}
-        </Text>
+        <Box width={endpointWidth} overflow="hidden">
+          <Text fg={colors.textDim}>{lowText}</Text>
+        </Box>
         <Box marginLeft={1} marginRight={1} width={barWidth} flexDirection="row">
           <Text fg={colors.border}>{"─".repeat(markerIndex)}</Text>
           <Text fg={markerColor}>{"●"}</Text>
           <Text fg={colors.border}>{"─".repeat(Math.max(0, barWidth - markerIndex - 1))}</Text>
         </Box>
-        <Text fg={colors.textDim}>
-          {padTo(highText, endpointWidth, "right")}
-        </Text>
+        <Box flexDirection="row" width={endpointWidth} justifyContent="flex-end" overflow="hidden">
+          <Text fg={colors.textDim}>{highText}</Text>
+        </Box>
       </Box>
     </Box>
   );
@@ -164,7 +165,10 @@ interface PositionColumn {
 
 function StatGrid({ fields, width }: { fields: StatField[]; width: number }) {
   const columnCount = width >= 58 ? 2 : 1;
-  const colWidth = Math.floor((width - STAT_COLUMN_GAP * (columnCount - 1)) / columnCount);
+  const availableWidth = width - STAT_COLUMN_GAP * (columnCount - 1);
+  const baseColWidth = Math.floor(availableWidth / columnCount);
+  const extraWidth = availableWidth - baseColWidth * columnCount;
+  const colWidths = Array.from({ length: columnCount }, (_, index) => baseColWidth + (index === columnCount - 1 ? extraWidth : 0));
   const rows: Array<Array<StatField | null>> = [];
   for (let i = 0; i < fields.length; i += columnCount) {
     rows.push(Array.from({ length: columnCount }, (_, offset) => fields[i + offset] ?? null));
@@ -175,6 +179,7 @@ function StatGrid({ fields, width }: { fields: StatField[]; width: number }) {
       {rows.map((row, i) => (
         <Box key={i} flexDirection="row" height={1}>
           {row.map((field, j) => {
+            const colWidth = colWidths[j] ?? baseColWidth;
             if (!field) {
               return (
                 <Box key={j} flexDirection="row">
@@ -189,8 +194,12 @@ function StatGrid({ fields, width }: { fields: StatField[]; width: number }) {
               <Box key={j} flexDirection="row">
                 {j > 0 && <Box width={STAT_COLUMN_GAP} />}
                 <Box width={colWidth} flexDirection="row">
-                  <Text fg={colors.textDim}>{padTo(field.label, labelWidth)}</Text>
-                  <Text fg={field.valueColor ?? colors.text}>{padTo(field.value, valueWidth, "right")}</Text>
+                  <Box width={labelWidth} overflow="hidden">
+                    <Text fg={colors.textDim}>{field.label}</Text>
+                  </Box>
+                  <Box flexDirection="row" width={valueWidth} justifyContent="flex-end" overflow="hidden">
+                    <Text fg={field.valueColor ?? colors.text}>{field.value}</Text>
+                  </Box>
                 </Box>
               </Box>
             );
@@ -300,6 +309,7 @@ export function OverviewTab({
   const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
   const exchangeRatesState = useAppSelector((state) => state.exchangeRates);
   const { width: termWidth } = useViewport();
+  const { fractionalViewport = false } = useUiCapabilities();
 
   if (!ticker) return <EmptyState title="No ticker selected." />;
 
@@ -336,7 +346,7 @@ export function OverviewTab({
     routingVenue && routingVenue !== listingVenue ? `route ${routingVenue}` : "",
   ].filter((part) => part.length > 0);
 
-  const contentWidth = Math.max((width || Math.floor(termWidth * 0.5)) - 4, 20);
+  const contentWidth = Math.max((width || Math.floor(termWidth * 0.5)) - (fractionalViewport ? 2 : 4), 20);
   const chartWidth = contentWidth;
   const hasHistory = (financials?.priceHistory?.length ?? 0) > 2;
   const hasBidAsk = quote?.bid != null || quote?.ask != null;
@@ -347,8 +357,8 @@ export function OverviewTab({
   const hasYearRange = quote?.low52w != null && quote?.high52w != null && quote.high52w > quote.low52w;
   const rangeInline = contentWidth >= 70 && hasDayRange && hasYearRange;
   const rangeWidth = rangeInline
-    ? Math.min(RANGE_MAX_WIDTH, Math.floor((contentWidth - 2) / 2))
-    : Math.min(RANGE_MAX_WIDTH, contentWidth);
+    ? Math.floor((contentWidth - 2) / 2)
+    : contentWidth;
   const rangeMarkerColor = quote ? priceColor(quote.change) : colors.textDim;
 
   const stats: StatField[] = [];

--- a/src/plugins/builtin/ticker-detail/quote-monitor.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor.tsx
@@ -1,97 +1,476 @@
-import { Box, Text } from "../../../ui";
+import { useCallback, useMemo } from "react";
+import { Box, Text, useUiCapabilities } from "../../../ui";
 import { TextAttributes } from "../../../ui";
 import type { PaneProps } from "../../../types/plugin";
 import type { Quote } from "../../../types/financials";
+import type { TickerFinancials } from "../../../types/financials";
+import type { TickerRecord } from "../../../types/ticker";
+import type { QuoteSubscriptionTarget } from "../../../types/data-provider";
 import { quoteSubscriptionTargetFromTicker } from "../../../market-data/request-types";
-import { usePaneTicker } from "../../../state/app-context";
+import { useTickerFinancials } from "../../../market-data/hooks";
+import { useAppSelector, usePaneInstance, usePaneTicker } from "../../../state/app-context";
 import { useQuoteStreaming } from "../../../state/use-quote-streaming";
+import { usePluginAppActions, usePluginTickerActions } from "../../plugin-runtime";
+import { useDoubleClickActivation } from "../../../components/use-double-click-activation";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatPercentRaw } from "../../../utils/format";
 import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../../utils/market-format";
 import { getActiveQuoteDisplay } from "../../../utils/market-status";
-import { EmptyState, usePaneFooter } from "../../../components";
+import { EmptyState } from "../../../components";
+import {
+  PriceAreaSparklineBackground,
+  PriceSparkline,
+  resolvePriceSparklineRange,
+  type PriceSparklinePeriod,
+  type PriceSparklineTrend,
+} from "../../../components/price-sparkline-view";
+import { getQuoteMonitorPaneSettings } from "./settings";
+import { useShortcut } from "../../../react/input";
 
 function getQuoteMonitorDisplay(quote: Quote | null | undefined) {
   return getActiveQuoteDisplay(quote);
 }
 
-export function QuoteMonitorPane({ focused, width }: PaneProps) {
-  const { ticker, financials } = usePaneTicker();
-  const streamingTarget = quoteSubscriptionTargetFromTicker(ticker, ticker?.metadata.ticker, "provider");
-  useQuoteStreaming(streamingTarget ? [streamingTarget] : []);
+function chunkSymbols(symbols: string[], columns: number): string[][] {
+  const rows: string[][] = [];
+  for (let index = 0; index < symbols.length; index += columns) {
+    rows.push(symbols.slice(index, index + columns));
+  }
+  return rows;
+}
+
+function resolveGridColumnCount(symbolCount: number, width: number, height: number, nativePaneChrome: boolean): number {
+  if (symbolCount <= 1) return 1;
+
+  const contentWidth = Math.max(1, width - (nativePaneChrome ? 0 : 2));
+  const contentHeight = Math.max(1, height);
+  const minimumCellWidth = nativePaneChrome ? 34 : 28;
+  const minimumCellHeight = nativePaneChrome ? 4 : 3;
+  const maxColumns = Math.max(1, Math.min(symbolCount, Math.floor(contentWidth / minimumCellWidth)));
+  const targetAspect = nativePaneChrome ? 5.5 : 4.5;
+  let bestColumns = 1;
+  let bestScore = Number.POSITIVE_INFINITY;
+
+  for (let columns = 1; columns <= maxColumns; columns++) {
+    const rows = Math.ceil(symbolCount / columns);
+    const cellWidth = Math.floor(contentWidth / columns);
+    const cellHeight = Math.floor(contentHeight / rows);
+    const aspect = cellWidth / Math.max(1, cellHeight);
+    const emptySlots = columns * rows - symbolCount;
+    const widthPenalty = cellWidth < minimumCellWidth ? (minimumCellWidth - cellWidth) * 0.5 : 0;
+    const heightPenalty = cellHeight < minimumCellHeight ? (minimumCellHeight - cellHeight) * 1.4 : 0;
+    const score = Math.abs(Math.log(aspect / targetAspect))
+      + emptySlots * 0.35
+      + widthPenalty
+      + heightPenalty
+      - columns * 0.03;
+    if (score < bestScore) {
+      bestScore = score;
+      bestColumns = columns;
+    }
+  }
+
+  return bestColumns;
+}
+
+function quoteTrend(value: number | null | undefined): PriceSparklineTrend {
+  if (value == null || value === 0) return "neutral";
+  return value > 0 ? "positive" : "negative";
+}
+
+function QuoteMonitorCard({
+  symbol,
+  ticker,
+  cachedFinancials,
+  width,
+  height,
+  showRightDivider,
+  showBottomDivider,
+  chartPeriod,
+  onOpen,
+}: {
+  symbol: string;
+  ticker: TickerRecord | null;
+  cachedFinancials: TickerFinancials | null;
+  width: number;
+  height: number;
+  showRightDivider: boolean;
+  showBottomDivider: boolean;
+  chartPeriod: PriceSparklinePeriod;
+  onOpen: (symbol: string) => void;
+}) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const marketFinancials = useTickerFinancials(symbol, ticker);
+  const financials = marketFinancials ?? cachedFinancials;
   const quote = financials?.quote;
+  const display = getQuoteMonitorDisplay(quote);
+  const changeColor = priceColor(display?.change ?? 0);
+  const currency = quote?.currency ?? ticker?.metadata.currency ?? "USD";
+  const stacked = width < 31;
+  const priceText = display
+    ? formatMarketPriceWithCurrency(display.price, currency, { assetCategory: ticker?.metadata.assetCategory })
+    : "";
+  const changePercentText = display ? formatPercentRaw(display.changePercent) : "";
+  const changeValueText = display ? formatSignedMarketPrice(display.change, { assetCategory: ticker?.metadata.assetCategory }) : "";
+  const priceColumnWidth = Math.max(priceText.length, changePercentText.length + changeValueText.length + 1);
+  const nameMaxWidth = Math.max(10, width - priceColumnWidth - (nativePaneChrome ? 5 : 3));
+  const sparklineRange = resolvePriceSparklineRange(financials?.priceHistory, chartPeriod);
+  const rangeLabel = sparklineRange
+    ? `${chartPeriod} ${formatMarketPriceWithCurrency(sparklineRange.min, currency, { assetCategory: ticker?.metadata.assetCategory })}-${formatMarketPriceWithCurrency(sparklineRange.max, currency, { assetCategory: ticker?.metadata.assetCategory })}`
+    : "";
+  const sparklineWidth = Math.max(8, width - (nativePaneChrome ? rangeLabel.length + 5 : 2));
+  const trend = quoteTrend(display?.change);
+  const terminalSparklineHeight = !nativePaneChrome && !stacked && height >= 4 ? 2 : 1;
+  const desktopPriceStyle = nativePaneChrome
+    ? {
+        fontSize: "22px",
+        lineHeight: "1.05",
+        fontWeight: 720,
+        textShadow: `0 1px 2px ${colors.bg}`,
+      }
+    : undefined;
+  const desktopChangeStyle = nativePaneChrome
+    ? {
+        fontSize: "12px",
+        lineHeight: "1.1",
+        fontWeight: 540,
+        textShadow: `0 1px 2px ${colors.bg}`,
+      }
+    : undefined;
+  const desktopSymbolStyle = nativePaneChrome
+    ? {
+        fontSize: "15px",
+        lineHeight: "18px",
+      }
+    : undefined;
 
-  usePaneFooter("quote-monitor", () => ({
-    info: [
-      ...(ticker ? [{ id: "ticker", parts: [{ text: ticker.metadata.ticker, tone: "value" as const, bold: true }] }] : []),
-      ...(quote?.lastUpdated ? [{
-        id: "updated",
-        parts: [{ text: `quote ${new Date(quote.lastUpdated).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`, tone: "muted" as const }],
-      }] : []),
-      ...(quote?.providerId || quote?.dataSource ? [{
-        id: "source",
-        parts: [{ text: quote.providerId ?? quote.dataSource ?? "", tone: "muted" as const }],
-      }] : []),
-    ],
-  }), [quote?.dataSource, quote?.lastUpdated, quote?.providerId, ticker?.metadata.ticker]);
+  const handleMouseDown = useDoubleClickActivation<string>({
+    onActivate: onOpen,
+  });
 
-  if (!ticker) {
+  return (
+    <Box
+      flexDirection="column"
+      width={nativePaneChrome ? undefined : width}
+      height={nativePaneChrome ? undefined : height}
+      backgroundColor={colors.bg}
+      paddingX={nativePaneChrome ? 0 : 1}
+      paddingY={0}
+      overflow="hidden"
+      onMouseDown={(event: any) => {
+        event.preventDefault?.();
+        handleMouseDown(symbol, symbol, event);
+      }}
+      data-gloom-role="quote-monitor-card"
+      style={nativePaneChrome ? {
+        cursor: "pointer",
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        paddingLeft: 10,
+        paddingRight: 10,
+        paddingTop: 6,
+        paddingBottom: 4,
+        borderRight: showRightDivider ? `1px solid ${colors.border}` : undefined,
+        borderBottom: showBottomDivider ? `1px solid ${colors.border}` : undefined,
+      } : undefined}
+    >
+      {nativePaneChrome && display && (
+        <PriceAreaSparklineBackground priceHistory={financials?.priceHistory} trend={trend} period={chartPeriod} />
+      )}
+      {!display ? (
+        <Box flexDirection="column" flexGrow={1} justifyContent="center">
+          <Text attributes={TextAttributes.BOLD} fg={colors.textBright} style={desktopSymbolStyle}>
+            {symbol}
+          </Text>
+          <Text fg={colors.textDim}>Waiting for quote...</Text>
+        </Box>
+      ) : nativePaneChrome ? (
+        <Box
+          flexGrow={1}
+          style={{
+            position: "relative",
+            zIndex: 1,
+            display: "grid",
+            gridTemplateColumns: "minmax(130px, 1fr) minmax(88px, auto)",
+            gridTemplateRows: "auto 1fr auto",
+            columnGap: 12,
+            width: "100%",
+            height: "100%",
+          }}
+        >
+          <Box
+            flexDirection="column"
+            minWidth={0}
+            style={{
+              gridColumn: "1",
+              gridRow: "1 / span 2",
+              minWidth: 0,
+              overflow: "hidden",
+            }}
+          >
+            <Text attributes={TextAttributes.BOLD} fg={colors.textBright} style={desktopSymbolStyle}>
+              {symbol}
+            </Text>
+            {ticker?.metadata.name && (
+              <Text
+                fg={colors.textDim}
+                style={{
+                  fontSize: "12px",
+                  lineHeight: "14px",
+                  maxWidth: "100%",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {ticker.metadata.name}
+              </Text>
+            )}
+          </Box>
+
+          <Box
+            flexDirection="column"
+            alignItems="flex-end"
+            style={{
+              gridColumn: "2",
+              gridRow: "1",
+              justifySelf: "end",
+              backgroundColor: colors.bg,
+              borderRadius: 4,
+              boxShadow: `0 0 0 2px ${colors.bg}`,
+              paddingLeft: 6,
+              paddingBottom: 1,
+            }}
+          >
+            <Text
+              attributes={TextAttributes.BOLD}
+              fg={changeColor}
+              style={desktopPriceStyle}
+            >
+              {priceText}
+            </Text>
+            <Box flexDirection="row" gap={1} justifyContent="flex-end">
+              <Text fg={changeColor} style={desktopChangeStyle}>{changePercentText}</Text>
+              <Text fg={changeColor} style={desktopChangeStyle}>{changeValueText}</Text>
+            </Box>
+          </Box>
+
+          {rangeLabel && (
+            <Text
+              fg={colors.textDim}
+              style={{
+                gridColumn: "2",
+                gridRow: "3",
+                justifySelf: "end",
+                alignSelf: "end",
+                fontSize: "11px",
+                lineHeight: "13px",
+                backgroundColor: colors.bg,
+                paddingLeft: 6,
+                paddingRight: 2,
+                boxShadow: `0 0 0 2px ${colors.bg}`,
+              }}
+            >
+              {rangeLabel}
+            </Text>
+          )}
+        </Box>
+      ) : (
+        <Box flexDirection="column" flexGrow={1} justifyContent="flex-start">
+          {stacked ? (
+            <Box flexDirection="column">
+              <Text attributes={TextAttributes.BOLD} fg={colors.textBright} style={desktopSymbolStyle}>
+                {symbol}
+              </Text>
+              <Box flexDirection="column">
+                <Text attributes={TextAttributes.BOLD} fg={changeColor} style={desktopPriceStyle}>
+                  {priceText}
+                </Text>
+                <Box flexDirection="row" gap={1}>
+                  <Text fg={changeColor} style={desktopChangeStyle}>{changePercentText}</Text>
+                  <Text fg={changeColor} style={desktopChangeStyle}>{changeValueText}</Text>
+                </Box>
+              </Box>
+            </Box>
+          ) : (
+            <Box
+              flexDirection="row"
+              alignItems="flex-start"
+              justifyContent="space-between"
+              gap={1}
+            >
+              <Box flexDirection="column" flexGrow={1} minWidth={0}>
+                <Text attributes={TextAttributes.BOLD} fg={colors.textBright} style={desktopSymbolStyle}>
+                  {symbol}
+                </Text>
+                {nativePaneChrome && ticker?.metadata.name && width >= 36 && (
+                  <Text
+                    fg={colors.textDim}
+                    style={{
+                      fontSize: "12px",
+                      lineHeight: "16px",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                    maxWidth={nameMaxWidth}
+                  >
+                    {ticker.metadata.name}
+                  </Text>
+                )}
+              </Box>
+              <Box flexDirection="column" alignItems="flex-end">
+                <Text
+                  attributes={TextAttributes.BOLD}
+                  fg={changeColor}
+                  style={desktopPriceStyle}
+                >
+                  {priceText}
+                </Text>
+                <Box flexDirection="row" gap={1} justifyContent="flex-end">
+                  <Text fg={changeColor} style={desktopChangeStyle}>{changePercentText}</Text>
+                  <Text fg={changeColor} style={desktopChangeStyle}>{changeValueText}</Text>
+                </Box>
+              </Box>
+            </Box>
+          )}
+
+          <Box height={terminalSparklineHeight} flexDirection="row" alignItems="center" gap={1}>
+            <PriceSparkline
+              priceHistory={financials?.priceHistory}
+              width={sparklineWidth}
+              height={terminalSparklineHeight}
+              trend={trend}
+              period={chartPeriod}
+              area={!nativePaneChrome}
+            />
+            {nativePaneChrome && rangeLabel && (
+              <Text fg={colors.textDim} style={{ fontSize: "11px", lineHeight: "14px" }}>
+                {rangeLabel}
+              </Text>
+            )}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) {
+  const pane = usePaneInstance();
+  const { symbol: fallbackSymbol, ticker: fallbackTicker } = usePaneTicker();
+  const settings = useMemo(
+    () => getQuoteMonitorPaneSettings(pane?.settings, fallbackSymbol),
+    [fallbackSymbol, pane?.settings],
+  );
+  const symbols = settings.symbols;
+  const financialsBySymbol = useAppSelector((state) => state.financials);
+  const tickersBySymbol = useAppSelector((state) => state.tickers);
+  const streamingTargets = useMemo(() => (
+    symbols
+      .map((symbol) => {
+        const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
+        return quoteSubscriptionTargetFromTicker(ticker, symbol, "provider");
+      })
+      .filter((target): target is QuoteSubscriptionTarget => target != null)
+  ), [fallbackTicker, symbols, tickersBySymbol]);
+  useQuoteStreaming(streamingTargets);
+  const { pinTicker } = usePluginTickerActions();
+  const { openPaneSettings } = usePluginAppActions();
+  const { nativePaneChrome } = useUiCapabilities();
+  const openTicker = useCallback((nextSymbol: string) => {
+    pinTicker(nextSymbol, { paneType: "ticker-detail", floating: true });
+  }, [pinTicker]);
+  useShortcut((event) => {
+    if (!focused || event.name !== "t") return;
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    openPaneSettings(paneId);
+  });
+
+  if (symbols.length === 0) {
     return (
       <Box flexDirection="column" flexGrow={1} paddingX={1}>
-        <EmptyState title="No ticker selected." />
+        <EmptyState title="No tickers selected." />
       </Box>
     );
   }
 
-  const display = getQuoteMonitorDisplay(financials?.quote);
-  const changeColor = priceColor(display?.change ?? 0);
-  const compact = width < 56;
-  const currency = financials?.quote?.currency ?? ticker.metadata.currency ?? "USD";
+  const columns = resolveGridColumnCount(symbols.length, width, height, nativePaneChrome);
+  const rows = chunkSymbols(symbols, columns);
+  const contentWidth = Math.max(1, width - (nativePaneChrome ? 0 : 2));
+  const contentHeight = Math.max(3, height);
+  const cardHeight = Math.max(nativePaneChrome ? 4 : 3, Math.floor(contentHeight / rows.length));
+  const cardWidth = Math.max(1, Math.floor(contentWidth / columns));
 
-  return (
-    <Box flexDirection="column" flexGrow={1} backgroundColor={colors.panel} padding={1}>
+  if (nativePaneChrome) {
+    return (
       <Box
         flexGrow={1}
-        border
-        borderColor={focused ? colors.borderFocused : colors.border}
         backgroundColor={colors.bg}
-        paddingX={compact ? 2 : 4}
-        paddingY={1}
-        justifyContent="center"
+        overflow="hidden"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(240px, 100%), 1fr))",
+          gridAutoRows: "minmax(66px, 1fr)",
+          alignItems: "stretch",
+          alignContent: "stretch",
+          width: "100%",
+          height: "100%",
+        }}
       >
-        {!display ? (
-          <Box flexDirection="column" alignItems="center" justifyContent="center" gap={1} flexGrow={1}>
-            <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
-              {ticker.metadata.ticker}
-            </Text>
-            <Text fg={colors.textDim}>Waiting for quote...</Text>
-          </Box>
-        ) : (
-          <Box
-            flexDirection={compact ? "column" : "row"}
-            alignItems={compact ? "flex-start" : "center"}
-            justifyContent="space-between"
-            gap={compact ? 1 : 2}
-            flexGrow={1}
-          >
-            <Box flexGrow={1} justifyContent="center">
-              <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
-                {ticker.metadata.ticker}
-              </Text>
-            </Box>
-
-            <Box flexDirection="column" alignItems={compact ? "flex-start" : "flex-end"}>
-              <Text attributes={TextAttributes.BOLD} fg={changeColor}>
-                {formatMarketPriceWithCurrency(display.price, currency, { assetCategory: ticker.metadata.assetCategory })}
-              </Text>
-              <Box flexDirection="row" gap={1}>
-                <Text fg={changeColor}>{formatPercentRaw(display.changePercent)}</Text>
-                <Text fg={changeColor}>{formatSignedMarketPrice(display.change, { assetCategory: ticker.metadata.assetCategory })}</Text>
-              </Box>
-            </Box>
-          </Box>
-        )}
+        {symbols.map((symbol, index) => {
+          const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
+          return (
+            <QuoteMonitorCard
+              key={symbol}
+              symbol={symbol}
+              ticker={ticker}
+              cachedFinancials={financialsBySymbol.get(symbol) ?? null}
+              width={width}
+              height={height}
+              showRightDivider={false}
+              showBottomDivider
+              chartPeriod={settings.chartPeriod}
+              onOpen={openTicker}
+            />
+          );
+        })}
       </Box>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      backgroundColor={colors.bg}
+      paddingX={nativePaneChrome ? 0 : 1}
+      paddingY={0}
+      overflow="hidden"
+    >
+      {rows.map((row, rowIndex) => (
+        <Box key={`${rowIndex}:${row.join(",")}`} flexDirection="row" height={cardHeight}>
+          {row.map((symbol, columnIndex) => {
+            const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
+            return (
+              <QuoteMonitorCard
+                key={symbol}
+                symbol={symbol}
+                ticker={ticker}
+                cachedFinancials={financialsBySymbol.get(symbol) ?? null}
+                width={cardWidth}
+                height={cardHeight}
+                showRightDivider={columnIndex < row.length - 1}
+                showBottomDivider={rowIndex < rows.length - 1}
+                chartPeriod={settings.chartPeriod}
+                onOpen={openTicker}
+              />
+            );
+          })}
+        </Box>
+      ))}
     </Box>
   );
 }

--- a/src/plugins/builtin/ticker-detail/settings.ts
+++ b/src/plugins/builtin/ticker-detail/settings.ts
@@ -8,7 +8,9 @@ import {
   DEFAULT_TICKER_CHART_RESOLUTION,
   normalizeChartResolution,
 } from "../../../components/chart/chart-resolution";
+import type { PriceSparklinePeriod } from "../../../components/price-sparkline-view";
 import { getSharedRegistry } from "../../registry";
+import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } from "../../../utils/ticker-list";
 
 type DetailTabSummary = { id: string; name: string; order: number };
 
@@ -23,6 +25,14 @@ export interface TickerDetailPaneSettings {
   chartRangePreset: TimeRange;
   chartResolution: ReturnType<typeof normalizeChartResolution>;
 }
+
+export interface QuoteMonitorPaneSettings {
+  symbols: string[];
+  symbolsText: string;
+  chartPeriod: PriceSparklinePeriod;
+}
+
+const DEFAULT_QUOTE_MONITOR_CHART_PERIOD: PriceSparklinePeriod = "1M";
 
 export function getTickerDetailPaneSettings(
   settings: Record<string, unknown> | undefined,
@@ -100,15 +110,86 @@ export function buildTickerDetailSettingsDef(settings: TickerDetailPaneSettings)
   };
 }
 
+function coerceQuoteMonitorSymbols(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const parsed = value.filter((entry): entry is string => typeof entry === "string");
+  try {
+    return parseTickerListInput(parsed.join(", "), MAX_TICKER_LIST_SIZE);
+  } catch {
+    return parsed.slice(0, MAX_TICKER_LIST_SIZE);
+  }
+}
+
+export function buildQuoteMonitorPaneTitle(symbols: string[]): string {
+  if (symbols.length === 0) return "Quote Monitor";
+  if (symbols.length <= 3) return symbols.join(" · ");
+  return `${symbols.slice(0, 2).join(" · ")} +${symbols.length - 2}`;
+}
+
+export function getQuoteMonitorPaneSettings(
+  settings: Record<string, unknown> | undefined,
+  fallbackSymbol?: string | null,
+): QuoteMonitorPaneSettings {
+  const storedSymbols = coerceQuoteMonitorSymbols(settings?.symbols);
+  const legacySymbol = typeof settings?.symbol === "string" ? settings.symbol.trim() : "";
+  const storedText = typeof settings?.symbolsText === "string" ? settings.symbolsText : "";
+  let symbols = storedSymbols;
+
+  if (symbols.length === 0 && storedText.trim().length > 0) {
+    try {
+      symbols = parseTickerListInput(storedText, MAX_TICKER_LIST_SIZE);
+    } catch {
+      symbols = [];
+    }
+  }
+  if (symbols.length === 0 && legacySymbol) {
+    try {
+      symbols = parseTickerListInput(legacySymbol, MAX_TICKER_LIST_SIZE);
+    } catch {
+      symbols = [legacySymbol.toUpperCase()];
+    }
+  }
+  if (symbols.length === 0 && fallbackSymbol) {
+    symbols = [fallbackSymbol.toUpperCase()];
+  }
+
+  return {
+    symbols,
+    symbolsText: storedText.trim().length > 0 ? storedText : formatTickerListInput(symbols),
+    chartPeriod: settings?.chartPeriod === "1D"
+      || settings?.chartPeriod === "1W"
+      || settings?.chartPeriod === "1M"
+      || settings?.chartPeriod === "1Y"
+      ? settings.chartPeriod
+      : DEFAULT_QUOTE_MONITOR_CHART_PERIOD,
+  };
+}
+
 export function buildQuoteMonitorSettingsDef(): PaneSettingsDef {
   return {
     title: "Quote Monitor Settings",
+    values: {
+      chartPeriod: DEFAULT_QUOTE_MONITOR_CHART_PERIOD,
+    },
     fields: [
       {
-        key: "symbol",
-        label: "Ticker",
+        key: "symbolsText",
+        label: "Tickers",
+        description: `Enter up to ${MAX_TICKER_LIST_SIZE} tickers separated by commas.`,
         type: "text",
-        placeholder: "AAPL",
+        placeholder: "AAPL, MSFT, NVDA",
+      },
+      {
+        key: "chartPeriod",
+        label: "Chart Period",
+        description: "Set the period used for quote sparklines and range labels.",
+        type: "select",
+        options: [
+          { value: "1D", label: "1D" },
+          { value: "1W", label: "1W" },
+          { value: "1M", label: "1M" },
+          { value: "1Y", label: "1Y" },
+        ],
       },
     ],
   };

--- a/src/plugins/prediction-markets/settings.ts
+++ b/src/plugins/prediction-markets/settings.ts
@@ -154,6 +154,10 @@ export function buildPredictionMarketsPaneSettingsDef(
 
   return {
     title: "Prediction Markets Settings",
+    values: {
+      ...settings,
+      columnIds: [...settings.columnIds],
+    },
     fields,
   };
 }

--- a/src/plugins/registry.test.ts
+++ b/src/plugins/registry.test.ts
@@ -222,6 +222,61 @@ describe("PluginRegistry detail tabs", () => {
 });
 
 describe("PluginRegistry pane settings", () => {
+  test("resolves effective pane setting values from settings definitions", async () => {
+    const registry = createRegistry();
+    const config = createDefaultConfig("/tmp/gloomberb-pane-settings-test");
+    config.layout = {
+      dockRoot: { kind: "pane", instanceId: "test-pane:main" },
+      instances: [{
+        instanceId: "test-pane:main",
+        paneId: "test-pane",
+        binding: { kind: "none" },
+        settings: {},
+      }],
+      floating: [],
+    };
+    registry.getConfigFn = () => config;
+    registry.getLayoutFn = () => config.layout;
+
+    await registry.register(plugin("tables", (ctx) => {
+      ctx.registerPane({
+        id: "test-pane",
+        name: "Test Pane",
+        defaultPosition: "right",
+        component: () => null,
+        settings: {
+          values: {
+            columnIds: ["ticker", "price"],
+            collectionScope: "all",
+          },
+          fields: [
+            {
+              key: "columnIds",
+              label: "Columns",
+              type: "ordered-multi-select",
+              options: [
+                { value: "ticker", label: "Ticker" },
+                { value: "price", label: "Price" },
+              ],
+            },
+            {
+              key: "collectionScope",
+              label: "Collections",
+              type: "select",
+              options: [{ value: "all", label: "All" }],
+            },
+          ],
+        },
+      });
+    }));
+
+    const descriptor = registry.resolvePaneSettings("test-pane:main");
+
+    expect(descriptor?.context.settings.columnIds).toEqual(["ticker", "price"]);
+    expect(descriptor?.context.settings.collectionScope).toBe("all");
+    expect(descriptor?.rawSettings.columnIds).toBeUndefined();
+  });
+
   test("resolves plugin-scoped pane setting values from plugin config", async () => {
     const registry = createRegistry();
     const config = createDefaultConfig("/tmp/gloomberb-pane-settings-test");

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -445,6 +445,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
     pane: PaneInstanceConfig;
     paneDef: PaneDef;
     settingsDef: PaneSettingsDef;
+    rawSettings: Record<string, unknown>;
     context: PaneSettingsContext;
   } | null {
     const targetPaneId = this.resolvePaneTarget(paneId);
@@ -484,8 +485,12 @@ export class PluginRegistry implements PluginRuntimeAccess {
       : paneDef.settings;
     if (!settingsDef) return null;
 
+    const rawSettings = { ...paneSettings };
+    const resolvedSettings = {
+      ...paneSettings,
+      ...(settingsDef.values ?? {}),
+    };
     if (pluginId) {
-      const resolvedSettings = { ...paneSettings };
       for (const field of settingsDef.fields) {
         if (field.storage !== "plugin") continue;
         const configValue = this.getConfigState(pluginId, field.key);
@@ -495,8 +500,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
           resolvedSettings[field.key] = configValue;
         }
       }
-      context.settings = resolvedSettings;
     }
+    context.settings = resolvedSettings;
 
     return {
       paneId: targetPaneId,
@@ -504,6 +509,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
       pane,
       paneDef,
       settingsDef,
+      rawSettings,
       context,
     };
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,6 @@
 import type { Portfolio, Watchlist } from "./ticker";
 
-export const CURRENT_CONFIG_VERSION = 15;
+export const CURRENT_CONFIG_VERSION = 16;
 
 export type DefaultChartRenderMode = "area" | "line" | "candles" | "ohlc" | "hlc";
 export type ChartRendererPreference = "auto" | "kitty" | "braille";
@@ -158,6 +158,7 @@ export const DEFAULT_COLUMNS: ColumnConfig[] = [
 
 export const DEFAULT_PORTFOLIO_COLUMN_IDS = [
   ...DEFAULT_COLUMNS.map((column) => column.id),
+  "sparkline",
   "shares",
   "avg_cost",
   "cost_basis",

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -110,6 +110,7 @@ export type PaneSettingField =
 
 export interface PaneSettingsDef {
   title?: string;
+  values?: Record<string, unknown>;
   fields: PaneSettingField[];
 }
 


### PR DESCRIPTION
Adds a reusable price sparkline renderer for portfolio tables and quote-monitor cards, with a default portfolio sparkline column and a config migration for existing pane layouts. Expands QQ into a multi-ticker quote monitor with editable ticker lists, chart period settings, direct comma-separated creation from the command bar, and double-click access to ticker details. Also tightens chart axis sizing for fractional viewports and keeps pane settings edits based on raw stored values so defaults do not get persisted accidentally.