### PR TITLE
Fix quote age freshness and flash opacity

### DIFF
--- a/src/components/ticker-list-table.tsx
+++ b/src/components/ticker-list-table.tsx
@@ -56,17 +56,6 @@ const FLASHABLE_QUOTE_COLUMN_IDS = new Set([
   "pnl_pct",
 ]);
 
-function resolveQuoteFlashColor(direction: QuoteFlashDirection, fallbackColor: string): string {
-  switch (direction) {
-    case "up":
-      return colors.positive;
-    case "down":
-      return colors.negative;
-    default:
-      return fallbackColor === colors.textDim ? colors.text : colors.textBright;
-  }
-}
-
 export interface TickerListTableProps {
   columns: ColumnConfig[];
   tickers: TickerRecord[];
@@ -239,13 +228,13 @@ const TickerListRow = memo(function TickerListRow({
         const { text, color } = resolveCell(column, ticker, financials);
         const baseFg = color || (isSelected ? colors.selectedText : colors.text);
         const shouldFlash = flashDirection != null && FLASHABLE_QUOTE_COLUMN_IDS.has(column.id);
-        const cellFg = shouldFlash
-          ? resolveQuoteFlashColor(flashDirection, baseFg)
-          : baseFg;
 
         return (
           <Box key={column.id} width={column.width + 1}>
-            <Text fg={cellFg}>
+            <Text
+              fg={baseFg}
+              attributes={shouldFlash ? TextAttributes.DIM : TextAttributes.NONE}
+            >
               {padTo(text, column.width, column.align)}
             </Text>
           </Box>

--- a/src/market-data/coordinator-subscriptions.test.ts
+++ b/src/market-data/coordinator-subscriptions.test.ts
@@ -170,29 +170,40 @@ describe("MarketDataCoordinator key subscriptions", () => {
     expect(coordinator.getVersion()).toBe(1);
   });
 
-  test("ignores repeated stream quotes that only refresh timestamp noise", async () => {
+  test("applies repeated stream quotes that refresh quote freshness", async () => {
+    const realDateNow = Date.now;
     const { provider, emitQuote } = createProvider();
     const coordinator = new MarketDataCoordinator(provider);
     const aapl = { symbol: "AAPL", exchange: "NASDAQ" };
     let calls = 0;
 
-    coordinator.subscribeKeys([buildQuoteKey(aapl)], () => { calls += 1; });
-    coordinator.subscribeQuotes([{ instrument: aapl }]);
-
     const firstTimestamp = 1_700_000_000_000;
-    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100, { lastUpdated: firstTimestamp }));
-    await flushCoordinator();
+    try {
+      coordinator.subscribeKeys([buildQuoteKey(aapl)], () => { calls += 1; });
+      coordinator.subscribeQuotes([{ instrument: aapl }]);
 
-    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100, { lastUpdated: firstTimestamp + 10_000 }));
-    await flushCoordinator();
+      Date.now = () => firstTimestamp;
+      emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100, { lastUpdated: firstTimestamp }));
+      await flushCoordinator();
 
-    expect(calls).toBe(1);
-    expect(coordinator.getQuoteEntry(aapl).data?.lastUpdated).toBe(firstTimestamp);
+      Date.now = () => firstTimestamp + 10_000;
+      emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 100, { lastUpdated: firstTimestamp + 10_000 }));
+      await flushCoordinator();
 
-    emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 101, { lastUpdated: firstTimestamp + 20_000 }));
-    await flushCoordinator();
+      expect(calls).toBe(2);
+      expect(coordinator.getQuoteEntry(aapl).data?.lastUpdated).toBe(firstTimestamp + 10_000);
+      expect(coordinator.getQuoteEntry(aapl).data?.receivedAt).toBe(firstTimestamp + 10_000);
 
-    expect(calls).toBe(2);
-    expect(coordinator.getQuoteEntry(aapl).data?.price).toBe(101);
+      Date.now = () => firstTimestamp + 20_000;
+      emitQuote({ symbol: "AAPL", exchange: "NASDAQ" }, quote("AAPL", 101, { lastUpdated: firstTimestamp + 10_000 }));
+      await flushCoordinator();
+
+      expect(calls).toBe(3);
+      expect(coordinator.getQuoteEntry(aapl).data?.price).toBe(101);
+      expect(coordinator.getQuoteEntry(aapl).data?.lastUpdated).toBe(firstTimestamp + 10_000);
+      expect(coordinator.getQuoteEntry(aapl).data?.receivedAt).toBe(firstTimestamp + 20_000);
+    } finally {
+      Date.now = realDateNow;
+    }
   });
 });

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -224,16 +224,12 @@ const STREAM_QUOTE_FIELDS: Array<keyof Quote> = [
   "dataSource",
 ];
 
