### PR TITLE
Add combined macOS app and TUI install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,7 @@ jobs:
           git config --global user.name "gloomberb-release"
           git config --global user.email "actions@users.noreply.github.com"
           gh repo clone vincelwt/homebrew-tap "$TAP_DIR"
+          git -C "$TAP_DIR" remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/vincelwt/homebrew-tap.git"
           bun run scripts/write-homebrew-cask.ts \
             --version "$VERSION" \
             --sha256 "$SHA256" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,9 @@ jobs:
           zstd -d -o "$tmp_dir/Gloomberb.app.tar" artifacts/stable-macos-arm64-Gloomberb.app.tar.zst
           tar -xf "$tmp_dir/Gloomberb.app.tar" -C "$tmp_dir"
           test -x "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb"
+          test -f "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb-tui/tui-entry.js"
+          test -f "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb-tui/node_modules/@opentui/core-darwin-arm64/index.ts"
+          "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb" help
           ditto -c -k --keepParent "$tmp_dir/Gloomberb.app" artifacts/stable-macos-arm64-Gloomberb.app.zip
 
       - name: Verify desktop artifacts

--- a/.github/workflows/verify-desktop-homebrew.yml
+++ b/.github/workflows/verify-desktop-homebrew.yml
@@ -2,9 +2,6 @@ name: Verify Desktop Homebrew Package
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - vincelwt/macos-tui-desktop-install
 
 permissions:
   contents: read

--- a/.github/workflows/verify-desktop-homebrew.yml
+++ b/.github/workflows/verify-desktop-homebrew.yml
@@ -83,6 +83,7 @@ jobs:
 
           test -x "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb"
           test -f "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb-tui/tui-entry.js"
+          test -f "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb-tui/node_modules/@opentui/core-darwin-arm64/index.ts"
           "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb" help
 
           codesign --verify --verbose=4 "$tmp_dir/Gloomberb.app"

--- a/.github/workflows/verify-desktop-homebrew.yml
+++ b/.github/workflows/verify-desktop-homebrew.yml
@@ -1,46 +1,16 @@
-name: Release
+name: Verify Desktop Homebrew Package
 
 on:
+  workflow_dispatch:
   push:
