### PR TITLE
Fix pane chrome occlusion and holder contrast

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -70,6 +70,7 @@ import {
   gridlockAllPanes,
   isPaneInLayout,
   removePane,
+  type LayoutBounds,
 } from "./plugins/pane-manager";
 import { notifyGridlockComplete } from "./plugins/gridlock-notification";
 import {
@@ -206,6 +207,7 @@ function AppInner({
   const isDetachedWindow = desktopWindowBridge?.kind === "detached";
   const detachedPaneId = isDetachedWindow ? desktopWindowBridge.paneId ?? null : null;
   const [desktopDockPreview, setDesktopDockPreview] = useState<DesktopDockPreviewState | null>(null);
+  const [commandBarNativeOccluder, setCommandBarNativeOccluder] = useState<LayoutBounds | null>(null);
   appActiveRef.current = appActive;
   const appNotifier = useMemo(() => createAppNotifier({
     isAppActive: () => appActiveRef.current,
@@ -1618,6 +1620,7 @@ function AppInner({
           pluginRegistry={pluginRegistry}
           desktopWindowBridge={desktopWindowBridge}
           desktopDockPreview={desktopDockPreview}
+          commandBarNativeOccluder={commandBarNativeOccluder}
         />
         <StatusBar />
         {state.commandBarOpen && (
@@ -1627,6 +1630,7 @@ function AppInner({
             pluginRegistry={pluginRegistry}
             quitApp={() => rendererHost.requestExit()}
             onCheckForUpdates={() => runUpdateCheck(true)}
+            onNativeOccluderChange={setCommandBarNativeOccluder}
           />
         )}
         <ToastViewport position="bottom-right" />

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -73,8 +73,10 @@ import {
   movePaneRelative,
   removePane,
   swapPanes,
+  type LayoutBounds,
 } from "../../plugins/pane-manager";
 import { notifyGridlockComplete } from "../../plugins/gridlock-notification";
+import { resolveAppHeaderHeightCells } from "../layout/shell";
 import { CHART_RENDERER_PREFERENCES } from "../chart/chart-types";
 import {
   getEmptyState,
@@ -168,6 +170,7 @@ interface CommandBarProps {
   pluginRegistry: PluginRegistry;
   quitApp: () => void;
   onCheckForUpdates?: () => void | Promise<void>;
+  onNativeOccluderChange?: (rect: LayoutBounds | null) => void;
 }
 
 type WorkflowStringValues = Record<string, string>;
@@ -645,6 +648,7 @@ export function CommandBar({
   pluginRegistry,
   quitApp,
   onCheckForUpdates,
+  onNativeOccluderChange,
 }: CommandBarProps) {
   const dispatch = useAppDispatch();
   const themeColors = useThemeColors();
@@ -709,7 +713,7 @@ export function CommandBar({
   }, []);
   const { symbol: activeTickerSymbol, ticker: activeTickerData, financials: activeFinancials } = useFocusedTicker();
   const { width: termWidth, height: termHeight } = useViewport();
-  const { nativePaneChrome, cellWidthPx = 8, cellHeightPx = 18 } = useUiCapabilities();
+  const { nativePaneChrome, cellWidthPx = 8, cellHeightPx = 18, titleBarOverlay } = useUiCapabilities();
   const availableCommands = useMemo(
     () => nativePaneChrome
       ? commands.filter((command) => command.id !== "cycle-chart-renderer")
@@ -5390,6 +5394,13 @@ export function CommandBar({
     : bodyHeight + 7;
   const barLeft = Math.max(4, Math.floor((termWidth - barWidth) / 2));
   const barTop = Math.max(1, Math.floor((termHeight - barHeight) / 2));
+  const appHeaderHeight = resolveAppHeaderHeightCells({ titleBarOverlay, cellHeightPx });
+  const nativeOccluderRect = useMemo<LayoutBounds>(() => ({
+    x: barLeft,
+    y: barTop - appHeaderHeight,
+    width: barWidth,
+    height: barHeight,
+  }), [appHeaderHeight, barHeight, barLeft, barTop, barWidth]);
   const resultsInnerWidth = Math.max(12, barWidth - nativePanelPaddingColumns - contentPadding * 2);
   const trailingWidth = Math.max(8, Math.min(12, Math.floor(resultsInnerWidth * 0.18)));
   const labelWidth = Math.max(10, resultsInnerWidth - trailingWidth);
@@ -5418,6 +5429,13 @@ export function CommandBar({
       scrollBox.scrollTo(selectedScrollRowIndex - viewportHeight + 1);
     }
   }, [listBodyHeight, selectedScrollRowIndex, visibleListState?.kind, visibleListState?.query]);
+
+  useLayoutEffect(() => {
+    onNativeOccluderChange?.(nativeOccluderRect);
+    return () => {
+      onNativeOccluderChange?.(null);
+    };
+  }, [nativeOccluderRect, onNativeOccluderChange]);
 
   useEffect(() => {
     if (!nativePaneChrome || currentRoute?.kind !== "workflow") return;

--- a/src/components/layout/shell.test.tsx
+++ b/src/components/layout/shell.test.tsx
@@ -560,6 +560,32 @@ describe("Shell", () => {
     ]);
   });
 
+  test("keeps command bar native occlusion scoped to the panel", () => {
+    const state = buildNativeWindowState(
+      ["portfolio-list:main"],
+      [],
+      null,
+      { open: false, width: 120, contentHeight: 40 },
+      [
+        {
+          id: "command-bar:panel",
+          rect: { x: 24, y: 8, width: 72, height: 14 },
+          zIndex: Number.MAX_SAFE_INTEGER,
+        },
+      ],
+    );
+
+    expect(state.occluders).toEqual([
+      {
+        id: "command-bar:panel",
+        paneId: null,
+        rect: { x: 24, y: 9, width: 72, height: 14 },
+        zIndex: Number.MAX_SAFE_INTEGER,
+      },
+    ]);
+    expect(state.occluders.some((occluder) => occluder.id === "overlay:global")).toBe(false);
+  });
+
   test("adds dock dividers as global native occluders", () => {
     const state = buildNativeWindowState(
       ["left:main", "right:main"],

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -76,6 +76,7 @@ interface ShellProps {
   pluginRegistry: PluginRegistry;
   desktopWindowBridge?: DesktopWindowBridge;
   desktopDockPreview?: DesktopDockPreviewState | null;
+  commandBarNativeOccluder?: LayoutBounds | null;
 }
 
 interface HoverOverlay {
@@ -192,6 +193,7 @@ const DEFAULT_HEADER_HEIGHT = 1;
 const MENU_MIN_WIDTH = 18;
 const MENU_MAX_WIDTH = 44;
 const MENU_Z_INDEX = 10_000;
+const DOCK_DIVIDER_SIZE = 1;
 const PANE_DRAG_THRESHOLD = 2;
 const PRECISE_PANE_DRAG_THRESHOLD = 0.15;
 const PANE_MANAGEMENT_ACCELERATORS = {
@@ -498,6 +500,39 @@ export function resolveNativeDockDividers(
   ));
 }
 
+function resolveDividerPreviewRect(
+  axis: "horizontal" | "vertical",
+  bounds: LayoutBounds,
+  ratio: number,
+  nativePaneChrome: boolean,
+): LayoutBounds {
+  if (axis === "horizontal") {
+    const offset = nativePaneChrome
+      ? bounds.width * ratio
+      : bounds.width > DOCK_DIVIDER_SIZE
+        ? Math.round((bounds.width - DOCK_DIVIDER_SIZE) * ratio)
+        : Math.max(0, Math.round(bounds.width * ratio) - DOCK_DIVIDER_SIZE);
+    return {
+      x: nativePaneChrome ? bounds.x + offset - (DOCK_DIVIDER_SIZE / 2) : bounds.x + offset,
+      y: bounds.y,
+      width: DOCK_DIVIDER_SIZE,
+      height: bounds.height,
+    };
+  }
+
+  const offset = nativePaneChrome
+    ? bounds.height * ratio
+    : bounds.height > DOCK_DIVIDER_SIZE
+      ? Math.round((bounds.height - DOCK_DIVIDER_SIZE) * ratio)
+      : Math.max(0, Math.round(bounds.height * ratio) - DOCK_DIVIDER_SIZE);
+  return {
+    x: bounds.x,
+    y: nativePaneChrome ? bounds.y + offset - (DOCK_DIVIDER_SIZE / 2) : bounds.y + offset,
+    width: bounds.width,
+    height: DOCK_DIVIDER_SIZE,
+  };
+}
+
 export function finalizePaneDragRelease(
   layout: LayoutConfig,
   paneId: string,
@@ -789,7 +824,12 @@ function resolveExternalDockPreview(
   }
 }
 
-export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview }: ShellProps) {
+export function Shell({
+  pluginRegistry,
+  desktopWindowBridge,
+  desktopDockPreview,
+  commandBarNativeOccluder = null,
+}: ShellProps) {
   useThemeColors();
   const dispatch = useAppDispatch();
   const config = useAppSelector((state) => state.config);
@@ -1047,7 +1087,9 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
     event.stopPropagation();
   });
 
-  const dockGeometryOptions = useMemo(() => (nativePaneChrome ? { precise: true } : undefined), [nativePaneChrome]);
+  const dockGeometryOptions = useMemo(() => (
+    nativePaneChrome ? { precise: true } : { reserveDividerGutters: true }
+  ), [nativePaneChrome]);
   const dockLeafLayouts = useMemo(() => getDockLeafLayouts(visibleLayout, bounds, dockGeometryOptions), [bounds, dockGeometryOptions, visibleLayout]);
   const dockDividerLayouts = useMemo(() => getDockDividerLayouts(visibleLayout, bounds, dockGeometryOptions), [bounds, dockGeometryOptions, visibleLayout]);
   const snapGuides = useMemo(() => makeSnapGuides(width, contentHeight), [contentHeight, width]);
@@ -1092,8 +1134,29 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
       });
     }
 
+    if (menuState) {
+      occluders.push({
+        id: `pane-menu:${menuState.paneId}`,
+        rect: {
+          x: menuState.x,
+          y: menuState.y,
+          width: menuState.width,
+          height: menuState.items.length + 2,
+        },
+        zIndex: MENU_Z_INDEX,
+      });
+    }
+
+    if (commandBarNativeOccluder) {
+      occluders.push({
+        id: "command-bar:panel",
+        rect: commandBarNativeOccluder,
+        zIndex: Number.MAX_SAFE_INTEGER,
+      });
+    }
+
     return occluders;
-  }, [activeHoverOverlay, activePaneDrag, dragFloatingRect, effectiveDockPreview]);
+  }, [activeHoverOverlay, activePaneDrag, commandBarNativeOccluder, dragFloatingRect, effectiveDockPreview, menuState]);
   const nativeDockDividers = useMemo(
     () => resolveNativeDockDividers(dockDividerLayouts, dividerPreview),
     [dividerPreview, dockDividerLayouts],
@@ -1107,12 +1170,12 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         zIndex: pane.floating?.zIndex ?? 50,
       })),
       dragFloatingRect,
-      { open: overlayOpen, width, contentHeight },
+      { open: dialogOpen, width, contentHeight },
       nativeTransientOccluders,
       nativeDockDividers,
       appHeaderHeight,
     ),
-    [appHeaderHeight, contentHeight, dockedPanes, dragFloatingRect, nativeDockDividers, nativeTransientOccluders, overlayOpen, visibleFloatingPanes, width],
+    [appHeaderHeight, contentHeight, dialogOpen, dockedPanes, dragFloatingRect, nativeDockDividers, nativeTransientOccluders, visibleFloatingPanes, width],
   );
 
   useEffect(() => {
@@ -1194,22 +1257,7 @@ export function Shell({ pluginRegistry, desktopWindowBridge, desktopDockPreview 
         const total = drag.axis === "horizontal" ? drag.bounds.width : drag.bounds.height;
         const delta = drag.axis === "horizontal" ? preciseX - drag.startX : preciseShellY - drag.startY;
         const nextRatio = Math.max(0.1, Math.min(0.9, drag.startRatio + (delta / Math.max(1, total))));
-        const offset = drag.axis === "horizontal"
-          ? drag.bounds.width * nextRatio
-          : drag.bounds.height * nextRatio;
-        const nextRect = drag.axis === "horizontal"
-          ? {
-            x: nativePaneChrome ? drag.bounds.x + offset - 0.5 : drag.bounds.x + Math.round(offset) - 1,
-            y: drag.bounds.y,
-            width: 1,
-            height: drag.bounds.height,
-          }
-          : {
-            x: drag.bounds.x,
-            y: nativePaneChrome ? drag.bounds.y + offset - 0.5 : drag.bounds.y + Math.round(offset) - 1,
-            width: drag.bounds.width,
-            height: 1,
-          };
+        const nextRect = resolveDividerPreviewRect(drag.axis, drag.bounds, nextRatio, nativePaneChrome);
         updateDividerPreview({ pathKey: drag.path.join("."), rect: nextRect, ratio: nextRatio });
       } else if (drag.type === "pane-drag") {
         if (!isMeaningfulPaneDrag(drag.startX, drag.startY, preciseX, preciseShellY, dragThreshold)) {

--- a/src/plugins/builtin/holders/index.test.ts
+++ b/src/plugins/builtin/holders/index.test.ts
@@ -1,11 +1,21 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import {
   buildTreemap,
   buildTreemapRects,
   formatHolderOwnershipPercent,
   resolveHolderOwnershipPercent,
+  tileTextColor,
 } from "./index";
+import { applyTheme, colors } from "../../../theme/colors";
+import { contrastRatio } from "../../../theme/color-utils";
+import { DEFAULT_THEME, themes } from "../../../theme/themes";
 import type { HolderRecord } from "../../../types/financials";
+
+const TILE_TEXT_MIN_CONTRAST = 4.5;
+
+afterEach(() => {
+  applyTheme(DEFAULT_THEME);
+});
 
 function holder(name: string, value: number): HolderRecord & { id: string } {
   return {
@@ -54,4 +64,23 @@ test("resolves holder ownership from provider percent before value over market c
   expect(resolveHolderOwnershipPercent({ value: 120 }, 1_000)).toBe(0.12);
   expect(resolveHolderOwnershipPercent({ value: 120 }, undefined)).toBeUndefined();
   expect(formatHolderOwnershipPercent(0.085)).toBe("8.50%");
+});
+
+test("keeps holder treemap text readable on semantic tile backgrounds", () => {
+  for (const themeId of Object.keys(themes)) {
+    applyTheme(themeId);
+    const backgrounds = {
+      positive: colors.positive,
+      negative: colors.negative,
+      neutral: colors.neutral,
+      selected: colors.selected,
+    };
+
+    for (const [name, background] of Object.entries(backgrounds)) {
+      expect(
+        contrastRatio(tileTextColor(background), background),
+        `${themeId} ${name}`,
+      ).toBeGreaterThanOrEqual(TILE_TEXT_MIN_CONTRAST);
+    }
+  }
 });

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
 import { blendHex, colors, priceColor } from "../../../theme/colors";
-import { higherContrast } from "../../../theme/color-utils";
+import { blendForContrast, higherContrast } from "../../../theme/color-utils";
 import type { HolderData, HolderRecord } from "../../../types/financials";
 import type { GloomPlugin } from "../../../types/plugin";
 import { formatCompact, formatPercent, formatPercentRaw, padTo } from "../../../utils/format";
@@ -447,12 +447,16 @@ function desktopTileColor(row: HolderRow): string {
   return blendHex(colors.panel, row.changePercent > 0 ? colors.positive : colors.negative, intensity);
 }
 
-function tileTextColor(backgroundColor: string): string {
-  return higherContrast(
+const TILE_TEXT_MIN_CONTRAST = 4.5;
+
+export function tileTextColor(backgroundColor: string): string {
+  const preferred = higherContrast(
     higherContrast(colors.text, colors.textBright, backgroundColor),
     colors.selectedText,
     backgroundColor,
   );
+  const fallback = higherContrast("#000000", "#ffffff", backgroundColor);
+  return blendForContrast(preferred, backgroundColor, fallback, TILE_TEXT_MIN_CONTRAST);
 }
 
 function Tile({ tile, selected, currency, marketCap, onSelect }: {

--- a/src/plugins/pane-manager.test.ts
+++ b/src/plugins/pane-manager.test.ts
@@ -5,6 +5,8 @@ import {
   applyDrop,
   floatAtRect,
   gridlockAllPanes,
+  getDockDividerLayouts,
+  getDockLeafLayouts,
   getDockedPaneIds,
   getLeafRect,
   simulateDrop,
@@ -42,6 +44,35 @@ describe("pane-manager split-tree drops", () => {
 
     expect(getLeafRect(next, notesPane.instanceId, BOUNDS)).toEqual(simulation.previewRect);
     expect(getDockedPaneIds(next)).toContain(notesPane.instanceId);
+  });
+
+  test("can reserve a gutter for dock dividers without overlapping pane rects", () => {
+    const layout = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: { kind: "pane" as const, instanceId: "left:main" },
+        second: { kind: "pane" as const, instanceId: "right:main" },
+      },
+      instances: [
+        createPaneInstance("left", { instanceId: "left:main" }),
+        createPaneInstance("right", { instanceId: "right:main" }),
+      ],
+      floating: [],
+      detached: [],
+    };
+
+    const leaves = getDockLeafLayouts(layout, BOUNDS, { reserveDividerGutters: true });
+    const divider = getDockDividerLayouts(layout, BOUNDS, { reserveDividerGutters: true })[0];
+    const left = leaves.find((leaf) => leaf.instanceId === "left:main");
+    const right = leaves.find((leaf) => leaf.instanceId === "right:main");
+
+    expect(left).toBeDefined();
+    expect(right).toBeDefined();
+    expect(divider).toBeDefined();
+    expect(divider!.rect.x).toBe(left!.rect.x + left!.rect.width);
+    expect(right!.rect.x).toBe(divider!.rect.x + divider!.rect.width);
   });
 
   test("splits the hovered pane on leaf drops and matches the preview", () => {

--- a/src/plugins/pane-manager.ts
+++ b/src/plugins/pane-manager.ts
@@ -84,6 +84,7 @@ export interface DockDividerLayout {
 export interface DockGeometryOptions {
   precise?: boolean;
   dividerSize?: number;
+  reserveDividerGutters?: boolean;
 }
 
 export interface LayoutSimulation {
@@ -430,18 +431,31 @@ function collectDockGeometry(
 
   const precise = options.precise === true;
   const dividerSize = options.dividerSize ?? 1;
+  const reserveDividerGutters = options.reserveDividerGutters === true && !precise;
 
   if (node.axis === "horizontal") {
-    const [firstWidth, secondWidth] = resolveSplitSizes(bounds.width, node.ratio, MIN_PANE_WIDTH, precise);
+    const reserveDividerGutter = reserveDividerGutters && bounds.width > dividerSize;
+    const splitWidth = reserveDividerGutter ? bounds.width - dividerSize : bounds.width;
+    const [firstWidth, secondWidth] = resolveSplitSizes(splitWidth, node.ratio, MIN_PANE_WIDTH, precise);
     const firstBounds = { x: bounds.x, y: bounds.y, width: firstWidth, height: bounds.height };
-    const secondBounds = { x: bounds.x + firstWidth, y: bounds.y, width: secondWidth, height: bounds.height };
+    const dividerX = reserveDividerGutter
+      ? bounds.x + firstWidth
+      : precise
+        ? bounds.x + firstWidth - (dividerSize / 2)
+        : bounds.x + firstWidth - 1;
+    const secondBounds = {
+      x: reserveDividerGutter ? bounds.x + firstWidth + dividerSize : bounds.x + firstWidth,
+      y: bounds.y,
+      width: secondWidth,
+      height: bounds.height,
+    };
     dividers.push({
       path,
       axis: node.axis,
       bounds: { ...bounds },
       ratio: node.ratio,
       rect: {
-        x: precise ? bounds.x + firstWidth - (dividerSize / 2) : bounds.x + firstWidth - 1,
+        x: dividerX,
         y: bounds.y,
         width: dividerSize,
         height: bounds.height,
@@ -452,9 +466,21 @@ function collectDockGeometry(
     return { leaves, dividers };
   }
 
-  const [firstHeight, secondHeight] = resolveSplitSizes(bounds.height, node.ratio, MIN_DOCKED_HEIGHT, precise);
+  const reserveDividerGutter = reserveDividerGutters && bounds.height > dividerSize;
+  const splitHeight = reserveDividerGutter ? bounds.height - dividerSize : bounds.height;
+  const [firstHeight, secondHeight] = resolveSplitSizes(splitHeight, node.ratio, MIN_DOCKED_HEIGHT, precise);
   const firstBounds = { x: bounds.x, y: bounds.y, width: bounds.width, height: firstHeight };
-  const secondBounds = { x: bounds.x, y: bounds.y + firstHeight, width: bounds.width, height: secondHeight };
+  const dividerY = reserveDividerGutter
+    ? bounds.y + firstHeight
+    : precise
+      ? bounds.y + firstHeight - (dividerSize / 2)
+      : bounds.y + firstHeight - 1;
+  const secondBounds = {
+    x: bounds.x,
+    y: reserveDividerGutter ? bounds.y + firstHeight + dividerSize : bounds.y + firstHeight,
+    width: bounds.width,
+    height: secondHeight,
+  };
   dividers.push({
     path,
     axis: node.axis,
@@ -462,7 +488,7 @@ function collectDockGeometry(
     ratio: node.ratio,
     rect: {
       x: bounds.x,
-      y: precise ? bounds.y + firstHeight - (dividerSize / 2) : bounds.y + firstHeight - 1,
+      y: dividerY,
       width: bounds.width,
       height: dividerSize,
     },


### PR DESCRIPTION
Fixes the native pane chrome occlusion model so command bar and pane menus only mask their actual panels instead of the full workspace.

Updates terminal dock divider geometry to reserve a one-cell gutter, keeping pane footers and status rows visible while preserving precise desktop dividers.

Improves holder treemap text contrast across themes by blending tile text toward the highest-contrast fallback when semantic backgrounds get too bright or saturated.