### PR TITLE
Improve TheBuildout pane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Tests:
 - When touching a test file, trim nearby low-value tests if the cleanup is clear and low-risk.
 
 Use tmux to test terminal TUI changes (see the `tui-testing` skill). Always kill the tmux session when done.
+Pane footers/status bars should only show status that can change, such as loading, error, live/delayed, stale, or auth state. Do not use them for fixed pane labels, row counts, or generic keyboard hints.
+Information density matters: never repeat the same information in a pane title/header and again in the body. If a stack/detail title already names the item, start the body with metadata or content.
 For Electrobun/desktop-web-only work, do not load the OpenTUI or tui-testing skills unless the change also touches terminal OpenTUI behavior or explicitly needs tmux coverage.
 Add mouse/cursor interactivity for everything interactive.
 Never fix chart issues by disabling / turning off the kitty renderer; preserve kitty support and fix the root cause.

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -83,6 +83,7 @@ export interface DataTableProps<
     rowState: { selected: boolean; hovered: boolean },
   ) => string | undefined;
   emptyContent?: ReactNode;
+  bodyAfter?: ReactNode;
   emptyStateTitle: string;
   emptyStateHint?: string;
   virtualize?: boolean;
@@ -151,6 +152,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
   renderSectionHeader,
   getRowBackgroundColor,
   emptyContent,
+  bodyAfter,
   emptyStateTitle,
   emptyStateHint,
   virtualize = true,
@@ -520,6 +522,7 @@ function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
             {virtualize && endIndex < items.length && (
               <Box height={Math.max(items.length - endIndex, 0)} />
             )}
+            {bodyAfter}
           </>
         )}
       </ScrollBox>