-    tags:
-      - "v*"
+    branches:
+      - vincelwt/macos-tui-desktop-install
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            asset: gloomberb-darwin-arm64
-          - os: ubuntu-latest
-            asset: gloomberb-linux-x64
-          - os: ubuntu-24.04-arm
-            asset: gloomberb-linux-arm64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - run: bun install
-
-      - name: Build
-        run: |
-          mkdir -p dist
-          bun run scripts/build.ts
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.asset }}
-          path: dist/*
-
-  desktop-macos:
+  verify:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -96,21 +66,26 @@ jobs:
 
           echo "ELECTROBUN_APPLEAPIKEYPATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build signed desktop DMG
+      - name: Build signed desktop artifacts
         env:
           ELECTROBUN_APPLEAPIISSUER: ${{ secrets.ELECTROBUN_APPLEAPIISSUER }}
           ELECTROBUN_APPLEAPIKEY: ${{ secrets.ELECTROBUN_APPLEAPIKEY }}
           ELECTROBUN_DEVELOPER_ID: ${{ secrets.ELECTROBUN_DEVELOPER_ID }}
         run: bun run desktop:release
 
-      - name: Build Homebrew app archive
+      - name: Build and verify Homebrew archive
         run: |
           set -euo pipefail
           brew install zstd
           tmp_dir="$(mktemp -d)"
           zstd -d -o "$tmp_dir/Gloomberb.app.tar" artifacts/stable-macos-arm64-Gloomberb.app.tar.zst
           tar -xf "$tmp_dir/Gloomberb.app.tar" -C "$tmp_dir"
+
           test -x "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb"
+          test -f "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb-tui/tui-entry.js"
+          "$tmp_dir/Gloomberb.app/Contents/Resources/gloomberb" help
+
+          codesign --verify --verbose=4 "$tmp_dir/Gloomberb.app"
           ditto -c -k --keepParent "$tmp_dir/Gloomberb.app" artifacts/stable-macos-arm64-Gloomberb.app.zip
 
       - name: Verify desktop artifacts
@@ -123,75 +98,26 @@ jobs:
           codesign --verify --verbose=4 artifacts/stable-macos-arm64-Gloomberb.dmg
           xcrun stapler validate -v artifacts/stable-macos-arm64-Gloomberb.dmg
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: gloomberb-desktop-macos-arm64
-          path: artifacts/*
-
-  release:
-    needs:
-      - build
-      - desktop-macos
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-
-      - name: Upload assets to GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Update Homebrew tap
+      - name: Verify cask generation and tap access
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "HOMEBREW_TAP_TOKEN is not configured; skipping Homebrew tap update."
-            exit 0
-          fi
+          : "${GH_TOKEN:?missing HOMEBREW_TAP_TOKEN secret}"
 
-          VERSION="${GITHUB_REF_NAME#v}"
-          ZIP_PATH="dist/stable-macos-arm64-Gloomberb.app.zip"
-          SHA256="$(sha256sum "$ZIP_PATH" | awk '{print $1}')"
-          TAP_DIR="$RUNNER_TEMP/homebrew-tap"
-
-          git config --global user.name "gloomberb-release"
-          git config --global user.email "actions@users.noreply.github.com"
-          gh repo clone vincelwt/homebrew-tap "$TAP_DIR"
+          sha256="$(shasum -a 256 artifacts/stable-macos-arm64-Gloomberb.app.zip | awk '{print $1}')"
+          tap_dir="$RUNNER_TEMP/homebrew-tap"
+          gh repo clone vincelwt/homebrew-tap "$tap_dir"
           bun run scripts/write-homebrew-cask.ts \
-            --version "$VERSION" \
-            --sha256 "$SHA256" \
-            --output "$TAP_DIR/Casks/gloomberb.rb"
+            --version "0.0.0" \
+            --sha256 "$sha256" \
+            --output "$tap_dir/Casks/gloomberb.rb"
 
-          cd "$TAP_DIR"
-          if git diff --quiet; then
-            echo "Homebrew tap already up to date."
-            exit 0
-          fi
+          ruby -c "$tap_dir/Casks/gloomberb.rb"
+          grep -q 'stable-macos-arm64-Gloomberb.app.zip' "$tap_dir/Casks/gloomberb.rb"
+          grep -q 'binary "#{appdir}/Gloomberb.app/Contents/Resources/gloomberb", target: "gloomberb"' "$tap_dir/Casks/gloomberb.rb"
+
+          cd "$tap_dir"
           git add Casks/gloomberb.rb
-          git commit -m "Update Gloomberb to $VERSION"
-          git push
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Install npm 11 (required for trusted publishing)
-        run: npm install -g npm@11
-
-      - name: Publish to npm
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          node -e "const p=require('./package.json'); p.version='$VERSION'; require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2)+'\n')"
-          npm publish --access public --provenance
+          git commit -m "Verify cask update" --allow-empty
+          git push --dry-run origin HEAD:homebrew-verify-${GITHUB_RUN_ID}

--- a/.github/workflows/verify-desktop-homebrew.yml
+++ b/.github/workflows/verify-desktop-homebrew.yml
@@ -109,6 +109,7 @@ jobs:
           sha256="$(shasum -a 256 artifacts/stable-macos-arm64-Gloomberb.app.zip | awk '{print $1}')"
           tap_dir="$RUNNER_TEMP/homebrew-tap"
           gh repo clone vincelwt/homebrew-tap "$tap_dir"
+          git -C "$tap_dir" remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/vincelwt/homebrew-tap.git"
           bun run scripts/write-homebrew-cask.ts \
             --version "0.0.0" \
             --sha256 "$sha256" \

--- a/README.md
+++ b/README.md
@@ -60,15 +60,23 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a shortcut or command n
 
 ## Install
 
-Desktop:
+macOS desktop app + terminal command:
+
+```bash
+brew install --cask vincelwt/tap/gloomberb
+# or
+curl -fsSL gloomberb.com/install | bash
+```
+
+Both install `Gloomberb.app` and a `gloomberb` terminal command that runs the TUI through the app bundle, so the Bun runtime is stored once.
+
+Desktop-only download:
 
 - [Download Gloomberb for Mac](https://gloomberb.com/download/desktop)
 
-Terminal UI:
+Terminal-only install:
 
 ```bash
-curl -fsSL gloomberb.com/install | bash
-# or
 bun install -g gloomberb
 ```
 
@@ -77,6 +85,8 @@ Then run:
 ```bash
 gloomberb
 ```
+
+On macOS, app updates replace the app bundle in place and keep the terminal command pointing at the updated bundle. Homebrew users can also update through `brew upgrade --cask gloomberb`.
 
 For the best terminal experience, use a [Kitty](https://sw.kovidgoyal.net/kitty/)-compatible terminal such as Ghostty, Kitty, or WezTerm.
 

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -42,7 +42,7 @@ const config: ElectrobunConfig = {
   },
   scripts: {
     preBuild: "scripts/build-electrobun-view.ts",
-    postBuild: "",
+    postBuild: "scripts/install-electrobun-tui-shim.ts",
     postWrap: "",
     postPackage: "",
   },

--- a/scripts/install-electrobun-tui-shim.ts
+++ b/scripts/install-electrobun-tui-shim.ts
@@ -1,0 +1,55 @@
+import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const SHIM = `#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+CONTENTS_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$CONTENTS_DIR/MacOS"
+exec "./bun" "$CONTENTS_DIR/Resources/gloomberb-tui/tui-entry.js" "$@"
+`;
+
+function appBundlesIn(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((entry) => entry.endsWith(".app"))
+    .map((entry) => join(dir, entry));
+}
+
+const bundlePaths = [
+  process.env.ELECTROBUN_WRAPPER_BUNDLE_PATH,
+  ...appBundlesIn(process.env.ELECTROBUN_BUILD_DIR ?? ""),
+].filter((value): value is string => Boolean(value));
+
+const uniqueBundlePaths = [...new Set(bundlePaths)];
+
+for (const bundlePath of uniqueBundlePaths) {
+  const resourcesPath = join(bundlePath, "Contents", "Resources");
+  if (!existsSync(resourcesPath)) continue;
+
+  const tuiBundleDir = join(resourcesPath, "gloomberb-tui");
+  rmSync(tuiBundleDir, { recursive: true, force: true });
+  mkdirSync(tuiBundleDir, { recursive: true });
+
+  const build = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "build",
+      join(process.cwd(), "src", "renderers", "electrobun", "bun", "tui-entry.ts"),
+      "--target=bun",
+      `--outdir=${tuiBundleDir}`,
+    ],
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  if (build.exitCode !== 0) {
+    process.exit(1);
+  }
+
+  const shimPath = join(resourcesPath, "gloomberb");
+  writeFileSync(shimPath, SHIM);
+  chmodSync(shimPath, 0o755);
+  console.log(`Installed TUI shim: ${shimPath}`);
+}

--- a/scripts/install-electrobun-tui-shim.ts
+++ b/scripts/install-electrobun-tui-shim.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const SHIM = `#!/bin/sh
@@ -23,6 +23,8 @@ const bundlePaths = [
 ].filter((value): value is string => Boolean(value));
 
 const uniqueBundlePaths = [...new Set(bundlePaths)];
+const nativeCorePackageName = `core-${process.platform}-${process.arch}`;
+const nativeCorePackagePath = join(process.cwd(), "node_modules", "@opentui", nativeCorePackageName);
 
 for (const bundlePath of uniqueBundlePaths) {
   const resourcesPath = join(bundlePath, "Contents", "Resources");
@@ -47,6 +49,11 @@ for (const bundlePath of uniqueBundlePaths) {
   if (build.exitCode !== 0) {
     process.exit(1);
   }
+
+  const nativeCoreDestPath = join(tuiBundleDir, "node_modules", "@opentui", nativeCorePackageName);
+  rmSync(nativeCoreDestPath, { recursive: true, force: true });
+  mkdirSync(join(tuiBundleDir, "node_modules", "@opentui"), { recursive: true });
+  cpSync(nativeCorePackagePath, nativeCoreDestPath, { recursive: true, dereference: true });
 
   const shimPath = join(resourcesPath, "gloomberb");
   writeFileSync(shimPath, SHIM);

--- a/scripts/install-electrobun-tui-shim.ts
+++ b/scripts/install-electrobun-tui-shim.ts
@@ -1,4 +1,4 @@
-import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const SHIM = `#!/bin/sh
@@ -15,6 +15,37 @@ function appBundlesIn(dir: string): string[] {
   return readdirSync(dir)
     .filter((entry) => entry.endsWith(".app"))
     .map((entry) => join(dir, entry));
+}
+
+function nativeFilesIn(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return nativeFilesIn(path);
+    if (entry.isFile() && (entry.name.endsWith(".dylib") || entry.name.endsWith(".node"))) return [path];
+    return [];
+  });
+}
+
+function signNativeFiles(dir: string): void {
+  const developerId = process.env.ELECTROBUN_DEVELOPER_ID;
+  if (process.platform !== "darwin" || !developerId) return;
+
+  for (const file of nativeFilesIn(dir)) {
+    const mode = statSync(file).mode;
+    chmodSync(file, mode | 0o755);
+
+    const signed = Bun.spawnSync({
+      cmd: ["codesign", "--force", "--timestamp", "--options", "runtime", "--sign", developerId, file],
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    if (signed.exitCode !== 0) {
+      process.exit(signed.exitCode ?? 1);
+    }
+  }
 }
 
 const bundlePaths = [
@@ -54,6 +85,7 @@ for (const bundlePath of uniqueBundlePaths) {
   rmSync(nativeCoreDestPath, { recursive: true, force: true });
   mkdirSync(join(tuiBundleDir, "node_modules", "@opentui"), { recursive: true });
   cpSync(nativeCorePackagePath, nativeCoreDestPath, { recursive: true, dereference: true });
+  signNativeFiles(nativeCoreDestPath);
 
   const shimPath = join(resourcesPath, "gloomberb");
   writeFileSync(shimPath, SHIM);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,7 @@ set -e
 
 REPO="vincelwt/gloomberb"
 INSTALL_DIR="${GLOOMBERB_INSTALL_DIR:-$HOME/.local/bin}"
+APP_DIR="${GLOOMBERB_APP_DIR:-/Applications}"
 
 # Detect platform
 OS="$(uname -s)"
@@ -31,39 +32,127 @@ if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
   arch="arm64"
 fi
 
-ASSET="gloomberb-${os}-${arch}.gz"
+download_file() {
+  url="$1"
+  dest="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fSL --progress-bar "$url" -o "$dest"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q --show-progress "$url" -O "$dest"
+  else
+    echo "Error: curl or wget required"
+    exit 1
+  fi
+}
 
-# Get latest release download URL
-echo "Fetching latest release..."
-DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+install_file() {
+  src="$1"
+  dest="$2"
+  dir="$(dirname "$dest")"
+  mkdir -p "$dir"
+  if [ -w "$dir" ]; then
+    mv "$src" "$dest"
+  else
+    echo "Installing to ${dest} (requires sudo)..."
+    sudo mv "$src" "$dest"
+  fi
+}
 
-# Download
-TMP="$(mktemp)"
-echo "Downloading ${ASSET}..."
-if command -v curl >/dev/null 2>&1; then
-  curl -fSL --progress-bar "$DOWNLOAD_URL" -o "$TMP"
-elif command -v wget >/dev/null 2>&1; then
-  wget -q --show-progress "$DOWNLOAD_URL" -O "$TMP"
+install_symlink() {
+  target="$1"
+  dest="$2"
+  dir="$(dirname "$dest")"
+  mkdir -p "$dir"
+  if [ -w "$dir" ]; then
+    ln -sfn "$target" "$dest"
+  else
+    echo "Linking ${dest} (requires sudo)..."
+    sudo ln -sfn "$target" "$dest"
+  fi
+}
+
+install_macos_app() {
+  ASSET="stable-macos-arm64-Gloomberb.app.zip"
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+  TMP_DIR="$(mktemp -d)"
+  ZIP_PATH="${TMP_DIR}/${ASSET}"
+  APP_PATH="${TMP_DIR}/Gloomberb.app"
+  DEST_APP="${APP_DIR}/Gloomberb.app"
+  DEST_CLI="${INSTALL_DIR}/gloomberb"
+
+  echo "Fetching latest macOS release..."
+  echo "Downloading ${ASSET}..."
+  if ! download_file "$DOWNLOAD_URL" "$ZIP_PATH"; then
+    rm -rf "$TMP_DIR"
+    echo "Combined macOS app install is not available for the latest release yet."
+    echo "Falling back to the standalone terminal command."
+    install_standalone_cli
+    return
+  fi
+
+  echo "Extracting app..."
+  if command -v ditto >/dev/null 2>&1; then
+    ditto -x -k "$ZIP_PATH" "$TMP_DIR"
+  else
+    unzip -q "$ZIP_PATH" -d "$TMP_DIR"
+  fi
+
+  if [ ! -d "$APP_PATH" ]; then
+    echo "Error: ${ASSET} did not contain Gloomberb.app"
+    exit 1
+  fi
+
+  echo "Installing Gloomberb.app to ${APP_DIR}..."
+  mkdir -p "$APP_DIR" 2>/dev/null || true
+  if [ -w "$APP_DIR" ]; then
+    rm -rf "$DEST_APP"
+    mv "$APP_PATH" "$DEST_APP"
+  else
+    echo "Installing app to ${APP_DIR} (requires sudo)..."
+    sudo rm -rf "$DEST_APP"
+    sudo mv "$APP_PATH" "$DEST_APP"
+  fi
+
+  APP_CLI="${DEST_APP}/Contents/Resources/gloomberb"
+  if [ ! -x "$APP_CLI" ]; then
+    echo "Error: installed app is missing the gloomberb terminal shim"
+    exit 1
+  fi
+
+  install_symlink "$APP_CLI" "$DEST_CLI"
+  rm -rf "$TMP_DIR"
+
+  echo "Installed Gloomberb.app to ${DEST_APP}"
+  echo "Installed terminal command to ${DEST_CLI}"
+}
+
+install_standalone_cli() {
+  ASSET="gloomberb-${os}-${arch}.gz"
+
+  # Get latest release download URL
+  echo "Fetching latest release..."
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+
+  # Download
+  TMP="$(mktemp)"
+  echo "Downloading ${ASSET}..."
+  download_file "$DOWNLOAD_URL" "$TMP"
+
+  # Decompress
+  echo "Extracting..."
+  mv "$TMP" "$TMP.gz"
+  gunzip "$TMP.gz"
+  chmod +x "$TMP"
+  install_file "$TMP" "$INSTALL_DIR/gloomberb"
+
+  echo "Installed gloomberb to ${INSTALL_DIR}/gloomberb"
+}
+
+if [ "$os" = "darwin" ]; then
+  install_macos_app
 else
-  echo "Error: curl or wget required"
-  exit 1
+  install_standalone_cli
 fi
-
-# Decompress
-echo "Extracting..."
-mv "$TMP" "$TMP.gz"
-gunzip "$TMP.gz"
-chmod +x "$TMP"
-mkdir -p "$INSTALL_DIR"
-
-if [ -w "$INSTALL_DIR" ]; then
-  mv "$TMP" "$INSTALL_DIR/gloomberb"
-else
-  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
-  sudo mv "$TMP" "$INSTALL_DIR/gloomberb"
-fi
-
-echo "Installed gloomberb to ${INSTALL_DIR}/gloomberb"
 
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) ;;

--- a/scripts/write-homebrew-cask.ts
+++ b/scripts/write-homebrew-cask.ts
@@ -1,0 +1,81 @@
+import { dirname } from "path";
+import { mkdirSync, writeFileSync } from "fs";
+
+interface Options {
+  version: string;
+  sha256: string;
+  output: string;
+}
+
+function readOptions(): Options {
+  const args = process.argv.slice(2);
+  const options: Partial<Options> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+    if (!value) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+    switch (arg) {
+      case "--version":
+        options.version = value;
+        i++;
+        break;
+      case "--sha256":
+        options.sha256 = value;
+        i++;
+        break;
+      case "--output":
+        options.output = value;
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.version || !/^\d+\.\d+\.\d+$/.test(options.version)) {
+    throw new Error("--version must be in X.Y.Z format");
+  }
+  if (!options.sha256 || !/^[a-f0-9]{64}$/.test(options.sha256)) {
+    throw new Error("--sha256 must be a lowercase SHA-256 digest");
+  }
+  if (!options.output) {
+    throw new Error("--output is required");
+  }
+
+  return options as Options;
+}
+
+function renderCask({ version, sha256 }: Pick<Options, "version" | "sha256">): string {
+  return `cask "gloomberb" do
+  version "${version}"
+  sha256 "${sha256}"
+
+  url "https://github.com/vincelwt/gloomberb/releases/download/v#{version}/stable-macos-arm64-Gloomberb.app.zip",
+      verified: "github.com/vincelwt/gloomberb/"
+  name "Gloomberb"
+  desc "Open-source finance terminal"
+  homepage "https://gloomberb.com"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+
+  app "Gloomberb.app"
+  binary "#{appdir}/Gloomberb.app/Contents/Resources/gloomberb", target: "gloomberb"
+
+  uninstall quit: "com.vincelwt.gloomberb"
+
+  zap trash: "~/.gloomberb"
+end
+`;
+}
+
+const options = readOptions();
+mkdirSync(dirname(options.output), { recursive: true });
+writeFileSync(options.output, renderCask(options));

--- a/src/renderers/electrobun/bun/desktop-update.ts
+++ b/src/renderers/electrobun/bun/desktop-update.ts
@@ -1,0 +1,162 @@
+import Electrobun from "electrobun/bun";
+import type { UpdateStatusEntry } from "electrobun/bun";
+import type {
+  ReleaseInfo,
+  UpdateCheckResult,
+  UpdateProgress,
+} from "../../../updater";
+
+let desktopUpdateInProgress = false;
+
+function desktopReleasePlatformPrefix(channel: string): string {
+  const os = process.platform === "darwin" ? "macos" : process.platform === "win32" ? "win" : "linux";
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  return `${channel}-${os}-${arch}`;
+}
+
+async function desktopReleaseInfo(updateInfo: {
+  version?: string;
+  hash?: string;
+}, currentVersion: string): Promise<ReleaseInfo> {
+  const [channel, baseUrl] = await Promise.all([
+    Electrobun.Updater.localInfo.channel(),
+    Electrobun.Updater.localInfo.baseUrl(),
+  ]);
+  const version = updateInfo.version || currentVersion;
+  return {
+    version,
+    tagName: `v${version}`,
+    downloadUrl: `${baseUrl.replace(/\/+$/, "")}/${desktopReleasePlatformPrefix(channel)}-update.json`,
+    publishedAt: "",
+    updateAction: { kind: "desktop" },
+  };
+}
+
+function mapDesktopUpdateStatus(entry: UpdateStatusEntry): UpdateProgress | null {
+  const progress = entry.details?.progress;
+  switch (entry.status) {
+    case "downloading":
+    case "download-starting":
+    case "checking-local-tar":
+    case "local-tar-found":
+    case "local-tar-missing":
+    case "fetching-patch":
+    case "patch-found":
+    case "patch-not-found":
+    case "downloading-patch":
+    case "downloading-full-bundle":
+    case "download-progress":
+      return {
+        phase: "downloading",
+        percent: typeof progress === "number" ? progress : undefined,
+      };
+    case "applying-patch":
+    case "patch-applied":
+    case "extracting-version":
+    case "patch-chain-complete":
+    case "decompressing":
+    case "download-complete":
+    case "applying":
+    case "extracting":
+    case "replacing-app":
+    case "launching-new-version":
+      return { phase: "replacing" };
+    case "complete":
+      return { phase: "done", message: "Update installed, restarting..." };
+    case "error":
+      return {
+        phase: "error",
+        error: entry.details?.errorMessage || entry.message,
+      };
+    default:
+      return null;
+  }
+}
+
+export async function checkElectrobunDesktopUpdate(currentVersion: string): Promise<UpdateCheckResult> {
+  try {
+    const [channel, baseUrl] = await Promise.all([
+      Electrobun.Updater.localInfo.channel(),
+      Electrobun.Updater.localInfo.baseUrl(),
+    ]);
+    if (channel === "dev" || !baseUrl) {
+      return { kind: "disabled" };
+    }
+
+    const info = await Electrobun.Updater.checkForUpdate();
+    if (info.error) {
+      return { kind: "error", error: info.error };
+    }
+    if (!info.updateAvailable) {
+      return { kind: "current" };
+    }
+
+    return {
+      kind: "available",
+      release: await desktopReleaseInfo(info, currentVersion),
+    };
+  } catch (error) {
+    return {
+      kind: "error",
+      error: error instanceof Error ? error.message : "Desktop update check failed",
+    };
+  }
+}
+
+export async function runElectrobunDesktopUpdate(
+  currentVersion: string,
+  onProgress: (progress: UpdateProgress) => void,
+): Promise<void> {
+  if (desktopUpdateInProgress) {
+    onProgress({
+      phase: "error",
+      error: "A desktop update is already in progress.",
+    });
+    return;
+  }
+
+  desktopUpdateInProgress = true;
+  Electrobun.Updater.clearStatusHistory();
+  Electrobun.Updater.onStatusChange((entry) => {
+    const progress = mapDesktopUpdateStatus(entry);
+    if (progress) onProgress(progress);
+  });
+
+  try {
+    onProgress({ phase: "downloading", percent: 0 });
+    const result = await checkElectrobunDesktopUpdate(currentVersion);
+    if (result.kind === "error") {
+      onProgress({ phase: "error", error: result.error });
+      return;
+    }
+    if (result.kind !== "available") {
+      onProgress({
+        phase: "done",
+        message: result.kind === "disabled" ? "Desktop updates are unavailable in this build" : "Already on the latest version",
+      });
+      return;
+    }
+
+    await Electrobun.Updater.downloadUpdate();
+    const updateInfo = Electrobun.Updater.updateInfo();
+    if (updateInfo?.error) {
+      onProgress({ phase: "error", error: updateInfo.error });
+      return;
+    }
+    if (!updateInfo?.updateReady) {
+      onProgress({ phase: "error", error: "Desktop update did not finish downloading." });
+      return;
+    }
+
+    onProgress({ phase: "replacing" });
+    await Electrobun.Updater.applyUpdate();
+  } catch (error) {
+    onProgress({
+      phase: "error",
+      error: error instanceof Error ? error.message : "Desktop update failed",
+    });
+  } finally {
+    desktopUpdateInProgress = false;
+    Electrobun.Updater.onStatusChange(null);
+  }
+}

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
 import { Buffer } from "node:buffer";
-import Electrobun, { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu, type UpdateStatusEntry } from "electrobun/bun";
+import Electrobun, { ApplicationMenu, BrowserView, BrowserWindow, Utils, ContextMenu } from "electrobun/bun";
 import {
   APP_SESSION_ID,
   APP_SESSION_SCHEMA_VERSION,
@@ -14,7 +14,7 @@ import { findPaneInstance, type AppConfig } from "../../../types/config";
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
 import { syncConfigActiveLayoutState, type PaneRuntimeState } from "../../../core/state/app-state";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState } from "../../../types/desktop-window";
-import type { ReleaseInfo, UpdateCheckResult, UpdateProgress } from "../../../updater";
+import type { ReleaseInfo, UpdateProgress } from "../../../updater";
 import { buildSoundCommand } from "../../../notifications/app-notifier";
 import { isPaneDetached } from "../../../plugins/pane-manager";
 import { ELECTROBUN_CONTEXT_MENU_ACTION, type DesktopRestartMessage, type ElectrobunDesktopRpcSchema } from "../shared/protocol";
@@ -27,6 +27,10 @@ import { applicationMenuCommand } from "./application-menu-click";
 import { registerElectrobunCoreCapabilities } from "./core-capabilities";
 import { setNativeIbkrGatewayModuleLoader } from "../../../plugins/ibkr/gateway-service";
 import { apiClient, type PersistedAuthUser } from "../../../utils/api-client";
+import {
+  checkElectrobunDesktopUpdate,
+  runElectrobunDesktopUpdate,
+} from "./desktop-update";
 import {
   DEFAULT_WINDOW_FRAME,
   DETACHED_WINDOW_MIN_SIZE,
@@ -64,7 +68,6 @@ let mainWindow: BrowserWindow | null = null;
 let desktopWorkspace: DesktopWorkspace | null = null;
 let currentDockPreview: DesktopDockPreviewState = { paneId: null, edge: null };
 let currentThemePreview: DesktopThemePreviewState = { theme: null };
-let desktopUpdateInProgress = false;
 let desktopRestartInProgress = false;
 
 const detachedWindows = new Map<string, BrowserWindow>();
@@ -272,71 +275,6 @@ function playNotificationSound(sound: string | undefined): void {
   }
 }
 
-function desktopReleasePlatformPrefix(channel: string): string {
-  const os = process.platform === "darwin" ? "macos" : process.platform === "win32" ? "win" : "linux";
-  const arch = process.arch === "arm64" ? "arm64" : "x64";
-  return `${channel}-${os}-${arch}`;
-}
-
-async function desktopReleaseInfo(updateInfo: {
-  version?: string;
-  hash?: string;
-}, currentVersion: string): Promise<ReleaseInfo> {
-  const [channel, baseUrl] = await Promise.all([
-    Electrobun.Updater.localInfo.channel(),
-    Electrobun.Updater.localInfo.baseUrl(),
-  ]);
-  const version = updateInfo.version || currentVersion;
-  return {
-    version,
-    tagName: `v${version}`,
-    downloadUrl: `${baseUrl.replace(/\/+$/, "")}/${desktopReleasePlatformPrefix(channel)}-update.json`,
-    publishedAt: "",
-    updateAction: { kind: "desktop" },
-  };
-}
-
-function mapDesktopUpdateStatus(entry: UpdateStatusEntry): UpdateProgress | null {
-  const progress = entry.details?.progress;
-  switch (entry.status) {
-    case "downloading":
-    case "download-starting":
-    case "checking-local-tar":
-    case "local-tar-found":
-    case "local-tar-missing":
-    case "fetching-patch":
-    case "patch-found":
-    case "patch-not-found":
-    case "downloading-patch":
-    case "downloading-full-bundle":
-    case "download-progress":
-      return {
-        phase: "downloading",
-        percent: typeof progress === "number" ? progress : undefined,
-      };
-    case "applying-patch":
-    case "patch-applied":
-    case "extracting-version":
-    case "patch-chain-complete":
-    case "decompressing":
-    case "download-complete":
-    case "applying":
-    case "extracting":
-    case "replacing-app":
-    case "launching-new-version":
-      return { phase: "replacing" };
-    case "complete":
-      return { phase: "done", message: "Update installed, restarting..." };
-    case "error":
-      return {
-        phase: "error",
-        error: entry.details?.errorMessage || entry.message,
-      };
-    default:
-      return null;
-  }
-}
-
 function sendUpdateProgress(rpc: DesktopRpc, progress: UpdateProgress): void {
   try {
     rpc.send["update.progress"]({
@@ -347,89 +285,8 @@ function sendUpdateProgress(rpc: DesktopRpc, progress: UpdateProgress): void {
   }
 }
 
-async function checkDesktopUpdate(currentVersion: string): Promise<UpdateCheckResult> {
-  try {
-    const [channel, baseUrl] = await Promise.all([
-      Electrobun.Updater.localInfo.channel(),
-      Electrobun.Updater.localInfo.baseUrl(),
-    ]);
-    if (channel === "dev" || !baseUrl) {
-      return { kind: "disabled" };
-    }
-
-    const info = await Electrobun.Updater.checkForUpdate();
-    if (info.error) {
-      return { kind: "error", error: info.error };
-    }
-    if (!info.updateAvailable) {
-      return { kind: "current" };
-    }
-
-    return {
-      kind: "available",
-      release: await desktopReleaseInfo(info, currentVersion),
-    };
-  } catch (error) {
-    return {
-      kind: "error",
-      error: error instanceof Error ? error.message : "Desktop update check failed",
-    };
-  }
-}
-
 async function runDesktopUpdate(rpc: DesktopRpc, currentVersion: string): Promise<void> {
-  if (desktopUpdateInProgress) {
-    sendUpdateProgress(rpc, {
-      phase: "error",
-      error: "A desktop update is already in progress.",
-    });
-    return;
-  }
-
-  desktopUpdateInProgress = true;
-  Electrobun.Updater.clearStatusHistory();
-  Electrobun.Updater.onStatusChange((entry) => {
-    const progress = mapDesktopUpdateStatus(entry);
-    if (progress) sendUpdateProgress(rpc, progress);
-  });
-
-  try {
-    sendUpdateProgress(rpc, { phase: "downloading", percent: 0 });
-    const result = await checkDesktopUpdate(currentVersion);
-    if (result.kind === "error") {
-      sendUpdateProgress(rpc, { phase: "error", error: result.error });
-      return;
-    }
-    if (result.kind !== "available") {
-      sendUpdateProgress(rpc, {
-        phase: "done",
-        message: result.kind === "disabled" ? "Desktop updates are unavailable in this build" : "Already on the latest version",
-      });
-      return;
-    }
-
-    await Electrobun.Updater.downloadUpdate();
-    const updateInfo = Electrobun.Updater.updateInfo();
-    if (updateInfo?.error) {
-      sendUpdateProgress(rpc, { phase: "error", error: updateInfo.error });
-      return;
-    }
-    if (!updateInfo?.updateReady) {
-      sendUpdateProgress(rpc, { phase: "error", error: "Desktop update did not finish downloading." });
-      return;
-    }
-
-    sendUpdateProgress(rpc, { phase: "replacing" });
-    await Electrobun.Updater.applyUpdate();
-  } catch (error) {
-    sendUpdateProgress(rpc, {
-      phase: "error",
-      error: error instanceof Error ? error.message : "Desktop update failed",
-    });
-  } finally {
-    desktopUpdateInProgress = false;
-    Electrobun.Updater.onStatusChange(null);
-  }
+  await runElectrobunDesktopUpdate(currentVersion, (progress) => sendUpdateProgress(rpc, progress));
 }
 
 interface PluginStateBackendSetEntry {

--- a/src/renderers/electrobun/bun/tui-entry.ts
+++ b/src/renderers/electrobun/bun/tui-entry.ts
@@ -1,0 +1,6 @@
+import { startOpenTuiApp } from "../../opentui/start";
+
+startOpenTuiApp().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exitCode = 1;
+});

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -62,6 +62,20 @@ describe("detectUpdateAction", () => {
       ["/opt/homebrew/bin/bun", "src/index.tsx"],
     )).toBeNull();
   });
+
+  test("does not treat a macOS app bundle launcher as a standalone CLI binary", () => {
+    expect(detectUpdateAction(
+      "/Applications/Gloomberb.app/Contents/MacOS/launcher",
+      ["/Applications/Gloomberb.app/Contents/MacOS/launcher"],
+    )).toBeNull();
+  });
+
+  test("does not suggest Bun-managed updates for the bundled macOS app runtime", () => {
+    expect(detectUpdateAction(
+      "/Applications/Gloomberb.app/Contents/MacOS/bun",
+      ["/Applications/Gloomberb.app/Contents/MacOS/bun", "/Applications/Gloomberb.app/Contents/Resources/gloomberb-tui/tui-entry.js"],
+    )).toBeNull();
+  });
 });
 
 describe("resolveSelfUpdateTargetPath", () => {
@@ -84,6 +98,13 @@ describe("resolveSelfUpdateTargetPath", () => {
       "/Applications/gloomberb",
       ["/Applications/gloomberb"],
     )).toBe("/Applications/gloomberb");
+  });
+
+  it("rejects launchers inside macOS app bundles", () => {
+    expect(resolveSelfUpdateTargetPath(
+      "/Applications/Gloomberb.app/Contents/MacOS/launcher",
+      ["/Applications/Gloomberb.app/Contents/MacOS/launcher"],
+    )).toBeNull();
   });
 });
 

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -100,12 +100,18 @@ function isSourceEntrypoint(entrypoint: string): boolean {
   return sourceEntrypointPattern.test(entrypoint) || tsEntrypointPattern.test(entrypoint);
 }
 
+function isMacAppBundleExecutable(execPath: string): boolean {
+  return normalizePath(execPath).includes(".app/contents/macos/");
+}
+
 export function resolveSelfUpdateTargetPath(
   execPath = getRuntimeProcess()?.execPath ?? "",
   argv = getRuntimeProcess()?.argv ?? [],
 ): string | null {
   const resolvedExecPath = tryRealpath(execPath);
   const normalizedExecPath = normalizePath(resolvedExecPath);
+  if (isMacAppBundleExecutable(resolvedExecPath)) return null;
+
   const execBase = basename(normalizedExecPath);
   const runtimeExecutables = new Set(["bun", "bunx", "node", "nodejs", "npm", "npx", "pnpm", "yarn"]);
   if (runtimeExecutables.has(execBase)) return null;
@@ -121,6 +127,8 @@ export function detectUpdateAction(
   execPath = getRuntimeProcess()?.execPath ?? "",
   argv = getRuntimeProcess()?.argv ?? [],
 ): UpdateAction | null {
+  if (isMacAppBundleExecutable(execPath)) return null;
+
   if (resolveSelfUpdateTargetPath(execPath, argv)) {
     return { kind: "self" };
   }


### PR DESCRIPTION
This adds a macOS install path that installs Gloomberb.app and exposes the terminal command from the same app bundle, avoiding a second embedded runtime. It packages a separate TUI entry inside the Electrobun app, signs the copied native OpenTUI runtime for notarization, and prevents app-bundled executables from using the standalone CLI self-updater. The release workflow now publishes the Homebrew app zip and can update the Homebrew tap cask from the GitHub release version and archive checksum. The README documents Homebrew and script-based combined installs plus how app updates keep the terminal command pointed at the updated bundle.