### PR TITLE
Improve IBKR portfolio metrics

### DIFF
--- a/src/brokers/remote-broker-adapter.ts
+++ b/src/brokers/remote-broker-adapter.ts
@@ -50,6 +50,7 @@ export function createRemoteBrokerAdapter(adapter: BrokerAdapter): BrokerAdapter
     subscribeStatus: (instance, listener) => getBrokerRemoteClient()?.subscribeStatus(instance.id, listener) ?? (() => {}),
     getPersistedConfigUpdate: (instance) => invoke<Record<string, unknown> | null>(instance, "getPersistedConfigUpdate"),
     listAccounts: (instance) => invoke(instance, "listAccounts"),
+    getPortfolioPerformance: (instance, accountId: string) => invoke(instance, "getPortfolioPerformance", [accountId]),
     searchInstruments: (query, instance) => invoke(instance, "searchInstruments", [query]),
     getTickerFinancials: (ticker, instance, exchange?: string, instrument?: BrokerContractRef | null) =>
       invoke(instance, "getTickerFinancials", [ticker, exchange, instrument]),

--- a/src/brokers/sync-broker-instance.test.ts
+++ b/src/brokers/sync-broker-instance.test.ts
@@ -147,8 +147,10 @@ describe("syncBrokerInstance", () => {
         brokerId: "demo",
         brokerInstanceId: "demo-broker",
         brokerAccountId: "ACC-1",
+        lastSyncedAt: expect.any(Number),
       },
     ]);