--- a/src/plugins/builtin/buildout-pane.tsx
+++ b/src/plugins/builtin/buildout-pane.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Box, ScrollBox, Text, TextAttributes } from "../../ui";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, TextAttributes, type ScrollBoxRenderable, useRendererHost } from "../../ui";
 import {
   DataTableStackView,
   EmptyState,
@@ -7,419 +7,198 @@ import {
   Tabs,
   usePaneFooter,
   type DataTableCell,
-  type DataTableColumn,
   type DataTableKeyEvent,
+  type PaneFooterSegment,
+  type PaneHint,
 } from "../../components";
 import type { PaneProps } from "../../types/plugin";
 import { colors } from "../../theme/colors";
-import { apiClient } from "../../utils/api-client";
-import { formatTimeAgo } from "../../utils/format";
-import { httpFetch } from "../../utils/http-transport";
-import { InlineAuthActions } from "./cloud-auth-actions";
+import { useShortcut } from "../../react/input";
+import { useInlineTickers } from "../../state/use-inline-tickers";
+import {
+  BuildoutDetail,
+  CompaniesUpgradeCta,
+  CompanyCell,
+  FavoriteCell,
+  tickerBadges,
+} from "./buildout/detail";
+import type {
+  BuildoutColumn,
+  BuildoutColumnId,
+  BuildoutCompany,
+  BuildoutList,
+  BuildoutLoadState,
+  BuildoutRow,
+  BuildoutTabId,
+  SortDirection,
+} from "./buildout/model";
+import {
+  BUILDOUT_NAME,
+  LOAD_MORE_THRESHOLD,
+  PAGE_SIZE,
+  activeRows,
+  activityColor,
+  activityLabel,
+  appendUniqueById,
+  applyFavoriteToState,
+  buildoutApi,
+  columnsForTab,
+  criticalityColor,
+  defaultSortDirection,
+  emptyPage,
+  favoriteApiPath,
+  favoriteKey,
+  fetchCompaniesPage,
+  fetchIntelPage,
+  fetchSitesPage,
+  formatRelativeTime,
+  getBuildoutProToken,
+  loadBuildoutData,
+  metricColor,
+  rowKey,
+  rowStarred,
+  rowTickerSymbols,
+  rowTitle,
+  rowWithFavorite,
+  sortRows,
+  tabs,
+  text,
+  tickerSearchText,
+  tickerSymbol,
+  truncate,
+} from "./buildout/model";
 
-const BUILDOUT_API_URL = "https://api.thebuildout.ai";
+const BUILDOUT_UPGRADE_URL = "https://thebuildout.ai/pricing";
 
-type BuildoutTabId = "companies" | "sites" | "intel";
-type SortDirection = "asc" | "desc";
-
-type BuildoutCompany = {
-  id: string;
-  name: string;
-  ticker?: string | null;
-  exchange?: string | null;
-  description?: string | null;
-  longDescription?: string | null;
-  primarySector?: string | null;
-  primarySubsector?: string | null;
-  primaryTechnology?: string | null;
-  aiCriticality?: string | null;
-  marketCap?: string | null;
-  revenue?: string | null;
-  revenueGrowthYoy?: string | null;
-  lastQuarterGrowth?: string | null;
-  countryHq?: string | null;
-  sites?: Array<{ name?: string; type?: string; relationship?: string }>;
-};
-
-type BuildoutSite = {
-  id: string;
-  name: string;
-  type?: string | null;
-  ownerName?: string | null;
-  ownerTicker?: string | null;
-  address?: string | null;
-  location?: { city?: string | null; country?: string | null };
-  constructionActivity?: number | null;
-  parkingActivity?: number | null;
-  latestCapture?: string | null;
-  powerCapacity?: string | null;
-  eta?: string | null;
-  description?: string | null;
-  builders?: Array<{ companyName?: string; companyTicker?: string | null; role?: string | null }>;
-};
-
-type BuildoutUpdate = {
-  id: string;
-  headline: string;
-  content?: string | null;
-  context?: string | null;
-  type?: string | null;
-  publishedAt?: string | null;
-  verificationStatus?: string | null;
-  companies?: Array<{ name?: string; ticker?: string | null }>;
-};
-
-type BuildoutRow =
-  | { kind: "company"; item: BuildoutCompany }
-  | { kind: "site"; item: BuildoutSite }
-  | { kind: "intel"; item: BuildoutUpdate };
-
-type BuildoutLoadState =
-  | { status: "loading" }
-  | { status: "auth" }
-  | { status: "inactive" }
-  | { status: "error"; message: string }
-  | {
-    status: "ready";
-    companies: BuildoutCompany[];
-    sites: BuildoutSite[];
-    intel: BuildoutUpdate[];
-    loadedAt: number;
-  };
-
-type BuildoutColumn = DataTableColumn & {
-  id:
-    | "company"
-    | "sector"
-    | "criticality"
-    | "marketCap"
-    | "revenue"
-    | "growth"
-    | "site"
-    | "type"
-    | "owner"
-    | "location"
-    | "construction"
-    | "capture"
-    | "time"
-    | "companies"
-    | "headline";
-};
-
-const tabs: Array<{ label: string; value: BuildoutTabId }> = [
-  { label: "Companies", value: "companies" },
-  { label: "Sites", value: "sites" },
-  { label: "Intel", value: "intel" },
-];
-
-const companyColumns: BuildoutColumn[] = [
-  { id: "company", label: "Company", width: 24, align: "left", flexGrow: 2 },
-  { id: "sector", label: "Sector", width: 18, align: "left", flexGrow: 1 },
-  { id: "criticality", label: "Crit", width: 10, align: "left" },
-  { id: "marketCap", label: "Mkt Cap", width: 10, align: "right" },
-  { id: "revenue", label: "Revenue", width: 10, align: "right" },
-  { id: "growth", label: "Growth", width: 10, align: "right" },
-];
-
-const siteColumns: BuildoutColumn[] = [
-  { id: "site", label: "Site", width: 26, align: "left", flexGrow: 2 },
-  { id: "type", label: "Type", width: 14, align: "left" },
-  { id: "owner", label: "Owner", width: 20, align: "left", flexGrow: 1 },
-  { id: "location", label: "Location", width: 18, align: "left", flexGrow: 1 },
-  { id: "construction", label: "Const", width: 8, align: "right" },
-  { id: "capture", label: "Last Sat", width: 12, align: "left" },
-];
-
-const intelColumns: BuildoutColumn[] = [
-  { id: "time", label: "Time", width: 12, align: "left" },
-  { id: "companies", label: "Companies", width: 22, align: "left", flexGrow: 1 },
-  { id: "headline", label: "Headline", width: 48, align: "left", flexGrow: 3 },
-];
-
-function truncate(text: string, width: number) {
-  if (width <= 0) return "";
-  if (text.length <= width) return text;
-  if (width <= 3) return text.slice(0, width);
-  return `${text.slice(0, width - 3)}...`;
+function activePage(state: BuildoutLoadState, activeTab: BuildoutTabId, selectedList: BuildoutList | null) {
+  if (state.status !== "ready") return null;
+  if (activeTab === "companies") return selectedList ? state.companies : null;
+  if (activeTab === "sites") return state.sites;
+  return state.intel;
 }
 
-function text(value: unknown, fallback = "-") {
-  if (value == null) return fallback;
-  const stringValue = String(value).trim();
-  return stringValue || fallback;
-}
-
-function dateShort(value: string | null | undefined) {
-  if (!value) return "-";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "-";
-  return date.toISOString().slice(0, 10);
-}
-
-function activityLabel(value: number | null | undefined) {
-  if (value == null) return "-";
-  if (value >= 2) return "High";
-  if (value >= 1) return "Low";
-  return "None";
-}
-
-function rowKey(row: BuildoutRow) {
-  return `${row.kind}:${row.item.id}`;
-}
-
-function activeRows(state: BuildoutLoadState, activeTab: BuildoutTabId): BuildoutRow[] {
-  if (state.status !== "ready") return [];
-  if (activeTab === "companies") {
-    return state.companies.map((item) => ({ kind: "company", item }));
-  }
-  if (activeTab === "sites") {
-    return state.sites.map((item) => ({ kind: "site", item }));
-  }
-  return state.intel.map((item) => ({ kind: "intel", item }));
-}
-
-function columnsForTab(activeTab: BuildoutTabId) {
-  if (activeTab === "companies") return companyColumns;
-  if (activeTab === "sites") return siteColumns;
-  return intelColumns;
-}
-
-function compareStrings(left: string, right: string, direction: SortDirection) {
-  const result = left.localeCompare(right);
-  return direction === "asc" ? result : -result;
-}
-
-function sortValue(row: BuildoutRow, columnId: string) {
-  const item = row.item as Record<string, unknown>;
-  switch (columnId) {
-    case "company":
-    case "site":
-      return text(item.name, "");
-    case "headline":
-      return text((row.item as BuildoutUpdate).headline, "");
-    case "sector":
-      return text((row.item as BuildoutCompany).primarySector, "");
-    case "criticality":
-      return text((row.item as BuildoutCompany).aiCriticality, "");
-    case "owner":
-      return text((row.item as BuildoutSite).ownerTicker ?? (row.item as BuildoutSite).ownerName, "");
-    case "time":
-      return text((row.item as BuildoutUpdate).publishedAt, "");
-    default:
-      return text(item[columnId], "");
-  }
-}
-
-function sortRows(rows: BuildoutRow[], columnId: string | null, direction: SortDirection) {
-  if (!columnId) return rows;
-  return [...rows].sort((left, right) => compareStrings(
-    sortValue(left, columnId),
-    sortValue(right, columnId),
-    direction,
-  ));
-}
-
-async function buildoutApi<T>(path: string, token: string): Promise<T> {
-  const response = await httpFetch(`${BUILDOUT_API_URL}${path}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    throw new Error(body || `TheBuildout.ai request failed (${response.status})`);
-  }
-  return response.json() as Promise<T>;
-}
-
-async function loadBuildoutData(token: string) {
-  const [companiesResponse, sites, intel] = await Promise.all([
-    buildoutApi<{ companies?: BuildoutCompany[] }>("/companies?limit=40&offset=0&detail=true&sort=marketCap&order=desc", token),
-    buildoutApi<BuildoutSite[]>("/sites?limit=40&offset=0&detail=true&sort=activityUpdatedAt&order=desc", token),
-    buildoutApi<BuildoutUpdate[]>("/updates?limit=40&offset=0", token),
-  ]);
-
-  return {
-    companies: companiesResponse.companies ?? [],
-    sites: Array.isArray(sites) ? sites : [],
-    intel: Array.isArray(intel) ? intel : [],
-  };
-}
-
-function renderCell(row: BuildoutRow, column: BuildoutColumn): DataTableCell {
-  if (row.kind === "company") {
-    const company = row.item;
-    switch (column.id) {
-      case "company":
-        return { text: company.ticker ? `${company.ticker} ${company.name}` : company.name };
-      case "sector":
-        return { text: text(company.primarySector ?? company.primaryTechnology) };
-      case "criticality":
-        return { text: text(company.aiCriticality), color: colors.warning };
-      case "marketCap":
-        return { text: text(company.marketCap), color: colors.textDim };
-      case "revenue":
-        return { text: text(company.revenue), color: colors.textDim };
-      case "growth":
-        return { text: text(company.revenueGrowthYoy ?? company.lastQuarterGrowth), color: colors.textDim };
-    }
+function updateFooterInfo(
+  state: BuildoutLoadState,
+  activeTab: BuildoutTabId,
+  selectedList: BuildoutList | null,
+  favoriteMessage: string | null,
+): PaneFooterSegment[] {
+  if (state.status === "loading") {
+    return [{ id: "loading", parts: [{ text: "loading", tone: "value" }] }];
   }
 
-  if (row.kind === "site") {
-    const site = row.item;
-    const location = [site.location?.city, site.location?.country].filter(Boolean).join(", ");
-    switch (column.id) {
-      case "site":
-        return { text: site.name };
-      case "type":
-        return { text: text(site.type) };
-      case "owner":
-        return { text: text(site.ownerTicker ?? site.ownerName) };
-      case "location":
-        return { text: text(location) };
-      case "construction":
-        return { text: activityLabel(site.constructionActivity), color: site.constructionActivity ? colors.warning : colors.textMuted };
-      case "capture":
-        return { text: dateShort(site.latestCapture), color: colors.textDim };
-    }
+  if (state.status === "error") {
+    return [{ id: "error", parts: [{ text: "load failed", tone: "negative" }] }];
   }
 
-  const update = row.item as BuildoutUpdate;
-  switch (column.id) {
-    case "time":
-      return { text: update.publishedAt ? formatTimeAgo(update.publishedAt).replace(" ago", "") : "-" };
-    case "companies":
-      return { text: text(update.companies?.map((company) => company.ticker || company.name).filter(Boolean).join(", ")) };
-    case "headline":
-      return { text: update.headline };
+  const info: PaneFooterSegment[] = [{
+    id: "access",
+    parts: [{
+      text: state.access === "pro"
+        ? "pro access"
+        : activeTab === "intel" ? "delayed 72h" : "upgrade for full data",
+      tone: state.access === "pro" ? "positive" : "warning",
+    }],
+  }];
+
+  const page = activePage(state, activeTab, selectedList);
+  if (page?.loadingMore) {
+    info.push({ id: "loading-more", parts: [{ text: "loading more", tone: "value" }] });
+  }
+  if (page?.error) {
+    info.push({ id: "page-error", parts: [{ text: page.error, tone: "negative" }] });
+  }
+  if (favoriteMessage) {
+    info.push({ id: "favorite-error", parts: [{ text: favoriteMessage, tone: "negative" }] });
   }
 
-  return { text: "" };
+  return info;
 }
 
-function DetailLine({ label, value }: { label: string; value?: string | null }) {
-  if (!value) return null;
-  return (
-    <Box flexDirection="row" minHeight={1}>
-      <Text fg={colors.textMuted}>{label}: </Text>
-      <Text fg={colors.text}>{value}</Text>
-    </Box>
-  );
-}
-
-function Paragraph({ children }: { children?: string | null }) {
-  if (!children) return null;
-  return (
-    <Box marginTop={1}>
-      <Text fg={colors.textDim}>{children}</Text>
-    </Box>
-  );
-}
-
-function BuildoutDetail({ row, width, height }: { row: BuildoutRow | null; width: number; height: number }) {
-  if (!row) return <EmptyState title="No row selected." />;
-
-  const bodyWidth = Math.max(width - 2, 20);
-  return (
-    <ScrollBox width={width} height={height}>
-      <Box flexDirection="column" paddingX={1} width={bodyWidth}>
-        {row.kind === "company" && (
-          <>
-            <Text attributes={TextAttributes.BOLD}>{row.item.name}</Text>
-            <DetailLine label="Ticker" value={row.item.ticker ?? null} />
-            <DetailLine label="Sector" value={row.item.primarySector ?? row.item.primaryTechnology ?? null} />
-            <DetailLine label="Criticality" value={row.item.aiCriticality ?? null} />
-            <DetailLine label="Market Cap" value={row.item.marketCap ?? null} />
-            <DetailLine label="Revenue" value={row.item.revenue ?? null} />
-            <Paragraph>{row.item.longDescription ?? row.item.description}</Paragraph>
-            {(row.item.sites?.length ?? 0) > 0 && (
-              <Box marginTop={1} flexDirection="column">
-                <Text fg={colors.textDim}>Sites</Text>
-                {row.item.sites!.slice(0, 8).map((site, index) => (
-                  <Text key={`${site.name}-${index}`} fg={colors.textMuted}>
-                    {truncate(`${site.name ?? "Site"}${site.type ? ` - ${site.type}` : ""}`, bodyWidth)}
-                  </Text>
-                ))}
-              </Box>
-            )}
-          </>
-        )}
-        {row.kind === "site" && (
-          <>
-            <Text attributes={TextAttributes.BOLD}>{row.item.name}</Text>
-            <DetailLine label="Type" value={row.item.type ?? null} />
-            <DetailLine label="Owner" value={row.item.ownerTicker ?? row.item.ownerName ?? null} />
-            <DetailLine label="Location" value={[row.item.location?.city, row.item.location?.country].filter(Boolean).join(", ")} />
-            <DetailLine label="Power" value={row.item.powerCapacity ?? null} />
-            <DetailLine label="ETA" value={row.item.eta ?? null} />
-            <DetailLine label="Latest Satellite" value={dateShort(row.item.latestCapture)} />
-            <Paragraph>{row.item.description}</Paragraph>
-            {(row.item.builders?.length ?? 0) > 0 && (
-              <Box marginTop={1} flexDirection="column">
-                <Text fg={colors.textDim}>Involved Companies</Text>
-                {row.item.builders!.slice(0, 8).map((builder, index) => (
-                  <Text key={`${builder.companyName}-${index}`} fg={colors.textMuted}>
-                    {truncate(`${builder.companyTicker ?? builder.companyName ?? "Company"}${builder.role ? ` - ${builder.role}` : ""}`, bodyWidth)}
-                  </Text>
-                ))}
-              </Box>
-            )}
-          </>
-        )}
-        {row.kind === "intel" && (
-          <>
-            <Text attributes={TextAttributes.BOLD}>{row.item.headline}</Text>
-            <DetailLine label="Published" value={row.item.publishedAt ? new Date(row.item.publishedAt).toLocaleString() : null} />
-            <DetailLine label="Type" value={row.item.type ?? null} />
-            <DetailLine label="Status" value={row.item.verificationStatus ?? null} />
-            <DetailLine label="Companies" value={row.item.companies?.map((company) => company.ticker || company.name).filter(Boolean).join(", ")} />
-            <Paragraph>{row.item.context ?? row.item.content}</Paragraph>
-          </>
-        )}
+function pageStatusContent(
+  state: BuildoutLoadState,
+  activeTab: BuildoutTabId,
+  selectedList: BuildoutList | null,
+) {
+  const page = activePage(state, activeTab, selectedList);
+  if (!page) return null;
+  if (page.loadingMore && page.items.length === 0) {
+    return (
+      <Box width="100%" paddingX={1} paddingY={1}>
+        <Spinner label={`Loading ${selectedList?.name ?? activeTab}...`} />
       </Box>
-    </ScrollBox>
-  );
+    );
+  }
+  if (page.error) {
+    return (
+      <Box width="100%" paddingX={1} paddingY={1}>
+        <EmptyState title="Could not load rows." message={page.error} />
+      </Box>
+    );
+  }
+  return null;
 }
 
 export function BuildoutPane({ focused, width, height }: PaneProps) {
+  const rendererHost = useRendererHost();
+  const tableScrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const loadingPageKeysRef = useRef<Set<string>>(new Set());
+  const favoriteBusyKeysRef = useRef<Set<string>>(new Set());
   const [state, setState] = useState<BuildoutLoadState>({ status: "loading" });
   const [activeTab, setActiveTab] = useState<BuildoutTabId>("companies");
+  const [selectedList, setSelectedList] = useState<BuildoutList | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [detailRow, setDetailRow] = useState<BuildoutRow | null>(null);
-  const [sortColumnId, setSortColumnId] = useState<string | null>("company");
+  const [sortColumnId, setSortColumnId] = useState<BuildoutColumnId | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const [refreshVersion, setRefreshVersion] = useState(0);
+  const [upgradeBusy, setUpgradeBusy] = useState(false);
+  const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
+  const [favoriteBusyKey, setFavoriteBusyKey] = useState<string | null>(null);
+  const [favoriteMessage, setFavoriteMessage] = useState<string | null>(null);
+  const favoriteToken = state.status === "ready" ? state.token : null;
+  const canFavorite = favoriteToken != null;
 
   const refresh = useCallback(() => {
     setRefreshVersion((version) => version + 1);
   }, []);
 
+  const startUpgrade = useCallback(() => {
+    if (upgradeBusy) return;
+    setUpgradeBusy(true);
+    setUpgradeMessage(null);
+    void rendererHost.openExternal(BUILDOUT_UPGRADE_URL)
+      .catch((error) => {
+        setUpgradeMessage(error instanceof Error ? error.message : "upgrade page failed");
+      })
+      .finally(() => {
+        setUpgradeBusy(false);
+      });
+  }, [rendererHost, upgradeBusy]);
+
+  useShortcut((event) => {
+    const key = (event.name ?? event.key ?? "").toLowerCase();
+    if (!focused || key !== "u" || state.status !== "ready" || state.access === "pro") return;
+    event.preventDefault();
+    event.stopPropagation();
+    startUpgrade();
+  }, { scope: "buildout-upgrade" });
+
   useEffect(() => {
     let cancelled = false;
 
     async function load() {
+      loadingPageKeysRef.current.clear();
+      favoriteBusyKeysRef.current.clear();
       setState({ status: "loading" });
       setDetailRow(null);
+      setSelectedList(null);
+      setUpgradeMessage(null);
+      setFavoriteMessage(null);
+      setFavoriteBusyKey(null);
 
-      if (!apiClient.getSessionToken()) {
-        if (!cancelled) setState({ status: "auth" });
-        return;
-      }
-
-      const session = await apiClient.getSession().catch(() => null);
-      if (!session) {
-        if (!cancelled) setState({ status: "auth" });
-        return;
-      }
-
-      const account = await apiClient.getBuildoutAccount();
-      if (!account.subscription.active) {
-        if (!cancelled) setState({ status: "inactive" });
-        return;
-      }
-
-      const token = await apiClient.getBuildoutToken();
-      const data = await loadBuildoutData(token.token);
+      const token = await getBuildoutProToken();
+      const data = await loadBuildoutData(token);
       if (!cancelled) {
         setState({
           status: "ready",
@@ -443,85 +222,574 @@ export function BuildoutPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     setSelectedIndex(0);
     setDetailRow(null);
-    setSortColumnId(activeTab === "companies" ? "company" : activeTab === "sites" ? "site" : "time");
-    setSortDirection(activeTab === "intel" ? "desc" : "asc");
-  }, [activeTab]);
+    setFavoriteMessage(null);
+    const nextColumn: BuildoutColumnId | null = activeTab === "companies"
+      ? selectedList ? "marketCap" : null
+      : activeTab === "sites" ? "capture" : "time";
+    setSortColumnId(nextColumn);
+    setSortDirection(defaultSortDirection(nextColumn));
+  }, [activeTab, selectedList?.slug]);
 
-  const rows = useMemo(() => sortRows(activeRows(state, activeTab), sortColumnId, sortDirection), [activeTab, sortColumnId, sortDirection, state]);
-  const columns = useMemo(() => columnsForTab(activeTab), [activeTab]);
+  const loadCompanies = useCallback(async (list: BuildoutList, offset: number, append: boolean) => {
+    const pageKey = `companies:${list.slug}:${offset}`;
+    if (loadingPageKeysRef.current.has(pageKey)) return;
+    loadingPageKeysRef.current.add(pageKey);
+    const token = state.status === "ready" ? state.token : null;
+    setState((current) => {
+      if (current.status !== "ready") return current;
+      return {
+        ...current,
+        companies: {
+          ...(append ? current.companies : { ...emptyPage<BuildoutCompany>(), blurredCompanyCount: 0 }),
+          loadingMore: true,
+          error: null,
+        },
+      };
+    });
+
+    try {
+      const page = await fetchCompaniesPage(token, list.slug, offset);
+      setState((current) => {
+        if (current.status !== "ready") return current;
+        const previousItems = append ? current.companies.items : [];
+        const items = appendUniqueById(previousItems, page.items);
+        return {
+          ...current,
+          companies: {
+            items,
+            offset: items.length,
+            hasMore: page.items.length >= PAGE_SIZE,
+            loadingMore: false,
+            error: null,
+            blurredCompanyCount: append
+              ? Math.max(current.companies.blurredCompanyCount, page.blurredCompanyCount)
+              : page.blurredCompanyCount,
+          },
+        };
+      });
+    } catch (error) {
+      setState((current) => {
+        if (current.status !== "ready") return current;
+        return {
+          ...current,
+          companies: {
+            ...current.companies,
+            loadingMore: false,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
+      });
+    } finally {
+      loadingPageKeysRef.current.delete(pageKey);
+    }
+  }, [state]);
+
+  const loadSites = useCallback(async (offset: number, append: boolean) => {
+    const pageKey = `sites:${offset}`;
+    if (loadingPageKeysRef.current.has(pageKey)) return;
+    loadingPageKeysRef.current.add(pageKey);
+    const token = state.status === "ready" ? state.token : null;
+    setState((current) => current.status === "ready"
+      ? { ...current, sites: { ...current.sites, loadingMore: true, error: null } }
+      : current);
+
+    try {
+      const page = await fetchSitesPage(token, offset);
+      setState((current) => {
+        if (current.status !== "ready") return current;
+        const previousItems = append ? current.sites.items : [];
+        const items = appendUniqueById(previousItems, page);
+        return {
+          ...current,
+          sites: {
+            items,
+            offset: items.length,
+            hasMore: page.length >= PAGE_SIZE,
+            loadingMore: false,
+            error: null,
+          },
+        };
+      });
+    } catch (error) {
+      setState((current) => current.status === "ready"
+        ? {
+          ...current,
+          sites: {
+            ...current.sites,
+            loadingMore: false,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        }
+        : current);
+    } finally {
+      loadingPageKeysRef.current.delete(pageKey);
+    }
+  }, [state]);
+
+  const loadIntel = useCallback(async (offset: number, append: boolean) => {
+    const pageKey = `intel:${offset}`;
+    if (loadingPageKeysRef.current.has(pageKey)) return;
+    loadingPageKeysRef.current.add(pageKey);
+    const token = state.status === "ready" ? state.token : null;
+    setState((current) => current.status === "ready"
+      ? { ...current, intel: { ...current.intel, loadingMore: true, error: null } }
+      : current);
+
+    try {
+      const page = await fetchIntelPage(token, offset);
+      setState((current) => {
+        if (current.status !== "ready") return current;
+        const previousItems = append ? current.intel.items : [];
+        const items = appendUniqueById(previousItems, page);
+        return {
+          ...current,
+          intel: {
+            items,
+            offset: items.length,
+            hasMore: page.length >= PAGE_SIZE,
+            loadingMore: false,
+            error: null,
+          },
+        };
+      });
+    } catch (error) {
+      setState((current) => current.status === "ready"
+        ? {
+          ...current,
+          intel: {
+            ...current.intel,
+            loadingMore: false,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        }
+        : current);
+    } finally {
+      loadingPageKeysRef.current.delete(pageKey);
+    }
+  }, [state]);
+
+  useEffect(() => {
+    if (state.status !== "ready" || activeTab !== "companies" || !selectedList) return;
+    if (state.companies.items.length > 0 || state.companies.loadingMore || state.companies.error) return;
+    void loadCompanies(selectedList, 0, false);
+  }, [activeTab, loadCompanies, selectedList, state]);
+
+  const rows = useMemo(
+    () => sortRows(activeRows(state, activeTab, selectedList), sortColumnId, sortDirection),
+    [activeTab, selectedList, sortColumnId, sortDirection, state],
+  );
+  const columns = useMemo(() => columnsForTab(activeTab, selectedList, canFavorite), [activeTab, canFavorite, selectedList]);
   const selectedRow = rows[selectedIndex] ?? rows[0] ?? null;
+  const tickerTexts = useMemo(() => {
+    const symbols = new Set<string>();
+    for (const row of rows) {
+      for (const symbol of rowTickerSymbols(row)) symbols.add(symbol);
+    }
+    if (detailRow) {
+      for (const symbol of rowTickerSymbols(detailRow)) symbols.add(symbol);
+    }
+    return [tickerSearchText([...symbols])];
+  }, [detailRow, rows]);
+  const { catalog: tickerCatalog, openTicker } = useInlineTickers(tickerTexts);
+  const detailCompanyTicker = detailRow?.kind === "company" ? tickerSymbol(detailRow.item.ticker) : null;
+  const openDetailTicker = useCallback(() => {
+    if (!detailCompanyTicker) return;
+    openTicker(detailCompanyTicker);
+  }, [detailCompanyTicker, openTicker]);
+  const footerHints = useMemo<PaneHint[]>(() => {
+    const hints: PaneHint[] = [];
+    if (state.status === "ready" && state.access !== "pro") {
+      hints.push({ id: "upgrade", key: "u", label: "pgrade", onPress: startUpgrade });
+    }
+    if (detailCompanyTicker) {
+      hints.push({ id: "open-ticker", key: "o", label: "pen", onPress: openDetailTicker });
+    }
+    return hints;
+  }, [detailCompanyTicker, openDetailTicker, startUpgrade, state]);
 
   usePaneFooter("buildout", () => ({
-    info: [
-      {
-        id: "state",
-        parts: [
-          { text: "TBO", tone: "label" },
-          { text: state.status === "ready" ? `${rows.length} ${activeTab}` : state.status, tone: state.status === "inactive" ? "warning" : "value" },
-        ],
-      },
-    ],
-    hints: [
-      { id: "refresh", key: "r", label: "refresh", onPress: refresh },
-      ...(detailRow ? [{ id: "back", key: "esc", label: "back", onPress: () => setDetailRow(null) }] : []),
-    ],
-  }), [activeTab, detailRow, refresh, rows.length, state.status]);
+    info: updateFooterInfo(state, activeTab, selectedList, favoriteMessage),
+    hints: footerHints,
+  }), [activeTab, favoriteMessage, footerHints, selectedList, state]);
 
   const handleHeaderClick = useCallback((columnId: string) => {
+    const nextColumnId = columnId as BuildoutColumnId;
     setSortColumnId((current) => {
-      if (current === columnId) {
+      if (current === nextColumnId) {
         setSortDirection((direction) => (direction === "asc" ? "desc" : "asc"));
         return current;
       }
-      setSortDirection("asc");
-      return columnId;
+      setSortDirection(defaultSortDirection(nextColumnId));
+      return nextColumnId;
     });
   }, []);
 
+  const openCompanyList = useCallback((list: BuildoutList) => {
+    setSelectedList(list);
+    setSelectedIndex(0);
+    setDetailRow(null);
+    setUpgradeMessage(null);
+    setFavoriteMessage(null);
+    setSortColumnId("marketCap");
+    setSortDirection("desc");
+    setState((current) => current.status === "ready"
+      ? {
+        ...current,
+        companies: { ...emptyPage<BuildoutCompany>(), blurredCompanyCount: 0 },
+      }
+      : current);
+  }, []);
+
+  const closeCompanyList = useCallback(() => {
+    setSelectedList(null);
+    setSelectedIndex(0);
+    setDetailRow(null);
+    setUpgradeMessage(null);
+    setFavoriteMessage(null);
+    setSortColumnId(null);
+    setSortDirection("asc");
+  }, []);
+
+  const activateRow = useCallback((row: BuildoutRow) => {
+    if (row.kind === "list") {
+      openCompanyList(row.item);
+      return;
+    }
+    setDetailRow(row);
+  }, [openCompanyList]);
+
+  const updateFavorite = useCallback((key: string, starred: boolean) => {
+    setState((current) => applyFavoriteToState(current, key, starred));
+    setDetailRow((current) => (
+      current && favoriteKey(current) === key ? rowWithFavorite(current, starred) : current
+    ));
+  }, []);
+
+  const toggleFavorite = useCallback(async (row: BuildoutRow) => {
+    if (!favoriteToken) return;
+    const key = favoriteKey(row);
+    const path = favoriteApiPath(row);
+    if (!key || !path || favoriteBusyKeysRef.current.has(key)) return;
+
+    const previous = rowStarred(row);
+    const next = !previous;
+    favoriteBusyKeysRef.current.add(key);
+    setFavoriteBusyKey(key);
+    setFavoriteMessage(null);
+    updateFavorite(key, next);
+
+    try {
+      const response = await buildoutApi<{ starred?: boolean }>(path, favoriteToken, { method: "POST" });
+      updateFavorite(key, typeof response.starred === "boolean" ? response.starred : next);
+    } catch {
+      updateFavorite(key, previous);
+      setFavoriteMessage("favorite failed");
+    } finally {
+      favoriteBusyKeysRef.current.delete(key);
+      setFavoriteBusyKey((current) => current === key ? null : current);
+    }
+  }, [favoriteToken, updateFavorite]);
+
+  const toggleFavoriteRow = useCallback((row: BuildoutRow | null) => {
+    if (!canFavorite || !row || !favoriteKey(row)) return false;
+    void toggleFavorite(row);
+    return true;
+  }, [canFavorite, toggleFavorite]);
+
+  const loadMoreActiveRows = useCallback(() => {
+    if (state.status !== "ready") return;
+    const scrollBox = tableScrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const page = activePage(state, activeTab, selectedList);
+    if (!page || page.loadingMore || !page.hasMore || page.error) return;
+    const visibleBottom = scrollBox.scrollTop + scrollBox.viewport.height;
+    const remaining = page.items.length - visibleBottom;
+    if (remaining > LOAD_MORE_THRESHOLD) return;
+
+    if (activeTab === "companies" && selectedList) {
+      void loadCompanies(selectedList, page.offset, true);
+    } else if (activeTab === "sites") {
+      void loadSites(page.offset, true);
+    } else if (activeTab === "intel") {
+      void loadIntel(page.offset, true);
+    }
+  }, [activeTab, loadCompanies, loadIntel, loadSites, selectedList, state]);
+
   const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
-    if (event.name !== "r") return false;
+    if (event.name === "u" && state.status === "ready" && state.access !== "pro") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      void startUpgrade();
+      return true;
+    }
+    if ((event.name === "s" || event.name === "f") && toggleFavoriteRow(selectedRow)) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      return true;
+    }
+    if (event.name === "r") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+      return true;
+    }
+    if (activeTab === "companies" && selectedList && (event.name === "escape" || event.name === "backspace")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      closeCompanyList();
+      return true;
+    }
+    return false;
+  }, [activeTab, closeCompanyList, refresh, selectedList, selectedRow, startUpgrade, state, toggleFavoriteRow]);
+
+  const handleDetailKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (event.name === "u" && state.status === "ready" && state.access !== "pro") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      void startUpgrade();
+      return true;
+    }
+    if ((event.name === "s" || event.name === "f") && toggleFavoriteRow(detailRow)) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      return true;
+    }
+    if (event.name !== "o" || !detailCompanyTicker) return false;
     event.preventDefault?.();
     event.stopPropagation?.();
-    refresh();
+    openDetailTicker();
     return true;
-  }, [refresh]);
+  }, [detailCompanyTicker, detailRow, openDetailTicker, startUpgrade, state, toggleFavoriteRow]);
+
+  const renderCell = useCallback((
+    row: BuildoutRow,
+    column: BuildoutColumn,
+    _index: number,
+    rowState: { selected: boolean; hovered: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+
+    if (row.kind === "list") {
+      const list = row.item;
+      switch (column.id) {
+        case "listName":
+          return { text: list.name, color: selectedColor ?? colors.text };
+        case "listDescription":
+          return { text: text(list.shortDescription ?? list.description), color: selectedColor ?? colors.textDim };
+        case "companyCount":
+          return { text: list.companyCount == null ? "-" : String(list.companyCount), color: selectedColor ?? colors.textDim };
+        case "totalMarketCap":
+          return { text: text(list.totalMarketCap), color: selectedColor ?? colors.textDim };
+        case "avgSectorGrowth":
+          return { text: text(list.avgSectorGrowth), color: selectedColor ?? metricColor(list.avgSectorGrowth) };
+        case "avgReturn1y":
+          return { text: text(list.avgReturn1y), color: selectedColor ?? metricColor(list.avgReturn1y) };
+        case "avgMargin":
+          return { text: text(list.avgMargin), color: selectedColor ?? metricColor(list.avgMargin) };
+      }
+    }
+
+    if (row.kind === "company") {
+      const company = row.item;
+      switch (column.id) {
+        case "favorite": {
+          const key = favoriteKey(row);
+          const busy = key != null && favoriteBusyKey === key;
+          return {
+            text: company.starred ? "★" : "☆",
+            content: (
+              <FavoriteCell
+                starred={company.starred === true}
+                busy={busy}
+                selected={rowState.selected}
+                interactive
+              />
+            ),
+            onMouseDown: (event) => {
+              event.preventDefault?.();
+              event.stopPropagation?.();
+              void toggleFavorite(row);
+            },
+          };
+        }
+        case "company":
+          return {
+            text: company.ticker ? `${company.ticker} ${company.name}` : company.name,
+            content: (
+              <CompanyCell
+                company={company}
+                width={column.width}
+                selected={rowState.selected}
+                catalog={tickerCatalog}
+                openTicker={openTicker}
+              />
+            ),
+          };
+        case "description":
+          return { text: text(company.description), color: selectedColor ?? colors.textDim };
+        case "sectorTech":
+          return { text: text([company.primarySector, company.primaryTechnology].filter(Boolean).join(" / ")), color: selectedColor ?? colors.textDim };
+        case "criticality":
+          return { text: text(company.aiCriticality), color: criticalityColor(company.aiCriticality, rowState.selected), attributes: TextAttributes.BOLD };
+        case "marketCap":
+          return { text: text(company.marketCap), color: selectedColor ?? colors.textDim };
+        case "revenue":
+          return { text: text(company.revenue), color: selectedColor ?? colors.textDim };
+        case "revenueGrowth":
+          return {
+            text: text(company.revenueGrowthYoy ?? company.lastQuarterGrowth),
+            color: selectedColor ?? metricColor(company.revenueGrowthYoy ?? company.lastQuarterGrowth),
+          };
+        case "netIncome":
+          return { text: text(company.netIncome), color: selectedColor ?? metricColor(company.netIncome) };
+        case "margin":
+          return { text: text(company.profitMargins), color: selectedColor ?? metricColor(company.profitMargins) };
+        case "forwardPE":
+          return { text: text(company.forwardPE), color: selectedColor ?? colors.textDim };
+        case "dividendYield":
+          return { text: text(company.dividendYield), color: selectedColor ?? metricColor(company.dividendYield) };
+        case "return1y":
+          return { text: text(company.return1y), color: selectedColor ?? metricColor(company.return1y) };
+        case "employees":
+          return { text: text(company.employeeCount), color: selectedColor ?? colors.textDim };
+      }
+    }
+
+    if (row.kind === "site") {
+      const site = row.item;
+      const location = [site.location?.city, site.location?.country].filter(Boolean).join(", ");
+      switch (column.id) {
+        case "favorite": {
+          const key = favoriteKey(row);
+          const busy = key != null && favoriteBusyKey === key;
+          return {
+            text: site.starred ? "★" : "☆",
+            content: (
+              <FavoriteCell
+                starred={site.starred === true}
+                busy={busy}
+                selected={rowState.selected}
+                interactive
+              />
+            ),
+            onMouseDown: (event) => {
+              event.preventDefault?.();
+              event.stopPropagation?.();
+              void toggleFavorite(row);
+            },
+          };
+        }
+        case "site":
+          return { text: site.name, color: selectedColor ?? colors.text };
+        case "type":
+          return { text: text(site.type), color: selectedColor ?? colors.textDim };
+        case "owner": {
+          const ownerTicker = tickerSymbol(site.ownerTicker);
+          if (ownerTicker) {
+            return {
+              text: ownerTicker,
+              content: tickerBadges({
+                symbols: [ownerTicker],
+                width: column.width,
+                catalog: tickerCatalog,
+                openTicker,
+                fallbackColor: selectedColor ?? colors.textBright,
+              }),
+            };
+          }
+          return { text: text(site.ownerName), color: selectedColor ?? colors.textDim };
+        }
+        case "location":
+          return { text: text(location), color: selectedColor ?? colors.textDim };
+        case "park":
+          return { text: text(site.parkName), color: selectedColor ?? colors.textDim };
+        case "power":
+          return { text: text(site.powerCapacity), color: selectedColor ?? colors.textDim };
+        case "construction":
+          return { text: activityLabel(site.constructionActivity), color: activityColor(site.constructionActivity, rowState.selected) };
+        case "parking":
+          return { text: activityLabel(site.parkingActivity), color: activityColor(site.parkingActivity, rowState.selected) };
+        case "capture":
+          return { text: formatRelativeTime(site.latestCapture), color: selectedColor ?? colors.textDim };
+        case "area":
+          return { text: text(site.areaKm2), color: selectedColor ?? colors.textDim };
+      }
+    }
+
+    if (row.kind === "intel") {
+      const update = row.item;
+      switch (column.id) {
+        case "time":
+          return { text: formatRelativeTime(update.publishedAt), color: selectedColor ?? colors.textDim };
+        case "companies": {
+          const symbols = (update.companies ?? [])
+            .map((company) => tickerSymbol(company.ticker))
+            .filter((symbol): symbol is string => symbol != null);
+          return symbols.length > 0
+            ? {
+              text: symbols.join(" "),
+              content: tickerBadges({
+                symbols,
+                width: column.width,
+                catalog: tickerCatalog,
+                openTicker,
+                fallbackColor: selectedColor ?? colors.textBright,
+              }),
+            }
+            : { text: text(update.companies?.map((company) => company.name).filter(Boolean).join(", ")), color: selectedColor ?? colors.textDim };
+        }
+        case "headline":
+          return { text: update.headline, color: selectedColor ?? colors.text };
+      }
+    }
+
+    return { text: "" };
+  }, [favoriteBusyKey, openTicker, tickerCatalog, toggleFavorite]);
 
   if (state.status === "loading") {
-    return <Box padding={1}><Spinner label="Loading TheBuildout.ai..." /></Box>;
-  }
-
-  if (state.status === "auth") {
-    return (
-      <Box flexDirection="column" padding={1} gap={1}>
-        <Text fg={colors.textDim}>Log in with your Gloom account to open TBO.</Text>
-        <InlineAuthActions />
-      </Box>
-    );
-  }
-
-  if (state.status === "inactive") {
-    return <Box padding={1}><EmptyState title="Requires TheBuildout.ai subscription." /></Box>;
+    return <Box padding={1}><Spinner label={`Loading ${BUILDOUT_NAME}...`} /></Box>;
   }
 
   if (state.status === "error") {
     return (
       <Box padding={1}>
-        <EmptyState title="Could not load TheBuildout.ai." message={state.message} hint="Press r to retry." />
+        <EmptyState title={`Could not load ${BUILDOUT_NAME}.`} message={state.message} />
       </Box>
     );
   }
+
+  const beforeHeight = selectedList && activeTab === "companies" ? 2 : 1;
+  const hiddenCompanyCount = state.status === "ready"
+    && activeTab === "companies"
+    && selectedList
+    && !state.companies.loadingMore
+    && !state.companies.hasMore
+    && !state.companies.error
+    ? state.companies.blurredCompanyCount
+    : 0;
 
   return (
     <DataTableStackView<BuildoutRow, BuildoutColumn>
       focused={focused}
       detailOpen={!!detailRow}
       onBack={() => setDetailRow(null)}
-      detailTitle={detailRow ? rowKey(detailRow) : undefined}
-      detailContent={<BuildoutDetail row={detailRow} width={width} height={height} />}
+      detailTitle={detailRow ? rowTitle(detailRow) : undefined}
+      detailContent={(
+        <BuildoutDetail
+          row={detailRow}
+          width={width}
+          height={height}
+          catalog={tickerCatalog}
+          openTicker={openTicker}
+          canFavorite={canFavorite}
+          favoriteBusyKey={favoriteBusyKey}
+          onToggleFavorite={toggleFavorite}
+        />
+      )}
       rootWidth={width}
       rootHeight={height}
       rootBefore={(
-        <Box height={1}>
+        <Box flexDirection="column" height={beforeHeight}>
           <Tabs
             tabs={tabs}
             activeValue={activeTab}
@@ -530,25 +798,51 @@ export function BuildoutPane({ focused, width, height }: PaneProps) {
             variant="bare"
             focused={focused && !detailRow}
           />
+          {selectedList && activeTab === "companies" ? (
+            <Box height={1} flexDirection="row" paddingX={1}>
+              <Box
+                onMouseDown={(event: any) => {
+                  event.preventDefault();
+                  closeCompanyList();
+                }}
+              >
+                <Text fg={colors.borderFocused} attributes={TextAttributes.BOLD}>{"< Lists"}</Text>
+              </Box>
+              <Text fg={colors.textMuted}>  /  </Text>
+              <Text fg={colors.text}>{truncate(selectedList.name, Math.max(0, width - 14))}</Text>
+            </Box>
+          ) : null}
         </Box>
       )}
       columns={columns}
       items={rows}
       selectedIndex={selectedIndex}
       onSelectIndex={(index) => setSelectedIndex(index)}
-      onActivateIndex={(_index, row) => setDetailRow(row)}
+      onActivateIndex={(_index, row) => activateRow(row)}
       sortColumnId={sortColumnId}
       sortDirection={sortDirection}
       onHeaderClick={handleHeaderClick}
       getItemKey={rowKey}
       isSelected={(row) => selectedRow ? rowKey(row) === rowKey(selectedRow) : false}
-      onSelect={(row, index) => setSelectedIndex(index)}
-      onActivate={(row) => setDetailRow(row)}
+      onSelect={(_row, index) => setSelectedIndex(index)}
+      onActivate={activateRow}
       renderCell={renderCell}
-      emptyStateTitle="No Buildout rows"
-      emptyStateHint="Press r to refresh."
+      bodyAfter={hiddenCompanyCount > 0 ? (
+        <CompaniesUpgradeCta
+          hiddenCount={hiddenCompanyCount}
+          width={width}
+          busy={upgradeBusy}
+          message={upgradeMessage}
+          onUpgrade={startUpgrade}
+        />
+      ) : null}
+      emptyContent={pageStatusContent(state, activeTab, selectedList)}
+      emptyStateTitle={selectedList ? "No companies" : "No rows"}
       onRootKeyDown={handleRootKeyDown}
-      resetScrollKey={activeTab}
+      onDetailKeyDown={handleDetailKeyDown}
+      onBodyScrollActivity={loadMoreActiveRows}
+      scrollRef={tableScrollRef}
+      resetScrollKey={`${activeTab}:${selectedList?.slug ?? "lists"}`}
     />
   );
 }

--- a/src/plugins/builtin/buildout/detail.tsx
+++ b/src/plugins/builtin/buildout/detail.tsx
@@ -1,0 +1,892 @@
+import type { ReactNode } from "react";
+import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import { Button, EmptyState, TickerBadgeList } from "../../../components";
+import { MarkdownText } from "../../../components/markdown-text";
+import { RemoteImage } from "../../../components/ui";
+import { colors } from "../../../theme/colors";
+import type {
+  BuildoutCompany,
+  BuildoutObservation,
+  BuildoutRelatedCompany,
+  BuildoutReportSection,
+  BuildoutRow,
+  BuildoutSite,
+  BuildoutSource,
+  RawObject,
+} from "./model";
+import {
+  activityColor,
+  activityLabel,
+  criticalityColor,
+  dateDetail,
+  dateShort,
+  domainFromUrl,
+  favoriteKey,
+  intelSourceDomains,
+  metricColor,
+  rowStarred,
+  sourceDomains,
+  text,
+  textOrNull,
+  tickerSymbol,
+  truncate,
+  uniqueStrings,
+} from "./model";
+
+type DetailSpec = {
+  label: string;
+  value?: string | null;
+  color?: string;
+};
+
+function DetailSpecGrid({ items, width, marginTop = 1 }: { items: DetailSpec[]; width: number; marginTop?: number }) {
+  const visibleItems = items.filter((item) => textOrNull(item.value) != null);
+  if (visibleItems.length === 0) return null;
+
+  const columnCount = width >= 110 ? 4 : width >= 78 ? 3 : width >= 52 ? 2 : 1;
+  const columnWidth = Math.max(18, Math.floor(width / columnCount));
+  const rows: DetailSpec[][] = [];
+  for (let index = 0; index < visibleItems.length; index += columnCount) {
+    rows.push(visibleItems.slice(index, index + columnCount));
+  }
+
+  return (
+    <Box marginTop={marginTop} flexDirection="column">
+      {rows.map((row, rowIndex) => (
+        <Box key={rowIndex} flexDirection="row" height={1} width={width} overflow="hidden">
+          {row.map((item) => {
+            const labelWidth = Math.min(Math.max(item.label.length + 2, 8), Math.max(8, Math.floor(columnWidth * 0.45)));
+            const valueWidth = Math.max(0, columnWidth - labelWidth);
+            const labelText = truncate(`${item.label}:`, Math.max(0, labelWidth - 1)).padEnd(labelWidth);
+            return (
+              <Box key={item.label} flexDirection="row" width={columnWidth} height={1} overflow="hidden">
+                <Text fg={colors.textMuted}>{labelText}</Text>
+                <Text fg={item.color ?? colors.text}>{truncate(text(item.value, ""), valueWidth)}</Text>
+              </Box>
+            );
+          })}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+function MetaBadge({ label, tone = "neutral" }: { label?: string | null; tone?: "neutral" | "warning" }) {
+  const value = textOrNull(label);
+  if (!value) return null;
+  const accent = tone === "warning" ? colors.warning : colors.borderFocused;
+  return (
+    <Box backgroundColor={accent} paddingX={1} height={1}>
+      <Text fg={colors.bg} attributes={TextAttributes.BOLD}>{value.toUpperCase()}</Text>
+    </Box>
+  );
+}
+
+function InlineSources({ domains, width }: { domains: readonly string[]; width: number }) {
+  if (domains.length === 0) return null;
+  const label = "Sources: ";
+  return (
+    <Box marginTop={1} flexDirection="row" width={width} height={1} overflow="hidden">
+      <Text fg={colors.textMuted}>{label}</Text>
+      <Text fg={colors.textDim}>{truncate(domains.join(", "), Math.max(0, width - label.length))}</Text>
+    </Box>
+  );
+}
+
+function valueWithOriginal(value?: string | null, original?: string | null) {
+  const main = textOrNull(value);
+  const originalValue = textOrNull(original);
+  if (!originalValue || originalValue === main) return main;
+  return main ? `${main} (${originalValue})` : originalValue;
+}
+
+function dateCell(value?: string | null) {
+  const short = dateShort(value);
+  return short === "-" ? null : short;
+}
+
+function booleanText(value: boolean | null | undefined) {
+  if (value == null) return null;
+  return value ? "Yes" : "No";
+}
+
+function recommendationColor(value: string | null | undefined) {
+  const normalized = (value ?? "").toLowerCase();
+  if (normalized.includes("buy")) return colors.positive;
+  if (normalized.includes("sell")) return colors.negative;
+  if (normalized.includes("hold")) return colors.neutral;
+  return colors.textDim;
+}
+
+function detailListValues(values: readonly (string | null | undefined)[], existing: readonly (string | null | undefined)[] = []) {
+  const existingSet = new Set(existing.map((item) => item?.trim()).filter(Boolean));
+  return uniqueStrings(values.filter((item): item is string => textOrNull(item) != null))
+    .filter((item) => !existingSet.has(item));
+}
+
+function DetailSection({
+  title,
+  width,
+  children,
+}: {
+  title: string;
+  width: number;
+  children: ReactNode;
+}) {
+  return (
+    <Box marginTop={1} flexDirection="column" width={width}>
+      <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{truncate(title, width)}</Text>
+      {children}
+    </Box>
+  );
+}
+
+function DetailListLine({
+  label,
+  values,
+  width,
+}: {
+  label: string;
+  values: readonly string[];
+  width: number;
+}) {
+  if (values.length === 0) return null;
+  const prefix = `${label}: `;
+  return (
+    <Box flexDirection="row" width={width} height={1} overflow="hidden">
+      <Text fg={colors.textMuted}>{prefix}</Text>
+      <Text fg={colors.textDim}>{truncate(values.join(", "), Math.max(0, width - prefix.length))}</Text>
+    </Box>
+  );
+}
+
+function metadataValue(value: unknown) {
+  if (value == null) return null;
+  if (typeof value === "string") return textOrNull(value);
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "boolean") return booleanText(value);
+  if (Array.isArray(value)) {
+    const values = value.map(textOrNull).filter((item): item is string => item != null);
+    return values.length > 0 ? values.slice(0, 5).join(", ") : null;
+  }
+  return null;
+}
+
+function metadataLabel(key: string) {
+  return key
+    .replace(/_/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function metadataSpecs(metadata: RawObject | null | undefined): DetailSpec[] {
+  if (!metadata) return [];
+  return Object.entries(metadata)
+    .flatMap(([key, value]) => {
+      const normalized = metadataValue(value);
+      return normalized ? [{ label: metadataLabel(key), value: normalized }] : [];
+    })
+    .slice(0, 12);
+}
+
+function RelatedCompaniesLine({
+  label,
+  companies,
+  width,
+  catalog,
+  openTicker,
+}: {
+  label: string;
+  companies: readonly BuildoutRelatedCompany[] | undefined;
+  width: number;
+  catalog: Parameters<typeof TickerBadgeList>[0]["catalog"];
+  openTicker: (symbol: string) => void;
+}) {
+  const items = companies ?? [];
+  if (items.length === 0) return null;
+
+  const visible = items.slice(0, 8);
+  const symbols = visible
+    .map((company) => tickerSymbol(company.ticker))
+    .filter((symbol): symbol is string => symbol != null);
+  const names = visible
+    .filter((company) => !tickerSymbol(company.ticker))
+    .map((company) => textOrNull(company.name))
+    .filter((name): name is string => name != null);
+  const overflow = items.length > visible.length ? ` +${items.length - visible.length}` : "";
+  const prefix = `${label}: `;
+  const badgeWidth = Math.min(Math.max(0, width - prefix.length - (names.length > 0 ? 1 : 0)), Math.max(0, symbols.length * 9));
+  return (
+    <Box flexDirection="row" width={width} height={1} overflow="hidden">
+      <Text fg={colors.textMuted}>{prefix}</Text>
+      {symbols.length > 0 ? (
+        <TickerBadgeList
+          symbols={symbols}
+          width={badgeWidth}
+          catalog={catalog}
+          fallbackColor={colors.textBright}
+          openTicker={openTicker}
+        />
+      ) : null}
+      <Text fg={colors.textDim}>
+        {truncate(`${names.length > 0 ? names.join(", ") : ""}${overflow}`, Math.max(0, width - prefix.length - badgeWidth))}
+      </Text>
+    </Box>
+  );
+}
+
+function SourceDetailLines({
+  sources,
+  width,
+  maxItems = 3,
+}: {
+  sources: readonly BuildoutSource[] | undefined;
+  width: number;
+  maxItems?: number;
+}) {
+  const entries = (sources ?? [])
+    .flatMap((source) => {
+      const flatUrl = source.url;
+      const flatTitle = source.title ?? source.snippet ?? source.reasoning;
+      const flat = flatUrl || flatTitle
+        ? [{
+          domain: source.domain ?? domainFromUrl(flatUrl) ?? null,
+          title: flatTitle,
+          note: source.reasoning ?? source.snippet,
+          tier: source.tier,
+        }]
+        : [];
+      const citations = (source.citations ?? []).map((citation) => ({
+        domain: domainFromUrl(citation.url) ?? null,
+        title: citation.title ?? citation.excerpts?.[0] ?? null,
+        note: citation.excerpts?.[0] ?? null,
+        tier: source.tier,
+      }));
+      return [...flat, ...citations];
+    })
+    .filter((entry) => textOrNull(entry.domain ?? entry.title ?? entry.note) != null)
+    .slice(0, maxItems);
+
+  if (entries.length === 0) return null;
+  return (
+    <Box marginTop={1} flexDirection="column" width={width}>
+      {entries.map((entry, index) => {
+        const prefix = entry.domain ? `${entry.domain}${entry.tier ? ` T${entry.tier}` : ""}: ` : "";
+        const body = entry.title ?? entry.note ?? "";
+        return (
+          <Text key={`${entry.domain ?? "source"}:${index}`} fg={colors.textMuted}>
+            {truncate(`${prefix}${body}`, width)}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function CompaniesUpgradeCta({
+  hiddenCount,
+  width,
+  busy,
+  message,
+  onUpgrade,
+}: {
+  hiddenCount: number;
+  width: number;
+  busy: boolean;
+  message: string | null;
+  onUpgrade: () => void;
+}) {
+  if (hiddenCount <= 0) return null;
+  const noun = hiddenCount === 1 ? "company" : "companies";
+  const contentWidth = Math.max(20, width - 2);
+  const title = truncate(`${hiddenCount} more ${noun} available`, contentWidth).padEnd(contentWidth);
+  const subtitle = truncate("Upgrade to unlock the full list and company profiles under $10B market cap.", contentWidth).padEnd(contentWidth);
+  const note = (message ? truncate(message, contentWidth) : "").padEnd(contentWidth);
+  return (
+    <Box
+      flexDirection="column"
+      height={message ? 6 : 5}
+      width="100%"
+      paddingX={1}
+      backgroundColor={colors.panel}
+      overflow="hidden"
+    >
+      <Box height={1} width="100%" backgroundColor={colors.panel}>
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{title}</Text>
+      </Box>
+      <Box height={1} width="100%" backgroundColor={colors.panel}>
+        <Text fg={colors.textDim}>{subtitle}</Text>
+      </Box>
+      <Box height={1} width="100%" backgroundColor={colors.panel} />
+      <Box flexDirection="row" height={1} width="100%" backgroundColor={colors.panel}>
+        <Button
+          label={busy ? "Opening..." : "Upgrade to Pro"}
+          variant="primary"
+          disabled={busy}
+          onPress={onUpgrade}
+        />
+      </Box>
+      {message ? (
+        <Box height={1} width="100%" backgroundColor={colors.panel}>
+          <Text fg={colors.warning}>{note}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function MarkdownBlock({
+  text: markdown,
+  width,
+  catalog,
+  openTicker,
+  marginTop = 1,
+}: {
+  text?: string | null;
+  width: number;
+  catalog: Parameters<typeof TickerBadgeList>[0]["catalog"];
+  openTicker: (symbol: string) => void;
+  marginTop?: number;
+}) {
+  if (!markdown) return null;
+  return (
+    <Box marginTop={marginTop}>
+      <MarkdownText
+        text={markdown}
+        lineWidth={width}
+        textColor={colors.textDim}
+        catalog={catalog}
+        openTicker={openTicker}
+      />
+    </Box>
+  );
+}
+
+export function tickerBadges({
+  symbols,
+  width,
+  catalog,
+  openTicker,
+  fallbackColor,
+}: {
+  symbols: readonly string[];
+  width: number;
+  catalog: Parameters<typeof TickerBadgeList>[0]["catalog"];
+  openTicker: (symbol: string) => void;
+  fallbackColor?: string;
+}) {
+  if (symbols.length === 0) return null;
+  return (
+    <TickerBadgeList
+      symbols={symbols}
+      width={width}
+      catalog={catalog}
+      fallbackColor={fallbackColor}
+      openTicker={openTicker}
+    />
+  );
+}
+
+export function FavoriteCell({
+  starred,
+  busy,
+  selected,
+  interactive = false,
+  onPress,
+}: {
+  starred: boolean;
+  busy: boolean;
+  selected: boolean;
+  interactive?: boolean;
+  onPress?: () => void;
+}) {
+  const color = selected
+    ? colors.selectedText
+    : busy ? colors.textMuted : starred ? colors.warning : colors.textMuted;
+  return (
+    <Box
+      width={2}
+      height={1}
+      style={{ cursor: interactive && !busy ? "pointer" : "default" }}
+      onMouseDown={onPress ? (event: any) => {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        if (!busy) onPress();
+      } : undefined}
+    >
+      <Text fg={color} attributes={starred ? TextAttributes.BOLD : TextAttributes.NONE} selectable={false}>
+        {busy ? "*" : starred ? "★" : "☆"}
+      </Text>
+    </Box>
+  );
+}
+
+export function CompanyCell({
+  company,
+  width,
+  selected,
+  catalog,
+  openTicker,
+}: {
+  company: BuildoutCompany;
+  width: number;
+  selected: boolean;
+  catalog: Parameters<typeof TickerBadgeList>[0]["catalog"];
+  openTicker: (symbol: string) => void;
+}) {
+  const symbol = tickerSymbol(company.ticker);
+  if (!symbol) {
+    return <Text fg={selected ? colors.selectedText : colors.text}>{truncate(company.name, width)}</Text>;
+  }
+  const badgeWidth = Math.min(11, width);
+  return (
+    <Box flexDirection="row" width={width} height={1} overflow="hidden">
+      <TickerBadgeList
+        symbols={[symbol]}
+        width={badgeWidth}
+        catalog={catalog}
+        fallbackColor={selected ? colors.selectedText : colors.textBright}
+        openTicker={openTicker}
+      />
+      <Text fg={selected ? colors.selectedText : colors.text}>
+        {truncate(company.name, Math.max(0, width - badgeWidth))}
+      </Text>
+    </Box>
+  );
+}
+
+function observationImageUrl(observation: BuildoutObservation) {
+  return observation.upscaledImageUrl
+    ?? observation.imageUrl
+    ?? observation.originalImageUrl
+    ?? observation.swirImageUrl
+    ?? observation.nirImageUrl
+    ?? null;
+}
+
+function pickObservationImages(observations: readonly BuildoutObservation[]) {
+  const seen = new Set<string>();
+  const preferred = [
+    observations.find((item) => item.observationSource === "sentinel2" && observationImageUrl(item)),
+    observations.find((item) => item.observationSource === "sentinel1" && observationImageUrl(item)),
+    ...observations.filter((item) => observationImageUrl(item)),
+  ].filter((item): item is BuildoutObservation => item != null);
+
+  return preferred.filter((item) => {
+    const url = observationImageUrl(item);
+    if (!url || seen.has(url)) return false;
+    seen.add(url);
+    return true;
+  }).slice(0, 2);
+}
+
+function SiteSatelliteImages({
+  site,
+  width,
+  height,
+}: {
+  site: BuildoutSite;
+  width: number;
+  height: number;
+}) {
+  const observations = site.observations ?? [];
+  if (observations.length === 0) return null;
+
+  const imageWidth = Math.max(20, Math.min(width, 96));
+  const imageHeight = Math.max(6, Math.min(18, Math.floor(height / 3)));
+  const imageObservations = pickObservationImages(observations);
+
+  if (imageObservations.length === 0) {
+    return (
+      <Box marginTop={1} flexDirection="column">
+        <Text fg={colors.textDim}>Satellite Observations</Text>
+        <Text fg={colors.textMuted}>
+          {`${observations.length} captures available. Image URLs require pro access.`}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box marginTop={1} flexDirection="column" gap={1}>
+      <Text fg={colors.textDim}>Satellite Observations</Text>
+      {imageObservations.map((observation, index) => {
+        const url = observationImageUrl(observation);
+        if (!url) return null;
+        const source = observation.observationSource === "sentinel1" ? "Radar" : "Optical";
+        const label = `${source} ${dateShort(observation.captureDate)}`;
+        return (
+          <RemoteImage
+            key={observation.id ?? `${url}:${index}`}
+            src={url}
+            alt={`${site.name} satellite observation`}
+            width={imageWidth}
+            height={imageHeight}
+            label={label}
+          />
+        );
+      })}
+    </Box>
+  );
+}
+
+function reportSectionText(section: BuildoutReportSection) {
+  return section.markdown ?? section.body ?? section.content ?? section.section ?? null;
+}
+
+export function BuildoutDetail({
+  row,
+  width,
+  height,
+  catalog,
+  openTicker,
+  canFavorite,
+  favoriteBusyKey,
+  onToggleFavorite,
+}: {
+  row: BuildoutRow | null;
+  width: number;
+  height: number;
+  catalog: Parameters<typeof TickerBadgeList>[0]["catalog"];
+  openTicker: (symbol: string) => void;
+  canFavorite: boolean;
+  favoriteBusyKey: string | null;
+  onToggleFavorite: (row: BuildoutRow) => void;
+}) {
+  if (!row) return <EmptyState title="No row selected." />;
+
+  const bodyWidth = Math.max(width - 2, 20);
+  const rowFavoriteKey = favoriteKey(row);
+  const favoriteToggle = canFavorite && rowFavoriteKey ? (
+    <FavoriteCell
+      starred={rowStarred(row)}
+      busy={favoriteBusyKey === rowFavoriteKey}
+      selected={false}
+      interactive
+      onPress={() => onToggleFavorite(row)}
+    />
+  ) : null;
+  return (
+    <ScrollBox width={width} height={height}>
+      <Box flexDirection="column" paddingX={1} width={bodyWidth}>
+        {row.kind === "company" && (() => {
+          const company = row.item;
+          const categoryAnchor = [company.primarySector, company.primarySubsector, company.primaryTechnology];
+          const sectors = detailListValues(company.sectors ?? [], [company.primarySector]);
+          const subSectors = detailListValues(company.subSectors ?? [], [company.primarySubsector]);
+          const technologies = detailListValues(company.technologies ?? [], [company.primaryTechnology]);
+          const valueChainStages = detailListValues(company.valueChainStages ?? [], categoryAnchor);
+          const hasCategories = sectors.length > 0 || subSectors.length > 0 || technologies.length > 0 || valueChainStages.length > 0;
+          const supplyChain = company.supplyChain;
+          const hasSupplyChain = (supplyChain?.suppliers.length ?? 0) > 0
+            || (supplyChain?.customers.length ?? 0) > 0
+            || (supplyChain?.competitors.length ?? 0) > 0
+            || textOrNull(company.aiCriticalityJustification) != null;
+          return (
+            <>
+              {favoriteToggle || company.ticker ? (
+                <Box flexDirection="row" height={1} gap={1}>
+                  {favoriteToggle}
+                  {company.ticker ? tickerBadges({
+                    symbols: [company.ticker],
+                    width: Math.min(bodyWidth - (favoriteToggle ? 3 : 0), 16),
+                    catalog,
+                    openTicker,
+                  }) : null}
+                </Box>
+              ) : null}
+              <DetailSpecGrid
+                width={bodyWidth}
+                items={[
+                  { label: "Exchange", value: company.exchange },
+                  { label: "Price", value: valueWithOriginal(company.stockPrice, company.stockPriceOriginal), color: metricColor(company.return1y) },
+                  { label: "1Y", value: company.return1y, color: metricColor(company.return1y) },
+                  { label: "3Y", value: company.return3y, color: metricColor(company.return3y) },
+                  { label: "Sector", value: [company.primarySector, company.primarySubsector, company.primaryTechnology].filter(Boolean).join(" / ") },
+                  { label: "Critical", value: company.aiCriticality, color: criticalityColor(company.aiCriticality, false) },
+                  { label: "Maturity", value: company.maturity },
+                  { label: "Export", value: company.exportControlExposure },
+                  { label: "Employees", value: company.employeeCount },
+                  { label: "HQ", value: company.hqAddress ?? [company.city, company.state, company.countryHq].filter(Boolean).join(", ") },
+                  { label: "Currency", value: company.currency && company.currency !== "USD" ? company.currency : null },
+                ]}
+              />
+              <MarkdownBlock text={company.listReason} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+              <MarkdownBlock text={company.longDescription ?? company.description} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+              {hasCategories ? (
+                <DetailSection title="Categories" width={bodyWidth}>
+                  <DetailListLine label="Sectors" values={sectors} width={bodyWidth} />
+                  <DetailListLine label="Subsectors" values={subSectors} width={bodyWidth} />
+                  <DetailListLine label="Technologies" values={technologies} width={bodyWidth} />
+                  <DetailListLine label="Chain" values={valueChainStages} width={bodyWidth} />
+                </DetailSection>
+              ) : null}
+              {hasSupplyChain ? (
+                <DetailSection title="Supply Chain" width={bodyWidth}>
+                  <MarkdownBlock text={company.aiCriticalityJustification} width={bodyWidth} catalog={catalog} openTicker={openTicker} marginTop={0} />
+                  <RelatedCompaniesLine label="Suppliers" companies={supplyChain?.suppliers} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+                  <RelatedCompaniesLine label="Customers" companies={supplyChain?.customers} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+                  <RelatedCompaniesLine label="Competitors" companies={supplyChain?.competitors} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+                </DetailSection>
+              ) : null}
+              <DetailSection title="Valuation & Trading" width={bodyWidth}>
+                <DetailSpecGrid
+                  width={bodyWidth}
+                  marginTop={0}
+                  items={[
+                    { label: "Mkt Cap", value: valueWithOriginal(company.marketCap, company.marketCapOriginal) },
+                    { label: "EV", value: company.enterpriseValue },
+                    { label: "Fwd P/E", value: company.forwardPE },
+                    { label: "Trail P/E", value: company.trailingPE },
+                    { label: "P/E", value: company.peRatio },
+                    { label: "PEG", value: company.pegRatio },
+                    { label: "P/B", value: company.priceToBook },
+                    { label: "EPS", value: valueWithOriginal(company.dilutedEps, company.dilutedEpsOriginal) },
+                    { label: "Beta", value: company.beta },
+                    { label: "52W High", value: valueWithOriginal(company.high52w, company.high52wOriginal) },
+                    { label: "52W Low", value: valueWithOriginal(company.low52w, company.low52wOriginal) },
+                  ]}
+                />
+              </DetailSection>
+              <DetailSection title="Operating Metrics" width={bodyWidth}>
+                <DetailSpecGrid
+                  width={bodyWidth}
+                  marginTop={0}
+                  items={[
+                    { label: "Revenue", value: valueWithOriginal(company.revenue, company.revenueOriginal) },
+                    { label: "Net Inc", value: valueWithOriginal(company.netIncome, company.netIncomeOriginal), color: metricColor(company.netIncome) },
+                    { label: "Rev Grw", value: company.revenueGrowthYoy, color: metricColor(company.revenueGrowthYoy) },
+                    { label: "Last Q", value: company.lastQuarterGrowth, color: metricColor(company.lastQuarterGrowth) },
+                    { label: "Gross Mgn", value: company.grossProfitMargin, color: metricColor(company.grossProfitMargin) },
+                    { label: "Op Mgn", value: company.operatingMargin, color: metricColor(company.operatingMargin) },
+                    { label: "Profit Mgn", value: company.profitMargins ?? company.netProfitMargin, color: metricColor(company.profitMargins ?? company.netProfitMargin) },
+                    { label: "ROE", value: company.returnOnEquity, color: metricColor(company.returnOnEquity) },
+                    { label: "ROA", value: company.returnOnAssets, color: metricColor(company.returnOnAssets) },
+                  ]}
+                />
+              </DetailSection>
+              <DetailSection title="Cash & Balance" width={bodyWidth}>
+                <DetailSpecGrid
+                  width={bodyWidth}
+                  marginTop={0}
+                  items={[
+                    { label: "FCF", value: valueWithOriginal(company.freeCashFlow, company.freeCashFlowOriginal), color: metricColor(company.freeCashFlow) },
+                    { label: "OCF", value: company.operatingCashFlow, color: metricColor(company.operatingCashFlow) },
+                    { label: "Cash", value: valueWithOriginal(company.totalCash, company.totalCashOriginal) },
+                    { label: "Debt", value: valueWithOriginal(company.totalDebt, company.totalDebtOriginal) },
+                    { label: "D/E", value: company.debtToEquity },
+                    { label: "Current", value: company.currentRatio },
+                    { label: "Quick", value: company.quickRatio },
+                    { label: "Div Yld", value: company.dividendYield, color: metricColor(company.dividendYield) },
+                    { label: "Ex-Div", value: dateCell(company.exDividendDate) },
+                    { label: "Div Date", value: dateCell(company.dividendDate) },
+                    { label: "Earnings", value: dateCell(company.nextEarningsDate) },
+                  ]}
+                />
+              </DetailSection>
+              <DetailSection title="Analyst & Ownership" width={bodyWidth}>
+                <DetailSpecGrid
+                  width={bodyWidth}
+                  marginTop={0}
+                  items={[
+                    { label: "Target Low", value: valueWithOriginal(company.targetLowPrice, company.targetLowPriceOriginal) },
+                    { label: "Target Mean", value: valueWithOriginal(company.targetMeanPrice, company.targetMeanPriceOriginal) },
+                    { label: "Target High", value: valueWithOriginal(company.targetHighPrice, company.targetHighPriceOriginal) },
+                    { label: "Analysts", value: company.analystCount },
+                    { label: "Rec", value: company.recommendation, color: recommendationColor(company.recommendation) },
+                    { label: "Strong Buy", value: company.strongBuy },
+                    { label: "Buy", value: company.buy },
+                    { label: "Hold", value: company.hold },
+                    { label: "Sell", value: company.sell },
+                    { label: "Strong Sell", value: company.strongSell },
+                    { label: "Insiders", value: company.heldByInsiders },
+                    { label: "Institutions", value: company.heldByInstitutions },
+                    { label: "Short", value: company.sharesShort },
+                    { label: "Short Ratio", value: company.shortRatio },
+                    { label: "Shares", value: company.sharesOutstanding },
+                    { label: "Float", value: company.floatShares },
+                  ]}
+                />
+              </DetailSection>
+              {(company.sites?.length ?? 0) > 0 ? (
+                <DetailSection title="Sites" width={bodyWidth}>
+                  {company.sites!.slice(0, 12).map((site, index) => {
+                    const activity = site.constructionActivity != null ? `construction ${activityLabel(site.constructionActivity)}` : null;
+                    const parts = [
+                      site.name ?? "Site",
+                      site.type,
+                      site.relationship === "involved" ? site.role : site.relationship,
+                      site.powerCapacity,
+                      site.areaKm2,
+                      [site.location?.city, site.location?.country].filter(Boolean).join(", "),
+                      activity,
+                    ].filter(Boolean);
+                    return (
+                      <Box key={`${site.name}-${index}`} flexDirection="column" marginTop={index === 0 ? 0 : 1}>
+                        <Text fg={colors.textMuted}>{truncate(parts.join(" - "), bodyWidth)}</Text>
+                        {site.involvementSummary ? (
+                          <MarkdownBlock text={site.involvementSummary} width={bodyWidth} catalog={catalog} openTicker={openTicker} marginTop={0} />
+                        ) : null}
+                      </Box>
+                    );
+                  })}
+                </DetailSection>
+              ) : null}
+              {(company.intelligence?.length ?? 0) > 0 ? (
+                <DetailSection title="Recent Intel" width={bodyWidth}>
+                  {company.intelligence!.slice(0, 5).map((item, index) => (
+                    <Box key={`${item.headline ?? "intel"}:${index}`} flexDirection="column" marginTop={index === 0 ? 0 : 1}>
+                      <Text fg={colors.textDim}>{truncate(`${dateShort(item.publishedAt)} ${item.headline ?? ""}`, bodyWidth)}</Text>
+                      <MarkdownBlock text={item.content} width={bodyWidth} catalog={catalog} openTicker={openTicker} marginTop={0} />
+                    </Box>
+                  ))}
+                </DetailSection>
+              ) : null}
+              {company.researchReport ? (
+                <DetailSection title="Research" width={bodyWidth}>
+                  <MarkdownBlock text={company.researchReport} width={bodyWidth} catalog={catalog} openTicker={openTicker} marginTop={0} />
+                </DetailSection>
+              ) : null}
+            </>
+          );
+        })()}
+        {row.kind === "site" && (() => {
+          const site = row.item;
+          const sourceList = [...(site.discoverySources ?? []), ...(site.projectReportSources ?? [])];
+          return (
+            <>
+              {favoriteToggle || site.ownerTicker ? (
+                <Box flexDirection="row" height={1} gap={1}>
+                  {favoriteToggle}
+                  {site.ownerTicker ? tickerBadges({
+                    symbols: [site.ownerTicker],
+                    width: Math.min(bodyWidth - (favoriteToggle ? 3 : 0), 16),
+                    catalog,
+                    openTicker,
+                  }) : null}
+                </Box>
+              ) : null}
+              <DetailSpecGrid
+                width={bodyWidth}
+                items={[
+                  { label: "Type", value: site.type },
+                  { label: "Owner", value: site.ownerName ?? site.ownerTicker },
+                  { label: "Location", value: [site.location?.city, site.location?.country].filter(Boolean).join(", ") },
+                  { label: "Address", value: site.address },
+                  { label: "Park", value: site.parkName },
+                  { label: "Power/Cap", value: site.powerCapacity },
+                  { label: "ETA", value: site.eta },
+                  { label: "Area", value: site.areaKm2 },
+                  { label: "Boundary", value: booleanText(site.boundaryConfirmed) },
+                  { label: "Construction", value: site.constructionActivity == null ? null : activityLabel(site.constructionActivity), color: activityColor(site.constructionActivity, false) },
+                  { label: "Parking", value: site.parkingActivity == null ? null : activityLabel(site.parkingActivity), color: activityColor(site.parkingActivity, false) },
+                  { label: "Last Sat", value: dateCell(site.latestCapture) },
+                  { label: "Activity At", value: dateCell(site.activityUpdatedAt) },
+                  { label: "Enriched", value: dateCell(site.lastEnrichedAt) },
+                ]}
+              />
+              <InlineSources domains={sourceDomains(sourceList)} width={bodyWidth} />
+              <SourceDetailLines sources={sourceList} width={bodyWidth} />
+              <MarkdownBlock text={site.description} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+              <SiteSatelliteImages site={site} width={bodyWidth} height={height} />
+              {(site.observations?.length ?? 0) > 0 ? (
+                <DetailSection title="Recent Captures" width={bodyWidth}>
+                  {site.observations!.slice(0, 8).map((observation, index) => {
+                    const bounds = observation.captureBounds?.minLat != null && observation.captureBounds?.minLng != null
+                      ? `${observation.captureBounds.minLat.toFixed(3)}, ${observation.captureBounds.minLng.toFixed(3)}`
+                      : null;
+                    return (
+                      <Text key={observation.id ?? index} fg={colors.textMuted}>
+                        {truncate([
+                          dateShort(observation.captureDate),
+                          observation.observationSource,
+                          observation.note,
+                          bounds,
+                        ].filter(Boolean).join(" - "), bodyWidth)}
+                      </Text>
+                    );
+                  })}
+                </DetailSection>
+              ) : null}
+              {metadataSpecs(site.siteMetadata).length > 0 ? (
+                <DetailSection title="Specs" width={bodyWidth}>
+                  <DetailSpecGrid width={bodyWidth} marginTop={0} items={metadataSpecs(site.siteMetadata)} />
+                </DetailSection>
+              ) : null}
+              {(site.projectReportSections?.length ?? 0) > 0 ? (
+                <DetailSection title="Project Report" width={bodyWidth}>
+                  {site.projectReportSections!.map((section, index) => (
+                    <Box key={`${section.title ?? "section"}:${index}`} flexDirection="column" marginTop={index === 0 ? 0 : 1}>
+                      {section.title ? <Text fg={colors.textDim}>{section.title}</Text> : null}
+                      <MarkdownBlock text={reportSectionText(section)} width={bodyWidth} catalog={catalog} openTicker={openTicker} marginTop={0} />
+                    </Box>
+                  ))}
+                </DetailSection>
+              ) : null}
+              {site.researchReport ? (
+                <DetailSection title="Research" width={bodyWidth}>
+                  <MarkdownBlock text={site.researchReport} width={bodyWidth} catalog={catalog} openTicker={openTicker} marginTop={0} />
+                </DetailSection>
+              ) : null}
+              {(site.builders?.length ?? 0) > 0 ? (
+                <DetailSection title="Involved Companies" width={bodyWidth}>
+                  {site.builders!.slice(0, 12).map((builder, index) => (
+                    <Box key={`${builder.companyName}-${index}`} flexDirection="column" marginTop={index === 0 ? 0 : 1}>
+                      <Box flexDirection="row" height={1}>
+                        {builder.companyTicker
+                          ? tickerBadges({
+                            symbols: [builder.companyTicker],
+                            width: Math.min(12, bodyWidth),
+                            catalog,
+                            openTicker,
+                          })
+                          : null}
+                        <Text fg={colors.textMuted}>
+                          {truncate(`${builder.companyName ?? "Company"}${builder.role ? ` - ${builder.role}` : ""}`, Math.max(0, bodyWidth - (builder.companyTicker ? 12 : 0)))}
+                        </Text>
+                      </Box>
+                      <MarkdownBlock text={builder.summary} width={bodyWidth} catalog={catalog} openTicker={openTicker} marginTop={0} />
+                    </Box>
+                  ))}
+                </DetailSection>
+              ) : null}
+            </>
+          );
+        })()}
+        {row.kind === "intel" && (
+          <>
+            <Box flexDirection="row" height={1} gap={1} overflow="hidden">
+              <MetaBadge label={row.item.type} />
+              {row.item.publishedAt ? <Text fg={colors.textDim}>{dateDetail(row.item.publishedAt)}</Text> : null}
+            </Box>
+            {(row.item.companies?.length ?? 0) > 0 && (
+              <Box marginTop={1} height={1}>
+                {tickerBadges({
+                  symbols: row.item.companies!.map((company) => tickerSymbol(company.ticker) ?? "").filter(Boolean),
+                  width: Math.min(bodyWidth, 56),
+                  catalog,
+                  openTicker,
+                })}
+              </Box>
+            )}
+            {row.item.imageUrl ? (
+              <Box marginTop={1}>
+                <RemoteImage
+                  src={row.item.imageUrl}
+                  alt={row.item.headline}
+                  width={Math.min(bodyWidth, 96)}
+                  height={Math.max(6, Math.min(16, Math.floor(height / 3)))}
+                  label="image"
+                />
+              </Box>
+            ) : null}
+            <MarkdownBlock text={row.item.context ?? row.item.content} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+            {row.item.context && row.item.content && row.item.context !== row.item.content
+              ? <MarkdownBlock text={row.item.content} width={bodyWidth} catalog={catalog} openTicker={openTicker} />
+              : null}
+            <InlineSources domains={intelSourceDomains(row.item)} width={bodyWidth} />
+          </>
+        )}
+      </Box>
+    </ScrollBox>
+  );
+}

--- a/src/plugins/builtin/buildout/model.ts
+++ b/src/plugins/builtin/buildout/model.ts
@@ -1,0 +1,1341 @@
+import type { DataTableColumn } from "../../../components";
+import { colors, priceColor } from "../../../theme/colors";
+import { apiClient } from "../../../utils/api-client";
+import { formatDetailDate as sharedFormatDetailDate, formatRelativeTime as sharedFormatRelativeTime, parseDisplayDate } from "../../../utils/datetime-format";
+import { httpFetch } from "../../../utils/http-transport";
+
+export const BUILDOUT_API_URL = "https://api.thebuildout.ai";
+export const BUILDOUT_NAME = "TheBuildout";
+export const PAGE_SIZE = 80;
+export const LOAD_MORE_THRESHOLD = 10;
+
+export type BuildoutTabId = "companies" | "sites" | "intel";
+export type BuildoutAccess = "free" | "pro";
+export type SortDirection = "asc" | "desc";
+
+export type RawObject = Record<string, unknown>;
+
+export type BuildoutSource = {
+  field?: string | null;
+  title?: string | null;
+  url?: string | null;
+  domain?: string | null;
+  snippet?: string | null;
+  reasoning?: string | null;
+  confidence?: string | null;
+  tier?: string | null;
+  citations?: Array<{
+    title?: string | null;
+    url?: string | null;
+    excerpts?: string[];
+  }>;
+};
+
+export type BuildoutRelatedCompany = {
+  id?: string | null;
+  name?: string | null;
+  ticker?: string | null;
+  logoUrl?: string | null;
+  websiteUrl?: string | null;
+};
+
+export type BuildoutList = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  shortDescription?: string | null;
+  companyCount?: number | null;
+  totalMarketCap?: string | null;
+  avgSectorGrowth?: string | null;
+  avgReturn1y?: string | null;
+  avgMargin?: string | null;
+};
+
+export type BuildoutCompany = {
+  id: string;
+  name: string;
+  ticker?: string | null;
+  exchange?: string | null;
+  starred?: boolean;
+  description?: string | null;
+  longDescription?: string | null;
+  primarySector?: string | null;
+  primarySubsector?: string | null;
+  primaryTechnology?: string | null;
+  sectors?: string[];
+  subSectors?: string[];
+  technologies?: string[];
+  valueChainStages?: string[];
+  aiCriticality?: string | null;
+  aiCriticalityJustification?: string | null;
+  exportControlExposure?: string | null;
+  maturity?: string | null;
+  currency?: string | null;
+  marketCap?: string | null;
+  marketCapOriginal?: string | null;
+  enterpriseValue?: string | null;
+  stockPrice?: string | null;
+  stockPriceOriginal?: string | null;
+  revenue?: string | null;
+  revenueOriginal?: string | null;
+  revenueGrowthYoy?: string | null;
+  lastQuarterGrowth?: string | null;
+  netIncome?: string | null;
+  netIncomeOriginal?: string | null;
+  peRatio?: string | null;
+  profitMargins?: string | null;
+  netProfitMargin?: string | null;
+  forwardPE?: string | null;
+  trailingPE?: string | null;
+  pegRatio?: string | null;
+  priceToBook?: string | null;
+  dilutedEps?: string | null;
+  dilutedEpsOriginal?: string | null;
+  beta?: string | null;
+  high52w?: string | null;
+  high52wOriginal?: string | null;
+  low52w?: string | null;
+  low52wOriginal?: string | null;
+  grossProfitMargin?: string | null;
+  operatingMargin?: string | null;
+  returnOnEquity?: string | null;
+  returnOnAssets?: string | null;
+  freeCashFlow?: string | null;
+  freeCashFlowOriginal?: string | null;
+  operatingCashFlow?: string | null;
+  totalCash?: string | null;
+  totalCashOriginal?: string | null;
+  totalDebt?: string | null;
+  totalDebtOriginal?: string | null;
+  debtToEquity?: string | null;
+  currentRatio?: string | null;
+  quickRatio?: string | null;
+  dividendYield?: string | null;
+  exDividendDate?: string | null;
+  dividendDate?: string | null;
+  targetHighPrice?: string | null;
+  targetHighPriceOriginal?: string | null;
+  targetLowPrice?: string | null;
+  targetLowPriceOriginal?: string | null;
+  targetMeanPrice?: string | null;
+  targetMeanPriceOriginal?: string | null;
+  analystCount?: string | null;
+  recommendation?: string | null;
+  strongBuy?: string | null;
+  buy?: string | null;
+  hold?: string | null;
+  sell?: string | null;
+  strongSell?: string | null;
+  heldByInsiders?: string | null;
+  heldByInstitutions?: string | null;
+  sharesShort?: string | null;
+  shortRatio?: string | null;
+  sharesOutstanding?: string | null;
+  floatShares?: string | null;
+  nextEarningsDate?: string | null;
+  return1y?: string | null;
+  return3y?: string | null;
+  employeeCount?: string | null;
+  countryHq?: string | null;
+  hqAddress?: string | null;
+  city?: string | null;
+  state?: string | null;
+  websiteUrl?: string | null;
+  logoUrl?: string | null;
+  researchReport?: string | null;
+  listReason?: string | null;
+  intelligence?: Array<{
+    publishedAt?: string | null;
+    headline?: string | null;
+    content?: string | null;
+    sentimentScore?: string | null;
+    sourceUrl?: string | null;
+  }>;
+  supplyChain?: {
+    suppliers: BuildoutRelatedCompany[];
+    customers: BuildoutRelatedCompany[];
+    competitors: BuildoutRelatedCompany[];
+  };
+  sites?: Array<{
+    name?: string | null;
+    type?: string | null;
+    relationship?: string | null;
+    role?: string | null;
+    involvementSummary?: string | null;
+    ownerName?: string | null;
+    ownerTicker?: string | null;
+    powerCapacity?: string | null;
+    areaKm2?: string | null;
+    constructionActivity?: number | null;
+    parkingActivity?: number | null;
+    location?: { city?: string | null; country?: string | null };
+  }>;
+};
+
+export type BuildoutObservation = {
+  id?: string;
+  captureDate?: string | null;
+  imageUrl?: string | null;
+  originalImageUrl?: string | null;
+  upscaledImageUrl?: string | null;
+  swirImageUrl?: string | null;
+  nirImageUrl?: string | null;
+  observationSource?: string | null;
+  note?: string | null;
+  captureBounds?: {
+    minLng?: number | null;
+    maxLng?: number | null;
+    minLat?: number | null;
+    maxLat?: number | null;
+  } | null;
+};
+
+export type BuildoutReportSection = {
+  title?: string | null;
+  body?: string | null;
+  content?: string | null;
+  markdown?: string | null;
+  section?: string | null;
+};
+
+export type BuildoutSite = {
+  id: string;
+  name: string;
+  type?: string | null;
+  starred?: boolean;
+  ownerName?: string | null;
+  ownerTicker?: string | null;
+  ownerLogoUrl?: string | null;
+  ownerWebsiteUrl?: string | null;
+  address?: string | null;
+  location?: { city?: string | null; country?: string | null };
+  boundaryConfirmed?: boolean | null;
+  constructionActivity?: number | null;
+  parkingActivity?: number | null;
+  latestCapture?: string | null;
+  activityUpdatedAt?: string | null;
+  powerCapacity?: string | null;
+  eta?: string | null;
+  description?: string | null;
+  parkName?: string | null;
+  areaKm2?: string | null;
+  siteMetadata?: RawObject | null;
+  observations?: BuildoutObservation[];
+  projectReportSections?: BuildoutReportSection[] | null;
+  projectReportSources?: BuildoutSource[];
+  researchReport?: string | null;
+  lastEnrichedAt?: string | null;
+  builders?: Array<{
+    companyName?: string | null;
+    companyTicker?: string | null;
+    companyWebsiteUrl?: string | null;
+    role?: string | null;
+    summary?: string | null;
+  }>;
+  discoverySources?: BuildoutSource[];
+};
+
+export type BuildoutUpdate = {
+  id: string;
+  headline: string;
+  content?: string | null;
+  context?: string | null;
+  imageUrl?: string | null;
+  type?: string | null;
+  publishedAt?: string | null;
+  verificationStatus?: string | null;
+  companies?: Array<{ name?: string | null; ticker?: string | null; websiteUrl?: string | null; countryHq?: string | null }>;
+  contextSources?: BuildoutSource[];
+  sourceUrls?: string[];
+  isDelayed?: boolean;
+};
+
+export type BuildoutRow =
+  | { kind: "list"; item: BuildoutList }
+  | { kind: "company"; item: BuildoutCompany }
+  | { kind: "site"; item: BuildoutSite }
+  | { kind: "intel"; item: BuildoutUpdate };
+
+export type BuildoutCompaniesPayload =
+  | { companies?: RawObject[]; blurredCount?: number }
+  | RawObject[];
+
+export type BuildoutPagedState<T> = {
+  items: T[];
+  offset: number;
+  hasMore: boolean;
+  loadingMore: boolean;
+  error: string | null;
+};
+
+export type BuildoutLoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | {
+    status: "ready";
+    access: BuildoutAccess;
+    token: string | null;
+    lists: BuildoutList[];
+    companies: BuildoutPagedState<BuildoutCompany> & { blurredCompanyCount: number };
+    sites: BuildoutPagedState<BuildoutSite>;
+    intel: BuildoutPagedState<BuildoutUpdate>;
+    loadedAt: number;
+  };
+
+export type BuildoutColumnId =
+  | "favorite"
+  | "listName"
+  | "listDescription"
+  | "companyCount"
+  | "totalMarketCap"
+  | "avgSectorGrowth"
+  | "avgReturn1y"
+  | "avgMargin"
+  | "company"
+  | "description"
+  | "sectorTech"
+  | "criticality"
+  | "marketCap"
+  | "revenue"
+  | "revenueGrowth"
+  | "netIncome"
+  | "margin"
+  | "forwardPE"
+  | "dividendYield"
+  | "return1y"
+  | "employees"
+  | "site"
+  | "type"
+  | "owner"
+  | "location"
+  | "park"
+  | "power"
+  | "construction"
+  | "parking"
+  | "capture"
+  | "area"
+  | "time"
+  | "companies"
+  | "headline";
+
+export type BuildoutColumn = DataTableColumn & { id: BuildoutColumnId };
+
+export type SortComparable =
+  | { type: "number"; value: number }
+  | { type: "string"; value: string }
+  | { type: "missing" };
+
+export const tabs: Array<{ label: string; value: BuildoutTabId }> = [
+  { label: "Companies", value: "companies" },
+  { label: "Sites", value: "sites" },
+  { label: "Intel", value: "intel" },
+];
+
+export const listColumns: BuildoutColumn[] = [
+  { id: "listName", label: "List Name", width: 30, align: "left", flexGrow: 2 },
+  { id: "listDescription", label: "Description", width: 42, align: "left", flexGrow: 3 },
+  { id: "companyCount", label: "Companies", width: 10, align: "right" },
+  { id: "totalMarketCap", label: "Market Cap", width: 12, align: "right" },
+  { id: "avgSectorGrowth", label: "Med Growth", width: 11, align: "right" },
+  { id: "avgReturn1y", label: "Med 1Y Rtn", width: 11, align: "right" },
+  { id: "avgMargin", label: "Med Margin", width: 10, align: "right" },
+];
+
+export const favoriteColumn: BuildoutColumn = { id: "favorite", label: "", width: 2, align: "left" };
+
+export const companyColumns: BuildoutColumn[] = [
+  { id: "company", label: "Company", width: 26, align: "left", flexGrow: 2 },
+  { id: "description", label: "Description", width: 34, align: "left", flexGrow: 2 },
+  { id: "sectorTech", label: "Sector & Tech", width: 26, align: "left", flexGrow: 1 },
+  { id: "criticality", label: "Criticality", width: 12, align: "left" },
+  { id: "marketCap", label: "Mkt Cap", width: 10, align: "right" },
+  { id: "revenue", label: "Revenue", width: 10, align: "right" },
+  { id: "revenueGrowth", label: "Rev Grw", width: 9, align: "right" },
+  { id: "netIncome", label: "Net Inc", width: 10, align: "right" },
+  { id: "margin", label: "Margin", width: 8, align: "right" },
+  { id: "forwardPE", label: "Fwd P/E", width: 8, align: "right" },
+  { id: "dividendYield", label: "Div Yld", width: 8, align: "right" },
+  { id: "return1y", label: "1Y Rtn", width: 8, align: "right" },
+  { id: "employees", label: "Employees", width: 9, align: "right" },
+];
+
+export const siteColumns: BuildoutColumn[] = [
+  { id: "site", label: "Site Name", width: 28, align: "left", flexGrow: 2 },
+  { id: "type", label: "Type", width: 14, align: "left" },
+  { id: "owner", label: "Owner", width: 18, align: "left", flexGrow: 1 },
+  { id: "location", label: "Location", width: 20, align: "left", flexGrow: 1 },
+  { id: "park", label: "Park", width: 20, align: "left", flexGrow: 1 },
+  { id: "power", label: "Power/Cap", width: 12, align: "right" },
+  { id: "construction", label: "Construction", width: 12, align: "right" },
+  { id: "parking", label: "Parking", width: 9, align: "right" },
+  { id: "capture", label: "Last Sat", width: 9, align: "left" },
+  { id: "area", label: "Area", width: 9, align: "right" },
+];
+
+export const intelColumns: BuildoutColumn[] = [
+  { id: "time", label: "Time", width: 4, align: "left" },
+  { id: "companies", label: "Companies", width: 24, align: "left" },
+  { id: "headline", label: "Title", width: 64, align: "left", flexGrow: 4 },
+];
+
+export function emptyPage<T>(loadingMore = false): BuildoutPagedState<T> {
+  return {
+    items: [],
+    offset: 0,
+    hasMore: true,
+    loadingMore,
+    error: null,
+  };
+}
+
+export function pageFromItems<T>(items: T[]): BuildoutPagedState<T> {
+  return {
+    items,
+    offset: items.length,
+    hasMore: items.length >= PAGE_SIZE,
+    loadingMore: false,
+    error: null,
+  };
+}
+
+export function truncate(text: string, width: number) {
+  if (width <= 0) return "";
+  if (text.length <= width) return text;
+  if (width <= 3) return text.slice(0, width);
+  return `${text.slice(0, width - 3)}...`;
+}
+
+export function text(value: unknown, fallback = "-") {
+  if (value == null) return fallback;
+  const stringValue = String(value).trim();
+  return stringValue || fallback;
+}
+
+export function textOrNull(value: unknown): string | null {
+  if (value == null) return null;
+  const stringValue = String(value).trim();
+  return stringValue || null;
+}
+
+export function stringField(raw: RawObject, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = textOrNull(raw[key]);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+export function stringArrayField(raw: RawObject, ...keys: string[]): string[] {
+  for (const key of keys) {
+    const value = raw[key];
+    if (Array.isArray(value)) {
+      return uniqueStrings(value.map(textOrNull).filter((item): item is string => item != null));
+    }
+    const textValue = textOrNull(value);
+    if (textValue) return [textValue];
+  }
+  return [];
+}
+
+export function numberField(raw: RawObject, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = raw[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string") {
+      const parsed = metricNumber(value);
+      if (parsed != null) return parsed;
+    }
+  }
+  return null;
+}
+
+export function booleanField(raw: RawObject, ...keys: string[]): boolean | null {
+  for (const key of keys) {
+    const value = raw[key];
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string") {
+      if (/^(true|yes)$/i.test(value.trim())) return true;
+      if (/^(false|no)$/i.test(value.trim())) return false;
+    }
+  }
+  return null;
+}
+
+export function objectField(raw: RawObject, ...keys: string[]): RawObject | null {
+  for (const key of keys) {
+    const value = raw[key];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return value as RawObject;
+    }
+  }
+  return null;
+}
+
+export function arrayField(raw: RawObject, ...keys: string[]): RawObject[] {
+  for (const key of keys) {
+    const value = raw[key];
+    if (Array.isArray(value)) return value.filter((item): item is RawObject => (
+      item != null && typeof item === "object" && !Array.isArray(item)
+    ));
+  }
+  return [];
+}
+
+export function metricNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value !== "string") return null;
+
+  const raw = value.trim();
+  if (!raw || raw === "-" || /^n\/a$/i.test(raw)) return null;
+  const negative = raw.startsWith("(") && raw.endsWith(")");
+  const suffixMatch = raw.match(/([KMBT])\s*%?\)?$/i);
+  const suffix = suffixMatch?.[1]?.toUpperCase() ?? "";
+  const multiplier = suffix === "K"
+    ? 1_000
+    : suffix === "M"
+      ? 1_000_000
+      : suffix === "B"
+        ? 1_000_000_000
+        : suffix === "T"
+          ? 1_000_000_000_000
+          : 1;
+  const numeric = raw
+    .replace(/[,$%+]/g, "")
+    .replace(/[()]/g, "")
+    .replace(/[KMBT]\s*$/i, "")
+    .trim();
+  const parsed = Number(numeric.match(/^-?\d+(?:\.\d+)?/)?.[0]);
+  if (!Number.isFinite(parsed)) return null;
+  return (negative ? -parsed : parsed) * multiplier;
+}
+
+export function compactInteger(value: number | null | undefined): string | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
+
+export function dateShort(value: string | null | undefined) {
+  const date = parseDisplayDate(value);
+  if (!date) return "-";
+  return date.toISOString().slice(5, 10);
+}
+
+export function dateDetail(value: string | null | undefined) {
+  const formatted = sharedFormatDetailDate(value, "");
+  return formatted || null;
+}
+
+export function formatRelativeTime(value: string | null | undefined): string {
+  return sharedFormatRelativeTime(value);
+}
+
+export function activityLabel(value: number | null | undefined) {
+  if (value == null) return "-";
+  if (value >= 2) return "High";
+  if (value >= 1) return "Low";
+  return "None";
+}
+
+export function activityColor(value: number | null | undefined, selected: boolean) {
+  if (selected) return colors.selectedText;
+  if (value == null || value <= 0) return colors.textMuted;
+  return value >= 2 ? colors.warning : colors.neutral;
+}
+
+export function metricColor(value: unknown, selected = false) {
+  if (selected) return colors.selectedText;
+  const parsed = metricNumber(value);
+  return parsed == null ? colors.textDim : priceColor(parsed);
+}
+
+export function criticalityColor(value: string | null | undefined, selected: boolean) {
+  if (selected) return colors.selectedText;
+  switch ((value ?? "").trim().toUpperCase()) {
+    case "CORE":
+      return colors.negative;
+    case "CRITICAL":
+      return colors.warning;
+    case "IMPORTANT":
+      return colors.neutral;
+    case "SUPPORTING":
+      return colors.textDim;
+    case "PERIPHERAL":
+      return colors.textMuted;
+    default:
+      return colors.textDim;
+  }
+}
+
+export function tickerSymbol(value: string | null | undefined): string | null {
+  const symbol = value?.trim();
+  return symbol ? symbol.toUpperCase() : null;
+}
+
+export function tickerSearchText(symbols: readonly string[]) {
+  return symbols
+    .filter((symbol) => /^[A-Z]/.test(symbol))
+    .map((symbol) => `$${symbol}`)
+    .join(" ");
+}
+
+export function appendUniqueById<T extends { id: string }>(existing: readonly T[], incoming: readonly T[]) {
+  const seen = new Set(existing.map((item) => item.id));
+  const merged = [...existing];
+  for (const item of incoming) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    merged.push(item);
+  }
+  return merged;
+}
+
+export function uniqueStrings(values: readonly string[]) {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+export function domainFromUrl(value: string | null | undefined) {
+  if (!value) return null;
+  try {
+    const hostname = new URL(value).hostname.replace(/^www\./, "");
+    return hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+export function sourceDomains(sources: readonly BuildoutSource[] | null | undefined) {
+  return uniqueStrings((sources ?? []).flatMap((source) => [
+    source.domain ?? domainFromUrl(source.url) ?? "",
+    ...(source.citations ?? []).map((citation) => domainFromUrl(citation.url) ?? ""),
+  ]));
+}
+
+export function intelSourceDomains(update: BuildoutUpdate) {
+  return uniqueStrings([
+    ...sourceDomains(update.contextSources),
+    ...(update.sourceUrls ?? []).map((url) => domainFromUrl(url) ?? ""),
+  ]);
+}
+
+export function normalizeSource(raw: RawObject): BuildoutSource {
+  return {
+    field: stringField(raw, "field"),
+    title: stringField(raw, "title", "name"),
+    url: stringField(raw, "url"),
+    domain: stringField(raw, "domain"),
+    snippet: stringField(raw, "snippet", "excerpt"),
+    reasoning: stringField(raw, "reasoning"),
+    confidence: stringField(raw, "confidence"),
+    tier: stringField(raw, "tier"),
+    citations: arrayField(raw, "citations").map((citation) => ({
+      title: stringField(citation, "title", "name"),
+      url: stringField(citation, "url"),
+      excerpts: stringArrayField(citation, "excerpts"),
+    })),
+  };
+}
+
+export function normalizeRelatedCompany(raw: RawObject): BuildoutRelatedCompany {
+  return {
+    id: stringField(raw, "id", "companyId", "company_id"),
+    name: stringField(raw, "name", "companyName", "company_name"),
+    ticker: tickerSymbol(stringField(raw, "ticker", "companyTicker", "company_ticker")),
+    logoUrl: stringField(raw, "logoUrl", "logo_url", "companyLogoUrl", "company_logo_url"),
+    websiteUrl: stringField(raw, "websiteUrl", "website_url", "companyWebsiteUrl", "company_website_url"),
+  };
+}
+
+export function normalizeList(raw: RawObject): BuildoutList {
+  const slug = stringField(raw, "slug") ?? stringField(raw, "id") ?? "all";
+  return {
+    id: stringField(raw, "id") ?? slug,
+    slug,
+    name: stringField(raw, "name") ?? slug,
+    description: stringField(raw, "description"),
+    shortDescription: stringField(raw, "shortDescription", "short_description"),
+    companyCount: numberField(raw, "companyCount", "company_count"),
+    totalMarketCap: stringField(raw, "totalMarketCap", "total_market_cap"),
+    avgSectorGrowth: stringField(raw, "avgSectorGrowth", "avg_sector_growth"),
+    avgReturn1y: stringField(raw, "avgReturn1y", "avg_return_1y"),
+    avgMargin: stringField(raw, "avgMargin", "avg_margin"),
+  };
+}
+
+export function normalizeCompany(raw: RawObject): BuildoutCompany {
+  const ticker = tickerSymbol(stringField(raw, "ticker"));
+  const name = stringField(raw, "name") ?? ticker ?? "Company";
+  const supplyChain = objectField(raw, "supplyChain", "supply_chain");
+  return {
+    id: stringField(raw, "id") ?? ticker ?? name,
+    name,
+    ticker,
+    exchange: stringField(raw, "exchange"),
+    starred: booleanField(raw, "starred") === true,
+    description: stringField(raw, "description"),
+    longDescription: stringField(raw, "longDescription", "long_description"),
+    primarySector: stringField(raw, "primarySector", "primary_sector", "sector_yf", "industry"),
+    primarySubsector: stringField(raw, "primarySubsector", "primary_subsector"),
+    primaryTechnology: stringField(raw, "primaryTechnology", "primary_technology"),
+    sectors: stringArrayField(raw, "sectors"),
+    subSectors: stringArrayField(raw, "subSectors", "sub_sectors"),
+    technologies: stringArrayField(raw, "technologies"),
+    valueChainStages: stringArrayField(raw, "valueChainStages", "value_chain_stages"),
+    aiCriticality: stringField(raw, "aiCriticality", "ai_criticality"),
+    aiCriticalityJustification: stringField(raw, "aiCriticalityJustification", "ai_criticality_justification"),
+    exportControlExposure: stringField(raw, "exportControlExposure", "export_control_exposure"),
+    maturity: stringField(raw, "maturity"),
+    currency: stringField(raw, "currency"),
+    marketCap: stringField(raw, "marketCap", "market_cap"),
+    marketCapOriginal: stringField(raw, "marketCapOriginal", "market_cap_original"),
+    enterpriseValue: stringField(raw, "enterpriseValue", "enterprise_value"),
+    stockPrice: stringField(raw, "stockPrice", "stock_price"),
+    stockPriceOriginal: stringField(raw, "stockPriceOriginal", "stock_price_original"),
+    revenue: stringField(raw, "revenue"),
+    revenueOriginal: stringField(raw, "revenueOriginal", "revenue_original"),
+    revenueGrowthYoy: stringField(raw, "revenueGrowthYoy", "revenue_growth_yoy", "revenue_growth"),
+    lastQuarterGrowth: stringField(raw, "lastQuarterGrowth", "last_quarter_growth", "last_quarter_revenue_growth"),
+    netIncome: stringField(raw, "netIncome", "net_income"),
+    netIncomeOriginal: stringField(raw, "netIncomeOriginal", "net_income_original"),
+    peRatio: stringField(raw, "peRatio", "pe_ratio", "pe_ratio_ttm"),
+    profitMargins: stringField(raw, "profitMargins", "profit_margins", "profit_margin", "margin"),
+    netProfitMargin: stringField(raw, "netProfitMargin", "net_profit_margin"),
+    forwardPE: stringField(raw, "forwardPE", "forwardPe", "forward_pe"),
+    trailingPE: stringField(raw, "trailingPE", "trailingPe", "trailing_pe"),
+    pegRatio: stringField(raw, "pegRatio", "peg_ratio"),
+    priceToBook: stringField(raw, "priceToBook", "price_to_book"),
+    dilutedEps: stringField(raw, "dilutedEps", "diluted_eps"),
+    dilutedEpsOriginal: stringField(raw, "dilutedEpsOriginal", "diluted_eps_original"),
+    beta: stringField(raw, "beta"),
+    high52w: stringField(raw, "high52w", "high_52w"),
+    high52wOriginal: stringField(raw, "high52wOriginal", "high_52w_original"),
+    low52w: stringField(raw, "low52w", "low_52w"),
+    low52wOriginal: stringField(raw, "low52wOriginal", "low_52w_original"),
+    grossProfitMargin: stringField(raw, "grossProfitMargin", "gross_profit_margin"),
+    operatingMargin: stringField(raw, "operatingMargin", "operating_margin"),
+    returnOnEquity: stringField(raw, "returnOnEquity", "return_on_equity"),
+    returnOnAssets: stringField(raw, "returnOnAssets", "return_on_assets"),
+    freeCashFlow: stringField(raw, "freeCashFlow", "free_cash_flow"),
+    freeCashFlowOriginal: stringField(raw, "freeCashFlowOriginal", "free_cash_flow_original"),
+    operatingCashFlow: stringField(raw, "operatingCashFlow", "operating_cash_flow"),
+    totalCash: stringField(raw, "totalCash", "total_cash"),
+    totalCashOriginal: stringField(raw, "totalCashOriginal", "total_cash_original"),
+    totalDebt: stringField(raw, "totalDebt", "total_debt"),
+    totalDebtOriginal: stringField(raw, "totalDebtOriginal", "total_debt_original"),
+    debtToEquity: stringField(raw, "debtToEquity", "debt_to_equity"),
+    currentRatio: stringField(raw, "currentRatio", "current_ratio"),
+    quickRatio: stringField(raw, "quickRatio", "quick_ratio"),
+    dividendYield: stringField(raw, "dividendYield", "dividend_yield"),
+    exDividendDate: stringField(raw, "exDividendDate", "ex_dividend_date"),
+    dividendDate: stringField(raw, "dividendDate", "dividend_date"),
+    targetHighPrice: stringField(raw, "targetHighPrice", "target_high_price"),
+    targetHighPriceOriginal: stringField(raw, "targetHighPriceOriginal", "target_high_price_original"),
+    targetLowPrice: stringField(raw, "targetLowPrice", "target_low_price"),
+    targetLowPriceOriginal: stringField(raw, "targetLowPriceOriginal", "target_low_price_original"),
+    targetMeanPrice: stringField(raw, "targetMeanPrice", "target_mean_price"),
+    targetMeanPriceOriginal: stringField(raw, "targetMeanPriceOriginal", "target_mean_price_original"),
+    analystCount: stringField(raw, "analystCount", "analyst_count"),
+    recommendation: stringField(raw, "recommendation"),
+    strongBuy: stringField(raw, "strongBuy", "strong_buy"),
+    buy: stringField(raw, "buy"),
+    hold: stringField(raw, "hold"),
+    sell: stringField(raw, "sell"),
+    strongSell: stringField(raw, "strongSell", "strong_sell"),
+    heldByInsiders: stringField(raw, "heldByInsiders", "held_by_insiders"),
+    heldByInstitutions: stringField(raw, "heldByInstitutions", "held_by_institutions"),
+    sharesShort: stringField(raw, "sharesShort", "shares_short"),
+    shortRatio: stringField(raw, "shortRatio", "short_ratio"),
+    sharesOutstanding: stringField(raw, "sharesOutstanding", "shares_outstanding"),
+    floatShares: stringField(raw, "floatShares", "float_shares"),
+    nextEarningsDate: stringField(raw, "nextEarningsDate", "next_earnings_date"),
+    return1y: stringField(raw, "return1y", "return_1y", "oneYearReturn", "one_year_return"),
+    return3y: stringField(raw, "return3y", "return_3y", "threeYearReturn", "three_year_return"),
+    employeeCount: compactInteger(numberField(raw, "employeeCount", "employee_count", "employees")) ?? stringField(raw, "employeeCount", "employee_count", "employees"),
+    countryHq: stringField(raw, "countryHq", "country_hq"),
+    hqAddress: stringField(raw, "hqAddress", "hq_address"),
+    city: stringField(raw, "city"),
+    state: stringField(raw, "state"),
+    websiteUrl: stringField(raw, "websiteUrl", "website_url"),
+    logoUrl: stringField(raw, "logoUrl", "logo_url"),
+    researchReport: stringField(raw, "researchReport", "research_report"),
+    listReason: stringField(raw, "listReason", "list_reason"),
+    intelligence: arrayField(raw, "intelligence").map((item) => ({
+      publishedAt: stringField(item, "publishedAt", "published_at"),
+      headline: stringField(item, "headline", "title"),
+      content: stringField(item, "content"),
+      sentimentScore: stringField(item, "sentimentScore", "sentiment_score"),
+      sourceUrl: stringField(item, "sourceUrl", "source_url"),
+    })),
+    supplyChain: supplyChain
+      ? {
+        suppliers: arrayField(supplyChain, "suppliers").map(normalizeRelatedCompany),
+        customers: arrayField(supplyChain, "customers").map(normalizeRelatedCompany),
+        competitors: arrayField(supplyChain, "competitors").map(normalizeRelatedCompany),
+      }
+      : undefined,
+    sites: arrayField(raw, "sites").map((site) => {
+      const siteLocation = objectField(site, "location");
+      const areaKm2 = numberField(site, "areaKm2", "area_km2");
+      return {
+        name: stringField(site, "name"),
+        type: stringField(site, "type"),
+        relationship: stringField(site, "relationship"),
+        role: stringField(site, "role"),
+        involvementSummary: stringField(site, "involvementSummary", "involvement_summary"),
+        ownerName: stringField(site, "ownerName", "owner_name"),
+        ownerTicker: tickerSymbol(stringField(site, "ownerTicker", "owner_ticker")),
+        powerCapacity: stringField(site, "powerCapacity", "power_capacity"),
+        areaKm2: areaKm2 == null ? stringField(site, "areaKm2", "area_km2") : `${areaKm2.toFixed(2)} km2`,
+        constructionActivity: numberField(site, "constructionActivity", "construction_activity"),
+        parkingActivity: numberField(site, "parkingActivity", "parking_activity"),
+        location: siteLocation
+          ? {
+            city: stringField(siteLocation, "city"),
+            country: stringField(siteLocation, "country"),
+          }
+          : undefined,
+      };
+    }),
+  };
+}
+
+export function normalizeObservation(raw: RawObject): BuildoutObservation {
+  const captureBounds = objectField(raw, "captureBounds", "capture_bounds");
+  return {
+    id: stringField(raw, "id") ?? undefined,
+    captureDate: stringField(raw, "captureDate", "capture_date"),
+    imageUrl: stringField(raw, "imageUrl", "image_url"),
+    originalImageUrl: stringField(raw, "originalImageUrl", "original_image_url"),
+    upscaledImageUrl: stringField(raw, "upscaledImageUrl", "upscaled_image_url"),
+    swirImageUrl: stringField(raw, "swirImageUrl", "swir_image_url"),
+    nirImageUrl: stringField(raw, "nirImageUrl", "nir_image_url"),
+    observationSource: stringField(raw, "observationSource", "observation_source"),
+    note: stringField(raw, "note"),
+    captureBounds: captureBounds
+      ? {
+        minLng: numberField(captureBounds, "minLng", "min_lng"),
+        maxLng: numberField(captureBounds, "maxLng", "max_lng"),
+        minLat: numberField(captureBounds, "minLat", "min_lat"),
+        maxLat: numberField(captureBounds, "maxLat", "max_lat"),
+      }
+      : null,
+  };
+}
+
+export function normalizeReportSection(raw: RawObject): BuildoutReportSection {
+  return {
+    title: stringField(raw, "title", "heading", "name"),
+    body: stringField(raw, "body", "text"),
+    content: stringField(raw, "content"),
+    markdown: stringField(raw, "markdown"),
+    section: stringField(raw, "section"),
+  };
+}
+
+export function normalizeReportSections(raw: RawObject): BuildoutReportSection[] {
+  const arraySections = arrayField(raw, "projectReportSections", "project_report_sections");
+  if (arraySections.length > 0) return arraySections.map(normalizeReportSection);
+
+  const objectSections = objectField(raw, "projectReportSections", "project_report_sections");
+  if (!objectSections) return [];
+
+  return [
+    { key: "overview", title: "Project Overview" },
+    { key: "construction", title: "Construction" },
+    { key: "technology", title: "Technology" },
+    { key: "funding", title: "Funding" },
+    { key: "future", title: "Future" },
+  ].flatMap(({ key, title }) => {
+    const value = stringField(objectSections, key);
+    return value ? [{ title, markdown: value }] : [];
+  });
+}
+
+export function normalizeSite(raw: RawObject): BuildoutSite {
+  const location = objectField(raw, "location");
+  const park = objectField(raw, "park");
+  const area = stringField(raw, "areaKm2", "area_km2");
+  return {
+    id: stringField(raw, "id") ?? stringField(raw, "name") ?? "site",
+    name: stringField(raw, "name") ?? "Site",
+    type: stringField(raw, "type"),
+    starred: booleanField(raw, "starred") === true,
+    ownerName: stringField(raw, "ownerName", "owner_name"),
+    ownerTicker: tickerSymbol(stringField(raw, "ownerTicker", "owner_ticker")),
+    ownerLogoUrl: stringField(raw, "ownerLogoUrl", "owner_logo_url"),
+    ownerWebsiteUrl: stringField(raw, "ownerWebsiteUrl", "owner_website_url"),
+    address: stringField(raw, "address"),
+    location: location
+      ? {
+        city: stringField(location, "city"),
+        country: stringField(location, "country"),
+      }
+      : undefined,
+    boundaryConfirmed: booleanField(raw, "boundaryConfirmed", "boundary_confirmed"),
+    constructionActivity: numberField(raw, "constructionActivity", "construction_activity"),
+    parkingActivity: numberField(raw, "parkingActivity", "parking_activity"),
+    latestCapture: stringField(raw, "latestCapture", "latest_capture"),
+    activityUpdatedAt: stringField(raw, "activityUpdatedAt", "activity_updated_at"),
+    powerCapacity: stringField(raw, "powerCapacity", "power_capacity"),
+    eta: stringField(raw, "eta"),
+    description: stringField(raw, "description"),
+    parkName: stringField(raw, "parkName", "park_name") ?? (park ? stringField(park, "name") : null),
+    areaKm2: area ? `${area} km2` : null,
+    siteMetadata: objectField(raw, "siteMetadata", "site_metadata"),
+    observations: arrayField(raw, "observations").map(normalizeObservation),
+    projectReportSections: normalizeReportSections(raw),
+    projectReportSources: arrayField(raw, "projectReportSources", "project_report_sources").map(normalizeSource),
+    researchReport: stringField(raw, "researchReport", "research_report"),
+    lastEnrichedAt: stringField(raw, "lastEnrichedAt", "last_enriched_at"),
+    builders: arrayField(raw, "builders").map((builder) => ({
+      companyName: stringField(builder, "companyName", "company_name", "name"),
+      companyTicker: tickerSymbol(stringField(builder, "companyTicker", "company_ticker", "ticker")),
+      companyWebsiteUrl: stringField(builder, "companyWebsiteUrl", "company_website_url", "websiteUrl", "website_url"),
+      role: stringField(builder, "role"),
+      summary: stringField(builder, "summary"),
+    })),
+    discoverySources: arrayField(raw, "discoverySources", "discovery_sources").map(normalizeSource),
+  };
+}
+
+export function normalizeUpdate(raw: RawObject): BuildoutUpdate {
+  return {
+    id: stringField(raw, "id") ?? stringField(raw, "headline") ?? "intel",
+    headline: stringField(raw, "headline", "title") ?? "Intel",
+    content: stringField(raw, "content"),
+    context: stringField(raw, "context"),
+    imageUrl: stringField(raw, "imageUrl", "image_url"),
+    type: stringField(raw, "type"),
+    publishedAt: stringField(raw, "publishedAt", "published_at"),
+    verificationStatus: stringField(raw, "verificationStatus", "verification_status"),
+    companies: arrayField(raw, "companies").map((company) => ({
+      name: stringField(company, "name"),
+      ticker: tickerSymbol(stringField(company, "ticker")),
+      websiteUrl: stringField(company, "websiteUrl", "website_url"),
+      countryHq: stringField(company, "countryHq", "country_hq"),
+    })),
+    contextSources: arrayField(raw, "contextSources", "context_sources").map(normalizeSource),
+    sourceUrls: Array.isArray(raw.sourceUrls)
+      ? raw.sourceUrls.map((value) => textOrNull(value)).filter((value): value is string => value != null)
+      : Array.isArray(raw.source_urls)
+        ? raw.source_urls.map((value) => textOrNull(value)).filter((value): value is string => value != null)
+        : [],
+    isDelayed: raw.isDelayed === true || raw.is_delayed === true,
+  };
+}
+
+export function allCompaniesList(): BuildoutList {
+  return {
+    id: "all",
+    slug: "all",
+    name: "All Companies",
+    description: "View all companies in the database.",
+  };
+}
+
+export function rowKey(row: BuildoutRow) {
+  switch (row.kind) {
+    case "list":
+      return `list:${row.item.slug}`;
+    case "company":
+      return `company:${row.item.id}`;
+    case "site":
+      return `site:${row.item.id}`;
+    case "intel":
+      return `intel:${row.item.id}`;
+  }
+}
+
+export function rowTitle(row: BuildoutRow) {
+  switch (row.kind) {
+    case "list":
+      return row.item.name;
+    case "company":
+      return row.item.ticker ? `${row.item.name} (${row.item.ticker})` : row.item.name;
+    case "site":
+      return row.item.name;
+    case "intel":
+      return row.item.headline;
+  }
+}
+
+export function companyFavoriteIdentifier(company: BuildoutCompany) {
+  const ticker = tickerSymbol(company.ticker);
+  if (!ticker) return company.id;
+  const exchange = textOrNull(company.exchange);
+  return exchange ? `${exchange}:${ticker}` : ticker;
+}
+
+export function favoriteKey(row: BuildoutRow) {
+  if (row.kind === "company" || row.kind === "site") return rowKey(row);
+  return null;
+}
+
+export function rowStarred(row: BuildoutRow) {
+  if (row.kind === "company" || row.kind === "site") return row.item.starred === true;
+  return false;
+}
+
+export function rowWithFavorite(row: BuildoutRow, starred: boolean): BuildoutRow {
+  if (row.kind === "company") return { ...row, item: { ...row.item, starred } };
+  if (row.kind === "site") return { ...row, item: { ...row.item, starred } };
+  return row;
+}
+
+export function favoriteApiPath(row: BuildoutRow) {
+  if (row.kind === "company") {
+    return `/starred/companies/${encodeURIComponent(companyFavoriteIdentifier(row.item))}`;
+  }
+  if (row.kind === "site") {
+    return `/starred/sites/${encodeURIComponent(row.item.id)}`;
+  }
+  return null;
+}
+
+export function applyFavoriteToState(state: BuildoutLoadState, key: string, starred: boolean): BuildoutLoadState {
+  if (state.status !== "ready") return state;
+  if (key.startsWith("company:")) {
+    const companyId = key.slice("company:".length);
+    return {
+      ...state,
+      companies: {
+        ...state.companies,
+        items: state.companies.items.map((company) => (
+          company.id === companyId ? { ...company, starred } : company
+        )),
+      },
+    };
+  }
+  if (key.startsWith("site:")) {
+    const siteId = key.slice("site:".length);
+    return {
+      ...state,
+      sites: {
+        ...state.sites,
+        items: state.sites.items.map((site) => (
+          site.id === siteId ? { ...site, starred } : site
+        )),
+      },
+    };
+  }
+  return state;
+}
+
+export function activeRows(
+  state: BuildoutLoadState,
+  activeTab: BuildoutTabId,
+  selectedList: BuildoutList | null,
+): BuildoutRow[] {
+  if (state.status !== "ready") return [];
+  if (activeTab === "companies") {
+    if (!selectedList) {
+      return state.lists.map((item) => ({ kind: "list", item }));
+    }
+    return state.companies.items.map((item) => ({ kind: "company", item }));
+  }
+  if (activeTab === "sites") {
+    return state.sites.items.map((item) => ({ kind: "site", item }));
+  }
+  return state.intel.items.map((item) => ({ kind: "intel", item }));
+}
+
+export function columnsForTab(activeTab: BuildoutTabId, selectedList: BuildoutList | null, canFavorite: boolean) {
+  if (activeTab === "companies") {
+    return selectedList && canFavorite ? [favoriteColumn, ...companyColumns] : selectedList ? companyColumns : listColumns;
+  }
+  if (activeTab === "sites") return canFavorite ? [favoriteColumn, ...siteColumns] : siteColumns;
+  return intelColumns;
+}
+
+export function compareText(left: string, right: string) {
+  return left.localeCompare(right, "en-US", { sensitivity: "base" });
+}
+
+export function compareValues(left: SortComparable, right: SortComparable, direction: SortDirection) {
+  if (left.type === "missing" && right.type === "missing") return 0;
+  if (left.type === "missing") return 1;
+  if (right.type === "missing") return -1;
+
+  const result = left.type === "number" && right.type === "number"
+    ? left.value - right.value
+    : compareText(String(left.value), String(right.value));
+  return direction === "asc" ? result : -result;
+}
+
+export function numberSort(value: unknown): SortComparable {
+  const numberValue = metricNumber(value);
+  return numberValue == null ? { type: "missing" } : { type: "number", value: numberValue };
+}
+
+export function dateSort(value: unknown): SortComparable {
+  const stringValue = textOrNull(value);
+  if (!stringValue) return { type: "missing" };
+  const parsed = Date.parse(stringValue);
+  return Number.isFinite(parsed) ? { type: "number", value: parsed } : { type: "missing" };
+}
+
+export function stringSort(value: unknown): SortComparable {
+  const stringValue = textOrNull(value);
+  return stringValue == null ? { type: "missing" } : { type: "string", value: stringValue };
+}
+
+export function sortValue(row: BuildoutRow, columnId: BuildoutColumnId): SortComparable {
+  if (row.kind === "list") {
+    const list = row.item;
+    switch (columnId) {
+      case "listName":
+        return stringSort(list.name);
+      case "listDescription":
+        return stringSort(list.shortDescription ?? list.description);
+      case "companyCount":
+        return numberSort(list.companyCount);
+      case "totalMarketCap":
+        return numberSort(list.totalMarketCap);
+      case "avgSectorGrowth":
+        return numberSort(list.avgSectorGrowth);
+      case "avgReturn1y":
+        return numberSort(list.avgReturn1y);
+      case "avgMargin":
+        return numberSort(list.avgMargin);
+      default:
+        return stringSort(rowTitle(row));
+    }
+  }
+
+  if (row.kind === "company") {
+    const company = row.item;
+    switch (columnId) {
+      case "favorite":
+        return numberSort(company.starred ? 1 : 0);
+      case "company":
+        return stringSort(company.name);
+      case "description":
+        return stringSort(company.description);
+      case "sectorTech":
+        return stringSort(company.primarySector ?? company.primaryTechnology);
+      case "criticality":
+        return stringSort(company.aiCriticality);
+      case "marketCap":
+        return numberSort(company.marketCap);
+      case "revenue":
+        return numberSort(company.revenue);
+      case "revenueGrowth":
+        return numberSort(company.revenueGrowthYoy ?? company.lastQuarterGrowth);
+      case "netIncome":
+        return numberSort(company.netIncome);
+      case "margin":
+        return numberSort(company.profitMargins);
+      case "forwardPE":
+        return numberSort(company.forwardPE);
+      case "dividendYield":
+        return numberSort(company.dividendYield);
+      case "return1y":
+        return numberSort(company.return1y);
+      case "employees":
+        return numberSort(company.employeeCount);
+      default:
+        return stringSort(rowTitle(row));
+    }
+  }
+
+  if (row.kind === "site") {
+    const site = row.item;
+    const location = [site.location?.city, site.location?.country].filter(Boolean).join(", ");
+    switch (columnId) {
+      case "favorite":
+        return numberSort(site.starred ? 1 : 0);
+      case "site":
+        return stringSort(site.name);
+      case "type":
+        return stringSort(site.type);
+      case "owner":
+        return stringSort(site.ownerTicker ?? site.ownerName);
+      case "location":
+        return stringSort(location);
+      case "park":
+        return stringSort(site.parkName);
+      case "power":
+        return numberSort(site.powerCapacity);
+      case "construction":
+        return numberSort(site.constructionActivity);
+      case "parking":
+        return numberSort(site.parkingActivity);
+      case "capture":
+        return dateSort(site.latestCapture);
+      case "area":
+        return numberSort(site.areaKm2);
+      default:
+        return stringSort(rowTitle(row));
+    }
+  }
+
+  const update = row.item;
+  switch (columnId) {
+    case "time":
+      return dateSort(update.publishedAt);
+    case "companies":
+      return stringSort(update.companies?.map((company) => company.ticker || company.name).filter(Boolean).join(", "));
+    case "headline":
+      return stringSort(update.headline);
+    default:
+      return stringSort(rowTitle(row));
+  }
+}
+
+export function sortRows(rows: BuildoutRow[], columnId: BuildoutColumnId | null, direction: SortDirection) {
+  if (!columnId) return rows;
+  return [...rows].sort((left, right) => compareValues(
+    sortValue(left, columnId),
+    sortValue(right, columnId),
+    direction,
+  ));
+}
+
+export function defaultSortDirection(columnId: BuildoutColumnId | null): SortDirection {
+  if (!columnId) return "asc";
+  return [
+    "companyCount",
+    "totalMarketCap",
+    "avgSectorGrowth",
+    "avgReturn1y",
+    "avgMargin",
+    "marketCap",
+    "revenue",
+    "revenueGrowth",
+    "netIncome",
+    "margin",
+    "forwardPE",
+    "dividendYield",
+    "return1y",
+    "employees",
+    "favorite",
+    "construction",
+    "parking",
+    "capture",
+    "area",
+    "time",
+  ].includes(columnId) ? "desc" : "asc";
+}
+
+export function buildPath(path: string, params: Record<string, string | number | boolean | null | undefined>) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value == null) continue;
+    query.set(key, String(value));
+  }
+  const queryString = query.toString();
+  return queryString ? `${path}?${queryString}` : path;
+}
+
+export async function buildoutApi<T>(path: string, token: string | null, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const response = await httpFetch(`${BUILDOUT_API_URL}${path}`, { ...init, headers });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(body || `${BUILDOUT_NAME} request failed (${response.status})`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function fetchLists(token: string | null) {
+  const response = await buildoutApi<RawObject[]>("/lists", token);
+  const lists = Array.isArray(response) ? response.map(normalizeList) : [];
+  return [allCompaniesList(), ...lists.filter((list) => list.slug !== "all")];
+}
+
+export async function fetchCompaniesPage(token: string | null, listSlug: string, offset: number) {
+  const response = await buildoutApi<BuildoutCompaniesPayload>(buildPath("/companies", {
+    limit: PAGE_SIZE,
+    offset,
+    detail: true,
+    sort: "marketCap",
+    order: "desc",
+    list: listSlug === "all" ? null : listSlug,
+  }), token);
+  const rawCompanies = Array.isArray(response) ? response : response.companies ?? [];
+  return {
+    items: rawCompanies.map(normalizeCompany),
+    blurredCompanyCount: Array.isArray(response) ? 0 : Number(response.blurredCount ?? 0),
+  };
+}
+
+export async function fetchSitesPage(token: string | null, offset: number) {
+  const response = await buildoutApi<RawObject[]>(buildPath("/sites", {
+    limit: PAGE_SIZE,
+    offset,
+    detail: true,
+    sort: "activityUpdatedAt",
+    order: "desc",
+  }), token);
+  return Array.isArray(response) ? response.map(normalizeSite) : [];
+}
+
+export async function fetchIntelPage(token: string | null, offset: number) {
+  const response = await buildoutApi<RawObject[]>(buildPath("/updates", {
+    limit: PAGE_SIZE,
+    offset,
+  }), token);
+  return Array.isArray(response) ? response.map(normalizeUpdate) : [];
+}
+
+export async function loadBuildoutData(token: string | null) {
+  const [lists, sites, intel] = await Promise.all([
+    fetchLists(token),
+    fetchSitesPage(token, 0),
+    fetchIntelPage(token, 0),
+  ]);
+
+  const access: BuildoutAccess = token ? "pro" : "free";
+
+  return {
+    access,
+    token,
+    lists,
+    companies: { ...emptyPage<BuildoutCompany>(), blurredCompanyCount: 0 },
+    sites: pageFromItems(sites),
+    intel: pageFromItems(intel),
+  };
+}
+
+export async function getBuildoutProToken() {
+  if (!apiClient.getSessionToken()) return null;
+
+  const session = await apiClient.getSession().catch(() => null);
+  if (!session) return null;
+
+  const account = await apiClient.getBuildoutAccount().catch(() => null);
+  if (!account?.subscription.active) return null;
+
+  const token = await apiClient.getBuildoutToken().catch(() => null);
+  return token?.token ?? null;
+}
+
+
+export function rowTickerSymbols(row: BuildoutRow): string[] {
+  switch (row.kind) {
+    case "company":
+      return [tickerSymbol(row.item.ticker)].filter((symbol): symbol is string => symbol != null);
+    case "site":
+      return [
+        tickerSymbol(row.item.ownerTicker),
+        ...(row.item.builders ?? []).map((builder) => tickerSymbol(builder.companyTicker)),
+      ].filter((symbol): symbol is string => symbol != null);
+    case "intel":
+      return (row.item.companies ?? [])
+        .map((company) => tickerSymbol(company.ticker))
+        .filter((symbol): symbol is string => symbol != null);
+    case "list":
+      return [];
+  }
+}

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -2421,8 +2421,8 @@ export const gloomberbCloudPlugin: GloomPlugin = {
     {
       id: "buildout-pane",
       paneId: "buildout",
-      label: "TheBuildout.ai",
-      description: "Open TheBuildout.ai infrastructure intelligence.",
+      label: "TheBuildout",
+      description: "Open TheBuildout infrastructure intelligence.",
       keywords: ["tbo", "buildout", "thebuildout", "infrastructure", "sites", "intel"],
       shortcut: { prefix: "TBO" },
       createInstance: () => ({
@@ -2461,7 +2461,7 @@ export const gloomberbCloudPlugin: GloomPlugin = {
 
     ctx.registerPane({
       id: "buildout",
-      name: "TBO",
+      name: "TheBuildout",
       icon: "T",
       component: BuildoutPane,
       defaultPosition: "right",

--- a/src/plugins/builtin/news-wire/news-detail-view.tsx
+++ b/src/plugins/builtin/news-wire/news-detail-view.tsx
@@ -10,6 +10,7 @@ import { collectNewsDisplayTickers } from "../../../news/ticker-symbols";
 import { useInlineTickers } from "../../../state/use-inline-tickers";
 import { isPlainKey } from "../../../utils/keyboard";
 import { wrapTextLines } from "../../../utils/text-wrap";
+import { formatDetailDate } from "../../../utils/datetime-format";
 
 function hasStoryItems(article: MarketNewsItem | null): boolean {
   return (article?.items?.length ?? 0) > 0;
@@ -92,19 +93,6 @@ export function wrapText(text: string, width: number): string[] {
 function storyItemDate(value: Date | string): Date {
   const date = value instanceof Date ? value : new Date(String(value));
   return Number.isNaN(date.getTime()) ? new Date(0) : date;
-}
-
-function formatDetailDate(date: Date): string {
-  const datePart = date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-  const timePart = date.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-  return `${datePart} at ${timePart}`;
 }
 
 function sortStoryItems(items: readonly NewsStoryItem[] | undefined): NewsStoryItem[] {

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -13,6 +13,7 @@ import type { MarketNewsItem } from "../../../types/news-source";
 import { colors } from "../../../theme/colors";
 import { collectNewsDisplayTickers } from "../../../news/ticker-symbols";
 import { useInlineTickers } from "../../../state/use-inline-tickers";
+import { formatRelativeTime } from "../../../utils/datetime-format";
 
 export type NewsColumnId = "rank" | "time" | "source" | "title" | "tickers" | "categories" | "importance";
 
@@ -36,17 +37,6 @@ interface NewsArticleStackBaseProps {
   emptyStateTitle: string;
   emptyStateHint?: string;
   titleForArticle?: (article: MarketNewsItem) => string;
-}
-
-function formatRelativeTime(date: Date): string {
-  const ms = Date.now() - date.getTime();
-  if (ms < 60_000) return "<1m";
-  const min = Math.floor(ms / 60_000);
-  if (min < 60) return `${min}m`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h`;
-  const days = Math.floor(hr / 24);
-  return `${days}d`;
 }
 
 function compareText(a: string, b: string): number {

--- a/src/renderers/electrobun/view/data-table.tsx
+++ b/src/renderers/electrobun/view/data-table.tsx
@@ -537,6 +537,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   renderSectionHeader,
   getRowBackgroundColor,
   emptyContent,
+  bodyAfter,
   emptyStateTitle,
   emptyStateHint,
   virtualize = true,
@@ -604,6 +605,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const totalHeight = virtualize
     ? rowVirtualizer.getTotalSize()
     : WEB_CELL_HEIGHT + items.length * WEB_CELL_HEIGHT;
+  const bodyAfterHeight = bodyAfter ? WEB_CELL_HEIGHT * 6 : 0;
   const horizontalScrollEnabled = showHorizontalScrollbar
     && hasMeaningfulTableHorizontalOverflow(tableWidth, viewportWidth);
   const scrollContentWidth = horizontalScrollEnabled
@@ -732,7 +734,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
           style={{
             position: "relative",
             width: scrollContentWidth,
-            height: items.length > 0 ? totalHeight : "100%",
+            height: items.length > 0 ? totalHeight + bodyAfterHeight : "100%",
             minHeight: WEB_CELL_HEIGHT,
           }}
         >
@@ -803,6 +805,20 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
               virtualize,
             },
           )}
+          {items.length > 0 && bodyAfter ? (
+            <div
+              data-gloom-role="data-table-body-after"
+              style={{
+                position: "absolute",
+                top: totalHeight,
+                left: 0,
+                width: "100%",
+                minHeight: bodyAfterHeight,
+              }}
+            >
+              {bodyAfter}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/utils/datetime-format.ts
+++ b/src/utils/datetime-format.ts
@@ -1,0 +1,40 @@
+export type DisplayDateValue = Date | string | number | null | undefined;
+
+export function parseDisplayDate(value: DisplayDateValue): Date | null {
+  if (value == null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatRelativeTime(value: DisplayDateValue, now = Date.now(), fallback = "-"): string {
+  const date = parseDisplayDate(value);
+  if (!date) return fallback;
+
+  const ms = now - date.getTime();
+  if (!Number.isFinite(ms)) return fallback;
+  if (ms < 60_000) return "<1m";
+
+  const min = Math.floor(ms / 60_000);
+  if (min < 60) return `${min}m`;
+
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+
+  return `${Math.floor(hr / 24)}d`;
+}
+
+export function formatDetailDate(value: DisplayDateValue, fallback = "-"): string {
+  const date = parseDisplayDate(value);
+  if (!date) return fallback;
+
+  const datePart = date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  const timePart = date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${datePart} at ${timePart}`;
+}


### PR DESCRIPTION
Adds a fuller TheBuildout pane for free and pro users, including list browsing, paginated companies/sites/intel, rich detail views, ticker badges, and favorite controls.

Free users now see explicit delayed/full-data footer states and upgrade actions that open TheBuildout pricing on the website instead of trying in-app checkout.

The shared table surface can render post-body CTA content, and news/Buildout panes now use shared datetime formatting for consistent timestamps.

The Buildout pane is split into model/detail modules to keep the main pane smaller and easier to maintain.
