### PR TITLE
Improve desktop persistence and portfolio warmups

### DIFF
--- a/src/data/config-store-node.ts
+++ b/src/data/config-store-node.ts
@@ -1,4 +1,5 @@
 import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
+import { homedir } from "os";
 import { dirname, join } from "path";
 import type {
   AppConfig,
@@ -46,11 +47,23 @@ const BUILTIN_PLUGIN_GROUP_ALIASES: Record<string, string> = {
 };
 
 function getGlobalConfigDir(): string {
-  return join(process.env.HOME || "~", ".gloomberb");
+  return join(getHomeDir(), ".gloomberb");
 }
 
 function getGlobalConfigFile(): string {
   return join(getGlobalConfigDir(), "config.json");
+}
+
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
+}
+
+function expandHomePath(filePath: string): string {
+  if (filePath === "~") return getHomeDir();
+  if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
+    return join(getHomeDir(), filePath.slice(2));
+  }
+  return filePath;
 }
 
 export async function getDataDir(): Promise<string | null> {
@@ -197,11 +210,11 @@ export async function resetAllData(dataDir: string): Promise<void> {
 
 export async function exportConfig(config: AppConfig, destPath: string): Promise<void> {
   const { dataDir, ...rest } = config;
-  await writeFile(destPath, JSON.stringify(rest, null, 2), "utf-8");
+  await writeFile(expandHomePath(destPath), JSON.stringify(rest, null, 2), "utf-8");
 }
 
 export async function importConfig(dataDir: string, srcPath: string): Promise<AppConfig> {
-  const raw = await readFile(srcPath, "utf-8");
+  const raw = await readFile(expandHomePath(srcPath), "utf-8");
   const saved = JSON.parse(raw) as Record<string, unknown>;
   const { config } = normalizeConfig(saved, dataDir);
   await saveConfig(config);

--- a/src/data/config-store.test.ts
+++ b/src/data/config-store.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { loadConfig, sanitizeLayout, saveConfig } from "./config-store";
+import { exportConfig, importConfig, loadConfig, sanitizeLayout, saveConfig } from "./config-store";
 import {
   CURRENT_CONFIG_VERSION,
   DEFAULT_COLUMNS,
@@ -449,5 +449,33 @@ describe("loadConfig", () => {
     expect(persisted.configVersion).toBe(CURRENT_CONFIG_VERSION);
     expect(persisted.activeLayoutIndex).toBe(1);
     expect(persisted.layouts[1]?.layout).toEqual(DEFAULT_LAYOUT);
+  });
+});
+
+describe("config backup files", () => {
+  test("expands a leading tilde when exporting and importing", async () => {
+    const originalHome = process.env.HOME;
+    const homeDir = await createTempConfigDir();
+    const dataDir = await createTempConfigDir();
+    const importDataDir = await createTempConfigDir();
+    process.env.HOME = homeDir;
+
+    try {
+      const config = await loadConfig(dataDir);
+      await exportConfig({ ...config, baseCurrency: "EUR" }, "~/gloomberb-config-backup.json");
+
+      const backupPath = join(homeDir, "gloomberb-config-backup.json");
+      const exported = JSON.parse(await readFile(backupPath, "utf-8")) as Record<string, unknown>;
+      expect(exported.baseCurrency).toBe("EUR");
+      expect(exported.dataDir).toBeUndefined();
+
+      await writeFile(backupPath, JSON.stringify({ ...exported, baseCurrency: "JPY" }), "utf-8");
+      const imported = await importConfig(importDataDir, "~/gloomberb-config-backup.json");
+
+      expect(imported.baseCurrency).toBe("JPY");
+      expect(imported.dataDir).toBe(importDataDir);
+    } finally {
+      process.env.HOME = originalHome;
+    }
   });
 });

--- a/src/data/plugin-state-store.ts
+++ b/src/data/plugin-state-store.ts
@@ -10,6 +10,13 @@ export interface PluginStateRecord<T = unknown> {
   updatedAt: number;
 }
 
+export interface PluginStateSetEntry {
+  pluginId: string;
+  key: string;
+  value: unknown;
+  schemaVersion?: number;
+}
+
 interface CachedPluginStateRecord {
   value: unknown;
   schemaVersion: number;
@@ -64,22 +71,41 @@ export class PluginStateStore {
   }
 
   set(pluginId: string, key: string, value: unknown, schemaVersion = DEFAULT_PLUGIN_STATE_SCHEMA_VERSION): void {
-    const rawValue = serializeJson(value);
+    this.setMany([{ pluginId, key, value, schemaVersion }]);
+  }
+
+  setMany(entries: PluginStateSetEntry[]): void {
+    if (entries.length === 0) return;
     const updatedAt = Date.now();
+    const records = entries.map((entry) => ({
+      pluginId: entry.pluginId,
+      key: entry.key,
+      value: entry.value,
+      schemaVersion: entry.schemaVersion ?? DEFAULT_PLUGIN_STATE_SCHEMA_VERSION,
+      rawValue: serializeJson(entry.value),
+    }));
+
     withSqliteBusyRetry("save plugin state", () => {
-      this.db
-        .query(
-          `INSERT OR REPLACE INTO plugin_state (plugin_id, key, schema_version, value, updated_at)
-           VALUES (?, ?, ?, ?, ?)`,
-        )
-        .run(pluginId, key, schemaVersion, rawValue, updatedAt);
+      const insert = this.db.query(
+        `INSERT OR REPLACE INTO plugin_state (plugin_id, key, schema_version, value, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      );
+      const tx = this.db.transaction(() => {
+        for (const record of records) {
+          insert.run(record.pluginId, record.key, record.schemaVersion, record.rawValue, updatedAt);
+        }
+      });
+      tx();
     });
-    this.cache.set(`${pluginId}:${key}`, {
-      value,
-      schemaVersion,
-      updatedAt,
-      rawValue,
-    });
+
+    for (const record of records) {
+      this.cache.set(`${record.pluginId}:${record.key}`, {
+        value: record.value,
+        schemaVersion: record.schemaVersion,
+        updatedAt,
+        rawValue: record.rawValue,
+      });
+    }
   }
 
   delete(pluginId: string, key: string): void {

--- a/src/data/sqlite-cache.test.ts
+++ b/src/data/sqlite-cache.test.ts
@@ -127,6 +127,19 @@ describe("AppPersistence", () => {
     persistence.close();
   });
 
+  test("stores multiple plugin state records in one batch", () => {
+    const dbPath = createTempDbPath("plugin-state-batch");
+    const persistence = new AppPersistence(dbPath);
+    persistence.pluginState.setMany([
+      { pluginId: "ai", key: "provider", value: "openai", schemaVersion: 1 },
+      { pluginId: "news", key: "resume:read", value: { ids: ["1"] }, schemaVersion: 2 },
+    ]);
+
+    expect(persistence.pluginState.get<string>("ai", "provider", 1)?.value).toBe("openai");
+    expect(persistence.pluginState.get<{ ids: string[] }>("news", "resume:read", 2)?.value.ids).toEqual(["1"]);
+    persistence.close();
+  });
+
   test("stores and returns session snapshots", () => {
     const dbPath = createTempDbPath("session-snapshot");
     const persistence = new AppPersistence(dbPath);

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -202,6 +202,13 @@ function areStreamQuotesEquivalent(current: Quote | null | undefined, next: Quot
     && JSON.stringify(current.provenance ?? null) === JSON.stringify(next.provenance ?? null);
 }
 
+function hasCachedSnapshotData(financials: TickerFinancials): boolean {
+  return !!financials.profile
+    || Object.keys(financials.fundamentals ?? {}).length > 0
+    || financials.annualStatements.length > 0
+    || financials.quarterlyStatements.length > 0;
+}
+
 function errorEntry<T>(current: QueryEntry<T>, attempt: ProviderAttempt): QueryEntry<T> {
   return {
     ...current,
@@ -365,7 +372,7 @@ export class MarketDataCoordinator {
       const fundamentalsKey = buildFundamentalsKey(instrument);
       const statementsKey = buildStatementsKey(instrument);
 
-      if (this.snapshotStore.get(snapshotKey).phase === "idle") {
+      if (hasCachedSnapshotData(normalized) && this.snapshotStore.get(snapshotKey).phase === "idle") {
         this.snapshotStore.set(
           snapshotKey,
           readyEntry(this.snapshotStore.get(snapshotKey), normalized, source, [], { keepLastGoodOnEmpty: true }),

--- a/src/plugins/builtin/news-wire/index.tsx
+++ b/src/plugins/builtin/news-wire/index.tsx
@@ -39,7 +39,7 @@ const TopPane = createNewsPresetPane({
   paneKey: "top",
   title: "Top News",
   query: NEWS_QUERY_PRESETS.top,
-  columns: ["rank", "time", "title", "tickers", "importance"],
+  columns: ["time", "title", "tickers", "importance"],
   defaultSort: { columnId: "importance", direction: "desc" },
   emptyStateTitle: "No top stories yet",
   emptyStateHint: "Try refreshing later as new headlines are ranked.",

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -13,6 +13,7 @@ import type { DataProvider } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
+import { instrumentFromTicker } from "../../market-data/request-types";
 import { createTestPluginRuntime } from "../../test-support/plugin-runtime";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
 import { PluginRegistry, setSharedMarketDataForTests, setSharedRegistryForTests } from "../registry";
@@ -999,6 +1000,8 @@ describe("PortfolioListPane cash and margin UI", () => {
       ["ticker", "market_cap", "pe", "forward_pe"],
       [createBrokerInstance("flex")],
     );
+    const seededTicker = makeTicker();
+    const seededQuote = makeQuote();
     let calls = 0;
     let resolveFinancials!: (value: {
       annualStatements: [];
@@ -1043,10 +1046,26 @@ describe("PortfolioListPane cash and margin UI", () => {
       },
     };
     sharedCoordinator = new MarketDataCoordinator(provider);
+    const instrument = instrumentFromTicker(seededTicker, seededTicker.metadata.ticker);
+    if (!instrument) throw new Error("expected ticker instrument");
+    sharedCoordinator.primeCachedFinancials([{
+      instrument,
+      financials: {
+        annualStatements: [],
+        quarterlyStatements: [],
+        priceHistory: [],
+        quote: seededQuote,
+      },
+    }]);
     setSharedMarketDataCoordinator(sharedCoordinator);
 
     testSetup = await testRender(
-      <PortfolioHarness config={config} collectionId="broker:ibkr-flex:DU12345" />,
+      <PortfolioHarness
+        config={config}
+        collectionId="broker:ibkr-flex:DU12345"
+        ticker={seededTicker}
+        quote={seededQuote}
+      />,
       { width: 100, height: 12 },
     );
 

--- a/src/plugins/builtin/portfolio-list/pane.tsx
+++ b/src/plugins/builtin/portfolio-list/pane.tsx
@@ -48,17 +48,45 @@ import { PortfolioTickerTable, type QuoteFlashDirection } from "./table";
 import { useThrottledCursorSymbol } from "./use-throttled-cursor-symbol";
 import { isManualPortfolio } from "./mutations";
 import { QuickAddTickerInput, type QuickAddCollectionKind } from "./quick-add";
+import { PRICE_SPARKLINE_COLUMN_ID } from "../../../components/price-sparkline-view";
 
 const VISIBLE_FINANCIAL_REFRESH_COOLDOWN_MS = 5 * 60_000;
 const VISIBLE_FINANCIAL_WARMUP_DELAY_MS = 350;
+const VISIBLE_SNAPSHOT_WARMUP_BATCH_LIMIT = 3;
 const STREAM_OVERSCAN_ROWS = 6;
+const FUNDAMENTAL_COLUMN_IDS = new Set(["pe", "forward_pe", "dividend_yield"]);
 const sortValueCache = createRowValueCache<string, ReturnType<typeof getSortValue>>(5000);
 
-function needsVisibleFinancialWarmup(ticker: TickerRecord, financials: TickerFinancials | undefined): boolean {
+interface VisibleWarmupRequirements {
+  fundamentals: boolean;
+  priceHistory: boolean;
+}
+
+function resolveVisibleWarmupRequirements(columns: ColumnConfig[]): VisibleWarmupRequirements {
+  return {
+    fundamentals: columns.some((column) => FUNDAMENTAL_COLUMN_IDS.has(column.id)),
+    priceHistory: columns.some((column) => column.id === PRICE_SPARKLINE_COLUMN_ID),
+  };
+}
+
+function visibleWarmupKey(kind: "quote" | "snapshot", ticker: TickerRecord): string {
+  return `${kind}:${ticker.metadata.ticker}:${ticker.metadata.exchange ?? ""}`;
+}
+
+function needsVisibleQuoteWarmup(ticker: TickerRecord, financials: TickerFinancials | undefined): boolean {
   if (ticker.metadata.assetCategory === "OPT") return false;
-  if (!financials) return true;
-  if (Object.keys(financials.fundamentals ?? {}).length === 0) return true;
-  return financials.priceHistory.length === 0;
+  return !financials?.quote;
+}
+
+function needsVisibleSnapshotWarmup(
+  ticker: TickerRecord,
+  financials: TickerFinancials | undefined,
+  requirements: VisibleWarmupRequirements,
+): boolean {
+  if (ticker.metadata.assetCategory === "OPT") return false;
+  if (!financials?.quote) return false;
+  if (requirements.fundamentals && Object.keys(financials.fundamentals ?? {}).length === 0) return true;
+  return requirements.priceHistory && financials.priceHistory.length === 0;
 }
 
 export function selectStreamTickers(
@@ -265,6 +293,10 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     () => resolveVisibleColumns(paneSettings.columnIds, isPortfolioTab),
     [isPortfolioTab, paneSettings.columnIds],
   );
+  const visibleWarmupRequirements = useMemo(
+    () => resolveVisibleWarmupRequirements(columns),
+    [columns],
+  );
 
   const trackedCurrencies = useMemo(
     () => buildTrackedCurrencies(tickers, financialsMap, accountState, config.baseCurrency),
@@ -448,31 +480,64 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     if (!sharedCoordinator) return;
 
     const nowTimestamp = Date.now();
-    const queue = visibleFinancialTickers.filter((ticker) => {
-      const key = `${ticker.metadata.ticker}:${ticker.metadata.exchange ?? ""}`;
-      if (warmupInFlightRef.current.has(key)) return false;
-      if (nowTimestamp - (warmupAttemptRef.current.get(key) ?? 0) < VISIBLE_FINANCIAL_REFRESH_COOLDOWN_MS) return false;
-      return needsVisibleFinancialWarmup(ticker, financialsMap.get(ticker.metadata.ticker));
-    });
-    if (queue.length === 0) return;
+    const quoteQueue: TickerRecord[] = [];
+    const snapshotQueue: TickerRecord[] = [];
+    for (const ticker of visibleFinancialTickers) {
+      const financials = financialsMap.get(ticker.metadata.ticker);
+      const quoteKey = visibleWarmupKey("quote", ticker);
+      if (
+        needsVisibleQuoteWarmup(ticker, financials)
+        && !warmupInFlightRef.current.has(quoteKey)
+        && nowTimestamp - (warmupAttemptRef.current.get(quoteKey) ?? 0) >= VISIBLE_FINANCIAL_REFRESH_COOLDOWN_MS
+      ) {
+        quoteQueue.push(ticker);
+        continue;
+      }
+
+      const snapshotKey = visibleWarmupKey("snapshot", ticker);
+      if (
+        needsVisibleSnapshotWarmup(ticker, financials, visibleWarmupRequirements)
+        && !warmupInFlightRef.current.has(snapshotKey)
+        && nowTimestamp - (warmupAttemptRef.current.get(snapshotKey) ?? 0) >= VISIBLE_FINANCIAL_REFRESH_COOLDOWN_MS
+      ) {
+        snapshotQueue.push(ticker);
+      }
+    }
+    const limitedSnapshotQueue = snapshotQueue.slice(0, VISIBLE_SNAPSHOT_WARMUP_BATCH_LIMIT);
+    if (quoteQueue.length === 0 && limitedSnapshotQueue.length === 0) return;
 
     let cancelled = false;
     const runBatch = async (): Promise<void> => {
-      const entries = queue.flatMap((ticker) => {
+      const quoteEntries = quoteQueue.flatMap((ticker) => {
         const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
         if (!instrument) return [];
-        const key = `${ticker.metadata.ticker}:${ticker.metadata.exchange ?? ""}`;
+        const key = visibleWarmupKey("quote", ticker);
         warmupInFlightRef.current.add(key);
         warmupAttemptRef.current.set(key, nowTimestamp);
         return [{ key, instrument }];
       });
-      if (entries.length === 0) return;
+      const snapshotEntries = limitedSnapshotQueue.flatMap((ticker) => {
+        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+        if (!instrument) return [];
+        const key = visibleWarmupKey("snapshot", ticker);
+        warmupInFlightRef.current.add(key);
+        warmupAttemptRef.current.set(key, nowTimestamp);
+        return [{ key, instrument }];
+      });
+      if (quoteEntries.length === 0 && snapshotEntries.length === 0) return;
       try {
-        await sharedCoordinator.loadSnapshotsBatch(entries.map((entry) => entry.instrument));
+        await Promise.allSettled([
+          quoteEntries.length > 0
+            ? sharedCoordinator.loadQuotesBatch(quoteEntries.map((entry) => entry.instrument))
+            : Promise.resolve(),
+          snapshotEntries.length > 0
+            ? sharedCoordinator.loadSnapshotsBatch(snapshotEntries.map((entry) => entry.instrument))
+            : Promise.resolve(),
+        ]);
       } catch {
         // Best-effort warmup for visible rows only.
       } finally {
-        for (const entry of entries) {
+        for (const entry of [...quoteEntries, ...snapshotEntries]) {
           warmupInFlightRef.current.delete(entry.key);
         }
       }
@@ -486,7 +551,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [appActive, financialsMap, focused, sharedCoordinator, visibleFinancialTickers]);
+  }, [appActive, financialsMap, focused, sharedCoordinator, visibleFinancialTickers, visibleWarmupRequirements]);
 
   useQuoteStreaming(streamTargets);
 

--- a/src/renderers/electrobun/bun/application-menu-click.test.ts
+++ b/src/renderers/electrobun/bun/application-menu-click.test.ts
@@ -21,6 +21,15 @@ describe("applicationMenuCommand", () => {
     })).toBeNull();
   });
 
+  test("parses the native devtools command", () => {
+    expect(applicationMenuCommand({
+      data: {
+        action: ELECTROBUN_APPLICATION_MENU_ACTION,
+        data: { type: "open-devtools" },
+      },
+    })).toEqual({ type: "open-devtools" });
+  });
+
   test("ignores unknown command types", () => {
     expect(applicationMenuCommand({
       data: {

--- a/src/renderers/electrobun/bun/application-menu-click.ts
+++ b/src/renderers/electrobun/bun/application-menu-click.ts
@@ -1,5 +1,7 @@
-import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu";
-import { ELECTROBUN_APPLICATION_MENU_ACTION } from "./application-menu";
+import {
+  ELECTROBUN_APPLICATION_MENU_ACTION,
+  type ElectrobunApplicationMenuCommand,
+} from "./application-menu";
 
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -19,7 +21,7 @@ function applicationMenuClickPayload(event: unknown): Record<string, unknown> | 
   return typeof eventRecord.action === "string" ? eventRecord : null;
 }
 
-function normalizeApplicationMenuCommand(value: unknown): DesktopApplicationMenuCommand | null {
+function normalizeApplicationMenuCommand(value: unknown): ElectrobunApplicationMenuCommand | null {
   const command = record(value);
   if (!command || typeof command.type !== "string") return null;
 
@@ -42,13 +44,14 @@ function normalizeApplicationMenuCommand(value: unknown): DesktopApplicationMenu
     case "layout-undo":
     case "layout-redo":
     case "layout-gridlock":
+    case "open-devtools":
       return { type: command.type };
     default:
       return null;
   }
 }
 
-export function applicationMenuCommand(event: unknown): DesktopApplicationMenuCommand | null {
+export function applicationMenuCommand(event: unknown): ElectrobunApplicationMenuCommand | null {
   const payload = applicationMenuClickPayload(event);
   if (payload?.action !== ELECTROBUN_APPLICATION_MENU_ACTION) return null;
   return normalizeApplicationMenuCommand(payload.data);

--- a/src/renderers/electrobun/bun/application-menu.ts
+++ b/src/renderers/electrobun/bun/application-menu.ts
@@ -4,9 +4,13 @@ import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu"
 export const ELECTROBUN_APPLICATION_MENU_ACTION = "gloom.application-menu.select";
 export const GITHUB_ISSUE_URL = "https://github.com/vincelwt/gloomberb/issues/new/choose";
 
+export type ElectrobunApplicationMenuCommand =
+  | DesktopApplicationMenuCommand
+  | { type: "open-devtools" };
+
 function commandItem(
   label: string,
-  command: DesktopApplicationMenuCommand,
+  command: ElectrobunApplicationMenuCommand,
   options: { accelerator?: string } = {},
 ): ApplicationMenuItemConfig {
   return {
@@ -72,6 +76,7 @@ export function buildApplicationMenu(): ApplicationMenuItemConfig[] {
       label: "View",
       submenu: [
         openCommandBar("Open Command Bar", "", { accelerator: "CmdOrCtrl+K" }),
+        commandItem("Open Developer Tools", { type: "open-devtools" }),
         { type: "divider" },
         commandItem("Toggle Status Bar", { type: "toggle-status-bar" }),
         { type: "divider" },

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -19,7 +19,6 @@ import { buildSoundCommand } from "../../../notifications/app-notifier";
 import { isPaneDetached } from "../../../plugins/pane-manager";
 import { ELECTROBUN_CONTEXT_MENU_ACTION, type ElectrobunDesktopRpcSchema } from "../shared/protocol";
 import { decodeRpcValue, encodeRpcValue } from "../view/rpc-codec";
-import { startMainThreadMonitor } from "../../../utils/main-thread-monitor";
 import { contextMenuSelectionMessage } from "./context-menu-click";
 import { getContextMenuRequestId, normalizeContextMenuItems } from "./context-menu-normalize";
 import { createDesktopWorkspace, type DesktopWorkspace } from "./desktop-workspace";
@@ -56,7 +55,6 @@ console.log = (...args) => console.error(...args);
 console.info = (...args) => console.error(...args);
 console.warn = (...args) => console.error(...args);
 
-startMainThreadMonitor("electrobun.bun", { mirrorToConsole: true });
 setConfigStoreHost(nodeConfigStoreHost);
 setNativeIbkrGatewayModuleLoader(() => import("../../../plugins/ibkr/gateway-service-native"));
 
@@ -134,6 +132,10 @@ function forEachReadyWindowRpc(callback: (rpc: DesktopRpc) => void): void {
     const rpc = windowRpcs.get(key);
     if (rpc) callback(rpc);
   }
+}
+
+function openMainWindowDevTools(): void {
+  mainWindow?.webview.openDevTools();
 }
 
 function scopeClientId(rpc: DesktopRpc, id: string): string {
@@ -414,6 +416,25 @@ async function runDesktopUpdate(rpc: DesktopRpc, currentVersion: string): Promis
     desktopUpdateInProgress = false;
     Electrobun.Updater.onStatusChange(null);
   }
+}
+
+interface PluginStateBackendSetEntry {
+  pluginId: string;
+  key: string;
+  value: unknown;
+  schemaVersion?: number;
+}
+
+function normalizePluginStateSetEntry(entry: unknown): PluginStateBackendSetEntry | null {
+  if (!entry || typeof entry !== "object") return null;
+  const record = entry as Record<string, unknown>;
+  if (typeof record.pluginId !== "string" || typeof record.key !== "string") return null;
+  return {
+    pluginId: record.pluginId,
+    key: record.key,
+    value: record.value,
+    schemaVersion: typeof record.schemaVersion === "number" ? record.schemaVersion : undefined,
+  };
 }
 
 function syncBackendCloudAuthState(pluginId: string, key: string, value: unknown): void {
@@ -1049,6 +1070,19 @@ async function handleBackendRequest(
       requireServices().persistence.pluginState.set(payload.pluginId as string, payload.key as string, payload.value, payload.schemaVersion as number | undefined);
       syncBackendCloudAuthState(payload.pluginId as string, payload.key as string, payload.value);
       return null;
+    case "pluginState.setMany": {
+      const entries = Array.isArray(payload.entries)
+        ? payload.entries.flatMap((entry) => {
+            const normalized = normalizePluginStateSetEntry(entry);
+            return normalized ? [normalized] : [];
+          })
+        : [];
+      requireServices().persistence.pluginState.setMany(entries);
+      for (const entry of entries) {
+        syncBackendCloudAuthState(entry.pluginId, entry.key, entry.value);
+      }
+      return null;
+    }
     case "pluginState.delete":
       requireServices().persistence.pluginState.delete(payload.pluginId as string, payload.key as string);
       syncBackendCloudAuthState(payload.pluginId as string, payload.key as string, null);
@@ -1142,7 +1176,12 @@ Electrobun.events.on("context-menu-clicked", (event: unknown) => {
 
 ApplicationMenu.on("application-menu-clicked", (event: unknown) => {
   const command = applicationMenuCommand(event);
-  if (!command || !readyWindowRpcs.has(MAIN_WINDOW_RPC_KEY)) return;
+  if (!command) return;
+  if (command.type === "open-devtools") {
+    openMainWindowDevTools();
+    return;
+  }
+  if (!readyWindowRpcs.has(MAIN_WINDOW_RPC_KEY)) return;
   windowRpcs.get(MAIN_WINDOW_RPC_KEY)?.send["application-menu.select"]({ command });
 });
 

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -24,6 +24,7 @@ import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 const servicesLog = debugLog.createLogger("services");
 const ASSET_DATA_CAPABILITY_ID = "asset-data.asset-data-router";
 const NEWS_CAPABILITY_ID = "news.core";
+const PLUGIN_STATE_BACKEND_FLUSH_DELAY_MS = 25;
 
 class RemoteTickerRepository {
   async loadAllTickers(): Promise<TickerRecord[]> {
@@ -274,14 +275,19 @@ class RemoteSessionStore {
   }
 }
 
+interface PluginStatePersistEntry {
+  pluginId: string;
+  key: string;
+  value: unknown;
+  schemaVersion: number;
+}
+
 class RemotePluginStateStore {
   private readonly state = new Map<string, Map<string, unknown>>();
-  private readonly schedulers = new Map<string, ReturnType<typeof createPersistScheduler<{
-    pluginId: string;
-    key: string;
-    value: unknown;
-    schemaVersion: number;
-  }>>>();
+  private readonly schedulers = new Map<string, ReturnType<typeof createPersistScheduler<PluginStatePersistEntry>>>();
+  private readonly pendingBackendSaves = new Map<string, PluginStatePersistEntry>();
+  private backendSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  private backendSaveInFlight: Promise<void> = Promise.resolve();
 
   constructor(initial: Record<string, Record<string, unknown>>) {
     for (const [pluginId, values] of Object.entries(initial)) {
@@ -304,7 +310,11 @@ class RemotePluginStateStore {
   delete(pluginId: string, key: string): void {
     this.state.get(pluginId)?.delete(key);
     this.getScheduler(pluginId, key).cancel();
-    void backendRequest("pluginState.delete", { pluginId, key }).catch(() => {});
+    this.pendingBackendSaves.delete(this.schedulerKey(pluginId, key));
+    void this.backendSaveInFlight
+      .catch(() => {})
+      .then(() => backendRequest("pluginState.delete", { pluginId, key }))
+      .catch(() => {});
   }
 
   keys(pluginId: string): string[] {
@@ -317,19 +327,51 @@ class RemotePluginStateStore {
 
   async flush(): Promise<void> {
     await Promise.all([...this.schedulers.values()].map((scheduler) => scheduler.flush()));
+    await this.flushBackendSaves();
   }
 
   private getScheduler(pluginId: string, key: string) {
-    const schedulerKey = `${pluginId}\u0000${key}`;
+    const schedulerKey = this.schedulerKey(pluginId, key);
     let scheduler = this.schedulers.get(schedulerKey);
     if (!scheduler) {
       scheduler = createPersistScheduler({
         delayMs: PLUGIN_STATE_SAVE_DEBOUNCE_MS,
-        save: (entry) => backendRequest("pluginState.set", entry),
+        save: (entry) => {
+          this.scheduleBackendSave(entry);
+        },
       });
       this.schedulers.set(schedulerKey, scheduler);
     }
     return scheduler;
+  }
+
+  private schedulerKey(pluginId: string, key: string): string {
+    return `${pluginId}\u0000${key}`;
+  }
+
+  private scheduleBackendSave(entry: PluginStatePersistEntry): void {
+    this.pendingBackendSaves.set(this.schedulerKey(entry.pluginId, entry.key), entry);
+    if (this.backendSaveTimer) return;
+    this.backendSaveTimer = setTimeout(() => {
+      void this.flushBackendSaves();
+    }, PLUGIN_STATE_BACKEND_FLUSH_DELAY_MS);
+  }
+
+  private async flushBackendSaves(): Promise<void> {
+    if (this.backendSaveTimer) {
+      clearTimeout(this.backendSaveTimer);
+      this.backendSaveTimer = null;
+    }
+    if (this.pendingBackendSaves.size === 0) return this.backendSaveInFlight;
+
+    const entries = [...this.pendingBackendSaves.values()];
+    this.pendingBackendSaves.clear();
+    const save = this.backendSaveInFlight
+      .catch(() => {})
+      .then(() => backendRequest<void>("pluginState.setMany", { entries }))
+      .catch(() => {});
+    this.backendSaveInFlight = save;
+    return save;
   }
 }
 

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -1,6 +1,5 @@
 /// <reference lib="dom" />
 import { Electroview } from "electrobun/view";
-import { measurePerfAsync } from "../../../utils/perf-marks";
 import {
   type ApplicationMenuSelectMessage,
   type CapabilityEventMessage,
@@ -119,13 +118,11 @@ async function waitForBridgeReady(): Promise<void> {
 }
 
 export async function backendRequest<T = unknown>(method: string, payload: unknown = null): Promise<T> {
-  const result = await measurePerfAsync("electrobun.rpc.request", async () => {
-    await waitForBridgeReady();
-    return rpc.request["backend.request"]({
-      method,
-      payload: encodeRpcValue(payload),
-    });
-  }, { method });
+  await waitForBridgeReady();
+  const result = await rpc.request["backend.request"]({
+    method,
+    payload: encodeRpcValue(payload),
+  });
   return decodeRpcValue<T>(result);
 }
 

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -5,7 +5,6 @@ import { App } from "../../../app";
 import { UiHostProvider } from "../../../ui/host";
 import { debugLog } from "../../../utils/debug-log";
 import { measurePerfAsync } from "../../../utils/perf-marks";
-import { startMainThreadMonitor } from "../../../utils/main-thread-monitor";
 import { backendRequest, initElectrobunBackend } from "./backend-rpc";
 import { installElectrobunAiHost } from "./ai-host";
 import { installElectrobunBrokerRemoteClient } from "./broker-remote-client";
@@ -31,23 +30,9 @@ if (!rootElement) {
 
 const root = createRoot(rootElement);
 const bootLog = debugLog.createLogger("electrobun-web-boot");
-const ELECTROBUN_WEB_CONSOLE_LOG_SOURCES = [
-  "app",
-  "main-thread",
-  "perf",
-  "refresh-queue",
-  "services",
-  "startup",
-  "electrobun-web-boot",
-];
-debugLog.mirrorToConsole({
-  sources: ELECTROBUN_WEB_CONSOLE_LOG_SOURCES,
-});
-const stopMainThreadMonitor = startMainThreadMonitor("electrobun.web", { mirrorToConsole: true });
 
 rootElement.tabIndex = -1;
 root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
-bootLog.warn("diagnostic console mirror enabled", { sources: ELECTROBUN_WEB_CONSOLE_LOG_SOURCES });
 
 function focusWebSurface(): void {
   window.focus();
@@ -111,7 +96,6 @@ async function boot() {
 }
 
 boot().catch((error) => {
-  stopMainThreadMonitor();
   root.render(
     <div className="gloom-fatal">
       <h1>Gloomberb failed to start</h1>

--- a/src/state/app-bootstrap.ts
+++ b/src/state/app-bootstrap.ts
@@ -37,11 +37,11 @@ interface RefreshPlanEntry {
 }
 
 const MAX_BACKGROUND_WARMUP_TICKERS = 12;
-const PORTFOLIO_FINANCIAL_COLUMN_IDS = new Set([
-  "market_cap",
+const PORTFOLIO_FULL_SNAPSHOT_COLUMN_IDS = new Set([
   "pe",
   "forward_pe",
   "dividend_yield",
+  "sparkline",
 ]);
 const startupLog = debugLog.createLogger("startup");
 
@@ -157,7 +157,7 @@ function buildRefreshPlan(
     const columnIds = Array.isArray(instance.settings?.columnIds)
       ? instance.settings.columnIds.filter((value): value is string => typeof value === "string")
       : [];
-    return columnIds.some((columnId) => PORTFOLIO_FINANCIAL_COLUMN_IDS.has(columnId))
+    return columnIds.some((columnId) => PORTFOLIO_FULL_SNAPSHOT_COLUMN_IDS.has(columnId))
       ? "financials"
       : "quote";
   };


### PR DESCRIPTION
Improves desktop persistence by batching plugin-state writes through the Electrobun backend and expanding `~` paths for config backup import/export.

Tunes portfolio warmups so visible rows fetch quotes first and only request full snapshots when displayed columns need fundamentals or sparklines, while quote-only cached data no longer blocks full snapshot refreshes.

Adds a native developer-tools menu command, removes temporary Electrobun diagnostic mirroring, and hides the Top News rank column by default.