### PR TITLE
Fix chart renderer readiness updates

### DIFF
--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -88,8 +88,7 @@ import {
   type NativeChartBitmap,
   type NativeCrosshairOverlay,
 } from "./native/chart-rasterizer";
-import { ensureKittySupport, getCachedKittySupport } from "./native/kitty-support";
-import { resolveChartRendererState } from "./native/renderer-selection";
+import { useResolvedChartRendererState } from "./native/renderer-selection";
 import { getNativeSurfaceManager } from "./native/surface-manager";
 import { syncCachedNativeSurface } from "./native/surface-sync";
 import {
@@ -562,7 +561,6 @@ function ComparisonStockChartView({
   });
   const [resolutionSupport, setResolutionSupport] = useState<ChartResolutionSupport[] | null>(null);
   const supportMap = useMemo(() => buildChartResolutionSupportMap(resolutionSupport ?? []), [resolutionSupport]);
-  const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
   const [displayCursor, setDisplayCursor] = useState<DisplayCursorState>(EMPTY_DISPLAY_CURSOR);
   const [canvasBaseBitmapState, setCanvasBaseBitmapState] = useState<{ key: string; bitmap: NativeChartBitmap } | null>(null);
   const plotRef = useRef<BoxRenderable | null>(null);
@@ -999,30 +997,6 @@ function ComparisonStockChartView({
     viewState.zoomLevel,
   ]);
 
-  useEffect(() => {
-    const refreshSupport = () => setKittySupport(getCachedKittySupport(renderer));
-    refreshSupport();
-    renderer.on("capabilities", refreshSupport);
-    return () => {
-      renderer.off("capabilities", refreshSupport);
-    };
-  }, [renderer]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const known = getCachedKittySupport(renderer);
-    setKittySupport(known);
-    if (preferredRenderer === "braille" || known !== null) return;
-    ensureKittySupport(renderer).then((supported) => {
-      if (!cancelled) setKittySupport(supported);
-    }).catch(() => {
-      if (!cancelled) setKittySupport(false);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [preferredRenderer, renderer]);
-
   const expandBufferRange = (action: PendingExpansionAction): boolean => {
     const nextCandidate = getNextBufferRange(viewState.bufferRange);
     const nextBufferRange = effectiveResolution === "auto"
@@ -1112,7 +1086,7 @@ function ComparisonStockChartView({
     );
   }, [cursorX, cursorY, renderer]);
 
-  const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
+  const rendererState = useResolvedChartRendererState(preferredRenderer, renderer);
   const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;
   const useCanvasChart = canvasCharts && effectiveRenderer !== "kitty";
   const showNativeUnavailable = rendererState.nativeUnavailable && !useCanvasChart;

--- a/src/components/chart/native/kitty-support.ts
+++ b/src/components/chart/native/kitty-support.ts
@@ -20,9 +20,9 @@ function readKnownSupport(renderer: CliRenderer): boolean | null {
 }
 
 export function getCachedKittySupport(renderer: CliRenderer): boolean | null {
-  const cached = supportCache.get(renderer)?.value ?? null;
-  if (cached !== null) return cached;
-  return readKnownSupport(renderer);
+  const known = readKnownSupport(renderer);
+  if (known !== null) return known;
+  return supportCache.get(renderer)?.value ?? null;
 }
 
 export function ensureKittySupport(renderer: CliRenderer): Promise<boolean> {
@@ -68,4 +68,3 @@ export function ensureKittySupport(renderer: CliRenderer): Promise<boolean> {
   supportCache.set(renderer, nextEntry);
   return promise;
 }
-

--- a/src/components/chart/native/kitty.test.ts
+++ b/src/components/chart/native/kitty.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./chart-rasterizer";
 import { KittyImageManager } from "./kitty-manager";
 import { chunkBase64Payload, encodeKittyTransmitRgba } from "./kitty-protocol";
+import { ensureKittySupport, getCachedKittySupport } from "./kitty-support";
 import { resolveChartRendererState } from "./renderer-selection";
 import { computeSurfaceVisibleFragments, NativeSurfaceManager } from "./surface-manager";
 import { syncCachedNativeSurface } from "./surface-sync";
@@ -41,6 +42,29 @@ describe("resolveChartRendererState", () => {
       nativeReady: true,
       nativeUnavailable: false,
     });
+  });
+});
+
+describe("getCachedKittySupport", () => {
+  test("prefers later renderer capabilities over a failed query cache", async () => {
+    let capabilities: { kitty_graphics?: boolean } | null = null;
+    const renderer = {
+      isDestroyed: false,
+      get capabilities() {
+        return capabilities;
+      },
+      on() {},
+      off() {},
+      write() {
+        return false;
+      },
+    } as unknown as CliRenderer;
+
+    expect(await ensureKittySupport(renderer)).toBe(false);
+    expect(getCachedKittySupport(renderer)).toBe(false);
+
+    capabilities = { kitty_graphics: true };
+    expect(getCachedKittySupport(renderer)).toBe(true);
   });
 });
 

