### PR TITLE
Improve X feed tabs and tweet details

### DIFF
--- a/src/components/ticker-badge-text.test.tsx
+++ b/src/components/ticker-badge-text.test.tsx
@@ -115,6 +115,37 @@ describe("TickerBadgeText", () => {
     expect(frame).toContain("TSLA -5%");
   });
 
+  test("renders usernames as clickable tags when a username opener is provided", async () => {
+    const opened: string[] = [];
+    testSetup = await testRender(
+      <TickerBadgeText
+        text="Watching @markets and $TSLA"
+        lineWidth={60}
+        catalog={{ TSLA: makeCatalogEntry() }}
+        textColor="#ffffff"
+        openTicker={() => {}}
+        openUsername={(username) => opened.push(username)}
+      />,
+      { width: 60, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("@markets"));
+    const col = lines[row]?.indexOf("@markets") ?? -1;
+
+    expect(row).toBeGreaterThanOrEqual(0);
+    expect(col).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(col + 1, row);
+      await testSetup!.renderOnce();
+    });
+
+    expect(opened).toEqual(["markets"]);
+  });
+
   test("wraps long text chunks at word boundaries", async () => {
     testSetup = await testRender(
       <TickerBadgeText

--- a/src/components/ticker-badge-text.tsx
+++ b/src/components/ticker-badge-text.tsx
@@ -1,10 +1,11 @@
-import { Box, Text } from "../ui";
+import { Box, Text, TextAttributes } from "../ui";
 import { useState } from "react";
 import { TickerBadge } from "./ticker-badge";
 import { ExternalLinkText, openUrl } from "./ui";
 import { tokenizeInlineContent } from "../utils/inline-content-tokenizer";
 import type { InlineTickerCatalogEntry } from "../state/use-inline-tickers";
 import { displayWidth } from "../utils/format";
+import { blendHex, colors } from "../theme/colors";
 
 export interface TickerBadgeTextProps {
   text: string;
@@ -13,6 +14,44 @@ export interface TickerBadgeTextProps {
   textColor: string;
   openTicker: (symbol: string) => void;
   openLink?: (url: string) => void;
+  openUsername?: (username: string) => void;
+}
+
+function UsernameBadge({
+  username,
+  hovered,
+  onHoverStart,
+  onHoverEnd,
+  onOpen,
+}: {
+  username: string;
+  hovered: boolean;
+  onHoverStart: () => void;
+  onHoverEnd: () => void;
+  onOpen: (username: string) => void;
+}) {
+  const backgroundColor = hovered
+    ? blendHex(colors.bg, colors.borderFocused, 0.34)
+    : blendHex(colors.bg, colors.borderFocused, 0.16);
+  const color = hovered ? colors.textBright : colors.borderFocused;
+
+  return (
+    <Box paddingRight={1} flexShrink={0}>
+      <Box
+        paddingX={1}
+        backgroundColor={backgroundColor}
+        onMouseOver={onHoverStart}
+        onMouseOut={onHoverEnd}
+        onMouseDown={(event: any) => {
+          event.stopPropagation?.();
+          event.preventDefault?.();
+          onOpen(username);
+        }}
+      >
+        <Text fg={color} attributes={TextAttributes.BOLD}>{`@${username}`}</Text>
+      </Box>
+    </Box>
+  );
 }
 
 function splitLongTextSegment(value: string, lineWidth: number): string[] {
@@ -46,8 +85,10 @@ export function TickerBadgeText({
   textColor,
   openTicker,
   openLink = openUrl,
+  openUsername,
 }: TickerBadgeTextProps) {
   const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
+  const [hoveredUsername, setHoveredUsername] = useState<string | null>(null);
   const lines = text.split("\n");
 
   return (
@@ -81,6 +122,25 @@ export function TickerBadgeText({
                     label={token.value}
                     color={textColor}
                     onOpen={openLink}
+                  />
+                );
+              }
+
+              if (token.kind === "username") {
+                if (!openUsername) {
+                  return <Text key={`raw-username:${lineIndex}:${index}`} fg={textColor}>{token.value}</Text>;
+                }
+
+                return (
+                  <UsernameBadge
+                    key={`username:${lineIndex}:${index}:${token.username}`}
+                    username={token.username}
+                    hovered={hoveredUsername === token.username}
+                    onHoverStart={() => setHoveredUsername(token.username)}
+                    onHoverEnd={() => {
+                      setHoveredUsername((current) => (current === token.username ? null : current));
+                    }}
+                    onOpen={openUsername}
                   />
                 );
               }

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -2242,4 +2242,93 @@ describe("ChatContent", () => {
       installServerChannels(chatController, []);
     }
   });
+
+  test("TWIT opens the feed pane directly and seeds a search tab request", async () => {
+    const registeredCommands: any[] = [];
+    const registeredTemplates: any[] = [];
+    const stateWrites: Array<{ key: string; value: unknown; schemaVersion?: number }> = [];
+    let focusedPaneId: string | null = null;
+    const config = createDefaultConfig("/tmp/gloomberb-twit-command");
+    config.layout.instances.push({
+      instanceId: "twitter-feed:test",
+      paneId: "twitter-feed",
+      binding: { kind: "none" },
+    });
+
+    gloomberbCloudPlugin.setup({
+      persistence: new MemoryPersistence(),
+      resume: {
+        getState: () => null,
+        setState: (key: string, value: unknown, options?: { schemaVersion?: number }) => {
+          stateWrites.push({ key, value, schemaVersion: options?.schemaVersion });
+        },
+        deleteState: () => {},
+        getPaneState: () => null,
+        setPaneState: () => {},
+        deletePaneState: () => {},
+      },
+      registerPane: () => {},
+      registerPaneTemplate: (template: any) => registeredTemplates.push(template),
+      registerCommand: (command: any) => registeredCommands.push(command),
+      registerColumn: () => {},
+      registerBroker: () => {},
+      registerCapability: () => {},
+      registerDetailTab: () => {},
+      registerShortcut: () => {},
+      registerTickerAction: () => {},
+      registerContextMenuProvider: () => {},
+      getData: () => null,
+      getTicker: () => null,
+      getConfig: () => config,
+      getPaneDef: () => undefined,
+      marketData: null,
+      tickerRepository: null,
+      log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      configState: { get: () => null, set: async () => {}, delete: async () => {}, keys: () => [] },
+      paneSettings: { get: () => null, set: async () => {}, delete: async () => {} },
+      createBrokerInstance: async () => ({}),
+      updateBrokerInstance: async () => {},
+      syncBrokerInstance: async () => {},
+      removeBrokerInstance: async () => {},
+      selectTicker: () => {},
+      switchPanel: () => {},
+      switchTab: () => {},
+      openCommandBar: () => {},
+      showPane: () => {},
+      createPaneFromTemplate: () => {},
+      hidePane: () => {},
+      focusPane: (paneId: string) => { focusedPaneId = paneId; },
+      pinTicker: () => {},
+      navigateTicker: () => {},
+      openPaneSettings: () => {},
+      on: () => () => {},
+      emit: () => {},
+      notify: () => {},
+    } as any);
+
+    const template = registeredTemplates.find((entry) => entry.id === "twitter-feed-pane");
+    expect(template?.wizard).toBeUndefined();
+    expect(template?.shortcut).toBeUndefined();
+    await expect(Promise.resolve(template?.createInstance?.({ config } as any, { arg: "" }))).resolves.toMatchObject({
+      placement: "floating",
+      params: { query: "" },
+    });
+
+    const command = registeredCommands.find((entry) => entry.id === "twitter-feed-open");
+    expect(command?.shortcut).toBe("TWIT");
+    expect(command?.shortcutArg?.parse("$NVDA")).toEqual({ query: "$NVDA" });
+
+    await command.execute({ query: "$NVDA" });
+
+    expect(focusedPaneId).toBe("twitter-feed");
+    expect(stateWrites).toHaveLength(1);
+    expect(stateWrites[0]).toMatchObject({
+      key: "twitter-feed-launch",
+      schemaVersion: 1,
+      value: {
+        query: "$NVDA",
+        targetPaneId: "twitter-feed:test",
+      },
+    });
+  });
 });

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -2,7 +2,7 @@ import { Box, ScrollBox, Span, Text, useUiCapabilities } from "../../ui";
 import { memo, useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useShortcut } from "../../react/input";
 import { TextAttributes, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
-import type { GloomPlugin, PaneProps } from "../../types/plugin";
+import type { GloomPlugin, GloomPluginContext, PaneProps } from "../../types/plugin";
 import { syncConfigActiveLayoutState, useAppDispatch, useAppSelector, useAppStateRef, usePaneInstance, usePaneInstanceId } from "../../state/app-context";
 import { useInlineTickers, type InlineTickerCatalogEntry } from "../../state/use-inline-tickers";
 import { ExternalLinkText, getMessageComposerBlockHeight, MessageComposer } from "../../components/ui";
@@ -19,7 +19,14 @@ import { scheduleConfigSave } from "../../state/config-save-scheduler";
 import { chatController, type ChatController } from "./chat-controller";
 import { createGloomberbCloudCapabilities, createGloomberbCloudProvider } from "../../sources/gloomberb-cloud";
 import { InlineAuthActions } from "./cloud-auth-actions";
-import { TwitterFeedPane, TwitterTickerTab } from "./cloud-tweets";
+import {
+  TWITTER_FEED_LAUNCH_SCHEMA_VERSION,
+  TWITTER_FEED_LAUNCH_STATE_KEY,
+  TWITTER_FEED_PANE_ID,
+  TwitterFeedPane,
+  TwitterTickerTab,
+  type TwitterFeedLaunchRequest,
+} from "./cloud-tweets";
 import { AccountManagementPane } from "./account-management";
 
 interface ChatContentProps {
@@ -79,6 +86,26 @@ const LAST_VISITED_CHAT_CHANNEL_KEY = "lastChatChannelId";
 const CHAT_CHANNEL_MOUSE_HANDLED = "__gloomberbChatChannelHandled";
 const SCROLL_BOTTOM_THRESHOLD_PX = 2;
 const USERNAME_MENTION_TOKEN = /@([A-Za-z][A-Za-z0-9_]{2,29})/g;
+
+function openTwitterFeed(ctx: GloomPluginContext, query = "") {
+  const targetPaneId = ctx.getConfig().layout.instances.find((instance) => (
+    instance.paneId === TWITTER_FEED_PANE_ID
+  ))?.instanceId ?? null;
+  const now = Date.now();
+  const launchRequest: TwitterFeedLaunchRequest = {
+    query: query.trim(),
+    targetPaneId,
+    nonce: `${now}-${Math.random().toString(36).slice(2)}`,
+    createdAt: now,
+  };
+
+  ctx.resume.setState(
+    TWITTER_FEED_LAUNCH_STATE_KEY,
+    launchRequest,
+    { schemaVersion: TWITTER_FEED_LAUNCH_SCHEMA_VERSION },
+  );
+  ctx.focusPane(TWITTER_FEED_PANE_ID);
+}
 
 function isGroupedWithPrevious(messages: ChatMessage[], index: number) {
   if (index === 0) return false;
@@ -2368,7 +2395,7 @@ export const gloomberbCloudPlugin: GloomPlugin = {
     });
 
     ctx.registerPane({
-      id: "twitter-feed",
+      id: TWITTER_FEED_PANE_ID,
       name: "X Feed",
       icon: "X",
       component: TwitterFeedPane,
@@ -2379,32 +2406,12 @@ export const gloomberbCloudPlugin: GloomPlugin = {
 
     ctx.registerPaneTemplate({
       id: "twitter-feed-pane",
-      paneId: "twitter-feed",
+      paneId: TWITTER_FEED_PANE_ID,
       label: "X Feed",
-      description: "Create a reusable X advanced-search feed.",
+      description: "Open an X advanced-search feed.",
       keywords: ["twitter", "x", "tweet", "tweets", "feed", "social"],
-      shortcut: { prefix: "TWIT", argPlaceholder: "query", argKind: "text" },
-      wizard: [
-        {
-          key: "query",
-          label: "Search Query",
-          type: "textarea",
-          placeholder: "$AAPL -filter:replies",
-        },
-        {
-          key: "queryType",
-          label: "Mode",
-          type: "select",
-          defaultValue: "Latest",
-          options: [
-            { label: "Latest", value: "Latest" },
-            { label: "Top", value: "Top" },
-          ],
-        },
-      ],
       createInstance: (_context, options) => {
         const query = options?.values?.query?.trim() || options?.arg?.trim() || "";
-        if (!query) return null;
         return {
           title: "X Feed",
           placement: "floating",
@@ -2413,6 +2420,23 @@ export const gloomberbCloudPlugin: GloomPlugin = {
             queryType: options?.values?.queryType === "Top" ? "Top" : "Latest",
           },
         };
+      },
+    });
+
+    ctx.registerCommand({
+      id: "twitter-feed-open",
+      label: "X Feed",
+      description: "Open an X advanced-search feed.",
+      keywords: ["twitter", "x", "tweet", "tweets", "feed", "social", "twit"],
+      category: "navigation",
+      shortcut: "TWIT",
+      shortcutArg: {
+        placeholder: "query",
+        kind: "text",
+        parse: (arg) => ({ query: arg.trim() }),
+      },
+      execute: (values) => {
+        openTwitterFeed(ctx, values?.query ?? values?.shortcut ?? "");
       },
     });
 

--- a/src/plugins/builtin/cloud-tweets.tsx
+++ b/src/plugins/builtin/cloud-tweets.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
-import { Box, ScrollBox, Text, TextAttributes, Textarea, useRendererHost, type TextareaRenderable } from "../../ui";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
+import { Box, Input, ScrollBox, Text, TextAttributes, useRendererHost, type InputRenderable } from "../../ui";
 import { useShortcut } from "../../react/input";
 import {
   DataTableStackView,
   EmptyState,
-  SegmentedControl,
   Tabs,
   TickerBadgeList,
   usePaneFooter,
@@ -14,9 +13,9 @@ import {
 } from "../../components";
 import type { DetailTabProps, PaneProps } from "../../types/plugin";
 import { usePaneInstance, usePaneInstanceId, usePaneTicker } from "../../state/app-context";
-import { usePluginPaneState, usePluginState } from "../plugin-runtime";
+import { usePluginAppActions, usePluginPaneState, usePluginState } from "../plugin-runtime";
 import { TickerBadgeText } from "../../components/ticker-badge-text";
-import { ExternalLinkText, RemoteImage } from "../../components/ui";
+import { RemoteImage } from "../../components/ui";
 import { useInlineTickers } from "../../state/use-inline-tickers";
 import { apiClient, type CloudTweetPayload, type CloudTweetQueryType, type CloudTweetSearchResponse } from "../../utils/api-client";
 import { collectUniqueTickerSymbols } from "../../utils/ticker-tokenizer";
@@ -30,6 +29,12 @@ import { CloudAuthNotice } from "./cloud-auth-actions";
 const DEFAULT_TWEET_HOURS = 6;
 const DEFAULT_TWEET_LIMIT = 50;
 const TWEET_SEARCH_SCHEMA_VERSION = 1;
+const TWEET_SEARCH_DEBOUNCE_MS = 450;
+const TWITTER_USERNAME_RE = /^[A-Za-z0-9_]{1,15}$/;
+
+export const TWITTER_FEED_PANE_ID = "twitter-feed";
+export const TWITTER_FEED_LAUNCH_STATE_KEY = "twitter-feed-launch";
+export const TWITTER_FEED_LAUNCH_SCHEMA_VERSION = 1;
 
 type TweetColumnId = "time" | "author" | "text" | "tickers" | "likes" | "views";
 type TweetColumn = DataTableColumn & { id: TweetColumnId };
@@ -57,25 +62,19 @@ interface PersistedTwitterFeedState {
   feeds: TwitterFeed[];
 }
 
-interface FeedEditorState {
-  mode: "create" | "edit";
-  feedId: string | null;
+export interface TwitterFeedLaunchRequest {
   query: string;
-  queryType: CloudTweetQueryType;
-  key: string;
-  error: string | null;
+  targetPaneId: string | null;
+  nonce: string;
+  createdAt: number;
+  queryType?: CloudTweetQueryType;
 }
 
 const EMPTY_FEED_STATE: PersistedTwitterFeedState = { feeds: [] };
 let nextTwitterFeedId = 1;
-let nextTwitterEditorId = 1;
 
 function generateFeedId(): string {
   return `${Date.now()}-${nextTwitterFeedId++}`;
-}
-
-function generateEditorKey(): string {
-  return `twitter-editor-${Date.now()}-${nextTwitterEditorId++}`;
 }
 
 function truncateWithEllipsis(text: string, width: number): string {
@@ -88,7 +87,7 @@ function truncateWithEllipsis(text: string, width: number): string {
 function deriveFeedTitle(query: string): string {
   const tickers = collectUniqueTickerSymbols([query]);
   if (tickers.length > 0) return tickers.slice(0, 3).map((ticker) => `$${ticker}`).join(" ");
-  return truncateWithEllipsis(query.replace(/\s+/g, " ").trim(), 24) || "X Feed";
+  return truncateWithEllipsis(query.replace(/\s+/g, " ").trim(), 24) || "New";
 }
 
 function createFeed(query: string, queryType: CloudTweetQueryType): TwitterFeed {
@@ -103,6 +102,19 @@ function createFeed(query: string, queryType: CloudTweetQueryType): TwitterFeed 
     lastSuccessAt: null,
     lastError: null,
   };
+}
+
+function normalizeFeedQuery(query: string): string {
+  return query.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function normalizeTwitterUsername(username: string): string | null {
+  const normalized = username.trim().replace(/^@/, "");
+  return TWITTER_USERNAME_RE.test(normalized) ? normalized : null;
+}
+
+function twitterUserSearchQuery(username: string): string {
+  return `from:${username}`;
 }
 
 function normalizeFeeds(value: unknown): TwitterFeed[] {
@@ -272,9 +284,11 @@ function isAuthError(error: string | null): boolean {
 function TweetDetail({
   tweet,
   width,
+  onOpenUsername,
 }: {
   tweet: CloudTweetPayload;
   width: number;
+  onOpenUsername: (username: string) => void;
 }) {
   const lineWidth = Math.max(1, width - 2);
   const tweetText = normalizeTweetDisplayText(tweet.text);
@@ -282,21 +296,17 @@ function TweetDetail({
   const imageWidth = Math.min(lineWidth, 72);
   const imageHeight = Math.max(6, Math.min(14, Math.floor(imageWidth * 0.35)));
   const { catalog, openTicker } = useInlineTickers([tweetText]);
-  const author = tweet.author.userName ? `@${tweet.author.userName}` : tweet.author.name;
 
   return (
     <ScrollBox scrollY focusable={false} flexGrow={1} paddingX={1}>
       <Box flexDirection="column" width={lineWidth} gap={1}>
-        <Box flexDirection="row" height={1}>
-          <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{author}</Text>
-          <Text fg={colors.textDim}> - {formatTimeAgo(tweet.createdAt)}</Text>
-        </Box>
         <TickerBadgeText
           text={tweetText}
           lineWidth={lineWidth}
           catalog={catalog}
           textColor={colors.text}
           openTicker={openTicker}
+          openUsername={onOpenUsername}
         />
         {imageUrls.length > 0 ? (
           <Box flexDirection="column" gap={1}>
@@ -317,11 +327,6 @@ function TweetDetail({
             {`likes ${formatMetric(tweet.metrics.likes)}  reposts ${formatMetric(tweet.metrics.retweets)}  replies ${formatMetric(tweet.metrics.replies)}  views ${formatMetric(tweet.metrics.views)}`}
           </Text>
         </Box>
-        {tweet.url ? (
-          <Box height={1}>
-            <ExternalLinkText url={tweet.url} label="Open on X" color={colors.textBright} />
-          </Box>
-        ) : null}
       </Box>
     </ScrollBox>
   );
@@ -332,6 +337,7 @@ function useTweetSearchData(
   load: () => Promise<CloudTweetSearchResponse>,
   onResult?: (result: CloudTweetSearchResponse) => void,
   onError?: (message: string) => void,
+  enabled = true,
 ) {
   const [state, setState] = useState<TweetLoadState>({
     data: null,
@@ -345,6 +351,16 @@ function useTweetSearchData(
   onErrorRef.current = onError;
 
   const reload = useCallback(() => {
+    if (!enabled) {
+      fetchGenRef.current += 1;
+      setState((current) => (
+        current.data || current.loading || current.error
+          ? { data: null, loading: false, error: null }
+          : current
+      ));
+      return;
+    }
+
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
     setState((current) => ({ ...current, loading: true, error: null }));
@@ -360,7 +376,7 @@ function useTweetSearchData(
         setState({ data: null, loading: false, error: message });
         onErrorRef.current?.(message);
       });
-  }, [load]);
+  }, [enabled, load]);
 
   useEffect(() => {
     reload();
@@ -375,21 +391,30 @@ function TweetSearchTable({
   height,
   requestKey,
   footerId,
+  rootBefore,
+  enabled = true,
   load,
   onResult,
   onError,
+  emptyStateTitle,
+  emptyStateHint,
 }: {
   focused: boolean;
   width: number;
   height: number;
   requestKey: string;
   footerId: string;
+  rootBefore?: ReactNode;
+  enabled?: boolean;
   load: () => Promise<CloudTweetSearchResponse>;
   onResult?: (result: CloudTweetSearchResponse) => void;
   onError?: (message: string) => void;
+  emptyStateTitle?: string;
+  emptyStateHint?: string;
 }) {
   const rendererHost = useRendererHost();
-  const { data, loading, error, reload } = useTweetSearchData(requestKey, load, onResult, onError);
+  const { createPaneFromTemplate } = usePluginAppActions();
+  const { data, loading, error, reload } = useTweetSearchData(requestKey, load, onResult, onError, enabled);
   const [selectedTweetId, setSelectedTweetId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [sort, setSort] = useState<{ columnId: TweetSortColumnId; direction: TweetSortDirection }>({
@@ -429,6 +454,18 @@ function TweetSearchTable({
   const openSelectedTweet = useCallback(() => {
     if (selectedTweet?.url) void rendererHost.openExternal(selectedTweet.url);
   }, [rendererHost, selectedTweet]);
+  const openUsernameFeed = useCallback((username: string) => {
+    const normalizedUsername = normalizeTwitterUsername(username);
+    if (!normalizedUsername) return;
+    const query = twitterUserSearchQuery(normalizedUsername);
+    createPaneFromTemplate("twitter-feed-pane", {
+      arg: query,
+      values: {
+        query,
+        queryType: "Latest",
+      },
+    });
+  }, [createPaneFromTemplate]);
 
   const handleHeaderClick = useCallback((columnId: string) => {
     if (!isTweetSortColumnId(columnId)) return;
@@ -516,8 +553,8 @@ function TweetSearchTable({
       focused={focused}
       detailOpen={detailOpen}
       onBack={() => setDetailOpen(false)}
-      detailTitle={selectedTweet ? `@${selectedTweet.author.userName || selectedTweet.author.name}` : "Tweet"}
-      detailContent={selectedTweet ? <TweetDetail tweet={selectedTweet} width={width} /> : null}
+      detailTitle={selectedTweet ? `@${selectedTweet.author.userName || selectedTweet.author.name} - ${formatTimeAgo(selectedTweet.createdAt)}` : "Tweet"}
+      detailContent={selectedTweet ? <TweetDetail tweet={selectedTweet} width={width} onOpenUsername={openUsernameFeed} /> : null}
       selectedIndex={activeIndex}
       onSelectIndex={(index) => setSelectedTweetId(rows[index]?.id ?? null)}
       onActivateIndex={(index) => {
@@ -528,6 +565,7 @@ function TweetSearchTable({
       }}
       onRootKeyDown={handleRootKeyDown}
       onDetailKeyDown={handleDetailKeyDown}
+      rootBefore={rootBefore}
       rootWidth={width}
       rootHeight={height}
       columns={columns}
@@ -544,8 +582,8 @@ function TweetSearchTable({
       }}
       renderCell={renderCell}
       emptyContent={emptyContent}
-      emptyStateTitle={loading ? "Loading tweets..." : error ?? "No tweets"}
-      emptyStateHint={data?.query}
+      emptyStateTitle={loading ? "Loading tweets..." : error ?? emptyStateTitle ?? "No tweets"}
+      emptyStateHint={emptyStateHint ?? data?.query}
     />
   );
 }
@@ -578,55 +616,82 @@ export function TwitterTickerTab({ focused, width, height }: DetailTabProps) {
   );
 }
 
-function TwitterFeedEditor({
-  editor,
+function TwitterFeedSearchBar({
+  feed,
   focused,
+  active,
   width,
-  textareaRef,
-  onChange,
+  focusToken,
+  inputRef,
+  onFocus,
+  onBlur,
+  onQueryChange,
 }: {
-  editor: FeedEditorState;
+  feed: TwitterFeed;
   focused: boolean;
+  active: boolean;
   width: number;
-  textareaRef: RefObject<TextareaRenderable | null>;
-  onChange: (patch: Partial<FeedEditorState>) => void;
+  focusToken: number;
+  inputRef: RefObject<InputRenderable | null>;
+  onFocus: () => void;
+  onBlur: () => void;
+  onQueryChange: (feedId: string, query: string) => void;
 }) {
+  const [draft, setDraft] = useState(feed.query);
+
   useEffect(() => {
-    if (focused) textareaRef.current?.focus?.();
-  }, [editor.key, focused, textareaRef]);
+    setDraft(feed.query);
+  }, [feed.id, feed.query]);
+
+  useEffect(() => {
+    if (focused && active) inputRef.current?.focus?.();
+  }, [active, feed.id, focused, focusToken, inputRef]);
+
+  useEffect(() => {
+    if (draft === feed.query) return;
+    const timer = setTimeout(() => {
+      onQueryChange(feed.id, draft);
+    }, TWEET_SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [draft, feed.id, feed.query, onQueryChange]);
+
+  const commitNow = useCallback((value: string) => {
+    onQueryChange(feed.id, value);
+    onBlur();
+  }, [feed.id, onBlur, onQueryChange]);
 
   return (
-    <Box flexDirection="column" flexGrow={1} padding={1} gap={1}>
-      <Box height={1} flexDirection="row" gap={1}>
-        <Text fg={colors.textDim}>Mode</Text>
-        <SegmentedControl
-          value={editor.queryType}
-          options={[
-            { label: "Latest", value: "Latest" },
-            { label: "Top", value: "Top" },
-          ]}
-          onChange={(value) => onChange({ queryType: value === "Top" ? "Top" : "Latest" })}
-        />
-      </Box>
-      <Box flexGrow={1} minHeight={5} border borderColor={colors.border} backgroundColor={colors.panel}>
-        <Textarea
-          key={editor.key}
-          ref={textareaRef}
-          initialValue={editor.query}
-          placeholder="$AAPL -filter:replies"
-          focused={focused}
-          textColor={colors.text}
-          placeholderColor={colors.textDim}
-          backgroundColor={colors.panel}
-          flexGrow={1}
-          wrapText
-        />
-      </Box>
-      {editor.error ? (
-        <Text fg={colors.negative}>{editor.error}</Text>
-      ) : (
-        <Text fg={colors.textDim}>{truncateWithEllipsis("Use X advanced search syntax. Example: $AAPL OR $MSFT -filter:replies", Math.max(1, width - 2))}</Text>
-      )}
+    <Box
+      height={1}
+      width={width}
+      flexDirection="row"
+      backgroundColor={colors.panel}
+      onMouseDown={(event) => {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        onFocus();
+        inputRef.current?.focus?.();
+      }}
+    >
+      <Text fg={active ? colors.textBright : colors.textDim}>/</Text>
+      <Box width={1} />
+      <Input
+        ref={inputRef}
+        value={draft}
+        focused={focused && active}
+        placeholder="$AAPL -filter:replies"
+        placeholderColor={colors.textDim}
+        textColor={colors.text}
+        focusedTextColor={colors.text}
+        backgroundColor={colors.panel}
+        focusedBackgroundColor={colors.panel}
+        cursorColor={colors.textBright}
+        flexGrow={1}
+        onFocus={onFocus}
+        onInput={setDraft}
+        onChange={setDraft}
+        onSubmit={commitNow}
+      />
     </Box>
   );
 }
@@ -639,27 +704,104 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
     EMPTY_FEED_STATE,
     { schemaVersion: TWEET_SEARCH_SCHEMA_VERSION },
   );
+  const [launchRequest, setLaunchRequest] = usePluginState<TwitterFeedLaunchRequest | null>(
+    TWITTER_FEED_LAUNCH_STATE_KEY,
+    null,
+    { schemaVersion: TWITTER_FEED_LAUNCH_SCHEMA_VERSION },
+  );
   const [activeFeedId, setActiveFeedId] = usePluginPaneState<string | null>("activeFeedId", null);
-  const [editorState, setEditorState] = useState<FeedEditorState | null>(null);
-  const textareaRef = useRef<TextareaRenderable | null>(null);
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const searchInputRef = useRef<InputRenderable | null>(null);
   const initializedRef = useRef(false);
   const feeds = useMemo(() => normalizeFeeds(persistedState), [persistedState]);
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((current) => current + 1);
+  }, []);
+
+  const blurSearch = useCallback(() => {
+    setSearchFocused(false);
+  }, []);
 
   const updateFeeds = useCallback((updater: (feeds: TwitterFeed[]) => TwitterFeed[]) => {
     setPersistedState((current) => ({ feeds: updater(normalizeFeeds(current)) }));
   }, [setPersistedState]);
 
+  const addFeed = useCallback((query = "", queryType: CloudTweetQueryType = "Latest") => {
+    const feed = createFeed(query, queryType);
+    updateFeeds((current) => [...current, feed]);
+    setActiveFeedId(feed.id);
+    focusSearch();
+    return feed.id;
+  }, [focusSearch, setActiveFeedId, updateFeeds]);
+
+  const openOrCreateFeed = useCallback((
+    query: string,
+    queryType: CloudTweetQueryType = "Latest",
+    options?: { focusSearch?: boolean },
+  ) => {
+    const normalizedQuery = normalizeFeedQuery(query);
+    if (!normalizedQuery) {
+      if (feeds.length === 0) addFeed("", queryType);
+      return;
+    }
+
+    let nextActiveId: string | null = null;
+    updateFeeds((current) => {
+      const existing = current.find((feed) => normalizeFeedQuery(feed.query) === normalizedQuery);
+      if (existing) {
+        nextActiveId = existing.id;
+        return current;
+      }
+      const feed = createFeed(query, queryType);
+      nextActiveId = feed.id;
+      return [...current, feed];
+    });
+    if (nextActiveId) setActiveFeedId(nextActiveId);
+    if (options?.focusSearch) focusSearch();
+  }, [addFeed, feeds.length, focusSearch, setActiveFeedId, updateFeeds]);
+
+  const updateFeedQuery = useCallback((feedId: string, query: string) => {
+    const now = Date.now();
+    updateFeeds((current) => current.map((feed) => (
+      feed.id === feedId
+        ? {
+          ...feed,
+          query,
+          title: deriveFeedTitle(query),
+          updatedAt: now,
+          lastError: null,
+        }
+        : feed
+    )));
+  }, [updateFeeds]);
+
   useEffect(() => {
     if (initializedRef.current) return;
     initializedRef.current = true;
     if (feeds.length > 0) return;
-    const seedQuery = typeof paneInstance?.params?.query === "string" ? paneInstance.params.query.trim() : "";
-    if (!seedQuery) return;
+    const seedQuery = typeof paneInstance?.params?.query === "string" ? paneInstance.params.query : "";
     const seedType = paneInstance?.params?.queryType === "Top" ? "Top" : "Latest";
     const feed = createFeed(seedQuery, seedType);
     setPersistedState({ feeds: [feed] });
     setActiveFeedId(feed.id);
-  }, [feeds.length, paneInstance?.params?.query, paneInstance?.params?.queryType, setActiveFeedId, setPersistedState]);
+    if (!seedQuery.trim()) focusSearch();
+  }, [feeds.length, focusSearch, paneInstance?.params?.query, paneInstance?.params?.queryType, setActiveFeedId, setPersistedState]);
+
+  useEffect(() => {
+    if (!launchRequest) return;
+    if (launchRequest.targetPaneId && launchRequest.targetPaneId !== paneId) return;
+
+    const queryType = launchRequest.queryType === "Top" ? "Top" : "Latest";
+    if (launchRequest.query.trim()) {
+      openOrCreateFeed(launchRequest.query, queryType);
+    } else if (feeds.length === 0) {
+      addFeed("", queryType);
+    }
+    setLaunchRequest(null);
+  }, [addFeed, feeds.length, launchRequest, openOrCreateFeed, paneId, setLaunchRequest]);
 
   useEffect(() => {
     if (feeds.length === 0) {
@@ -673,72 +815,27 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
 
   const activeFeed = feeds.find((feed) => feed.id === activeFeedId) ?? feeds[0] ?? null;
 
-  const openCreateEditor = useCallback(() => {
-    setEditorState({
-      mode: "create",
-      feedId: null,
-      query: "",
-      queryType: "Latest",
-      key: generateEditorKey(),
-      error: null,
-    });
-  }, []);
-
-  const openEditEditor = useCallback((feed: TwitterFeed | null) => {
-    if (!feed) return;
-    setEditorState({
-      mode: "edit",
-      feedId: feed.id,
-      query: feed.query,
-      queryType: feed.queryType,
-      key: generateEditorKey(),
-      error: null,
-    });
-  }, []);
-
-  const closeEditor = useCallback(() => {
-    textareaRef.current = null;
-    setEditorState(null);
-  }, []);
-
-  const saveEditor = useCallback(() => {
-    if (!editorState) return;
-    const query = textareaRef.current?.editBuffer.getText().trim() || editorState.query.trim();
-    if (!query) {
-      setEditorState((current) => current ? { ...current, error: "Query is required." } : current);
-      return;
-    }
-
-    if (editorState.mode === "create") {
-      const feed = createFeed(query, editorState.queryType);
-      updateFeeds((current) => [...current, feed]);
-      setActiveFeedId(feed.id);
-    } else if (editorState.feedId) {
-      const now = Date.now();
-      updateFeeds((current) => current.map((feed) => (
-        feed.id === editorState.feedId
-          ? {
-            ...feed,
-            query,
-            queryType: editorState.queryType,
-            title: deriveFeedTitle(query),
-            updatedAt: now,
-            lastError: null,
-          }
-          : feed
-      )));
-    }
-
-    closeEditor();
-  }, [closeEditor, editorState, setActiveFeedId, updateFeeds]);
-
   const removeFeed = useCallback((feedId: string) => {
-    updateFeeds((current) => current.filter((feed) => feed.id !== feedId));
-    if (activeFeedId === feedId) {
-      const next = feeds.filter((feed) => feed.id !== feedId)[0] ?? null;
-      setActiveFeedId(next?.id ?? null);
-    }
-  }, [activeFeedId, feeds, setActiveFeedId, updateFeeds]);
+    let nextActiveId: string | null = null;
+    let createdEmpty = false;
+    updateFeeds((current) => {
+      const next = current.filter((feed) => feed.id !== feedId);
+      if (next.length === 0) {
+        const feed = createFeed("", "Latest");
+        nextActiveId = feed.id;
+        createdEmpty = true;
+        return [feed];
+      }
+      nextActiveId = activeFeedId === feedId
+        ? next[0]!.id
+        : activeFeedId && next.some((feed) => feed.id === activeFeedId)
+          ? activeFeedId
+          : next[0]!.id;
+      return next;
+    });
+    if (nextActiveId) setActiveFeedId(nextActiveId);
+    if (createdEmpty) focusSearch();
+  }, [activeFeedId, focusSearch, setActiveFeedId, updateFeeds]);
 
   const cycleFeeds = useCallback((direction: -1 | 1) => {
     if (!activeFeed || feeds.length <= 1) return;
@@ -750,16 +847,11 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
   useShortcut((event) => {
     if (!focused) return;
 
-    if (editorState) {
+    if (searchFocused) {
       if (event.name === "escape") {
         event.preventDefault?.();
         event.stopPropagation?.();
-        closeEditor();
-      }
-      if (event.ctrl && event.name === "s") {
-        event.preventDefault?.();
-        event.stopPropagation?.();
-        saveEditor();
+        blurSearch();
       }
       return;
     }
@@ -767,13 +859,13 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
     if (event.name === "n") {
       event.preventDefault?.();
       event.stopPropagation?.();
-      openCreateEditor();
+      addFeed();
       return;
     }
-    if (event.name === "e") {
+    if (event.name === "/" || event.sequence === "/") {
       event.preventDefault?.();
       event.stopPropagation?.();
-      openEditEditor(activeFeed);
+      focusSearch();
       return;
     }
     if (event.name === "d" && activeFeed) {
@@ -796,8 +888,9 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
   }, { allowEditable: true });
 
   const activeFeedIdValue = activeFeed?.id ?? null;
-  const activeFeedQuery = activeFeed?.query ?? null;
+  const activeFeedQuery = activeFeed?.query.trim() ?? "";
   const activeFeedQueryType = activeFeed?.queryType ?? "Latest";
+  const searchEnabled = activeFeedQuery.length > 0;
   const loadActiveFeed = useCallback(() => {
     if (!activeFeedQuery) throw new Error("No X feed selected");
     return apiClient.searchCloudTweets({
@@ -825,24 +918,37 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
     )));
   }, [activeFeedIdValue, updateFeeds]);
 
-  usePaneFooter("twitter-feed", () => ({
+  usePaneFooter(TWITTER_FEED_PANE_ID, () => ({
     info: activeFeed
       ? [
         { id: "mode", parts: [{ text: activeFeed.queryType, tone: "value" }] },
         ...(activeFeed.lastSuccessAt ? [{ id: "last", parts: [{ text: `ran ${formatTimeAgo(new Date(activeFeed.lastSuccessAt))}`, tone: "muted" as const }] }] : []),
       ]
       : [],
-    hints: editorState
+    hints: searchFocused
       ? [
-        { id: "save", key: "Ctrl+S", label: "save", onPress: saveEditor },
-        { id: "cancel", key: "Esc", label: "cancel", onPress: closeEditor },
+        { id: "done", key: "Esc", label: "done", onPress: blurSearch },
       ]
       : [
-        { id: "new", key: "n", label: "ew", onPress: openCreateEditor },
-        { id: "edit", key: "e", label: "dit", onPress: () => openEditEditor(activeFeed), disabled: !activeFeed },
+        { id: "new", key: "n", label: "ew", onPress: () => addFeed() },
+        { id: "search", key: "/", label: "search", onPress: focusSearch, disabled: !activeFeed },
         { id: "delete", key: "d", label: "elete", onPress: activeFeed ? () => removeFeed(activeFeed.id) : undefined, disabled: !activeFeed },
       ],
-  }), [activeFeed, closeEditor, editorState, openCreateEditor, openEditEditor, removeFeed, saveEditor]);
+  }), [activeFeed, addFeed, blurSearch, focusSearch, removeFeed, searchFocused]);
+
+  const searchBar = activeFeed ? (
+    <TwitterFeedSearchBar
+      feed={activeFeed}
+      focused={focused}
+      active={searchFocused}
+      width={width}
+      focusToken={searchFocusToken}
+      inputRef={searchInputRef}
+      onFocus={focusSearch}
+      onBlur={blurSearch}
+      onQueryChange={updateFeedQuery}
+    />
+  ) : null;
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -851,44 +957,39 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
           tabs={feeds.map((feed) => ({
             label: truncateWithEllipsis(feed.title, 18),
             value: feed.id,
-            onClose: editorState ? undefined : removeFeed,
-            onDoubleClick: (id) => openEditEditor(feeds.find((feed) => feed.id === id) ?? null),
+            onClose: removeFeed,
+            onDoubleClick: focusSearch,
           }))}
           activeValue={activeFeed?.id ?? null}
           onSelect={(id) => {
-            if (editorState) return;
             setActiveFeedId(id);
           }}
           compact
           variant="pill"
           closeMode="active"
-          onAdd={editorState ? undefined : openCreateEditor}
-          focused={focused && !editorState}
+          onAdd={() => addFeed()}
+          focused={focused && !searchFocused}
         />
       </Box>
 
-      {editorState ? (
-        <TwitterFeedEditor
-          editor={editorState}
-          focused={focused}
-          width={width}
-          textareaRef={textareaRef}
-          onChange={(patch) => setEditorState((current) => current ? { ...current, ...patch, error: null } : current)}
-        />
-      ) : !activeFeed ? (
+      {!activeFeed ? (
         <Box padding={1} flexGrow={1}>
-          <EmptyState title="No X feeds yet." hint="Use + or TWIT <query>." />
+          <EmptyState title="No X feeds yet." />
         </Box>
       ) : (
         <TweetSearchTable
-          focused={focused}
+          focused={focused && !searchFocused}
           width={width}
           height={Math.max(1, height - 1)}
           requestKey={`feed:${activeFeed.id}:${activeFeed.query}:${activeFeed.queryType}`}
           footerId="twitter-feed-search"
+          rootBefore={searchBar}
+          enabled={searchEnabled}
           load={loadActiveFeed}
           onResult={markFeedResult}
           onError={markFeedError}
+          emptyStateTitle={searchEnabled ? "No tweets" : "Enter a search query"}
+          emptyStateHint={searchEnabled ? activeFeedQuery : undefined}
         />
       )}
     </Box>

--- a/src/plugins/builtin/quote-monitor.test.tsx
+++ b/src/plugins/builtin/quote-monitor.test.tsx
@@ -44,6 +44,7 @@ function makeRuntime(options: {
     switchPanel: () => {},
     openCommandBar: () => {},
     showPane: () => {},
+    createPaneFromTemplate: () => {},
     hidePane: () => {},
     openPaneSettings: (paneId) => {
       options.settingsCalls?.push(paneId);

--- a/src/plugins/plugin-runtime.test.tsx
+++ b/src/plugins/plugin-runtime.test.tsx
@@ -203,6 +203,9 @@ describe("plugin runtime hooks", () => {
       showPane(paneId: string) {
         calls.push(`show:${paneId}`);
       },
+      createPaneFromTemplate(templateId: string) {
+        calls.push(`create:${templateId}`);
+      },
       hidePane(paneId: string) {
         calls.push(`hide:${paneId}`);
       },
@@ -232,6 +235,7 @@ describe("plugin runtime hooks", () => {
 
     actions?.openCommandBar("PL ");
     actions?.showPane("debug");
+    actions?.createPaneFromTemplate("twitter-feed-pane");
     actions?.hidePane("chat");
     actions?.openPluginCommandWorkflow("set-alert");
     actions?.notify({ body: "Saved", type: "success" });
@@ -239,6 +243,7 @@ describe("plugin runtime hooks", () => {
     expect(calls).toEqual([
       "command:PL ",
       "show:debug",
+      "create:twitter-feed-pane",
       "hide:chat",
       "workflow:set-alert",
       "notify:Saved",

--- a/src/plugins/plugin-runtime.tsx
+++ b/src/plugins/plugin-runtime.tsx
@@ -20,7 +20,7 @@ import {
 import type { BrokerAdapter } from "../types/broker";
 import type { PluginCapability } from "../capabilities";
 import type { DataProvider } from "../types/data-provider";
-import type { AppNotificationRequest, BrokerInstanceUpdateOptions, PinTickerOptions } from "../types/plugin";
+import type { AppNotificationRequest, BrokerInstanceUpdateOptions, PaneTemplateCreateOptions, PinTickerOptions } from "../types/plugin";
 
 export interface PluginRuntimeAccess {
   getMarketData(): DataProvider | null;
@@ -37,6 +37,7 @@ export interface PluginRuntimeAccess {
   switchPanel(panel: "left" | "right"): void;
   openCommandBar(query?: string): void;
   showPane(paneId: string): void;
+  createPaneFromTemplate(templateId: string, options?: PaneTemplateCreateOptions): void;
   hidePane(paneId: string): void;
   openPaneSettings(paneId?: string): void;
   openPluginCommandWorkflow(commandId: string): void;
@@ -123,6 +124,9 @@ export function usePluginAppActions() {
   const showPane = useCallback((paneId: string) => {
     runtime.showPane(paneId);
   }, [runtime]);
+  const createPaneFromTemplate = useCallback((templateId: string, options?: PaneTemplateCreateOptions) => {
+    runtime.createPaneFromTemplate(templateId, options);
+  }, [runtime]);
   const hidePane = useCallback((paneId: string) => {
     runtime.hidePane(paneId);
   }, [runtime]);
@@ -139,6 +143,7 @@ export function usePluginAppActions() {
   return {
     openCommandBar,
     showPane,
+    createPaneFromTemplate,
     hidePane,
     openPaneSettings,
     openPluginCommandWorkflow,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -179,6 +179,9 @@ export class PluginRegistry implements PluginRuntimeAccess {
   showPane = (paneId: string) => {
     this.showPaneFn(paneId);
   };
+  createPaneFromTemplate = (templateId: string, options?: PaneTemplateCreateOptions) => {
+    this.createPaneFromTemplateFn(templateId, options);
+  };
   hidePane = (paneId: string) => {
     this.hidePaneFn(paneId);
   };

--- a/src/test-support/plugin-runtime.ts
+++ b/src/test-support/plugin-runtime.ts
@@ -24,6 +24,7 @@ export function createTestPluginRuntime(
     switchPanel() {},
     openCommandBar() {},
     showPane() {},
+    createPaneFromTemplate() {},
     hidePane() {},
     openPaneSettings() {},
     openPluginCommandWorkflow() {},

--- a/src/utils/inline-content-tokenizer.test.ts
+++ b/src/utils/inline-content-tokenizer.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { tokenizeInlineContent } from "./inline-content-tokenizer";
 
 describe("tokenizeInlineContent", () => {
-  test("returns mixed text, link, and ticker tokens in one pass", () => {
-    expect(tokenizeInlineContent("Read https://example.com then watch $NVDA")).toEqual([
+  test("returns mixed text, link, ticker, and username tokens in one pass", () => {
+    expect(tokenizeInlineContent("Read https://example.com then watch $NVDA with @lisa")).toEqual([
       { kind: "text", value: "Read " },
       { kind: "link", value: "https://example.com", url: "https://example.com" },
       { kind: "text", value: " then watch " },
       { kind: "ticker", value: "$NVDA", symbol: "NVDA" },
+      { kind: "text", value: " with " },
+      { kind: "username", value: "@lisa", username: "lisa" },
     ]);
   });
 
@@ -17,6 +19,13 @@ describe("tokenizeInlineContent", () => {
       { kind: "link", value: "https://example.com/$TSLA", url: "https://example.com/$TSLA" },
       { kind: "text", value: " before " },
       { kind: "ticker", value: "$NVDA", symbol: "NVDA" },
+    ]);
+  });
+
+  test("does not split username-like text out of links or email addresses", () => {
+    expect(tokenizeInlineContent("Email desk@example.com or read https://x.com/@desk")).toEqual([
+      { kind: "text", value: "Email desk@example.com or read " },
+      { kind: "link", value: "https://x.com/@desk", url: "https://x.com/@desk" },
     ]);
   });
 });

--- a/src/utils/inline-content-tokenizer.ts
+++ b/src/utils/inline-content-tokenizer.ts
@@ -17,13 +17,21 @@ export interface InlineContentTickerToken {
   symbol: string;
 }
 
+export interface InlineContentUsernameToken {
+  kind: "username";
+  value: string;
+  username: string;
+}
+
 export type InlineContentToken =
   | InlineContentTextToken
   | InlineContentLinkToken
-  | InlineContentTickerToken;
+  | InlineContentTickerToken
+  | InlineContentUsernameToken;
 
-const TICKER_TOKEN_RE = /\$[A-Z][A-Z0-9.-]{0,9}/g;
+const INLINE_SYMBOL_TOKEN_RE = /\$[A-Z][A-Z0-9.-]{0,9}|@[A-Za-z0-9_]{1,15}/g;
 const SYMBOL_CHAR_RE = /[A-Za-z0-9.-]/;
+const USERNAME_CHAR_RE = /[A-Za-z0-9_]/;
 
 function trimTrailingTickerPunctuation(value: string): string {
   let trimmed = value;
@@ -39,6 +47,12 @@ function isValidTickerBoundary(text: string, start: number, end: number): boolea
   return !SYMBOL_CHAR_RE.test(prev) && !SYMBOL_CHAR_RE.test(next);
 }
 
+function isValidUsernameBoundary(text: string, start: number, end: number): boolean {
+  const prev = start > 0 ? text[start - 1] : "";
+  const next = end < text.length ? text[end] : "";
+  return !USERNAME_CHAR_RE.test(prev) && !USERNAME_CHAR_RE.test(next);
+}
+
 export function tokenizeInlineContent(text: string): InlineContentToken[] {
   const tokens: InlineContentToken[] = [];
 
@@ -51,19 +65,26 @@ export function tokenizeInlineContent(text: string): InlineContentToken[] {
     let cursor = 0;
     let match: RegExpExecArray | null;
 
-    TICKER_TOKEN_RE.lastIndex = 0;
-    while ((match = TICKER_TOKEN_RE.exec(segment.value)) !== null) {
+    INLINE_SYMBOL_TOKEN_RE.lastIndex = 0;
+    while ((match = INLINE_SYMBOL_TOKEN_RE.exec(segment.value)) !== null) {
       const rawValue = match[0];
       const start = match.index;
       const rawEnd = start + rawValue.length;
-      const value = trimTrailingTickerPunctuation(rawValue);
+      const isTicker = rawValue.startsWith("$");
+      const value = isTicker ? trimTrailingTickerPunctuation(rawValue) : rawValue;
       const end = start + value.length;
-      if (!isValidTickerBoundary(segment.value, start, rawEnd)) continue;
+      if (
+        isTicker
+          ? !isValidTickerBoundary(segment.value, start, rawEnd)
+          : !isValidUsernameBoundary(segment.value, start, rawEnd)
+      ) continue;
 
       if (start > cursor) {
         tokens.push({ kind: "text", value: segment.value.slice(cursor, start) });
       }
-      tokens.push({ kind: "ticker", value, symbol: value.slice(1) });
+      tokens.push(isTicker
+        ? { kind: "ticker", value, symbol: value.slice(1) }
+        : { kind: "username", value, username: value.slice(1) });
       cursor = end;
     }
 


### PR DESCRIPTION
This updates the X Feed pane so TWIT opens it directly, accepts a search argument, reuses an existing matching tab, and gives each tab an editable debounced search bar that stays out of tweet detail views.

Tweet details now keep the author and timestamp in the top bar, remove the duplicate body metadata and Open on X link, and continue exposing external open from the status bar.

Tweet text now renders @usernames as compact clickable tags that open a new X Feed pane for that user's posts.