### PR TITLE
Fix market mover ticker opens

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -40,7 +40,7 @@ import {
   type PaneBinding,
   type PaneInstanceConfig,
 } from "./types/config";
-import type { CliLaunchRequest, PaneTemplateCreateOptions, PaneTemplateInstanceConfig, WizardStep } from "./types/plugin";
+import type { CliLaunchRequest, PaneTemplateCreateOptions, PaneTemplateInstanceConfig, PinTickerOptions, WizardStep } from "./types/plugin";
 import type { PaneSettingField } from "./types/plugin";
 import type { TickerRecord } from "./types/ticker";
 import type { DataProvider } from "./types/data-provider";
@@ -48,7 +48,7 @@ import type { TickerFinancials } from "./types/financials";
 import type { BrokerAccount } from "./types/trading";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState, DesktopWindowBridge } from "./types/desktop-window";
 import type { DesktopApplicationMenuBridge } from "./types/desktop-menu";
-import { resolveTickerSearch, upsertTickerFromSearchResult } from "./utils/ticker-search";
+import { resolveTickerOpenTarget, type TickerOpenTarget } from "./utils/ticker-search";
 
 import {
   clearPersistedBrokerAccounts,
@@ -1361,14 +1361,45 @@ function AppInner({
 
     focusVisiblePane(instanceId);
   };
-  pluginRegistry.pinTickerFn = (symbol, options) => {
-    if (isDetachedWindow) return;
+  const resolveOpenTickerTarget = async (rawSymbol: string): Promise<TickerOpenTarget | null> => {
+    try {
+      const target = await resolveTickerOpenTarget({
+        query: rawSymbol,
+        tickers: stateRef.current.tickers,
+        dataProvider,
+        tickerRepository,
+      });
+      if (!target) {
+        pluginRegistry.notify({ body: `Could not open ${rawSymbol}.`, type: "error" });
+      }
+      return target;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      pluginRegistry.notify({ body: `Failed to open ${rawSymbol}: ${message}`, type: "error" });
+      return null;
+    }
+  };
+  const publishTickerOpenTarget = (target: TickerOpenTarget) => {
+    const currentTicker = stateRef.current.tickers.get(target.symbol);
+    if (currentTicker !== target.ticker) {
+      dispatch({ type: "UPDATE_TICKER", ticker: target.ticker });
+    }
+    if (target.created) {
+      pluginRegistry.events.emit("ticker:added", { symbol: target.symbol, ticker: target.ticker });
+    }
+  };
+  const placePinnedTickerTarget = (target: TickerOpenTarget, options?: PinTickerOptions) => {
     const paneType = options?.paneType ?? "ticker-detail";
     const paneDef = pluginRegistry.panes.get(paneType);
     if (!paneDef) return;
+
+    publishTickerOpenTarget(target);
+    const symbol = target.symbol;
+    const currentState = stateRef.current;
+    const currentLayout = currentState.config.layout;
     const existing = options?.forceNewPane
       ? null
-      : findFixedTickerPaneForSymbol(state.config.layout, paneType, symbol);
+      : findFixedTickerPaneForSymbol(currentLayout, paneType, symbol);
     if (existing) {
       focusVisiblePane(existing.instanceId);
       return;
@@ -1381,19 +1412,28 @@ function AppInner({
     const { width, height } = pluginRegistry.getTermSizeFn();
     const shouldFloat = options?.floating ?? true;
     const nextLayout = shouldFloat
-      ? addPaneFloating(state.config.layout, instance, width, height, paneDef)
+      ? addPaneFloating(currentLayout, instance, width, height, paneDef)
       : addPaneToLayout(
-        state.config.layout,
+        currentLayout,
         instance,
         {
-          relativeTo: state.focusedPaneId && isPaneInLayout(state.config.layout, state.focusedPaneId)
-            ? state.focusedPaneId
-            : (getDockedPaneIds(state.config.layout).at(-1) ?? instance.instanceId),
+          relativeTo: currentState.focusedPaneId && isPaneInLayout(currentLayout, currentState.focusedPaneId)
+            ? currentState.focusedPaneId
+            : (getDockedPaneIds(currentLayout).at(-1) ?? instance.instanceId),
           position: "right",
         },
       );
     persistLayout(nextLayout);
     activatePane(instance.instanceId, nextLayout);
+  };
+  const openPinnedTicker = async (rawSymbol: string, options?: PinTickerOptions) => {
+    const target = await resolveOpenTickerTarget(rawSymbol);
+    if (!target) return;
+    placePinnedTickerTarget(target, options);
+  };
+  pluginRegistry.pinTickerFn = (symbol, options) => {
+    if (isDetachedWindow) return;
+    void openPinnedTicker(symbol, options);
   };
 
   pluginRegistry.navigateTickerFn = (rawSymbol, options) => {
@@ -1401,25 +1441,9 @@ function AppInner({
     const sourcePaneId = options?.sourcePaneId ?? stateRef.current.focusedPaneId;
     (async () => {
       try {
-        // Resolve or create the ticker in the local database
-        const resolved = await resolveTickerSearch({
-          query: rawSymbol,
-          activeTicker: null,
-          tickers: stateRef.current.tickers,
-          dataProvider,
-        });
-
-        let symbol = rawSymbol;
-        if (resolved?.kind === "local") {
-          symbol = resolved.symbol;
-        } else if (resolved?.kind === "provider" && resolved.result) {
-          const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolved.result);
-          symbol = ticker.metadata.ticker;
-          dispatch({ type: "UPDATE_TICKER", ticker });
-          if (created) {
-            pluginRegistry.events.emit("ticker:added", { symbol, ticker });
-          }
-        }
+        const target = await resolveOpenTickerTarget(rawSymbol);
+        if (!target) return;
+        const symbol = target.symbol;
 
         // Only actions that originate from a ticker detail replace that exact pane.
         // Everything else opens or focuses a fixed ticker detail for the symbol.
@@ -1438,6 +1462,7 @@ function AppInner({
         };
 
         if (detailPane) {
+          publishTickerOpenTarget(target);
           const nextLayout = {
             ...currentLayout,
             instances: currentLayout.instances.map((instance) => (
@@ -1453,7 +1478,7 @@ function AppInner({
           currentFocusedPaneId: stateRef.current.focusedPaneId,
           targetPaneId: null,
         })) {
-          pluginRegistry.pinTicker(symbol, { floating: false });
+          placePinnedTickerTarget(target, { floating: false });
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/utils/ticker-search.ts
+++ b/src/utils/ticker-search.ts
@@ -84,6 +84,12 @@ export type ResolvedTickerSearch =
   | { kind: "local"; symbol: string; ticker: TickerRecord }
   | { kind: "provider"; symbol: string; result: InstrumentSearchResult };
 
+export interface TickerOpenTarget {
+  symbol: string;
+  ticker: TickerRecord;
+  created: boolean;
+}
+
 interface SearchQueryIntent {
   normalizedQuery: string;
   compactQuery: string;
@@ -295,6 +301,71 @@ export async function upsertTickerFromSearchResult(
   }
 
   return { ticker, created };
+}
+
+export async function resolveTickerOpenTarget({
+  query,
+  tickers,
+  dataProvider,
+  tickerRepository,
+  searchContext,
+}: {
+  query: string;
+  tickers: ReadonlyMap<string, TickerRecord>;
+  dataProvider: DataProvider;
+  tickerRepository: TickerRepository;
+  searchContext?: SearchRequestContext;
+}): Promise<TickerOpenTarget | null> {
+  const symbol = normalizeTickerInput(null, query);
+  if (!symbol) return null;
+
+  let resolved: ResolvedTickerSearch | null = null;
+  try {
+    resolved = await resolveTickerSearch({
+      query: symbol,
+      activeTicker: null,
+      tickers,
+      dataProvider,
+      searchContext,
+    });
+  } catch {
+    resolved = null;
+  }
+
+  if (resolved?.kind === "local") {
+    return { symbol: resolved.symbol, ticker: resolved.ticker, created: false };
+  }
+
+  if (resolved?.kind === "provider") {
+    const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolved.result);
+    return { symbol: ticker.metadata.ticker, ticker, created };
+  }
+
+  try {
+    const quote = await dataProvider.getQuote(symbol, "");
+    const quoteSymbol = normalizeTickerSymbol(quote.symbol || symbol);
+    const existing = await tickerRepository.loadTicker(quoteSymbol);
+    if (existing) {
+      return { symbol: existing.metadata.ticker, ticker: existing, created: false };
+    }
+
+    const ticker = await tickerRepository.createTicker({
+      ticker: quoteSymbol,
+      exchange: quote.listingExchangeName ?? quote.exchangeName ?? "",
+      currency: quote.currency || "USD",
+      name: quote.name || quoteSymbol,
+      assetCategory: undefined,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    });
+
+    return { symbol: ticker.metadata.ticker, ticker, created: true };
+  } catch {
+    return null;
+  }
 }
 
 export function findExactTickerSearchMatch<T extends Pick<TickerSearchRankableItem, "label"> & Partial<TickerSearchRankableItem>>(
@@ -618,7 +689,7 @@ function analyzeSearchQuery(query: string): SearchQueryIntent {
       .map((token) => ASSET_HINT_MAP[token])
       .filter((token): token is TickerSearchInstrumentClass => token != null),
   ));
-  const assetPreference = assetHints.length === 1 ? assetHints[0] : null;
+  const assetPreference = assetHints.length === 1 ? assetHints[0]! : null;
 
   const companyTokens = tokens.filter((token) => !(token in EXCHANGE_HINT_ALIASES) && !(token in ASSET_HINT_MAP));
   const companyQuery = companyTokens.join(" ");


### PR DESCRIPTION
Market mover rows now resolve a ticker record before opening a detail pane, so screener-only symbols no longer land on an empty "No ticker selected" view.

The shared ticker open path uses existing local/provider search first, then falls back to quote-backed ticker creation before placing the pane. This keeps market movers, pinned ticker opens, and ticker navigation aligned while preserving source-pane replacement behavior for existing detail panes.