--- a/src/components/chart/native/renderer-selection.ts
+++ b/src/components/chart/native/renderer-selection.ts
@@ -1,5 +1,8 @@
+import { useEffect, useMemo, useState } from "react";
 import { type PixelResolution } from "../../../ui";
+import { type NativeRendererHost as CliRenderer } from "../../../ui";
 import type { ChartRendererPreference, ResolvedChartRenderer } from "../chart-types";
+import { ensureKittySupport, getCachedKittySupport } from "./kitty-support";
 
 export interface ResolvedChartRendererState {
   renderer: ResolvedChartRenderer;
@@ -22,3 +25,80 @@ export function resolveChartRendererState(
   return { renderer: nativeReady ? "kitty" : "braille", nativeUnavailable: false, nativeReady };
 }
 
+interface NativeChartRendererSnapshot {
+  kittySupport: boolean | null;
+  resolution: PixelResolution | null;
+}
+
+function readNativeChartRendererSnapshot(renderer: CliRenderer): NativeChartRendererSnapshot {
+  return {
+    kittySupport: getCachedKittySupport(renderer),
+    resolution: renderer.resolution,
+  };
+}
+
+function sameResolution(left: PixelResolution | null, right: PixelResolution | null): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.width === right.width && left.height === right.height;
+}
+
+function sameSnapshot(left: NativeChartRendererSnapshot, right: NativeChartRendererSnapshot): boolean {
+  return left.kittySupport === right.kittySupport
+    && sameResolution(left.resolution, right.resolution);
+}
+
+function shouldQueryKittySupport(
+  preference: ChartRendererPreference,
+  renderer: CliRenderer,
+  snapshot: NativeChartRendererSnapshot,
+): boolean {
+  return !renderer.isDestroyed && preference !== "braille" && snapshot.kittySupport === null;
+}
+
+export function useResolvedChartRendererState(
+  preference: ChartRendererPreference,
+  renderer: CliRenderer,
+): ResolvedChartRendererState {
+  const [snapshot, setSnapshot] = useState<NativeChartRendererSnapshot>(() => (
+    readNativeChartRendererSnapshot(renderer)
+  ));
+
+  useEffect(() => {
+    let cancelled = false;
+    const commitSnapshot = (next: NativeChartRendererSnapshot) => {
+      if (cancelled) return;
+      setSnapshot((current) => (sameSnapshot(current, next) ? current : next));
+    };
+
+    const refreshReadiness = () => {
+      const next = readNativeChartRendererSnapshot(renderer);
+      commitSnapshot(next);
+    };
+
+    renderer.on("capabilities", refreshReadiness);
+    renderer.on("resolution", refreshReadiness);
+    renderer.on("resize", refreshReadiness);
+    refreshReadiness();
+
+    if (shouldQueryKittySupport(preference, renderer, readNativeChartRendererSnapshot(renderer))) {
+      ensureKittySupport(renderer).then(() => {
+        refreshReadiness();
+      }).catch(() => {
+        refreshReadiness();
+      });
+    }
+
+    return () => {
+      cancelled = true;
+      renderer.off("capabilities", refreshReadiness);
+      renderer.off("resolution", refreshReadiness);
+      renderer.off("resize", refreshReadiness);
+    };
+  }, [preference, renderer]);
+
+  return useMemo(
+    () => resolveChartRendererState(preference, snapshot.kittySupport, snapshot.resolution),
+    [preference, snapshot.kittySupport, snapshot.resolution],
+  );
+}

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -116,8 +116,7 @@ import {
   type NativeChartBitmap,
   type NativeCrosshairOverlay,
 } from "./native/chart-rasterizer";
