### PR TITLE
Debounce Congress table selection and stop chart-surface cleanup updates

### DIFF
--- a/src/plugins/builtin/congress-trades.tsx
+++ b/src/plugins/builtin/congress-trades.tsx
@@ -12,7 +12,7 @@ import {
   type DataTableColumn,
   type DataTableKeyEvent,
 } from "../../components";
-import { usePluginPaneState } from "../plugin-runtime";
+import { useDebouncedPluginPaneState, usePluginPaneState } from "../plugin-runtime";
 import { useInlineTickers } from "../../state/use-inline-tickers";
 import { colors } from "../../theme/colors";
 import { formatCompact, formatTimeAgo, padTo } from "../../utils/format";
@@ -390,8 +390,8 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
   const [status, setStatus] = useState<LoadStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = usePluginPaneState<CongressTab>("activeTab", "trades");
-  const [selectedTradeId, setSelectedTradeId] = usePluginPaneState<string | null>("selectedTradeId", null);
-  const [selectedMemberId, setSelectedMemberId] = usePluginPaneState<string | null>("selectedMemberId", null);
+  const [selectedTradeId, setSelectedTradeId] = useDebouncedPluginPaneState<string | null>("selectedTradeId", null);
+  const [selectedMemberId, setSelectedMemberId] = useDebouncedPluginPaneState<string | null>("selectedMemberId", null);
   const [detailMode, setDetailMode] = useState<DetailMode>(null);
   const [tradeSort, setTradeSort] = useState<{ columnId: TradeColumnId; direction: SortDirection }>({
     columnId: "filed",
@@ -516,7 +516,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
     if (!trade) return;
     const member = members.find((entry) => entry.memberName === trade.memberName && entry.stateDistrict === trade.stateDistrict);
     if (!member) return;
-    setSelectedMemberId(member.id);
+    setSelectedMemberId(member.id, { immediate: true });
     setDetailMode({ kind: "member", memberId: member.id });
   }, [detailTrade, members, selectedTrade, setSelectedMemberId]);
 
@@ -773,7 +773,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
           onActivateIndex={(index) => {
             const trade = tradeRows[index];
             if (!trade) return;
-            setSelectedTradeId(trade.id);
+            setSelectedTradeId(trade.id, { immediate: true });
             setDetailMode({ kind: "trade", tradeId: trade.id });
           }}
           onRootKeyDown={handleRootKeyDown}
@@ -789,7 +789,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
           isSelected={(trade) => trade.id === selectedTradeId}
           onSelect={(trade) => setSelectedTradeId(trade.id)}
           onActivate={(trade) => {
-            setSelectedTradeId(trade.id);
+            setSelectedTradeId(trade.id, { immediate: true });
             setDetailMode({ kind: "trade", tradeId: trade.id });
           }}
           renderCell={renderTradeCell}
@@ -808,7 +808,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
           onActivateIndex={(index) => {
             const member = memberRows[index];
             if (!member) return;
-            setSelectedMemberId(member.id);
+            setSelectedMemberId(member.id, { immediate: true });
             setDetailMode({ kind: "member", memberId: member.id });
           }}
           onRootKeyDown={handleRootKeyDown}
@@ -824,7 +824,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
           isSelected={(member) => member.id === selectedMemberId}
           onSelect={(member) => setSelectedMemberId(member.id)}
           onActivate={(member) => {
-            setSelectedMemberId(member.id);
+            setSelectedMemberId(member.id, { immediate: true });
             setDetailMode({ kind: "member", memberId: member.id });
           }}
           renderCell={renderMemberCell}

--- a/src/renderers/opentui/chart-surface.tsx
+++ b/src/renderers/opentui/chart-surface.tsx
@@ -147,7 +147,6 @@ export const OpenTuiChartSurface = forwardRef<unknown, ChartSurfaceProps>(functi
         renderable.onLifecyclePass = previousLifecyclePass;
       }
       renderer.unregisterLifecyclePass(renderable);
-      setTarget(null);
     };
   }, [kittySupport, nativeBitmap, nativeBitmapKey, renderer]);
 


### PR DESCRIPTION
## Summary
- Debounced Congress trades and members selection so arrow navigation no longer commits pane state on every move.
- Kept detail-open actions immediate so activation still updates selection right away.
- Removed the OpenTUI chart-surface cleanup `setTarget(null)` call that could feed React’s update-depth loop during repeated renders.

## Testing
- `bun test src/plugins/plugin-runtime.test.tsx src/components/ui/ui.test.tsx`
- `bun run build`
- Manual tmux smoke test of the Congress pane with repeated arrow navigation