### PR TITLE
Clean up unused Gloomberb internals

### DIFF
--- a/src/brokers/profile-form.ts
+++ b/src/brokers/profile-form.ts
@@ -23,7 +23,7 @@ function normalizeFormValue(value: unknown): string {
   return "";
 }
 
-export function flattenBrokerConfigValues(
+function flattenBrokerConfigValues(
   adapter: BrokerAdapter,
   instance?: BrokerInstanceConfig,
 ): Record<string, string> {
@@ -66,7 +66,7 @@ function getPreviousPasswordValue(
   return normalizeFormValue((adapter.toConfigValues?.(previous) ?? previous.config)[key]);
 }
 
-export function withPreservedBrokerPasswords(
+function withPreservedBrokerPasswords(
   adapter: BrokerAdapter,
   values: Record<string, string>,
   previous?: BrokerInstanceConfig,

--- a/src/components/chart/chart-controller.ts
+++ b/src/components/chart/chart-controller.ts
@@ -351,53 +351,6 @@ export function getVisibleWindowForDateRange(
   };
 }
 
-export function formatVisibleSpanLabel(window: Pick<VisibleDateWindow, "start" | "end">): string {
-  if (!window.start || !window.end) return "view: --";
-  const sameYear = window.start.getFullYear() === window.end.getFullYear();
-  const sameMonth = sameYear && window.start.getMonth() === window.end.getMonth();
-  const sameDay = sameMonth && window.start.getDate() === window.end.getDate();
-  const spanMs = Math.max(window.end.getTime() - window.start.getTime(), 0);
-  const showTime = sameDay || spanMs <= 2 * 24 * 60 * 60_000;
-
-  if (showTime) {
-    const startLabel = window.start.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      ...(sameYear ? {} : { year: "numeric" }),
-    });
-    const startTime = window.start.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-    });
-    const endLabel = sameDay
-      ? window.end.toLocaleTimeString("en-US", {
-        hour: "numeric",
-        minute: "2-digit",
-      })
-      : `${window.end.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: sameYear ? undefined : "numeric",
-      })} ${window.end.toLocaleTimeString("en-US", {
-        hour: "numeric",
-        minute: "2-digit",
-      })}`;
-    return `view:${startLabel} ${startTime}-${endLabel}`;
-  }
-
-  const startLabel = window.start.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    ...(sameYear ? {} : { year: "numeric" }),
-  });
-  const endLabel = window.end.toLocaleDateString("en-US", {
-    month: sameMonth ? undefined : "short",
-    day: "numeric",
-    year: sameYear ? undefined : "numeric",
-  });
-  return `view:${startLabel}-${endLabel}`;
-}
-
 function isCanonicalPresetViewport(
   dates: readonly Date[],
   state: Pick<ViewStateWithViewport, "activePreset" | "panOffset" | "zoomLevel" | "resolution">,

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -5,6 +5,12 @@ import { TextAttributes, type InputRenderable, type ScrollBoxRenderable, type Te
 import { useShortcut, useViewport } from "../../react/input";
 import { Button, NumberField, Spinner, TextField } from "../ui";
 import { NativeSelect, openNativeSelect, type NativeSelectElement } from "../ui/native-select";
+import {
+  moveMultiSelectValue,
+  toggleMultiSelectValue,
+  toggleOrderedMultiSelectValue,
+  type MultiSelectOption,
+} from "../ui/multi-select";
 import { ToggleList } from "../toggle-list";
 import {
   applyTheme,
@@ -140,7 +146,6 @@ import {
   isRouteCommandId,
   isWorkflowTextField,
   looksDestructiveCommand,
-  moveSelectedValue,
   normalizeFieldOptions,
   normalizeWizardFields,
   routeCommandIdToScreen,
@@ -148,7 +153,6 @@ import {
   summarizeError,
   summarizePaneSettingValue,
   summarizeWorkflowFieldValue,
-  toggleSelectedValue,
 } from "./helpers";
 import {
   buildAddToPortfolioWorkflow,
@@ -336,6 +340,15 @@ function getVisibleMultiSelectPickerOptions(
       description,
     };
   });
+}
+
+function toMultiSelectOptions(options: CommandBarPickerOption[]): MultiSelectOption[] {
+  return options.map((option) => ({
+    value: option.id,
+    label: option.label,
+    description: option.description,
+    disabled: option.disabled,
+  }));
 }
 
 type CommandBarListScrollEvent = {
@@ -4972,7 +4985,10 @@ export function CommandBar({
     updateTopRoute((route) => {
       if (route.kind !== "picker" || route.pickerId !== "field-multi-select") return route;
       const selectedValues = coerceFieldValues(route.payload?.selectedValues as CommandBarFieldValue | undefined);
-      const nextSelectedValues = toggleSelectedValue(selectedValues, optionId);
+      const options = toMultiSelectOptions(route.options);
+      const nextSelectedValues = route.payload?.fieldType === "ordered-multi-select"
+        ? toggleOrderedMultiSelectValue(options, selectedValues, optionId)
+        : toggleMultiSelectValue(options, selectedValues, optionId);
       const nextRoute = {
         ...route,
         payload: {
@@ -4999,18 +5015,13 @@ export function CommandBar({
       if (route.kind !== "picker" || route.pickerId !== "field-multi-select") return route;
       const fieldType = String(route.payload?.fieldType ?? "");
       if (fieldType !== "ordered-multi-select") return route;
-      const workflowField: CommandBarWorkflowField = {
-        id: "selectedValues",
-        label: route.title,
-        type: "ordered-multi-select",
-        options: route.options.map((option) => ({
-          label: option.label,
-          value: option.id,
-          description: option.description,
-        })),
-      };
       const selectedValues = coerceFieldValues(route.payload?.selectedValues as CommandBarFieldValue | undefined);
-      const nextSelectedValues = moveSelectedValue(workflowField, selectedValues, selectedItem.id, direction);
+      const nextSelectedValues = moveMultiSelectValue(
+        toMultiSelectOptions(route.options),
+        selectedValues,
+        selectedItem.id,
+        direction,
+      );
       const nextRoute = {
         ...route,
         payload: {

--- a/src/components/command-bar/helpers.test.ts
+++ b/src/components/command-bar/helpers.test.ts
@@ -18,14 +18,12 @@ import {
   isRouteCommandId,
   isWorkflowTextField,
   looksDestructiveCommand,
-  moveSelectedValue,
   normalizeWizardFields,
   routeCommandIdToScreen,
   slugifyName,
   summarizeError,
   summarizePaneSettingValue,
   summarizeWorkflowFieldValue,
-  toggleSelectedValue,
 } from "./helpers";
 
 const workflowFields: CommandBarWorkflowField[] = [
@@ -99,24 +97,6 @@ describe("command-bar helpers", () => {
         { label: "Volume", value: "volume" },
       ],
     }, ["symbol", "price", "pnl", "volume"])).toBe("Symbol, Price, P&L +1");
-  });
-
-  test("toggles and reorders selected values while preserving unknown entries", () => {
-    expect(toggleSelectedValue(["symbol", "price"], "price")).toEqual(["symbol"]);
-    expect(toggleSelectedValue(["symbol"], "price")).toEqual(["symbol", "price"]);
-
-    expect(moveSelectedValue(
-      {
-        options: [
-          { label: "Symbol", value: "symbol" },
-          { label: "Price", value: "price" },
-          { label: "P&L", value: "pnl" },
-        ],
-      },
-      ["symbol", "price", "custom"],
-      "price",
-      "up",
-    )).toEqual(["price", "symbol", "custom"]);
   });
 
   test("normalizes wizard fields and derives defaults from steps", () => {

--- a/src/components/command-bar/helpers.ts
+++ b/src/components/command-bar/helpers.ts
@@ -136,37 +136,6 @@ export function summarizePaneSettingValue(field: PaneSettingField, value: unknow
   }
 }
 
-export function toggleSelectedValue(currentValues: string[], value: string): string[] {
-  return currentValues.includes(value)
-    ? currentValues.filter((entry) => entry !== value)
-    : [...currentValues, value];
-}
-
-export function moveSelectedValue(
-  field: { options: CommandBarFieldOption[] },
-  currentValues: string[],
-  selectedOption: string,
-  direction: "up" | "down",
-): string[] {
-  if (!currentValues.includes(selectedOption)) return currentValues;
-
-  const optionValueSet = new Set(field.options.map((option) => option.value));
-  const ordered = currentValues.filter((value) => optionValueSet.has(value));
-  const index = ordered.indexOf(selectedOption);
-  if (index < 0) return currentValues;
-
-  const targetIndex = direction === "up"
-    ? Math.max(0, index - 1)
-    : Math.min(ordered.length - 1, index + 1);
-  if (targetIndex === index) return currentValues;
-
-  const next = [...ordered];
-  const [entry] = next.splice(index, 1);
-  next.splice(targetIndex, 0, entry!);
-  const unknownValues = currentValues.filter((value) => !optionValueSet.has(value));
-  return [...next, ...unknownValues];
-}
-
 export function normalizeWizardFields(steps: WizardStep[]): {
   fields: CommandBarWorkflowField[];
   description: string[];

--- a/src/data/plugin-state-store.ts
+++ b/src/data/plugin-state-store.ts
@@ -2,7 +2,7 @@ import type { Database } from "bun:sqlite";
 import { safeParseJson, serializeJson } from "./sqlite-json";
 import { withSqliteBusyRetry } from "./sqlite-retry";
 
-export const DEFAULT_PLUGIN_STATE_SCHEMA_VERSION = 1;
+const DEFAULT_PLUGIN_STATE_SCHEMA_VERSION = 1;
 
 export interface PluginStateRecord<T = unknown> {
   value: T;

--- a/src/data/session-store.ts
+++ b/src/data/session-store.ts
@@ -2,7 +2,7 @@ import type { Database } from "bun:sqlite";
 import { safeParseJson, serializeJson } from "./sqlite-json";
 import { withSqliteBusyRetry } from "./sqlite-retry";
 
-export const DEFAULT_SESSION_SCHEMA_VERSION = 1;
+const DEFAULT_SESSION_SCHEMA_VERSION = 1;
 
 export interface SessionSnapshotRecord<T = unknown> {
   sessionId: string;

--- a/src/market-data/hooks.tsx
+++ b/src/market-data/hooks.tsx
@@ -69,7 +69,7 @@ function buildTickerFinancialsMapKey(tickers: TickerRecord[]): string {
   }).join("::");
 }
 
-export function useTickerInstrument(symbol: string | null | undefined, ticker: TickerRecord | null | undefined): InstrumentRef | null {
+function useTickerInstrument(symbol: string | null | undefined, ticker: TickerRecord | null | undefined): InstrumentRef | null {
   return useMemo(() => instrumentFromTicker(ticker, symbol ?? null), [symbol, ticker]);
 }
 

--- a/src/news/ticker-symbols.ts
+++ b/src/news/ticker-symbols.ts
@@ -1,4 +1,4 @@
-export function newsDisplayTickerSymbol(value: string | null | undefined): string | null {
+function newsDisplayTickerSymbol(value: string | null | undefined): string | null {
   const normalized = value?.trim().toUpperCase();
   if (!normalized) return null;
   return normalized.split(":")[0] || null;

--- a/src/plugins/builtin/ai/settings.ts
+++ b/src/plugins/builtin/ai/settings.ts
@@ -5,14 +5,14 @@ export interface AiScreenerPaneSettings {
   columnIds: string[];
 }
 
-export const AI_REASON_COLUMN: ColumnConfig = {
+const AI_REASON_COLUMN: ColumnConfig = {
   id: "reason",
   label: "REASON",
   width: 34,
   align: "left",
 };
 
-export const AI_SCREENER_COLUMN_DEFS: ColumnConfig[] = [
+const AI_SCREENER_COLUMN_DEFS: ColumnConfig[] = [
   ...DEFAULT_COLUMNS,
   { id: "bid", label: "BID", width: 10, align: "right", format: "currency" },
   { id: "ask", label: "ASK", width: 10, align: "right", format: "currency" },
@@ -23,7 +23,7 @@ export const AI_SCREENER_COLUMN_DEFS: ColumnConfig[] = [
   AI_REASON_COLUMN,
 ];
 
-export const DEFAULT_AI_SCREENER_COLUMN_IDS = [
+const DEFAULT_AI_SCREENER_COLUMN_IDS = [
   "ticker",
   "price",
   "change_pct",

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -248,7 +248,7 @@ function nextSectorSortPreference(current: SectorSortPreference, columnId: strin
   return { columnId: null, direction: "asc" };
 }
 
-export function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
+function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
   const focusedCollectionId = useAppSelector((state) => getFocusedCollectionId(state));
   const portfolios = useAppSelector((state) => state.config.portfolios);
   const baseCurrency = useAppSelector((state) => state.config.baseCurrency);

--- a/src/plugins/builtin/analytics/metrics.ts
+++ b/src/plugins/builtin/analytics/metrics.ts
@@ -105,7 +105,7 @@ export function computeWeightedPortfolioReturns(series: WeightedReturnSeries[]):
     .sort((left, right) => left.dateKey.localeCompare(right.dateKey));
 }
 
-export function alignReturnSeries(
+function alignReturnSeries(
   assetReturns: DatedReturn[],
   marketReturns: DatedReturn[],
 ): { asset: number[]; market: number[] } {

--- a/src/plugins/builtin/broker-manager/model.ts
+++ b/src/plugins/builtin/broker-manager/model.ts
@@ -34,7 +34,7 @@ function titleCase(value: string): string {
     .join(" ");
 }
 
-export function formatBrokerMode(value: unknown): string {
+function formatBrokerMode(value: unknown): string {
   const text = typeof value === "string" ? value.trim() : "";
   return text ? titleCase(text) : "Configured";
 }
@@ -48,7 +48,7 @@ export function formatBrokerUpdatedAt(updatedAt: number | undefined, now = Date.
   return `${Math.floor(ageMs / (24 * 60 * 60_000))}d ago`;
 }
 
-export function summarizeBrokerAccounts(accounts: BrokerAccount[]): string {
+function summarizeBrokerAccounts(accounts: BrokerAccount[]): string {
   if (accounts.length === 0) return "0 acct";
   const currencies = new Set(accounts.map((account) => account.currency || "USD"));
   const canSum = currencies.size === 1 && accounts.every((account) => typeof account.netLiquidation === "number");

--- a/src/plugins/builtin/comparison-chart.tsx
+++ b/src/plugins/builtin/comparison-chart.tsx
@@ -15,7 +15,7 @@ import type { GloomPlugin, PaneProps, PaneSettingsDef } from "../../types/plugin
 import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } from "../../utils/ticker-list";
 
 export const COMPARISON_CHART_PANE_ID = "comparison-chart";
-export const COMPARISON_CHART_TEMPLATE_ID = "comparison-chart-pane";
+const COMPARISON_CHART_TEMPLATE_ID = "comparison-chart-pane";
 export const MIN_COMPARISON_CHART_SYMBOLS = 2;
 
 interface ComparisonChartPaneSettings {

--- a/src/plugins/builtin/correlation/compute.ts
+++ b/src/plugins/builtin/correlation/compute.ts
@@ -106,10 +106,3 @@ export function formatCorrelation(r: number | null): string {
   if (r === null) return "  —  ";
   return r >= 0 ? ` ${r.toFixed(2)}` : r.toFixed(2);
 }
-
-export function correlationColor(r: number | null, positive: string, negative: string, neutral: string): string {
-  if (r === null) return neutral;
-  if (r > 0.7) return positive;
-  if (r < -0.7) return negative;
-  return neutral;
-}

--- a/src/plugins/builtin/correlation/settings.ts
+++ b/src/plugins/builtin/correlation/settings.ts
@@ -3,8 +3,8 @@ import type { PaneSettingsDef } from "../../../types/plugin";
 import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } from "../../../utils/ticker-list";
 
 export const MAX_CORRELATION_TICKERS = MAX_TICKER_LIST_SIZE;
-export const DEFAULT_CORRELATION_RANGE: CorrelationRangePreset = "1Y";
-export const CORRELATION_RANGE_OPTIONS = ["1M", "3M", "6M", "1Y", "5Y"] as const;
+const DEFAULT_CORRELATION_RANGE: CorrelationRangePreset = "1Y";
+const CORRELATION_RANGE_OPTIONS = ["1M", "3M", "6M", "1Y", "5Y"] as const;
 export const DEFAULT_CORRELATION_SYMBOLS = ["AAPL", "MSFT", "NVDA", "AMD"];
 
 export type CorrelationRangePreset = Extract<TimeRange, typeof CORRELATION_RANGE_OPTIONS[number]>;
@@ -16,11 +16,11 @@ export interface CorrelationPaneSettings {
   symbolsError: string | null;
 }
 
-export function isCorrelationRangePreset(value: unknown): value is CorrelationRangePreset {
+function isCorrelationRangePreset(value: unknown): value is CorrelationRangePreset {
   return CORRELATION_RANGE_OPTIONS.includes(value as CorrelationRangePreset);
 }
 
-export function normalizeCorrelationRange(value: unknown): CorrelationRangePreset {
+function normalizeCorrelationRange(value: unknown): CorrelationRangePreset {
   return isCorrelationRangePreset(value) ? value : DEFAULT_CORRELATION_RANGE;
 }
 

--- a/src/plugins/builtin/earnings/earnings-cache.ts
+++ b/src/plugins/builtin/earnings/earnings-cache.ts
@@ -35,7 +35,7 @@ export function resetEarningsCalendarPersistence(): void {
   activeFetches.clear();
 }
 
-export function normalizeEarningsSymbols(symbols: string[]): string[] {
+function normalizeEarningsSymbols(symbols: string[]): string[] {
   return Array.from(
     new Set(
       symbols

--- a/src/plugins/builtin/econ/fred-series-map.ts
+++ b/src/plugins/builtin/econ/fred-series-map.ts
@@ -83,7 +83,3 @@ export function resolveFredMapping(eventTitle: string, country: string): FredMap
 export function getRelatedTickers(eventTitle: string, country: string): string[] {
   return resolveFredMapping(eventTitle, country)?.relatedTickers ?? [];
 }
-
-export function getFredSeriesId(eventTitle: string, country: string): string | null {
-  return resolveFredMapping(eventTitle, country)?.seriesId ?? null;
-}

--- a/src/plugins/builtin/fear-greed/fear-greed-data.ts
+++ b/src/plugins/builtin/fear-greed/fear-greed-data.ts
@@ -85,7 +85,7 @@ export interface FearGreedData {
   indicators: FearGreedIndicator[];
 }
 
-export const FEAR_GREED_INDICATORS: FearGreedIndicatorDefinition[] = [
+const FEAR_GREED_INDICATORS: FearGreedIndicatorDefinition[] = [
   {
     id: "market-momentum",
     title: "Market Momentum",

--- a/src/plugins/builtin/fx-matrix/pairs.ts
+++ b/src/plugins/builtin/fx-matrix/pairs.ts
@@ -2,28 +2,6 @@
 export const MAJOR_CURRENCIES = ["USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD", "NZD"] as const;
 export type MajorCurrency = typeof MAJOR_CURRENCIES[number];
 
-export const CURRENCY_LABELS: Record<MajorCurrency, string> = {
-  USD: "US Dollar",
-  EUR: "Euro",
-  GBP: "British Pound",
-  JPY: "Japanese Yen",
-  CHF: "Swiss Franc",
-  CAD: "Canadian Dollar",
-  AUD: "Australian Dollar",
-  NZD: "New Zealand Dollar",
-};
-
-export const CURRENCY_FLAGS: Record<MajorCurrency, string> = {
-  USD: "🇺🇸",
-  EUR: "🇪🇺",
-  GBP: "🇬🇧",
-  JPY: "🇯🇵",
-  CHF: "🇨🇭",
-  CAD: "🇨🇦",
-  AUD: "🇦🇺",
-  NZD: "🇳🇿",
-};
-
 /** Format rate with appropriate precision — JPY pairs get 2 decimals, others get 4 */
 export function formatRate(rate: number, toCurrency: MajorCurrency): string {
   const decimals = toCurrency === "JPY" ? 2 : 4;

--- a/src/plugins/builtin/layout-manager.tsx
+++ b/src/plugins/builtin/layout-manager.tsx
@@ -24,7 +24,7 @@ export function setLayoutManagerDispatch(
   getStateRef = getState;
 }
 
-export function clearLayoutManagerDispatch() {
+function clearLayoutManagerDispatch() {
   dispatchRef = null;
   getStateRef = null;
 }

--- a/src/plugins/builtin/news-wire/categories.ts
+++ b/src/plugins/builtin/news-wire/categories.ts
@@ -18,7 +18,7 @@ const KNOWN_TICKERS = new Set([
   "WFC", "C", "DIS", "PYPL", "SQ", "COIN", "PLTR", "SNOW", "CRWD",
 ]);
 
-export function classifyArticle(item: MarketNewsItem): string[] {
+function classifyArticle(item: MarketNewsItem): string[] {
   const text = `${item.title} ${item.summary ?? ""}`.toLowerCase();
   const matched: string[] = [];
 
@@ -34,7 +34,7 @@ export function classifyArticle(item: MarketNewsItem): string[] {
   return matched;
 }
 
-export function extractTickers(text: string, knownTickers?: Set<string>): string[] {
+function extractTickers(text: string, knownTickers?: Set<string>): string[] {
   const combined = new Set([...KNOWN_TICKERS, ...(knownTickers ?? [])]);
   const matches = text.match(/\b[A-Z]{1,5}\b/g) ?? [];
   const seen = new Set<string>();
@@ -58,7 +58,7 @@ const BREAKING_PATTERNS = [
   /\burgent\b/i,
 ];
 
-export function detectBreaking(title: string, publishedAt: Date, authority: number): boolean {
+function detectBreaking(title: string, publishedAt: Date, authority: number): boolean {
   for (const re of BREAKING_PATTERNS) {
     if (re.test(title)) return true;
   }
@@ -69,7 +69,7 @@ export function detectBreaking(title: string, publishedAt: Date, authority: numb
   return false;
 }
 
-export function scoreImportance(authority: number, publishedAt: Date, isBreaking: boolean): number {
+function scoreImportance(authority: number, publishedAt: Date, isBreaking: boolean): number {
   const ageMs = Date.now() - publishedAt.getTime();
   let score = authority;
 

--- a/src/plugins/builtin/news-wire/feed-config.ts
+++ b/src/plugins/builtin/news-wire/feed-config.ts
@@ -60,7 +60,7 @@ function normalizeAuthority(value: unknown, fallback: number): number {
   return Math.max(0, Math.min(100, Math.round(parsed)));
 }
 
-export function createUserFeedId(url: string, name: string): string {
+function createUserFeedId(url: string, name: string): string {
   return `user-${hashString(`${url}|${name}`)}`;
 }
 

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -38,7 +38,7 @@ interface NewsArticleStackBaseProps {
   titleForArticle?: (article: MarketNewsItem) => string;
 }
 
-export function formatRelativeTime(date: Date): string {
+function formatRelativeTime(date: Date): string {
   const ms = Date.now() - date.getTime();
   if (ms < 60_000) return "<1m";
   const min = Math.floor(ms / 60_000);
@@ -74,7 +74,7 @@ function compareArticle(a: MarketNewsItem, b: MarketNewsItem, columnId: NewsColu
   }
 }
 
-export function sortNewsArticles(
+function sortNewsArticles(
   articles: MarketNewsItem[],
   preference: NewsSortPreference,
 ): MarketNewsItem[] {

--- a/src/plugins/builtin/news-wire/read-state.ts
+++ b/src/plugins/builtin/news-wire/read-state.ts
@@ -5,7 +5,7 @@ export interface NewsReadState {
   articleIds: string[];
 }
 
-export const NEWS_READ_STATE_SCHEMA_VERSION = 1;
+const NEWS_READ_STATE_SCHEMA_VERSION = 1;
 export const MAX_READ_ARTICLE_IDS = 2_000;
 
 const READ_STATE_KEY = "read-articles";

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -395,7 +395,7 @@ function mostReadableColor(surface: string, candidates: readonly string[]): stri
   );
 }
 
-export function optionRoleColor(role: OptionColorRole, surface: string): string {
+function optionRoleColor(role: OptionColorRole, surface: string): string {
   const preferred = optionRoleThemeColor(role);
   const fallback = mostReadableColor(surface, [
     preferred,

--- a/src/plugins/builtin/portfolio-list/header.tsx
+++ b/src/plugins/builtin/portfolio-list/header.tsx
@@ -1,21 +1,17 @@
 import { Box, ScrollBox, Text } from "../../../ui";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { TextAttributes } from "../../../ui";
 import type { AppState } from "../../../state/app-context";
-import { colors, priceColor } from "../../../theme/colors";
+import { colors } from "../../../theme/colors";
 import type { BrokerConnectionStatus } from "../../../types/broker";
-import type { TickerFinancials } from "../../../types/financials";
-import type { Portfolio, TickerRecord } from "../../../types/ticker";
+import type { Portfolio } from "../../../types/ticker";
 import type { BrokerAccount } from "../../../types/trading";
-import { formatCompact, formatPercentRaw, padTo } from "../../../utils/format";
+import { formatCompact, padTo } from "../../../utils/format";
 import { formatMarketQuantity } from "../../../utils/market-format";
-import { getMostRecentQuoteUpdate } from "../../../utils/quote-time";
 import { getBrokerInstance } from "../../../utils/broker-instances";
 import { usePluginBrokerActions } from "../../plugin-runtime";
-import { calculatePortfolioSummaryTotals } from "./metrics";
 import {
   buildDrawerMetricSegments,
-  buildPortfolioSummarySegments,
   renderSummarySegments,
   resolvePortfolioAccountState,
   type ResolvedPortfolioAccountState,
@@ -156,90 +152,3 @@ export function PortfolioCashMarginDrawer({
     </Box>
   );
 }
-
-export const PortfolioSummaryBar = memo(function PortfolioSummaryBar({
-  tickers,
-  financialsMap,
-  baseCurrency,
-  exchangeRates,
-  refreshingCount,
-  isPortfolio,
-  collectionId,
-  width,
-  accountState,
-}: {
-  tickers: TickerRecord[];
-  financialsMap: Map<string, TickerFinancials>;
-  baseCurrency: string;
-  exchangeRates: Map<string, number>;
-  refreshingCount: number;
-  isPortfolio: boolean;
-  collectionId: string | null;
-  width: number;
-  accountState: ResolvedPortfolioAccountState | null;
-}) {
-  const lastRefreshTimestamp = useMemo(() => getMostRecentQuoteUpdate(
-    tickers.map((ticker) => financialsMap.get(ticker.metadata.ticker)?.quote),
-  ), [financialsMap, tickers]);
-  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
-  const wasRefreshing = useRef(false);
-
-  useEffect(() => {
-    if (refreshingCount > 0) {
-      wasRefreshing.current = true;
-      return;
-    }
-    if (wasRefreshing.current) {
-      wasRefreshing.current = false;
-      setLastRefresh(new Date());
-    }
-  }, [refreshingCount]);
-
-  useEffect(() => {
-    if (financialsMap.size > 0 && !lastRefresh) {
-      setLastRefresh(new Date());
-    }
-  }, [financialsMap.size, lastRefresh]);
-
-  const totals = useMemo(
-    () => calculatePortfolioSummaryTotals(
-      tickers,
-      financialsMap,
-      baseCurrency,
-      exchangeRates,
-      isPortfolio,
-      collectionId,
-    ),
-    [baseCurrency, collectionId, exchangeRates, financialsMap, isPortfolio, tickers],
-  );
-
-  const refreshTimestamp = lastRefreshTimestamp ?? lastRefresh?.getTime() ?? null;
-  const refreshText = refreshTimestamp != null
-    ? new Date(refreshTimestamp).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
-    : "—";
-  const isRefreshing = refreshingCount > 0;
-
-  if (!isPortfolio) {
-    if (totals.watchlistCount === 0) return null;
-    return (
-      <Box flexDirection="row" height={1} width={width} justifyContent="flex-start" overflow="hidden">
-        <Text fg={colors.textDim}>{"Avg Day "}</Text>
-        <Text fg={priceColor(totals.avgWatchlistChange)} attributes={TextAttributes.BOLD}>
-          {formatPercentRaw(totals.avgWatchlistChange)}
-        </Text>
-        <Text fg={colors.textDim}>{`  ${refreshText}`}</Text>
-      </Box>
-    );
-  }
-
-  if (!totals.hasPositions && !accountState) return null;
-
-  const segments = buildPortfolioSummarySegments({
-    totals,
-    accountState: accountState ? { account: accountState.account, sourceLabel: accountState.sourceLabel } : null,
-    widthBudget: width,
-    refreshText: isRefreshing ? "Refreshing…" : refreshText,
-  });
-
-  return <Box height={1}>{renderSummarySegments(segments, width)}</Box>;
-});

--- a/src/plugins/builtin/portfolio-list/settings.ts
+++ b/src/plugins/builtin/portfolio-list/settings.ts
@@ -18,7 +18,7 @@ export interface CollectionEntry {
   kind: "portfolio" | "watchlist";
 }
 
-export const PORTFOLIO_COLUMN_DEFS: ColumnConfig[] = [
+const PORTFOLIO_COLUMN_DEFS: ColumnConfig[] = [
   ...DEFAULT_COLUMNS,
   { id: PRICE_SPARKLINE_COLUMN_ID, label: PRICE_SPARKLINE_PERIOD_LABEL, width: 6, align: "left" },
   { id: "bid", label: "BID", width: 10, align: "right", format: "currency" },

--- a/src/plugins/builtin/portfolio-list/use-throttled-cursor-symbol.ts
+++ b/src/plugins/builtin/portfolio-list/use-throttled-cursor-symbol.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-export const FOLLOW_CURSOR_THROTTLE_MS = 300;
+const FOLLOW_CURSOR_THROTTLE_MS = 300;
 
 export function useThrottledCursorSymbol(
   committedCursorSymbol: string | null,

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -130,7 +130,7 @@ function latestHistoryClose(history: readonly PricePoint[]): number | null {
   return getSortedHistory(history).at(-1)?.point.close ?? null;
 }
 
-export function computeTrailingReturn(
+function computeTrailingReturn(
   history: readonly PricePoint[],
   days: number,
   latestPrice?: number | null,

--- a/src/plugins/builtin/sectors/sector-data.ts
+++ b/src/plugins/builtin/sectors/sector-data.ts
@@ -52,8 +52,6 @@ export const SECTOR_COLLECTIONS: SectorCollection[] = [
   { id: "industries", label: "Industries", items: INDUSTRIES },
 ];
 
-export const SECTORS = CORE_SECTORS;
-
 export function getSectorCollection(id: SectorCollectionId): SectorCollection {
   return SECTOR_COLLECTIONS.find((collection) => collection.id === id) ?? SECTOR_COLLECTIONS[0]!;
 }

--- a/src/plugins/builtin/ticker-detail/index.tsx
+++ b/src/plugins/builtin/ticker-detail/index.tsx
@@ -12,7 +12,6 @@ import { formatTickerListInput } from "../../../utils/ticker-list";
 
 export { FinancialsTab } from "./financials-tab";
 export { QuoteMonitorPane } from "./quote-monitor";
-export { buildVisibleDetailTabs } from "./settings";
 
 export const tickerDetailPlugin: GloomPlugin = {
   id: "ticker-detail",

--- a/src/plugins/builtin/ticker-surface.ts
+++ b/src/plugins/builtin/ticker-surface.ts
@@ -21,7 +21,7 @@ export interface TickerSurfacePaneTemplateOptions {
   ) => boolean;
 }
 
-export function resolveTickerSurfaceSymbol(
+function resolveTickerSurfaceSymbol(
   context: Pick<PaneTemplateContext, "activeTicker">,
   options?: Pick<PaneTemplateCreateOptions, "arg" | "symbol">,
 ): string | null {
@@ -29,7 +29,7 @@ export function resolveTickerSurfaceSymbol(
   return explicitSymbol || normalizeTickerInput(context.activeTicker, options?.arg);
 }
 
-export function createTickerSurfacePaneInstance(
+function createTickerSurfacePaneInstance(
   context: Pick<PaneTemplateContext, "activeTicker">,
   options: Pick<PaneTemplateCreateOptions, "arg" | "symbol"> | undefined,
   titlePrefix: string,

--- a/src/plugins/builtin/yahoo.ts
+++ b/src/plugins/builtin/yahoo.ts
@@ -8,7 +8,7 @@ class YahooPluginProvider extends YahooFinanceClient {
   readonly priority = 1000;
 }
 
-export function createYahooProvider() {
+function createYahooProvider() {
   return new YahooPluginProvider();
 }
 

--- a/src/plugins/catalog.ts
+++ b/src/plugins/catalog.ts
@@ -11,7 +11,7 @@ export interface PluginCatalogEntry {
   error?: string;
 }
 
-export const builtinPlugins: GloomPlugin[] = [
+const builtinPlugins: GloomPlugin[] = [
   yahooPlugin,
   ...uiBuiltinPlugins,
   debugPlugin,

--- a/src/plugins/ibkr/config.ts
+++ b/src/plugins/ibkr/config.ts
@@ -25,9 +25,9 @@ const DEFAULT_FLEX_CONFIG: FlexQueryConfig = {
   endpoint: IBKR_STATEMENT_URL,
 };
 
-export const DEFAULT_GATEWAY_HOST = "127.0.0.1";
+const DEFAULT_GATEWAY_HOST = "127.0.0.1";
 
-export const DEFAULT_GATEWAY_CONFIG: IbkrGatewayConfig = {
+const DEFAULT_GATEWAY_CONFIG: IbkrGatewayConfig = {
   host: DEFAULT_GATEWAY_HOST,
   marketDataType: "auto",
 };
@@ -196,10 +196,6 @@ export function getGatewayConfig(raw?: Record<string, unknown>): IbkrGatewayConf
   return normalizeIbkrConfig(raw).gateway;
 }
 
-export function getFlexConfig(raw?: Record<string, unknown>): FlexQueryConfig {
-  return normalizeIbkrConfig(raw).flex;
-}
-
 export function isGatewayConfigured(raw?: Record<string, unknown>): boolean {
   const config = normalizeIbkrConfig(raw);
   return config.connectionMode === "gateway"
@@ -244,19 +240,4 @@ export function buildPersistedIbkrGatewayConfig(
     flex: normalized.flex,
     gateway,
   };
-}
-
-export function getIbkrConfigIdentity(raw?: Record<string, unknown>): string {
-  const normalized = normalizeIbkrConfig(raw);
-  return JSON.stringify({
-    connectionMode: normalized.connectionMode,
-    gatewaySetupMode: normalized.gatewaySetupMode,
-    flex: normalized.flex,
-    gateway: {
-      host: normalized.gateway.host,
-      port: normalized.gateway.port ?? null,
-      clientId: normalized.gateway.clientId ?? null,
-      marketDataType: normalized.gateway.marketDataType ?? "auto",
-    },
-  });
 }

--- a/src/plugins/ibkr/flex.ts
+++ b/src/plugins/ibkr/flex.ts
@@ -136,7 +136,7 @@ export async function requestFlexStatement(config: FlexQueryConfig): Promise<str
   return codeMatch[1]!;
 }
 
-export async function getFlexStatement(
+async function getFlexStatement(
   token: string,
   referenceCode: string,
   context: Pick<FlexQueryConfig, "endpoint" | "queryId"> = {},

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -13,7 +13,6 @@ import { hasIbkrTradingProfiles } from "./trade-utils";
 import { TradeTab } from "./trade-tab";
 import { TradingPane } from "./trading-pane";
 
-export { hasIbkrTradingProfiles } from "./trade-utils";
 export { TradeTab } from "./trade-tab";
 
 let lastSelectedTickerSymbol: string | null = null;

--- a/src/plugins/ibkr/instance-selection.ts
+++ b/src/plugins/ibkr/instance-selection.ts
@@ -2,7 +2,7 @@ import type { AppConfig, BrokerInstanceConfig } from "../../types/config";
 import { getBrokerInstance, getBrokerInstancesByType } from "../../utils/broker-instances";
 import { isGatewayConfigured, normalizeIbkrConfig } from "./config";
 
-export function isIbkrGatewayInstance(instance?: BrokerInstanceConfig): instance is BrokerInstanceConfig {
+function isIbkrGatewayInstance(instance?: BrokerInstanceConfig): instance is BrokerInstanceConfig {
   if (!instance || instance.brokerType !== "ibkr" || instance.enabled === false) return false;
   const normalized = normalizeIbkrConfig(instance.config);
   return normalized.connectionMode === "gateway" && isGatewayConfigured(instance.config);

--- a/src/plugins/ibkr/trading-state.ts
+++ b/src/plugins/ibkr/trading-state.ts
@@ -127,7 +127,7 @@ export function updateTradeTicketState(
   updateTicketState(symbol, ticker, updater);
 }
 
-export function subscribeTradingPane(listener: () => void): () => void {
+function subscribeTradingPane(listener: () => void): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
 }
@@ -276,10 +276,6 @@ export function setTradeTicketPreview(
   ticker?: TickerRecord | null,
 ): void {
   updateTicketState(symbol, ticker, (current) => ({ ...current, preview, lastError: undefined }));
-}
-
-export function clearTradeTicketPreview(symbol: string, ticker?: TickerRecord | null): void {
-  updateTicketState(symbol, ticker, (current) => ({ ...current, preview: null }));
 }
 
 export function clearTradingDraft(symbol?: string): void {

--- a/src/plugins/pane-manager.ts
+++ b/src/plugins/pane-manager.ts
@@ -16,10 +16,10 @@ import {
   type DockSplitNode,
 } from "../types/config";
 
-export const MIN_PANE_WIDTH = 20;
+const MIN_PANE_WIDTH = 20;
 export const MIN_FLOAT_WIDTH = 15;
 export const MIN_FLOAT_HEIGHT = 6;
-export const MIN_DOCKED_HEIGHT = 5;
+const MIN_DOCKED_HEIGHT = 5;
 
 export interface ResolvedPane {
   instance: PaneInstanceConfig;
@@ -33,8 +33,7 @@ export interface DockTarget {
   position: "left" | "right" | "above" | "below";
 }
 
-export type GlobalDockRegion = "left" | "right" | "top" | "bottom" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
-export type LeafDropPosition =
+type LeafDropPosition =
   | "left"
   | "right"
   | "top"
@@ -641,7 +640,7 @@ function inferDockTreeFromRects(rects: GridlockRect[], bounds?: LayoutBounds): D
   };
 }
 
-export function traverseDockLeaves(layout: LayoutConfig): DockLeafRef[] {
+function traverseDockLeaves(layout: LayoutConfig): DockLeafRef[] {
   return collectDockLeafRefs(layout.dockRoot);
 }
 
@@ -751,7 +750,7 @@ export function floatPane(
   return floatAtRect(layout, instanceId, rect);
 }
 
-export function insertRelativeToLeaf(layout: LayoutConfig, instanceId: string, targetId: string, position: DockTarget["position"]): LayoutConfig {
+function insertRelativeToLeaf(layout: LayoutConfig, instanceId: string, targetId: string, position: DockTarget["position"]): LayoutConfig {
   if (instanceId === targetId) return layout;
   const base = detachPane(layout, instanceId);
   const targetLeaf = findDockLeaf(base, targetId);
@@ -775,7 +774,7 @@ export function insertAtRootEdge(layout: LayoutConfig, instanceId: string, edge:
   });
 }
 
-export function dockAtTarget(layout: LayoutConfig, instanceId: string, target: DockTarget): LayoutConfig {
+function dockAtTarget(layout: LayoutConfig, instanceId: string, target: DockTarget): LayoutConfig {
   return insertRelativeToLeaf(layout, instanceId, target.relativeTo, target.position);
 }
 
@@ -794,28 +793,6 @@ export function dockPane(layout: LayoutConfig, instanceId: string, target?: Dock
     return finalizeLayout({ ...detachPane(layout, instanceId), dockRoot: { kind: "pane", instanceId } });
   }
   return insertAtRootEdge(layout, instanceId, "right");
-}
-
-export function dockPaneToRegion(layout: LayoutConfig, instanceId: string, region: GlobalDockRegion): LayoutConfig {
-  switch (region) {
-    case "left":
-      return insertAtRootEdge(layout, instanceId, "left");
-    case "right":
-      return insertAtRootEdge(layout, instanceId, "right");
-    case "top":
-    case "top-left":
-    case "top-right":
-      return insertAtRootEdge(layout, instanceId, "top");
-    case "bottom":
-    case "bottom-left":
-    case "bottom-right":
-      return insertAtRootEdge(layout, instanceId, "bottom");
-  }
-}
-
-export function insertIntoQuadrant(layout: LayoutConfig, instanceId: string, targetId: string, quadrant: Exclude<LeafDropPosition, "left" | "right" | "top" | "bottom" | "center">): LayoutConfig {
-  const normalized = normalizeDropPosition(quadrant);
-  return insertRelativeToLeaf(layout, instanceId, targetId, normalized === "top" ? "above" : normalized === "bottom" ? "below" : normalized);
 }
 
 export function applyDrop(layout: LayoutConfig, draggedId: string, dropTarget: DropTarget): LayoutConfig {
@@ -864,10 +841,6 @@ export function movePaneRelative(
   const target = candidates[0]?.entry;
   if (!target) return layout;
   return insertRelativeToLeaf(layout, instanceId, target.instanceId, position);
-}
-
-export function swapLeaves(layout: LayoutConfig, firstId: string, secondId: string): LayoutConfig {
-  return swapPanes(layout, firstId, secondId);
 }
 
 export function swapPanes(layout: LayoutConfig, firstId: string, secondId: string): LayoutConfig {
@@ -924,10 +897,6 @@ export function swapPanes(layout: LayoutConfig, firstId: string, secondId: strin
   });
 }
 
-export function removeLeafAndCollapse(layout: LayoutConfig, instanceId: string): LayoutConfig {
-  return finalizeLayout(removeDockedLeaf(layout, instanceId));
-}
-
 export function resizeSplitAtPath(layout: LayoutConfig, path: Array<0 | 1>, ratio: number): LayoutConfig {
   const target = getNodeAtPath(layout.dockRoot, path);
   if (!target || target.kind !== "split" || !layout.dockRoot) return layout;
@@ -938,18 +907,6 @@ export function resizeSplitAtPath(layout: LayoutConfig, path: Array<0 | 1>, rati
       ratio: clampRatio(ratio),
     }),
   });
-}
-
-export function restorePlacementMemory(
-  layout: LayoutConfig,
-  instanceId: string,
-  termWidth: number,
-  termHeight: number,
-  def?: PaneDef,
-): LayoutConfig {
-  const isFloating = layout.floating.some((entry) => entry.instanceId === instanceId);
-  if (isFloating) return dockPane(layout, instanceId);
-  return floatPane(layout, instanceId, termWidth, termHeight, def);
 }
 
 export function addPaneToLayout(layout: LayoutConfig, instance: PaneInstanceConfig, target: DockTarget): LayoutConfig {
@@ -1001,7 +958,7 @@ export function isPaneDocked(layout: LayoutConfig, instanceId: string): boolean 
   return !!findDockLeaf(layout, instanceId);
 }
 
-export function updateFloatingPane(
+function updateFloatingPane(
   layout: LayoutConfig,
   instanceId: string,
   updates: Partial<Pick<FloatingPaneEntry, "x" | "y" | "width" | "height" | "zIndex">>,


### PR DESCRIPTION
Removes unused chart, portfolio, FX, sector, IBKR, and pane-manager code that was no longer referenced.
Reuses the shared multi-select helpers in the command bar and drops the duplicate local helpers and low-value helper test.
Demotes internal-only plugin, state, market-data, news, and broker exports so the module surface is smaller.
Leaves the remaining candidates alone where they look like public API, renderer aliases, or broader type surfaces.
