### PR TITLE
Fix short-range chart freshness

### DIFF
--- a/scripts/build-electrobun-view.ts
+++ b/scripts/build-electrobun-view.ts
@@ -85,9 +85,9 @@ function renderElectrobunViewHtml(entrySrc: string, stylesheet: string): string 
         '<pre></pre>',
         '</div>',
       ].join("");
-      const renderBootstrapError = (error, details = "") => {
+      const renderBootstrapError = (error, details = "", source = "bootstrap-error") => {
         if (typeof window.__gloomRenderFatalError === "function") {
-          window.__gloomRenderFatalError(error, details);
+          window.__gloomRenderFatalError(error, details, source);
           return;
         }
         const root = document.getElementById("root");
@@ -111,8 +111,9 @@ function renderElectrobunViewHtml(entrySrc: string, stylesheet: string): string 
       window.addEventListener("error", (event) => renderBootstrapError(
         event.error || event.message,
         [event.filename, event.lineno, event.colno].filter(Boolean).join(":"),
+        "error",
       ));
-      window.addEventListener("unhandledrejection", (event) => renderBootstrapError(event.reason));
+      window.addEventListener("unhandledrejection", (event) => renderBootstrapError(event.reason, "", "unhandledrejection"));
       document.getElementById("root").innerHTML = '<div class="gloom-loading">Booting Gloomberb renderer...</div>';
     </script>
     <script type="module" src="${entrySrc}"></script>

--- a/src/market-data/coordinator.ts
+++ b/src/market-data/coordinator.ts
@@ -74,7 +74,10 @@ function isIntradayChartRequest(request: ChartRequest): boolean {
 
 function normalizeFreshChartData(points: PricePoint[] | null | undefined, request: ChartRequest): PricePoint[] {
   const normalized = normalizePriceHistory(points ?? []);
-  if (isIntradayChartRequest(request) && isPriceHistoryStaleForCurrentWindow(normalized)) {
+  if (
+    isIntradayChartRequest(request)
+    && isPriceHistoryStaleForCurrentWindow(normalized, Date.now(), { exchange: request.instrument.exchange })
+  ) {
     return [];
   }
   return normalized;
@@ -502,8 +505,8 @@ export class MarketDataCoordinator {
 
   prefetchTicker(instrument: InstrumentRef | null | undefined): void {
     if (!instrument) return;
-    void this.loadSnapshot(instrument);
-    void this.loadChart(createBaselineChartRequest(instrument));
+    void this.loadSnapshot(instrument).catch(() => {});
+    void this.loadChart(createBaselineChartRequest(instrument)).catch(() => {});
   }
 
   private runSingleFlight<T>(key: string, task: () => Promise<T>): Promise<T> {

--- a/src/market-data/hooks.tsx
+++ b/src/market-data/hooks.tsx
@@ -37,7 +37,7 @@ function loadChartRequests(
   options: { forceRefresh?: boolean } = {},
 ): void {
   for (const request of requests) {
-    void coordinator.loadChart(request, options);
+    void coordinator.loadChart(request, options).catch(() => {});
   }
 }
 
@@ -113,7 +113,7 @@ export function useTickerFinancials(symbol: string | null | undefined, ticker: T
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !instrument) return;
     const timeoutId = setTimeout(() => {
-      void coordinator.loadSnapshot(instrument);
+      void coordinator.loadSnapshot(instrument).catch(() => {});
     }, TICKER_FINANCIALS_LOAD_DELAY_MS);
     return () => clearTimeout(timeoutId);
   }, [instrument?.brokerId, instrument?.brokerInstanceId, instrument?.exchange, instrument?.instrument?.conId, instrument?.symbol]);
@@ -169,7 +169,7 @@ export function useQuoteEntry(symbol: string | null | undefined, ticker: TickerR
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !instrument) return;
-    void coordinator.loadQuote(instrument);
+    void coordinator.loadQuote(instrument).catch(() => {});
   }, [instrument?.brokerId, instrument?.brokerInstanceId, instrument?.exchange, instrument?.instrument?.conId, instrument?.symbol]);
 
   return entry;
@@ -200,7 +200,7 @@ export function useChartQuery(
 
     const forceRefresh = refreshIntervalMs > 0 && !wasActiveRef.current;
     wasActiveRef.current = true;
-    void coordinator.loadChart(request, { forceRefresh });
+    void coordinator.loadChart(request, { forceRefresh }).catch(() => {});
   }, [appActive, key, refreshIntervalMs]);
 
   useEffect(() => {
@@ -208,7 +208,7 @@ export function useChartQuery(
     if (!coordinator || !request || !appActive || refreshIntervalMs <= 0) return;
 
     const interval = setInterval(() => {
-      void coordinator.loadChart(request, { forceRefresh: true });
+      void coordinator.loadChart(request, { forceRefresh: true }).catch(() => {});
     }, refreshIntervalMs);
     return () => clearInterval(interval);
   }, [appActive, key, refreshIntervalMs]);
@@ -279,7 +279,7 @@ export function useOptionsQuery(request: OptionsRequest | null | undefined): Que
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !request) return;
-    void coordinator.loadOptions(request);
+    void coordinator.loadOptions(request).catch(() => {});
   }, [requestKey]);
 
   return entry;
