### PR TITLE
Remove gridlock from window context menu

### DIFF
--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -776,14 +776,6 @@ function menuForPane(
       accelerator: PANE_MANAGEMENT_ACCELERATORS.layoutActions,
       onSelect: () => pluginRegistry.openCommandBar("LAY "),
     },
-    {
-      id: "gridlock-all",
-      label: "Gridlock All Windows",
-      accelerator: PANE_MANAGEMENT_ACCELERATORS.gridlockAll,
-      onSelect: () => {
-        persistLayout(gridlockAllPanes(layout, { x: 0, y: 0, width, height: contentHeight }));
-      },
-    },
   );
 
   return baseActions;


### PR DESCRIPTION
Removes the direct Gridlock All Windows item from the pane/window context menu because it affects all windows, not the selected window.

The global action remains available through Layout Actions and the native Layout menu.