### PR TITLE
Create clean release notes drafts

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Bump version, commit, tag, and push.
-# Called by release.sh after Codex decides the version.
+# Called by release.sh after selecting the version.
 
 usage() {
   cat <<'EOF'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,8 +13,59 @@ Arguments:
 Steps:
 1. Find the latest published GitHub release
 2. Run ./scripts/bump-version.sh <version> to bump, commit, tag, and push
-3. Create a draft GitHub release with generated notes
+3. Create a draft GitHub release with clean notes from commit/PR titles
+4. Edit the draft release before publishing:
+   - Add 3-5 user-facing highlights for substantial releases
+   - Group large releases by area instead of keeping one long flat list
+   - Remove release-only maintenance noise unless it matters to users
+   - Keep PR references as compact #123 links
+   - Never publish generated "by @user in https://..." notes
 EOF
+}
+
+build_release_notes() {
+  local notes_file="$1"
+  local previous_tag="$2"
+  local current_tag="$3"
+  local range="$current_tag"
+  local changes_file
+
+  if [[ -n "$previous_tag" ]]; then
+    range="$previous_tag..$current_tag"
+  fi
+
+  changes_file="$(mktemp "${TMPDIR:-/tmp}/gloomberb-release-changes-$current_tag.XXXXXX")"
+  git log --reverse --format='%s' "$range" \
+    | sed -E "s/[[:space:]]+\\(#([0-9]+)\\)$/ #\\1/" \
+    | awk '
+        /^v[0-9]+\.[0-9]+\.[0-9]+$/ { next }
+        /^Merge pull request #[0-9]+/ { next }
+        /^release script$/ { next }
+        /^Update release automation runner$/ { next }
+        /^Make release script self-contained$/ { next }
+        !seen[$0]++ { print "- " $0 }
+      ' > "$changes_file"
+
+  {
+    cat <<EOF
+## Changes
+
+EOF
+
+    if [[ -s "$changes_file" ]]; then
+      cat "$changes_file"
+    else
+      echo "- Release packaging and maintenance updates."
+    fi
+
+    if [[ -n "$previous_tag" ]]; then
+      printf '\n[Full diff](https://github.com/%s/compare/%s...%s)\n' "$REPO" "$previous_tag" "$current_tag"
+    else
+      printf '\n[Full diff](https://github.com/%s/commits/%s)\n' "$REPO" "$current_tag"
+    fi
+  } > "$notes_file"
+
+  rm -f "$changes_file"
 }
 
 VERSION=""
@@ -83,19 +134,27 @@ fi
 
 ./scripts/bump-version.sh "$VERSION"
 
+NOTES_FILE="$(mktemp "${TMPDIR:-/tmp}/gloomberb-release-notes-$TAG.XXXXXX.md")"
+build_release_notes "$NOTES_FILE" "$LATEST_RELEASE_TAG" "$TAG"
+
 create_args=(
   release create "$TAG"
   --repo "$REPO"
   --draft
   --verify-tag
   --title "$TAG"
-  --generate-notes
+  --notes-file "$NOTES_FILE"
 )
-
-if [[ -n "$LATEST_RELEASE_TAG" ]]; then
-  create_args+=(--notes-start-tag "$LATEST_RELEASE_TAG")
-fi
 
 gh "${create_args[@]}"
 
 echo "Created draft release $TAG. The tag-triggered GitHub Actions workflow will build and upload assets."
+echo
+echo "Clean the draft release before publishing:"
+echo "- Add a Highlights section with 3-5 user-facing bullets for substantial releases."
+echo "- Group a long Changes list by area when the release is large."
+echo "- Remove release-only maintenance noise unless it matters to users."
+echo "- Keep PR references compact, like #123."
+echo "- Do not publish generated author/full-URL notes."
+echo
+echo "Draft notes source: $NOTES_FILE"


### PR DESCRIPTION
## Summary

- Replace GitHub generated release notes with a clean draft notes file built from commit and PR titles.
- Add release-time guidance to add highlights, group large changelogs, remove maintenance noise, and avoid generated author/full-URL notes.
- Clean up a stale release-tooling comment in the version bump script.

## Validation

- `bash -n scripts/release.sh scripts/bump-version.sh`
- `./scripts/release.sh --help`
- `git diff --check`
- Simulated release-note generation for `v0.7.2..v0.7.3`
- Scanned the diff for credential-like values

`scriptcheck`: shellcheck is not installed in this environment.