@@ -294,7 +294,7 @@ export function useSecFilingsQuery(request: SecFilingsRequest | null | undefined
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !request) return;
-    void coordinator.loadSecFilings(request);
+    void coordinator.loadSecFilings(request).catch(() => {});
   }, [requestKey]);
 
   return entry;
@@ -309,7 +309,7 @@ export function useSecFilingContent(filing: SecFilingItem | null | undefined): Q
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !filing) return;
-    void coordinator.loadSecFilingContent(filing);
+    void coordinator.loadSecFilingContent(filing).catch(() => {});
   }, [key]);
 
   return entry;
@@ -324,7 +324,7 @@ export function useArticleSummary(url: string | null | undefined): QueryEntry<st
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator || !url) return;
-    void coordinator.loadArticleSummary(url);
+    void coordinator.loadArticleSummary(url).catch(() => {});
   }, [url]);
 
   return entry;

--- a/src/plugins/builtin/ai/screener-pane.tsx
+++ b/src/plugins/builtin/ai/screener-pane.tsx
@@ -446,7 +446,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
     for (const ticker of sortedTickers) {
       const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
       if (instrument) {
-        void coordinator.loadSnapshot(instrument);
+        void coordinator.loadSnapshot(instrument).catch(() => {});
       }
     }
   }, [sortedTickers]);

--- a/src/renderers/electrobun/view/fatal-screen.tsx
+++ b/src/renderers/electrobun/view/fatal-screen.tsx
@@ -5,7 +5,7 @@ import { backendRequest, requestElectrobunRestart } from "./backend-rpc";
 
 declare global {
   interface Window {
-    __gloomRenderFatalError?: (error: unknown, details?: string) => void;
+    __gloomRenderFatalError?: (error: unknown, details?: string, source?: string) => void;
   }
 }
 

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -32,6 +32,7 @@ const appRootElement = rootElement;
 
 const root = createRoot(appRootElement);
 const bootLog = debugLog.createLogger("electrobun-web-boot");
+let appMounted = false;
 
 appRootElement.tabIndex = -1;
 root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
@@ -47,7 +48,10 @@ function renderFatalError(error: unknown, details?: string, title = "Gloomberb f
   );
 }
 