-function quoteTimestampMinute(quote: Quote): number | null {
-  return Number.isFinite(quote.lastUpdated) ? Math.floor(quote.lastUpdated / 60_000) : null;
-}
-
 function areStreamQuotesEquivalent(current: Quote | null | undefined, next: Quote): boolean {
   if (!current) return false;
   for (const field of STREAM_QUOTE_FIELDS) {
     if (current[field] !== next[field]) return false;
   }
-  return quoteTimestampMinute(current) === quoteTimestampMinute(next)
+  return current.lastUpdated === next.lastUpdated
     && JSON.stringify(current.provenance ?? null) === JSON.stringify(next.provenance ?? null);
 }
 
@@ -1133,8 +1129,9 @@ export class MarketDataCoordinator {
     const key = buildQuoteKey(instrument);
     const current = this.quoteStore.get(key);
     if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, quote)) return;
-    const attempts = [createAttempt(quote.providerId ?? this.dataProvider.id, Date.now(), "success")];
-    this.quoteStore.set(key, readyQuoteEntry(current, quote, quote.providerId ?? this.dataProvider.id, attempts));
+    const receivedAt = Date.now();
+    const attempts = [createAttempt(quote.providerId ?? this.dataProvider.id, receivedAt, "success")];
+    this.quoteStore.set(key, readyQuoteEntry(current, { ...quote, receivedAt }, quote.providerId ?? this.dataProvider.id, attempts));
   }
 }
 

--- a/src/plugins/builtin/portfolio-list.test.tsx
+++ b/src/plugins/builtin/portfolio-list.test.tsx
@@ -3,6 +3,7 @@ import { existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { act, useReducer } from "react";
+import { RGBA, TextAttributes } from "@opentui/core";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { AppPersistence } from "../../data/app-persistence";
 import { TickerRepository } from "../../data/ticker-repository";
@@ -18,6 +19,7 @@ import { createTestPluginRuntime } from "../../test-support/plugin-runtime";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
 import { PluginRegistry, setSharedMarketDataForTests, setSharedRegistryForTests } from "../registry";
 import type { BrokerAdapter } from "../../types/broker";
+import { colors } from "../../theme/colors";
 import { portfolioListPlugin } from "./portfolio-list";
 
 const TEST_PANE_ID = "portfolio-list:test";
@@ -314,6 +316,10 @@ async function flushFrame() {
     await Promise.resolve();
     await testSetup!.renderOnce();
   });
+}
+
+function lineText(line: { spans: Array<{ text: string }> }) {
+  return line.spans.map((span) => span.text).join("");
 }
 
 afterEach(async () => {
@@ -1438,7 +1444,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(frame).toContain("+5.41%");
   });
 
