### PR TITLE
Fix command bar ticker match ordering

### DIFF
--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -47,7 +47,7 @@ describe("command bar view model helpers", () => {
     expect(sections.map((section) => section.category)).toEqual(["Tickers", "Config", "Danger", "Debug"]);
   });
 
-  test("keeps provider ticker suggestions behind app sections in app-first order", () => {
+  test("keeps non-exact ticker suggestions behind app sections in app-first order", () => {
     const sections = buildSections([
       { id: "pane", category: "Panes" },
       { id: "primary", category: "Primary Listing" },
@@ -59,8 +59,8 @@ describe("command bar view model helpers", () => {
 
     expect(sections.map((section) => section.category)).toEqual([
       "Exact Match",
-      "Saved",
       "Panes",
+      "Saved",
       "Primary Listing",
       "Other Listings",
       "Funds & Derivatives",

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -136,12 +136,13 @@ export function truncateText(text: string, width: number): string {
 function getCategoryPriority(category: string, sectionOrder: CommandBarSectionOrder = "default"): number {
   const normalized = category.trim().toLowerCase();
   if (normalized === "exact match") return -50;
-  if (normalized === "saved") return -40;
   if (sectionOrder === "app-first") {
-    if (normalized === "primary listing") return 100;
-    if (normalized === "other listings") return 110;
-    if (normalized === "funds & derivatives") return 120;
+    if (normalized === "saved") return 100;
+    if (normalized === "primary listing") return 110;
+    if (normalized === "other listings") return 120;
+    if (normalized === "funds & derivatives") return 130;
   }
+  if (normalized === "saved") return -40;
   if (normalized === "primary listing") return -30;
   if (normalized === "other listings") return -20;
   if (normalized === "funds & derivatives") return -10;


### PR DESCRIPTION
Fix root command-bar ordering so exact ticker matches still lead, but weaker saved/provider ticker sections no longer outrank stronger app commands in app-first search.
Queries like `float` now keep `Float Pane` ahead of loose saved ticker matches while preserving dedicated ticker-search ordering.
