### PR TITLE
Add desktop crash recovery controls

### DIFF
--- a/scripts/build-electrobun-view.ts
+++ b/scripts/build-electrobun-view.ts
@@ -74,13 +74,39 @@ function renderElectrobunViewHtml(entrySrc: string, stylesheet: string): string 
   <body style="margin:0;background:#000;">
     <div id="root"><div class="gloom-loading">Loading Gloomberb...</div></div>
     <script>
+      const bootstrapFatalHtml = [
+        '<div class="gloom-fatal">',
+        '<h1>Gloomberb failed to start</h1>',
+        '<div class="gloom-fatal-actions">',
+        '<button type="button" data-variant="primary" data-action="reload">Reload window</button>',
+        '<button type="button" data-action="copy">Copy error</button>',
+        '</div>',
+        '<div class="gloom-fatal-status" aria-live="polite"></div>',
+        '<pre></pre>',
+        '</div>',
+      ].join("");
       const renderBootstrapError = (error, details = "") => {
+        if (typeof window.__gloomRenderFatalError === "function") {
+          window.__gloomRenderFatalError(error, details);
+          return;
+        }
         const root = document.getElementById("root");
         if (!root) return;
         const message = error && typeof error === "object" && "message" in error ? error.message : String(error);
         const stack = error && typeof error === "object" && "stack" in error ? error.stack : "";
-        root.innerHTML = '<div class="gloom-fatal"><h1>Gloomberb failed to start</h1><pre></pre></div>';
-        root.querySelector("pre").textContent = [message, details, stack].filter(Boolean).join("\\n");
+        const errorText = [message, details, stack].filter(Boolean).join("\\n");
+        root.innerHTML = bootstrapFatalHtml;
+        root.querySelector("pre").textContent = errorText;
+        root.querySelector('[data-action="reload"]')?.addEventListener("click", () => window.location.reload());
+        root.querySelector('[data-action="copy"]')?.addEventListener("click", async () => {
+          const status = root.querySelector(".gloom-fatal-status");
+          try {
+            await navigator.clipboard.writeText(errorText);
+            status.textContent = "Error copied.";
+          } catch (copyError) {
+            status.textContent = "Copy failed.";
+          }
+        });
       };
       window.addEventListener("error", (event) => renderBootstrapError(
         event.error || event.message,

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { Buffer } from "node:buffer";
 import Electrobun, { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu, type UpdateStatusEntry } from "electrobun/bun";
 import {
@@ -17,7 +17,7 @@ import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemeP
 import type { ReleaseInfo, UpdateCheckResult, UpdateProgress } from "../../../updater";
 import { buildSoundCommand } from "../../../notifications/app-notifier";
 import { isPaneDetached } from "../../../plugins/pane-manager";
-import { ELECTROBUN_CONTEXT_MENU_ACTION, type ElectrobunDesktopRpcSchema } from "../shared/protocol";
+import { ELECTROBUN_CONTEXT_MENU_ACTION, type DesktopRestartMessage, type ElectrobunDesktopRpcSchema } from "../shared/protocol";
 import { decodeRpcValue, encodeRpcValue } from "../view/rpc-codec";
 import { contextMenuSelectionMessage } from "./context-menu-click";
 import { getContextMenuRequestId, normalizeContextMenuItems } from "./context-menu-normalize";
@@ -65,6 +65,7 @@ let desktopWorkspace: DesktopWorkspace | null = null;
 let currentDockPreview: DesktopDockPreviewState = { paneId: null, edge: null };
 let currentThemePreview: DesktopThemePreviewState = { theme: null };
 let desktopUpdateInProgress = false;
+let desktopRestartInProgress = false;
 
 const detachedWindows = new Map<string, BrowserWindow>();
 const detachedFrameTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -80,6 +81,19 @@ const capabilitySubscriptions = new Map<string, () => void>();
 
 function summarizeError(error: unknown): string {
   return error instanceof Error ? error.stack ?? error.message : String(error);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function findMacAppBundle(execPath: string): string | null {
+  let current = dirname(execPath);
+  while (current && current !== dirname(current)) {
+    if (current.endsWith(".app")) return current;
+    current = dirname(current);
+  }
+  return null;
 }
 
 function requireServices(): AppServices {
@@ -633,6 +647,62 @@ function teardownServices(): void {
   services = null;
 }
 
+function spawnDetached(command: string[]): void {
+  const child = Bun.spawn(command, {
+    detached: true,
+    stdio: ["ignore", "ignore", "ignore"],
+  } as any);
+  child.unref();
+}
+
+function scheduleDesktopRelaunch(): void {
+  const pid = process.pid;
+  const macAppBundle = process.platform === "darwin" ? findMacAppBundle(process.execPath) : null;
+
+  if (macAppBundle) {
+    spawnDetached([
+      "sh",
+      "-c",
+      `while kill -0 ${pid} 2>/dev/null; do sleep 0.25; done; sleep 0.5; open ${shellQuote(macAppBundle)}`,
+    ]);
+    return;
+  }
+
+  if (process.platform === "win32") {
+    spawnDetached([process.execPath, ...process.argv.slice(1)]);
+    return;
+  }
+
+  const args = process.argv.slice(1).map(shellQuote).join(" ");
+  spawnDetached([
+    "sh",
+    "-c",
+    `while kill -0 ${pid} 2>/dev/null; do sleep 0.25; done; cd ${shellQuote(process.cwd())}; ${shellQuote(process.execPath)}${args ? ` ${args}` : ""}`,
+  ]);
+}
+
+function restartDesktopApp(message: DesktopRestartMessage = {}): void {
+  if (desktopRestartInProgress) return;
+  desktopRestartInProgress = true;
+  console.error("[desktop-recovery] restart requested", {
+    reason: message.reason,
+    source: message.source,
+    pid: process.pid,
+    execPath: process.execPath,
+    argv: process.argv,
+  });
+  try {
+    scheduleDesktopRelaunch();
+  } catch (error) {
+    desktopRestartInProgress = false;
+    console.error("[desktop-recovery] failed to schedule restart", summarizeError(error));
+    throw error;
+  }
+  closeAllDetachedWindows();
+  teardownServices();
+  Utils.quit();
+}
+
 function resolveDetachedWindowTitle(instanceId: string): string {
   const instance = currentConfig ? findPaneInstance(currentConfig.layout, instanceId) : null;
   if (!instance) return "Gloomberb";
@@ -1087,6 +1157,12 @@ async function handleBackendRequest(
       requireServices().persistence.pluginState.delete(payload.pluginId as string, payload.key as string);
       syncBackendCloudAuthState(payload.pluginId as string, payload.key as string, null);
       return null;
+    case "host.restart":
+      restartDesktopApp({
+        reason: typeof payload.reason === "string" ? payload.reason : undefined,
+        source: typeof payload.source === "string" ? payload.source : "backend-request",
+      });
+      return null;
     case "host.exit":
       closeAllDetachedWindows();
       teardownServices();
@@ -1153,7 +1229,11 @@ function createWindowRpc(key: string): DesktopRpc {
       requests: {
         "backend.request": async ({ method, payload }) => encodeRpcValue(await handleBackendRequest(rpc, method, payload)),
       },
-      messages: {},
+      messages: {
+        "host.restart": (message) => {
+          restartDesktopApp(message);
+        },
+      },
     },
   });
   registerWindowRpc(key, rpc);

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -53,6 +53,11 @@ export interface CapabilityEventMessage {
   event: unknown;
 }
 
+export interface DesktopRestartMessage {
+  reason?: string;
+  source?: string;
+}
+
 export interface ElectrobunDesktopRpcSchema {
   bun: {
     requests: {
@@ -61,7 +66,9 @@ export interface ElectrobunDesktopRpcSchema {
         response: unknown;
       };
     };
-    messages: {};
+    messages: {
+      "host.restart": DesktopRestartMessage;
+    };
   };
   webview: {
     requests: {};

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -5,6 +5,7 @@ import {
   type CapabilityEventMessage,
   type ContextMenuSelectMessage,
   type DesktopDockPreviewMessage,
+  type DesktopRestartMessage,
   type DesktopStateMessage,
   type DesktopThemePreviewMessage,
   type ElectrobunBackendInit,
@@ -129,6 +130,10 @@ export async function backendRequest<T = unknown>(method: string, payload: unkno
 export async function initElectrobunBackend(payload?: { kind?: "main" | "detached"; paneId?: string }): Promise<ElectrobunBackendInit> {
   initSnapshot = await backendRequest<ElectrobunBackendInit>("init", payload ?? null);
   return initSnapshot;
+}
+
+export function requestElectrobunRestart(message: DesktopRestartMessage = {}): void {
+  rpc.send["host.restart"](message);
 }
 
 export function getElectrobunBackendInitSnapshot(): ElectrobunBackendInit | null {

--- a/src/renderers/electrobun/view/fatal-screen.tsx
+++ b/src/renderers/electrobun/view/fatal-screen.tsx
@@ -1,0 +1,118 @@
+/// <reference lib="dom" />
+/** @jsxImportSource react */
+import { Component, useMemo, useState, type ErrorInfo, type ReactNode } from "react";
+import { backendRequest, requestElectrobunRestart } from "./backend-rpc";
+
+declare global {
+  interface Window {
+    __gloomRenderFatalError?: (error: unknown, details?: string) => void;
+  }
+}
+
+interface DesktopFatalScreenProps {
+  title?: string;
+  error: unknown;
+  details?: string;
+  source: string;
+}
+
+interface ElectrobunErrorBoundaryState {
+  hasError: boolean;
+  error: unknown;
+  details?: string;
+}
+
+export function formatFatalError(error: unknown, details?: string): string {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  return [message, details].filter((value): value is string => Boolean(value)).join("\n");
+}
+
+export function DesktopFatalScreen({
+  title = "Gloomberb crashed",
+  error,
+  details,
+  source,
+}: DesktopFatalScreenProps) {
+  const [status, setStatus] = useState<string | null>(null);
+  const errorText = useMemo(() => formatFatalError(error, details), [details, error]);
+
+  const reloadWindow = () => {
+    window.location.reload();
+  };
+
+  const restartApp = () => {
+    setStatus("Restart requested...");
+    try {
+      requestElectrobunRestart({
+        source,
+        reason: errorText.slice(0, 240),
+      });
+      window.setTimeout(() => {
+        setStatus("If the app stays open, quit it and open it again.");
+      }, 2500);
+    } catch (restartError) {
+      setStatus(`Restart request failed: ${formatFatalError(restartError)}`);
+    }
+  };
+
+  const copyError = async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(errorText);
+      } else {
+        await backendRequest("host.copyText", { text: errorText });
+      }
+      setStatus("Error copied.");
+    } catch (copyError) {
+      setStatus(`Copy failed: ${formatFatalError(copyError)}`);
+    }
+  };
+
+  return (
+    <div className="gloom-fatal">
+      <h1>{title}</h1>
+      <div className="gloom-fatal-actions">
+        <button type="button" data-variant="primary" onClick={restartApp}>Restart app</button>
+        <button type="button" onClick={reloadWindow}>Reload window</button>
+        <button type="button" onClick={copyError}>Copy error</button>
+      </div>
+      {status && <div className="gloom-fatal-status" aria-live="polite">{status}</div>}
+      <pre>{errorText}</pre>
+    </div>
+  );
+}
+
+export class ElectrobunErrorBoundary extends Component<
+  { children: ReactNode },
+  ElectrobunErrorBoundaryState
+> {
+  override state: ElectrobunErrorBoundaryState = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown): ElectrobunErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  override componentDidCatch(error: unknown, errorInfo: ErrorInfo): void {
+    console.error("[desktop-recovery] renderer error boundary", error, errorInfo.componentStack);
+    this.setState({
+      hasError: true,
+      error,
+      details: errorInfo.componentStack ?? undefined,
+    });
+  }
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <DesktopFatalScreen
+          title="Gloomberb crashed"
+          error={this.state.error}
+          details={this.state.details}
+          source="react-error-boundary"
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -15,6 +15,7 @@ import {
   installElectrobunHttpFetchTransport,
 } from "./http-fetch";
 import { installElectrobunUpdateHost } from "./update-host";
+import { DesktopFatalScreen, ElectrobunErrorBoundary } from "./fatal-screen";
 import { WebInputHostProvider } from "./input-host";
 import { webNativeRenderer } from "./native-renderer";
 import { WebToastHostProvider } from "./toast-host";
@@ -27,16 +28,32 @@ const rootElement = document.getElementById("root");
 if (!rootElement) {
   throw new Error("Missing root element");
 }
+const appRootElement = rootElement;
 
-const root = createRoot(rootElement);
+const root = createRoot(appRootElement);
 const bootLog = debugLog.createLogger("electrobun-web-boot");
 
-rootElement.tabIndex = -1;
+appRootElement.tabIndex = -1;
 root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
+
+function renderFatalError(error: unknown, details?: string, title = "Gloomberb failed to start"): void {
+  root.render(
+    <DesktopFatalScreen
+      title={title}
+      error={error}
+      details={details}
+      source="renderer-fatal"
+    />,
+  );
+}
+
+window.__gloomRenderFatalError = (error, details) => {
+  renderFatalError(error, details, "Gloomberb crashed");
+};
 
 function focusWebSurface(): void {
   window.focus();
-  rootElement.focus({ preventScroll: true });
+  appRootElement.focus({ preventScroll: true });
 }
 
 function requestStartupFocus(): void {
@@ -69,21 +86,23 @@ async function boot() {
   const desktopApplicationMenuBridge = createApplicationMenuBridge();
   measurePerfAsync("startup.electrobun.root-render", async () => {
     root.render(
-      <UiHostProvider ui={webUiHost} renderer={webRendererHost} nativeRenderer={webNativeRenderer}>
-        <WebInputHostProvider>
-          <WebToastHostProvider>
-            <WebDialogHostProvider>
-              <App
-                config={config}
-                desktopWindowBridge={desktopWindowBridge}
-                desktopApplicationMenuBridge={desktopApplicationMenuBridge}
-                desktopSnapshot={desktopSnapshot}
-                desktopThemePreview={init.desktopThemePreview}
-              />
-            </WebDialogHostProvider>
-          </WebToastHostProvider>
-        </WebInputHostProvider>
-      </UiHostProvider>,
+      <ElectrobunErrorBoundary>
+        <UiHostProvider ui={webUiHost} renderer={webRendererHost} nativeRenderer={webNativeRenderer}>
+          <WebInputHostProvider>
+            <WebToastHostProvider>
+              <WebDialogHostProvider>
+                <App
+                  config={config}
+                  desktopWindowBridge={desktopWindowBridge}
+                  desktopApplicationMenuBridge={desktopApplicationMenuBridge}
+                  desktopSnapshot={desktopSnapshot}
+                  desktopThemePreview={init.desktopThemePreview}
+                />
+              </WebDialogHostProvider>
+            </WebToastHostProvider>
+          </WebInputHostProvider>
+        </UiHostProvider>
+      </ElectrobunErrorBoundary>,
     );
   });
   requestStartupFocus();
@@ -96,10 +115,5 @@ async function boot() {
 }
 
 boot().catch((error) => {
-  root.render(
-    <div className="gloom-fatal">
-      <h1>Gloomberb failed to start</h1>
-      <pre>{error instanceof Error ? error.stack ?? error.message : String(error)}</pre>
-    </div>,
-  );
+  renderFatalError(error);
 });

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -1,5 +1,5 @@
 @keyframes gloom-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-html, body, #root { width: 100%; height: 100%; min-height: 100%; overflow: hidden; background: var(--gloom-bg); }
+html, body, #root { width: 100%; height: 100%; min-height: 100%; overflow: hidden; background: var(--gloom-bg, #272a34); }
 #root:focus { outline: none; }
 body {
   --cell-w: 8px;
@@ -8,7 +8,7 @@ body {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 12px;
   line-height: var(--cell-h);
-  color: var(--gloom-text);
+  color: var(--gloom-text, #f2f2f2);
   cursor: default;
   user-select: none;
   color-scheme: dark;
@@ -284,8 +284,52 @@ body.gloom-dragging {
   top: 50%;
   height: 1px;
 }
-.gloom-loading, .gloom-fatal { padding: 24px; color: var(--gloom-text); }
-.gloom-fatal pre { white-space: pre-wrap; color: var(--gloom-negative); }
+.gloom-loading, .gloom-fatal {
+  padding: 24px;
+  color: var(--gloom-text, #f2f2f2);
+  background: var(--gloom-bg, #272a34);
+}
+.gloom-fatal {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow: auto;
+}
+.gloom-fatal h1 {
+  margin: 0 0 6px;
+  font-size: 28px;
+  line-height: 1.25;
+}
+.gloom-fatal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.gloom-fatal button {
+  border: 1px solid var(--gloom-border, #5b6070);
+  border-radius: 6px;
+  padding: 5px 10px;
+  color: var(--gloom-text, #f2f2f2);
+  background: var(--gloom-panel, #1f222b);
+}
+.gloom-fatal button:hover {
+  background: color-mix(in srgb, var(--gloom-text-bright, #fff) 10%, var(--gloom-panel, #1f222b));
+}
+.gloom-fatal button[data-variant="primary"] {
+  border-color: var(--gloom-border-focused, #8cb4ff);
+  color: var(--gloom-bg, #111318);
+  background: var(--gloom-border-focused, #8cb4ff);
+}
+.gloom-fatal-status {
+  min-height: var(--cell-h);
+  color: var(--gloom-text-dim, #a7acba);
+}
+.gloom-fatal pre {
+  margin: 0;
+  white-space: pre-wrap;
+  color: var(--gloom-negative, #ff5f5f);
+  user-select: text;
+}
 .gloom-toast-viewport {
   position: fixed;
   right: 16px;


### PR DESCRIPTION
Desktop startup and renderer crashes now land on an interactive fatal screen instead of a static dead window. The screen lets users restart the app, reload the window, or copy the error, while the Bun process relaunches the current bundle or process and quits cleanly. The bootstrap HTML fallback now exposes reload and copy actions before React has mounted, so RPC startup timeouts have a recovery path too.