+    expect(result.config.brokerInstances[0]?.lastSyncedAt).toEqual(expect.any(Number));
     expect(result.positions).toHaveLength(1);
     expect(result.addedTickers).toHaveLength(1);
     expect(result.tickers.get("AAPL")?.metadata.positions).toEqual([
@@ -195,6 +197,144 @@ describe("syncBrokerInstance", () => {
       brokerInstanceId: "demo-personal",
       brokerAccountId: "PERSONAL",
     }));
+  });
+
+  test("removes stale broker portfolios and positions for the same profile when account ids change", async () => {
+    const stalePortfolioId = "broker:demo-broker:OLD-ALIAS";
+    const currentPortfolioId = "broker:demo-broker:ACC-1";
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-sync-broker-stale-account"),
+      portfolios: [
+        { id: stalePortfolioId, name: "OLD-ALIAS", currency: "USD", brokerId: "demo", brokerInstanceId: "demo-broker", brokerAccountId: "OLD-ALIAS" },
+      ],
+      brokerInstances: [createBrokerInstance()],
+    };
+    const tickerRepository = createTickerRepository([{
+      metadata: {
+        ticker: "AAPL",
+        exchange: "NASDAQ",
+        currency: "USD",
+        name: "Apple Inc.",
+        portfolios: [stalePortfolioId],
+        watchlists: [],
+        positions: [{
+          portfolio: stalePortfolioId,
+          shares: 10,
+          avgCost: 170,
+          currency: "USD",
+          broker: "demo",
+          brokerInstanceId: "demo-broker",
+          brokerAccountId: "OLD-ALIAS",
+        }],
+        broker_contracts: [{ brokerId: "demo", brokerInstanceId: "demo-broker", conId: 123, symbol: "AAPL" }],
+        custom: {},
+        tags: [],
+      },
+    }]);
+
+    const result = await syncBrokerInstance({
+      config,
+      instanceId: "demo-broker",
+      brokers: new Map([["demo", createDemoBroker()]]),
+      tickerRepository: tickerRepository as any,
+    });
+
+    expect(result.config.portfolios.map((portfolio) => portfolio.id)).toEqual([currentPortfolioId]);
+    expect(result.tickers.get("AAPL")?.metadata.portfolios).toEqual([currentPortfolioId]);
+    expect(result.tickers.get("AAPL")?.metadata.positions).toEqual([
+      expect.objectContaining({
+        portfolio: currentPortfolioId,
+        brokerInstanceId: "demo-broker",
+        brokerAccountId: "ACC-1",
+        shares: 12,
+      }),
+    ]);
+    expect(result.tickers.get("AAPL")?.metadata.broker_contracts).toEqual([]);
+  });
+
+  test("reuses a broker account portfolio across Flex and Gateway profiles", async () => {
+    const flexInstance: BrokerInstanceConfig = {
+      ...createBrokerInstanceWithId("demo-flex"),
+      connectionMode: "flex",
+      config: { connectionMode: "flex", apiKey: "flex-key" },
+    };
+    const gatewayInstance: BrokerInstanceConfig = {
+      ...createBrokerInstanceWithId("demo-gateway"),
+      connectionMode: "gateway",
+      config: { connectionMode: "gateway", apiKey: "gateway-key" },
+    };
+    const flexPortfolioId = "broker:demo-flex:ACC-1";
+    const staleGatewayPortfolioId = "broker:demo-gateway:ACC-1";
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-sync-broker-shared-account"),
+      portfolios: [
+        { id: flexPortfolioId, name: "Primary", currency: "USD", brokerId: "demo", brokerInstanceId: "demo-flex", brokerAccountId: "ACC-1" },
+        { id: staleGatewayPortfolioId, name: "Primary", currency: "USD", brokerId: "demo", brokerInstanceId: "demo-gateway", brokerAccountId: "ACC-1" },
+      ],
+      brokerInstances: [flexInstance, gatewayInstance],
+    };
+    const tickerRepository = createTickerRepository([{
+      metadata: {
+        ticker: "AAPL",
+        exchange: "NASDAQ",
+        currency: "USD",
+        name: "Apple Inc.",
+        portfolios: [flexPortfolioId, staleGatewayPortfolioId],
+        watchlists: [],
+        positions: [
+          {
+            portfolio: flexPortfolioId,
+            shares: 10,
+            avgCost: 170,
+            currency: "USD",
+            broker: "demo",
+            brokerInstanceId: "demo-flex",
+            brokerAccountId: "ACC-1",
+          },
+          {
+            portfolio: staleGatewayPortfolioId,
+            shares: 11,
+            avgCost: 171,
+            currency: "USD",
+            broker: "demo",
+            brokerInstanceId: "demo-gateway",
+            brokerAccountId: "ACC-1",
+          },
+        ],
+        broker_contracts: [],
+        custom: {},
+        tags: [],
+      },
+    }]);
+
+    const result = await syncBrokerInstance({
+      config,
+      instanceId: "demo-gateway",
+      brokers: new Map([["demo", createDemoBroker()]]),
+      tickerRepository: tickerRepository as any,
+    });
+
+    expect(result.portfolioIds).toEqual([flexPortfolioId]);
+    expect(result.config.portfolios).toEqual([{
+      id: flexPortfolioId,
+      name: "Primary",
+      currency: "USD",
+      brokerId: "demo",
+      brokerInstanceId: "demo-gateway",
+      brokerAccountId: "ACC-1",
+      lastSyncedAt: expect.any(Number),
+    }]);
+    expect(result.config.brokerInstances.find((instance) => instance.id === "demo-gateway")?.lastSyncedAt)
+      .toEqual(expect.any(Number));
+    expect(result.tickers.get("AAPL")?.metadata.portfolios).toEqual([flexPortfolioId]);
+    expect(result.tickers.get("AAPL")?.metadata.positions).toEqual([
+      expect.objectContaining({
+        portfolio: flexPortfolioId,
+        shares: 12,
+        brokerInstanceId: "demo-gateway",
+        brokerAccountId: "ACC-1",
+      }),
+    ]);
   });
 
   test("restores missing broker portfolios from existing ticker positions", () => {

--- a/src/brokers/sync-broker-instance.ts
+++ b/src/brokers/sync-broker-instance.ts
@@ -5,7 +5,7 @@ import type { BrokerAdapter, BrokerPosition } from "../types/broker";
 import type { AppConfig, BrokerInstanceConfig } from "../types/config";
 import type { BrokerContractRef } from "../types/instrument";
 import type { BrokerAccount } from "../types/trading";
-import type { TickerMetadata, TickerPosition, TickerRecord } from "../types/ticker";
+import type { Portfolio, TickerMetadata, TickerPosition, TickerRecord } from "../types/ticker";
 import { buildBrokerPortfolioId, getBrokerInstance, isBrokerPortfolioId } from "../utils/broker-instances";
 
 export interface SyncBrokerInstanceArgs {
@@ -54,6 +54,55 @@ function mergeBrokerContracts(existing: BrokerContractRef[], next: BrokerContrac
   return [...merged.values()];
 }
 
+function getInstanceMode(instance: BrokerInstanceConfig): string {
+  return typeof instance.connectionMode === "string"
+    ? instance.connectionMode
+    : typeof instance.config.connectionMode === "string"
+      ? instance.config.connectionMode
+      : "";
+}
+
+function findBrokerInstanceMode(config: AppConfig, instanceId: string | undefined): string {
+  const instance = config.brokerInstances.find((entry) => entry.id === instanceId);
+  return instance ? getInstanceMode(instance) : "";
+}
+
+function shouldPreferBrokerInstance(config: AppConfig, current: Portfolio, next: BrokerInstanceConfig): boolean {
+  if (current.brokerInstanceId === next.id) return false;
+  const currentMode = findBrokerInstanceMode(config, current.brokerInstanceId);
+  const nextMode = getInstanceMode(next);
+  return nextMode === "gateway" && currentMode !== "gateway";
+}
+
+function updateBrokerPortfolioSource(
+  config: AppConfig,
+  portfolio: Portfolio,
+  instance: BrokerInstanceConfig,
+  brokerAccountId?: string,
+  syncedAt?: number,
+): Portfolio {
+  const lastSyncedAt = syncedAt ?? portfolio.lastSyncedAt;
+  if (
+    !shouldPreferBrokerInstance(config, portfolio, instance)
+    && portfolio.brokerId
+    && portfolio.brokerAccountId
+    && portfolio.brokerInstanceId
+    && portfolio.lastSyncedAt === lastSyncedAt
+  ) {
+    return portfolio;
+  }
+
+  return {
+    ...portfolio,
+    brokerId: portfolio.brokerId ?? instance.brokerType,
+    brokerInstanceId: shouldPreferBrokerInstance(config, portfolio, instance)
+      ? instance.id
+      : portfolio.brokerInstanceId ?? instance.id,
+    brokerAccountId: portfolio.brokerAccountId ?? brokerAccountId,
+    lastSyncedAt,
+  };
+}
+
 function ensureBrokerPortfolio(
   config: AppConfig,
   instance: BrokerInstanceConfig,
@@ -61,9 +110,17 @@ function ensureBrokerPortfolio(
   name: string,
   currency: string,
   brokerAccountId?: string,
+  syncedAt?: number,
 ): AppConfig {
-  if (config.portfolios.some((portfolio) => portfolio.id === portfolioId)) {
-    return config;
+  const existing = config.portfolios.find((portfolio) => portfolio.id === portfolioId);
+  if (existing) {
+    const updated = updateBrokerPortfolioSource(config, existing, instance, brokerAccountId, syncedAt);
+    return updated === existing
+      ? config
+      : {
+        ...config,
+        portfolios: config.portfolios.map((portfolio) => portfolio.id === portfolioId ? updated : portfolio),
+      };
   }
 
   return {
@@ -77,8 +134,79 @@ function ensureBrokerPortfolio(
         brokerId: instance.brokerType,
         brokerInstanceId: instance.id,
         brokerAccountId,
+        lastSyncedAt: syncedAt,
       },
     ],
+  };
+}
+
+function findReusableBrokerPortfolioId(
+  config: AppConfig,
+  instance: BrokerInstanceConfig,
+  accountId: string | undefined,
+): string {
+  if (!accountId) return buildBrokerPortfolioId(instance.id, accountId);
+  const existing = config.portfolios.find((portfolio) =>
+    portfolio.brokerId === instance.brokerType
+    && portfolio.brokerAccountId === accountId
+  );
+  return existing?.id ?? buildBrokerPortfolioId(instance.id, accountId);
+}
+
+function markBrokerInstanceSynced(
+  config: AppConfig,
+  instanceId: string,
+  syncedAt: number,
+): AppConfig {
+  return {
+    ...config,
+    brokerInstances: config.brokerInstances.map((entry) =>
+      entry.id === instanceId ? { ...entry, lastSyncedAt: syncedAt } : entry
+    ),
+  };
+}
+
+function removeStaleBrokerPortfolios(
+  config: AppConfig,
+  instanceId: string,
+  currentPortfolioIds: Set<string>,
+): AppConfig {
+  const portfolios = config.portfolios.filter((portfolio) =>
+    portfolio.brokerInstanceId !== instanceId || currentPortfolioIds.has(portfolio.id)
+  );
+  return portfolios.length === config.portfolios.length
+    ? config
+    : { ...config, portfolios };
+}
+
+function clearBrokerInstanceTickerData(
+  ticker: TickerRecord,
+  instanceId: string,
+  brokerPortfolioIds: Set<string>,
+): TickerRecord | null {
+  const positions = ticker.metadata.positions.filter((position) => position.brokerInstanceId !== instanceId);
+  const remainingPositionPortfolios = new Set(positions.map((position) => position.portfolio));
+  const portfolios = ticker.metadata.portfolios.filter((portfolioId) =>
+    !brokerPortfolioIds.has(portfolioId) || remainingPositionPortfolios.has(portfolioId)
+  );
+  const brokerContracts = (ticker.metadata.broker_contracts ?? []).filter((contract) => contract.brokerInstanceId !== instanceId);
+
+  if (
+    positions.length === ticker.metadata.positions.length
+    && portfolios.length === ticker.metadata.portfolios.length
+    && brokerContracts.length === (ticker.metadata.broker_contracts ?? []).length
+  ) {
+    return null;
+  }
+
+  return {
+    ...ticker,
+    metadata: {
+      ...ticker.metadata,
+      positions,
+      portfolios,
+      broker_contracts: brokerContracts,
+    },
   };
 }
 
@@ -229,7 +357,7 @@ function updateExistingTicker(
   }
 
   const otherPositions = ticker.metadata.positions.filter(
-    (entry) => !(entry.brokerInstanceId === instance.id && entry.portfolio === portfolioId),
+    (entry) => !(entry.portfolio === portfolioId && entry.broker === instance.brokerType),
   );
   ticker.metadata.positions = [...otherPositions, positionEntry];
   ticker.metadata.broker_contracts = mergeBrokerContracts(
@@ -297,6 +425,7 @@ export async function syncBrokerInstance({
   );
 
   const positions = await broker.importPositions(instance);
+  const syncedAt = Date.now();
 
   let nextConfig = config;
   const accountIds = new Set<string>();
@@ -314,7 +443,7 @@ export async function syncBrokerInstance({
   const portfolioIds: string[] = [];
   if (accountIds.size > 0) {
     for (const accountId of accountIds) {
-      const portfolioId = buildBrokerPortfolioId(instance.id, accountId);
+      const portfolioId = findReusableBrokerPortfolioId(nextConfig, instance, accountId);
       const account = accountMetadata.get(accountId);
       nextConfig = ensureBrokerPortfolio(
         nextConfig,
@@ -323,12 +452,13 @@ export async function syncBrokerInstance({
         account?.name || accountId,
         account?.currency || "USD",
         accountId,
+        syncedAt,
       );
       portfolioIds.push(portfolioId);
     }
   } else {
     const defaultAccount = brokerAccounts[0];
-    const portfolioId = buildBrokerPortfolioId(instance.id, defaultAccount?.accountId);
+    const portfolioId = findReusableBrokerPortfolioId(nextConfig, instance, defaultAccount?.accountId);
     const fallbackName = defaultAccount?.name || defaultAccount?.accountId || instance.label || broker.name;
     nextConfig = ensureBrokerPortfolio(
       nextConfig,
@@ -337,17 +467,36 @@ export async function syncBrokerInstance({
       fallbackName,
       defaultAccount?.currency || "USD",
       defaultAccount?.accountId,
+      syncedAt,
     );
     portfolioIds.push(portfolioId);
   }
 
+  const currentPortfolioIds = new Set(portfolioIds);
+  const brokerPortfolioIds = new Set([
+    ...config.portfolios
+      .filter((portfolio) => portfolio.brokerInstanceId === instance.id)
+      .map((portfolio) => portfolio.id),
+    ...portfolioIds,
+  ]);
+
+  nextConfig = removeStaleBrokerPortfolios(nextConfig, instance.id, currentPortfolioIds);
+  const cleanedTickers = new Map<string, TickerRecord>();
+  for (const ticker of tickers.values()) {
+    const cleanedTicker = clearBrokerInstanceTickerData(ticker, instance.id, brokerPortfolioIds);
+    if (!cleanedTicker) continue;
+    tickers.set(cleanedTicker.metadata.ticker, cleanedTicker);
+    cleanedTickers.set(cleanedTicker.metadata.ticker, cleanedTicker);
+  }
+
   nextConfig = await maybePersistResolvedBrokerConfig(nextConfig, instance, broker, persistResolvedBrokerConfig);
+  nextConfig = markBrokerInstanceSynced(nextConfig, instance.id, syncedAt);
 
   const addedTickers = new Map<string, TickerRecord>();
   const updatedTickers = new Map<string, TickerRecord>();
 
   for (const position of positions) {
-    const portfolioId = buildBrokerPortfolioId(instance.id, position.accountId);
+    const portfolioId = findReusableBrokerPortfolioId(nextConfig, instance, position.accountId);
     const brokerContract = position.brokerContract
       ? {
         ...position.brokerContract,
@@ -366,6 +515,7 @@ export async function syncBrokerInstance({
     } else {
       ticker = updateExistingTicker(ticker, instance, portfolioId, position, positionEntry, brokerContract);
       await tickerRepository.saveTicker(ticker);
+      cleanedTickers.delete(ticker.metadata.ticker);
       if (!addedTickers.has(position.ticker)) {
         updatedTickers.set(position.ticker, ticker);
       }
@@ -376,6 +526,13 @@ export async function syncBrokerInstance({
       addedTickers.set(position.ticker, ticker);
     } else {
       updatedTickers.set(position.ticker, ticker);
+    }
+  }
+
+  for (const ticker of cleanedTickers.values()) {
+    await tickerRepository.saveTicker(ticker);
+    if (!addedTickers.has(ticker.metadata.ticker) && !updatedTickers.has(ticker.metadata.ticker)) {
+      updatedTickers.set(ticker.metadata.ticker, ticker);
     }
   }
 

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -13,6 +13,7 @@ import type { AppConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
 import { debugLog } from "../utils/debug-log";
 import { measurePerf } from "../utils/perf-marks";
+import { setIbkrPortfolioPerformanceResourceStore } from "../plugins/ibkr/portfolio-performance";
 
 const servicesLog = debugLog.createLogger("services");
 
@@ -40,6 +41,7 @@ export function createAppServices({
   });
   const dbPath = join(config.dataDir, ".gloomberb-cache.db");
   const persistence = measurePerf("startup.services.persistence", () => new AppPersistence(dbPath));
+  setIbkrPortfolioPerformanceResourceStore(persistence.resources);
   const tickerRepository = measurePerf("startup.services.ticker-repository", () => new TickerRepository(persistence.tickers));
   const providerRouter = measurePerf("startup.services.asset-data-router", () => new AssetDataRouter(null, [], persistence.resources));
   const dataProvider: DataProvider = providerRouter;
@@ -89,6 +91,7 @@ export function createAppServices({
       setSharedNewsService(null);
       newsService.stop();
       pluginRegistry.destroy();
+      setIbkrPortfolioPerformanceResourceStore(null);
       persistence.close();
     },
   };

--- a/src/plugins/builtin/analytics/index.test.tsx
+++ b/src/plugins/builtin/analytics/index.test.tsx
@@ -13,11 +13,12 @@ import { cloneLayout, createDefaultConfig, type AppConfig } from "../../../types
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import type { BrokerAccount } from "../../../types/trading";
-import { PluginRenderProvider } from "../../plugin-runtime";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../plugin-runtime";
 import { analyticsPlugin } from "./index";
 
 const TEST_PANE_ID = "analytics:test";
 const BROKER_PORTFOLIO_ID = "broker:ibkr-flex:DU12345";
+const GATEWAY_PORTFOLIO_ID = "broker:ibkr-live:DU12345";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let harnessState: ReturnType<typeof createInitialState> | null = null;
@@ -100,6 +101,33 @@ function createSharedTicker(): TickerRecord {
   };
 }
 
+function createBrokerTicker(portfolioId: string, brokerInstanceId: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: "AAPL",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "Apple",
+      sector: "Technology",
+      portfolios: [portfolioId],
+      watchlists: [],
+      positions: [{
+        portfolio: portfolioId,
+        shares: 10,
+        avgCost: 100,
+        currency: "USD",
+        broker: "ibkr",
+        brokerInstanceId,
+        brokerAccountId: "DU12345",
+        marketValue: 1250,
+        unrealizedPnl: 250,
+      }],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
 function createFinancials(price: number): TickerFinancials {
   return {
     annualStatements: [],
@@ -121,17 +149,21 @@ function AnalyticsHarness({
   config,
   brokerAccounts,
   financials,
+  runtime = createTestPluginRuntime(),
+  ticker = createSharedTicker(),
 }: {
   config: AppConfig;
   brokerAccounts?: Record<string, BrokerAccount[]>;
   financials?: TickerFinancials;
+  runtime?: PluginRuntimeAccess;
+  ticker?: TickerRecord;
 }) {
   const initialState = createInitialState(config);
   initialState.focusedPaneId = TEST_PANE_ID;
   initialState.paneState[TEST_PANE_ID] = {
     portfolioId: config.layout.instances[0]?.params?.portfolioId,
   };
-  initialState.tickers = new Map([["AAPL", createSharedTicker()]]);
+  initialState.tickers = new Map([["AAPL", ticker]]);
   initialState.brokerAccounts = brokerAccounts ?? {};
   if (financials) {
     initialState.financials = new Map([["AAPL", financials]]);
@@ -143,7 +175,7 @@ function AnalyticsHarness({
   return (
     <AppContext value={{ state, dispatch }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
-        <PluginRenderProvider pluginId={analyticsPlugin.id} runtime={createTestPluginRuntime()}>
+        <PluginRenderProvider pluginId={analyticsPlugin.id} runtime={runtime}>
           <AnalyticsPane
             paneId={TEST_PANE_ID}
             paneType="analytics"
@@ -240,10 +272,20 @@ describe("PortfolioAnalyticsPane", () => {
   });
 
   test("shows broker cash and margin data when account data is available", async () => {
+    const baseConfig = createAnalyticsConfig(BROKER_PORTFOLIO_ID);
+    const config = {
+      ...baseConfig,
+      portfolios: baseConfig.portfolios.map((portfolio) =>
+        portfolio.id === BROKER_PORTFOLIO_ID
+          ? { ...portfolio, lastSyncedAt: Date.now() + 10_000 }
+          : portfolio
+      ),
+    };
+
     await act(async () => {
       testSetup = await testRender(
         <AnalyticsHarness
-          config={createAnalyticsConfig(BROKER_PORTFOLIO_ID)}
+          config={config}
           brokerAccounts={{
             "ibkr-flex": [{
               accountId: "DU12345",
@@ -257,6 +299,9 @@ describe("PortfolioAnalyticsPane", () => {
               excessLiquidity: 12000,
               buyingPower: 30000,
               netLiquidation: 125000,
+              dailyPnl: 900,
+              unrealizedPnl: 777,
+              realizedPnl: -25,
               cashBalances: [
                 { currency: "USD", quantity: -50000, baseValue: -50000, baseCurrency: "USD" },
               ],
@@ -274,11 +319,105 @@ describe("PortfolioAnalyticsPane", () => {
     const frame = testSetup!.captureCharFrame();
     expect(frame).toContain("Net Liq       125k");
     expect(frame).toContain("Cash          -50k");
+    expect(frame).toContain("Day           +900");
+    expect(frame).toContain("P&L           +777");
+    expect(frame).toContain("Realized      -25");
     expect(frame).toContain("Settled       -45k");
     expect(frame).toContain("Avail         15k");
     expect(frame).toContain("Excess        12k");
     expect(frame).toContain("BP            30k");
+    expect(frame).toContain("Synced        just now");
     expect(frame).toContain("Source        Flex Mar 27");
+  });
+
+  test("falls back from a Gateway portfolio to a configured Flex profile for IBKR history", async () => {
+    const calls: Array<{ instanceId: string; accountId: string }> = [];
+    const historyBroker = {
+      id: "ibkr",
+      name: "Interactive Brokers",
+      configSchema: [],
+      validate: async () => true,
+      importPositions: async () => [],
+      getPortfolioPerformance: async (instance: { id: string }, accountId: string) => {
+        calls.push({ instanceId: instance.id, accountId });
+        if (instance.id !== "ibkr-flex") return null;
+        return {
+          accountId,
+          source: "flex" as const,
+          period: "FLEX",
+          currency: "USD",
+          fetchedAt: 1,
+          points: [
+            { date: "2025-01-02", value: 100000, cumulativeReturn: 0 },
+            { date: "2026-05-15", value: 110000, cumulativeReturn: 0.1 },
+          ],
+        };
+      },
+    };
+    const runtime = createTestPluginRuntime({
+      getBrokerAdapter: (brokerType) => brokerType === "ibkr"
+        ? historyBroker
+        : null,
+    });
+    const baseConfig = createAnalyticsConfig(GATEWAY_PORTFOLIO_ID);
+    const config = {
+      ...baseConfig,
+      portfolios: [
+        ...baseConfig.portfolios,
+        {
+          id: GATEWAY_PORTFOLIO_ID,
+          name: "Gateway DU12345",
+          currency: "USD",
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-live",
+          brokerAccountId: "DU12345",
+        },
+      ],
+      brokerInstances: [
+        {
+          id: "ibkr-live",
+          brokerType: "ibkr",
+          label: "IBKR Gateway",
+          connectionMode: "gateway",
+          config: { connectionMode: "gateway", gateway: { host: "127.0.0.1" } },
+          enabled: true,
+        },
+        {
+          id: "ibkr-flex",
+          brokerType: "ibkr",
+          label: "IBKR Flex",
+          connectionMode: "flex",
+          config: { connectionMode: "flex", flex: { token: "token", queryId: "query" } },
+          enabled: true,
+        },
+      ],
+    };
+
+    await act(async () => {
+      testSetup = await testRender(
+        <AnalyticsHarness
+          config={config}
+          runtime={runtime}
+          ticker={createBrokerTicker(GATEWAY_PORTFOLIO_ID, "ibkr-live")}
+        />,
+        { width: 100, height: 24 },
+      );
+      await Promise.resolve();
+      await testSetup.renderOnce();
+    });
+
+    await flushFrame();
+    await flushFrame();
+
+    const frame = testSetup!.captureCharFrame();
+    expect(calls).toEqual([
+      { instanceId: "ibkr-live", accountId: "DU12345" },
+      { instanceId: "ibkr-flex", accountId: "DU12345" },
+    ]);
+    expect(frame).toContain("Hist Ret");
+    expect(frame).toContain("+10.00%");
+    expect(frame).toContain("Portfolio History");
+    expect(frame).toContain("Flex FLEX");
   });
 
   test("uses the portfolio pane quote math for value, pnl, and return", async () => {

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -1,13 +1,17 @@
 import { Box, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TextAttributes } from "../../../ui";
-import { DataTableView, Tabs, type DataTableColumn } from "../../../components";
+import { DataTableView, StaticChartSurface, Tabs, type DataTableColumn } from "../../../components";
+import { resolveChartPalette } from "../../../components/chart/chart-renderer";
+import type { ProjectedChartPoint } from "../../../components/chart/chart-data";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
-import type { ColumnConfig } from "../../../types/config";
+import type { AppConfig, BrokerInstanceConfig, ColumnConfig } from "../../../types/config";
 import type { TickerFinancials } from "../../../types/financials";
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
+import type { BrokerPortfolioPerformance } from "../../../types/trading";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCompact, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { formatRelativeAge } from "../../../utils/relative-time";
 import {
   getFocusedCollectionId,
   useAppSelector,
@@ -18,8 +22,10 @@ import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "../../..
 import { instrumentFromTicker, type ChartRequest } from "../../../market-data/request-types";
 import { buildChartKey } from "../../../market-data/selectors";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
+import { resolvePortfolioAccountMetrics } from "../portfolio-list/account-metrics";
 import { usePortfolioAccountState } from "../portfolio-list/header";
 import { calculatePortfolioSummaryTotals, getSortValue, type ColumnContext } from "../portfolio-list/metrics";
+import { usePluginBrokerActions } from "../../plugin-runtime";
 import {
   computeDatedBeta,
   computeDatedReturns,
@@ -61,6 +67,12 @@ interface SectorSortPreference {
 interface PortfolioChartTarget {
   ticker: TickerRecord;
   request: ChartRequest;
+}
+
+interface BrokerPerformanceState {
+  loading: boolean;
+  performance: BrokerPortfolioPerformance | null;
+  error: string | null;
 }
 
 const DEFAULT_SECTOR_SORT: SectorSortPreference = {
@@ -116,6 +128,141 @@ function formatSignedCompact(value: number): string {
 
 function formatWeight(weight: number): string {
   return `${(weight * 100).toFixed(1)}%`;
+}
+
+function formatReturn(value: number): string {
+  const pct = value * 100;
+  return `${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`;
+}
+
+function findBrokerInstance(config: AppConfig, portfolio: Portfolio | null): BrokerInstanceConfig | null {
+  if (!portfolio?.brokerInstanceId) return null;
+  return config.brokerInstances.find((instance) => instance.id === portfolio.brokerInstanceId) ?? null;
+}
+
+function isConfiguredIbkrFlexProfile(instance: BrokerInstanceConfig): boolean {
+  if (instance.brokerType !== "ibkr" || instance.enabled === false) return false;
+  const config = instance.config ?? {};
+  const flex = typeof config.flex === "object" && config.flex
+    ? config.flex as Record<string, unknown>
+    : {};
+  const mode = instance.connectionMode ?? config.connectionMode;
+  return mode === "flex"
+    && typeof flex.token === "string"
+    && flex.token.length > 0
+    && typeof flex.queryId === "string"
+    && flex.queryId.length > 0;
+}
+
+function findBrokerPerformanceCandidates(
+  config: AppConfig,
+  portfolio: Portfolio | null,
+): BrokerInstanceConfig[] {
+  const primary = findBrokerInstance(config, portfolio);
+  if (!primary) return [];
+  if (primary.brokerType !== "ibkr") return [primary];
+
+  const candidates = [primary];
+  for (const instance of config.brokerInstances) {
+    if (instance.id === primary.id) continue;
+    if (!isConfiguredIbkrFlexProfile(instance)) continue;
+    candidates.push(instance);
+  }
+  return candidates;
+}
+
+function resolveBrokerAccountId(portfolio: Portfolio | null): string | null {
+  if (portfolio?.brokerAccountId) return portfolio.brokerAccountId;
+  const parts = portfolio?.id.split(":") ?? [];
+  return parts[0] === "broker" && parts.length >= 3 ? parts.slice(2).join(":") : null;
+}
+
+function performancePointValue(point: BrokerPortfolioPerformance["points"][number]): number | null {
+  if (point.value != null && Number.isFinite(point.value)) return point.value;
+  if (point.cumulativeReturn != null && Number.isFinite(point.cumulativeReturn)) return point.cumulativeReturn;
+  return null;
+}
+
+function buildPerformanceChartPoints(performance: BrokerPortfolioPerformance | null): ProjectedChartPoint[] {
+  if (!performance) return [];
+  return performance.points.flatMap((point) => {
+    const value = performancePointValue(point);
+    const date = new Date(point.date);
+    if (value == null || !Number.isFinite(date.getTime())) return [];
+    return [{
+      date,
+      open: value,
+      high: value,
+      low: value,
+      close: value,
+      volume: 0,
+    }];
+  });
+}
+
+function useBrokerPortfolioPerformance(
+  portfolio: Portfolio | null,
+  config: AppConfig,
+): BrokerPerformanceState {
+  const { getBrokerAdapter } = usePluginBrokerActions();
+  const brokerInstances = useMemo(() => findBrokerPerformanceCandidates(config, portfolio), [config, portfolio]);
+  const accountId = useMemo(() => resolveBrokerAccountId(portfolio), [portfolio]);
+  const [state, setState] = useState<BrokerPerformanceState>({
+    loading: false,
+    performance: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (brokerInstances.length === 0 || !accountId) {
+      setState({ loading: false, performance: null, error: null });
+      return;
+    }
+
+    setState((current) => ({ ...current, loading: true, error: null }));
+    void (async () => {
+      let lastError: string | null = null;
+      for (const brokerInstance of brokerInstances) {
+        const broker = getBrokerAdapter(brokerInstance.brokerType);
+        if (!broker?.getPortfolioPerformance) continue;
+        try {
+          const performance = await broker.getPortfolioPerformance(brokerInstance, accountId);
+          if (performance && performance.points.length > 0) {
+            if (!cancelled) {
+              setState({ loading: false, performance, error: null });
+            }
+            return;
+          }
+        } catch (error) {
+          lastError = error instanceof Error ? error.message : String(error);
+        }
+      }
+
+      if (!cancelled) {
+        setState({
+          loading: false,
+          performance: null,
+          error: lastError ?? "No IBKR portfolio history returned",
+        });
+      }
+    })()
+      .catch((error) => {
+        if (!cancelled) {
+          setState({
+            loading: false,
+            performance: null,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accountId, brokerInstances, getBrokerAdapter]);
+
+  return state;
 }
 
 function buildSectorColumns(width: number): SectorTableColumn[] {
@@ -334,6 +481,11 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     }
     return merged;
   }, [cachedFinancials, marketFinancials]);
+  const brokerPerformance = useBrokerPortfolioPerformance(activePortfolio, config);
+  const performanceChartPoints = useMemo(
+    () => buildPerformanceChartPoints(brokerPerformance.performance),
+    [brokerPerformance.performance],
+  );
   const accountStateInput = useMemo(() => ({ brokerAccounts, config }), [brokerAccounts, config]);
   const accountState = usePortfolioAccountState(activePortfolio, accountStateInput);
   const trackedCurrencies = useMemo(
@@ -423,6 +575,8 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
   const summaryRows = useMemo<AnalyticsMetricRow[]>(() => {
     const rows: AnalyticsMetricRow[] = [];
     const account = accountState?.account;
+    const accountMetrics = resolvePortfolioAccountMetrics(portfolioStats, account);
+    const syncedAt = activePortfolio?.lastSyncedAt ?? account?.updatedAt;
 
     if (account?.netLiquidation != null) {
       rows.push({
@@ -452,17 +606,36 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     rows.push({
       id: "day-pnl",
       label: "Day",
-      value: formatSignedCompact(portfolioStats.dailyPnl),
-      detail: `(${formatPercentRaw(portfolioStats.dailyPnlPct)})`,
-      color: priceColor(portfolioStats.dailyPnl),
+      value: formatSignedCompact(accountMetrics.dailyPnl),
+      detail: `(${formatPercentRaw(accountMetrics.dailyPnlPct)})`,
+      color: priceColor(accountMetrics.dailyPnl),
     });
     rows.push({
       id: "pnl",
       label: "P&L",
-      value: formatSignedCompact(portfolioStats.unrealizedPnl),
-      detail: `(${formatPercentRaw(portfolioStats.unrealizedPnlPct)})`,
-      color: priceColor(portfolioStats.unrealizedPnl),
+      value: formatSignedCompact(accountMetrics.unrealizedPnl),
+      detail: `(${formatPercentRaw(accountMetrics.unrealizedPnlPct)})`,
+      color: priceColor(accountMetrics.unrealizedPnl),
     });
+    if (accountMetrics.realizedPnl != null) {
+      rows.push({
+        id: "realized-pnl",
+        label: "Realized",
+        value: formatSignedCompact(accountMetrics.realizedPnl),
+        color: priceColor(accountMetrics.realizedPnl),
+      });
+    }
+
+    const latestPerformancePoint = brokerPerformance.performance?.points.at(-1);
+    if (latestPerformancePoint?.cumulativeReturn != null) {
+      rows.push({
+        id: "historical-return",
+        label: "Hist Ret",
+        value: formatReturn(latestPerformancePoint.cumulativeReturn),
+        detail: brokerPerformance.performance?.period,
+        color: priceColor(latestPerformancePoint.cumulativeReturn),
+      });
+    }
 
     if (account?.settledCash != null) {
       rows.push({
@@ -497,6 +670,14 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
       });
     }
     if (accountState) {
+      if (syncedAt) {
+        rows.push({
+          id: "last-sync",
+          label: "Synced",
+          value: formatRelativeAge(syncedAt),
+          color: colors.textDim,
+        });
+      }
       rows.push({
         id: "account-source",
         label: "Source",
@@ -508,8 +689,11 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     return rows;
   }, [
     accountState,
+    activePortfolio?.lastSyncedAt,
+    brokerPerformance.performance,
     portfolioStats.dailyPnl,
     portfolioStats.dailyPnlPct,
+    portfolioStats.totalCostBasis,
     portfolioStats.totalMktValue,
     portfolioStats.unrealizedPnl,
     portfolioStats.unrealizedPnlPct,
@@ -548,6 +732,27 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
       },
   ], [beta, sharpe]);
   const metricsHeight = summaryRows.length + riskRows.length + 5;
+  const availableHistoryChartHeight = height - metricsHeight - 7;
+  const historyChartHeight = performanceChartPoints.length >= 2 && availableHistoryChartHeight >= 5
+    ? Math.min(8, availableHistoryChartHeight)
+    : 0;
+  const showHistoryChart = historyChartHeight >= 5;
+  const performancePalette = useMemo(() => {
+    const points = brokerPerformance.performance?.points ?? [];
+    const first = points.find((point) => performancePointValue(point) != null);
+    const last = [...points].reverse().find((point) => performancePointValue(point) != null);
+    const firstValue = first ? performancePointValue(first) : null;
+    const lastValue = last ? performancePointValue(last) : null;
+    return resolveChartPalette(colors, firstValue != null && lastValue != null && lastValue < firstValue ? "negative" : "positive");
+  }, [brokerPerformance.performance]);
+  const historyAxisLabel = brokerPerformance.performance?.points.some((point) => point.value != null)
+    ? `Value (${brokerPerformance.performance.currency ?? activePortfolio?.currency ?? baseCurrency})`
+    : "Return";
+  const formatHistoryAxis = useCallback((value: number) => (
+    brokerPerformance.performance?.points.some((point) => point.value != null)
+      ? formatCompact(value)
+      : `${(value * 100).toFixed(1)}%`
+  ), [brokerPerformance.performance]);
 
   const handleSectorHeaderClick = useCallback((columnId: string) => {
     setSectorSort((current) => nextSectorSortPreference(current, columnId));
@@ -624,6 +829,39 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
                 ))}
                 <Box height={1} />
               </Box>
+
+              {showHistoryChart ? (
+                <>
+                  <Box height={1} paddingX={1} flexDirection="row">
+                    <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+                      Portfolio History
+                    </Text>
+                    <Text fg={colors.textDim}>
+                      {`  Flex ${brokerPerformance.performance?.period ?? ""}${brokerPerformance.performance?.stale ? " - cached" : ""}`}
+                    </Text>
+                  </Box>
+                  <Box paddingX={1} height={historyChartHeight}>
+                    <StaticChartSurface
+                      points={performanceChartPoints}
+                      width={Math.max(10, width - 2)}
+                      height={historyChartHeight}
+                      mode="line"
+                      colors={performancePalette}
+                      yAxisLabel={historyAxisLabel}
+                      yAxisColor={colors.textDim}
+                      formatYAxisValue={formatHistoryAxis}
+                    />
+                  </Box>
+                </>
+              ) : brokerPerformance.loading ? (
+                <Box height={1} paddingX={1}>
+                  <Text fg={colors.textDim}>Loading IBKR history...</Text>
+                </Box>
+              ) : brokerPerformance.error ? (
+                <Box height={1} paddingX={1}>
+                  <Text fg={colors.textDim}>IBKR history unavailable</Text>
+                </Box>
+              ) : null}
 
               <Box height={1} paddingX={1}>
                 <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>

--- a/src/plugins/builtin/broker-manager/index.tsx
+++ b/src/plugins/builtin/broker-manager/index.tsx
@@ -166,7 +166,7 @@ function buildBrokerColumns(width: number): BrokerColumn[] {
     { id: "broker", label: "BROKER", width: brokerWidth, align: "left" },
     { id: "mode", label: "MODE", width: modeWidth, align: "left" },
     { id: "accounts", label: "ACCOUNTS", width: accountWidth, align: "right" },
-    { id: "updated", label: "UPDATED", width: updatedWidth, align: "right" },
+    { id: "updated", label: "SYNCED", width: updatedWidth, align: "right" },
   ];
 }
 
@@ -518,7 +518,7 @@ export function BrokersPane({ focused, width, height }: PaneProps) {
       case "accounts":
         return { text: row.accountSummary, color: row.accountCount > 0 ? colors.text : colors.textMuted };
       case "updated":
-        return { text: formatBrokerUpdatedAt(row.updatedAt), color: colors.textMuted };
+        return { text: formatBrokerUpdatedAt(row.lastSyncedAt), color: colors.textMuted };
     }
     return { text: "" };
   }, []);
@@ -562,7 +562,8 @@ export function BrokersPane({ focused, width, height }: PaneProps) {
         >
           {detailStatusMessage}
         </Text>
-        <Text fg={colors.textMuted}>{`Updated ${formatBrokerUpdatedAt(selectedRow.updatedAt)}`}</Text>
+        <Text fg={colors.textMuted}>{`Last sync ${formatBrokerUpdatedAt(selectedRow.lastSyncedAt)}`}</Text>
+        <Text fg={colors.textMuted}>{`Status updated ${formatBrokerUpdatedAt(selectedRow.updatedAt)}`}</Text>
         <Box height={1} />
 
         {editDraft && selectedRow.adapter ? (

--- a/src/plugins/builtin/broker-manager/model.test.ts
+++ b/src/plugins/builtin/broker-manager/model.test.ts
@@ -31,7 +31,7 @@ describe("broker manager rows", () => {
   test("derives live status and account summary", () => {
     const config = {
       ...createDefaultConfig("/tmp/gloomberb-broker-manager"),
-      brokerInstances: [createInstance()],
+      brokerInstances: [createInstance({ lastSyncedAt: 900_000 })],
     };
     const rows = buildBrokerProfileRows(
       config,
@@ -50,7 +50,45 @@ describe("broker manager rows", () => {
       state: "connected",
       stateLabel: "Connected",
       accountSummary: "$150.00",
+      lastSyncedAt: 900_000,
     });
+  });
+
+  test("uses generated portfolio sync time when the profile has no direct timestamp", () => {
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-broker-manager"),
+      portfolios: [{
+        id: "broker:demo-live:DU1",
+        name: "DU1",
+        currency: "USD",
+        brokerId: "demo",
+        brokerInstanceId: "demo-live",
+        brokerAccountId: "DU1",
+        lastSyncedAt: 750_000,
+      }],
+      brokerInstances: [createInstance()],
+    };
+    const rows = buildBrokerProfileRows(config, new Map([["demo", createAdapter()]]), {});
+
+    expect(rows[0]?.lastSyncedAt).toBe(750_000);
+  });
+
+  test("falls back to cached account update time for older configs", () => {
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-broker-manager"),
+      brokerInstances: [createInstance()],
+    };
+    const rows = buildBrokerProfileRows(
+      config,
+      new Map([["demo", createAdapter()]]),
+      {
+        "demo-live": [
+          { accountId: "DU1", name: "DU1", currency: "USD", updatedAt: 650_000 },
+        ],
+      },
+    );
+
+    expect(rows[0]?.lastSyncedAt).toBe(650_000);
   });
 
   test("handles disabled and unavailable profiles before adapter status", () => {

--- a/src/plugins/builtin/broker-manager/model.ts
+++ b/src/plugins/builtin/broker-manager/model.ts
@@ -2,6 +2,7 @@ import type { BrokerAdapter, BrokerConnectionStatus } from "../../../types/broke
 import type { AppConfig, BrokerInstanceConfig } from "../../../types/config";
 import type { BrokerAccount } from "../../../types/trading";
 import { formatCurrency } from "../../../utils/format";
+import { formatRelativeAge } from "../../../utils/relative-time";
 
 export type BrokerDisplayState =
   | "disabled"
@@ -19,6 +20,7 @@ export interface BrokerProfileRow {
   stateLabel: string;
   message: string;
   updatedAt: number;
+  lastSyncedAt: number;
   accountCount: number;
   accountSummary: string;
   accountIds: string[];
@@ -40,12 +42,7 @@ function formatBrokerMode(value: unknown): string {
 }
 
 export function formatBrokerUpdatedAt(updatedAt: number | undefined, now = Date.now()): string {
-  if (!updatedAt) return "never";
-  const ageMs = Math.max(0, now - updatedAt);
-  if (ageMs < 60_000) return "just now";
-  if (ageMs < 60 * 60_000) return `${Math.floor(ageMs / 60_000)}m ago`;
-  if (ageMs < 24 * 60 * 60_000) return `${Math.floor(ageMs / (60 * 60_000))}h ago`;
-  return `${Math.floor(ageMs / (24 * 60 * 60_000))}d ago`;
+  return formatRelativeAge(updatedAt, now);
 }
 
 function summarizeBrokerAccounts(accounts: BrokerAccount[]): string {
@@ -121,6 +118,14 @@ export function buildBrokerProfileRows(
     const mode = resolveMode(adapter, instance, status);
     const state = resolveState(instance, adapter, mode, status);
     const accounts = brokerAccounts[instance.id] ?? [];
+    const portfolioLastSyncedAt = Math.max(
+      0,
+      ...config.portfolios
+        .filter((portfolio) => portfolio.brokerInstanceId === instance.id)
+        .map((portfolio) => portfolio.lastSyncedAt ?? 0),
+    );
+    const accountLastUpdatedAt = Math.max(0, ...accounts.map((account) => account.updatedAt ?? 0));
+    const lastSyncedAt = instance.lastSyncedAt ?? (portfolioLastSyncedAt || accountLastUpdatedAt);
 
     return {
       id: instance.id,
@@ -132,6 +137,7 @@ export function buildBrokerProfileRows(
       stateLabel: state.label,
       message: state.message,
       updatedAt: state.updatedAt,
+      lastSyncedAt,
       accountCount: accounts.length,
       accountSummary: summarizeBrokerAccounts(accounts),
       accountIds: accounts.map((account) => account.accountId),

--- a/src/plugins/builtin/portfolio-list/account-metrics.test.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { BrokerAccount } from "../../../types/trading";
+import type { PortfolioSummaryTotals } from "./metrics";
+import { resolvePortfolioAccountMetrics } from "./account-metrics";
+
+function createTotals(overrides: Partial<PortfolioSummaryTotals> = {}): PortfolioSummaryTotals {
+  return {
+    totalMktValue: 10_000,
+    dailyPnl: 50,
+    dailyPnlPct: 0.5,
+    totalCostBasis: 8_000,
+    hasPositions: true,
+    unrealizedPnl: 2_000,
+    unrealizedPnlPct: 25,
+    avgWatchlistChange: 0,
+    watchlistCount: 0,
+    ...overrides,
+  };
+}
+
+describe("resolvePortfolioAccountMetrics", () => {
+  test("prefers broker account P&L while preserving position fallback percentages", () => {
+    const account: BrokerAccount = {
+      accountId: "DU12345",
+      name: "DU12345",
+      netLiquidation: 12_500,
+      dailyPnl: 250,
+      unrealizedPnl: 1_600,
+      realizedPnl: -40,
+    };
+
+    expect(resolvePortfolioAccountMetrics(createTotals(), account)).toEqual({
+      dailyPnl: 250,
+      dailyPnlPct: 250 / 12_250 * 100,
+      unrealizedPnl: 1_600,
+      unrealizedPnlPct: 20,
+      realizedPnl: -40,
+    });
+  });
+
+  test("falls back to reconstructed portfolio totals when broker P&L is missing", () => {
+    expect(resolvePortfolioAccountMetrics(createTotals(), null)).toEqual({
+      dailyPnl: 50,
+      dailyPnlPct: 0.5,
+      unrealizedPnl: 2_000,
+      unrealizedPnlPct: 25,
+      realizedPnl: undefined,
+    });
+  });
+});

--- a/src/plugins/builtin/portfolio-list/account-metrics.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.ts
@@ -1,0 +1,46 @@
+import type { BrokerAccount } from "../../../types/trading";
+import type { PortfolioSummaryTotals } from "./metrics";
+
+export interface PortfolioAccountMetrics {
+  dailyPnl: number;
+  dailyPnlPct: number;
+  unrealizedPnl: number;
+  unrealizedPnlPct: number;
+  realizedPnl?: number;
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function percentChange(value: number, previousValue: number): number {
+  return previousValue !== 0 ? (value / previousValue) * 100 : 0;
+}
+
+export function resolvePortfolioAccountMetrics(
+  totals: PortfolioSummaryTotals,
+  account?: BrokerAccount | null,
+): PortfolioAccountMetrics {
+  const brokerDailyPnl = finiteNumber(account?.dailyPnl) ? account.dailyPnl : null;
+  const dailyPnl = brokerDailyPnl ?? totals.dailyPnl;
+  const previousNetLiquidation = brokerDailyPnl != null && finiteNumber(account?.netLiquidation)
+    ? account.netLiquidation - dailyPnl
+    : null;
+  const dailyPnlPct = previousNetLiquidation != null
+    ? percentChange(dailyPnl, previousNetLiquidation)
+    : totals.dailyPnlPct;
+
+  const brokerUnrealizedPnl = finiteNumber(account?.unrealizedPnl) ? account.unrealizedPnl : null;
+  const unrealizedPnl = brokerUnrealizedPnl ?? totals.unrealizedPnl;
+  const unrealizedPnlPct = totals.totalCostBasis !== 0
+    ? percentChange(unrealizedPnl, totals.totalCostBasis)
+    : totals.unrealizedPnlPct;
+
+  return {
+    dailyPnl,
+    dailyPnlPct,
+    unrealizedPnl,
+    unrealizedPnlPct,
+    realizedPnl: finiteNumber(account?.realizedPnl) ? account.realizedPnl : undefined,
+  };
+}

--- a/src/plugins/builtin/portfolio-list/summary.test.ts
+++ b/src/plugins/builtin/portfolio-list/summary.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePortfolioAccountState } from "./summary";
+
+describe("resolvePortfolioAccountState", () => {
+  test("does not reuse a single cached broker account for a different explicit portfolio account", () => {
+    const accountState = resolvePortfolioAccountState({
+      id: "broker:ibkr-flex:U12345",
+      name: "U12345",
+      currency: "USD",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-flex",
+      brokerAccountId: "U12345",
+    }, {
+      config: {
+        brokerInstances: [{
+          id: "ibkr-flex",
+          label: "IBKR Flex",
+          brokerType: "ibkr",
+          enabled: true,
+          config: {},
+        }],
+      } as any,
+      brokerAccounts: {
+        "ibkr-flex": [{
+          accountId: "alias-account",
+          name: "alias-account",
+          currency: "USD",
+          source: "flex",
+          updatedAt: new Date("2026-05-15T05:02:17.000Z").getTime(),
+        }],
+      },
+    }, {
+      status: null,
+      accounts: [],
+    });
+
+    expect(accountState).toBeNull();
+  });
+
+  test("still uses the only cached broker account for legacy broker portfolios without an account id", () => {
+    const accountState = resolvePortfolioAccountState({
+      id: "broker:ibkr-flex:default",
+      name: "IBKR Flex",
+      currency: "USD",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-flex",
+    }, {
+      config: {
+        brokerInstances: [{
+          id: "ibkr-flex",
+          label: "IBKR Flex",
+          brokerType: "ibkr",
+          enabled: true,
+          config: {},
+        }],
+      } as any,
+      brokerAccounts: {
+        "ibkr-gateway": [{
+          accountId: "U12345",
+          name: "U12345",
+          currency: "USD",
+          source: "gateway",
+          updatedAt: new Date("2026-05-14T05:02:17.000Z").getTime(),
+          netLiquidation: 100000,
+        }],
+        "ibkr-flex": [{
+          accountId: "U12345",
+          name: "U12345",
+          currency: "USD",
+          source: "flex",
+        }],
+      },
+    }, {
+      status: null,
+      accounts: [],
+    });
+
+    expect(accountState?.account.accountId).toBe("U12345");
+  });
+
+  test("uses exact cached account data from another profile for the same broker account", () => {
+    const accountState = resolvePortfolioAccountState({
+      id: "broker:ibkr-gateway:U12345",
+      name: "U12345",
+      currency: "USD",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-gateway",
+      brokerAccountId: "U12345",
+    }, {
+      config: {
+        brokerInstances: [
+          {
+            id: "ibkr-gateway",
+            label: "IBKR Gateway",
+            brokerType: "ibkr",
+            enabled: true,
+            config: {},
+          },
+          {
+            id: "ibkr-flex",
+            label: "IBKR Flex",
+            brokerType: "ibkr",
+            enabled: true,
+            config: {},
+          },
+        ],
+      } as any,
+      brokerAccounts: {
+        "ibkr-flex": [{
+          accountId: "U12345",
+          name: "U12345",
+          currency: "USD",
+          source: "flex",
+          updatedAt: new Date("2026-05-15T05:02:17.000Z").getTime(),
+          netLiquidation: 123456,
+        }],
+      },
+    }, {
+      status: null,
+      accounts: [],
+    });
+
+    expect(accountState?.account.netLiquidation).toBe(123456);
+    expect(accountState?.sourceLabel).toBe("Flex May 15");
+  });
+});

--- a/src/plugins/builtin/portfolio-list/summary.tsx
+++ b/src/plugins/builtin/portfolio-list/summary.tsx
@@ -7,6 +7,7 @@ import type { Portfolio } from "../../../types/ticker";
 import type { BrokerAccount, BrokerCashBalance } from "../../../types/trading";
 import { formatCompact, formatPercentRaw } from "../../../utils/format";
 import { getBrokerInstance } from "../../../utils/broker-instances";
+import { resolvePortfolioAccountMetrics } from "./account-metrics";
 import type { PortfolioSummaryTotals } from "./metrics";
 
 export interface PortfolioSummarySegment {
@@ -44,6 +45,10 @@ function createSummarySegment(
     parts,
     length: parts.reduce((sum, part) => sum + part.text.length, 0) + Math.max(0, parts.length - 1),
   };
+}
+
+function formatSignedCompact(value: number): string {
+  return `${value >= 0 ? "+" : ""}${formatCompact(value)}`;
 }
 
 function fitSummarySegments(candidates: PortfolioSummarySegment[], widthBudget: number): PortfolioSummarySegment[] {
@@ -97,11 +102,22 @@ function findPortfolioAccount(
   const accountId = portfolio.brokerAccountId?.trim();
   const portfolioName = portfolio.name.trim();
   const collectionAccountId = portfolio.id.split(":").pop()?.trim();
+  const explicitAccountIds = [accountId, collectionAccountId === "default" ? undefined : collectionAccountId]
+    .filter((value): value is string => !!value);
 
-  return accounts.find((account) => account.accountId === accountId)
-    ?? accounts.find((account) => account.accountId === portfolioName || account.name === portfolioName)
-    ?? accounts.find((account) => account.accountId === collectionAccountId || account.name === collectionAccountId)
-    ?? (accounts.length === 1 ? accounts[0] : undefined);
+  for (const id of explicitAccountIds) {
+    const matched = accounts.find((account) => account.accountId === id || account.name === id);
+    if (matched) return matched;
+  }
+
+  const nameMatched = accounts.find((account) => account.accountId === portfolioName || account.name === portfolioName);
+  if (nameMatched) return nameMatched;
+
+  return explicitAccountIds.length === 0 && accounts.length === 1 ? accounts[0] : undefined;
+}
+
+function sortAccountsByFreshness(accounts: BrokerAccount[]): BrokerAccount[] {
+  return [...accounts].sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
 }
 
 export function resolvePortfolioAccountState(
@@ -112,7 +128,18 @@ export function resolvePortfolioAccountState(
   if (!portfolio?.brokerInstanceId) return null;
 
   const brokerInstance = getBrokerInstance(state.config.brokerInstances, portfolio.brokerInstanceId);
-  const cachedAccounts = state.brokerAccounts[portfolio.brokerInstanceId] ?? [];
+  const relatedInstanceIds = [
+    portfolio.brokerInstanceId,
+    ...state.config.brokerInstances
+      .filter((instance) =>
+        instance.id !== portfolio.brokerInstanceId
+        && instance.brokerType === (portfolio.brokerId ?? brokerInstance?.brokerType)
+      )
+      .map((instance) => instance.id),
+  ];
+  const cachedAccounts = sortAccountsByFreshness(
+    relatedInstanceIds.flatMap((instanceId) => state.brokerAccounts[instanceId] ?? []),
+  );
   const cachedAccount = findPortfolioAccount(cachedAccounts, portfolio);
 
   const liveAccount = brokerInstance
@@ -144,6 +171,7 @@ export function buildPortfolioSummarySegments({
   refreshText?: string;
 }): PortfolioSummarySegment[] {
   const candidates: PortfolioSummarySegment[] = [];
+  const accountMetrics = resolvePortfolioAccountMetrics(totals, accountState?.account);
 
   if (accountState?.account.netLiquidation != null) {
     candidates.push(createSummarySegment("netliq", [
@@ -166,18 +194,24 @@ export function buildPortfolioSummarySegments({
 
   candidates.push(createSummarySegment("day", [
     { text: "Day", tone: "label" },
-    { text: `${totals.dailyPnl >= 0 ? "+" : ""}${formatCompact(totals.dailyPnl)}`, tone: "value", color: priceColor(totals.dailyPnl), bold: true },
-    { text: `(${formatPercentRaw(totals.dailyPnlPct)})`, tone: "muted", color: priceColor(totals.dailyPnlPct) },
+    { text: formatSignedCompact(accountMetrics.dailyPnl), tone: "value", color: priceColor(accountMetrics.dailyPnl), bold: true },
+    { text: `(${formatPercentRaw(accountMetrics.dailyPnlPct)})`, tone: "muted", color: priceColor(accountMetrics.dailyPnlPct) },
   ]));
   candidates.push(createSummarySegment("pnl", [
     { text: "P&L", tone: "label" },
-    { text: `${totals.unrealizedPnl >= 0 ? "+" : ""}${formatCompact(totals.unrealizedPnl)}`, tone: "value", color: priceColor(totals.unrealizedPnl), bold: true },
-    { text: `(${formatPercentRaw(totals.unrealizedPnlPct)})`, tone: "muted", color: priceColor(totals.unrealizedPnlPct) },
+    { text: formatSignedCompact(accountMetrics.unrealizedPnl), tone: "value", color: priceColor(accountMetrics.unrealizedPnl), bold: true },
+    { text: `(${formatPercentRaw(accountMetrics.unrealizedPnlPct)})`, tone: "muted", color: priceColor(accountMetrics.unrealizedPnlPct) },
   ]));
 
   if (accountState) {
     const { account, sourceLabel } = accountState;
     const brokerSegments = [
+      accountMetrics.realizedPnl != null
+        ? createSummarySegment("realized", [
+          { text: "Realized", tone: "label" },
+          { text: formatSignedCompact(accountMetrics.realizedPnl), tone: "value", color: priceColor(accountMetrics.realizedPnl), bold: true },
+        ])
+        : null,
       account.settledCash != null
         ? createSummarySegment("settled", [
           { text: "Settled", tone: "label" },
@@ -245,6 +279,15 @@ export function renderSummarySegments(segments: PortfolioSummarySegment[], width
 
 export function buildDrawerMetricSegments(account: BrokerAccount, widthBudget: number): PortfolioSummarySegment[] {
   const candidates = [
+    account.dailyPnl != null
+      ? createSummarySegment("day", [{ text: "Day", tone: "label" }, { text: formatSignedCompact(account.dailyPnl), tone: "value", color: priceColor(account.dailyPnl), bold: true }])
+      : null,
+    account.unrealizedPnl != null
+      ? createSummarySegment("unreal", [{ text: "Unreal", tone: "label" }, { text: formatSignedCompact(account.unrealizedPnl), tone: "value", color: priceColor(account.unrealizedPnl), bold: true }])
+      : null,
+    account.realizedPnl != null
+      ? createSummarySegment("realized", [{ text: "Realized", tone: "label" }, { text: formatSignedCompact(account.realizedPnl), tone: "value", color: priceColor(account.realizedPnl), bold: true }])
+      : null,
     account.totalCashValue != null
       ? createSummarySegment("cash", [{ text: "Cash", tone: "label" }, { text: formatCompact(account.totalCashValue), tone: "value", bold: true }])
       : null,

--- a/src/plugins/ibkr/broker-adapter.ts
+++ b/src/plugins/ibkr/broker-adapter.ts
@@ -1,5 +1,6 @@
 import type { BrokerAdapter, BrokerPosition } from "../../types/broker";
 import {
+  buildPersistedIbkrGatewayConfig,
   buildIbkrConfigFromValues,
   IBKR_CONFIG_FIELDS,
   isFlexConfigured,
@@ -11,6 +12,7 @@ import { getIbkrAccountCachePolicy, getIbkrAccountCacheSourceKey } from "./accou
 import { loadFlexStatement, parseFlexAccounts, parseFlexPositions } from "./flex";
 import { ibkrGatewayManager } from "./gateway-service";
 import { refreshGatewayData } from "./gateway-helpers";
+import { getIbkrPortfolioPerformance } from "./portfolio-performance";
 
 async function importFlexPositions(config: FlexQueryConfig): Promise<BrokerPosition[]> {
   const xml = await loadFlexStatement(config);
@@ -104,7 +106,7 @@ export const ibkrBroker: BrokerAdapter = {
   fromConfigValues(values, previous) {
     const next = buildIbkrConfigFromValues(values);
     const previousConfig = previous ? normalizeIbkrConfig(previous.config) : null;
-    if (!previousConfig || next.connectionMode !== "gateway") return next;
+    if (!previousConfig || next.connectionMode !== "gateway") return next as unknown as Record<string, unknown>;
 
     return {
       ...next,
@@ -114,7 +116,7 @@ export const ibkrBroker: BrokerAdapter = {
         lastSuccessfulPort: previousConfig.gateway.lastSuccessfulPort,
         lastSuccessfulClientId: previousConfig.gateway.lastSuccessfulClientId,
       },
-    };
+    } as unknown as Record<string, unknown>;
   },
 
   async listAccounts(instance) {
@@ -124,6 +126,10 @@ export const ibkrBroker: BrokerAdapter = {
     }
     const xml = await loadFlexStatement(normalized.flex);
     return parseFlexAccounts(xml);
+  },
+
+  async getPortfolioPerformance(instance, accountId) {
+    return getIbkrPortfolioPerformance(instance, accountId);
   },
 
   async searchInstruments(query, instance) {

--- a/src/plugins/ibkr/flex.test.ts
+++ b/src/plugins/ibkr/flex.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { setHttpFetchTransport } from "../../utils/http-transport";
-import { parseFlexAccounts, parseFlexPositions, requestFlexStatement } from "./flex";
+import {
+  parseFlexAccounts,
+  parseFlexPortfolioPerformance,
+  parseFlexPositions,
+  requestFlexStatement,
+} from "./flex";
 
 const originalFetch = globalThis.fetch;
 
@@ -114,6 +119,75 @@ describe("parseFlexAccounts", () => {
   });
 });
 
+describe("parseFlexPortfolioPerformance", () => {
+  test("parses historical NAV rows when a Flex query includes them", () => {
+    const xml = `
+      <FlexQueryResponse>
+        <FlexStatements count="2">
+          <FlexStatement accountId="DU12345" fromDate="20260514" toDate="20260514">
+            <ChangeInNAV accountId="DU12345" currency="USD" endingValue="100000" cumulativeReturn="0" />
+          </FlexStatement>
+          <FlexStatement accountId="DU12345" fromDate="20260515" toDate="20260515">
+            <ChangeInNAV accountId="DU12345" currency="USD" endingValue="101500" cumulativeReturn="1.5" />
+          </FlexStatement>
+        </FlexStatements>
+      </FlexQueryResponse>
+    `;
+
+    expect(parseFlexPortfolioPerformance(xml, "DU12345", 123)).toEqual({
+      accountId: "DU12345",
+      source: "flex",
+      period: "FLEX",
+      currency: "USD",
+      fetchedAt: 123,
+      startDate: "2026-05-14",
+      endDate: "2026-05-15",
+      points: [
+        { date: "2026-05-14", value: 100000, cumulativeReturn: 0 },
+        { date: "2026-05-15", value: 101500, cumulativeReturn: 0.015 },
+      ],
+    });
+  });
+
+  test("matches account aliases in single-account Flex history statements", () => {
+    const xml = `
+      <FlexQueryResponse>
+        <FlexStatements count="1">
+          <FlexStatement accountId="U12345" acctAlias="alias-account" fromDate="20260514" toDate="20260515">
+            <ChangeInNAV accountId="U12345" currency="USD" reportDate="20260514" endingValue="100000" cumulativeReturn="0" />
+            <ChangeInNAV accountId="U12345" currency="USD" reportDate="20260515" endingValue="101000" cumulativeReturn="1.5" />
+          </FlexStatement>
+        </FlexStatements>
+      </FlexQueryResponse>
+    `;
+
+    const performance = parseFlexPortfolioPerformance(xml, "alias-account", 123);
+
+    expect(performance?.accountId).toBe("alias-account");
+    expect(performance?.points).toEqual([
+      { date: "2026-05-14", value: 100000, cumulativeReturn: 0 },
+      { date: "2026-05-15", value: 101000, cumulativeReturn: 0.015 },
+    ]);
+  });
+
+  test("does not match a different account in multi-account Flex history statements", () => {
+    const xml = `
+      <FlexQueryResponse>
+        <FlexStatements count="2">
+          <FlexStatement accountId="U12345" fromDate="20260514" toDate="20260514">
+            <ChangeInNAV accountId="U12345" currency="USD" endingValue="100000" />
+          </FlexStatement>
+          <FlexStatement accountId="U67890" fromDate="20260514" toDate="20260514">
+            <ChangeInNAV accountId="U67890" currency="USD" endingValue="200000" />
+          </FlexStatement>
+        </FlexStatements>
+      </FlexQueryResponse>
+    `;
+
+    expect(parseFlexPortfolioPerformance(xml, "alias-account", 123)).toBeNull();
+  });
+});
+
 describe("requestFlexStatement", () => {
   test("uses the configured HTTP transport for statement requests", async () => {
     const requests: string[] = [];
@@ -139,7 +213,7 @@ describe("requestFlexStatement", () => {
     globalThis.fetch = (async () => new Response(
       "<FlexStatementResponse><ErrorMessage>Load failed</ErrorMessage></FlexStatementResponse>",
       { status: 200 },
-    )) as typeof fetch;
+    )) as unknown as typeof fetch;
 
     let message = "";
     try {

--- a/src/plugins/ibkr/flex.ts
+++ b/src/plugins/ibkr/flex.ts
@@ -1,12 +1,20 @@
 import type { BrokerPosition } from "../../types/broker";
 import type { BrokerContractRef } from "../../types/instrument";
-import type { BrokerAccount, BrokerCashBalance } from "../../types/trading";
+import type {
+  BrokerAccount,
+  BrokerCashBalance,
+  BrokerPortfolioPerformance,
+  BrokerPortfolioPerformancePoint,
+} from "../../types/trading";
 import { httpFetch } from "../../utils/http-transport";
 import type { FlexQueryConfig } from "./config";
 import { IBKR_STATEMENT_URL } from "./config";
 
 const IBKR_STATEMENT_GET_URL = "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.GetStatement";
-const FLEX_STATEMENT_CACHE_MS = 15_000;
+const FLEX_STATEMENT_CACHE_MS = 15 * 60_000;
+const FLEX_STATEMENT_INITIAL_WAIT_MS = 3_000;
+const FLEX_STATEMENT_POLL_DELAY_MS = 5_000;
+const FLEX_STATEMENT_MAX_DOWNLOAD_ATTEMPTS = 60;
 const flexStatementCache = new Map<string, { createdAt: number; promise: Promise<string> }>();
 
 type FlexRequestPhase = "request" | "download";
@@ -56,6 +64,19 @@ function parseFlexTimestamp(raw: string | undefined, fallbackDate: string | unde
   if (!match) return undefined;
   const [, year, month, day] = match;
   return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+}
+
+function parseFlexDate(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const match = raw.match(/^(\d{4})(\d{2})(\d{2})$/);
+  if (match) {
+    const [, year, month, day] = match;
+    return `${year}-${month}-${day}`;
+  }
+
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString().slice(0, 10);
 }
 
 function decodeXmlText(value: string): string {
@@ -139,12 +160,12 @@ export async function requestFlexStatement(config: FlexQueryConfig): Promise<str
 async function getFlexStatement(
   token: string,
   referenceCode: string,
-  context: Pick<FlexQueryConfig, "endpoint" | "queryId"> = {},
+  context: Partial<Pick<FlexQueryConfig, "endpoint" | "queryId">> = {},
 ): Promise<string> {
-  await new Promise((resolve) => setTimeout(resolve, 3_000));
+  await new Promise((resolve) => setTimeout(resolve, FLEX_STATEMENT_INITIAL_WAIT_MS));
 
   const url = `${IBKR_STATEMENT_GET_URL}?t=${token}&q=${referenceCode}&v=3`;
-  for (let attempt = 0; attempt < 5; attempt += 1) {
+  for (let attempt = 0; attempt < FLEX_STATEMENT_MAX_DOWNLOAD_ATTEMPTS; attempt += 1) {
     let resp: Response;
     let text: string;
     try {
@@ -165,7 +186,7 @@ async function getFlexStatement(
     }
 
     if (text.includes("Statement generation in progress")) {
-      await new Promise((resolve) => setTimeout(resolve, 2_000 * (attempt + 1)));
+      await new Promise((resolve) => setTimeout(resolve, FLEX_STATEMENT_POLL_DELAY_MS));
       continue;
     }
 
@@ -203,6 +224,12 @@ export async function loadFlexStatement(config: FlexQueryConfig): Promise<string
     return getFlexStatement(config.token, referenceCode, config);
   })();
   flexStatementCache.set(cacheKey, { createdAt: Date.now(), promise });
+  promise.catch(() => {
+    const cached = flexStatementCache.get(cacheKey);
+    if (cached?.promise === promise) {
+      flexStatementCache.delete(cacheKey);
+    }
+  });
   setTimeout(() => {
     const cached = flexStatementCache.get(cacheKey);
     if (cached?.promise === promise) {
@@ -368,4 +395,119 @@ export function parseFlexAccounts(xml: string): BrokerAccount[] {
   }
 
   return accounts;
+}
+
+function firstNumberAttribute(
+  attributes: Record<string, string>,
+  names: string[],
+): number | undefined {
+  for (const name of names) {
+    const value = parseNumber(attributes[name]);
+    if (value != null) return value;
+  }
+  return undefined;
+}
+
+function firstStringAttribute(
+  attributes: Record<string, string>,
+  names: string[],
+): string | undefined {
+  for (const name of names) {
+    const value = attributes[name];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function parseFlexReturn(value: number | undefined): number | undefined {
+  if (value == null) return undefined;
+  return Math.abs(value) > 1 ? value / 100 : value;
+}
+
+function flexAccountTokens(attributes: Record<string, string>): Set<string> {
+  return new Set([
+    attributes.accountId,
+    attributes.acctAlias,
+    attributes.accountAlias,
+    attributes.alias,
+    attributes.name,
+  ].filter((value): value is string => !!value));
+}
+
+export function parseFlexPortfolioPerformance(
+  xml: string,
+  accountId: string,
+  fetchedAt = Date.now(),
+): BrokerPortfolioPerformance | null {
+  const points: BrokerPortfolioPerformancePoint[] = [];
+  let currency: string | undefined;
+
+  const statementRegex = /<FlexStatement\b([^>]*)>([\s\S]*?)<\/FlexStatement>/g;
+  const statements = [...xml.matchAll(statementRegex)].map((statementMatch) => ({
+    attributes: parseAttributes(statementMatch[1] ?? ""),
+    body: statementMatch[2] ?? "",
+  }));
+
+  for (const statement of statements) {
+    const statementAttrs = statement.attributes;
+    const body = statement.body;
+    const statementAccountId = statementAttrs.accountId || "";
+    const statementTokens = flexAccountTokens(statementAttrs);
+    const statementMatchesAccount = statementTokens.has(accountId);
+    if (statementAccountId && !statementMatchesAccount && statements.length !== 1) continue;
+
+    for (const entry of body.matchAll(/<ChangeInNAV\b([^>]*)\/>/g)) {
+      const attributes = parseAttributes(entry[1] ?? "");
+      const entryAccountId = attributes.accountId || statementAccountId;
+      const entryTokens = flexAccountTokens(attributes);
+      const entryMatchesAccount = entryTokens.has(accountId)
+        || (statementMatchesAccount && (!entryAccountId || entryAccountId === statementAccountId));
+      if (entryAccountId && !entryMatchesAccount && statements.length !== 1) continue;
+
+      const date = parseFlexDate(firstStringAttribute(attributes, [
+        "reportDate",
+        "date",
+        "toDate",
+        "asOfDate",
+      ]) ?? statementAttrs.toDate ?? statementAttrs.fromDate);
+      if (!date) continue;
+
+      const value = firstNumberAttribute(attributes, [
+        "endingValue",
+        "endingNAV",
+        "nav",
+        "netAssetValue",
+      ]);
+      const cumulativeReturn = parseFlexReturn(firstNumberAttribute(attributes, [
+        "cumulativeReturn",
+        "timeWeightedReturnCumulative",
+        "twrCumulative",
+        "twr",
+        "mwr",
+      ]));
+      if (value == null && cumulativeReturn == null) continue;
+
+      currency = currency ?? attributes.currency;
+      points.push({ date, value, cumulativeReturn });
+    }
+  }
+
+  const uniquePoints = [...new Map(
+    points
+      .sort((left, right) => left.date.localeCompare(right.date))
+      .map((point) => [point.date, point] as const),
+  ).values()];
+
+  if (uniquePoints.length === 0) return null;
+
+  return {
+    accountId,
+    source: "flex",
+    period: "FLEX",
+    currency,
+    fetchedAt,
+    startDate: uniquePoints[0]?.date,
+    endDate: uniquePoints.at(-1)?.date,
+    points: uniquePoints,
+  };
 }

--- a/src/plugins/ibkr/gateway-service-native.ts
+++ b/src/plugins/ibkr/gateway-service-native.ts
@@ -111,6 +111,15 @@ export function setResolvedIbkrGatewayListener(listener: ResolvedGatewayListener
 
 type AccountSummaryValueMap = ReadonlyMap<string, { value: string }>;
 type AccountSummaryTags = ReadonlyMap<string, AccountSummaryValueMap>;
+interface AccountPnlSnapshot {
+  dailyPnl?: number;
+  unrealizedPnl?: number;
+  realizedPnl?: number;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
 
 function getAccountSummaryEntry(
   values: AccountSummaryValueMap | undefined,
@@ -237,6 +246,7 @@ export function summarizeBrokerAccount(
   updatedAt: number,
   aggregateTags?: AccountSummaryTags,
   allowAggregateCashBalances = false,
+  pnl?: AccountPnlSnapshot,
 ): BrokerAccount {
   const currency = inferAccountCurrency(tags) ?? (allowAggregateCashBalances ? inferAccountCurrency(aggregateTags) : undefined);
   return {
@@ -253,6 +263,9 @@ export function summarizeBrokerAccount(
     excessLiquidity: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "ExcessLiquidity", currency, allowAggregateCashBalances),
     initMarginReq: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "InitMarginReq", currency, allowAggregateCashBalances),
     maintMarginReq: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "MaintMarginReq", currency, allowAggregateCashBalances),
+    dailyPnl: pnl?.dailyPnl,
+    unrealizedPnl: pnl?.unrealizedPnl,
+    realizedPnl: pnl?.realizedPnl,
     cashBalances: buildCashBalances(tags, aggregateTags, currency, allowAggregateCashBalances),
   };
 }
@@ -269,6 +282,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 }
 
 const IBKR_DATA_TIMEOUT = 8_000;
+const IBKR_PNL_TIMEOUT = 3_000;
 const IBKR_QUOTE_STREAM_TICKS = "165,221,233";
 
 const HISTORY_PARAMS: Record<TimeRange, { duration: string; size: BarSizeSetting }> = {
@@ -1995,13 +2009,48 @@ export class IbkrGatewayService {
     const updatedAt = Date.now();
     const aggregateTags = summary?.get("All");
     const allowAggregateCashBalances = managedAccounts.length === 1;
+    const pnlByAccount = await this.loadAccountPnlForAccounts(managedAccounts);
     return managedAccounts.map((accountId) => summarizeBrokerAccount(
       accountId,
       summary?.get(accountId),
       updatedAt,
       aggregateTags,
       allowAggregateCashBalances,
+      pnlByAccount.get(accountId),
     ));
+  }
+
+  private async loadAccountPnlForAccounts(accountIds: string[]): Promise<Map<string, AccountPnlSnapshot>> {
+    const entries = await Promise.all(accountIds.map(async (accountId) => {
+      const pnl = await this.loadAccountPnl(accountId);
+      return pnl ? ([accountId, pnl] as const) : null;
+    }));
+    return new Map(entries.filter((entry): entry is readonly [string, AccountPnlSnapshot] => entry != null));
+  }
+
+  private async loadAccountPnl(accountId: string): Promise<AccountPnlSnapshot | null> {
+    if (!this.api || typeof this.api.getPnL !== "function") return null;
+
+    try {
+      const pnl = await firstValueFrom(
+        this.api.getPnL(accountId).pipe(
+          take(1),
+          timeout(IBKR_PNL_TIMEOUT),
+        ),
+      );
+      return {
+        dailyPnl: finiteNumber(pnl.dailyPnL),
+        unrealizedPnl: finiteNumber(pnl.unrealizedPnL),
+        realizedPnl: finiteNumber(pnl.realizedPnL),
+      };
+    } catch (error: any) {
+      gatewayLog.warn("Failed to load IBKR account P&L", {
+        instanceId: this.instanceId,
+        accountId,
+        error: error?.message || String(error || ""),
+      });
+      return null;
+    }
   }
 
   private async loadAccountsAndUpdateSnapshot(): Promise<BrokerAccount[]> {

--- a/src/plugins/ibkr/gateway-service.test.ts
+++ b/src/plugins/ibkr/gateway-service.test.ts
@@ -58,6 +58,9 @@ describe("summarizeBrokerAccount", () => {
       excessLiquidity: 98321.12,
       initMarginReq: 45678.9,
       maintMarginReq: 34567.8,
+      dailyPnl: undefined,
+      unrealizedPnl: undefined,
+      realizedPnl: undefined,
       cashBalances: [
         { currency: "USD", quantity: -303029.14, baseValue: -303029.14, baseCurrency: "USD" },
         { currency: "EUR", quantity: -351957.02, baseValue: undefined, baseCurrency: "USD" },
@@ -102,6 +105,9 @@ describe("summarizeBrokerAccount", () => {
       excessLiquidity: 129061.51,
       initMarginReq: 328.63,
       maintMarginReq: 298.64,
+      dailyPnl: undefined,
+      unrealizedPnl: undefined,
+      realizedPnl: undefined,
       cashBalances: [
         { currency: "HKD", quantity: 1012836.31, baseValue: 129314.68614829802, baseCurrency: "USD" },
         { currency: "USD", quantity: -1020.86, baseValue: -1020.86, baseCurrency: "USD" },
@@ -144,10 +150,30 @@ describe("summarizeBrokerAccount", () => {
       excessLiquidity: 129061.51,
       initMarginReq: 328.63,
       maintMarginReq: 298.64,
+      dailyPnl: undefined,
+      unrealizedPnl: undefined,
+      realizedPnl: undefined,
       cashBalances: [
         { currency: "HKD", quantity: 1012836.31, baseValue: 129314.68614829802, baseCurrency: "USD" },
         { currency: "USD", quantity: -1020.86, baseValue: -1020.86, baseCurrency: "USD" },
       ],
+    });
+  });
+
+  test("maps account-level P&L into gateway account snapshots", () => {
+    const tags = makeTags({
+      NetLiquidation: { USD: "100000" },
+    });
+
+    expect(summarizeBrokerAccount("DU12345", tags, 1_717_000_000_000, undefined, false, {
+      dailyPnl: 1200.5,
+      unrealizedPnl: 5000,
+      realizedPnl: -250,
+    })).toMatchObject({
+      accountId: "DU12345",
+      dailyPnl: 1200.5,
+      unrealizedPnl: 5000,
+      realizedPnl: -250,
     });
   });
 
@@ -166,6 +192,9 @@ describe("summarizeBrokerAccount", () => {
       excessLiquidity: undefined,
       initMarginReq: undefined,
       maintMarginReq: undefined,
+      dailyPnl: undefined,
+      unrealizedPnl: undefined,
+      realizedPnl: undefined,
       cashBalances: undefined,
     });
   });

--- a/src/plugins/ibkr/portfolio-performance.test.ts
+++ b/src/plugins/ibkr/portfolio-performance.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { BrokerInstanceConfig } from "../../types/config";
+import {
+  getIbkrPortfolioPerformance,
+  setIbkrPortfolioPerformanceResourceStore,
+} from "./portfolio-performance";
+
+function createGatewayInstance(): BrokerInstanceConfig {
+  return {
+    id: "ibkr-live",
+    brokerType: "ibkr",
+    label: "IBKR Live",
+    connectionMode: "gateway",
+    enabled: true,
+    config: {
+      connectionMode: "gateway",
+      gateway: { host: "127.0.0.1", port: 4001, clientId: 1 },
+    },
+  };
+}
+
+afterEach(() => {
+  setIbkrPortfolioPerformanceResourceStore(null);
+});
+
+describe("getIbkrPortfolioPerformance", () => {
+  test("uses Flex only for historical portfolio performance", async () => {
+    const performance = await getIbkrPortfolioPerformance(createGatewayInstance(), "U12345");
+
+    expect(performance).toBeNull();
+  });
+});

--- a/src/plugins/ibkr/portfolio-performance.ts
+++ b/src/plugins/ibkr/portfolio-performance.ts
@@ -1,0 +1,137 @@
+import type { ResourceStore } from "../../data/resource-store";
+import type { BrokerInstanceConfig } from "../../types/config";
+import type { CachePolicy } from "../../types/persistence";
+import type { BrokerPortfolioPerformance } from "../../types/trading";
+import { debugLog } from "../../utils/debug-log";
+import { loadFlexStatement, parseFlexPortfolioPerformance } from "./flex";
+import { normalizeIbkrConfig } from "./config";
+
+const PERFORMANCE_LOG = debugLog.createLogger("ibkr-performance");
+const PERFORMANCE_CACHE_KIND = "portfolio-performance";
+const PERFORMANCE_CACHE_SCHEMA_VERSION = 1;
+const PERFORMANCE_CACHE_POLICY = {
+  staleMs: 15 * 60 * 1000,
+  expireMs: 90 * 24 * 60 * 60 * 1000,
+} as const satisfies CachePolicy;
+
+let resourceStore: ResourceStore | null = null;
+
+export function setIbkrPortfolioPerformanceResourceStore(store: ResourceStore | null): void {
+  resourceStore = store;
+}
+
+function hashString(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function cacheKey(instance: BrokerInstanceConfig, accountId: string): string {
+  return `${instance.id}:${accountId}`;
+}
+
+function cacheSourceKey(instance: BrokerInstanceConfig): string {
+  const config = normalizeIbkrConfig(instance.config);
+  return hashString(JSON.stringify({
+    connectionMode: config.connectionMode,
+    flexQueryId: config.flex.queryId,
+    flexEndpoint: config.flex.endpoint,
+  }));
+}
+
+function normalizeCachedPerformance(
+  value: BrokerPortfolioPerformance | undefined,
+  stale: boolean,
+): BrokerPortfolioPerformance | null {
+  if (!value || value.source !== "flex") return null;
+  return { ...value, stale };
+}
+
+function readCachedPerformance(
+  instance: BrokerInstanceConfig,
+  accountId: string,
+  allowExpired = false,
+): BrokerPortfolioPerformance | null {
+  const record = resourceStore?.get<BrokerPortfolioPerformance>({
+    namespace: "plugin:ibkr",
+    kind: PERFORMANCE_CACHE_KIND,
+    entityKey: cacheKey(instance, accountId),
+    sourceKey: cacheSourceKey(instance),
+  }, {
+    schemaVersion: PERFORMANCE_CACHE_SCHEMA_VERSION,
+    allowExpired,
+  });
+  return normalizeCachedPerformance(record?.value, !!record && (record.stale || record.expired));
+}
+
+function readAnyCachedPerformance(
+  instance: BrokerInstanceConfig,
+  accountId: string,
+  allowExpired = false,
+): BrokerPortfolioPerformance | null {
+  const records = resourceStore?.list<BrokerPortfolioPerformance>({
+    namespace: "plugin:ibkr",
+    kind: PERFORMANCE_CACHE_KIND,
+    entityKey: cacheKey(instance, accountId),
+  }, {
+    schemaVersion: PERFORMANCE_CACHE_SCHEMA_VERSION,
+    allowExpired,
+  });
+  return normalizeCachedPerformance(records?.[0]?.value, true);
+}
+
+function writeCachedPerformance(
+  instance: BrokerInstanceConfig,
+  accountId: string,
+  performance: BrokerPortfolioPerformance,
+): void {
+  resourceStore?.set<BrokerPortfolioPerformance>({
+    namespace: "plugin:ibkr",
+    kind: PERFORMANCE_CACHE_KIND,
+    entityKey: cacheKey(instance, accountId),
+    sourceKey: cacheSourceKey(instance),
+  }, performance, {
+    schemaVersion: PERFORMANCE_CACHE_SCHEMA_VERSION,
+    cachePolicy: PERFORMANCE_CACHE_POLICY,
+  });
+}
+
+async function loadFreshFlexPerformance(
+  instance: BrokerInstanceConfig,
+  accountId: string,
+): Promise<BrokerPortfolioPerformance | null> {
+  const config = normalizeIbkrConfig(instance.config);
+  if (config.connectionMode !== "flex") return null;
+
+  const xml = await loadFlexStatement(config.flex);
+  return parseFlexPortfolioPerformance(xml, accountId, Date.now());
+}
+
+export async function getIbkrPortfolioPerformance(
+  instance: BrokerInstanceConfig,
+  accountId: string,
+): Promise<BrokerPortfolioPerformance | null> {
+  const cached = readCachedPerformance(instance, accountId);
+  if (cached && !cached.stale) return cached;
+
+  try {
+    const fresh = await loadFreshFlexPerformance(instance, accountId);
+    if (fresh) {
+      writeCachedPerformance(instance, accountId, fresh);
+      return fresh;
+    }
+  } catch (error) {
+    PERFORMANCE_LOG.warn("Unable to refresh IBKR Flex portfolio performance", {
+      instanceId: instance.id,
+      accountId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return cached
+    ?? readCachedPerformance(instance, accountId, true)
+    ?? readAnyCachedPerformance(instance, accountId, true);
+}

--- a/src/renderers/electrobun/bun/core-capabilities.ts
+++ b/src/renderers/electrobun/bun/core-capabilities.ts
@@ -23,6 +23,7 @@ const BROKER_INVOKE_OPERATIONS = new Set([
   "disconnect",
   "getPersistedConfigUpdate",
   "listAccounts",
+  "getPortfolioPerformance",
   "searchInstruments",
   "getTickerFinancials",
   "getQuote",
@@ -102,6 +103,8 @@ function invokeBrokerOperation(
     case "listOpenOrders":
     case "listExecutions":
       return (broker[operation] as any)?.call(broker, instance);
+    case "getPortfolioPerformance":
+      return broker.getPortfolioPerformance?.(instance, args[0] as string);
     case "searchInstruments":
       return broker.searchInstruments?.(args[0] as string, instance);
     case "getTickerFinancials":

--- a/src/state/app-bootstrap.ts
+++ b/src/state/app-bootstrap.ts
@@ -314,6 +314,7 @@ export async function initializeAppState({
     }
     return nextTickerMap;
   }, { tickerCount: tickers.length });
+
   measurePerf("startup.dispatch-set-tickers", () => {
     dispatch({ type: "SET_TICKERS", tickers: tickerMap });
   }, { tickerCount: tickerMap.size });

--- a/src/types/broker.ts
+++ b/src/types/broker.ts
@@ -4,7 +4,14 @@ import type { ChartResolutionSupport, ManualChartResolution } from "../component
 import type { BrokerInstanceConfig } from "./config";
 import type { QuoteSubscriptionTarget } from "./data-provider";
 import type { BrokerContractRef, InstrumentSearchResult } from "./instrument";
-import type { BrokerAccount, BrokerExecution, BrokerOrder, BrokerOrderPreview, BrokerOrderRequest } from "./trading";
+import type {
+  BrokerAccount,
+  BrokerExecution,
+  BrokerOrder,
+  BrokerOrderPreview,
+  BrokerOrderRequest,
+  BrokerPortfolioPerformance,
+} from "./trading";
 import type { CachePolicy, CachePolicyMap } from "./persistence";
 
 export interface BrokerPosition {
@@ -90,6 +97,7 @@ export interface BrokerAdapter {
   toConfigValues?(instance: BrokerInstanceConfig): Record<string, unknown>;
   fromConfigValues?(values: Record<string, unknown>, previous?: BrokerInstanceConfig): Record<string, unknown>;
   listAccounts?(instance: BrokerInstanceConfig): Promise<BrokerAccount[]>;
+  getPortfolioPerformance?(instance: BrokerInstanceConfig, accountId: string): Promise<BrokerPortfolioPerformance | null>;
   searchInstruments?(query: string, instance: BrokerInstanceConfig): Promise<InstrumentSearchResult[]>;
   getTickerFinancials?(ticker: string, instance: BrokerInstanceConfig, exchange?: string, instrument?: BrokerContractRef | null): Promise<TickerFinancials>;
   getQuote?(ticker: string, instance: BrokerInstanceConfig, exchange?: string, instrument?: BrokerContractRef | null): Promise<Quote>;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -17,6 +17,7 @@ export interface BrokerInstanceConfig {
   connectionMode?: string;
   config: Record<string, unknown>;
   enabled?: boolean;
+  lastSyncedAt?: number;
 }
 
 export interface ColumnConfig {

--- a/src/types/ticker.ts
+++ b/src/types/ticker.ts
@@ -49,6 +49,7 @@ export interface Portfolio {
   brokerId?: string;
   brokerInstanceId?: string;
   brokerAccountId?: string;
+  lastSyncedAt?: number;
 }
 
 export interface Watchlist {

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -24,7 +24,29 @@ export interface BrokerAccount {
   excessLiquidity?: number;
   initMarginReq?: number;
   maintMarginReq?: number;
+  dailyPnl?: number;
+  unrealizedPnl?: number;
+  realizedPnl?: number;
   cashBalances?: BrokerCashBalance[];
+}
+
+export interface BrokerPortfolioPerformancePoint {
+  date: string;
+  value?: number;
+  cumulativeReturn?: number;
+}
+
+export interface BrokerPortfolioPerformance {
+  accountId: string;
+  source: "flex";
+  period: string;
+  currency?: string;
+  fetchedAt: number;
+  startDate?: string;
+  endDate?: string;
+  lastSuccessfulUpdate?: string;
+  stale?: boolean;
+  points: BrokerPortfolioPerformancePoint[];
 }
 
 export interface BrokerOrderRequest {

--- a/src/utils/relative-time.ts
+++ b/src/utils/relative-time.ts
@@ -1,0 +1,8 @@
+export function formatRelativeAge(timestamp: number | undefined, now = Date.now(), empty = "never"): string {
+  if (!timestamp) return empty;
+  const ageMs = Math.max(0, now - timestamp);
+  if (ageMs < 60_000) return "just now";
+  if (ageMs < 60 * 60_000) return `${Math.floor(ageMs / 60_000)}m ago`;
+  if (ageMs < 24 * 60 * 60_000) return `${Math.floor(ageMs / (60 * 60_000))}h ago`;
+  return `${Math.floor(ageMs / (24 * 60 * 60_000))}d ago`;
+}


### PR DESCRIPTION
Adds IBKR account-level daily, unrealized, and realized P&L to broker account snapshots and uses those values in portfolio summaries and analytics instead of relying only on reconstructed position math.

Adds Flex-backed historical portfolio performance with caching, Gateway-to-Flex fallback for the same IBKR account, and a Portfolio Analytics history chart.

Prevents future duplicate generated IBKR portfolios by reusing the same broker account portfolio across Flex and Gateway syncs, removes stale per-profile broker data on sync, and surfaces last sync freshness in Broker Manager and Portfolio Analytics.
