### PR TITLE
Fix bare chat shortcut opening

### DIFF
--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -2432,6 +2432,18 @@ export const gloomberbCloudPlugin: GloomPlugin = {
     });
 
     ctx.registerCommand({
+      id: "open-chat",
+      label: "Chat",
+      description: "Open chat",
+      keywords: ["chat", "message", "messages"],
+      category: "navigation",
+      shortcut: "CHAT",
+      execute: () => {
+        ctx.showPane("chat");
+      },
+    });
+
+    ctx.registerCommand({
       id: "auth-login",
       label: "Log In",
       description: "Log in to your Gloomberb account",


### PR DESCRIPTION
Bare `CHAT` was being handled as the channel-pane shortcut without an argument, so the command bar opened the pane creation workflow instead of chat.
This adds a direct `CHAT` navigation command that opens the existing chat pane while leaving `CHAT <channel>` available for channel-specific chat panes.
