### PR TITLE
Prioritize app matches in command search

### DIFF
--- a/src/components/command-bar/command-bar.test.tsx
+++ b/src/components/command-bar/command-bar.test.tsx
@@ -1276,7 +1276,7 @@ describe("CommandBar", () => {
     );
 
     await testSetup.renderOnce();
-    const frame = await waitForFrameToContain("DES");
+    const frame = await waitForFrameToContain("Exact Match");
     const resultLines = frame
       .split("\n")
       .filter((line) => /\b(AMD|AMDL|AMUU|DES)\b/.test(line) && /\b(NASDAQ|ASX)\b/.test(line));

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -4000,7 +4000,11 @@ export function CommandBar({
     rootResultModel.items,
     rootTickerSearchArg,
   ]);
-  const orderedRootResults = useMemo(() => orderListResults(rootResults), [rootResults]);
+  const rootSectionOrder = rootPlainTickerSearchArg ? "app-first" : "default";
+  const orderedRootResults = useMemo(
+    () => orderListResults(rootResults, { sectionOrder: rootSectionOrder }),
+    [rootResults, rootSectionOrder],
+  );
   const activeRootProviderResultsKey = useMemo(() => {
     if (!rootTickerSearchArg || rootProviderResultsQuery !== rootTickerSearchArg || !rootProviderResults) return null;
     return [
@@ -4316,6 +4320,7 @@ export function CommandBar({
         emptyDetail: emptyState.detail,
         footerLeft: getScreenFooterLeft(null),
         footerRight: getScreenFooterRight(null),
+        sectionOrder: rootSectionOrder,
       };
     }
 
@@ -4463,6 +4468,7 @@ export function CommandBar({
     rootModeInfo.kind,
     rootQuery,
     orderedRootResults,
+    rootSectionOrder,
     rootSearching,
     rootSelectedIdx,
     rootShortcutIntent,

--- a/src/components/command-bar/list-model.ts
+++ b/src/components/command-bar/list-model.ts
@@ -1,4 +1,4 @@
-import { buildSections } from "./view-model";
+import { buildSections, type CommandBarSectionOrder } from "./view-model";
 
 export interface ResultItem {
   id: string;
@@ -31,6 +31,7 @@ export interface ListScreenState {
   emptyDetail: string;
   footerLeft: string;
   footerRight: string;
+  sectionOrder?: CommandBarSectionOrder;
 }
 
 export type CommandBarListRow =
@@ -41,13 +42,16 @@ export type CommandBarListRow =
   | { kind: "spinner"; id: string; label: string }
   | { kind: "filler"; id: string };
 
-export function orderListResults(results: ResultItem[]): ResultItem[] {
-  return buildSections(results).flatMap((section) => section.items);
+export function orderListResults(
+  results: ResultItem[],
+  options?: { sectionOrder?: CommandBarSectionOrder },
+): ResultItem[] {
+  return buildSections(results, options).flatMap((section) => section.items);
 }
 
 export function buildListRows(listState: ListScreenState): CommandBarListRow[] {
   const rows: CommandBarListRow[] = [];
-  const sections = buildSections(listState.results);
+  const sections = buildSections(listState.results, { sectionOrder: listState.sectionOrder });
   let globalIdx = 0;
   sections.forEach((section, sectionIndex) => {
     if (sectionIndex > 0) {

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -47,6 +47,26 @@ describe("command bar view model helpers", () => {
     expect(sections.map((section) => section.category)).toEqual(["Tickers", "Config", "Danger", "Debug"]);
   });
 
+  test("keeps provider ticker suggestions behind app sections in app-first order", () => {
+    const sections = buildSections([
+      { id: "pane", category: "Panes" },
+      { id: "primary", category: "Primary Listing" },
+      { id: "other", category: "Other Listings" },
+      { id: "fund", category: "Funds & Derivatives" },
+      { id: "saved", category: "Saved" },
+      { id: "exact", category: "Exact Match" },
+    ], { sectionOrder: "app-first" });
+
+    expect(sections.map((section) => section.category)).toEqual([
+      "Exact Match",
+      "Saved",
+      "Panes",
+      "Primary Listing",
+      "Other Listings",
+      "Funds & Derivatives",
+    ]);
+  });
+
   test("derives row presentation for toggles and current rows", () => {
     expect(getRowPresentation({
       id: "plugin:news",

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -15,6 +15,8 @@ export interface CommandBarSection<T> {
   items: T[];
 }
 
+export type CommandBarSectionOrder = "default" | "app-first";
+
 export interface CommandBarItemView {
   id: string;
   label: string;
@@ -59,7 +61,10 @@ export function resolveCommandBarMode(query: string, commandList?: Command[]): C
   }
 }
 
-export function buildSections<T extends { category: string }>(items: T[]): Array<CommandBarSection<T>> {
+export function buildSections<T extends { category: string }>(
+  items: T[],
+  options?: { sectionOrder?: CommandBarSectionOrder },
+): Array<CommandBarSection<T>> {
   const sections: Array<CommandBarSection<T>> = [];
   for (const item of items) {
     let section = sections.find((candidate) => candidate.category === item.category);
@@ -72,7 +77,9 @@ export function buildSections<T extends { category: string }>(items: T[]): Array
   return sections
     .map((section, index) => ({ section, index }))
     .sort((a, b) => {
-      const priorityDiff = getCategoryPriority(a.section.category) - getCategoryPriority(b.section.category);
+      const leftPriority = getCategoryPriority(a.section.category, options?.sectionOrder);
+      const rightPriority = getCategoryPriority(b.section.category, options?.sectionOrder);
+      const priorityDiff = leftPriority - rightPriority;
       return priorityDiff !== 0 ? priorityDiff : a.index - b.index;
     })
     .map(({ section }) => section);
@@ -126,10 +133,15 @@ export function truncateText(text: string, width: number): string {
   return `${text.slice(0, width - 3)}...`;
 }
 
-function getCategoryPriority(category: string): number {
+function getCategoryPriority(category: string, sectionOrder: CommandBarSectionOrder = "default"): number {
   const normalized = category.trim().toLowerCase();
   if (normalized === "exact match") return -50;
   if (normalized === "saved") return -40;
+  if (sectionOrder === "app-first") {
+    if (normalized === "primary listing") return 100;
+    if (normalized === "other listings") return 110;
+    if (normalized === "funds & derivatives") return 120;
+  }
   if (normalized === "primary listing") return -30;
   if (normalized === "other listings") return -20;
   if (normalized === "funds & derivatives") return -10;


### PR DESCRIPTION
Plain root command search now keeps exact and saved ticker matches first, then app-level panes and commands, before provider listing suggestions.

This prevents broad provider categories like primary listings, other listings, and funds/derivatives from pushing Portfolio-related panes below ticker-looking rows when typing prefixes such as "portf".

Dedicated ticker-search flows keep their ticker-first grouping, so T and DES still prioritize listings.