-  test("quote flash keeps the existing row background intact", async () => {
+  test("quote flash dims cells without changing quote sign color or row background", async () => {
     const config = createPortfolioConfigWithColumns(
       "broker:ibkr-flex:DU12345",
       ["ticker", "price", "change", "latency"],
@@ -1455,7 +1461,18 @@ describe("PortfolioListPane cash and margin UI", () => {
             ["MSFT", makeTicker({ ticker: "MSFT", name: "Microsoft" })],
           ]);
           state.financials = new Map([
-            ["AAPL", { annualStatements: [], quarterlyStatements: [], priceHistory: [], quote: makeQuote() }],
+            ["AAPL", {
+              annualStatements: [],
+              quarterlyStatements: [],
+              priceHistory: [],
+              quote: makeQuote({
+                price: 125,
+                bid: 124.95,
+                ask: 125.05,
+                change: -5,
+                changePercent: -4.17,
+              }),
+            }],
             ["MSFT", {
               annualStatements: [],
               quarterlyStatements: [],
@@ -1484,7 +1501,7 @@ describe("PortfolioListPane cash and margin UI", () => {
 
     await flushFrame();
     const beforeFrame = testSetup.captureSpans();
-    const beforeLine = beforeFrame.lines.find((line) => line.spans.map((span) => span.text).join("").includes("AAPL"));
+    const beforeLine = beforeFrame.lines.find((line) => lineText(line).includes("AAPL"));
     expect(beforeLine).toBeDefined();
 
     await act(async () => {
@@ -1495,8 +1512,8 @@ describe("PortfolioListPane cash and margin UI", () => {
           price: 126,
           bid: 125.95,
           ask: 126.05,
-          change: 6,
-          changePercent: 5,
+          change: -4,
+          changePercent: -3.08,
           lastUpdated: Date.now() + 1_000,
         }),
       });
@@ -1504,11 +1521,15 @@ describe("PortfolioListPane cash and margin UI", () => {
     await flushFrame();
 
     const frame = testSetup.captureSpans();
-    const aaplLine = frame.lines.find((line) => line.spans.map((span) => span.text).join("").includes("AAPL"));
+    const aaplLine = frame.lines.find((line) => lineText(line).includes("AAPL"));
     expect(aaplLine).toBeDefined();
 
     const beforeBackgrounds = beforeLine!.spans.map((span) => span.bg.toInts().join(","));
     const afterBackgrounds = aaplLine!.spans.map((span) => span.bg.toInts().join(","));
     expect(afterBackgrounds).toEqual(beforeBackgrounds);
+    const priceSpan = aaplLine!.spans.find((span) => span.text.includes("126"));
+    expect(priceSpan).toBeDefined();
+    expect(priceSpan!.fg.toInts().join(",")).toBe(RGBA.fromHex(colors.negative).toInts().join(","));
+    expect(priceSpan!.attributes & TextAttributes.DIM).not.toBe(0);
   });
 });

--- a/src/plugins/builtin/portfolio-list/metrics.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.ts
@@ -3,7 +3,7 @@ import type { ColumnConfig } from "../../../types/config";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { priceColor } from "../../../theme/colors";
-import { clampQuoteTimestamp, formatQuoteAgeWithSource } from "../../../utils/quote-time";
+import { formatQuoteAgeWithSource, resolveQuoteAgeTimestamp } from "../../../utils/quote-time";
 import { convertCurrency, formatCompact, formatNumber, formatPercentRaw } from "../../../utils/format";
 import { formatMarketCost, formatMarketPrice, formatMarketQuantity, formatSignedMarketPrice, type MarketFormatOptions } from "../../../utils/market-format";
 import { getActiveQuoteDisplay, marketStateDot, type ActiveQuoteDisplay } from "../../../utils/market-status";
@@ -389,7 +389,7 @@ export function getSortValue(
       }
       return null;
     case "latency":
-      return quote?.lastUpdated != null ? ctx.now - (clampQuoteTimestamp(quote.lastUpdated, ctx.now) ?? ctx.now) : null;
+      return quote ? ctx.now - (resolveQuoteAgeTimestamp(quote, ctx.now) ?? ctx.now) : null;
     case PRICE_SPARKLINE_COLUMN_ID: {
       const values = (financials?.priceHistory ?? [])
         .map((point) => point.close)

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -32,6 +32,7 @@ export interface Quote {
   volume?: number;
   name?: string;
   lastUpdated: number; // timestamp ms
+  receivedAt?: number; // local receipt timestamp ms for streamed/display freshness
   exchangeName?: string;
   fullExchangeName?: string;
   listingExchangeName?: string;

--- a/src/utils/quote-resolution.ts
+++ b/src/utils/quote-resolution.ts
@@ -30,6 +30,7 @@ const PRICE_FIELD_KEYS = [
   "low",
   "mark",
   "lastUpdated",
+  "receivedAt",
 ] as const;
 
 const SESSION_FIELD_KEYS = [
@@ -516,6 +517,7 @@ export function resolveCanonicalQuote(
     volume: resolved.volume as Quote["volume"],
     name: resolved.name as Quote["name"],
     lastUpdated: Number(resolved.lastUpdated ?? priceProvider?.lastUpdated ?? sessionProvider?.lastUpdated ?? now),
+    receivedAt: resolved.receivedAt as Quote["receivedAt"],
     exchangeName: resolved.exchangeName as Quote["exchangeName"],
     fullExchangeName: resolved.fullExchangeName as Quote["fullExchangeName"],
     listingExchangeName: resolved.listingExchangeName as Quote["listingExchangeName"],

--- a/src/utils/quote-time.test.ts
+++ b/src/utils/quote-time.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { formatQuoteAge, formatQuoteAgeWithSource, getMostRecentQuoteUpdate } from "./quote-time";
+
+describe("quote-time", () => {
+  test("formats sub-second quote age in milliseconds", () => {
+    const now = 1_700_000_030_000;
+
+    expect(formatQuoteAge(now - 999, now)).toBe("999ms");
+    expect(formatQuoteAge(now, now)).toBe("0ms");
+    expect(formatQuoteAgeWithSource({
+      lastUpdated: now - 100,
+      dataSource: "delayed",
+    }, now)).toBe("◷100ms");
+  });
+
+  test("uses stream receipt time for displayed quote age when available", () => {
+    const now = 1_700_000_030_000;
+    const quote = {
+      lastUpdated: 1_700_000_000_000,
+      receivedAt: 1_700_000_029_000,
+    };
+
+    expect(formatQuoteAgeWithSource(quote, now)).toBe("1s");
+    expect(getMostRecentQuoteUpdate([quote], now)).toBe(1_700_000_029_000);
+  });
+
+  test("keeps delayed source marker while using receipt time for age", () => {
+    expect(formatQuoteAgeWithSource({
+      lastUpdated: 1_700_000_000_000,
+      receivedAt: 1_700_000_029_000,
+      dataSource: "delayed",
+    }, 1_700_000_030_000)).toBe("◷1s");
+  });
+});

--- a/src/utils/quote-time.ts
+++ b/src/utils/quote-time.ts
@@ -11,20 +11,33 @@ export function formatQuoteAge(lastUpdated: number | undefined, now = Date.now()
   const clamped = clampQuoteTimestamp(lastUpdated, now);
   if (clamped == null) return "—";
 
-  const ageSeconds = Math.max(0, (now - clamped) / 1000);
+  const ageMs = Math.max(0, now - clamped);
+  if (ageMs < 1000) return `${Math.floor(ageMs)}ms`;
+
+  const ageSeconds = ageMs / 1000;
   if (ageSeconds < 60) return `${Math.floor(ageSeconds)}s`;
   if (ageSeconds < 3600) return `${Math.floor(ageSeconds / 60)}m`;
   if (ageSeconds < 86400) return `${Math.floor(ageSeconds / 3600)}h`;
   return `${Math.floor(ageSeconds / 86400)}d`;
 }
 
+export function resolveQuoteAgeTimestamp(
+  quote: Pick<Quote, "lastUpdated" | "receivedAt"> | null | undefined,
+  now = Date.now(),
+): number | null {
+  if (!quote) return null;
+  const receivedAt = clampQuoteTimestamp(quote.receivedAt, now);
+  return receivedAt ?? clampQuoteTimestamp(quote.lastUpdated, now);
+}
+
 export function formatQuoteAgeWithSource(
-  quote: Pick<Quote, "lastUpdated" | "dataSource"> | null | undefined,
+  quote: Pick<Quote, "lastUpdated" | "receivedAt" | "dataSource"> | null | undefined,
   now = Date.now(),
 ): string {
   if (!quote) return "—";
 
-  const age = formatQuoteAge(quote.lastUpdated, now);
+  const timestamp = resolveQuoteAgeTimestamp(quote, now);
+  const age = timestamp == null ? "—" : formatQuoteAge(timestamp, now);
   if (age === "—") return age;
 
   const prefix = quote.dataSource === "delayed" ? "◷" : "";
@@ -32,12 +45,12 @@ export function formatQuoteAgeWithSource(
 }
 
 export function getMostRecentQuoteUpdate(
-  quotes: Iterable<Pick<Quote, "lastUpdated"> | null | undefined>,
+  quotes: Iterable<Pick<Quote, "lastUpdated" | "receivedAt"> | null | undefined>,
   now = Date.now(),
 ): number | null {
   let latest: number | null = null;
   for (const quote of quotes) {
-    const timestamp = clampQuoteTimestamp(quote?.lastUpdated, now);
+    const timestamp = resolveQuoteAgeTimestamp(quote, now);
     if (timestamp != null && (latest == null || timestamp > latest)) {
       latest = timestamp;
     }


### PR DESCRIPTION
Quotes from the live stream now keep a local receipt timestamp, and the AGE column uses that freshness timestamp so it resets when the displayed quote updates even if the provider timestamp stays coarse or stale.

Sub-second freshness renders in milliseconds. Quote flashing now dims existing cell colors instead of switching red/green, preserving sign color and row background.