-window.__gloomRenderFatalError = (error, details) => {
+window.__gloomRenderFatalError = (error, details, source) => {
+  if (appMounted && source === "unhandledrejection") {
+    return;
+  }
   renderFatalError(error, details, "Gloomberb crashed");
 };
 
@@ -104,6 +108,7 @@ async function boot() {
         </UiHostProvider>
       </ElectrobunErrorBoundary>,
     );
+    appMounted = true;
   });
   requestStartupFocus();
   bootLog.info("root render scheduled", {

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -2600,6 +2600,42 @@ describe("AssetDataRouter", () => {
     expect(history[0]?.close).toBe(102);
   });
 
+  test("accepts previous-session short-range chart history while the exchange is closed", async () => {
+    const originalDateNow = Date.now;
+    Date.now = () => Date.parse("2026-05-17T12:00:00Z");
+
+    try {
+      const cloudProvider: DataProvider = {
+        ...fallbackProvider,
+        id: "cloud",
+        name: "Cloud",
+        priority: 100,
+        async getPriceHistoryForResolution() {
+          return [];
+        },
+      };
+      const yahooProvider: DataProvider = {
+        ...fallbackProvider,
+        id: "yahoo",
+        name: "Yahoo",
+        priority: 1000,
+        async getPriceHistoryForResolution() {
+          return [
+            { date: new Date("2026-05-15T15:15:00Z"), close: 101 },
+            { date: new Date("2026-05-15T15:30:00Z"), close: 102 },
+          ];
+        },
+      };
+
+      const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
+      const history = await router.getPriceHistoryForResolution("AAPL", "NASDAQ", "1M", "15m");
+
+      expect(history.map((point) => point.close)).toEqual([101, 102]);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
   test("returns normalized manual chart resolution capabilities", async () => {
     const cloudProvider: DataProvider = {
       ...fallbackProvider,

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -200,8 +200,8 @@ function isIntradayRange(range: TimeRange): boolean {
   return range === "1D" || range === "1W" || range === "1M" || range === "3M";
 }
 
-function isStaleIntradayHistory(points: PricePoint[], enabled: boolean): boolean {
-  return enabled && isPriceHistoryStaleForCurrentWindow(points);
+function isStaleIntradayHistory(points: PricePoint[], enabled: boolean, exchange?: string): boolean {
+  return enabled && isPriceHistoryStaleForCurrentWindow(points, Date.now(), { exchange });
 }
 
 function isCurrentHistoryWindow(endDate?: Date): boolean {
@@ -997,7 +997,7 @@ export class AssetDataRouter implements DataProvider {
     ];
     const cached = this.selectCachedArrayResource<PricePoint>("price-history", entityKey, variantKeys, sourceKeys, false);
     const cachedValue = cached ? normalizePriceHistory(cached.value) : [];
-    const cachedHistoryStale = isStaleIntradayHistory(cachedValue, isIntradayRange(range));
+    const cachedHistoryStale = isStaleIntradayHistory(cachedValue, isIntradayRange(range), exchange);
     const forceRefresh = context?.cacheMode === "refresh";
     if (cachedValue.length > 0 && !forceRefresh && cached && !cached.stale && !cachedHistoryStale) {
       return cachedValue;
@@ -1035,7 +1035,7 @@ export class AssetDataRouter implements DataProvider {
     ];
     const cached = this.selectCachedArrayResource<PricePoint>("price-history", entityKey, variantKeys, sourceKeys, false);
     const cachedValue = cached ? normalizePriceHistory(cached.value) : [];
-    const cachedHistoryStale = isStaleIntradayHistory(cachedValue, isIntradayResolution(resolution));
+    const cachedHistoryStale = isStaleIntradayHistory(cachedValue, isIntradayResolution(resolution), exchange);
     const forceRefresh = context?.cacheMode === "refresh";
     if (cachedValue.length > 0 && !forceRefresh && cached && !cached.stale && !cachedHistoryStale) {
       return cachedValue;
@@ -1097,7 +1097,7 @@ export class AssetDataRouter implements DataProvider {
     const cached = this.selectCachedArrayResource<PricePoint>("detailed-price-history", entityKey, variantKeys, sourceKeys, false);
     const cachedValue = cached ? normalizePriceHistory(cached.value) : [];
     const isCurrentWindow = isCurrentHistoryWindow(endDate);
-    const cachedHistoryStale = isCurrentWindow && isPriceHistoryStaleForCurrentWindow(cachedValue);
+    const cachedHistoryStale = isCurrentWindow && isPriceHistoryStaleForCurrentWindow(cachedValue, Date.now(), { exchange });
     const forceRefresh = context?.cacheMode === "refresh";
     if (cachedValue.length > 0 && !forceRefresh && cached && !cached.stale && !cachedHistoryStale) {
       return cachedValue;
@@ -1702,7 +1702,7 @@ export class AssetDataRouter implements DataProvider {
           range,
           context?.instrument ?? null,
         ));
-        if (isStaleIntradayHistory(result, isIntradayRange(range))) continue;
+        if (isStaleIntradayHistory(result, isIntradayRange(range), exchange)) continue;
         this.cacheResource(
           "price-history",
           entityKey,
@@ -1739,7 +1739,7 @@ export class AssetDataRouter implements DataProvider {
           resolution,
           context?.instrument ?? null,
         ));
-        if (isStaleIntradayHistory(result, isIntradayResolution(resolution))) continue;
+        if (isStaleIntradayHistory(result, isIntradayResolution(resolution), exchange)) continue;
         this.cacheResource(
           "price-history",
           entityKey,
@@ -1769,7 +1769,7 @@ export class AssetDataRouter implements DataProvider {
     for (const provider of this.providersInPriorityOrder()) {
       try {
         const value = normalizePriceHistory(await provider.getPriceHistory(ticker, exchange, range, context));
-        if (isStaleIntradayHistory(value, isIntradayRange(range))) continue;
+        if (isStaleIntradayHistory(value, isIntradayRange(range), exchange)) continue;
         const sourceKey = this.providerSourceKey(provider);
         this.cacheResource(
           "price-history",
@@ -1808,7 +1808,7 @@ export class AssetDataRouter implements DataProvider {
       if (!provider.getPriceHistoryForResolution) continue;
       try {
         const value = normalizePriceHistory(await provider.getPriceHistoryForResolution(ticker, exchange, bufferRange, resolution, context));
-        if (isStaleIntradayHistory(value, isIntradayResolution(resolution))) continue;
+        if (isStaleIntradayHistory(value, isIntradayResolution(resolution), exchange)) continue;
         const sourceKey = this.providerSourceKey(provider);
         this.cacheResource(
           "price-history",
@@ -1911,7 +1911,7 @@ export class AssetDataRouter implements DataProvider {
           barSize,
           context?.instrument ?? null,
         ));
-        if (isCurrentHistoryWindow(endDate) && isPriceHistoryStaleForCurrentWindow(result)) continue;
+        if (isCurrentHistoryWindow(endDate) && isPriceHistoryStaleForCurrentWindow(result, Date.now(), { exchange })) continue;
         this.cacheResource(
           "detailed-price-history",
           entityKey,
@@ -1944,7 +1944,7 @@ export class AssetDataRouter implements DataProvider {
       if (!provider.getDetailedPriceHistory) continue;
       try {
         const value = normalizePriceHistory(await provider.getDetailedPriceHistory(ticker, exchange, startDate, endDate, barSize, context));
-        if (isCurrentHistoryWindow(endDate) && isPriceHistoryStaleForCurrentWindow(value)) continue;
+        if (isCurrentHistoryWindow(endDate) && isPriceHistoryStaleForCurrentWindow(value, Date.now(), { exchange })) continue;
         const sourceKey = this.providerSourceKey(provider);
         this.cacheResource(
           "detailed-price-history",

--- a/src/utils/market-freshness.ts
+++ b/src/utils/market-freshness.ts
@@ -1,0 +1,140 @@
+import type { MarketState } from "../types/financials";
+import { canonicalExchange, EXCHANGE_TIME_ZONES } from "./exchanges";
+
+const US_EXTENDED_HOURS_EXCHANGES = new Set(["NASDAQ", "NYSE", "AMEX", "ARCA", "BATS"]);
+const ALWAYS_OPEN_EXCHANGES = new Set(["CCC"]);
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const OVERNIGHT_CLOSE_MAX_AGE_MS = 20 * 60 * 60 * 1000;
+const exchangeLocalDateFormatters = new Map<string, Intl.DateTimeFormat>();
+const usSessionFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: "America/New_York",
+  weekday: "short",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+});
+
+type UsSessionState = Exclude<MarketState, never>;
+
+function isUsExtendedHoursExchange(exchange?: string): boolean {
+  return US_EXTENDED_HOURS_EXCHANGES.has(canonicalExchange(exchange));
+}
+
+function getExchangeLocalDateFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = exchangeLocalDateFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    exchangeLocalDateFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+function exchangeLocalDate(exchange: string, timestampMs: number): string | null {
+  const timeZone = EXCHANGE_TIME_ZONES[canonicalExchange(exchange)];
+  if (!timeZone) return null;
+
+  const parts = getExchangeLocalDateFormatter(timeZone).formatToParts(new Date(timestampMs));
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (!year || !month || !day) return null;
+  return `${year}-${month}-${day}`;
+}
+
+function isoLocalDateToUtcDay(date: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+
+  return Math.floor(Date.UTC(year, month - 1, day) / MS_PER_DAY);
+}
+
+function localWeekdaysBetween(earlierDate: string, laterDate: string): number {
+  const earlierDay = isoLocalDateToUtcDay(earlierDate);
+  const laterDay = isoLocalDateToUtcDay(laterDate);
+  if (earlierDay == null || laterDay == null || laterDay <= earlierDay) return 0;
+
+  let weekdays = 0;
+  for (let day = earlierDay + 1; day <= laterDay; day += 1) {
+    const weekday = new Date(day * MS_PER_DAY).getUTCDay();
+    if (weekday !== 0 && weekday !== 6) {
+      weekdays += 1;
+    }
+  }
+  return weekdays;
+}
+
+function localWeekday(date: string): number | null {
+  const day = isoLocalDateToUtcDay(date);
+  return day == null ? null : new Date(day * MS_PER_DAY).getUTCDay();
+}
+
+function usSessionState(timestampMs: number): UsSessionState {
+  const parts = usSessionFormatter.formatToParts(new Date(timestampMs));
+
+  const weekday = parts.find((part) => part.type === "weekday")?.value ?? "";
+  if (weekday === "Sat" || weekday === "Sun") return "CLOSED";
+
+  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0");
+  const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
+  const totalMinutes = hour * 60 + minute;
+
+  if (totalMinutes < 4 * 60) return "PREPRE";
+  if (totalMinutes < 9 * 60 + 30) return "PRE";
+  if (totalMinutes < 16 * 60) return "REGULAR";
+  if (totalMinutes < 20 * 60) return "POST";
+  return "POSTPOST";
+}
+
+export function isTimestampStaleForExchangeSession(
+  timestampMs: number,
+  exchange?: string,
+  now = Date.now(),
+  marketState?: MarketState,
+): boolean {
+  try {
+    return isTimestampStaleForExchangeSessionUnsafe(timestampMs, exchange, now, marketState);
+  } catch {
+    return true;
+  }
+}
+
+function isTimestampStaleForExchangeSessionUnsafe(
+  timestampMs: number,
+  exchange?: string,
+  now = Date.now(),
+  marketState?: MarketState,
+): boolean {
+  const canonical = canonicalExchange(exchange);
+  if (!canonical || !Number.isFinite(timestampMs) || !Number.isFinite(now)) return false;
+
+  const timestampDate = exchangeLocalDate(canonical, timestampMs);
+  const currentDate = exchangeLocalDate(canonical, now);
+  if (!timestampDate || !currentDate || timestampDate === currentDate) return false;
+
+  if (ALWAYS_OPEN_EXCHANGES.has(canonical)) return true;
+  if (marketState === "REGULAR") return true;
+
+  if (isUsExtendedHoursExchange(canonical)) {
+    const session = usSessionState(now);
+    if (session === "PRE" || session === "REGULAR" || session === "POST") {
+      return true;
+    }
+  }
+
+  const weekdaysBehind = localWeekdaysBetween(timestampDate, currentDate);
+  if (weekdaysBehind > 1) return true;
+  if (weekdaysBehind === 1 && now - timestampMs > OVERNIGHT_CLOSE_MAX_AGE_MS) {
+    return localWeekday(currentDate) !== 1;
+  }
+  return false;
+}

--- a/src/utils/price-history.test.ts
+++ b/src/utils/price-history.test.ts
@@ -49,4 +49,24 @@ describe("normalizePriceHistory", () => {
       ),
     ).toBe(false);
   });
+
+  test("keeps Friday short-range history usable while the exchange is closed", () => {
+    expect(
+      isPriceHistoryStaleForCurrentWindow(
+        [{ date: new Date("2026-05-15T15:30:00Z"), close: 67 }],
+        Date.parse("2026-05-17T12:00:00Z"),
+        { exchange: "NASDAQ" },
+      ),
+    ).toBe(false);
+  });
+
+  test("still treats old always-open market history as stale", () => {
+    expect(
+      isPriceHistoryStaleForCurrentWindow(
+        [{ date: new Date("2026-05-15T15:30:00Z"), close: 67 }],
+        Date.parse("2026-05-17T12:00:00Z"),
+        { exchange: "CCC" },
+      ),
+    ).toBe(true);
+  });
 });

--- a/src/utils/price-history.ts
+++ b/src/utils/price-history.ts
@@ -1,6 +1,12 @@
 import type { PricePoint, TickerFinancials } from "../types/financials";
+import { resolveExchangeTimeZone } from "./exchanges";
+import { isTimestampStaleForExchangeSession } from "./market-freshness";
 
 const MAX_CURRENT_INTRADAY_HISTORY_LAG_MS = 18 * 60 * 60 * 1000;
+
+interface PriceHistoryFreshnessOptions {
+  exchange?: string;
+}
 
 function getPointTimestamp(point: PricePoint): number {
   const value = point.date as Date | string | number | null | undefined;
@@ -62,13 +68,29 @@ export function normalizePriceHistory(points: PricePoint[]): PricePoint[] {
   return validPoints.length === points.length ? points : validPoints;
 }
 
-export function isPriceHistoryStaleForCurrentWindow(points: PricePoint[], now = Date.now()): boolean {
+export function isPriceHistoryStaleForCurrentWindow(
+  points: PricePoint[],
+  now = Date.now(),
+  options: PriceHistoryFreshnessOptions = {},
+): boolean {
   const normalized = normalizePriceHistory(points);
   const latest = normalized.at(-1);
   if (!latest) return false;
 
   const latestTime = getPointTimestamp(latest);
-  return Number.isFinite(latestTime) && now - latestTime > MAX_CURRENT_INTRADAY_HISTORY_LAG_MS;
+  if (!Number.isFinite(latestTime) || now - latestTime <= MAX_CURRENT_INTRADAY_HISTORY_LAG_MS) {
+    return false;
+  }
+
+  if (
+    options.exchange
+    && resolveExchangeTimeZone(options.exchange)
+    && !isTimestampStaleForExchangeSession(latestTime, options.exchange, now)
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 export function normalizeTickerFinancialsPriceHistory(financials: TickerFinancials): TickerFinancials {

--- a/src/utils/quote-freshness.ts
+++ b/src/utils/quote-freshness.ts
@@ -1,98 +1,5 @@
-import type { MarketState, Quote } from "../types/financials";
-import { canonicalExchange, EXCHANGE_TIME_ZONES } from "./exchanges";
-
-const US_EXTENDED_HOURS_EXCHANGES = new Set(["NASDAQ", "NYSE", "AMEX", "ARCA", "BATS"]);
-const exchangeLocalDateFormatters = new Map<string, Intl.DateTimeFormat>();
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-const OVERNIGHT_CLOSE_MAX_AGE_MS = 20 * 60 * 60 * 1000;
-const usSessionFormatter = new Intl.DateTimeFormat("en-US", {
-  timeZone: "America/New_York",
-  weekday: "short",
-  hour: "2-digit",
-  minute: "2-digit",
-  hourCycle: "h23",
-});
-
-type UsSessionState = Exclude<MarketState, never>;
-
-function isUsExtendedHoursExchange(exchange?: string): boolean {
-  return US_EXTENDED_HOURS_EXCHANGES.has(canonicalExchange(exchange));
-}
-
-function getExchangeLocalDateFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = exchangeLocalDateFormatters.get(timeZone);
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat("en-CA", {
-      timeZone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-    exchangeLocalDateFormatters.set(timeZone, formatter);
-  }
-  return formatter;
-}
-
-function exchangeLocalDate(exchange: string, timestampMs: number): string | null {
-  const timeZone = EXCHANGE_TIME_ZONES[canonicalExchange(exchange)];
-  if (!timeZone) return null;
-
-  const parts = getExchangeLocalDateFormatter(timeZone).formatToParts(new Date(timestampMs));
-  const year = parts.find((part) => part.type === "year")?.value;
-  const month = parts.find((part) => part.type === "month")?.value;
-  const day = parts.find((part) => part.type === "day")?.value;
-  if (!year || !month || !day) return null;
-  return `${year}-${month}-${day}`;
-}
-
-function isoLocalDateToUtcDay(date: string): number | null {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
-  if (!match) return null;
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
-
-  return Math.floor(Date.UTC(year, month - 1, day) / MS_PER_DAY);
-}
-
-function localWeekdaysBetween(earlierDate: string, laterDate: string): number {
-  const earlierDay = isoLocalDateToUtcDay(earlierDate);
-  const laterDay = isoLocalDateToUtcDay(laterDate);
-  if (earlierDay == null || laterDay == null || laterDay <= earlierDay) return 0;
-
-  let weekdays = 0;
-  for (let day = earlierDay + 1; day <= laterDay; day += 1) {
-    const weekday = new Date(day * MS_PER_DAY).getUTCDay();
-    if (weekday !== 0 && weekday !== 6) {
-      weekdays += 1;
-    }
-  }
-  return weekdays;
-}
-
-function localWeekday(date: string): number | null {
-  const day = isoLocalDateToUtcDay(date);
-  return day == null ? null : new Date(day * MS_PER_DAY).getUTCDay();
-}
-
-function usSessionState(timestampMs: number): UsSessionState {
-  const parts = usSessionFormatter.formatToParts(new Date(timestampMs));
-
-  const weekday = parts.find((part) => part.type === "weekday")?.value ?? "";
-  if (weekday === "Sat" || weekday === "Sun") return "CLOSED";
-
-  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0");
-  const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
-  const totalMinutes = hour * 60 + minute;
-
-  if (totalMinutes < 4 * 60) return "PREPRE";
-  if (totalMinutes < 9 * 60 + 30) return "PRE";
-  if (totalMinutes < 16 * 60) return "REGULAR";
-  if (totalMinutes < 20 * 60) return "POST";
-  return "POSTPOST";
-}
+import type { Quote } from "../types/financials";
+import { isTimestampStaleForExchangeSession } from "./market-freshness";
 
 export function isQuoteMissingActiveSessionPrice(quote: Quote): boolean {
   if ((quote.marketState === "PRE" || quote.marketState === "PREPRE") && quote.preMarketPrice == null) {
@@ -108,28 +15,12 @@ export function isQuoteStaleForCurrentSession(quote: Quote | null | undefined, n
   if (!quote) return false;
   if (isQuoteMissingActiveSessionPrice(quote)) return true;
 
-  const exchange = canonicalExchange(quote.listingExchangeName || quote.exchangeName);
-  if (!exchange || !Number.isFinite(quote.lastUpdated)) return false;
-
-  const quoteDate = exchangeLocalDate(exchange, quote.lastUpdated);
-  const currentDate = exchangeLocalDate(exchange, now);
-  if (!quoteDate || !currentDate || quoteDate === currentDate) return false;
-
-  if (quote.marketState === "REGULAR") return true;
-
-  if (isUsExtendedHoursExchange(exchange)) {
-    const session = usSessionState(now);
-    if (session === "PRE" || session === "REGULAR" || session === "POST") {
-      return true;
-    }
-  }
-
-  const weekdaysBehind = localWeekdaysBetween(quoteDate, currentDate);
-  if (weekdaysBehind > 1) return true;
-  if (weekdaysBehind === 1 && now - quote.lastUpdated > OVERNIGHT_CLOSE_MAX_AGE_MS) {
-    return localWeekday(currentDate) !== 1;
-  }
-  return false;
+  return isTimestampStaleForExchangeSession(
+    quote.lastUpdated,
+    quote.listingExchangeName || quote.exchangeName,
+    now,
+    quote.marketState,
+  );
 }
 
 export function hasFreshQuoteForCurrentSession(


### PR DESCRIPTION
Fixes short-range charts by sharing exchange-session freshness checks between quotes and price history, so previous-session bars are accepted while markets are closed across provider fallback and cache paths. Always-open markets still reject old intraday history. The desktop renderer now keeps post-boot async backend/provider rejections from replacing the app with the fatal crash screen while preserving fatal startup and render errors.