### PR TITLE
Add changelog pane

### DIFF
--- a/src/plugins/builtin/changelog.tsx
+++ b/src/plugins/builtin/changelog.tsx
@@ -1,0 +1,370 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { Box, ScrollBox, Text, TextAttributes, type ScrollBoxRenderable } from "../../ui";
+import { useShortcut } from "../../react/input";
+import {
+  DataTableStackView,
+  Spinner,
+  useExternalLinkFooter,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+  type PaneFooterSegment,
+  type PaneHint,
+} from "../../components";
+import { MarkdownText } from "../../components/markdown-text";
+import { fetchChangelogReleases, type ChangelogRelease } from "../../updater/github-releases";
+import { colors } from "../../theme/colors";
+import type { GloomPlugin, PaneProps } from "../../types/plugin";
+import { isPlainKey } from "../../utils/keyboard";
+import { usePluginPaneState } from "../plugin-runtime";
+
+const CHANGELOG_LIMIT = 40;
+
+type ChangelogColumnId = "date" | "version" | "title";
+type ChangelogColumn = DataTableColumn & { id: ChangelogColumnId };
+type LoadStatus = "idle" | "loading" | "loaded" | "error";
+
+function formatReleaseDate(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return "";
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function buildColumns(width: number, releases: ChangelogRelease[]): ChangelogColumn[] {
+  const dateWidth = 12;
+  const versionWidth = Math.min(
+    Math.max(7, ...releases.map((release) => release.version.length)),
+    14,
+  );
+  const titleWidth = Math.max(
+    18,
+    width - (dateWidth + 1) - (versionWidth + 1) - 3,
+  );
+
+  return [
+    { id: "date", label: "Date", width: dateWidth, align: "left" },
+    { id: "version", label: "Version", width: versionWidth, align: "left" },
+    { id: "title", label: "Title", width: titleWidth, align: "left" },
+  ];
+}
+
+function releaseDetailTitle(release: ChangelogRelease): string {
+  return release.title === release.version
+    ? release.version
+    : `${release.version} ${release.title}`;
+}
+
+function ChangelogDetail({
+  release,
+  width,
+  scrollRef,
+}: {
+  release: ChangelogRelease;
+  width: number;
+  scrollRef: RefObject<ScrollBoxRenderable | null>;
+}) {
+  const lineWidth = Math.max(width - 2, 12);
+
+  return (
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+      paddingX={1}
+      paddingY={1}
+    >
+      <ScrollBox
+        ref={scrollRef}
+        flexGrow={1}
+        flexBasis={0}
+        minHeight={0}
+        scrollY
+        focusable={false}
+      >
+        <Box flexDirection="column" width={lineWidth}>
+          <Text fg={colors.textMuted}>
+            {`${formatReleaseDate(release.publishedAt)} | ${release.version}`}
+          </Text>
+          <Text>{" "}</Text>
+          <MarkdownText text={release.body} lineWidth={lineWidth} />
+        </Box>
+      </ScrollBox>
+    </Box>
+  );
+}
+
+function ChangelogPane({ focused, width, height }: PaneProps) {
+  const [releases, setReleases] = useState<ChangelogRelease[]>([]);
+  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
+  const [openReleaseId, setOpenReleaseId] = useState<string | null>(null);
+  const detailScrollRef = useRef<ScrollBoxRenderable>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const loadReleases = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setStatus("loading");
+    setError(null);
+
+    try {
+      const nextReleases = await fetchChangelogReleases(CHANGELOG_LIMIT, controller.signal);
+      setReleases(nextReleases);
+      setStatus("loaded");
+    } catch (loadError) {
+      if (
+        loadError instanceof Error
+        && loadError.name === "AbortError"
+      ) {
+        return;
+      }
+      setError(loadError instanceof Error ? loadError.message : "Failed to load changelog");
+      setStatus("error");
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadReleases();
+    return () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, [loadReleases]);
+
+  useEffect(() => {
+    if (releases.length > 0 && selectedIdx >= releases.length) {
+      setSelectedIdx(Math.max(0, releases.length - 1));
+    }
+  }, [releases.length, selectedIdx, setSelectedIdx]);
+
+  const openRelease = useMemo(
+    () =>
+      openReleaseId
+        ? releases.find((release) => release.id === openReleaseId) ?? null
+        : null,
+    [openReleaseId, releases],
+  );
+
+  useEffect(() => {
+    if (openReleaseId && !openRelease) {
+      setOpenReleaseId(null);
+    }
+  }, [openRelease, openReleaseId]);
+
+  useEffect(() => {
+    if (!openReleaseId) return;
+    const scrollBox = detailScrollRef.current;
+    if (scrollBox) scrollBox.scrollTop = 0;
+  }, [openReleaseId]);
+
+  useShortcut((event) => {
+    if (!focused || !isPlainKey(event, "r")) return;
+    event.stopPropagation?.();
+    event.preventDefault?.();
+    void loadReleases();
+  });
+
+  const columns = useMemo(() => buildColumns(width, releases), [releases, width]);
+  const activeSelectedIdx = releases.length > 0
+    ? Math.max(0, Math.min(selectedIdx, releases.length - 1))
+    : -1;
+
+  const scrollDetailBy = useCallback((delta: number) => {
+    const scrollBox = detailScrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const maxScrollTop = Math.max(
+      0,
+      scrollBox.scrollHeight - scrollBox.viewport.height,
+    );
+    scrollBox.scrollTop = Math.max(
+      0,
+      Math.min(maxScrollTop, scrollBox.scrollTop + delta),
+    );
+  }, []);
+
+  const handleDetailKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (isPlainKey(event, "j", "down")) {
+      event.stopPropagation?.();
+      event.preventDefault?.();
+      scrollDetailBy(1);
+      return true;
+    }
+    if (isPlainKey(event, "k", "up")) {
+      event.stopPropagation?.();
+      event.preventDefault?.();
+      scrollDetailBy(-1);
+      return true;
+    }
+    return false;
+  }, [scrollDetailBy]);
+
+  const renderCell = useCallback((
+    release: ChangelogRelease,
+    column: ChangelogColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+    switch (column.id) {
+      case "date":
+        return {
+          text: formatReleaseDate(release.publishedAt),
+          color: selectedColor ?? colors.textDim,
+        };
+      case "version":
+        return {
+          text: release.version,
+          color: selectedColor ?? colors.textBright,
+          attributes: TextAttributes.BOLD,
+        };
+      case "title":
+        return {
+          text: release.title,
+          color: selectedColor ?? colors.text,
+        };
+    }
+  }, []);
+
+  const footerInfo = useMemo<PaneFooterSegment[]>(() => {
+    const segments: PaneFooterSegment[] = [];
+    if (status === "loading") {
+      segments.push({
+        id: "loading",
+        parts: [{ text: "loading", tone: "muted" }],
+      });
+    }
+    if (status === "error") {
+      segments.push({
+        id: "error",
+        parts: [{ text: "error", tone: "warning" }],
+      });
+    }
+    if (releases.length > 0) {
+      segments.push({
+        id: "versions",
+        parts: [
+          { text: "versions", tone: "label" },
+          { text: String(releases.length), tone: "value" },
+        ],
+      });
+    }
+    return segments;
+  }, [releases.length, status]);
+
+  const footerHints = useMemo<PaneHint[]>(() => [{
+    id: "refresh",
+    key: "r",
+    label: "efresh",
+    onPress: () => {
+      void loadReleases();
+    },
+  }], [loadReleases]);
+
+  useExternalLinkFooter({
+    registrationId: "changelog",
+    focused,
+    url: openRelease?.url,
+    source: openRelease?.version,
+    label: "release",
+    info: footerInfo,
+    hints: footerHints,
+  });
+
+  if (status === "loading" && releases.length === 0) {
+    return <Spinner label="Loading changelog..." />;
+  }
+
+  if (status === "error" && releases.length === 0) {
+    return (
+      <Box paddingX={1} paddingY={1}>
+        <Text fg={colors.textDim}>
+          {`Failed to load changelog: ${error ?? "unknown error"}`}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (releases.length === 0) {
+    return (
+      <Box paddingX={1} paddingY={1}>
+        <Text fg={colors.textDim}>No changelog entries found.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <DataTableStackView<ChangelogRelease, ChangelogColumn>
+      focused={focused}
+      detailOpen={!!openRelease}
+      onBack={() => setOpenReleaseId(null)}
+      detailContent={openRelease ? (
+        <ChangelogDetail
+          release={openRelease}
+          width={width}
+          scrollRef={detailScrollRef}
+        />
+      ) : (
+        <Box flexGrow={1} />
+      )}
+      detailTitle={openRelease ? releaseDetailTitle(openRelease) : undefined}
+      selectedIndex={activeSelectedIdx}
+      onSelectIndex={(index) => setSelectedIdx(index)}
+      onActivateIndex={(_index, release) => setOpenReleaseId(release.id)}
+      onDetailKeyDown={handleDetailKeyDown}
+      rootWidth={width}
+      rootHeight={height}
+      columns={columns}
+      items={releases}
+      getItemKey={(release) => release.id}
+      isSelected={(_release, index) => index === activeSelectedIdx}
+      onSelect={(_release, index) => setSelectedIdx(index)}
+      onActivate={(release) => setOpenReleaseId(release.id)}
+      renderCell={renderCell}
+      emptyStateTitle="No changelog entries."
+      showHorizontalScrollbar={false}
+    />
+  );
+}
+
+export const changelogPlugin: GloomPlugin = {
+  id: "changelog",
+  name: "Changelog",
+  version: "1.0.0",
+  description: "Browse Gloomberb release notes.",
+  toggleable: true,
+
+  panes: [
+    {
+      id: "changelog",
+      name: "Changelog",
+      icon: "L",
+      component: ChangelogPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 32 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "changelog-pane",
+      paneId: "changelog",
+      label: "Changelog",
+      description: "Browse version history and release notes.",
+      keywords: ["changelog", "release", "releases", "version", "updates"],
+      shortcut: { prefix: "CHG" },
+    },
+  ],
+};

--- a/src/plugins/catalog-ui.ts
+++ b/src/plugins/catalog-ui.ts
@@ -6,6 +6,7 @@ import { newsPlugin } from "./builtin/news";
 import { notesPlugin } from "./builtin/notes";
 import { aiPlugin } from "./builtin/ai";
 import { gloomberbCloudPlugin } from "./builtin/chat";
+import { changelogPlugin } from "./builtin/changelog";
 import { helpPlugin } from "./builtin/help";
 import { ibkrPlugin } from "./ibkr";
 import { layoutManagerPlugin } from "./builtin/layout-manager";
@@ -31,6 +32,7 @@ export const uiBuiltinPlugins: GloomPlugin[] = [
   companyResearchPlugin,
   notesPlugin,
   aiPlugin,
+  changelogPlugin,
   helpPlugin,
   predictionMarketsPlugin,
   marketOverviewPlugin,

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,5 +1,4 @@
-const REPO = "vincelwt/gloomberb";
-const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
+import { GITHUB_LATEST_RELEASE_API_URL } from "./updater/github-releases";
 
 function getRuntimeProcess(): Pick<NodeJS.Process, "platform" | "arch" | "argv" | "execPath"> | null {
   return (globalThis as { process?: NodeJS.Process }).process ?? null;
@@ -179,7 +178,7 @@ export async function checkForUpdateDetailed(
     const controller = new AbortController();
     timeout = setTimeout(() => controller.abort(), 5000);
 
-    const res = await fetch(API_URL, {
+    const res = await fetch(GITHUB_LATEST_RELEASE_API_URL, {
       signal: controller.signal,
       headers: { Accept: "application/vnd.github+json" },
     });

--- a/src/updater/github-releases.test.ts
+++ b/src/updater/github-releases.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeChangelogRelease } from "./github-releases";
+
+describe("normalizeChangelogRelease", () => {
+  test("maps a GitHub release into changelog row fields", () => {
+    const release = normalizeChangelogRelease({
+      id: 75,
+      tag_name: "v0.7.5",
+      name: "v0.7.5 - Crash recovery and ticker opens",
+      published_at: "2026-05-14T23:27:47Z",
+      body: "## Highlights\n\n- Fixed startup recovery.",
+      html_url: "https://github.com/vincelwt/gloomberb/releases/tag/v0.7.5",
+    });
+
+    expect(release).toEqual({
+      id: "75",
+      tagName: "v0.7.5",
+      version: "v0.7.5",
+      title: "Crash recovery and ticker opens",
+      publishedAt: "2026-05-14T23:27:47Z",
+      body: "## Highlights\n\n- Fixed startup recovery.",
+      url: "https://github.com/vincelwt/gloomberb/releases/tag/v0.7.5",
+    });
+  });
+
+  test("falls back to the tag page and a default body", () => {
+    const release = normalizeChangelogRelease({
+      tag_name: "v1.0.0",
+      name: "v1.0.0",
+    });
+
+    expect(release?.id).toBe("v1.0.0");
+    expect(release?.title).toBe("v1.0.0");
+    expect(release?.body).toBe("No changelog details were published for this release.");
+    expect(release?.url).toBe("https://github.com/vincelwt/gloomberb/releases/tag/v1.0.0");
+  });
+
+  test("drops malformed releases without a tag", () => {
+    expect(normalizeChangelogRelease({ name: "Missing tag" })).toBeNull();
+  });
+});

--- a/src/updater/github-releases.ts
+++ b/src/updater/github-releases.ts
@@ -1,0 +1,73 @@
+export const GLOOMBERB_REPO = "vincelwt/gloomberb";
+export const GITHUB_RELEASES_API_URL = `https://api.github.com/repos/${GLOOMBERB_REPO}/releases`;
+export const GITHUB_LATEST_RELEASE_API_URL = `${GITHUB_RELEASES_API_URL}/latest`;
+
+export interface ChangelogRelease {
+  id: string;
+  tagName: string;
+  version: string;
+  title: string;
+  body: string;
+  publishedAt: string;
+  url: string;
+}
+
+interface GitHubReleasePayload {
+  id?: number | string;
+  tag_name?: string;
+  name?: string | null;
+  body?: string | null;
+  published_at?: string | null;
+  html_url?: string | null;
+}
+
+const DEFAULT_CHANGELOG_BODY = "No changelog details were published for this release.";
+
+function stripTagPrefix(name: string, tagName: string): string {
+  if (!tagName) return name;
+  const escapedTag = tagName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return name.replace(new RegExp(`^${escapedTag}\\s*(?:-|:)\\s*`, "i"), "").trim();
+}
+
+export function normalizeChangelogRelease(release: GitHubReleasePayload): ChangelogRelease | null {
+  const tagName = release.tag_name?.trim();
+  if (!tagName) return null;
+
+  const rawName = release.name?.trim() || "";
+  const title = stripTagPrefix(rawName, tagName) || rawName || tagName;
+  const body = release.body?.trim() || DEFAULT_CHANGELOG_BODY;
+
+  return {
+    id: String(release.id ?? tagName),
+    tagName,
+    version: tagName,
+    title,
+    body,
+    publishedAt: release.published_at ?? "",
+    url: release.html_url?.trim() || `https://github.com/${GLOOMBERB_REPO}/releases/tag/${encodeURIComponent(tagName)}`,
+  };
+}
+
+export async function fetchChangelogReleases(
+  limit = 30,
+  signal?: AbortSignal,
+): Promise<ChangelogRelease[]> {
+  const perPage = Math.max(1, Math.min(Math.floor(limit), 100));
+  const response = await fetch(`${GITHUB_RELEASES_API_URL}?per_page=${perPage}`, {
+    signal,
+    headers: { Accept: "application/vnd.github+json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub returned ${response.status}`);
+  }
+
+  const data = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error("GitHub returned an unexpected releases payload");
+  }
+
+  return data
+    .map((release) => normalizeChangelogRelease(release as GitHubReleasePayload))
+    .filter((release): release is ChangelogRelease => release !== null);
+}


### PR DESCRIPTION
Adds a builtin Changelog pane that fetches GitHub releases and displays them in a date/version/title table.

Opening a row shows the formatted release notes in the shared datatable detail view, with refresh and release-open footer actions.

The updater now shares the GitHub releases endpoint helper with the pane instead of duplicating release URL constants.