### PR TITLE
Show active ticker values in header and news

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -15,7 +15,7 @@ import { getSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { useQuoteEntry, useResolvedEntryValue } from "../../market-data/hooks";
 import { formatPercentRaw } from "../../utils/format";
 import { formatMarketPrice } from "../../utils/market-format";
-import { marketStateLabel, marketStateColor, getExtendedHoursInfo } from "../../utils/market-status";
+import { marketStateLabel, marketStateColor, getActiveQuoteDisplay } from "../../utils/market-status";
 import { VERSION } from "../../version";
 import { TITLEBAR_TRAFFIC_LIGHT_WIDTH } from "./titlebar-overlay";
 
@@ -141,13 +141,11 @@ export function Header() {
     return () => { clearInterval(id); };
   }, [appActive]);
 
-  const spyColor = spyQuote ? priceColor(spyQuote.change) : colors.headerText;
-  const spyText = spyQuote
-    ? `SPY ${formatMarketPrice(spyQuote.price, { assetCategory: "ETF" })} ${formatPercentRaw(spyQuote.changePercent)}`
+  const activeSpyQuote = getActiveQuoteDisplay(spyQuote);
+  const spyColor = activeSpyQuote ? priceColor(activeSpyQuote.change) : colors.headerText;
+  const spyText = activeSpyQuote
+    ? `SPY ${formatMarketPrice(activeSpyQuote.price, { assetCategory: "ETF" })} ${formatPercentRaw(activeSpyQuote.changePercent)}`
     : "SPY —";
-
-  // Extended hours info
-  const extText = getExtendedHoursInfo(spyQuote);
 
   // Market status
   const mktState = spyQuote?.marketState;
@@ -197,11 +195,6 @@ export function Header() {
         <Box paddingRight={1}>
           <Text fg={spyColor}>{spyText}</Text>
         </Box>
-        {extText ? (
-          <Box paddingRight={1}>
-            <Text fg={extText.color}>{extText.text}</Text>
-          </Box>
-        ) : null}
         <Text fg={colors.headerText}>{baseCurrency}</Text>
       </Box>
     );
@@ -229,14 +222,9 @@ export function Header() {
           <Text fg={mktColor}>{mktLabel}</Text>
         </Box>
       )}
-      <Box paddingRight={extText ? 0 : 1}>
+      <Box paddingRight={1}>
         <Text fg={spyColor}>{spyText}</Text>
       </Box>
-      {extText && (
-        <Box paddingRight={1} paddingLeft={1}>
-          <Text fg={extText.color}>{extText.text}</Text>
-        </Box>
-      )}
       <Box paddingRight={1}>
         <Text fg={colors.headerText}>
           {baseCurrency}

--- a/src/plugins/builtin/news-wire/news-table.tsx
+++ b/src/plugins/builtin/news-wire/news-table.tsx
@@ -223,7 +223,6 @@ export function NewsArticleStackView({
               symbols={tickers}
               width={column.width}
               fallbackColor={selectedColor ?? colors.textBright}
-              liveQuote={false}
             />
           ),
           color: selectedColor ?? colors.textBright,

--- a/src/utils/market-status.ts
+++ b/src/utils/market-status.ts
@@ -1,7 +1,5 @@
 import type { MarketState, Quote, QuoteFieldProvenance } from "../types/financials";
-import { colors, priceColor } from "../theme/colors";
-import { formatPercentRaw } from "./format";
-import { formatMarketPrice } from "./market-format";
+import { colors } from "../theme/colors";
 
 export interface ActiveQuoteDisplay {
   price: number;
@@ -88,20 +86,6 @@ export function quoteSourceLabel(
   if (provenance.providerId === "gloomberb-cloud") return "Cloud";
   if (provenance.providerId === "yahoo") return "Yahoo";
   return provenance.providerId;
-}
-
-/** Get extended hours price info (pre-market or after-hours) for display */
-export function getExtendedHoursInfo(quote: Quote | null | undefined): { text: string; color: string } | null {
-  if (!quote) return null;
-  if ((quote.marketState === "PRE" || quote.marketState === "PREPRE") && quote.preMarketPrice != null) {
-    const chg = quote.preMarketChangePercent ?? 0;
-    return { text: `Pre ${formatMarketPrice(quote.preMarketPrice)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
-  }
-  if ((quote.marketState === "POST" || quote.marketState === "POSTPOST") && quote.postMarketPrice != null) {
-    const chg = quote.postMarketChangePercent ?? 0;
-    return { text: `AH ${formatMarketPrice(quote.postMarketPrice)} ${formatPercentRaw(chg)}`, color: priceColor(chg) };
-  }
-  return null;
 }
 
 export function getActiveQuoteDisplay(quote: Quote | null | undefined): ActiveQuoteDisplay | null {


### PR DESCRIPTION
Uses active quote display so pre-market and after-hours header states show only the extended-session SPY value instead of a regular quote plus a separate extended quote.

Removes the now-unused extended-hours header helper.

Lets news article ticker badges use live quote values instead of forcing the static fallback.
