### PR TITLE
Refine chart market hours and indicators

### DIFF
--- a/src/components/chart/chart-renderer.ts
+++ b/src/components/chart/chart-renderer.ts
@@ -1,7 +1,17 @@
 import { RGBA } from "../../ui";
-import type { ChartAxisMode, ChartColors, ChartIndicatorOverlays, Pixel, PixelBuffer, ChartRenderMode } from "./chart-types";
+import type {
+  ChartAxisMode,
+  ChartColors,
+  ChartIndicatorOverlays,
+  ChartMarketSession,
+  ChartSessionBackgroundSpan,
+  Pixel,
+  PixelBuffer,
+  ChartRenderMode,
+} from "./chart-types";
 import type { ProjectedChartPoint } from "./chart-data";
 import { formatCompactMarketPriceWithCurrency, formatMarketPrice, resolveAssetDisplayKind } from "../../utils/market-format";
+import { resolveExtendedHoursBackgroundSpans } from "./market-session";
 
 // ---------------------------------------------------------------------------
 // Styled output types (unchanged public API)
@@ -26,7 +36,7 @@ export interface StyledContent {
 const LAYER_GRID = 0;
 const LAYER_FILL = 1;
 const LAYER_DATA = 2;
-const LAYER_OVERLAY = 2;
+const LAYER_OVERLAY = 1;
 const LAYER_CROSSHAIR = 3;
 
 function normalizeCount(value: number, min: number): number {
@@ -135,6 +145,8 @@ export function resolveChartPalette(
     axisColor: baseColors.textDim,
     activeRangeColor: baseColors.text,
     inactiveRangeColor: blendHex(baseColors.bg, baseColors.textDim, 0.75),
+    preMarketBgColor: blendHex(baseColors.bg, "#8a641f", 0.28),
+    postMarketBgColor: blendHex(baseColors.bg, "#7a4624", 0.28),
     candleUp: baseColors.positive,
     candleDown: baseColors.negative,
     wickUp: blendHex(baseColors.positive, baseColors.text, 0.35),
@@ -150,10 +162,12 @@ export function createPixelBuffer(width: number, heightPixels: number): PixelBuf
   const bufferWidth = normalizeCount(width, 0);
   const bufferHeight = normalizeCount(heightPixels, 0);
   const pixels: (Pixel | null)[][] = [];
+  const backgrounds: (string | null)[][] = [];
   for (let y = 0; y < bufferHeight; y++) {
     pixels.push(new Array(bufferWidth).fill(null));
+    backgrounds.push(new Array(bufferWidth).fill(null));
   }
-  return { width: bufferWidth, height: bufferHeight, pixels };
+  return { width: bufferWidth, height: bufferHeight, pixels, backgrounds };
 }
 
 function setPixel(buf: PixelBuffer, x: number, y: number, color: string, layer: number) {
@@ -221,6 +235,27 @@ function fillColumn(buf: PixelBuffer, x: number, y0: number, y1: number, color: 
 function fillRect(buf: PixelBuffer, x0: number, y0: number, x1: number, y1: number, color: string, layer: number) {
   for (let x = Math.min(x0, x1); x <= Math.max(x0, x1); x++) {
     fillColumn(buf, x, y0, y1, color, layer);
+  }
+}
+
+function setBackgroundPixel(buf: PixelBuffer, x: number, y: number, color: string) {
+  const px = Math.round(x);
+  const py = Math.round(y);
+  if (px < 0 || px >= buf.width || py < 0 || py >= buf.height) return;
+  const row = buf.backgrounds[py];
+  if (!row) return;
+  row[px] = color;
+}
+
+function fillBackgroundRect(buf: PixelBuffer, x0: number, y0: number, x1: number, y1: number, color: string) {
+  const left = Math.max(Math.min(Math.round(x0), Math.round(x1)), 0);
+  const right = Math.min(Math.max(Math.round(x0), Math.round(x1)), Math.max(buf.width - 1, 0));
+  const top = Math.max(Math.min(Math.round(y0), Math.round(y1)), 0);
+  const bottom = Math.min(Math.max(Math.round(y0), Math.round(y1)), Math.max(buf.height - 1, 0));
+  for (let y = top; y <= bottom; y += 1) {
+    for (let x = left; x <= right; x += 1) {
+      setBackgroundPixel(buf, x, y, color);
+    }
   }
 }
 
@@ -327,6 +362,38 @@ function getPointDotX(index: number, pointCount: number, width: number, mode: Ch
 export function getPointTerminalColumn(index: number, pointCount: number, width: number, mode: ChartRenderMode): number {
   if (width <= 1) return 0;
   return Math.min(Math.max(Math.floor(getPointDotX(index, pointCount, width, mode) / 2), 0), width - 1);
+}
+
+function getTimePointBand(index: number, pointCount: number, width: number): { left: number; right: number } {
+  const currentX = getSeriesPosition(index, pointCount, width);
+  const previousX = index > 0 ? getSeriesPosition(index - 1, pointCount, width) : currentX;
+  const nextX = index < pointCount - 1 ? getSeriesPosition(index + 1, pointCount, width) : currentX;
+  return {
+    left: index === 0 ? 0 : Math.floor((previousX + currentX) / 2) + 1,
+    right: index === pointCount - 1 ? Math.max(width - 1, 0) : Math.floor((currentX + nextX) / 2),
+  };
+}
+
+function getSessionBackgroundColor(span: ChartSessionBackgroundSpan, colors: ChartColors): string {
+  return span.kind === "pre" ? colors.preMarketBgColor : colors.postMarketBgColor;
+}
+
+function drawSessionBackgrounds(
+  buf: PixelBuffer,
+  points: ProjectedChartPoint[],
+  spans: readonly ChartSessionBackgroundSpan[],
+  yTop: number,
+  yBottom: number,
+  colors: ChartColors,
+) {
+  if (spans.length === 0 || points.length === 0) return;
+  for (const span of spans) {
+    const startIndex = Math.max(Math.min(span.startIndex, points.length - 1), 0);
+    const endIndex = Math.max(Math.min(span.endIndex, points.length - 1), startIndex);
+    const startBand = getTimePointBand(startIndex, points.length, buf.width);
+    const endBand = getTimePointBand(endIndex, points.length, buf.width);
+    fillBackgroundRect(buf, startBand.left, yTop, endBand.right, yBottom, getSessionBackgroundColor(span, colors));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -573,14 +640,19 @@ export function bufferToBrailleLines(buf: PixelBuffer): StyledContent[] {
       let topLayer = -1;
 
       // Track dots per layer so we can render only the top layer's dots
-      const dotsByLayer: Map<number, number> = new Map(); // layer → braille bits
+      const dotsByLayer: Map<number, number> = new Map(); // layer -> braille bits
       const colorByLayer: Map<number, Map<string, number>> = new Map();
+      const backgroundCounts: Map<string, number> = new Map();
 
       for (let dy = 0; dy < 4; dy++) {
         for (let dx = 0; dx < 2; dx++) {
           const px = col * 2 + dx;
           const py = row * 4 + dy;
           if (px >= buf.width || py >= buf.height) continue;
+          const bg = buf.backgrounds[py]?.[px] ?? null;
+          if (bg) {
+            backgroundCounts.set(bg, (backgroundCounts.get(bg) || 0) + 1);
+          }
           const pixel = buf.pixels[py]?.[px] ?? null;
           if (pixel) {
             const bit = BRAILLE_DOT[dy]![dx]!;
@@ -598,14 +670,19 @@ export function bufferToBrailleLines(buf: PixelBuffer): StyledContent[] {
       let char: string;
       let cellFg: string | undefined;
       let cellBg: string | undefined;
+      let bestBackgroundCount = 0;
+      for (const [bg, count] of backgroundCounts) {
+        if (count > bestBackgroundCount) {
+          bestBackgroundCount = count;
+          cellBg = bg;
+        }
+      }
 
       if (topLayer < 0) {
         char = " ";
         cellFg = undefined;
-        cellBg = undefined;
       } else {
-        // Only show dots from the highest layer — keeps lines thin in mixed
-        // cells (e.g. area chart where line and fill overlap).
+        // Only show dots from the highest layer so lines stay thin in mixed cells.
         const pattern = dotsByLayer.get(topLayer) || 0;
         char = String.fromCharCode(BRAILLE_BASE + pattern);
 
@@ -617,7 +694,6 @@ export function bufferToBrailleLines(buf: PixelBuffer): StyledContent[] {
         }
 
         cellFg = topColor;
-        cellBg = undefined;
       }
 
       if (char === runChar && cellFg === runFg && cellBg === runBg) {
@@ -823,6 +899,10 @@ function formatClockTime(date: Date, unit: AxisLabelUnit): string {
   }
 }
 
+function formatFullCalendarDate(date: Date): string {
+  return `${MONTHS[date.getMonth()]} ${date.getDate()} ${date.getFullYear()}`;
+}
+
 function isSameCalendarDay(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear()
     && a.getMonth() === b.getMonth()
@@ -985,6 +1065,10 @@ function formatCursorTimeAxisValue(
   const minGapMs = getMinPositiveGapMs(validDates);
   const effectiveStepMs = Math.max(spanMs / Math.max(roughLabelCount - 1, 1), minGapMs || 0);
   const unit = resolveAxisLabelUnit(effectiveStepMs);
+  if (unit === "year" || unit === "month") {
+    return formatFullCalendarDate(date);
+  }
+
   const counterpart = isSameCalendarDay(first, last)
     ? first
     : isSameCalendarDay(date, first)
@@ -1152,6 +1236,7 @@ export interface RenderChartOptions {
   colors: ResolvedChartPalette;
   timeAxisDates?: Array<Date | string | number>;
   indicators?: ChartIndicatorOverlays | null;
+  marketSession?: ChartMarketSession | null;
 }
 
 export interface ChartScene {
@@ -1164,6 +1249,7 @@ export interface ChartScene {
   mode: ChartRenderMode;
   colors: ResolvedChartPalette;
   indicators: ChartIndicatorOverlays | null;
+  sessionBackgroundSpans: ChartSessionBackgroundSpan[];
   min: number;
   max: number;
   activeIdx: number;
@@ -1225,27 +1311,6 @@ export function getActivePointIndex(
   return bestIndex;
 }
 
-function getIndicatorOverlayValues(indicators: ChartIndicatorOverlays | null | undefined): number[] {
-  if (!indicators) return [];
-
-  const values: number[] = [];
-  for (const line of indicators.smaLines) {
-    values.push(...line.points.map((point) => point.value));
-  }
-  for (const line of indicators.emaLines) {
-    values.push(...line.points.map((point) => point.value));
-  }
-  if (indicators.bollinger) {
-    values.push(
-      ...indicators.bollinger.upper.map((point) => point.value),
-      ...indicators.bollinger.middle.map((point) => point.value),
-      ...indicators.bollinger.lower.map((point) => point.value),
-    );
-  }
-
-  return values.filter((value) => Number.isFinite(value));
-}
-
 export function buildChartScene(
   points: ProjectedChartPoint[],
   opts: RenderChartOptions,
@@ -1259,9 +1324,8 @@ export function buildChartScene(
   const dataMax = isHighLowMode(opts.mode)
     ? Math.max(...points.map((point) => point.high))
     : Math.max(...points.map((point) => point.close));
-  const indicatorValues = getIndicatorOverlayValues(opts.indicators);
-  const min = indicatorValues.length > 0 ? Math.min(dataMin, ...indicatorValues) : dataMin;
-  const max = indicatorValues.length > 0 ? Math.max(dataMax, ...indicatorValues) : dataMax;
+  const min = dataMin;
+  const max = dataMax;
   const activeIdx = getActivePointIndex(points.length, dimensions.width, opts.cursorX, opts.mode);
   const activePoint = points[activeIdx]!;
   const range = max - min || 1;
@@ -1290,6 +1354,10 @@ export function buildChartScene(
     : max - (cursorY / Math.max(dimensions.chartRows - 1, 1)) * range;
 
   const timeAxisDates = opts.timeAxisDates ?? points.map((point) => point.date);
+  const sessionBackgroundSpans = resolveExtendedHoursBackgroundSpans(
+    points.map((point) => point.date),
+    opts.marketSession,
+  );
 
   return {
     points,
@@ -1301,6 +1369,7 @@ export function buildChartScene(
     mode: opts.mode,
     colors: opts.colors,
     indicators: opts.indicators ?? null,
+    sessionBackgroundSpans,
     min,
     max,
     activeIdx,
@@ -1412,6 +1481,14 @@ export function renderChart(
       getAxisFractionDigitFloor(assetCategory, priceRange),
     )
     : null;
+  drawSessionBackgrounds(
+    buf,
+    points,
+    scene.sessionBackgroundSpans,
+    0,
+    showVolume ? volDotBottom : chartDotBottom,
+    palette,
+  );
   drawGridLines(buf, gridLines.map((line) => line.y), palette.gridColor);
 
   switch (mode) {

--- a/src/components/chart/chart-types.ts
+++ b/src/components/chart/chart-types.ts
@@ -7,6 +7,7 @@ export type ChartAxisMode = "price" | "percent";
 export type ChartRendererPreference = "auto" | "kitty" | "braille";
 export type ResolvedChartRenderer = "kitty" | "braille";
 export type ComparisonChartRenderMode = "area" | "line";
+export type ChartSessionBackgroundKind = "pre" | "post";
 
 export const TIME_RANGES: TimeRange[] = ["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
 export const CHART_RENDER_MODES: ChartRenderMode[] = ["area", "line", "candles", "ohlc", "hlc"];
@@ -46,6 +47,7 @@ export interface PixelBuffer {
   width: number;
   height: number; // virtual pixel rows (4x terminal rows for braille rendering)
   pixels: (Pixel | null)[][]; // [y][x] = pixel with color and layer, or null
+  backgrounds: (string | null)[][];
 }
 
 export interface ChartColors {
@@ -59,6 +61,22 @@ export interface ChartColors {
   axisColor: string;
   activeRangeColor: string;
   inactiveRangeColor: string;
+  preMarketBgColor: string;
+  postMarketBgColor: string;
+}
+
+export interface ChartMarketSession {
+  timeZone: string;
+  regularStartMinutes: number;
+  regularEndMinutes: number;
+  preMarketStartMinutes: number;
+  postMarketEndMinutes: number;
+}
+
+export interface ChartSessionBackgroundSpan {
+  kind: ChartSessionBackgroundKind;
+  startIndex: number;
+  endIndex: number;
 }
 
 export interface VisibleWindow {

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -7,8 +7,9 @@ import {
 } from "./chart-data";
 import { stepCursorTowards } from "./cursor-motion";
 import { buildChartScene, buildCursorTimeAxisSegments, buildTimeAxis, formatAxisValue, formatCursorAxisValue, renderChart, resolveChartAxisWidth, resolveChartPalette } from "./chart-renderer";
-import { buildCursorTimeAxisOverlay } from "./time-axis-label";
+import { buildCursorTimeAxisOverlay, resolveCursorDateFromAxis } from "./time-axis-label";
 import { buildCursorPriceAxisOverlay } from "./price-axis-labels";
+import { resolveChartMarketSession, resolveExtendedHoursBackgroundSpans } from "./market-session";
 import type { PricePoint } from "../../types/financials";
 import type { ChartRenderMode } from "./chart-types";
 
@@ -280,9 +281,19 @@ describe("renderChart", () => {
     expect(result.axisLabels.every((entry) => entry.label.includes("."))).toBe(true);
   });
 
-  test("includes visible indicator overlays in the chart price range", () => {
+  test("keeps indicator overlays out of the chart price range", () => {
     const projection = projectChartData(chartFixture, 12, "line", false);
-    const scene = buildChartScene(projection.points, {
+    const baseScene = buildChartScene(projection.points, {
+      width: 12,
+      height: 6,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: projection.effectiveMode,
+      colors: palette,
+    });
+    const sceneWithIndicators = buildChartScene(projection.points, {
       width: 12,
       height: 6,
       showVolume: false,
@@ -300,6 +311,63 @@ describe("renderChart", () => {
             { index: 1, value: 18 },
           ],
         }],
+        emaLines: [{
+          period: 2,
+          color: "#00ffff",
+          points: [
+            { index: 0, value: 4 },
+            { index: 1, value: 20 },
+          ],
+        }],
+        bollinger: {
+          color: "#ffaa00",
+          upper: [
+            { index: 0, value: 22 },
+            { index: 1, value: 23 },
+          ],
+          middle: [
+            { index: 0, value: 14 },
+            { index: 1, value: 15 },
+          ],
+          lower: [
+            { index: 0, value: 3 },
+            { index: 1, value: 4 },
+          ],
+        },
+        rsi: null,
+        macd: null,
+      },
+    });
+
+    expect(sceneWithIndicators?.min).toBe(baseScene?.min);
+    expect(sceneWithIndicators?.max).toBe(baseScene?.max);
+  });
+
+  test("draws indicator overlays below price pixels", () => {
+    const points: PricePoint[] = [
+      { date: new Date("2024-01-02"), close: 10, volume: 100 },
+      { date: new Date("2024-01-03"), close: 11, volume: 120 },
+      { date: new Date("2024-01-04"), close: 12, volume: 140 },
+    ];
+    const result = renderChart(points, {
+      width: 12,
+      height: 6,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "line",
+      colors: palette,
+      indicators: {
+        smaLines: [{
+          period: 2,
+          color: "#ff00ff",
+          points: [
+            { index: 0, value: 10 },
+            { index: 1, value: 11 },
+            { index: 2, value: 12 },
+          ],
+        }],
         emaLines: [],
         bollinger: null,
         rsi: null,
@@ -307,8 +375,9 @@ describe("renderChart", () => {
       },
     });
 
-    expect(scene?.min).toBe(6);
-    expect(scene?.max).toBe(18);
+    const pixels = result.pixelBuffer?.pixels.flat().filter(Boolean) ?? [];
+    expect(pixels.some((pixel) => pixel?.color === palette.lineColor)).toBe(true);
+    expect(pixels.some((pixel) => pixel?.color === "#ff00ff")).toBe(false);
   });
 
   test("normalizes fractional web dimensions before drawing volume bars", () => {
@@ -434,6 +503,31 @@ describe("renderChart", () => {
     expect(segments.find((segment) => segment.highlighted)?.text).toBe("12:30");
   });
 
+  test("keeps day precision for cursor labels when the axis coarsens to months", () => {
+    const dates = Array.from({ length: 12 }, (_, index) => new Date(2025, index, 1));
+    const width = 48;
+    const segments = buildCursorTimeAxisSegments({
+      timeLabels: buildTimeAxis(dates, width),
+      width,
+      cursorColumn: 27,
+      cursorDate: new Date(2025, 8, 15),
+      dates,
+    });
+
+    expect(segments.find((segment) => segment.highlighted)?.text).toBe("Sep 15 2025");
+  });
+
+  test("resolves cursor dates from the full source axis between coarse month ticks", () => {
+    const dates = Array.from({ length: 32 }, (_, index) => new Date(2025, 2, index + 1));
+    const resolved = resolveCursorDateFromAxis({
+      dates,
+      width: 32,
+      cursorColumn: 15,
+    });
+
+    expect(resolved?.toISOString()).toBe(dates[15]!.toISOString());
+  });
+
   test("positions desktop cursor x-axis overlay from exact pixels", () => {
     const dates = Array.from({ length: 13 }, (_, index) => new Date(2026, 0, 5, 9, 30 + index * 30));
     const width = 72;
@@ -497,6 +591,59 @@ describe("renderChart", () => {
 
     expect(buildTimeAxis(monthlyDates, 48)).toBe("Jan 2025        May          Aug        Dec 2025");
     expect(buildTimeAxis(yearlyDates, 48)).toBe("2020   2021      2022     2023      2024    2025");
+  });
+
+  test("marks US premarket and postmarket bars for chart backgrounds", () => {
+    const session = resolveChartMarketSession([{ exchange: "NASDAQ", currency: "USD", assetCategory: "STK" }]);
+    const dates = [
+      new Date("2026-05-14T11:00:00Z"),
+      new Date("2026-05-14T14:00:00Z"),
+      new Date("2026-05-14T20:30:00Z"),
+    ];
+
+    expect(resolveExtendedHoursBackgroundSpans(dates, session)).toEqual([
+      { kind: "pre", startIndex: 0, endIndex: 0 },
+      { kind: "post", startIndex: 2, endIndex: 2 },
+    ]);
+  });
+
+  test("omits extended-hours backgrounds for wide intraday windows", () => {
+    const session = resolveChartMarketSession([{ exchange: "NASDAQ", currency: "USD", assetCategory: "STK" }]);
+    const dates = Array.from({ length: 12 }).flatMap((_, dayIndex) => {
+      const day = 4 + dayIndex;
+      return [
+        new Date(Date.UTC(2026, 4, day, 11, 0)),
+        new Date(Date.UTC(2026, 4, day, 14, 0)),
+        new Date(Date.UTC(2026, 4, day, 20, 30)),
+      ];
+    });
+
+    expect(resolveExtendedHoursBackgroundSpans(dates, session)).toEqual([]);
+  });
+
+  test("paints extended-hours chart cells as background colors", () => {
+    const session = resolveChartMarketSession([{ exchange: "NASDAQ", currency: "USD", assetCategory: "STK" }]);
+    const points: PricePoint[] = [
+      { date: new Date("2026-05-14T11:00:00Z"), close: 10, volume: 100 },
+      { date: new Date("2026-05-14T14:00:00Z"), close: 12, volume: 120 },
+      { date: new Date("2026-05-14T20:30:00Z"), close: 11, volume: 110 },
+    ];
+
+    const result = renderChart(points, {
+      width: 12,
+      height: 4,
+      showVolume: false,
+      volumeHeight: 0,
+      cursorX: null,
+      cursorY: null,
+      mode: "line",
+      colors: palette,
+      marketSession: session,
+    });
+
+    const backgrounds = result.lines.flatMap((line) => line.chunks.map((chunk) => chunk.bg));
+    expect(backgrounds).toContain(palette.preMarketBgColor);
+    expect(backgrounds).toContain(palette.postMarketBgColor);
   });
 
   test("uses source time-axis dates instead of projected extrema dates when provided", () => {

--- a/src/components/chart/comparison-chart-renderer.test.ts
+++ b/src/components/chart/comparison-chart-renderer.test.ts
@@ -8,6 +8,14 @@ import {
 } from "./comparison-chart-renderer";
 import type { ComparisonChartSeries } from "./chart-types";
 
+const comparisonColors = {
+  bgColor: "#000000",
+  gridColor: "#333333",
+  crosshairColor: "#ffffff",
+  preMarketBgColor: "#001b44",
+  postMarketBgColor: "#442300",
+};
+
 function makeSeries(symbol: string, color: string, closes: number[]): ComparisonChartSeries {
   return {
     symbol,
@@ -51,11 +59,7 @@ describe("renderComparisonChart", () => {
       cursorX: null,
       cursorY: null,
       selectedSymbol: "AAPL",
-      colors: {
-        bgColor: "#000000",
-        gridColor: "#333333",
-        crosshairColor: "#ffffff",
-      },
+      colors: comparisonColors,
     });
 
     expect(result.axisFractionDigits).toBeGreaterThanOrEqual(1);
@@ -78,11 +82,7 @@ describe("renderComparisonChart", () => {
       cursorX: null,
       cursorY: null,
       selectedSymbol: "AAPL",
-      colors: {
-        bgColor: "#000000",
-        gridColor: "#333333",
-        crosshairColor: "#ffffff",
-      },
+      colors: comparisonColors,
     });
 
     expect(result.axisFractionDigits).toBe(1);
@@ -105,11 +105,7 @@ describe("renderComparisonChart", () => {
       cursorX: 5,
       cursorY: null,
       selectedSymbol: "MSFT",
-      colors: {
-        bgColor: "#000000",
-        gridColor: "#333333",
-        crosshairColor: "#ffffff",
-      },
+      colors: comparisonColors,
     });
 
     expect(result.lines).toHaveLength(6);
@@ -134,11 +130,7 @@ describe("renderComparisonChart", () => {
       cursorX: null,
       cursorY: null,
       selectedSymbol: "AAPL",
-      colors: {
-        bgColor: "#000000",
-        gridColor: "#333333",
-        crosshairColor: "#ffffff",
-      },
+      colors: comparisonColors,
     });
 
     expect(result.lines.length).toBeGreaterThan(0);
@@ -160,11 +152,7 @@ describe("renderComparisonChart", () => {
       cursorX: null,
       cursorY: null,
       selectedSymbol: "AAPL",
-      colors: {
-        bgColor: "#000000",
-        gridColor: "#333333",
-        crosshairColor: "#ffffff",
-      },
+      colors: comparisonColors,
     });
 
     const chunks = result.lines.flatMap((line) => line.chunks);
@@ -188,11 +176,7 @@ describe("renderComparisonChart", () => {
       cursorX: 9,
       cursorY: null,
       selectedSymbol: "NVDA",
-      colors: {
-        bgColor: "#000000",
-        gridColor: "#333333",
-        crosshairColor: "#ffffff",
-      },
+      colors: comparisonColors,
     });
 
     expect(scene).not.toBeNull();

--- a/src/components/chart/comparison-chart-renderer.ts
+++ b/src/components/chart/comparison-chart-renderer.ts
@@ -15,10 +15,12 @@ import {
   resolveAxisFractionDigits,
   type StyledContent,
 } from "./chart-renderer";
-import type { ChartAxisMode, ComparisonChartRenderMode } from "./chart-types";
+import type { ChartAxisMode, ChartColors, ChartMarketSession, ChartSessionBackgroundSpan, ComparisonChartRenderMode } from "./chart-types";
+import { resolveExtendedHoursBackgroundSpans } from "./market-session";
 
 const LAYER_FILL = 1;
 const LAYER_DATA = 2;
+type ComparisonChartColors = Pick<ChartColors, "bgColor" | "gridColor" | "crosshairColor" | "preMarketBgColor" | "postMarketBgColor">;
 
 export interface ComparisonChartScene {
   dates: Date[];
@@ -29,11 +31,8 @@ export interface ComparisonChartScene {
   mode: ComparisonChartRenderMode;
   axisMode: ChartAxisMode;
   selectedSymbol: string | null;
-  colors: {
-    bgColor: string;
-    gridColor: string;
-    crosshairColor: string;
-  };
+  colors: ComparisonChartColors;
+  sessionBackgroundSpans: ChartSessionBackgroundSpan[];
   min: number;
   max: number;
   activeIdx: number;
@@ -55,11 +54,8 @@ export interface RenderComparisonChartOptions {
   cursorX: number | null;
   cursorY: number | null;
   selectedSymbol: string | null;
-  colors: {
-    bgColor: string;
-    gridColor: string;
-    crosshairColor: string;
-  };
+  colors: ComparisonChartColors;
+  marketSession?: ChartMarketSession | null;
 }
 
 export interface RenderComparisonChartResult {
@@ -88,6 +84,16 @@ function normalizeCount(value: number, min: number): number {
 function getComparisonDotX(index: number, count: number, width: number): number {
   if (count <= 1) return Math.round(Math.max(width - 1, 0) / 2);
   return Math.round((index / (count - 1)) * Math.max(width - 1, 0));
+}
+
+function getComparisonPointBand(index: number, pointCount: number, width: number): { left: number; right: number } {
+  const currentX = getComparisonDotX(index, pointCount, width);
+  const previousX = index > 0 ? getComparisonDotX(index - 1, pointCount, width) : currentX;
+  const nextX = index < pointCount - 1 ? getComparisonDotX(index + 1, pointCount, width) : currentX;
+  return {
+    left: index === 0 ? 0 : Math.floor((previousX + currentX) / 2) + 1,
+    right: index === pointCount - 1 ? Math.max(width - 1, 0) : Math.floor((currentX + nextX) / 2),
+  };
 }
 
 function getScaledY(value: number, min: number, max: number, chartTop: number, chartBottom: number): number {
@@ -223,6 +229,29 @@ function drawComparisonAreaSeries(
   }
 }
 
+function drawSessionBackgrounds(
+  buf: ReturnType<typeof createPixelBuffer>,
+  spans: readonly ChartSessionBackgroundSpan[],
+  pointCount: number,
+  yTop: number,
+  yBottom: number,
+  colors: ComparisonChartColors,
+) {
+  if (spans.length === 0 || pointCount === 0) return;
+  for (const span of spans) {
+    const startIndex = Math.max(Math.min(span.startIndex, pointCount - 1), 0);
+    const endIndex = Math.max(Math.min(span.endIndex, pointCount - 1), startIndex);
+    const startBand = getComparisonPointBand(startIndex, pointCount, buf.width);
+    const endBand = getComparisonPointBand(endIndex, pointCount, buf.width);
+    const color = span.kind === "pre" ? colors.preMarketBgColor : colors.postMarketBgColor;
+    for (let y = Math.max(yTop, 0); y <= Math.min(yBottom, Math.max(buf.height - 1, 0)); y += 1) {
+      for (let x = Math.max(startBand.left, 0); x <= Math.min(endBand.right, Math.max(buf.width - 1, 0)); x += 1) {
+        buf.backgrounds[y]![x] = color;
+      }
+    }
+  }
+}
+
 function getActiveIndex(pointCount: number, width: number, cursorX: number | null): number {
   if (pointCount <= 0) return 0;
   if (cursorX === null || cursorX < 0 || cursorX >= width) {
@@ -294,6 +323,7 @@ export function buildComparisonChartScene(
   const crosshairValue = cursorY === null
     ? null
     : max - (cursorY / Math.max(chartRows - 1, 1)) * range;
+  const sessionBackgroundSpans = resolveExtendedHoursBackgroundSpans(projection.dates, opts.marketSession);
 
   return {
     dates: projection.dates,
@@ -305,6 +335,7 @@ export function buildComparisonChartScene(
     axisMode: projection.effectiveAxisMode,
     selectedSymbol: selectedSeries?.symbol ?? null,
     colors: opts.colors,
+    sessionBackgroundSpans,
     min,
     max,
     activeIdx,
@@ -354,6 +385,14 @@ export function renderComparisonChart(
       getComparisonAxisFractionDigitFloor(priceRange),
     )
     : null;
+  drawSessionBackgrounds(
+    buf,
+    scene.sessionBackgroundSpans,
+    scene.dates.length,
+    0,
+    chartDotBottom,
+    scene.colors,
+  );
   drawGridLines(buf, gridLines.map((line) => line.y), scene.colors.gridColor);
 
   const selectedSeries = getSelectedSeries(scene.series, scene.selectedSymbol);

--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -98,6 +98,7 @@ import {
 import { resolveChartAxisWidth, type StyledContent } from "./chart-renderer";
 import { TimeAxisLabel } from "./time-axis-label";
 import { PriceAxisLabels } from "./price-axis-labels";
+import { getChartMarketSessionKey, resolveChartMarketSession } from "./market-session";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
   area: "A",
@@ -392,6 +393,7 @@ function buildComparisonNativeBitmapKey(
   pixelWidth: number,
   pixelHeight: number,
   paletteKey: string,
+  marketSessionKey: string,
 ): string {
   const fingerprint = projection.series
     .map((series) => [
@@ -412,6 +414,7 @@ function buildComparisonNativeBitmapKey(
     pixelWidth,
     pixelHeight,
     paletteKey,
+    marketSessionKey,
     fingerprint,
   ].join("::");
 }
@@ -598,7 +601,16 @@ function ComparisonStockChartView({
     bgColor: colors.bg,
     gridColor: blendHex(colors.bg, colors.border, 0.55),
     crosshairColor: colors.borderFocused,
+    preMarketBgColor: blendHex(colors.bg, "#1d4ed8", 0.18),
+    postMarketBgColor: blendHex(colors.bg, "#b45309", 0.18),
   }), [colors.bg, colors.border, colors.borderFocused]);
+  const marketSession = useMemo(() => resolveChartMarketSession(symbolSources.map((source) => ({
+    exchange: source.exchange,
+    primaryExchange: source.instrument?.primaryExchange,
+    currency: source.currency,
+    assetCategory: source.instrument?.secType,
+  }))), [symbolSources]);
+  const marketSessionKey = useMemo(() => getChartMarketSessionKey(marketSession), [marketSession]);
 
   const setSelectedSymbol = (symbol: string) => {
     setViewState((current) => (
@@ -1088,7 +1100,8 @@ function ComparisonStockChartView({
     cursorY: null,
     selectedSymbol: viewState.selectedSymbol,
     colors: chartColors,
-  }), [chartColors, chartHeight, chartWidth, projection, viewState.selectedSymbol]);
+    marketSession,
+  }), [chartColors, chartHeight, chartWidth, marketSession, projection, viewState.selectedSymbol]);
   const displayScene = useMemo(() => buildComparisonChartScene(projection, {
     width: chartWidth,
     height: chartHeight,
@@ -1096,7 +1109,8 @@ function ComparisonStockChartView({
     cursorY: displayCursorY,
     selectedSymbol: viewState.selectedSymbol,
     colors: chartColors,
-  }), [chartColors, chartHeight, chartWidth, displayCursorX, displayCursorY, projection, viewState.selectedSymbol]);
+    marketSession,
+  }), [chartColors, chartHeight, chartWidth, displayCursorX, displayCursorY, marketSession, projection, viewState.selectedSymbol]);
 
   const staticResult = useMemo(() => renderComparisonChart(projection, {
     width: chartWidth,
@@ -1105,7 +1119,8 @@ function ComparisonStockChartView({
     cursorY: null,
     selectedSymbol: viewState.selectedSymbol,
     colors: chartColors,
-  }), [chartColors, chartHeight, chartWidth, projection, viewState.selectedSymbol]);
+    marketSession,
+  }), [chartColors, chartHeight, chartWidth, marketSession, projection, viewState.selectedSymbol]);
 
   const interactiveResult = useMemo(() => (
     effectiveRenderer === "kitty" || useCanvasChart
@@ -1117,8 +1132,9 @@ function ComparisonStockChartView({
         cursorY: displayCursorY,
         selectedSymbol: viewState.selectedSymbol,
         colors: chartColors,
+        marketSession,
       })
-  ), [chartColors, chartHeight, chartWidth, displayCursorX, displayCursorY, effectiveRenderer, projection, useCanvasChart, viewState.selectedSymbol]);
+  ), [chartColors, chartHeight, chartWidth, displayCursorX, displayCursorY, effectiveRenderer, marketSession, projection, useCanvasChart, viewState.selectedSymbol]);
 
   const result = effectiveRenderer === "kitty" || useCanvasChart ? staticResult : interactiveResult!;
   const timeAxisLabel = result.timeLabels || staticResult.timeLabels;
@@ -1282,7 +1298,14 @@ function ComparisonStockChartView({
       viewState.selectedSymbol,
       bitmapSize.pixelWidth,
       bitmapSize.pixelHeight,
-      [chartColors.bgColor, chartColors.gridColor, chartColors.crosshairColor].join(","),
+      [
+        chartColors.bgColor,
+        chartColors.gridColor,
+        chartColors.crosshairColor,
+        chartColors.preMarketBgColor,
+        chartColors.postMarketBgColor,
+      ].join(","),
+      marketSessionKey,
     );
     const cachedBitmap = lastNativeBaseBitmapRef.current?.key === bitmapKey
       ? lastNativeBaseBitmapRef.current.bitmap
@@ -1312,7 +1335,10 @@ function ComparisonStockChartView({
     chartColors.bgColor,
     chartColors.crosshairColor,
     chartColors.gridColor,
+    chartColors.postMarketBgColor,
+    chartColors.preMarketBgColor,
     effectiveRenderer,
+    marketSessionKey,
     nativeSurfaceManager,
     paneId,
     projection,
@@ -1685,9 +1711,10 @@ function ComparisonStockChartView({
         cursorY: null,
         selectedSymbol: viewState.selectedSymbol,
         colors: chartColors,
+        marketSession,
       })
       : null
-  ), [canvasBitmapSize?.pixelWidth, canvasProjection, chartColors, chartHeight, chartWidth, viewState.selectedSymbol]);
+  ), [canvasBitmapSize?.pixelWidth, canvasProjection, chartColors, chartHeight, chartWidth, marketSession, viewState.selectedSymbol]);
 
   const canvasBaseBitmapKey = useMemo(() => {
     if (!canvasBitmapSize || !canvasProjection || !hasChartData || isBlockingBody || bodyMessage) return null;
@@ -1697,7 +1724,14 @@ function ComparisonStockChartView({
       viewState.selectedSymbol,
       canvasBitmapSize.pixelWidth,
       canvasBitmapSize.pixelHeight,
-      [chartColors.bgColor, chartColors.gridColor, chartColors.crosshairColor].join(","),
+      [
+        chartColors.bgColor,
+        chartColors.gridColor,
+        chartColors.crosshairColor,
+        chartColors.preMarketBgColor,
+        chartColors.postMarketBgColor,
+      ].join(","),
+      marketSessionKey,
     );
   }, [
     bodyMessage,
@@ -1706,8 +1740,11 @@ function ComparisonStockChartView({
     chartColors.bgColor,
     chartColors.crosshairColor,
     chartColors.gridColor,
+    chartColors.postMarketBgColor,
+    chartColors.preMarketBgColor,
     hasChartData,
     isBlockingBody,
+    marketSessionKey,
     symbols.length,
     viewState.selectedSymbol,
   ]);
@@ -1922,7 +1959,7 @@ function ComparisonStockChartView({
           cursorColumn={cursorTimeAxisColumn}
           cursorPixelX={hasDisplayCursor ? displayCursor.pixelX : null}
           cursorDate={cursorTimeAxisDate}
-          dates={projection.dates}
+          dates={visibleWindow.dates}
           cursorColor={chartColors.crosshairColor}
         />
       </Box>

--- a/src/components/chart/market-session.ts
+++ b/src/components/chart/market-session.ts
@@ -1,0 +1,187 @@
+import type { ChartMarketSession, ChartSessionBackgroundKind, ChartSessionBackgroundSpan } from "./chart-types";
+
+const INTRADAY_SESSION_GAP_MS = 6 * 60 * 60_000;
+const MAX_SESSION_BACKGROUND_WINDOW_MS = 10 * 24 * 60 * 60_000;
+
+const US_EXTENDED_HOURS_SESSION: ChartMarketSession = {
+  timeZone: "America/New_York",
+  preMarketStartMinutes: 4 * 60,
+  regularStartMinutes: 9 * 60 + 30,
+  regularEndMinutes: 16 * 60,
+  postMarketEndMinutes: 20 * 60,
+};
+
+const US_EXCHANGE_PATTERN = /\b(NASDAQ|NYSE|AMEX|ARCA|BATS|IEX|NMS|XNAS|XNYS|ARCX|XASE|NYSEARCA|NASDAQGS|NASDAQGM|NASDAQCM)\b/i;
+const EQUITY_LIKE_ASSET_CATEGORIES = new Set(["", "STK", "ETF", "ADR", "EQUITY"]);
+
+interface MarketSessionSource {
+  exchange?: string | null;
+  primaryExchange?: string | null;
+  currency?: string | null;
+  assetCategory?: string | null;
+}
+
+interface ZonedDateTime {
+  dayKey: string;
+  minutes: number;
+}
+
+const zonedFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getZonedFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = zonedFormatterCache.get(timeZone);
+  if (cached) return cached;
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  zonedFormatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+function normalizeDate(value: Date | string | number): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getMinPositiveGapMs(dates: readonly Date[]): number {
+  let minGapMs = Number.POSITIVE_INFINITY;
+  for (let index = 1; index < dates.length; index += 1) {
+    const gapMs = Math.abs(dates[index]!.getTime() - dates[index - 1]!.getTime());
+    if (gapMs > 0 && gapMs < minGapMs) {
+      minGapMs = gapMs;
+    }
+  }
+  return Number.isFinite(minGapMs) ? minGapMs : 0;
+}
+
+function isIntradaySeries(dates: readonly Date[]): boolean {
+  if (dates.length < 2) return false;
+  const minGapMs = getMinPositiveGapMs(dates);
+  return minGapMs > 0 && minGapMs <= INTRADAY_SESSION_GAP_MS;
+}
+
+function getDateSpanMs(dates: readonly Date[]): number {
+  let minTime = Number.POSITIVE_INFINITY;
+  let maxTime = Number.NEGATIVE_INFINITY;
+  for (const date of dates) {
+    const time = date.getTime();
+    if (time < minTime) minTime = time;
+    if (time > maxTime) maxTime = time;
+  }
+  return Number.isFinite(minTime) && Number.isFinite(maxTime) ? maxTime - minTime : 0;
+}
+
+function shouldShowSessionBackgrounds(dates: readonly Date[]): boolean {
+  return isIntradaySeries(dates) && getDateSpanMs(dates) <= MAX_SESSION_BACKGROUND_WINDOW_MS;
+}
+
+function getZonedDateTime(date: Date, timeZone: string): ZonedDateTime | null {
+  const values = new Map<string, string>();
+  for (const part of getZonedFormatter(timeZone).formatToParts(date)) {
+    if (part.type !== "literal") values.set(part.type, part.value);
+  }
+
+  const year = values.get("year");
+  const month = values.get("month");
+  const day = values.get("day");
+  const hour = values.get("hour");
+  const minute = values.get("minute");
+  if (!year || !month || !day || !hour || !minute) return null;
+
+  return {
+    dayKey: `${year}-${month}-${day}`,
+    minutes: Number.parseInt(hour, 10) * 60 + Number.parseInt(minute, 10),
+  };
+}
+
+function getSessionBackgroundKind(minutes: number, session: ChartMarketSession): ChartSessionBackgroundKind | null {
+  if (minutes >= session.preMarketStartMinutes && minutes < session.regularStartMinutes) return "pre";
+  if (minutes >= session.regularEndMinutes && minutes < session.postMarketEndMinutes) return "post";
+  return null;
+}
+
+function isEquityLike(assetCategory: string | null | undefined): boolean {
+  return EQUITY_LIKE_ASSET_CATEGORIES.has((assetCategory ?? "").trim().toUpperCase());
+}
+
+function hasUsExchange(source: MarketSessionSource): boolean {
+  const exchangeText = [
+    source.exchange,
+    source.primaryExchange,
+  ].filter(Boolean).join(" ");
+  return US_EXCHANGE_PATTERN.test(exchangeText);
+}
+
+function isExplicitNonUsSource(source: MarketSessionSource): boolean {
+  const exchangeText = [
+    source.exchange,
+    source.primaryExchange,
+  ].filter(Boolean).join(" ");
+  return exchangeText.length > 0 && !US_EXCHANGE_PATTERN.test(exchangeText) && (source.currency ?? "").toUpperCase() !== "USD";
+}
+
+export function resolveChartMarketSession(sources: readonly MarketSessionSource[]): ChartMarketSession | null {
+  if (sources.length === 0) return null;
+  if (sources.some((source) => !isEquityLike(source.assetCategory))) return null;
+  if (sources.some(isExplicitNonUsSource)) return null;
+
+  const hasSupportedSource = sources.some((source) => hasUsExchange(source) || (source.currency ?? "").toUpperCase() === "USD");
+  return hasSupportedSource ? US_EXTENDED_HOURS_SESSION : null;
+}
+
+export function getChartMarketSessionKey(session: ChartMarketSession | null | undefined): string {
+  if (!session) return "session:none";
+  return [
+    session.timeZone,
+    session.preMarketStartMinutes,
+    session.regularStartMinutes,
+    session.regularEndMinutes,
+    session.postMarketEndMinutes,
+  ].join(":");
+}
+
+export function resolveExtendedHoursBackgroundSpans(
+  values: readonly Array<Date | string | number>,
+  session: ChartMarketSession | null | undefined,
+): ChartSessionBackgroundSpan[] {
+  if (!session) return [];
+
+  const dates = values.map(normalizeDate);
+  const validDates = dates.filter((date): date is Date => date !== null);
+  if (!shouldShowSessionBackgrounds(validDates)) return [];
+
+  const spans: ChartSessionBackgroundSpan[] = [];
+  let active: ChartSessionBackgroundSpan | null = null;
+  let activeDayKey: string | null = null;
+
+  for (let index = 0; index < dates.length; index += 1) {
+    const date = dates[index];
+    const zoned = date ? getZonedDateTime(date, session.timeZone) : null;
+    const kind = zoned ? getSessionBackgroundKind(zoned.minutes, session) : null;
+    if (!kind) {
+      if (active) spans.push(active);
+      active = null;
+      activeDayKey = null;
+      continue;
+    }
+
+    if (active && active.kind === kind && activeDayKey === zoned!.dayKey) {
+      active.endIndex = index;
+      continue;
+    }
+
+    if (active) spans.push(active);
+    active = { kind, startIndex: index, endIndex: index };
+    activeDayKey = zoned!.dayKey;
+  }
+
+  if (active) spans.push(active);
+  return spans;
+}

--- a/src/components/chart/native/chart-rasterizer.ts
+++ b/src/components/chart/native/chart-rasterizer.ts
@@ -2,7 +2,7 @@ import { type PixelResolution } from "../../../ui";
 import { measurePerf } from "../../../utils/perf-marks";
 import { computeGridLines, type ChartScene } from "../chart-renderer";
 import type { ComparisonChartScene } from "../comparison-chart-renderer";
-import type { ChartRenderMode } from "../chart-types";
+import type { ChartColors, ChartRenderMode, ChartSessionBackgroundSpan } from "../chart-types";
 
 interface RgbaColor {
   r: number;
@@ -284,6 +284,47 @@ function projectChartX(index: number, count: number, width: number, mode: ChartR
   return projectX(index, count, horizontalPad, Math.max(width - 1 - horizontalPad, horizontalPad));
 }
 
+function getProjectedPointBand(
+  index: number,
+  count: number,
+  width: number,
+  projectIndex: (targetIndex: number) => number,
+): PixelRect {
+  const currentX = projectIndex(index);
+  const previousX = index > 0 ? projectIndex(index - 1) : currentX;
+  const nextX = index < count - 1 ? projectIndex(index + 1) : currentX;
+  const left = index === 0 ? 0 : Math.floor((previousX + currentX) / 2) + 1;
+  const right = index === count - 1 ? Math.max(width - 1, 0) : Math.floor((currentX + nextX) / 2);
+  return {
+    x: clamp(left, 0, Math.max(width - 1, 0)),
+    y: 0,
+    width: Math.max(clamp(right, 0, Math.max(width - 1, 0)) - clamp(left, 0, Math.max(width - 1, 0)) + 1, 1),
+    height: 1,
+  };
+}
+
+function drawSessionBackgroundSpans(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  spans: readonly ChartSessionBackgroundSpan[],
+  pointCount: number,
+  top: number,
+  bottom: number,
+  colors: Pick<ChartColors, "preMarketBgColor" | "postMarketBgColor">,
+  projectIndex: (targetIndex: number) => number,
+) {
+  if (spans.length === 0 || pointCount === 0) return;
+  for (const span of spans) {
+    const startIndex = clamp(span.startIndex, 0, pointCount - 1);
+    const endIndex = clamp(span.endIndex, startIndex, pointCount - 1);
+    const startBand = getProjectedPointBand(startIndex, pointCount, width, projectIndex);
+    const endBand = getProjectedPointBand(endIndex, pointCount, width, projectIndex);
+    const color = parseHex(span.kind === "pre" ? colors.preMarketBgColor : colors.postMarketBgColor, 1);
+    fillRect(data, width, height, startBand.x, top, endBand.x + endBand.width - 1, bottom, color, 1);
+  }
+}
+
 function projectY(value: number, min: number, max: number, top: number, bottom: number): number {
   const range = max - min || 1;
   return lerp(bottom, top, (value - min) / range);
@@ -496,7 +537,19 @@ export function renderNativeChartBase(scene: ChartScene, pixelWidth: number, pix
     }
 
     const layout = getChartPixelLayout(scene, pixelWidth, pixelHeight);
+    drawSessionBackgroundSpans(
+      pixels,
+      pixelWidth,
+      pixelHeight,
+      scene.sessionBackgroundSpans,
+      scene.points.length,
+      layout.plotTop,
+      scene.showVolume ? layout.volumeBottom : layout.plotBottom,
+      scene.colors,
+      (index) => projectX(index, scene.points.length, 0, Math.max(pixelWidth - 1, 0)),
+    );
     drawPriceGrid(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
+    drawIndicatorOverlays(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
 
     switch (scene.mode) {
       case "area":
@@ -514,7 +567,6 @@ export function renderNativeChartBase(scene: ChartScene, pixelWidth: number, pix
         break;
     }
 
-    drawIndicatorOverlays(pixels, pixelWidth, pixelHeight, scene, layout.plotTop, layout.plotBottom);
     drawVolume(pixels, pixelWidth, pixelHeight, scene, layout.volumeTop, layout.volumeBottom);
 
     return { width: pixelWidth, height: pixelHeight, pixels };
@@ -603,6 +655,17 @@ export function renderNativeComparisonChartBase(
   }
 
   const layout = getComparisonPixelLayout(pixelWidth, pixelHeight);
+  drawSessionBackgroundSpans(
+    pixels,
+    pixelWidth,
+    pixelHeight,
+    scene.sessionBackgroundSpans,
+    scene.dates.length,
+    layout.plotTop,
+    layout.plotBottom,
+    scene.colors,
+    (index) => projectX(index, Math.max(scene.dates.length, 1), 0, pixelWidth - 1),
+  );
   drawPriceGrid(
     pixels,
     pixelWidth,

--- a/src/components/chart/stock-chart-renderer-switch.test.tsx
+++ b/src/components/chart/stock-chart-renderer-switch.test.tsx
@@ -204,6 +204,12 @@ function getFrameLineContaining(frame: string, text: string): string {
   return frame.split("\n").find((line) => line.includes(text)) ?? "";
 }
 
+const MONTH_LABEL_PATTERN = /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b/;
+
+function getTimeAxisLine(frame: string): string {
+  return frame.split("\n").find((line) => MONTH_LABEL_PATTERN.test(line)) ?? "";
+}
+
 function getFrameRowContaining(frame: string, text: string): number {
   return frame.split("\n").findIndex((line) => line.includes(text));
 }
@@ -573,6 +579,96 @@ describe("StockChart renderer switching", () => {
     expect(frame).not.toContain("AAPL -");
     expect(frame).toContain("May 28");
     expect(frame).not.toContain("view:");
+  });
+
+  test("keeps the visible range stable when indicator warmup expands history", async () => {
+    const symbol = "AAPL";
+    const config = makeChartConfig(symbol);
+    config.layout.instances = config.layout.instances.map((instance) => (
+      instance.instanceId === TEST_PANE_ID
+        ? {
+          ...instance,
+          settings: {
+            chartRangePreset: "1M",
+            chartResolution: "1d",
+          },
+        }
+        : instance
+    ));
+    config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+
+    const ticker = makeTicker(symbol);
+    const fullHistory = makeHistory(260);
+    const monthHistory = fullHistory.slice(-21);
+    const yearHistory = fullHistory.slice(-252);
+    const historyForRange = (range: string) => range === "1Y" ? yearHistory : monthHistory;
+    const provider = {
+      ...makeProvider({ [symbol]: fullHistory }),
+      getPriceHistory: async (_requestSymbol: string, _exchange: string, range: string) => historyForRange(range),
+      getPriceHistoryForResolution: async (_requestSymbol: string, _exchange: string, range: string) => historyForRange(range),
+      getDetailedPriceHistory: async (
+        _requestSymbol: string,
+        _exchange: string,
+        startDate: Date,
+        endDate: Date,
+      ) => yearHistory.filter((point) => {
+        const date = point.date instanceof Date ? point.date : new Date(point.date);
+        return date >= startDate && date <= endDate;
+      }),
+    } satisfies DataProvider;
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedMarketDataForTests(provider);
+    const financials: TickerFinancials = {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: monthHistory,
+    };
+
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 120, height: 32 });
+    root = createRoot(testSetup.renderer);
+    act(() => {
+      root!.render(
+        <ChartHarness
+          config={config}
+          ticker={ticker}
+          financials={financials}
+        />,
+      );
+    });
+
+    await flushFrames(6);
+    await flushDebouncedChartRequests();
+    const beforeAxis = getTimeAxisLine(testSetup.captureCharFrame());
+    expect(beforeAxis).not.toBe("");
+
+    const nextConfig = {
+      ...config,
+      layout: cloneLayout(config.layout),
+    };
+    nextConfig.layout.instances = nextConfig.layout.instances.map((instance) => (
+      instance.instanceId === TEST_PANE_ID
+        ? {
+          ...instance,
+          settings: {
+            ...(instance.settings ?? {}),
+            indicators: { sma: [200] },
+          },
+        }
+        : instance
+    ));
+    nextConfig.layouts = [{ name: "Default", layout: cloneLayout(nextConfig.layout) }];
+
+    act(() => {
+      harnessDispatch!({ type: "SET_CONFIG", config: nextConfig });
+    });
+
+    await flushFrames(4);
+    await flushDebouncedChartRequests();
+    await flushFrames(4);
+
+    expect(getTimeAxisLine(testSetup.captureCharFrame())).toBe(beforeAxis);
   });
 
   test("chooses supported auto detail resolutions as the visible window changes", async () => {

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -128,6 +128,7 @@ import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { TimeAxisLabel } from "./time-axis-label";
 import { PriceAxisLabels } from "./price-axis-labels";
+import { getChartMarketSessionKey, resolveChartMarketSession } from "./market-session";
 
 const MODE_CHIPS: Record<ChartRenderMode, string> = {
   area: "A",
@@ -1086,6 +1087,7 @@ function buildNativeBitmapKey(
   showVolume: boolean,
   paletteId: string,
   indicatorKey: string,
+  marketSessionKey: string,
 ): string {
   const fingerprint = points
     .map((point) => {
@@ -1093,7 +1095,7 @@ function buildNativeBitmapKey(
       return `${date}:${point.open}:${point.high}:${point.low}:${point.close}:${point.volume ?? 0}`;
     })
     .join("|");
-  return [pointCount, pixelWidth, pixelHeight, mode, showVolume ? "1" : "0", paletteId, indicatorKey, fingerprint].join("::");
+  return [pointCount, pixelWidth, pixelHeight, mode, showVolume ? "1" : "0", paletteId, indicatorKey, marketSessionKey, fingerprint].join("::");
 }
 
 function buildNativeCrosshairBitmapKey(
@@ -1715,7 +1717,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     !compact && instrumentRef
       ? {
         instrument: instrumentRef,
-        bufferRange: indicatorBufferRange,
+        bufferRange: viewState.bufferRange,
         granularity: "range",
       }
       : null,
@@ -3044,6 +3046,14 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     themeColors.text,
     themeColors.textDim,
   ]);
+  const marketSession = useMemo(() => resolveChartMarketSession(ticker
+    ? [{
+      exchange: ticker.metadata.exchange,
+      currency: ticker.metadata.currency,
+      assetCategory: ticker.metadata.assetCategory,
+    }]
+    : []), [ticker]);
+  const marketSessionKey = useMemo(() => getChartMarketSessionKey(marketSession), [marketSession]);
 
   const cursorX = viewState.cursorX !== null ? clamp(viewState.cursorX, 0, chartWidth - 1) : null;
   const cursorY = viewState.cursorY !== null ? clamp(viewState.cursorY, 0, chartHeight - 1) : null;
@@ -3071,7 +3081,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     axisMode,
     colors: chartColors,
     timeAxisDates,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, projection.effectiveMode, projection.points, selectionCursorX, selectionCursorY, showVolume, timeAxisDates, volumeHeight]);
+    marketSession,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, marketSession, projection.effectiveMode, projection.points, selectionCursorX, selectionCursorY, showVolume, timeAxisDates, volumeHeight]);
   const displayScene = useMemo(() => buildChartScene(projection.points, {
     width: chartWidth,
     height: chartHeight,
@@ -3084,7 +3095,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     colors: chartColors,
     timeAxisDates,
     indicators,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+    marketSession,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, indicators, marketSession, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
   const snappedSelectionCursorX = selectionScene
     ? getPointTerminalColumn(selectionScene.activeIdx, projection.points.length, chartWidth, projection.effectiveMode)
     : null;
@@ -3130,7 +3142,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     colors: chartColors,
     timeAxisDates,
     indicators,
-  }), [axisMode, chartColors, chartHeight, chartWidth, compact, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+    marketSession,
+  }), [axisMode, chartColors, chartHeight, chartWidth, compact, indicators, marketSession, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const staticResult = useMemo(() => renderChart(projection.points, {
     width: chartWidth,
@@ -3146,7 +3159,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     colors: chartColors,
     timeAxisDates,
     indicators,
-  }), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
+    marketSession,
+  }), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, indicators, marketSession, projection.effectiveMode, projection.points, showVolume, timeAxisDates, volumeHeight]);
 
   const interactiveResult = useMemo(() => (
     effectiveRenderer === "kitty" || useCanvasChart
@@ -3165,8 +3179,9 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         colors: chartColors,
         timeAxisDates,
         indicators,
+        marketSession,
       })
-  ), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, indicators, projection.effectiveMode, projection.points, showVolume, timeAxisDates, useCanvasChart, volumeHeight]);
+  ), [axisMode, chartAssetCategory, chartColors, chartCurrency, chartHeight, chartWidth, compact, displayCursorX, displayCursorY, effectiveRenderer, indicators, marketSession, projection.effectiveMode, projection.points, showVolume, timeAxisDates, useCanvasChart, volumeHeight]);
 
   const result = effectiveRenderer === "kitty" || useCanvasChart ? staticResult : interactiveResult!;
 
@@ -3300,8 +3315,11 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         chartColors.volumeDown,
         chartColors.candleUp,
         chartColors.candleDown,
+        chartColors.preMarketBgColor,
+        chartColors.postMarketBgColor,
       ].join(","),
       indicatorRenderKey,
+      marketSessionKey,
     );
     const cachedBitmap = lastNativeBaseBitmapRef.current?.key === bitmapKey
       ? lastNativeBaseBitmapRef.current.bitmap
@@ -3331,11 +3349,14 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     chartColors.fillColor,
     chartColors.gridColor,
     chartColors.lineColor,
+    chartColors.postMarketBgColor,
+    chartColors.preMarketBgColor,
     chartColors.volumeDown,
     chartColors.volumeUp,
     compact,
     effectiveRenderer,
     indicatorRenderKey,
+    marketSessionKey,
     nativeBaseScene,
     nativeBaseSurfaceId,
     nativeSurfaceManager,
@@ -3829,9 +3850,10 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         colors: chartColors,
         timeAxisDates,
         indicators: canvasIndicators,
+        marketSession,
       })
       : null
-  ), [axisMode, canvasIndicators, canvasProjection, chartColors, chartHeight, compact, showVolume, timeAxisDates, volumeHeight]);
+  ), [axisMode, canvasIndicators, canvasProjection, chartColors, chartHeight, compact, marketSession, showVolume, timeAxisDates, volumeHeight]);
 
   const canvasBaseBitmapKey = useMemo(() => {
     if (!canvasBitmapSize || !canvasProjection || !hasHistory || isBlockingBody || bodyMessage) return null;
@@ -3850,8 +3872,11 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         chartColors.volumeDown,
         chartColors.candleUp,
         chartColors.candleDown,
+        chartColors.preMarketBgColor,
+        chartColors.postMarketBgColor,
       ].join(","),
       canvasIndicatorRenderKey,
+      marketSessionKey,
     );
   }, [
     bodyMessage,
@@ -3863,11 +3888,14 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
     chartColors.fillColor,
     chartColors.gridColor,
     chartColors.lineColor,
+    chartColors.postMarketBgColor,
+    chartColors.preMarketBgColor,
     chartColors.volumeDown,
     chartColors.volumeUp,
     compact,
     hasHistory,
     isBlockingBody,
+    marketSessionKey,
     showVolume,
   ]);
 

--- a/src/components/chart/time-axis-label.tsx
+++ b/src/components/chart/time-axis-label.tsx
@@ -23,6 +23,51 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
+function normalizeDate(value: Date | string | number): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+export function resolveCursorDateFromAxis({
+  dates,
+  width,
+  cursorColumn,
+  cursorPixelX,
+  cellWidthPx,
+}: {
+  dates: Array<Date | string | number>;
+  width: number;
+  cursorColumn: number | null;
+  cursorPixelX?: number | null;
+  cellWidthPx?: number | null;
+}): Date | null {
+  const normalizedDates = dates
+    .map(normalizeDate)
+    .filter((date): date is Date => date !== null);
+  if (normalizedDates.length === 0) return null;
+  if (normalizedDates.length === 1) return normalizedDates[0]!;
+
+  let ratio: number | null = null;
+  if (
+    cursorPixelX !== null
+    && cursorPixelX !== undefined
+    && Number.isFinite(cursorPixelX)
+    && cellWidthPx !== null
+    && cellWidthPx !== undefined
+    && Number.isFinite(cellWidthPx)
+    && cellWidthPx > 0
+  ) {
+    const pixelWidth = Math.max(width * cellWidthPx, 1);
+    ratio = clamp(cursorPixelX / Math.max(pixelWidth - 1, 1), 0, 1);
+  } else if (cursorColumn !== null && Number.isFinite(cursorColumn) && width > 1) {
+    ratio = clamp(cursorColumn / Math.max(width - 1, 1), 0, 1);
+  }
+
+  if (ratio === null) return null;
+  const index = Math.round(ratio * (normalizedDates.length - 1));
+  return normalizedDates[clamp(index, 0, normalizedDates.length - 1)] ?? null;
+}
+
 export function buildCursorTimeAxisOverlay({
   segments,
   width,
@@ -61,13 +106,22 @@ export function TimeAxisLabel({
   cursorColor,
 }: TimeAxisLabelProps) {
   const { cellWidthPx = 8, fractionalViewport = false } = useUiCapabilities();
+  const resolvedCursorDate = useMemo(() => {
+    return resolveCursorDateFromAxis({
+      dates,
+      width,
+      cursorColumn,
+      cursorPixelX: fractionalViewport ? cursorPixelX : null,
+      cellWidthPx,
+    }) ?? cursorDate;
+  }, [cellWidthPx, cursorColumn, cursorDate, cursorPixelX, dates, fractionalViewport, width]);
   const segments = useMemo(() => buildCursorTimeAxisSegments({
     timeLabels,
     width,
     cursorColumn,
-    cursorDate,
+    cursorDate: resolvedCursorDate,
     dates,
-  }), [cursorColumn, cursorDate, dates, timeLabels, width]);
+  }), [cursorColumn, dates, resolvedCursorDate, timeLabels, width]);
   const overlay = useMemo(() => buildCursorTimeAxisOverlay({
     segments,
     width,

--- a/src/sources/gloomberb-cloud.test.ts
+++ b/src/sources/gloomberb-cloud.test.ts
@@ -105,8 +105,8 @@ describe("GloomberbCloudProvider", () => {
     const history = await provider.getDetailedPriceHistory(
       "AAPL",
       "NASDAQ",
-      new Date(2026, 2, 27, 10, 0, 0),
-      new Date(2026, 2, 27, 12, 0, 0),
+      new Date("2026-03-27T14:00:00Z"),
+      new Date("2026-03-27T16:00:00Z"),
       "15m",
     );
 
@@ -121,6 +121,7 @@ describe("GloomberbCloudProvider", () => {
     });
     expect(history).toHaveLength(1);
     expect(history[0]?.close).toBe(250.12);
+    expect(history[0]?.date.toISOString()).toBe("2026-03-27T14:15:00.000Z");
   });
 
   test("normalizes daily detailed history requests to 1day", async () => {

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -33,7 +33,7 @@ import {
 } from "../utils/api-client";
 import type { NewsArticle, NewsQuery, NewsStoryItem } from "../types/news-source";
 import { normalizePriceValueByDivisor, resolveCurrencyUnit } from "../utils/currency-units";
-import { canonicalTickerKey, publicExchange } from "../utils/exchanges";
+import { canonicalTickerKey, publicExchange, resolveExchangeTimeZone } from "../utils/exchanges";
 import { collectNewsDisplayTickers } from "../news/ticker-symbols";
 import { createProviderMiss } from "./provider-errors";
 
@@ -136,9 +136,73 @@ function mapQuote(quote: CloudQuotePayload, providerMeta?: CloudProviderMeta): Q
   };
 }
 
-function mapPricePoint(point: CloudPricePointPayload, divisor = 1): PricePoint {
+const LOCAL_DATE_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.\d{1,3})?)?)?$/;
+const EXPLICIT_TIME_ZONE_PATTERN = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+function getZonedDateParts(date: Date, timeZone: string): Map<string, string> {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts = new Map<string, string>();
+  for (const part of formatter.formatToParts(date)) {
+    if (part.type !== "literal") parts.set(part.type, part.value);
+  }
+  return parts;
+}
+
+function getTimeZoneOffsetMs(utcMs: number, timeZone: string): number {
+  const parts = getZonedDateParts(new Date(utcMs), timeZone);
+  const zonedAsUtcMs = Date.UTC(
+    Number(parts.get("year")),
+    Number(parts.get("month")) - 1,
+    Number(parts.get("day")),
+    Number(parts.get("hour")),
+    Number(parts.get("minute")),
+    Number(parts.get("second")),
+  );
+  return zonedAsUtcMs - utcMs;
+}
+
+function exchangeLocalDateTimeToUtc(match: RegExpMatchArray, timeZone: string): Date {
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4] ?? "0");
+  const minute = Number(match[5] ?? "0");
+  const second = Number(match[6] ?? "0");
+  const localAsUtcMs = Date.UTC(year, month - 1, day, hour, minute, second);
+  const firstOffset = getTimeZoneOffsetMs(localAsUtcMs, timeZone);
+  const firstUtcMs = localAsUtcMs - firstOffset;
+  const verifiedOffset = getTimeZoneOffsetMs(firstUtcMs, timeZone);
+  return new Date(localAsUtcMs - verifiedOffset);
+}
+
+function parseCloudPricePointDate(value: Date | string | number, exchange: string): Date {
+  if (value instanceof Date || typeof value === "number") return new Date(value);
+  if (EXPLICIT_TIME_ZONE_PATTERN.test(value)) return new Date(value);
+
+  const match = value.match(LOCAL_DATE_TIME_PATTERN);
+  if (!match) return new Date(value);
+
+  const hasTime = match[4] !== undefined;
+  if (!hasTime) {
+    return new Date(`${match[1]}-${match[2]}-${match[3]}T00:00:00Z`);
+  }
+
+  const timeZone = resolveExchangeTimeZone(exchange);
+  return timeZone ? exchangeLocalDateTimeToUtc(match, timeZone) : new Date(value);
+}
+
+function mapPricePoint(point: CloudPricePointPayload, divisor = 1, exchange = ""): PricePoint {
   return {
-    date: new Date(point.date),
+    date: parseCloudPricePointDate(point.date, exchange),
     open: normalizePriceValueByDivisor(point.open, divisor),
     high: normalizePriceValueByDivisor(point.high, divisor),
     low: normalizePriceValueByDivisor(point.low, divisor),
@@ -317,10 +381,18 @@ function padTimePart(value: number): string {
   return String(value).padStart(2, "0");
 }
 
-function formatCloudDateTime(date: Date, includeTime: boolean): string {
-  const year = date.getFullYear();
-  const month = padTimePart(date.getMonth() + 1);
-  const day = padTimePart(date.getDate());
+function formatCloudDateTime(date: Date, includeTime: boolean, exchange = ""): string {
+  if (includeTime) {
+    const timeZone = resolveExchangeTimeZone(exchange);
+    if (timeZone) {
+      const parts = getZonedDateParts(date, timeZone);
+      return `${parts.get("year")}-${parts.get("month")}-${parts.get("day")} ${parts.get("hour")}:${parts.get("minute")}:${parts.get("second")}`;
+    }
+  }
+
+  const year = includeTime ? date.getFullYear() : date.getUTCFullYear();
+  const month = padTimePart((includeTime ? date.getMonth() : date.getUTCMonth()) + 1);
+  const day = padTimePart(includeTime ? date.getDate() : date.getUTCDate());
   if (!includeTime) {
     return `${year}-${month}-${day}`;
   }
@@ -611,7 +683,7 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     }
     const { divisor } = resolveCurrencyUnit(response.currency ?? response.providerMeta?.currency);
     return unwrapRequiredCloudResponse(response, `Cloud chart data is unavailable for ${ticker}`)
-      .map((point) => mapPricePoint(point, divisor));
+      .map((point) => mapPricePoint(point, divisor, exchange));
   }
 
   async getPriceHistoryForResolution(
@@ -629,8 +701,8 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     const response = await withCloudFallback(
       () => apiClient.getCloudHistory(ticker, exchange, {
         interval,
-        startDate: formatCloudDateTime(startDate, includeTime),
-        endDate: formatCloudDateTime(endDate, includeTime),
+        startDate: formatCloudDateTime(startDate, includeTime, exchange),
+        endDate: formatCloudDateTime(endDate, includeTime, exchange),
       }),
       `Cloud chart data is unavailable for ${ticker}`,
     );
@@ -639,7 +711,7 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     }
     const { divisor } = resolveCurrencyUnit(response.currency ?? response.providerMeta?.currency);
     return unwrapRequiredCloudResponse(response, `Cloud chart data is unavailable for ${ticker}`)
-      .map((point) => mapPricePoint(point, divisor));
+      .map((point) => mapPricePoint(point, divisor, exchange));
   }
 
   async getDetailedPriceHistory(
@@ -656,8 +728,8 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     const response = await withCloudFallback(
       () => apiClient.getCloudHistory(ticker, exchange, {
         interval,
-        startDate: formatCloudDateTime(startDate, includeTime),
-        endDate: formatCloudDateTime(endDate, includeTime),
+        startDate: formatCloudDateTime(startDate, includeTime, exchange),
+        endDate: formatCloudDateTime(endDate, includeTime, exchange),
       }),
       `Cloud detailed chart history is unavailable for ${ticker}`,
     );
@@ -666,7 +738,7 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     }
     const { divisor } = resolveCurrencyUnit(response.currency ?? response.providerMeta?.currency);
     return unwrapRequiredCloudResponse(response, `Cloud detailed chart history is unavailable for ${ticker}`)
-      .map((point) => mapPricePoint(point, divisor));
+      .map((point) => mapPricePoint(point, divisor, exchange));
   }
 
   async getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, _context?: MarketDataRequestContext): Promise<OptionsChain> {

--- a/src/utils/exchanges.ts
+++ b/src/utils/exchanges.ts
@@ -224,6 +224,11 @@ export function canonicalExchange(value?: string): string {
   return CANONICAL_EXCHANGE_ALIASES[normalized] ?? normalized;
 }
 
+export function resolveExchangeTimeZone(value?: string): string | null {
+  const canonical = canonicalExchange(value);
+  return canonical ? EXCHANGE_TIME_ZONES[canonical] ?? null : null;
+}
+
 export function publicExchange(value?: string): string {
   const canonical = canonicalExchange(value);
   return PUBLIC_EXCHANGE_ALIASES[canonical] ?? canonical;


### PR DESCRIPTION
Adds exchange-aware extended-hours chart backgrounds for US equities and hides them on wider intraday windows where the bands become noisy.
Improves cursor x-axis precision by resolving labels from the full source date axis, so long ranges still show exact hovered dates.
Normalizes Gloomberb Cloud intraday request and response timestamps through the exchange timezone so market-hours shading aligns with volume.
Keeps SMA/EMA/Bollinger overlays from changing the visible price/date range and draws them underneath the price series.
