### PR TITLE
Add DM command

### DIFF
--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -50,6 +50,7 @@ import type { TickerRecord } from "../../types/ticker";
 import type { Quote } from "../../types/financials";
 import type {
   CommandDef,
+  CommandResultDef,
   PaneSettingField,
   PaneTemplateCreateOptions,
   PaneTemplateDef,
@@ -3172,6 +3173,45 @@ export function CommandBar({
     runPluginCommandDirect,
   ]);
 
+  const createPluginCommandResultItem = useCallback((
+    command: CommandDef,
+    result: CommandResultDef,
+  ): ResultItem => {
+    const pluginId = pluginRegistry.getCommandPluginId(command.id);
+    const pluginName = pluginId ? pluginRegistry.allPlugins.get(pluginId)?.name : null;
+    const category = result.category ?? pluginName ?? command.label;
+    return {
+      id: `plugin-command-result:${command.id}:${result.id}`,
+      label: result.label,
+      detail: result.detail ?? command.description ?? "",
+      category,
+      kind: "command",
+      right: (result.right ?? command.shortcut?.trim()) || undefined,
+      searchText: `${result.label} ${result.detail || ""} ${(result.keywords ?? []).join(" ")} ${command.label} ${command.description || ""} ${(command.keywords ?? []).join(" ")}`,
+      disabled: result.disabled,
+      current: result.current,
+      action: async () => {
+        try {
+          await result.execute();
+          closeAll({ revertThemePreview: false });
+        } catch (error) {
+          notify(
+            error instanceof Error ? error.message : `Could not run ${command.label.toLowerCase()}.`,
+            { type: "error" },
+          );
+        }
+      },
+    };
+  }, [closeAll, notify, pluginRegistry]);
+
+  const pluginCommandResultItems = useCallback((
+    command: CommandDef,
+    shortcutArg: string,
+  ): ResultItem[] => {
+    const results = command.buildResults?.(shortcutArg) ?? [];
+    return results.map((result) => createPluginCommandResultItem(command, result));
+  }, [createPluginCommandResultItem]);
+
   const pluginCommandItems = useCallback((): ResultItem[] => {
     return getAvailablePluginCommands().map((command) => createPluginCommandItem(command));
   }, [createPluginCommandItem, getAvailablePluginCommands]);
@@ -3765,7 +3805,8 @@ export function CommandBar({
       && rootShortcutIntent.source === "plugin-command"
       && shortcutItem
     ) {
-      items.push(shortcutItem);
+      const dynamicItems = pluginCommandResultItems(rootShortcutIntent.command, rootShortcutIntent.argText);
+      items.push(...(dynamicItems.length > 0 ? dynamicItems : [shortcutItem]));
     } else if (match && match.command.id === "plugins") {
       items.push(...buildPluginItems(match.arg));
     } else if (match && match.command.id === "layout") {
@@ -3860,6 +3901,7 @@ export function CommandBar({
     nonShortcutPaneTemplateItems,
     paneShortcutItems,
     pluginCommandItems,
+    pluginCommandResultItems,
     pluginRegistry,
     rootModeInfo.kind,
     rootQuery,
@@ -4213,6 +4255,8 @@ export function CommandBar({
     }
 
     if (intent.kind !== "none" && intent.source === "plugin-command") {
+      const dynamicItems = pluginCommandResultItems(intent.command, intent.argText);
+      if (dynamicItems.length > 0) return dynamicItems[0] ?? null;
       return createPluginCommandItem(intent.command, {
         shortcutArg: intent.argText,
       });
@@ -4335,6 +4379,7 @@ export function CommandBar({
     getAvailablePluginCommands,
     getAvailablePaneShortcutTemplates,
     openModeRoute,
+    pluginCommandResultItems,
     runDirectCommand,
     runSecurityDescriptionShortcut,
     setRootQuery,

--- a/src/plugins/builtin/account-management.tsx
+++ b/src/plugins/builtin/account-management.tsx
@@ -769,7 +769,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
               onChange={(checked) => setDraftValue("profilePublic", checked)}
             />
             <CheckboxRow
-              label="Unknown DMs"
+              label="Incoming DMs"
               checked={draft.acceptUnknownDms}
               active={activeField === "acceptUnknownDms"}
               width={fieldWidth}

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -2,7 +2,7 @@ import { Box, ScrollBox, Span, Text, useUiCapabilities } from "../../ui";
 import { memo, useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useShortcut } from "../../react/input";
 import { TextAttributes, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
-import type { GloomPlugin, GloomPluginContext, PaneProps } from "../../types/plugin";
+import type { CommandResultDef, GloomPlugin, GloomPluginContext, PaneProps } from "../../types/plugin";
 import { syncConfigActiveLayoutState, useAppDispatch, useAppSelector, useAppStateRef, usePaneInstance, usePaneInstanceId } from "../../state/app-context";
 import { useInlineTickers, type InlineTickerCatalogEntry } from "../../state/use-inline-tickers";
 import { ExternalLinkText, getMessageComposerBlockHeight, MessageComposer } from "../../components/ui";
@@ -88,6 +88,7 @@ const CHAT_CHANNEL_MOUSE_HANDLED = "__gloomberbChatChannelHandled";
 const SCROLL_BOTTOM_THRESHOLD_PX = 2;
 const PROFILE_POPOVER_CLOSE_DELAY_MS = 40;
 const USERNAME_MENTION_TOKEN = /@([A-Za-z][A-Za-z0-9_]{2,29})/g;
+const CHAT_USERNAME_ARG = /^@?([A-Za-z][A-Za-z0-9_]{2,29})$/;
 
 function openTwitterFeed(ctx: GloomPluginContext, query = "") {
   const targetPaneId = ctx.getConfig().layout.instances.find((instance) => (
@@ -306,6 +307,104 @@ function formatChannelLabel(channel: ChatChannel | undefined, fallbackId: string
     return channel.name?.trim() || "Group";
   }
   return channel.name?.trim() || fallbackId;
+}
+
+function conversationDetail(channel: ChatChannel): string {
+  if (channel.kind === "direct") {
+    const displayName = channel.dmUser?.displayName?.trim();
+    const username = channel.dmUser?.username?.trim();
+    return [displayName && username ? displayName : null, "Direct message"].filter(Boolean).join(" - ");
+  }
+  const members = (channel.members ?? [])
+    .map((member) => member.username ? `@${member.username}` : member.displayName)
+    .filter(Boolean)
+    .slice(0, 4);
+  const suffix = (channel.members?.length ?? 0) > members.length ? ` +${(channel.members?.length ?? 0) - members.length}` : "";
+  return members.length > 0 ? `Group chat - ${members.join(", ")}${suffix}` : "Group chat";
+}
+
+function parseDmUsernames(value: string): string[] {
+  const usernames = new Set<string>();
+  for (const rawPart of value.split(/[\s,]+/)) {
+    const part = rawPart.trim();
+    if (!part) continue;
+    const match = part.match(CHAT_USERNAME_ARG);
+    if (!match?.[1]) continue;
+    usernames.add(match[1].toLowerCase());
+  }
+  return [...usernames];
+}
+
+function hasOnlyDmUsernameArgs(value: string): boolean {
+  const parts = value.split(/[\s,]+/).map((part) => part.trim()).filter(Boolean);
+  return parts.length > 0 && parts.every((part) => CHAT_USERNAME_ARG.test(part));
+}
+
+function openChatChannelFromCommand(ctx: GloomPluginContext, channelId: string): void {
+  ctx.createPaneFromTemplate("new-chat-pane", { arg: channelId });
+}
+
+async function openDmTargetFromCommand(ctx: GloomPluginContext, usernames: string[]): Promise<void> {
+  if (usernames.length === 0) {
+    ctx.showPane("chat");
+    return;
+  }
+  const channel = usernames.length === 1
+    ? await chatController.openDirectChannel({ username: usernames[0] })
+    : await chatController.openGroupChannel({ usernames });
+  openChatChannelFromCommand(ctx, channel.id);
+}
+
+function buildDmCommandResults(ctx: GloomPluginContext, arg: string): CommandResultDef[] {
+  const trimmed = arg.trim();
+  if (trimmed) {
+    const usernames = parseDmUsernames(trimmed);
+    const valid = hasOnlyDmUsernameArgs(trimmed) && usernames.length > 0;
+    const label = usernames.length <= 1
+      ? `DM ${usernames[0] ? `@${usernames[0]}` : trimmed}`
+      : `Group ${usernames.map((username) => `@${username}`).join(", ")}`;
+    return [{
+      id: `start:${valid ? usernames.join(",") : trimmed}`,
+      label,
+      detail: valid
+        ? usernames.length === 1
+          ? "Start or open direct message"
+          : "Start group chat"
+        : "Use @username, or multiple usernames for a group chat",
+      category: "Chat",
+      right: "DM",
+      disabled: !valid,
+      execute: () => openDmTargetFromCommand(ctx, usernames),
+    }];
+  }
+
+  const conversations = chatController.getSnapshot().channels
+    .filter((channel) => channel.kind === "direct" || channel.kind === "group");
+  if (conversations.length === 0) {
+    return [{
+      id: "empty",
+      label: "No DMs yet",
+      detail: "Type DM @username to start one",
+      category: "Chat",
+      right: "DM",
+      disabled: true,
+      execute: () => {},
+    }];
+  }
+
+  return conversations.map((channel) => ({
+    id: `channel:${channel.id}`,
+    label: formatChannelLabel(channel, channel.id),
+    detail: conversationDetail(channel),
+    category: "Conversations",
+    right: channel.kind === "group" ? "Group" : "DM",
+    keywords: [
+      channel.name,
+      channel.dmUser?.username ?? "",
+      ...(channel.members ?? []).map((member) => member.username ?? member.displayName),
+    ],
+    execute: () => openChatChannelFromCommand(ctx, channel.id),
+  }));
 }
 
 function channelPrefix(channel: ChatChannel | undefined, active: boolean) {
@@ -2547,6 +2646,29 @@ export const gloomberbCloudPlugin: GloomPlugin = {
       shortcut: "CHAT",
       execute: () => {
         ctx.showPane("chat");
+      },
+    });
+
+    ctx.registerCommand({
+      id: "direct-message",
+      label: "DM",
+      description: "Open an existing DM or start a direct/group chat",
+      keywords: ["dm", "direct", "message", "group", "chat"],
+      category: "navigation",
+      shortcut: "DM",
+      shortcutArg: {
+        placeholder: "@username [@username...]",
+        kind: "text",
+        parse: (arg) => ({ participants: arg.trim() }),
+      },
+      buildResults: (arg) => buildDmCommandResults(ctx, arg),
+      execute: async (values) => {
+        const participants = values?.participants ?? values?.shortcut ?? "";
+        const usernames = parseDmUsernames(participants);
+        if (participants.trim() && !hasOnlyDmUsernameArgs(participants)) {
+          throw new Error("Use @username, or multiple usernames for a group chat.");
+        }
+        await openDmTargetFromCommand(ctx, usernames);
       },
     });
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -186,6 +186,18 @@ export interface CommandShortcutArgDef {
   ) => Record<string, string>;
 }
 
+export interface CommandResultDef {
+  id: string;
+  label: string;
+  detail?: string;
+  category?: string;
+  right?: string;
+  keywords?: string[];
+  current?: boolean;
+  disabled?: boolean;
+  execute: () => void | Promise<void>;
+}
+
 export interface CliHelpColumn {
   header: string;
   align?: "left" | "right" | "center";
@@ -261,6 +273,7 @@ export interface CommandDef {
   keywords: string[];
   shortcut?: string;
   shortcutArg?: CommandShortcutArgDef;
+  buildResults?: (arg: string) => CommandResultDef[];
   execute: (values?: Record<string, string>) => void | Promise<void>;
   category: "navigation" | "data" | "portfolio" | "config";
   description?: string;


### PR DESCRIPTION
Adds a command-bar DM entry that can open existing direct and group chats or start a new conversation from one or more usernames.
The command bar now supports plugin commands that provide dynamic result rows, so DM can show conversation choices instead of only the command itself.
The account setting label now says Incoming DMs.