-import { ensureKittySupport, getCachedKittySupport } from "./native/kitty-support";
-import { resolveChartRendererState } from "./native/renderer-selection";
+import { useResolvedChartRendererState } from "./native/renderer-selection";
 import { getNativeSurfaceManager } from "./native/surface-manager";
 import { syncCachedNativeSurface } from "./native/surface-sync";
 import {
@@ -1501,8 +1500,7 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
   const [pendingAutoWindowOverride, setPendingAutoWindowOverride] = useState<DateWindowRange | null>(null);
   const [lastReadyRenderView, setLastReadyRenderView] = useState<CachedRenderedView | null>(null);
   const showVolume = showVolumeOverride ?? !compact;
-  const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
-  const rendererState = resolveChartRendererState(preferredRenderer, kittySupport, renderer.resolution);
+  const rendererState = useResolvedChartRendererState(preferredRenderer, renderer);
   const effectiveRenderer: ResolvedChartRenderer = rendererState.renderer;
   const useCanvasChart = canvasCharts && effectiveRenderer !== "kitty";
   const showNativeUnavailable = rendererState.nativeUnavailable && !useCanvasChart;
@@ -2593,30 +2591,6 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
         : current));
     }
   }, [interactive, chartWidth]);
-
-  useEffect(() => {
-    const refreshSupport = () => setKittySupport(getCachedKittySupport(renderer));
-    refreshSupport();
-    renderer.on("capabilities", refreshSupport);
-    return () => {
-      renderer.off("capabilities", refreshSupport);
-    };
-  }, [renderer]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const known = getCachedKittySupport(renderer);
-    setKittySupport(known);
-    if (preferredRenderer === "braille" || known !== null) return;
-    ensureKittySupport(renderer).then((supported) => {
-      if (!cancelled) setKittySupport(supported);
-    }).catch(() => {
-      if (!cancelled) setKittySupport(false);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [preferredRenderer, renderer]);
 
   const persistRenderMode = useCallback((nextMode: ChartRenderMode) => {
     if (!compact && nextMode !== storedRenderMode) {

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -3,7 +3,7 @@ import { createRoot, useKeyboard, useRenderer, useTerminalDimensions } from "@op
 import type { ReactNode } from "react";
 import { resetTerminalInputState } from "../../utils/terminal-input-reset";
 import type { KeyEventLike } from "../../react/input";
-import type { NativeRendererHost, RendererHost } from "../../ui/host";
+import type { NativeRendererHost, PixelResolution, RendererHost } from "../../ui/host";
 import { colors } from "../../theme/colors";
 
 export { useKeyboard, useRenderer, useTerminalDimensions };
@@ -50,6 +50,30 @@ export function toKeyEventLike(event: {
   };
 }
 
+function samePixelResolution(left: PixelResolution | null, right: PixelResolution | null): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.width === right.width && left.height === right.height;
+}
+
+function installResolutionEventBridge(renderer: CliRenderer): void {
+  let lastResolution = renderer.resolution ?? null;
+  const emitIfChanged = () => {
+    const nextResolution = renderer.resolution ?? null;
+    if (samePixelResolution(lastResolution, nextResolution)) return;
+    lastResolution = nextResolution;
+    renderer.emit("resolution", nextResolution);
+  };
+
+  renderer.prependInputHandler(() => {
+    queueMicrotask(emitIfChanged);
+    return false;
+  });
+  renderer.on("resize", () => {
+    queueMicrotask(emitIfChanged);
+  });
+}
+
 export async function createOpenTuiHost(): Promise<OpenTuiHost> {
   resetTerminalInputState();
 
@@ -59,6 +83,7 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
     enableMouseMovement: true,
   });
   const root = createRoot(renderer);
+  installResolutionEventBridge(renderer);
 
   const rendererHost: RendererHost = {
     requestExit: () => renderer.destroy(),


### PR DESCRIPTION
Unifies the chart renderer readiness path used by stock and comparison charts so both respond to the same kitty capability and pixel-resolution state.

Prefers live renderer capabilities over an earlier failed kitty probe, preventing stale fallback to braille when the terminal reports kitty support later.

Adds an OpenTUI resolution event bridge so charts re-resolve renderer state when pixel resolution becomes available.