### PR TITLE
Clean command bar and shared UI plumbing

### DIFF
--- a/scripts/build-electrobun-view.ts
+++ b/scripts/build-electrobun-view.ts
@@ -1,93 +1,27 @@
-import { mkdir, readFile, rm, writeFile } from "fs/promises";
-import { join, relative } from "path";
-import { TITLEBAR_OVERLAY_HEIGHT_PX } from "../src/components/layout/titlebar-overlay";
+import { mkdir, rm } from "fs/promises";
+import { join } from "path";
+import {
+  electrobunViewPath,
+  writeElectrobunViewPage,
+} from "../src/renderers/electrobun/view/build-assets";
 
 const outdir = join(process.cwd(), "dist", "electrobun-view");
-const electrobunViewDir = join(process.cwd(), "src", "renderers", "electrobun", "view");
-
-interface ResolveArgs {
-  path: string;
-  importer?: string;
-}
-
-function aliasImport(args: ResolveArgs, sourceSuffix: string, target: string) {
-  if (args.path.endsWith(sourceSuffix)) {
-    return { path: join(electrobunViewDir, target) };
-  }
-  return undefined;
-}
-
-function aliasRelativeImport(args: ResolveArgs, importerSuffix: string, sourcePath: string, target: string) {
-  if (args.path === sourcePath && args.importer?.endsWith(importerSuffix)) {
-    return { path: join(electrobunViewDir, target) };
-  }
-  return undefined;
-}
 
 await rm(outdir, { recursive: true, force: true });
 await mkdir(outdir, { recursive: true });
 
-const result = await Bun.build({
-  entrypoints: [join(process.cwd(), "src", "renderers", "electrobun", "view", "main.tsx")],
+await writeElectrobunViewPage({
+  entrypoint: electrobunViewPath("main.tsx"),
   outdir,
-  target: "browser",
-  format: "esm",
-  splitting: false,
-  sourcemap: "external",
-  minify: true,
-  define: {
-    "process.env.NODE_ENV": "\"production\"",
-  },
-  plugins: [
-    {
-      name: "electrobun-renderer-native-bridges",
-      setup(build) {
-        build.onResolve({ filter: /.*/ }, (args) => (
-          aliasImport(args, "plugins/builtin/notes-files", "notes-files.ts")
-          ?? aliasImport(args, "notes-files", "notes-files.ts")
-          ?? aliasImport(args, "core/app-services", "app-services.ts")
-          ?? aliasImport(args, "kitty-support", "native-stubs/chart-kitty-support.ts")
-          ?? aliasImport(args, "native/kitty-support", "native-stubs/chart-kitty-support.ts")
-          ?? aliasRelativeImport(args, "components/chart/native/renderer-selection.ts", "./kitty-support", "native-stubs/chart-kitty-support.ts")
-          ?? aliasImport(args, "native/surface-manager", "native-stubs/chart-surface-manager.ts")
-          ?? aliasImport(args, "native/surface-sync", "native-stubs/chart-surface-sync.ts")
-        ));
-      },
-    },
+  pluginName: "electrobun-renderer-native-bridges",
+  extraAliasRules: [
+    ["core/app-services", "app-services.ts"],
   ],
-});
-
-if (!result.success) {
-  for (const log of result.logs) {
-    console.error(log);
-  }
-  process.exitCode = 1;
-  throw new Error("Failed to build Electrobun view assets");
-}
-
-const entry = result.outputs.find((output) => output.kind === "entry-point" && output.path.endsWith(".js"));
-if (!entry) {
-  throw new Error("Electrobun view build did not produce a JavaScript entrypoint");
-}
-
-const entrySrc = `./${relative(outdir, entry.path).replaceAll("\\", "/")}`;
-const stylesheet = (await readFile(join(electrobunViewDir, "styles.css"), "utf8"))
-  .replaceAll("__TITLEBAR_OVERLAY_HEIGHT_PX__", String(TITLEBAR_OVERLAY_HEIGHT_PX));
-
-await writeFile(join(outdir, "index.html"), renderElectrobunViewHtml(entrySrc, stylesheet));
-
-function renderElectrobunViewHtml(entrySrc: string, stylesheet: string): string {
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gloomberb</title>
-    <style>${stylesheet}</style>
-  </head>
-  <body style="margin:0;background:#000;">
-    <div id="root"><div class="gloom-loading">Loading Gloomberb...</div></div>
-    <script>
+  failureMessage: "Failed to build Electrobun view assets",
+  missingEntryMessage: "Electrobun view build did not produce a JavaScript entrypoint",
+  title: "Gloomberb",
+  loadingText: "Loading Gloomberb...",
+  bootstrapScript: `
       const bootstrapFatalHtml = [
         '<div class="gloom-fatal">',
         '<h1>Gloomberb failed to start</h1>',
@@ -129,9 +63,5 @@ function renderElectrobunViewHtml(entrySrc: string, stylesheet: string): string 
       ));
       window.addEventListener("unhandledrejection", (event) => renderBootstrapError(event.reason, "", "unhandledrejection"));
       document.getElementById("root").innerHTML = '<div class="gloom-loading">Booting Gloomberb renderer...</div>';
-    </script>
-    <script type="module" src="${entrySrc}"></script>
-  </body>
-</html>
-`;
-}
+`,
+});

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -419,7 +419,7 @@ function AppInner({
     });
   }, [buildPaneBinding, state]);
 
-  const performRefreshTicker = useCallback(async (symbol: string, exchange = "", tickerOverride?: TickerRecord | null) => {
+  const performRefreshTicker = useCallback(async (symbol: string, tickerOverride?: TickerRecord | null) => {
     if (refreshInFlight.has(symbol)) return;
     refreshInFlight.add(symbol);
     dispatch({ type: "SET_REFRESHING", symbol, refreshing: true });
@@ -447,7 +447,7 @@ function AppInner({
     }
   }, [dispatch, marketData, pluginRegistry.events, state.config.baseCurrency, state.tickers]);
 
-  const performRefreshQuote = useCallback(async (symbol: string, exchange = "", tickerOverride?: TickerRecord | null) => {
+  const performRefreshQuote = useCallback(async (symbol: string, tickerOverride?: TickerRecord | null) => {
     if (refreshInFlight.has(symbol) || quoteRefreshInFlight.has(symbol)) return;
     quoteRefreshInFlight.add(symbol);
     try {
@@ -490,7 +490,7 @@ function AppInner({
     appLog.info("app activity propagated", { active: appActive });
   }, [appActive]);
 
-  const refreshTicker = useCallback((symbol: string, exchange = "", tickerOverride?: TickerRecord | null, priority = 2) => {
+  const refreshTicker = useCallback((symbol: string, _exchange = "", tickerOverride?: TickerRecord | null, priority = 2) => {
     if (refreshInFlight.has(symbol) || pendingRefreshesRef.current.financials.has(symbol)) return;
     pendingRefreshesRef.current.financials.add(symbol);
     refreshQueueRef.current.queue.enqueue({
@@ -498,7 +498,7 @@ function AppInner({
       priority,
       run: async () => {
         try {
-          await performRefreshTicker(symbol, exchange, tickerOverride ?? null);
+          await performRefreshTicker(symbol, tickerOverride ?? null);
         } finally {
           pendingRefreshesRef.current.financials.delete(symbol);
         }
@@ -506,7 +506,7 @@ function AppInner({
     });
   }, [performRefreshTicker]);
 
-  const refreshQuote = useCallback((symbol: string, exchange = "", tickerOverride?: TickerRecord | null, priority = 2) => {
+  const refreshQuote = useCallback((symbol: string, _exchange = "", tickerOverride?: TickerRecord | null, priority = 2) => {
     if (
       refreshInFlight.has(symbol)
       || quoteRefreshInFlight.has(symbol)
@@ -522,7 +522,7 @@ function AppInner({
       run: async () => {
         try {
           if (pendingRefreshesRef.current.financials.has(symbol) || refreshInFlight.has(symbol)) return;
-          await performRefreshQuote(symbol, exchange, tickerOverride ?? null);
+          await performRefreshQuote(symbol, tickerOverride ?? null);
         } finally {
           pendingRefreshesRef.current.quotes.delete(symbol);
         }

--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -1,12 +1,15 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
-import { join, relative } from "path";
+import { join } from "path";
 import { pathToFileURL } from "url";
-import { TITLEBAR_OVERLAY_HEIGHT_PX } from "../components/layout/titlebar-overlay";
 import type { AppConfig } from "../types/config";
 import type { TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
 import type { PaneRuntimeState } from "../core/state/app-state";
+import {
+  electrobunViewPath,
+  writeElectrobunViewPage,
+} from "../renderers/electrobun/view/build-assets";
 
 export interface DesktopPaneShotPayload {
   config: AppConfig;
@@ -59,74 +62,20 @@ export async function renderDesktopPaneScreenshot(
   }
 }
 
-function aliasImport(args: { path: string }, sourceSuffix: string, target: string) {
-  const electrobunViewDir = join(process.cwd(), "src", "renderers", "electrobun", "view");
-  if (args.path.endsWith(sourceSuffix)) {
-    return { path: join(electrobunViewDir, target) };
-  }
-  return undefined;
-}
-
 async function buildShotPage(outdir: string, payload: DesktopPaneShotPayload): Promise<string> {
-  const entrypoint = join(process.cwd(), "src", "renderers", "electrobun", "view", "cli-pane-shot-entry.tsx");
-  const result = await Bun.build({
-    entrypoints: [entrypoint],
-    outdir,
-    target: "browser",
-    format: "esm",
-    splitting: false,
-    sourcemap: "external",
-    minify: true,
-    define: {
-      "process.env.NODE_ENV": "\"production\"",
-    },
-    plugins: [
-      {
-        name: "desktop-pane-shot-native-bridges",
-        setup(build) {
-          build.onResolve({ filter: /.*/ }, (args) => (
-            aliasImport(args, "plugins/builtin/notes-files", "notes-files.ts")
-            ?? aliasImport(args, "notes-files", "notes-files.ts")
-            ?? aliasImport(args, "backend-rpc", "native-stubs/backend-rpc.ts")
-            ?? aliasImport(args, "native/kitty-support", "native-stubs/chart-kitty-support.ts")
-            ?? aliasImport(args, "native/surface-manager", "native-stubs/chart-surface-manager.ts")
-            ?? aliasImport(args, "native/surface-sync", "native-stubs/chart-surface-sync.ts")
-          ));
-        },
-      },
-    ],
-  });
-
-  if (!result.success) {
-    const details = result.logs.map((log) => log.message).join("\n");
-    throw new Error(`Failed to build desktop pane screenshot renderer.\n${details}`);
-  }
-
-  const entry = result.outputs.find((output) => output.kind === "entry-point" && output.path.endsWith(".js"));
-  if (!entry) throw new Error("Desktop pane screenshot build did not produce a JavaScript entrypoint.");
-
-  const electrobunViewDir = join(process.cwd(), "src", "renderers", "electrobun", "view");
-  const stylesheet = (await readFile(join(electrobunViewDir, "styles.css"), "utf8"))
-    .replaceAll("__TITLEBAR_OVERLAY_HEIGHT_PX__", String(TITLEBAR_OVERLAY_HEIGHT_PX));
-  const entrySrc = `./${relative(outdir, entry.path).replaceAll("\\", "/")}`;
-  const htmlPath = join(outdir, "index.html");
-  await writeFile(htmlPath, renderShotHtml(entrySrc, stylesheet, payload));
-  return htmlPath;
-}
-
-function renderShotHtml(entrySrc: string, stylesheet: string, payload: DesktopPaneShotPayload): string {
   const payloadJson = JSON.stringify(payload).replace(/</g, "\\u003c");
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gloomberb Pane Shot</title>
-    <style>${stylesheet}</style>
-  </head>
-  <body style="margin:0;background:#000;">
-    <div id="root"><div class="gloom-loading">Rendering pane...</div></div>
-    <script>
+  return writeElectrobunViewPage({
+    entrypoint: electrobunViewPath("cli-pane-shot-entry.tsx"),
+    outdir,
+    pluginName: "desktop-pane-shot-native-bridges",
+    extraAliasRules: [
+      ["backend-rpc", "native-stubs/backend-rpc.ts"],
+    ],
+    failureMessage: "Failed to build desktop pane screenshot renderer.",
+    missingEntryMessage: "Desktop pane screenshot build did not produce a JavaScript entrypoint.",
+    title: "Gloomberb Pane Shot",
+    loadingText: "Rendering pane...",
+    bootstrapScript: `
       window.__GLOOM_CLI_SHOT_PAYLOAD__ = ${payloadJson};
       window.addEventListener("error", (event) => {
         window.__GLOOM_CLI_SHOT_ERROR__ = event.error && event.error.stack ? event.error.stack : String(event.error || event.message);
@@ -134,10 +83,8 @@ function renderShotHtml(entrySrc: string, stylesheet: string, payload: DesktopPa
       window.addEventListener("unhandledrejection", (event) => {
         window.__GLOOM_CLI_SHOT_ERROR__ = event.reason && event.reason.stack ? event.reason.stack : String(event.reason);
       });
-    </script>
-    <script type="module" src="${entrySrc}"></script>
-  </body>
-</html>`;
+`,
+  });
 }
 
 async function findChromeExecutable(): Promise<string> {

--- a/src/cli/pane-functions.ts
+++ b/src/cli/pane-functions.ts
@@ -17,7 +17,6 @@ import {
   formatFinancialHeader,
   FINANCIAL_SUB_TABS,
   resolveFinancialPeriodOption,
-  resolveFinancialSubTabKey,
 } from "../plugins/builtin/ticker-detail/financials-model";
 import { renderDesktopPaneScreenshot, type DesktopPaneShotPayload } from "./desktop-pane-shot";
 import type { PaneRuntimeState } from "../core/state/app-state";

--- a/src/components/chart/chart.test.ts
+++ b/src/components/chart/chart.test.ts
@@ -28,14 +28,6 @@ const chartFixture: PricePoint[] = [
   { date: new Date("2024-01-05"), open: 9, high: 11, low: 8.5, close: 10.5, volume: 160 },
 ];
 
-function buildDenseHistory(length: number): PricePoint[] {
-  return Array.from({ length }, (_, index) => ({
-    date: new Date(Date.UTC(2024, 0, index + 1)),
-    close: 100 + index,
-    volume: 1_000 + index,
-  }));
-}
-
 const palette = resolveChartPalette({
   bg: "#000000",
   border: "#333333",

--- a/src/components/chart/comparison-chart-data.ts
+++ b/src/components/chart/comparison-chart-data.ts
@@ -4,7 +4,6 @@ import type {
   ComparisonChartRenderMode,
   ComparisonChartSeries,
   ComparisonChartViewState,
-  TimeRange,
 } from "./chart-types";
 import { getVisiblePointCount, resolveAnchoredChartZoom } from "./chart-viewport";
 

--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -1,10 +1,10 @@
-import { Box, Input, ScrollBox, Text, Textarea, useUiCapabilities } from "../../ui";
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, useUiCapabilities } from "../../ui";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { TextAttributes, type InputRenderable, type ScrollBoxRenderable, type TextareaRenderable } from "../../ui";
 import { useShortcut, useViewport } from "../../react/input";
-import { Button, NumberField, Spinner, TextField } from "../ui";
-import { NativeSelect, openNativeSelect, type NativeSelectElement } from "../ui/native-select";
+import { Button } from "../ui";
+import { openNativeSelect, type NativeSelectElement } from "../ui/native-select";
 import {
   moveMultiSelectValue,
   toggleMultiSelectValue,
@@ -23,7 +23,6 @@ import {
   commandBarSelectedText,
   commandBarSubtleText,
   commandBarText,
-  colors,
   getCurrentThemeId,
   previewTheme,
 } from "../../theme/colors";
@@ -43,7 +42,7 @@ import { ThemePicker, type ThemePickerHandle } from "./theme-picker";
 import { exportConfig, importConfig, resetAllData } from "../../data/config-store";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerRepository } from "../../data/ticker-repository";
-import type { PluginRegistry, WindowEditMode } from "../../plugins/registry";
+import type { PluginRegistry } from "../../plugins/registry";
 import type { TickerRecord } from "../../types/ticker";
 import type { Quote } from "../../types/financials";
 import type {
@@ -54,8 +53,6 @@ import type {
   PaneTemplateDef,
 } from "../../types/plugin";
 import {
-  DEFAULT_LAYOUT,
-  cloneLayout,
   createPaneInstance,
   findPaneInstance,
   findPrimaryPaneInstance,
@@ -69,13 +66,6 @@ import {
 import {
   addPaneFloating,
   addPaneToLayout,
-  dockPane,
-  floatPane,
-  getDockedPaneIds,
-  getLayoutPreview,
-  gridlockAllPanes,
-  isPaneDocked,
-  removePane,
   swapPanes,
   type LayoutBounds,
 } from "../../plugins/pane-manager";
@@ -84,7 +74,6 @@ import { resolveAppHeaderHeightCells } from "../layout/shell";
 import { CHART_RENDERER_PREFERENCES } from "../chart/chart-types";
 import {
   getEmptyState,
-  getRowPresentation,
   resolveCommandBarMode,
   truncateText,
 } from "./view-model";
@@ -92,10 +81,15 @@ import {
   buildListRows,
   buildNativeListRows,
   orderListResults,
-  type CommandBarListRow,
   type ListScreenState,
   type ResultItem,
 } from "./list-model";
+import {
+  CommandBarListBody,
+  CommandBarListHeader,
+  type CommandBarListScrollEvent,
+} from "./list-view";
+import { CommandBarWorkflowBody } from "./workflow-body";
 import { CommandBarConfirmBody } from "./confirm-body";
 import {
   createLocalTickerSearchCandidates,
@@ -118,7 +112,6 @@ import type {
 } from "./workflow-types";
 import {
   estimateWorkflowBodyRows,
-  getWorkflowFieldDescription,
   toMultiSelectOptions,
 } from "./workflow-view";
 import { parseRootShortcutIntent } from "./root-shortcuts";
@@ -145,7 +138,6 @@ import {
   getScreenFooterRight,
   getVisibleWorkflowFields,
   isCollectionCommand,
-  isRootParsedCommand,
   isRouteCommandId,
   isWorkflowTextField,
   looksDestructiveCommand,
@@ -155,8 +147,12 @@ import {
   slugifyName,
   summarizeError,
   summarizePaneSettingValue,
-  summarizeWorkflowFieldValue,
 } from "./helpers";
+import {
+  buildLayoutResultItems,
+  buildWindowModeResultItems,
+  parseWindowModeCommandArg,
+} from "./layout-items";
 import {
   buildAddToPortfolioWorkflow,
   buildSetPortfolioPositionWorkflow,
@@ -182,37 +178,6 @@ interface CommandBarProps {
 
 type WorkflowStringValues = Record<string, string>;
 
-const WINDOW_MODE_COMMAND_OPTIONS: Array<{
-  mode: WindowEditMode;
-  label: string;
-  detail: string;
-  query: string;
-  searchText: string;
-}> = [
-  {
-    mode: "move",
-    label: "Move Window",
-    detail: "Enter window edit mode with Tab cycling windows",
-    query: "WIN move",
-    searchText: "window mode move reposition",
-  },
-  {
-    mode: "resize",
-    label: "Resize Window",
-    detail: "Enter window edit mode with Tab cycling resize handles",
-    query: "WIN resize",
-    searchText: "window mode resize size corner divider",
-  },
-];
-
-function parseWindowModeCommandArg(arg: string): WindowEditMode | null {
-  const normalized = arg.trim().toLowerCase();
-  if (!normalized) return null;
-  if ("move".startsWith(normalized) || normalized === "m") return "move";
-  if ("resize".startsWith(normalized) || normalized === "r") return "resize";
-  return null;
-}
-
 const commandBarLog = debugLog.createLogger("command-bar");
 const COMMAND_BAR_OVERLAY_Z_INDEX = 2_147_483_646;
 const COMMAND_BAR_PANEL_Z_INDEX = 2_147_483_647;
@@ -220,6 +185,18 @@ const NATIVE_COMMAND_BAR_PADDING_X_PX = 14;
 const NATIVE_COMMAND_BAR_PADDING_Y_PX = 14;
 const NATIVE_COMMAND_BAR_SHADOW = "0 10px 18px color-mix(in srgb, var(--gloom-bg) 34%, transparent)";
 const QUICK_LOOK_TICKER_SEARCH_OPTIONS = { includeOptionContracts: false } as const;
+
+function buildTickerSearchCacheKey(
+  query: string,
+  brokerId?: string | null,
+  brokerInstanceId?: string | null,
+): string {
+  return [query.trim().toUpperCase(), brokerId || "", brokerInstanceId || ""].join("|");
+}
+
+function createQuickLookTickerCandidates(tickers: Iterable<TickerRecord>): TickerSearchCandidate[] {
+  return createLocalTickerSearchCandidates(tickers, new Map(), QUICK_LOOK_TICKER_SEARCH_OPTIONS);
+}
 
 function normalizeCommandTickerSearchText(value: string): string {
   return value.trim().toUpperCase().replace(/[^A-Z0-9]+/g, "");
@@ -340,310 +317,6 @@ function getVisibleMultiSelectPickerOptions(
     };
   });
 }
-
-type CommandBarListScrollEvent = {
-  stopPropagation: () => void;
-  preventDefault: () => void;
-  scroll?: { direction?: string; delta?: number };
-};
-
-interface CommandBarListHeaderProps {
-  kind: ListScreenState["kind"];
-  query: string;
-  queryDisplayWidth: number;
-  nativePaneChrome: boolean;
-  inputBg: string;
-  paletteBg: string;
-  paletteText: string;
-  paletteSubtleText: string;
-  cursorColor: string;
-  contentPadding: number;
-  rootGhostSuffix: string | null;
-  rootQueryLength: number;
-  rootShortcutFeedback: string | null;
-  onQueryChange: (query: string) => void;
-}
-
-const CommandBarListHeader = memo(function CommandBarListHeader({
-  kind,
-  query,
-  queryDisplayWidth,
-  nativePaneChrome,
-  inputBg,
-  paletteBg,
-  paletteText,
-  paletteSubtleText,
-  cursorColor,
-  contentPadding,
-  rootGhostSuffix,
-  rootQueryLength,
-  rootShortcutFeedback,
-  onQueryChange,
-}: CommandBarListHeaderProps) {
-  return (
-    <>
-      <Box height={1} paddingX={contentPadding}>
-        <Box
-          width={queryDisplayWidth}
-          height={1}
-          position="relative"
-          backgroundColor={nativePaneChrome ? undefined : inputBg}
-          style={nativePaneChrome ? undefined : {
-            overflow: "hidden",
-          }}
-        >
-          <Input
-            value={query}
-            onInput={onQueryChange}
-            onChange={onQueryChange}
-            placeholder={kind === "root" ? "Search" : "Filter"}
-            focused
-            width={nativePaneChrome ? "100%" : queryDisplayWidth}
-            backgroundColor={nativePaneChrome ? "transparent" : paletteBg}
-            focusedBackgroundColor={nativePaneChrome ? "transparent" : paletteBg}
-            textColor={paletteText}
-            focusedTextColor={paletteText}
-            placeholderColor={paletteSubtleText}
-            cursorColor={cursorColor}
-          />
-          {kind === "root" && rootGhostSuffix && (
-            <Box
-              position="absolute"
-              top={0}
-              left={Math.max(0, Math.min(rootQueryLength, queryDisplayWidth - 1))}
-              width={Math.max(0, queryDisplayWidth - Math.min(rootQueryLength, queryDisplayWidth - 1))}
-              height={1}
-            >
-              <Text fg={paletteSubtleText}>
-                {truncateText(
-                  rootGhostSuffix,
-                  Math.max(0, queryDisplayWidth - Math.min(rootQueryLength, queryDisplayWidth - 1)),
-                )}
-              </Text>
-            </Box>
-          )}
-        </Box>
-      </Box>
-      <Box height={1} paddingX={contentPadding}>
-        {kind === "root" && rootShortcutFeedback
-          ? (
-            <Text fg={paletteSubtleText}>
-              {truncateText(rootShortcutFeedback, queryDisplayWidth)}
-            </Text>
-          )
-          : null}
-      </Box>
-    </>
-  );
-});
-
-interface CommandBarListItemRowProps {
-  item: ResultItem;
-  globalIdx: number;
-  isSelected: boolean;
-  isHovered: boolean;
-  contentPadding: number;
-  labelWidth: number;
-  trailingWidth: number;
-  nativePaneChrome: boolean;
-  paletteBg: string;
-  paletteHoverBg: string;
-  paletteSelectedBg: string;
-  paletteSelectedText: string;
-  paletteSubtleText: string;
-  paletteText: string;
-  panelBg: string;
-  onHoverIndex: (index: number | null) => void;
-  onListScroll: (event: CommandBarListScrollEvent) => void;
-  onRowMouseDown: (event: any, item: ResultItem, globalIdx: number) => void;
-}
-
-const CommandBarListItemRow = memo(function CommandBarListItemRow({
-  item,
-  globalIdx,
-  isSelected,
-  isHovered,
-  contentPadding,
-  labelWidth,
-  trailingWidth,
-  nativePaneChrome,
-  paletteBg,
-  paletteHoverBg,
-  paletteSelectedBg,
-  paletteSelectedText,
-  paletteSubtleText,
-  paletteText,
-  panelBg,
-  onHoverIndex,
-  onListScroll,
-  onRowMouseDown,
-}: CommandBarListItemRowProps) {
-  const presentation = getRowPresentation(item, isSelected, trailingWidth > 0);
-  const label = truncateText(presentation.label, labelWidth);
-  const trailing = truncateText(presentation.trailing, trailingWidth);
-
-  return (
-    <Box
-      key={item.id}
-      flexDirection="row"
-      height={1}
-      paddingX={contentPadding}
-      backgroundColor={isSelected
-        ? paletteSelectedBg
-        : isHovered
-          ? paletteHoverBg
-          : (nativePaneChrome ? panelBg : paletteBg)}
-      onMouseMove={() => onHoverIndex(globalIdx)}
-      onMouseOut={() => onHoverIndex(null)}
-      {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}
-      onMouseDown={(event: any) => onRowMouseDown(event, item, globalIdx)}
-      data-command-bar-row-selected={nativePaneChrome && isSelected ? "true" : undefined}
-      style={nativePaneChrome ? { borderRadius: 6 } : undefined}
-    >
-      <Box width={labelWidth}>
-        <Text fg={isSelected ? paletteSelectedText : presentation.primaryMuted ? paletteSubtleText : paletteText}>
-          {label}
-        </Text>
-      </Box>
-      <Box width={trailingWidth}>
-        <Text fg={isSelected ? paletteSelectedText : paletteSubtleText}>{trailing}</Text>
-      </Box>
-    </Box>
-  );
-});
-
-interface CommandBarListBodyProps {
-  visibleListState: ListScreenState;
-  nativeListRows: CommandBarListRow[];
-  listBodyHeight: number;
-  contentPadding: number;
-  labelWidth: number;
-  nativePaneChrome: boolean;
-  nativeListScrollRef: RefObject<ScrollBoxRenderable | null>;
-  paletteBg: string;
-  paletteHeadingText: string;
-  paletteHoverBg: string;
-  paletteSelectedBg: string;
-  paletteSelectedText: string;
-  paletteSubtleText: string;
-  paletteText: string;
-  panelBg: string;
-  queryDisplayWidth: number;
-  trailingWidth: number;
-  onHoverIndex: (index: number | null) => void;
-  onListScroll: (event: CommandBarListScrollEvent) => void;
-  onRowMouseDown: (event: any, item: ResultItem, globalIdx: number) => void;
-}
-
-const CommandBarListBody = memo(function CommandBarListBody({
-  visibleListState,
-  nativeListRows,
-  listBodyHeight,
-  contentPadding,
-  labelWidth,
-  nativePaneChrome,
-  nativeListScrollRef,
-  paletteBg,
-  paletteHeadingText,
-  paletteHoverBg,
-  paletteSelectedBg,
-  paletteSelectedText,
-  paletteSubtleText,
-  paletteText,
-  panelBg,
-  queryDisplayWidth,
-  trailingWidth,
-  onHoverIndex,
-  onListScroll,
-  onRowMouseDown,
-}: CommandBarListBodyProps) {
-  const visibleRows = useMemo(() => {
-    const rows = nativeListRows;
-    if (nativePaneChrome) return rows;
-    const paddedRows = [...rows];
-    while (paddedRows.length < listBodyHeight) {
-      paddedRows.push({ kind: "filler", id: `filler:${paddedRows.length}` });
-    }
-    return paddedRows;
-  }, [
-    listBodyHeight,
-    nativeListRows,
-    nativePaneChrome,
-  ]);
-
-  const renderedRows = (
-    <>
-      {visibleRows.map((row) => {
-        if (row.kind === "filler" || row.kind === "spacer") {
-          return <Box key={row.id} height={1} />;
-        }
-        if (row.kind === "spinner") {
-          return (
-            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
-              <Spinner label={row.label} />
-            </Box>
-          );
-        }
-        if (row.kind === "message") {
-          return (
-            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
-              <Text fg={paletteText}>{truncateText(row.label, queryDisplayWidth)}</Text>
-            </Box>
-          );
-        }
-        if (row.kind === "heading") {
-          return (
-            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
-              <Text attributes={TextAttributes.BOLD} fg={paletteHeadingText}>
-                {truncateText(row.label, queryDisplayWidth)}
-              </Text>
-            </Box>
-          );
-        }
-
-        const isSelected = row.globalIdx === visibleListState.selectedIdx;
-        const isHovered = row.globalIdx === visibleListState.hoveredIdx && !isSelected;
-        const itemRowKey = `item:${row.globalIdx}:${row.item.id}:${row.item.category}:${row.item.label}:${row.item.right || ""}`;
-        return (
-          <CommandBarListItemRow
-            key={itemRowKey}
-            item={row.item}
-            globalIdx={row.globalIdx}
-            isSelected={isSelected}
-            isHovered={isHovered}
-            contentPadding={contentPadding}
-            labelWidth={labelWidth}
-            trailingWidth={trailingWidth}
-            nativePaneChrome={nativePaneChrome}
-            paletteBg={paletteBg}
-            paletteHoverBg={paletteHoverBg}
-            paletteSelectedBg={paletteSelectedBg}
-            paletteSelectedText={paletteSelectedText}
-            paletteSubtleText={paletteSubtleText}
-            paletteText={paletteText}
-            panelBg={panelBg}
-            onHoverIndex={onHoverIndex}
-            onListScroll={onListScroll}
-            onRowMouseDown={onRowMouseDown}
-          />
-        );
-      })}
-    </>
-  );
-
-  return (
-    <ScrollBox
-      ref={nativeListScrollRef}
-      flexDirection="column"
-      height={listBodyHeight}
-      scrollY
-      focusable={false}
-      {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}
-    >
-      {renderedRows}
-    </ScrollBox>
-  );
-});
 
 export function CommandBar({
   dataProvider,
@@ -851,7 +524,7 @@ export function CommandBar({
     }
 
     setRouteStack((current) => current.slice(0, -1));
-  }, [clearThemePreview, closeAll, currentRoute, routeStack.length, setRootQuery]);
+  }, [closeAll, currentRoute, routeStack.length, setRootQuery]);
 
   const dismissCommandBar = useCallback(() => {
     if (currentRoute) {
@@ -1491,7 +1164,7 @@ export function CommandBar({
       default:
         return;
       }
-  }, [activeCollectionId, activeTickerData, buildBrokerWorkflow, notify, openWorkflowRoute, pluginRegistry, state.config]);
+  }, [activeCollectionId, activeTickerData, buildBrokerWorkflow, notify, openWorkflowRoute, state.config]);
 
   const buildSharedWorkflowDeps = useCallback(() => ({
     dataProvider,
@@ -1563,285 +1236,39 @@ export function CommandBar({
     });
   }, [dispatch, persistConfig, pluginRegistry, state.config]);
 
-  const buildWindowModeItems = useCallback((arg: string): ResultItem[] => {
-    const normalized = arg.trim().toLowerCase();
-    const exactMode = parseWindowModeCommandArg(arg);
-    const options = normalized
-      ? WINDOW_MODE_COMMAND_OPTIONS.filter((option) => (
-        option.mode === exactMode
-        || option.mode.startsWith(normalized)
-        || fuzzyFilter([option], normalized, (item) => `${item.label} ${item.detail} ${item.searchText}`).length > 0
-      ))
-      : WINDOW_MODE_COMMAND_OPTIONS;
-
-    const visibleOptions = options.length > 0 ? options : WINDOW_MODE_COMMAND_OPTIONS;
-    return visibleOptions.map((option) => ({
-      id: `window-mode:${option.mode}`,
-      label: option.label,
-      detail: option.detail,
-      category: "Config",
-      kind: "action" as const,
-      right: option.query,
-      shortcutQuery: option.query,
-      action: () => {
-        closeAll({ revertThemePreview: false });
-        pluginRegistry.openWindowMode(state.focusedPaneId ?? undefined, option.mode);
-      },
-    }));
-  }, [closeAll, pluginRegistry, state.focusedPaneId]);
+  const buildWindowModeItems = useCallback((arg: string): ResultItem[] => buildWindowModeResultItems({
+    arg,
+    closeAll,
+    focusedPaneId: state.focusedPaneId,
+    pluginRegistry,
+  }), [closeAll, pluginRegistry, state.focusedPaneId]);
 
   const buildLayoutItems = useCallback((
     query: string,
     options?: { confirmDangerousActions?: boolean },
-  ): ResultItem[] => {
-    const currentLayout = state.config.layout;
-    const focusedPane = state.focusedPaneId ? findPaneInstance(currentLayout, state.focusedPaneId) : null;
-    const focusedPaneDef = focusedPane ? pluginRegistry.panes.get(focusedPane.paneId) : null;
-    const dockedPaneIds = getDockedPaneIds(currentLayout);
-    const layoutHistory = state.layoutHistory[state.config.activeLayoutIndex];
-    const layoutItems: ResultItem[] = [];
-
-    if (focusedPane && focusedPaneDef) {
-      const focusedFloating = currentLayout.floating.find((entry) => entry.instanceId === focusedPane.instanceId);
-      layoutItems.push({
-        id: "layout-toggle-mode",
-        label: focusedFloating ? "Dock Pane" : "Float Pane",
-        detail: focusedFloating ? "Return the focused window to the layout" : "Detach the focused pane into a floating window",
-        category: "Focused Pane",
-        kind: "action",
-        action: () => {
-          const { width, height } = pluginRegistry.getTermSizeFn();
-          const nextLayout = focusedFloating
-            ? dockPane(currentLayout, focusedPane.instanceId)
-            : floatPane(currentLayout, focusedPane.instanceId, width, height, focusedPaneDef);
-          persistLayoutChange(nextLayout);
-          closeAll({ revertThemePreview: false });
-        },
-      });
-
-      layoutItems.push(...WINDOW_MODE_COMMAND_OPTIONS.map((option) => ({
-        id: `layout-window-mode:${option.mode}`,
-        label: option.label,
-        detail: option.detail,
-        category: "Focused Pane",
-        kind: "action" as const,
-        right: option.query,
-        action: () => {
-          closeAll({ revertThemePreview: false });
-          pluginRegistry.openWindowMode(focusedPane.instanceId, option.mode);
-        },
-      })));
-
-      layoutItems.push({
-        id: "layout-swap",
-        label: "Swap With…",
-        detail: dockedPaneIds.length + currentLayout.floating.length > 1
-          ? "Choose another pane to swap positions"
-          : "Need at least two panes",
-        category: "Focused Pane",
-        kind: "action",
-        disabled: dockedPaneIds.length + currentLayout.floating.length <= 1,
-        action: () => {
-          const pickerOptions = [
-            ...dockedPaneIds,
-            ...currentLayout.floating.map((entry) => entry.instanceId),
-          ]
-            .filter((paneId) => paneId !== focusedPane.instanceId)
-            .map((paneId) => {
-              const instance = findPaneInstance(currentLayout, paneId)!;
-              const isFloating = currentLayout.floating.some((entry) => entry.instanceId === paneId);
-              return {
-                id: paneId,
-                label: instance.title || pluginRegistry.panes.get(instance.paneId)?.name || instance.paneId,
-                detail: isFloating ? "Floating window" : "Docked pane",
-                description: isFloating ? "Floating window" : "Docked pane",
-              };
-            });
-          if (pickerOptions.length === 0) return;
-          pushRoute({
-            kind: "picker",
-            pickerId: "layout-swap",
-            title: "Swap With…",
-            query: "",
-            selectedIdx: 0,
-            hoveredIdx: null,
-            options: pickerOptions,
-            payload: { sourcePaneId: focusedPane.instanceId },
-          });
-        },
-      });
-
-      layoutItems.push({
-        id: "layout-duplicate",
-        label: "Duplicate Pane",
-        detail: "Create another instance next to the focused pane",
-        category: "Focused Pane",
-        kind: "action",
-        action: () => {
-          duplicatePane(focusedPane.instanceId);
-          closeAll({ revertThemePreview: false });
-        },
-      });
-
-      layoutItems.push({
-        id: "layout-close-pane",
-        label: "Close Pane",
-        detail: "Remove the focused pane from the layout",
-        category: "Focused Pane",
-        kind: "action",
-        action: options?.confirmDangerousActions
-          ? () => {
-            openInlineConfirm({
-              confirmId: "layout-close-pane",
-              title: "Close Pane",
-              body: [`Close "${focusedPane.title || focusedPaneDef.name || focusedPane.instanceId}"?`],
-              confirmLabel: "Close Pane",
-              cancelLabel: "Back",
-              tone: "danger",
-              onConfirm: () => {
-                persistLayoutChange(removePane(currentLayout, focusedPane.instanceId));
-              },
-            });
-          }
-          : () => {
-            persistLayoutChange(removePane(currentLayout, focusedPane.instanceId));
-            closeAll({ revertThemePreview: false });
-          },
-      });
-    } else {
-      layoutItems.push({
-        id: "layout-no-focused-pane",
-        label: "No focused pane",
-        detail: "Focus a pane to show pane-specific layout actions",
-        category: "Focused Pane",
-        kind: "info",
-        action: () => {},
-      });
-    }
-
-    layoutItems.push({
-      id: "layout-undo",
-      label: "Undo Layout Change",
-      detail: (layoutHistory?.past.length ?? 0) > 0 ? "Restore the previous layout state" : "No previous layout state",
-      category: "Current Layout",
-      kind: "action",
-      disabled: (layoutHistory?.past.length ?? 0) === 0,
-      action: () => {
-        if ((layoutHistory?.past.length ?? 0) === 0) return;
-        dispatch({ type: "UNDO_LAYOUT" });
-        closeAll({ revertThemePreview: false });
-      },
-    });
-    layoutItems.push({
-      id: "layout-redo",
-      label: "Redo Layout Change",
-      detail: (layoutHistory?.future.length ?? 0) > 0 ? "Reapply the next layout state" : "No later layout state",
-      category: "Current Layout",
-      kind: "action",
-      disabled: (layoutHistory?.future.length ?? 0) === 0,
-      action: () => {
-        if ((layoutHistory?.future.length ?? 0) === 0) return;
-        dispatch({ type: "REDO_LAYOUT" });
-        closeAll({ revertThemePreview: false });
-      },
-    });
-    layoutItems.push({
-      id: "layout-reset",
-      label: "Reset Current Layout",
-      detail: "Restore the default two-pane layout",
-      category: "Current Layout",
-      kind: "action",
-      action: options?.confirmDangerousActions
-        ? () => {
-          openInlineConfirm({
-            confirmId: "layout-reset",
-            title: "Reset Current Layout",
-            body: ["Reset the current layout to the default two-pane arrangement?"],
-            confirmLabel: "Reset Layout",
-            cancelLabel: "Back",
-            tone: "danger",
-            onConfirm: () => {
-              persistLayoutChange(cloneLayout(DEFAULT_LAYOUT));
-            },
-          });
-        }
-        : () => {
-          persistLayoutChange(cloneLayout(DEFAULT_LAYOUT));
-          closeAll({ revertThemePreview: false });
-        },
-    });
-    layoutItems.push({
-      id: "layout-gridlock",
-      label: "Gridlock All Windows",
-      detail: currentLayout.floating.length > 0
-        ? "Infer a tiled layout from the current window positions"
-        : "Retile all panes from their current arrangement",
-      category: "Current Layout",
-      kind: "action",
-      action: () => {
-        const { width, height } = pluginRegistry.getTermSizeFn();
-        persistLayoutChange(gridlockAllPanes(currentLayout, { x: 0, y: 0, width, height }));
-        notifyGridlockRevert();
-        closeAll({ revertThemePreview: false });
-      },
-    });
-    layoutItems.push({
-      id: "layout-rename",
-      label: "Rename Layout",
-      detail: "Change the current saved layout name",
-      category: "Current Layout",
-      kind: "action",
-      action: () => openBuiltInWorkflow("rename-layout"),
-    });
-    layoutItems.push({
-      id: "layout-duplicate-layout",
-      label: "Duplicate Layout",
-      detail: "Create a copy of the current layout",
-      category: "Current Layout",
-      kind: "action",
-      action: () => {
-        dispatch({ type: "DUPLICATE_LAYOUT", index: state.config.activeLayoutIndex });
-        closeAll({ revertThemePreview: false });
-      },
-    });
-    layoutItems.push({
-      id: "layout-new",
-      label: "New Layout",
-      detail: "Create a fresh saved layout",
-      category: "Current Layout",
-      kind: "action",
-      action: () => openBuiltInWorkflow("new-layout"),
-    });
-
-    state.config.layouts.forEach((savedLayout, index) => {
-      layoutItems.push({
-        id: `layout-switch:${index}`,
-        label: savedLayout.name,
-        detail: index === state.config.activeLayoutIndex ? "Current layout" : "Switch to this saved layout",
-        right: getLayoutPreview(savedLayout.layout),
-        category: "Saved Layouts",
-        kind: "action",
-        current: index === state.config.activeLayoutIndex,
-        action: () => {
-          dispatch({ type: "SWITCH_LAYOUT", index });
-          closeAll({ revertThemePreview: false });
-        },
-      });
-    });
-
-    return query
-      ? fuzzyFilter(layoutItems, query, (item) => `${item.label} ${item.detail} ${item.right || ""}`)
-      : layoutItems;
-  }, [
+  ): ResultItem[] => buildLayoutResultItems({
+    closeAll,
+    confirmDangerousActions: options?.confirmDangerousActions,
+    dispatch,
+    duplicatePane,
+    notifyGridlockRevert,
+    openBuiltInWorkflow,
+    openInlineConfirm,
+    persistLayoutChange,
+    pluginRegistry,
+    pushRoute,
+    query,
+    state,
+  }), [
     closeAll,
     dispatch,
     duplicatePane,
     notifyGridlockRevert,
     openBuiltInWorkflow,
     openInlineConfirm,
-    pushRoute,
     persistLayoutChange,
     pluginRegistry,
+    pushRoute,
     state,
   ]);
 
@@ -1868,7 +1295,7 @@ export function CommandBar({
       cancelLabel: "Back",
       tone: "danger" as const,
     };
-  }, [activeCollectionId, activeTickerSymbol, state.config, state.config.layout]);
+  }, [activeCollectionId, activeTickerSymbol, state.config]);
 
   const openPaneSettingsRoute = useCallback((paneId: string) => {
     const descriptor = pluginRegistry.resolvePaneSettings(paneId);
@@ -2071,7 +1498,6 @@ export function CommandBar({
     openAddToPortfolioWorkflow,
     openModeRoute,
     pushRoute,
-    pluginRegistry,
   ]);
 
   const runSecurityDescriptionShortcut = useCallback(async (query?: string) => {
@@ -2830,12 +2256,6 @@ export function CommandBar({
     return merged.length > 0 ? merged : rootItems;
   }, []);
 
-  const buildTickerSearchCacheKey = useCallback((
-    query: string,
-    brokerId?: string | null,
-    brokerInstanceId?: string | null,
-  ) => [query.trim().toUpperCase(), brokerId || "", brokerInstanceId || ""].join("|"), []);
-
   const readTickerSearchCache = useCallback((
     query: string,
     brokerId?: string | null,
@@ -2843,7 +2263,7 @@ export function CommandBar({
   ): TickerSearchCandidate[] | null => {
     const key = buildTickerSearchCacheKey(query, brokerId, brokerInstanceId);
     return tickerSearchCacheRef.current.get(key) ?? null;
-  }, [buildTickerSearchCacheKey]);
+  }, []);
 
   const writeTickerSearchCache = useCallback((
     query: string,
@@ -2858,30 +2278,26 @@ export function CommandBar({
       if (!oldestKey) break;
       tickerSearchCacheRef.current.delete(oldestKey);
     }
-  }, [buildTickerSearchCacheKey]);
+  }, []);
 
   useEffect(() => {
     tickerSearchCacheRef.current.clear();
   }, [state.tickers]);
-
-  const createQuickLookLocalTickerCandidates = useCallback((tickers: Iterable<TickerRecord>) => (
-    createLocalTickerSearchCandidates(tickers, new Map(), QUICK_LOOK_TICKER_SEARCH_OPTIONS)
-  ), []);
 
   const localTickerSearchResultItems = useCallback((query?: string, options?: {
     category?: string;
     limit?: number;
   }): ResultItem[] => {
     const items = query
-      ? rankTickerSearchItems(createQuickLookLocalTickerCandidates(state.tickers.values()), query)
-      : createQuickLookLocalTickerCandidates(state.tickers.values());
+      ? rankTickerSearchItems(createQuickLookTickerCandidates(state.tickers.values()), query)
+      : createQuickLookTickerCandidates(state.tickers.values());
     return items
       .slice(0, options?.limit)
       .map((candidate) => ({
         ...mapTickerSearchCandidateToResultItem(candidate),
         category: options?.category ?? candidate.category,
       }));
-  }, [createQuickLookLocalTickerCandidates, mapTickerSearchCandidateToResultItem, state.tickers]);
+  }, [mapTickerSearchCandidateToResultItem, state.tickers]);
 
   const adaptTickerSearchRouteResult = useCallback((
     item: ResultItem,
@@ -3855,18 +3271,18 @@ export function CommandBar({
       const recentTickers = recentSymbols
         .map((symbol) => state.tickers.get(symbol))
         .filter((ticker): ticker is NonNullable<typeof ticker> => (
-          ticker != null && createQuickLookLocalTickerCandidates([ticker]).length > 0
+          ticker != null && createQuickLookTickerCandidates([ticker]).length > 0
         ));
       if (recentTickers.length < maxDefaultTickers) {
         const seen = new Set(recentSymbols);
         for (const ticker of state.tickers.values()) {
           if (recentTickers.length >= maxDefaultTickers) break;
-          if (createQuickLookLocalTickerCandidates([ticker]).length === 0) continue;
+          if (createQuickLookTickerCandidates([ticker]).length === 0) continue;
           if (!seen.has(ticker.metadata.ticker)) recentTickers.push(ticker);
         }
       }
       items.push(...recentTickers.flatMap((ticker) => {
-        const candidate = createQuickLookLocalTickerCandidates([ticker])[0];
+        const candidate = createQuickLookTickerCandidates([ticker])[0];
         return candidate
           ? [{
             ...mapTickerSearchCandidateToResultItem(candidate),
@@ -3909,7 +3325,6 @@ export function CommandBar({
     buildWindowModeItems,
     buildPaneSettingItems,
     buildPluginItems,
-    createQuickLookLocalTickerCandidates,
     createPluginCommandItem,
     currentRoute,
     executeCollectionCommand,
@@ -3919,7 +3334,6 @@ export function CommandBar({
     pluginCommandItems,
     pluginCommandResultItems,
     pluginRegistry,
-    rootModeInfo.kind,
     rootQuery,
     rootShortcutIntent,
     runDirectCommand,
@@ -4537,32 +3951,11 @@ export function CommandBar({
     return null;
   }, [
     adaptTickerSearchRouteResult,
-    activeCollectionId,
     activeMatch,
-    activeTickerData,
-    activeTickerSymbol,
     buildLayoutItems,
     buildPaneSettingItems,
     buildPluginItems,
-    closeAll,
-    createPaneTemplateItem,
     currentRoute,
-    dispatch,
-    duplicatePane,
-    executeCollectionCommand,
-    getAvailablePaneShortcutTemplates,
-    getAvailablePaneTemplates,
-    localTickerSearchResultItems,
-    mapTickerSearchCandidateToResultItem,
-    nonShortcutPaneTemplateItems,
-    notifyGridlockRevert,
-    openBuiltInWorkflow,
-    openInlineConfirm,
-    openPaneSettingsRoute,
-    pushRoute,
-    paneShortcutItems,
-    persistLayoutChange,
-    pluginCommandItems,
     pluginRegistry,
     rootHoveredIdx,
     rootModeInfo.kind,
@@ -4571,11 +3964,6 @@ export function CommandBar({
     rootSectionOrder,
     rootSearching,
     rootSelectedIdx,
-    rootShortcutIntent,
-    runDirectCommand,
-    shouldOpenTemplateConfig,
-    state,
-    tickerActionItems,
     tickerSearchPending,
     tickerSearchResults,
   ]);
@@ -4625,7 +4013,7 @@ export function CommandBar({
     }
   }, [availableCommands, clearThemePreview, setRootQuery, updateTopRoute]);
 
-  const applyListSelectionDelta = useCallback((delta: number) => {
+  const moveListSelection = useCallback((delta: number) => {
     const listState = visibleListStateRef.current;
     if (!listState || listState.results.length === 0 || delta === 0) return;
     const nextIndex = clampListIndex(listState.selectedIdx + delta, listState.results.length);
@@ -4653,10 +4041,6 @@ export function CommandBar({
     });
   }, []);
 
-  const moveListSelection = useCallback((delta: number) => {
-    applyListSelectionDelta(delta);
-  }, [applyListSelectionDelta]);
-
   const setHoveredIndex = useCallback((index: number | null) => {
     if (!currentRouteRef.current) {
       setRootHoveredIdx((current) => (current === index ? current : index));
@@ -4676,11 +4060,7 @@ export function CommandBar({
     });
   }, []);
 
-  const handleListScroll = useCallback((event: {
-    stopPropagation: () => void;
-    preventDefault: () => void;
-    scroll?: { direction?: string; delta?: number };
-  }) => {
+  const handleListScroll = useCallback((event: CommandBarListScrollEvent) => {
     event.stopPropagation();
     event.preventDefault();
     const direction = event.scroll?.direction;
@@ -5531,234 +4911,45 @@ export function CommandBar({
     };
   }, [nativeOccluderRect, onNativeOccluderChange]);
 
-  useEffect(() => {
-    if (!nativePaneChrome || currentRoute?.kind !== "workflow") return;
-    const scrollBox = workflowScrollRef.current;
-    if (!scrollBox) return;
-    const visibleFields = getVisibleWorkflowFields(currentRoute.fields, currentRoute.values);
-    const activeIndex = visibleFields.findIndex((field) => field.id === currentRoute.activeFieldId);
-    if (activeIndex < 0) return;
+  const getWorkflowInputRef = useCallback((fieldId: string) => (
+    getInputRef(workflowInputRefs.current, fieldId)
+  ), []);
 
-    const estimatedFieldHeight = 4;
-    const fieldTop = activeIndex * estimatedFieldHeight;
-    const fieldBottom = fieldTop + estimatedFieldHeight;
-    const viewportHeight = Math.max(1, scrollBox.viewport?.height ?? bodyHeight);
-    if (fieldTop < scrollBox.scrollTop) {
-      scrollBox.scrollTo(fieldTop);
-    } else if (fieldBottom > scrollBox.scrollTop + viewportHeight) {
-      scrollBox.scrollTo(fieldBottom - viewportHeight);
-    }
-  }, [bodyHeight, currentRoute, nativePaneChrome]);
+  const focusWorkflowField = useCallback((fieldId: string) => {
+    updateTopRoute((route) => route.kind === "workflow"
+      ? { ...route, activeFieldId: fieldId, error: null }
+      : route);
+  }, [updateTopRoute]);
 
   const renderWorkflowBody = () => {
     if (currentRoute?.kind !== "workflow") return null;
-    const visibleFields = getVisibleWorkflowFields(currentRoute.fields, currentRoute.values);
-    const workflowContent = (
-      <>
-        {currentRoute.subtitle && (
-          <Box height={1}>
-            <Text fg={paletteSubtleText}>{truncateText(currentRoute.subtitle, queryDisplayWidth)}</Text>
-          </Box>
-        )}
-        {currentRoute.description?.map((line, index) => (
-          <Box key={`workflow-desc:${index}`} height={1}>
-            <Text fg={paletteSubtleText}>{truncateText(line, queryDisplayWidth)}</Text>
-          </Box>
-        ))}
-        {currentRoute.subtitle || (currentRoute.description?.length ?? 0) > 0 ? <Box height={1} /> : null}
-        {visibleFields.map((field, fieldIndex) => {
-          const active = field.id === currentRoute.activeFieldId;
-          const isLastField = fieldIndex === visibleFields.length - 1;
-          const value = currentRoute.values[field.id];
-          const borderColor = active ? paletteSelectedBg : paletteBg;
-          const fieldBg = nativePaneChrome ? "transparent" : active ? inputBg : panelBg;
-          const useNativeSelect = nativePaneChrome && field.type === "select";
-          const fieldDescription = getWorkflowFieldDescription(field, active);
-          return (
-            <Box
-              key={field.id}
-              flexDirection="column"
-              {...(!nativePaneChrome ? { marginBottom: isLastField ? 0 : 1 } : {})}
-              backgroundColor={fieldBg}
-              onMouseDown={(event: any) => {
-                event.stopPropagation?.();
-                syncActiveWorkflowTextarea(currentRoute);
-                updateTopRoute((route) => route.kind === "workflow"
-                  ? { ...route, activeFieldId: field.id, error: null }
-                  : route);
-                if (!isWorkflowTextField(field) && !useNativeSelect) {
-                  openWorkflowFieldPicker(currentRoute, field);
-                }
-              }}
-              style={nativePaneChrome ? {
-                marginBottom: isLastField ? 8 : 10,
-                paddingBlock: 3,
-              } : undefined}
-            >
-              <Box height={1}>
-                <Text fg={active ? paletteText : paletteSubtleText} attributes={active ? TextAttributes.BOLD : 0}>
-                  {field.label}
-                </Text>
-              </Box>
-              {isWorkflowTextField(field) ? (
-                field.type === "number" ? (
-                  <NumberField
-                    inputRef={getInputRef(workflowInputRefs.current, field.id) as RefObject<InputRenderable | null>}
-                    value={coerceFieldString(value)}
-                    placeholder={field.placeholder}
-                    focused={active && !currentRoute.pending}
-                    variant="default"
-                    backgroundColor={nativePaneChrome ? inputBg : fieldBg}
-                    onChange={(nextValue) => updateWorkflowValue(field.id, nextValue)}
-                    onSubmit={() => {
-                      const index = visibleFields.findIndex((entry) => entry.id === field.id);
-                      if (index === visibleFields.length - 1) {
-                        void submitWorkflowRoute(currentRoute);
-                      } else {
-                        moveWorkflowFocus(1);
-                      }
-                    }}
-                  />
-                ) : field.type === "textarea" ? (
-                  <Box
-                    minHeight={6}
-                    height={6}
-                    border={!nativePaneChrome}
-                    borderColor={active ? paletteSelectedBg : paletteBg}
-                    backgroundColor={nativePaneChrome ? inputBg : fieldBg}
-                    style={nativePaneChrome ? {
-                      border: `1px solid ${active ? themeColors.borderFocused : themeColors.border}`,
-                      borderRadius: 6,
-                      overflow: "hidden",
-                    } : undefined}
-                  >
-                    {active ? (
-                      <Textarea
-                        key={field.id}
-                        ref={getInputRef(workflowInputRefs.current, field.id) as RefObject<TextareaRenderable | null>}
-                        initialValue={coerceFieldString(value)}
-                        placeholder={field.placeholder || ""}
-                        focused={!currentRoute.pending}
-                        textColor={paletteText}
-                        placeholderColor={paletteSubtleText}
-                        backgroundColor={nativePaneChrome ? inputBg : themeColors.panel}
-                        flexGrow={1}
-                        wrapText
-                      />
-                    ) : (
-                      <Box flexDirection="column" paddingX={1} paddingY={0}>
-                        {(() => {
-                          const preview = coerceFieldString(value).trim();
-                          const lines = (preview || field.placeholder || "Unset")
-                            .split("\n")
-                            .flatMap((line) => line.match(new RegExp(`.{1,${Math.max(1, queryDisplayWidth - 8)}}`, "g")) ?? [""])
-                            .slice(0, 4);
-                          return lines.map((line, index) => (
-                            <Box key={`${field.id}:preview:${index}`} height={1}>
-                              <Text fg={preview ? paletteText : paletteSubtleText}>{line || " "}</Text>
-                            </Box>
-                          ));
-                        })()}
-                      </Box>
-                    )}
-                  </Box>
-                ) : (
-                  <TextField
-                    inputRef={getInputRef(workflowInputRefs.current, field.id) as RefObject<InputRenderable | null>}
-                    type={field.type === "password" ? "password" : "text"}
-                    value={coerceFieldString(value)}
-                    placeholder={field.placeholder}
-                    focused={active && !currentRoute.pending}
-                    variant="default"
-                    backgroundColor={nativePaneChrome ? inputBg : fieldBg}
-                    onChange={(nextValue) => updateWorkflowValue(field.id, nextValue)}
-                    onSubmit={() => {
-                      const index = visibleFields.findIndex((entry) => entry.id === field.id);
-                      if (index === visibleFields.length - 1) {
-                        void submitWorkflowRoute(currentRoute);
-                      } else {
-                        moveWorkflowFocus(1);
-                      }
-                    }}
-                  />
-                )
-              ) : useNativeSelect ? (
-                <NativeSelect
-                  value={coerceFieldString(value)}
-                  options={field.options}
-                  width="100%"
-                  selectRef={(element) => setWorkflowNativeSelectRef(field.id, element)}
-                  onFocus={() => {
-                    updateTopRoute((route) => route.kind === "workflow"
-                      ? { ...route, activeFieldId: field.id, error: null }
-                      : route);
-                  }}
-                  onChange={(nextValue) => updateWorkflowValue(field.id, nextValue)}
-                />
-              ) : (
-                <Box
-                  height={1}
-                  backgroundColor={nativePaneChrome ? "transparent" : borderColor}
-                  onMouseDown={(event: any) => {
-                    event.stopPropagation?.();
-                    openWorkflowFieldPicker(currentRoute, field);
-                  }}
-                  style={nativePaneChrome ? { borderRadius: 4 } : undefined}
-                >
-                  <Text fg={active ? paletteText : paletteSubtleText}>
-                    {truncateText(summarizeWorkflowFieldValue(field, value), queryDisplayWidth)}
-                  </Text>
-                </Box>
-              )}
-              {fieldDescription && (
-                <Box height={1}>
-                  <Text fg={paletteSubtleText}>
-                    {truncateText(fieldDescription, queryDisplayWidth)}
-                  </Text>
-                </Box>
-              )}
-            </Box>
-          );
-        })}
-        {currentRoute.error && (
-          <Box height={1}>
-            <Text fg={themeColors.negative}>{truncateText(currentRoute.error, queryDisplayWidth)}</Text>
-          </Box>
-        )}
-        {currentRoute.pendingLabel && currentRoute.pending && (
-          <Box height={1}>
-            <Spinner label={currentRoute.pendingLabel} />
-          </Box>
-        )}
-        {!nativePaneChrome && <Box flexGrow={1} />}
-        <Box flexDirection="row" gap={1} justifyContent={visibleFields.some((field) => field.type === "textarea") ? "flex-end" : "flex-start"}>
-          <Button label={currentRoute.submitLabel} variant="primary" onPress={() => { void submitWorkflowRoute(currentRoute); }} disabled={currentRoute.pending} />
-        </Box>
-      </>
-    );
-
-    if (nativePaneChrome) {
-      return (
-        <ScrollBox
-          ref={workflowScrollRef}
-          height={bodyHeight}
-          scrollY
-          style={{ overflowX: "hidden", paddingRight: 4 }}
-        >
-          <Box
-            flexDirection="column"
-            paddingX={contentPadding}
-          >
-            {workflowContent}
-          </Box>
-        </ScrollBox>
-      );
-    }
-
     return (
-      <Box flexDirection="column" height={bodyHeight} paddingX={contentPadding}>
-        {workflowContent}
-      </Box>
+      <CommandBarWorkflowBody
+        route={currentRoute}
+        bodyHeight={bodyHeight}
+        contentPadding={contentPadding}
+        inputBg={inputBg}
+        nativePaneChrome={nativePaneChrome}
+        paletteBg={paletteBg}
+        paletteSelectedBg={paletteSelectedBg}
+        paletteSubtleText={paletteSubtleText}
+        paletteText={paletteText}
+        panelBg={panelBg}
+        queryDisplayWidth={queryDisplayWidth}
+        themeBorder={themeColors.border}
+        themeBorderFocused={themeColors.borderFocused}
+        themeNegative={themeColors.negative}
+        themePanel={themeColors.panel}
+        workflowScrollRef={workflowScrollRef}
+        getWorkflowInputRef={getWorkflowInputRef}
+        onActiveTextareaSync={syncActiveWorkflowTextarea}
+        onFieldFocus={focusWorkflowField}
+        onFieldPickerOpen={openWorkflowFieldPicker}
+        onFieldValueChange={updateWorkflowValue}
+        onMoveFieldFocus={moveWorkflowFocus}
+        onNativeSelectRef={setWorkflowNativeSelectRef}
+        onSubmit={submitWorkflowRoute}
+      />
     );
   };
 

--- a/src/components/command-bar/layout-items.ts
+++ b/src/components/command-bar/layout-items.ts
@@ -1,0 +1,368 @@
+import type { Dispatch } from "react";
+import type { PluginRegistry, WindowEditMode } from "../../plugins/registry";
+import {
+  dockPane,
+  floatPane,
+  getDockedPaneIds,
+  getLayoutPreview,
+  gridlockAllPanes,
+  removePane,
+} from "../../plugins/pane-manager";
+import type { AppAction, AppState } from "../../state/app-context";
+import {
+  DEFAULT_LAYOUT,
+  cloneLayout,
+  findPaneInstance,
+  type LayoutConfig,
+} from "../../types/config";
+import { fuzzyFilter } from "../../utils/fuzzy-search";
+import type { ResultItem } from "./list-model";
+import type { CommandBarRoute } from "./workflow-types";
+
+const WINDOW_MODE_COMMAND_OPTIONS: Array<{
+  mode: WindowEditMode;
+  label: string;
+  detail: string;
+  query: string;
+  searchText: string;
+}> = [
+  {
+    mode: "move",
+    label: "Move Window",
+    detail: "Enter window edit mode with Tab cycling windows",
+    query: "WIN move",
+    searchText: "window mode move reposition",
+  },
+  {
+    mode: "resize",
+    label: "Resize Window",
+    detail: "Enter window edit mode with Tab cycling resize handles",
+    query: "WIN resize",
+    searchText: "window mode resize size corner divider",
+  },
+];
+
+type CloseAll = (options?: { revertThemePreview?: boolean }) => void;
+
+type OpenInlineConfirm = (options: {
+  confirmId: string;
+  title: string;
+  body: string[];
+  confirmLabel: string;
+  cancelLabel?: string;
+  tone?: "default" | "danger";
+  onConfirm: () => void | Promise<void>;
+  successBehavior?: "close" | "back" | "stay";
+}) => void;
+
+export function parseWindowModeCommandArg(arg: string): WindowEditMode | null {
+  const normalized = arg.trim().toLowerCase();
+  if (!normalized) return null;
+  if ("move".startsWith(normalized) || normalized === "m") return "move";
+  if ("resize".startsWith(normalized) || normalized === "r") return "resize";
+  return null;
+}
+
+export function buildWindowModeResultItems({
+  arg,
+  closeAll,
+  focusedPaneId,
+  pluginRegistry,
+}: {
+  arg: string;
+  closeAll: CloseAll;
+  focusedPaneId: string | null;
+  pluginRegistry: PluginRegistry;
+}): ResultItem[] {
+  const normalized = arg.trim().toLowerCase();
+  const exactMode = parseWindowModeCommandArg(arg);
+  const options = normalized
+    ? WINDOW_MODE_COMMAND_OPTIONS.filter((option) => (
+      option.mode === exactMode
+      || option.mode.startsWith(normalized)
+      || fuzzyFilter([option], normalized, (item) => `${item.label} ${item.detail} ${item.searchText}`).length > 0
+    ))
+    : WINDOW_MODE_COMMAND_OPTIONS;
+
+  const visibleOptions = options.length > 0 ? options : WINDOW_MODE_COMMAND_OPTIONS;
+  return visibleOptions.map((option) => ({
+    id: `window-mode:${option.mode}`,
+    label: option.label,
+    detail: option.detail,
+    category: "Config",
+    kind: "action" as const,
+    right: option.query,
+    shortcutQuery: option.query,
+    action: () => {
+      closeAll({ revertThemePreview: false });
+      pluginRegistry.openWindowMode(focusedPaneId ?? undefined, option.mode);
+    },
+  }));
+}
+
+export function buildLayoutResultItems({
+  closeAll,
+  confirmDangerousActions,
+  dispatch,
+  duplicatePane,
+  notifyGridlockRevert,
+  openBuiltInWorkflow,
+  openInlineConfirm,
+  persistLayoutChange,
+  pluginRegistry,
+  pushRoute,
+  query,
+  state,
+}: {
+  closeAll: CloseAll;
+  confirmDangerousActions?: boolean;
+  dispatch: Dispatch<AppAction>;
+  duplicatePane: (paneId: string) => void;
+  notifyGridlockRevert: () => void;
+  openBuiltInWorkflow: (actionId: string) => void;
+  openInlineConfirm: OpenInlineConfirm;
+  persistLayoutChange: (layout: LayoutConfig) => void;
+  pluginRegistry: PluginRegistry;
+  pushRoute: (route: CommandBarRoute) => void;
+  query: string;
+  state: AppState;
+}): ResultItem[] {
+  const currentLayout = state.config.layout;
+  const focusedPane = state.focusedPaneId ? findPaneInstance(currentLayout, state.focusedPaneId) : null;
+  const focusedPaneDef = focusedPane ? pluginRegistry.panes.get(focusedPane.paneId) : null;
+  const dockedPaneIds = getDockedPaneIds(currentLayout);
+  const layoutHistory = state.layoutHistory[state.config.activeLayoutIndex];
+  const layoutItems: ResultItem[] = [];
+
+  if (focusedPane && focusedPaneDef) {
+    const focusedFloating = currentLayout.floating.find((entry) => entry.instanceId === focusedPane.instanceId);
+    layoutItems.push({
+      id: "layout-toggle-mode",
+      label: focusedFloating ? "Dock Pane" : "Float Pane",
+      detail: focusedFloating ? "Return the focused window to the layout" : "Detach the focused pane into a floating window",
+      category: "Focused Pane",
+      kind: "action",
+      action: () => {
+        const { width, height } = pluginRegistry.getTermSizeFn();
+        const nextLayout = focusedFloating
+          ? dockPane(currentLayout, focusedPane.instanceId)
+          : floatPane(currentLayout, focusedPane.instanceId, width, height, focusedPaneDef);
+        persistLayoutChange(nextLayout);
+        closeAll({ revertThemePreview: false });
+      },
+    });
+
+    layoutItems.push(...WINDOW_MODE_COMMAND_OPTIONS.map((option) => ({
+      id: `layout-window-mode:${option.mode}`,
+      label: option.label,
+      detail: option.detail,
+      category: "Focused Pane",
+      kind: "action" as const,
+      right: option.query,
+      action: () => {
+        closeAll({ revertThemePreview: false });
+        pluginRegistry.openWindowMode(focusedPane.instanceId, option.mode);
+      },
+    })));
+
+    layoutItems.push({
+      id: "layout-swap",
+      label: "Swap With…",
+      detail: dockedPaneIds.length + currentLayout.floating.length > 1
+        ? "Choose another pane to swap positions"
+        : "Need at least two panes",
+      category: "Focused Pane",
+      kind: "action",
+      disabled: dockedPaneIds.length + currentLayout.floating.length <= 1,
+      action: () => {
+        const pickerOptions = [
+          ...dockedPaneIds,
+          ...currentLayout.floating.map((entry) => entry.instanceId),
+        ]
+          .filter((paneId) => paneId !== focusedPane.instanceId)
+          .map((paneId) => {
+            const instance = findPaneInstance(currentLayout, paneId)!;
+            const isFloating = currentLayout.floating.some((entry) => entry.instanceId === paneId);
+            return {
+              id: paneId,
+              label: instance.title || pluginRegistry.panes.get(instance.paneId)?.name || instance.paneId,
+              detail: isFloating ? "Floating window" : "Docked pane",
+              description: isFloating ? "Floating window" : "Docked pane",
+            };
+          });
+        if (pickerOptions.length === 0) return;
+        pushRoute({
+          kind: "picker",
+          pickerId: "layout-swap",
+          title: "Swap With…",
+          query: "",
+          selectedIdx: 0,
+          hoveredIdx: null,
+          options: pickerOptions,
+          payload: { sourcePaneId: focusedPane.instanceId },
+        });
+      },
+    });
+
+    layoutItems.push({
+      id: "layout-duplicate",
+      label: "Duplicate Pane",
+      detail: "Create another instance next to the focused pane",
+      category: "Focused Pane",
+      kind: "action",
+      action: () => {
+        duplicatePane(focusedPane.instanceId);
+        closeAll({ revertThemePreview: false });
+      },
+    });
+
+    layoutItems.push({
+      id: "layout-close-pane",
+      label: "Close Pane",
+      detail: "Remove the focused pane from the layout",
+      category: "Focused Pane",
+      kind: "action",
+      action: confirmDangerousActions
+        ? () => {
+          openInlineConfirm({
+            confirmId: "layout-close-pane",
+            title: "Close Pane",
+            body: [`Close "${focusedPane.title || focusedPaneDef.name || focusedPane.instanceId}"?`],
+            confirmLabel: "Close Pane",
+            cancelLabel: "Back",
+            tone: "danger",
+            onConfirm: () => {
+              persistLayoutChange(removePane(currentLayout, focusedPane.instanceId));
+            },
+          });
+        }
+        : () => {
+          persistLayoutChange(removePane(currentLayout, focusedPane.instanceId));
+          closeAll({ revertThemePreview: false });
+        },
+    });
+  } else {
+    layoutItems.push({
+      id: "layout-no-focused-pane",
+      label: "No focused pane",
+      detail: "Focus a pane to show pane-specific layout actions",
+      category: "Focused Pane",
+      kind: "info",
+      action: () => {},
+    });
+  }
+
+  layoutItems.push({
+    id: "layout-undo",
+    label: "Undo Layout Change",
+    detail: (layoutHistory?.past.length ?? 0) > 0 ? "Restore the previous layout state" : "No previous layout state",
+    category: "Current Layout",
+    kind: "action",
+    disabled: (layoutHistory?.past.length ?? 0) === 0,
+    action: () => {
+      if ((layoutHistory?.past.length ?? 0) === 0) return;
+      dispatch({ type: "UNDO_LAYOUT" });
+      closeAll({ revertThemePreview: false });
+    },
+  });
+  layoutItems.push({
+    id: "layout-redo",
+    label: "Redo Layout Change",
+    detail: (layoutHistory?.future.length ?? 0) > 0 ? "Reapply the next layout state" : "No later layout state",
+    category: "Current Layout",
+    kind: "action",
+    disabled: (layoutHistory?.future.length ?? 0) === 0,
+    action: () => {
+      if ((layoutHistory?.future.length ?? 0) === 0) return;
+      dispatch({ type: "REDO_LAYOUT" });
+      closeAll({ revertThemePreview: false });
+    },
+  });
+  layoutItems.push({
+    id: "layout-reset",
+    label: "Reset Current Layout",
+    detail: "Restore the default two-pane layout",
+    category: "Current Layout",
+    kind: "action",
+    action: confirmDangerousActions
+      ? () => {
+        openInlineConfirm({
+          confirmId: "layout-reset",
+          title: "Reset Current Layout",
+          body: ["Reset the current layout to the default two-pane arrangement?"],
+          confirmLabel: "Reset Layout",
+          cancelLabel: "Back",
+          tone: "danger",
+          onConfirm: () => {
+            persistLayoutChange(cloneLayout(DEFAULT_LAYOUT));
+          },
+        });
+      }
+      : () => {
+        persistLayoutChange(cloneLayout(DEFAULT_LAYOUT));
+        closeAll({ revertThemePreview: false });
+      },
+  });
+  layoutItems.push({
+    id: "layout-gridlock",
+    label: "Gridlock All Windows",
+    detail: currentLayout.floating.length > 0
+      ? "Infer a tiled layout from the current window positions"
+      : "Retile all panes from their current arrangement",
+    category: "Current Layout",
+    kind: "action",
+    action: () => {
+      const { width, height } = pluginRegistry.getTermSizeFn();
+      persistLayoutChange(gridlockAllPanes(currentLayout, { x: 0, y: 0, width, height }));
+      notifyGridlockRevert();
+      closeAll({ revertThemePreview: false });
+    },
+  });
+  layoutItems.push({
+    id: "layout-rename",
+    label: "Rename Layout",
+    detail: "Change the current saved layout name",
+    category: "Current Layout",
+    kind: "action",
+    action: () => openBuiltInWorkflow("rename-layout"),
+  });
+  layoutItems.push({
+    id: "layout-duplicate-layout",
+    label: "Duplicate Layout",
+    detail: "Create a copy of the current layout",
+    category: "Current Layout",
+    kind: "action",
+    action: () => {
+      dispatch({ type: "DUPLICATE_LAYOUT", index: state.config.activeLayoutIndex });
+      closeAll({ revertThemePreview: false });
+    },
+  });
+  layoutItems.push({
+    id: "layout-new",
+    label: "New Layout",
+    detail: "Create a fresh saved layout",
+    category: "Current Layout",
+    kind: "action",
+    action: () => openBuiltInWorkflow("new-layout"),
+  });
+
+  state.config.layouts.forEach((savedLayout, index) => {
+    layoutItems.push({
+      id: `layout-switch:${index}`,
+      label: savedLayout.name,
+      detail: index === state.config.activeLayoutIndex ? "Current layout" : "Switch to this saved layout",
+      right: getLayoutPreview(savedLayout.layout),
+      category: "Saved Layouts",
+      kind: "action",
+      current: index === state.config.activeLayoutIndex,
+      action: () => {
+        dispatch({ type: "SWITCH_LAYOUT", index });
+        closeAll({ revertThemePreview: false });
+      },
+    });
+  });
+
+  return query
+    ? fuzzyFilter(layoutItems, query, (item) => `${item.label} ${item.detail} ${item.right || ""}`)
+    : layoutItems;
+}

--- a/src/components/command-bar/list-view.tsx
+++ b/src/components/command-bar/list-view.tsx
@@ -1,0 +1,316 @@
+import { memo, useMemo, type RefObject } from "react";
+import {
+  Box,
+  Input,
+  ScrollBox,
+  Text,
+  TextAttributes,
+  type ScrollBoxRenderable,
+} from "../../ui";
+import { Spinner } from "../ui";
+import type { CommandBarListRow, ListScreenState, ResultItem } from "./list-model";
+import { getRowPresentation, truncateText } from "./view-model";
+
+export type CommandBarListScrollEvent = {
+  stopPropagation: () => void;
+  preventDefault: () => void;
+  scroll?: { direction?: string; delta?: number };
+};
+
+interface CommandBarListHeaderProps {
+  kind: ListScreenState["kind"];
+  query: string;
+  queryDisplayWidth: number;
+  nativePaneChrome: boolean;
+  inputBg: string;
+  paletteBg: string;
+  paletteText: string;
+  paletteSubtleText: string;
+  cursorColor: string;
+  contentPadding: number;
+  rootGhostSuffix: string | null;
+  rootQueryLength: number;
+  rootShortcutFeedback: string | null;
+  onQueryChange: (query: string) => void;
+}
+
+export const CommandBarListHeader = memo(function CommandBarListHeader({
+  kind,
+  query,
+  queryDisplayWidth,
+  nativePaneChrome,
+  inputBg,
+  paletteBg,
+  paletteText,
+  paletteSubtleText,
+  cursorColor,
+  contentPadding,
+  rootGhostSuffix,
+  rootQueryLength,
+  rootShortcutFeedback,
+  onQueryChange,
+}: CommandBarListHeaderProps) {
+  return (
+    <>
+      <Box height={1} paddingX={contentPadding}>
+        <Box
+          width={queryDisplayWidth}
+          height={1}
+          position="relative"
+          backgroundColor={nativePaneChrome ? undefined : inputBg}
+          style={nativePaneChrome ? undefined : {
+            overflow: "hidden",
+          }}
+        >
+          <Input
+            value={query}
+            onInput={onQueryChange}
+            onChange={onQueryChange}
+            placeholder={kind === "root" ? "Search" : "Filter"}
+            focused
+            width={nativePaneChrome ? "100%" : queryDisplayWidth}
+            backgroundColor={nativePaneChrome ? "transparent" : paletteBg}
+            focusedBackgroundColor={nativePaneChrome ? "transparent" : paletteBg}
+            textColor={paletteText}
+            focusedTextColor={paletteText}
+            placeholderColor={paletteSubtleText}
+            cursorColor={cursorColor}
+          />
+          {kind === "root" && rootGhostSuffix && (
+            <Box
+              position="absolute"
+              top={0}
+              left={Math.max(0, Math.min(rootQueryLength, queryDisplayWidth - 1))}
+              width={Math.max(0, queryDisplayWidth - Math.min(rootQueryLength, queryDisplayWidth - 1))}
+              height={1}
+            >
+              <Text fg={paletteSubtleText}>
+                {truncateText(
+                  rootGhostSuffix,
+                  Math.max(0, queryDisplayWidth - Math.min(rootQueryLength, queryDisplayWidth - 1)),
+                )}
+              </Text>
+            </Box>
+          )}
+        </Box>
+      </Box>
+      <Box height={1} paddingX={contentPadding}>
+        {kind === "root" && rootShortcutFeedback
+          ? (
+            <Text fg={paletteSubtleText}>
+              {truncateText(rootShortcutFeedback, queryDisplayWidth)}
+            </Text>
+          )
+          : null}
+      </Box>
+    </>
+  );
+});
+
+interface CommandBarListItemRowProps {
+  item: ResultItem;
+  globalIdx: number;
+  isSelected: boolean;
+  isHovered: boolean;
+  contentPadding: number;
+  labelWidth: number;
+  trailingWidth: number;
+  nativePaneChrome: boolean;
+  paletteBg: string;
+  paletteHoverBg: string;
+  paletteSelectedBg: string;
+  paletteSelectedText: string;
+  paletteSubtleText: string;
+  paletteText: string;
+  panelBg: string;
+  onHoverIndex: (index: number | null) => void;
+  onListScroll: (event: CommandBarListScrollEvent) => void;
+  onRowMouseDown: (event: any, item: ResultItem, globalIdx: number) => void;
+}
+
+const CommandBarListItemRow = memo(function CommandBarListItemRow({
+  item,
+  globalIdx,
+  isSelected,
+  isHovered,
+  contentPadding,
+  labelWidth,
+  trailingWidth,
+  nativePaneChrome,
+  paletteBg,
+  paletteHoverBg,
+  paletteSelectedBg,
+  paletteSelectedText,
+  paletteSubtleText,
+  paletteText,
+  panelBg,
+  onHoverIndex,
+  onListScroll,
+  onRowMouseDown,
+}: CommandBarListItemRowProps) {
+  const presentation = getRowPresentation(item, isSelected, trailingWidth > 0);
+  const label = truncateText(presentation.label, labelWidth);
+  const trailing = truncateText(presentation.trailing, trailingWidth);
+
+  return (
+    <Box
+      key={item.id}
+      flexDirection="row"
+      height={1}
+      paddingX={contentPadding}
+      backgroundColor={isSelected
+        ? paletteSelectedBg
+        : isHovered
+          ? paletteHoverBg
+          : (nativePaneChrome ? panelBg : paletteBg)}
+      onMouseMove={() => onHoverIndex(globalIdx)}
+      onMouseOut={() => onHoverIndex(null)}
+      {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}
+      onMouseDown={(event: any) => onRowMouseDown(event, item, globalIdx)}
+      data-command-bar-row-selected={nativePaneChrome && isSelected ? "true" : undefined}
+      style={nativePaneChrome ? { borderRadius: 6 } : undefined}
+    >
+      <Box width={labelWidth}>
+        <Text fg={isSelected ? paletteSelectedText : presentation.primaryMuted ? paletteSubtleText : paletteText}>
+          {label}
+        </Text>
+      </Box>
+      <Box width={trailingWidth}>
+        <Text fg={isSelected ? paletteSelectedText : paletteSubtleText}>{trailing}</Text>
+      </Box>
+    </Box>
+  );
+});
+
+interface CommandBarListBodyProps {
+  visibleListState: ListScreenState;
+  nativeListRows: CommandBarListRow[];
+  listBodyHeight: number;
+  contentPadding: number;
+  labelWidth: number;
+  nativePaneChrome: boolean;
+  nativeListScrollRef: RefObject<ScrollBoxRenderable | null>;
+  paletteBg: string;
+  paletteHeadingText: string;
+  paletteHoverBg: string;
+  paletteSelectedBg: string;
+  paletteSelectedText: string;
+  paletteSubtleText: string;
+  paletteText: string;
+  panelBg: string;
+  queryDisplayWidth: number;
+  trailingWidth: number;
+  onHoverIndex: (index: number | null) => void;
+  onListScroll: (event: CommandBarListScrollEvent) => void;
+  onRowMouseDown: (event: any, item: ResultItem, globalIdx: number) => void;
+}
+
+export const CommandBarListBody = memo(function CommandBarListBody({
+  visibleListState,
+  nativeListRows,
+  listBodyHeight,
+  contentPadding,
+  labelWidth,
+  nativePaneChrome,
+  nativeListScrollRef,
+  paletteBg,
+  paletteHeadingText,
+  paletteHoverBg,
+  paletteSelectedBg,
+  paletteSelectedText,
+  paletteSubtleText,
+  paletteText,
+  panelBg,
+  queryDisplayWidth,
+  trailingWidth,
+  onHoverIndex,
+  onListScroll,
+  onRowMouseDown,
+}: CommandBarListBodyProps) {
+  const visibleRows = useMemo(() => {
+    const rows = nativeListRows;
+    if (nativePaneChrome) return rows;
+    const paddedRows = [...rows];
+    while (paddedRows.length < listBodyHeight) {
+      paddedRows.push({ kind: "filler", id: `filler:${paddedRows.length}` });
+    }
+    return paddedRows;
+  }, [
+    listBodyHeight,
+    nativeListRows,
+    nativePaneChrome,
+  ]);
+
+  const renderedRows = (
+    <>
+      {visibleRows.map((row) => {
+        if (row.kind === "filler" || row.kind === "spacer") {
+          return <Box key={row.id} height={1} />;
+        }
+        if (row.kind === "spinner") {
+          return (
+            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
+              <Spinner label={row.label} />
+            </Box>
+          );
+        }
+        if (row.kind === "message") {
+          return (
+            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
+              <Text fg={paletteText}>{truncateText(row.label, queryDisplayWidth)}</Text>
+            </Box>
+          );
+        }
+        if (row.kind === "heading") {
+          return (
+            <Box key={row.id} height={1} paddingX={contentPadding} {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}>
+              <Text attributes={TextAttributes.BOLD} fg={paletteHeadingText}>
+                {truncateText(row.label, queryDisplayWidth)}
+              </Text>
+            </Box>
+          );
+        }
+
+        const isSelected = row.globalIdx === visibleListState.selectedIdx;
+        const isHovered = row.globalIdx === visibleListState.hoveredIdx && !isSelected;
+        const itemRowKey = `item:${row.globalIdx}:${row.item.id}:${row.item.category}:${row.item.label}:${row.item.right || ""}`;
+        return (
+          <CommandBarListItemRow
+            key={itemRowKey}
+            item={row.item}
+            globalIdx={row.globalIdx}
+            isSelected={isSelected}
+            isHovered={isHovered}
+            contentPadding={contentPadding}
+            labelWidth={labelWidth}
+            trailingWidth={trailingWidth}
+            nativePaneChrome={nativePaneChrome}
+            paletteBg={paletteBg}
+            paletteHoverBg={paletteHoverBg}
+            paletteSelectedBg={paletteSelectedBg}
+            paletteSelectedText={paletteSelectedText}
+            paletteSubtleText={paletteSubtleText}
+            paletteText={paletteText}
+            panelBg={panelBg}
+            onHoverIndex={onHoverIndex}
+            onListScroll={onListScroll}
+            onRowMouseDown={onRowMouseDown}
+          />
+        );
+      })}
+    </>
+  );
+
+  return (
+    <ScrollBox
+      ref={nativeListScrollRef}
+      flexDirection="column"
+      height={listBodyHeight}
+      scrollY
+      focusable={false}
+      {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}
+    >
+      {renderedRows}
+    </ScrollBox>
+  );
+});

--- a/src/components/command-bar/workflow-body.tsx
+++ b/src/components/command-bar/workflow-body.tsx
@@ -1,0 +1,303 @@
+import type { RefObject } from "react";
+import { useEffect } from "react";
+import {
+  Box,
+  ScrollBox,
+  Text,
+  Textarea,
+  TextAttributes,
+  type InputRenderable,
+  type ScrollBoxRenderable,
+  type TextareaRenderable,
+} from "../../ui";
+import { Button, NumberField, Spinner, TextField } from "../ui";
+import { NativeSelect, type NativeSelectElement } from "../ui/native-select";
+import {
+  coerceFieldString,
+  getVisibleWorkflowFields,
+  isWorkflowTextField,
+  summarizeWorkflowFieldValue,
+} from "./helpers";
+import type {
+  CommandBarFieldValue,
+  CommandBarWorkflowField,
+  CommandBarWorkflowRoute,
+} from "./workflow-types";
+import { getWorkflowFieldDescription } from "./workflow-view";
+import { truncateText } from "./view-model";
+
+interface CommandBarWorkflowBodyProps {
+  route: CommandBarWorkflowRoute;
+  bodyHeight: number;
+  contentPadding: number;
+  inputBg: string;
+  nativePaneChrome: boolean;
+  paletteBg: string;
+  paletteSelectedBg: string;
+  paletteSubtleText: string;
+  paletteText: string;
+  panelBg: string;
+  queryDisplayWidth: number;
+  themeBorder: string;
+  themeBorderFocused: string;
+  themeNegative: string;
+  themePanel: string;
+  workflowScrollRef: RefObject<ScrollBoxRenderable | null>;
+  getWorkflowInputRef: (fieldId: string) => RefObject<InputRenderable | TextareaRenderable | null>;
+  onActiveTextareaSync: (route: CommandBarWorkflowRoute) => void;
+  onFieldFocus: (fieldId: string) => void;
+  onFieldPickerOpen: (route: CommandBarWorkflowRoute, field: CommandBarWorkflowField) => void;
+  onFieldValueChange: (fieldId: string, value: CommandBarFieldValue) => void;
+  onMoveFieldFocus: (delta: number) => void;
+  onNativeSelectRef: (fieldId: string, element: NativeSelectElement | null) => void;
+  onSubmit: (route: CommandBarWorkflowRoute) => void | Promise<void>;
+}
+
+export function CommandBarWorkflowBody({
+  route,
+  bodyHeight,
+  contentPadding,
+  inputBg,
+  nativePaneChrome,
+  paletteBg,
+  paletteSelectedBg,
+  paletteSubtleText,
+  paletteText,
+  panelBg,
+  queryDisplayWidth,
+  themeBorder,
+  themeBorderFocused,
+  themeNegative,
+  themePanel,
+  workflowScrollRef,
+  getWorkflowInputRef,
+  onActiveTextareaSync,
+  onFieldFocus,
+  onFieldPickerOpen,
+  onFieldValueChange,
+  onMoveFieldFocus,
+  onNativeSelectRef,
+  onSubmit,
+}: CommandBarWorkflowBodyProps) {
+  const visibleFields = getVisibleWorkflowFields(route.fields, route.values);
+
+  useEffect(() => {
+    if (!nativePaneChrome) return;
+    const scrollBox = workflowScrollRef.current;
+    if (!scrollBox) return;
+    const activeIndex = visibleFields.findIndex((field) => field.id === route.activeFieldId);
+    if (activeIndex < 0) return;
+
+    const estimatedFieldHeight = 4;
+    const fieldTop = activeIndex * estimatedFieldHeight;
+    const fieldBottom = fieldTop + estimatedFieldHeight;
+    const viewportHeight = Math.max(1, scrollBox.viewport?.height ?? bodyHeight);
+    if (fieldTop < scrollBox.scrollTop) {
+      scrollBox.scrollTo(fieldTop);
+    } else if (fieldBottom > scrollBox.scrollTop + viewportHeight) {
+      scrollBox.scrollTo(fieldBottom - viewportHeight);
+    }
+  }, [bodyHeight, nativePaneChrome, route.activeFieldId, visibleFields, workflowScrollRef]);
+
+  const workflowContent = (
+    <>
+      {route.subtitle && (
+        <Box height={1}>
+          <Text fg={paletteSubtleText}>{truncateText(route.subtitle, queryDisplayWidth)}</Text>
+        </Box>
+      )}
+      {route.description?.map((line, index) => (
+        <Box key={`workflow-desc:${index}`} height={1}>
+          <Text fg={paletteSubtleText}>{truncateText(line, queryDisplayWidth)}</Text>
+        </Box>
+      ))}
+      {route.subtitle || (route.description?.length ?? 0) > 0 ? <Box height={1} /> : null}
+      {visibleFields.map((field, fieldIndex) => {
+        const active = field.id === route.activeFieldId;
+        const isLastField = fieldIndex === visibleFields.length - 1;
+        const value = route.values[field.id];
+        const borderColor = active ? paletteSelectedBg : paletteBg;
+        const fieldBg = nativePaneChrome ? "transparent" : active ? inputBg : panelBg;
+        const useNativeSelect = nativePaneChrome && field.type === "select";
+        const fieldDescription = getWorkflowFieldDescription(field, active);
+        return (
+          <Box
+            key={field.id}
+            flexDirection="column"
+            {...(!nativePaneChrome ? { marginBottom: isLastField ? 0 : 1 } : {})}
+            backgroundColor={fieldBg}
+            onMouseDown={(event: any) => {
+              event.stopPropagation?.();
+              onActiveTextareaSync(route);
+              onFieldFocus(field.id);
+              if (!isWorkflowTextField(field) && !useNativeSelect) {
+                onFieldPickerOpen(route, field);
+              }
+            }}
+            style={nativePaneChrome ? {
+              marginBottom: isLastField ? 8 : 10,
+              paddingBlock: 3,
+            } : undefined}
+          >
+            <Box height={1}>
+              <Text fg={active ? paletteText : paletteSubtleText} attributes={active ? TextAttributes.BOLD : 0}>
+                {field.label}
+              </Text>
+            </Box>
+            {isWorkflowTextField(field) ? (
+              field.type === "number" ? (
+                <NumberField
+                  inputRef={getWorkflowInputRef(field.id) as RefObject<InputRenderable | null>}
+                  value={coerceFieldString(value)}
+                  placeholder={field.placeholder}
+                  focused={active && !route.pending}
+                  variant="default"
+                  backgroundColor={nativePaneChrome ? inputBg : fieldBg}
+                  onChange={(nextValue) => onFieldValueChange(field.id, nextValue)}
+                  onSubmit={() => {
+                    const index = visibleFields.findIndex((entry) => entry.id === field.id);
+                    if (index === visibleFields.length - 1) {
+                      void onSubmit(route);
+                    } else {
+                      onMoveFieldFocus(1);
+                    }
+                  }}
+                />
+              ) : field.type === "textarea" ? (
+                <Box
+                  minHeight={6}
+                  height={6}
+                  border={!nativePaneChrome}
+                  borderColor={active ? paletteSelectedBg : paletteBg}
+                  backgroundColor={nativePaneChrome ? inputBg : fieldBg}
+                  style={nativePaneChrome ? {
+                    border: `1px solid ${active ? themeBorderFocused : themeBorder}`,
+                    borderRadius: 6,
+                    overflow: "hidden",
+                  } : undefined}
+                >
+                  {active ? (
+                    <Textarea
+                      key={field.id}
+                      ref={getWorkflowInputRef(field.id) as RefObject<TextareaRenderable | null>}
+                      initialValue={coerceFieldString(value)}
+                      placeholder={field.placeholder || ""}
+                      focused={!route.pending}
+                      textColor={paletteText}
+                      placeholderColor={paletteSubtleText}
+                      backgroundColor={nativePaneChrome ? inputBg : themePanel}
+                      flexGrow={1}
+                      wrapText
+                    />
+                  ) : (
+                    <Box flexDirection="column" paddingX={1} paddingY={0}>
+                      {(() => {
+                        const preview = coerceFieldString(value).trim();
+                        const lines = (preview || field.placeholder || "Unset")
+                          .split("\n")
+                          .flatMap((line) => line.match(new RegExp(`.{1,${Math.max(1, queryDisplayWidth - 8)}}`, "g")) ?? [""])
+                          .slice(0, 4);
+                        return lines.map((line, index) => (
+                          <Box key={`${field.id}:preview:${index}`} height={1}>
+                            <Text fg={preview ? paletteText : paletteSubtleText}>{line || " "}</Text>
+                          </Box>
+                        ));
+                      })()}
+                    </Box>
+                  )}
+                </Box>
+              ) : (
+                <TextField
+                  inputRef={getWorkflowInputRef(field.id) as RefObject<InputRenderable | null>}
+                  type={field.type === "password" ? "password" : "text"}
+                  value={coerceFieldString(value)}
+                  placeholder={field.placeholder}
+                  focused={active && !route.pending}
+                  variant="default"
+                  backgroundColor={nativePaneChrome ? inputBg : fieldBg}
+                  onChange={(nextValue) => onFieldValueChange(field.id, nextValue)}
+                  onSubmit={() => {
+                    const index = visibleFields.findIndex((entry) => entry.id === field.id);
+                    if (index === visibleFields.length - 1) {
+                      void onSubmit(route);
+                    } else {
+                      onMoveFieldFocus(1);
+                    }
+                  }}
+                />
+              )
+            ) : useNativeSelect ? (
+              <NativeSelect
+                value={coerceFieldString(value)}
+                options={field.options}
+                width="100%"
+                selectRef={(element) => onNativeSelectRef(field.id, element)}
+                onFocus={() => onFieldFocus(field.id)}
+                onChange={(nextValue) => onFieldValueChange(field.id, nextValue)}
+              />
+            ) : (
+              <Box
+                height={1}
+                backgroundColor={nativePaneChrome ? "transparent" : borderColor}
+                onMouseDown={(event: any) => {
+                  event.stopPropagation?.();
+                  onFieldPickerOpen(route, field);
+                }}
+                style={nativePaneChrome ? { borderRadius: 4 } : undefined}
+              >
+                <Text fg={active ? paletteText : paletteSubtleText}>
+                  {truncateText(summarizeWorkflowFieldValue(field, value), queryDisplayWidth)}
+                </Text>
+              </Box>
+            )}
+            {fieldDescription && (
+              <Box height={1}>
+                <Text fg={paletteSubtleText}>
+                  {truncateText(fieldDescription, queryDisplayWidth)}
+                </Text>
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+      {route.error && (
+        <Box height={1}>
+          <Text fg={themeNegative}>{truncateText(route.error, queryDisplayWidth)}</Text>
+        </Box>
+      )}
+      {route.pendingLabel && route.pending && (
+        <Box height={1}>
+          <Spinner label={route.pendingLabel} />
+        </Box>
+      )}
+      {!nativePaneChrome && <Box flexGrow={1} />}
+      <Box flexDirection="row" gap={1} justifyContent={visibleFields.some((field) => field.type === "textarea") ? "flex-end" : "flex-start"}>
+        <Button label={route.submitLabel} variant="primary" onPress={() => { void onSubmit(route); }} disabled={route.pending} />
+      </Box>
+    </>
+  );
+
+  if (nativePaneChrome) {
+    return (
+      <ScrollBox
+        ref={workflowScrollRef}
+        height={bodyHeight}
+        scrollY
+        style={{ overflowX: "hidden", paddingRight: 4 }}
+      >
+        <Box
+          flexDirection="column"
+          paddingX={contentPadding}
+        >
+          {workflowContent}
+        </Box>
+      </ScrollBox>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" height={bodyHeight} paddingX={contentPadding}>
+      {workflowContent}
+    </Box>
+  );
+}

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -8,8 +8,9 @@ import type { PluginRegistry } from "../../plugins/registry";
 import { colors, floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
 import { hasPaneFooterContent, PaneFooterBar, PaneFooterProvider } from "./pane-footer";
+import { PaneBodyFrame, getPaneWindowAttributes } from "./pane-frame";
 import { PaneContent } from "./pane-content";
-import { getNativePaneBodyWidth, getPaneBodyWidth, NATIVE_PANE_BODY_LAYOUT_PROPS } from "./pane-sizing";
+import { resolvePaneBodyFrame } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX, TITLEBAR_TRAFFIC_LIGHT_WIDTH } from "./titlebar-overlay";
 import {
@@ -52,7 +53,6 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     ? getPaneDisplayTitle(titleState, instance, paneDef)
     : "Detached Pane";
   const focused = windowFocused;
-  const bodyWidth = nativePaneChrome ? getNativePaneBodyWidth(width) : getPaneBodyWidth(width);
 
   const focusPane = useCallback(() => {
     setWindowFocused(true);
@@ -128,13 +128,17 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
       {(footer) => {
         const showFooter = hasPaneFooterContent(footer);
         const headerHeightRows = titleBarOverlay ? TITLEBAR_OVERLAY_HEIGHT_PX / cellHeightPx : 1;
-        const footerHeightRows = showFooter ? 1 : 0;
-        const bodyHeight = Math.max(1, height - headerHeightRows - footerHeightRows);
         const background = floatingPaneBg(focused);
         const titleBackground = floatingPaneTitleBg(focused);
-        const bodyLayoutProps = nativePaneChrome
-          ? NATIVE_PANE_BODY_LAYOUT_PROPS
-          : { height: bodyHeight };
+        const bodyFrame = resolvePaneBodyFrame({
+          width,
+          height,
+          nativePaneChrome,
+          reserveFooter: showFooter,
+          headerRows: headerHeightRows,
+        });
+        const bodyWidth = bodyFrame.width ?? 1;
+        const bodyHeight = bodyFrame.height ?? 1;
 
         return (
           <Box
@@ -143,9 +147,11 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
             width={width}
             height={height}
             backgroundColor={background}
-            data-gloom-role="detached-pane-window"
-            data-gloom-pane-id={desktopWindowBridge.paneId}
-            data-focused={focused ? "true" : "false"}
+            {...getPaneWindowAttributes({
+              role: "detached-pane-window",
+              paneId: desktopWindowBridge.paneId,
+              focused,
+            })}
             onMouseDown={focusPane}
           >
             <Box
@@ -185,7 +191,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
                 )}
               </Box>
             </Box>
-            <Box {...bodyLayoutProps} overflow="hidden" backgroundColor={background}>
+            <PaneBodyFrame layoutProps={bodyFrame.layoutProps} backgroundColor={background}>
               <PaneContent
                 component={paneDef.component}
                 paneId={instance.instanceId}
@@ -194,7 +200,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
                 width={bodyWidth}
                 height={bodyHeight}
               />
-            </Box>
+            </PaneBodyFrame>
             {showFooter && <PaneFooterBar footer={footer} focused={focused} width={width} />}
           </Box>
         );

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -1,14 +1,10 @@
 import { Box, Text, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
+import { PaneBodyFrame, getPaneWindowAttributes } from "./pane-frame";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import {
-  getNativePaneBodyHeight,
-  getPaneBodyHeight,
-  NATIVE_PANE_BODY_LAYOUT_PROPS,
-  shouldReservePaneFooter,
-} from "./pane-sizing";
+import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./pane-sizing";
 
 interface FloatingPaneWrapperProps {
   paneId?: string;
@@ -84,12 +80,7 @@ export function FloatingPaneWrapper({
   const bg = floatingPaneBg(focused);
   const showFooter = hasPaneFooterContent(footer);
   const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
-  const bodyHeight = nativePaneChrome
-    ? getNativePaneBodyHeight(height, reserveFooter)
-    : getPaneBodyHeight(height, reserveFooter);
-  const bodyLayoutProps = nativePaneChrome
-    ? NATIVE_PANE_BODY_LAYOUT_PROPS
-    : { height: bodyHeight };
+  const bodyFrame = resolvePaneBodyFrame({ height, nativePaneChrome, reserveFooter });
 
   return (
     <Box
@@ -102,14 +93,15 @@ export function FloatingPaneWrapper({
       backgroundColor={bg}
       flexDirection="column"
       overflow="hidden"
-      {...(nativePaneChrome ? {
-        "data-gloom-role": "pane-window",
-        "data-gloom-pane-id": paneId,
-        "data-floating": "true",
-        "data-focused": focused ? "true" : "false",
-        "data-window-mode-selected": windowModeSelected ? "true" : "false",
-        style: { "--pane-border-color": focused || windowModeSelected ? colors.borderFocused : colors.border },
-      } : {})}
+      {...getPaneWindowAttributes({
+        enabled: nativePaneChrome,
+        role: "pane-window",
+        paneId,
+        floating: true,
+        focused,
+        windowModeSelected,
+        showBorderColor: true,
+      })}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
     >
@@ -128,10 +120,9 @@ export function FloatingPaneWrapper({
         onCloseMouseDown={onCloseMouseDown}
       />
 
-      {/* Content */}
-      <Box {...bodyLayoutProps} overflow="hidden" backgroundColor={bg}>
+      <PaneBodyFrame layoutProps={bodyFrame.layoutProps} backgroundColor={bg}>
         {children}
-      </Box>
+      </PaneBodyFrame>
 
       {reserveFooter && (
         <PaneFooterBar

--- a/src/components/layout/pane-footer.test.tsx
+++ b/src/components/layout/pane-footer.test.tsx
@@ -3,7 +3,6 @@ import { act } from "react";
 import { Box } from "../../ui";
 import { testRender } from "../../renderers/opentui/test-utils";
 import {
-  hasPaneFooterContent,
   PaneFooterBar,
   PaneFooterProvider,
   usePaneFooter,
@@ -20,14 +19,11 @@ afterEach(() => {
 });
 
 function Registration({
-  visible = true,
   onRefresh,
 }: {
-  visible?: boolean;
   onRefresh?: () => void;
 }) {
   usePaneFooter("test", () => {
-    if (!visible) return null;
     return {
       info: [
         {
@@ -42,7 +38,7 @@ function Registration({
         { id: "refresh", key: "r", label: "efresh", onPress: onRefresh },
       ],
     };
-  }, [onRefresh, visible]);
+  }, [onRefresh]);
   return null;
 }
 
@@ -58,18 +54,16 @@ function ExternalLinkRegistration() {
 
 function FooterHarness({
   focused = false,
-  visible = true,
   onRefresh,
 }: {
   focused?: boolean;
-  visible?: boolean;
   onRefresh?: () => void;
 }) {
   return (
     <PaneFooterProvider>
       {(footer) => (
         <Box width={64} height={1}>
-          <Registration visible={visible} onRefresh={onRefresh} />
+          <Registration onRefresh={onRefresh} />
           <PaneFooterBar footer={footer} focused={focused} width={64} />
         </Box>
       )}
@@ -91,27 +85,6 @@ function ExternalLinkFooterHarness() {
 }
 
 describe("PaneFooterBar", () => {
-  test("reports when footer has content", () => {
-    expect(hasPaneFooterContent(null)).toBe(false);
-    expect(hasPaneFooterContent({ info: [], hints: [] })).toBe(false);
-    expect(hasPaneFooterContent({
-      info: [{ id: "rows", parts: [{ text: "Rows", tone: "label" }] }],
-      hints: [],
-    })).toBe(true);
-  });
-
-  test("renders focused info left and hints right", async () => {
-    testSetup = await testRender(<FooterHarness focused />, { width: 64, height: 1 });
-    await act(async () => {
-      await testSetup!.renderOnce();
-      await testSetup!.renderOnce();
-    });
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("Rows 12");
-    expect(frame).toContain("[r]efresh");
-  });
-
   test("hides hints on inactive footers but keeps info visible", async () => {
     testSetup = await testRender(<FooterHarness />, { width: 64, height: 1 });
     await act(async () => {
@@ -154,17 +127,5 @@ describe("PaneFooterBar", () => {
       await testSetup!.renderOnce();
     });
     expect(refreshCount).toBe(1);
-  });
-
-  test("clears a registration when the component unmounts", async () => {
-    testSetup = await testRender(<FooterHarness visible={false} />, { width: 64, height: 1 });
-    await act(async () => {
-      await testSetup!.renderOnce();
-      await testSetup!.renderOnce();
-    });
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).not.toContain("Rows 12");
-    expect(frame).not.toContain("[r]efresh");
   });
 });

--- a/src/components/layout/pane-frame.tsx
+++ b/src/components/layout/pane-frame.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { Box } from "../../ui";
+import { colors } from "../../theme/colors";
+
+export function getPaneWindowAttributes({
+  enabled = true,
+  role,
+  paneId,
+  floating,
+  focused,
+  windowModeSelected,
+  showBorderColor = false,
+}: {
+  enabled?: boolean;
+  role: string;
+  paneId?: string;
+  floating?: boolean;
+  focused: boolean;
+  windowModeSelected?: boolean;
+  showBorderColor?: boolean;
+}): Record<string, unknown> {
+  if (!enabled) return {};
+
+  const attributes: Record<string, unknown> = {
+    "data-gloom-role": role,
+    "data-focused": focused ? "true" : "false",
+  };
+  if (paneId) attributes["data-gloom-pane-id"] = paneId;
+  if (floating != null) attributes["data-floating"] = floating ? "true" : "false";
+  if (windowModeSelected != null) {
+    attributes["data-window-mode-selected"] = windowModeSelected ? "true" : "false";
+  }
+  if (showBorderColor) {
+    attributes.style = {
+      "--pane-border-color": focused || windowModeSelected ? colors.borderFocused : colors.border,
+    };
+  }
+  return attributes;
+}
+
+export function PaneBodyFrame({
+  layoutProps,
+  backgroundColor,
+  children,
+}: {
+  layoutProps: Record<string, unknown>;
+  backgroundColor: string;
+  children: ReactNode;
+}) {
+  return (
+    <Box {...layoutProps} overflow="hidden" backgroundColor={backgroundColor}>
+      {children}
+    </Box>
+  );
+}

--- a/src/components/layout/pane-sizing.ts
+++ b/src/components/layout/pane-sizing.ts
@@ -12,23 +12,55 @@ export function shouldReservePaneFooter(nativePaneChrome: boolean | undefined, s
   return !nativePaneChrome || showFooter;
 }
 
-export function getPaneBodyHeight(height: number, reserveFooter = true): number {
-  const cellHeight = Math.max(1, Math.floor(height));
-  return Math.max(1, cellHeight - PANE_HEADER_ROWS - (reserveFooter ? PANE_FOOTER_ROWS : 0));
+export function resolvePaneBodyHeight({
+  height,
+  nativePaneChrome,
+  reserveFooter = true,
+  headerRows = PANE_HEADER_ROWS,
+}: {
+  height: number;
+  nativePaneChrome?: boolean;
+  reserveFooter?: boolean;
+  headerRows?: number;
+}): number {
+  const finiteHeight = Number.isFinite(height) ? height : 1;
+  const normalizedHeight = nativePaneChrome ? finiteHeight : Math.max(1, Math.floor(finiteHeight));
+  return Math.max(1, normalizedHeight - headerRows - (reserveFooter ? PANE_FOOTER_ROWS : 0));
 }
 
-export function getPaneBodyWidth(width: number): number {
-  return Math.max(1, Math.floor(width));
+export function getPaneBodyLayoutProps(nativePaneChrome: boolean | undefined, bodyHeight: number | undefined) {
+  if (nativePaneChrome) return NATIVE_PANE_BODY_LAYOUT_PROPS;
+  return {
+    height: bodyHeight,
+    flexGrow: bodyHeight == null ? 1 : 0,
+    flexBasis: bodyHeight == null ? 0 : undefined,
+  };
 }
 
-export function getNativePaneBodyHeight(height: number, reserveFooter = true): number {
-  const preciseHeight = Number.isFinite(height) ? height : 1;
-  return Math.max(
-    1,
-    preciseHeight - PANE_HEADER_ROWS - (reserveFooter ? PANE_FOOTER_ROWS : 0),
-  );
+export function resolvePaneBodyFrame({
+  width,
+  height,
+  nativePaneChrome,
+  reserveFooter = true,
+  headerRows = PANE_HEADER_ROWS,
+}: {
+  width?: number;
+  height?: number;
+  nativePaneChrome?: boolean;
+  reserveFooter?: boolean;
+  headerRows?: number;
+}) {
+  const bodyHeight = typeof height === "number"
+    ? resolvePaneBodyHeight({ height, nativePaneChrome, reserveFooter, headerRows })
+    : undefined;
+  return {
+    width: typeof width === "number" ? resolvePaneBodyWidth(width, nativePaneChrome) : undefined,
+    height: bodyHeight,
+    layoutProps: getPaneBodyLayoutProps(nativePaneChrome, bodyHeight),
+  };
 }
 
-export function getNativePaneBodyWidth(width: number): number {
-  return Math.max(1, Number.isFinite(width) ? width : 1);
+function resolvePaneBodyWidth(width: number, nativePaneChrome: boolean | undefined): number {
+  const finiteWidth = Number.isFinite(width) ? width : 1;
+  return nativePaneChrome ? Math.max(1, finiteWidth) : Math.max(1, Math.floor(finiteWidth));
 }

--- a/src/components/layout/pane.tsx
+++ b/src/components/layout/pane.tsx
@@ -1,14 +1,10 @@
 import { Box, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
-import { colors, paneBg } from "../../theme/colors";
+import { paneBg } from "../../theme/colors";
+import { PaneBodyFrame, getPaneWindowAttributes } from "./pane-frame";
 import { PaneHeader } from "./pane-header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane-footer";
-import {
-  getNativePaneBodyHeight,
-  getPaneBodyHeight,
-  NATIVE_PANE_BODY_LAYOUT_PROPS,
-  shouldReservePaneFooter,
-} from "./pane-sizing";
+import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./pane-sizing";
 
 interface PaneWrapperProps {
   paneId?: string;
@@ -28,23 +24,6 @@ interface PaneWrapperProps {
   onActionMouseDown?: (event: any) => void;
   footer?: CombinedPaneFooter | null;
   children: ReactNode;
-}
-
-function resolvePaneBodyHeight(
-  height: number,
-  hasTitle: boolean,
-  reserveFooter: boolean,
-  nativePaneChrome: boolean | undefined,
-): number {
-  if (nativePaneChrome) {
-    return hasTitle
-      ? getNativePaneBodyHeight(height, reserveFooter)
-      : Math.max(1, height);
-  }
-
-  return hasTitle
-    ? getPaneBodyHeight(height, reserveFooter)
-    : Math.max(1, Math.floor(height));
 }
 
 export function PaneWrapper({
@@ -69,17 +48,13 @@ export function PaneWrapper({
   const { nativePaneChrome } = useUiCapabilities();
   const bg = paneBg(focused);
   const showFooter = hasPaneFooterContent(footer);
-  const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
-  const bodyHeight = typeof height === "number"
-    ? resolvePaneBodyHeight(height, !!title, reserveFooter, nativePaneChrome)
-    : undefined;
-  const bodyLayoutProps = nativePaneChrome
-    ? NATIVE_PANE_BODY_LAYOUT_PROPS
-    : {
-        height: bodyHeight,
-        flexGrow: bodyHeight == null ? 1 : 0,
-        flexBasis: bodyHeight == null ? 0 : undefined,
-      };
+  const reserveFooter = !!title && shouldReservePaneFooter(nativePaneChrome, showFooter);
+  const bodyFrame = resolvePaneBodyFrame({
+    height: typeof height === "number" ? height : undefined,
+    nativePaneChrome,
+    reserveFooter,
+    headerRows: title ? 1 : 0,
+  });
 
   return (
     <Box
@@ -89,14 +64,15 @@ export function PaneWrapper({
       flexGrow={flexGrow}
       backgroundColor={bg}
       overflow="hidden"
-      {...(nativePaneChrome ? {
-        "data-gloom-role": "pane-window",
-        "data-gloom-pane-id": paneId,
-        "data-floating": "false",
-        "data-focused": focused ? "true" : "false",
-        "data-window-mode-selected": windowModeSelected ? "true" : "false",
-        style: { "--pane-border-color": focused || windowModeSelected ? colors.borderFocused : colors.border },
-      } : {})}
+      {...getPaneWindowAttributes({
+        enabled: nativePaneChrome,
+        role: "pane-window",
+        paneId,
+        floating: false,
+        focused,
+        windowModeSelected,
+        showBorderColor: true,
+      })}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
     >
@@ -114,13 +90,9 @@ export function PaneWrapper({
           onActionMouseDown={onActionMouseDown}
         />
       )}
-      <Box
-        {...bodyLayoutProps}
-        overflow="hidden"
-        backgroundColor={bg}
-      >
+      <PaneBodyFrame layoutProps={bodyFrame.layoutProps} backgroundColor={bg}>
         {children}
-      </Box>
+      </PaneBodyFrame>
       {title && reserveFooter && (
         <PaneFooterBar
           footer={footer}

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -53,13 +53,7 @@ import { FloatingPaneWrapper } from "./floating-pane";
 import { PaneContent } from "./pane-content";
 import { PaneWrapper } from "./pane";
 import { hasPaneFooterContent, PaneFooterProvider } from "./pane-footer";
-import {
-  getNativePaneBodyHeight,
-  getNativePaneBodyWidth,
-  getPaneBodyHeight,
-  getPaneBodyWidth,
-  shouldReservePaneFooter,
-} from "./pane-sizing";
+import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./pane-sizing";
 import { getPaneDisplayTitle } from "./pane-title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX } from "./titlebar-overlay";
 import { capturePaneScreenshotPngBase64 } from "../../utils/dom-screenshot";
@@ -2017,7 +2011,6 @@ export function Shell({
         const focused = focusedPaneId === leaf.instanceId && (!overlayOpen || menuState?.paneId === leaf.instanceId);
         const windowModeSelected = windowMode?.paneId === leaf.instanceId;
         const showActions = focused || hoveredPaneId === leaf.instanceId || menuState?.paneId === leaf.instanceId;
-        const bodyWidth = nativePaneChrome ? getNativePaneBodyWidth(leaf.rect.width) : getPaneBodyWidth(leaf.rect.width);
         return (
           <Box
             key={`dock:${leaf.instanceId}`}
@@ -2030,9 +2023,12 @@ export function Shell({
             <PaneFooterProvider>
               {(footer) => {
                 const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
-                const bodyHeight = nativePaneChrome
-                  ? getNativePaneBodyHeight(leaf.rect.height, reserveFooter)
-                  : getPaneBodyHeight(leaf.rect.height, reserveFooter);
+                const bodyFrame = resolvePaneBodyFrame({
+                  width: leaf.rect.width,
+                  height: leaf.rect.height,
+                  nativePaneChrome,
+                  reserveFooter,
+                });
                 return (
                   <PaneWrapper
                     paneId={leaf.instanceId}
@@ -2056,8 +2052,8 @@ export function Shell({
                       paneId={pane.instance.instanceId}
                       paneType={pane.instance.paneId}
                       focused={focused}
-                      width={bodyWidth}
-                      height={bodyHeight}
+                      width={bodyFrame.width ?? 1}
+                      height={bodyFrame.height ?? 1}
                     />
                   </PaneWrapper>
                 );
@@ -2074,14 +2070,16 @@ export function Shell({
         const focused = focusedPaneId === pane.instance.instanceId && (!overlayOpen || menuState?.paneId === pane.instance.instanceId);
         const windowModeSelected = windowMode?.paneId === pane.instance.instanceId;
         const showActions = focused || hoveredPaneId === pane.instance.instanceId || menuState?.paneId === pane.instance.instanceId;
-        const bodyWidth = nativePaneChrome ? getNativePaneBodyWidth(preview.width) : getPaneBodyWidth(preview.width);
         return (
           <PaneFooterProvider key={`float:${pane.instance.instanceId}`}>
             {(footer) => {
               const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
-              const bodyHeight = nativePaneChrome
-                ? getNativePaneBodyHeight(preview.height, reserveFooter)
-                : getPaneBodyHeight(preview.height, reserveFooter);
+              const bodyFrame = resolvePaneBodyFrame({
+                width: preview.width,
+                height: preview.height,
+                nativePaneChrome,
+                reserveFooter,
+              });
               return (
                 <FloatingPaneWrapper
                   paneId={pane.instance.instanceId}
@@ -2112,8 +2110,8 @@ export function Shell({
                     paneId={pane.instance.instanceId}
                     paneType={pane.instance.paneId}
                     focused={focused}
-                    width={bodyWidth}
-                    height={bodyHeight}
+                    width={bodyFrame.width ?? 1}
+                    height={bodyFrame.height ?? 1}
                     onClose={handleFloatingClose}
                   />
                 </FloatingPaneWrapper>

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -45,37 +45,6 @@ describe("StatusBar", () => {
     expect(actions).toContainEqual({ type: "SET_COMMAND_BAR", open: true, query: "" });
   });
 
-  test("renders layout tabs without preview suffixes", async () => {
-    const config = createDefaultConfig("/tmp/gloomberb-test");
-    const researchLayout = cloneLayout(config.layout);
-    researchLayout.dockRoot = { kind: "pane", instanceId: "portfolio-list:main" };
-    researchLayout.floating = [{ instanceId: "ticker-detail:main", x: 8, y: 2, width: 36, height: 12 }];
-
-    const state = {
-      ...createInitialState({
-        ...config,
-        layouts: [
-          { name: "Default", layout: cloneLayout(config.layout) },
-          { name: "Research", layout: researchLayout },
-        ],
-      }),
-      statusBarVisible: true,
-    };
-
-    testSetup = await testRender(
-      <AppContext value={{ state, dispatch: () => {} }}>
-        <StatusBar />
-      </AppContext>,
-      { width: 120, height: 1 },
-    );
-
-    await testSetup.renderOnce();
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("Default");
-    expect(frame).toContain("Research");
-  });
-
   test("shows a gridlock tip after a corner snap and runs gridlock on click", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     const floatingLayout = cloneLayout(config.layout);
@@ -185,74 +154,5 @@ describe("StatusBar", () => {
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
     }
-  });
-
-  test("omits focused ticker quote details", async () => {
-    const config = createDefaultConfig("/tmp/gloomberb-test");
-    config.layout.instances = config.layout.instances.map((instance) => (
-      instance.instanceId === "ticker-detail:main"
-        ? { ...instance, binding: { kind: "fixed" as const, symbol: "AMD" } }
-        : instance
-    ));
-    const state = createInitialState(config);
-    state.statusBarVisible = true;
-    state.focusedPaneId = "ticker-detail:main";
-    state.tickers = new Map([["AMD", {
-      metadata: {
-        ticker: "AMD",
-        exchange: "NASDAQ",
-        currency: "USD",
-        name: "Advanced Micro Devices",
-        portfolios: [],
-        watchlists: [],
-        positions: [],
-        custom: {},
-        tags: [],
-      },
-    }]]);
-    state.financials = new Map([["AMD", {
-      annualStatements: [],
-      quarterlyStatements: [],
-      priceHistory: [],
-      quote: {
-        symbol: "AMD",
-        providerId: "ibkr",
-        dataSource: "live",
-        price: 100,
-        currency: "USD",
-        change: 1,
-        changePercent: 1,
-        lastUpdated: Date.now(),
-        listingExchangeName: "NASDAQ",
-        routingExchangeName: "SMART",
-        marketState: "PRE",
-        sessionConfidence: "derived",
-        preMarketPrice: 101,
-        preMarketChange: 2,
-        preMarketChangePercent: 2,
-        provenance: {
-          price: { providerId: "ibkr", dataSource: "live" },
-          session: { providerId: "yahoo", dataSource: "delayed" },
-        },
-      },
-    }]]);
-
-    testSetup = await testRender(
-      <AppContext value={{ state, dispatch: () => {} }}>
-        <StatusBar />
-      </AppContext>,
-      { width: 120, height: 1 },
-    );
-
-    await testSetup.renderOnce();
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).not.toContain("AMD");
-    expect(frame).not.toContain("Pre");
-    expect(frame).not.toContain("101");
-    expect(frame).not.toContain("NASDAQ PRE-MKT");
-    expect(frame).not.toContain("px IBKR live");
-    expect(frame).not.toContain("ses Yahoo");
-    expect(frame).not.toContain("SMART OPEN");
   });
 });

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -558,7 +558,7 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
   const contentTop = Math.max(1, Math.floor((termHeight - 24) / 2));
 
   // Progress bar
-  const progressDots = STEPS.map((s, i) => {
+  const progressDots = STEPS.map((_, i) => {
     if (i < stepIdx) return "\u2501";
     if (i === stepIdx) return "\u25cf";
     return "\u00b7";

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useEffect, useRef, useState } from "react";
 import { TestDialogProvider, testRender } from "../../renderers/opentui/test-utils";
 import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core";
-import { Button } from "./button";
 import { ChoiceDialog } from "./choice-dialog";
 import { DataTable, type DataTableColumn } from "./data-table";
 import { TextField } from "./fields";
@@ -17,7 +16,6 @@ import {
   toggleOrderedMultiSelectValue,
 } from "./multi-select";
 import { Tabs } from "./tabs";
-import { ToggleList } from "../toggle-list";
 import { AppContext, PaneInstanceProvider, createInitialState } from "../../state/app-context";
 import { createDefaultConfig } from "../../types/config";
 import { DataTableView } from "../data-table-view";
@@ -282,30 +280,6 @@ afterEach(() => {
 });
 
 describe("shared UI kit", () => {
-  test("renders navigation and button primitives", async () => {
-    testSetup = await testRender(
-      <box flexDirection="column">
-        <Tabs
-          tabs={[
-            { label: "Overview", value: "overview" },
-            { label: "News", value: "news" },
-          ]}
-          activeValue="overview"
-          onSelect={() => {}}
-        />
-        <box height={1} />
-        <Button label="Save" variant="primary" shortcut="⌘S" onPress={() => {}} />
-      </box>,
-      { width: 40, height: 6 },
-    );
-
-    await testSetup.renderOnce();
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("Overview");
-    expect(frame).toContain("Save");
-  });
-
   test("scrolls overflowing tabs horizontally with the mouse wheel", async () => {
     testSetup = await testRender(
       <Tabs
@@ -418,52 +392,6 @@ describe("shared UI kit", () => {
       await testSetup!.renderOnce();
     });
     expect(addedTab).toBe(true);
-  });
-
-  test("renders default tabs in one row", async () => {
-    testSetup = await testRender(
-      <box flexDirection="column">
-        <Tabs
-          tabs={[
-            { label: "Overview", value: "overview" },
-            { label: "Chart", value: "chart" },
-          ]}
-          activeValue="chart"
-          onSelect={() => {}}
-        />
-        <text>After tabs</text>
-      </box>,
-      { width: 32, height: 3 },
-    );
-
-    await testSetup.renderOnce();
-
-    const lines = testSetup.captureCharFrame().split("\n");
-    expect(lines[0]).toContain("Overview");
-    expect(lines[0]).toContain("Chart");
-    expect(lines[1]).toContain("After tabs");
-  });
-
-  test("renders toggle lists with selection and descriptions", async () => {
-    testSetup = await testRender(
-      <ToggleList
-        items={[
-          { id: "news", label: "News", enabled: true, description: "Headlines and previews" },
-          { id: "notes", label: "Notes", enabled: false, description: "Ticker notes" },
-        ]}
-        selectedIdx={0}
-        onSelect={() => {}}
-        onToggle={() => {}}
-      />,
-      { width: 40, height: 6 },
-    );
-
-    await testSetup.renderOnce();
-
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("[✓] News");
-    expect(frame).toContain("Notes");
-    expect(frame).toContain("Headlines and previews");
   });
 
   test("opens compact multi-select dialogs from a button", async () => {

--- a/src/plugins/builtin/chat-controller.test.ts
+++ b/src/plugins/builtin/chat-controller.test.ts
@@ -339,13 +339,11 @@ describe("ChatController", () => {
     });
 
     controller.ensureConnection();
-    expect((controller as any).wsConnection).not.toBeNull();
 
     controller.dispose();
 
     expect(closed).toBe(true);
     expect((controller as any).verificationPollTimer).toBeNull();
-    expect((controller as any).wsConnection).toBeNull();
   });
 
   test("runs a quiet safety refresh while the live connection is active", async () => {

--- a/src/plugins/builtin/chat-controller.ts
+++ b/src/plugins/builtin/chat-controller.ts
@@ -239,10 +239,6 @@ export class ChatController {
   private chatPresenceUnsubscribe: (() => void) | null = null;
   private notifiedMessageIds = new Set<string>();
 
-  private get wsConnection(): ChatConnection | null {
-    return this.ensureChannelState(DEFAULT_CHAT_CHANNEL_ID).wsConnection;
-  }
-
   attachPersistence(persistence: PluginPersistence, resume?: PluginResumeState): void {
     this.persistence = persistence;
     this.resume = resume ?? this.resume;

--- a/src/plugins/builtin/chat.test.tsx
+++ b/src/plugins/builtin/chat.test.tsx
@@ -12,7 +12,7 @@ import { Box, TextAttributes } from "../../ui";
 import { apiClient, type ChatChannel, type ChatMessage } from "../../utils/api-client";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../plugin-runtime";
 import { setSharedMarketDataForTests, setSharedRegistryForTests } from "../registry";
-import { ChatContent, ChatStatusWidget, getScrollTopForElementIntoView, getSelectedMessageScrollTop, gloomberbCloudPlugin } from "./chat";
+import { ChatContent, ChatStatusWidget, gloomberbCloudPlugin } from "./chat";
 import { chatController, ChatController } from "./chat-controller";
 
 const TRANSCRIPT_KIND = "channel-transcript";

--- a/src/plugins/builtin/chat.tsx
+++ b/src/plugins/builtin/chat.tsx
@@ -39,7 +39,6 @@ interface ChatContentProps {
   width: number;
   height: number;
   focused: boolean;
-  close?: () => void;
   channelId?: string;
   onChannelChange?: (channelId: string) => void;
   controller?: Pick<
@@ -1302,7 +1301,6 @@ export function ChatContent({
   width,
   height,
   focused,
-  close,
   channelId: rawChannelId,
   onChannelChange,
   controller = chatController,
@@ -2326,7 +2324,7 @@ export function ChatContent({
   );
 }
 
-function ChatPane({ focused, width, height, close }: PaneProps) {
+function ChatPane({ focused, width, height }: PaneProps) {
   const dispatch = useAppDispatch();
   const stateRef = useAppStateRef();
   const paneId = usePaneInstanceId();
@@ -2393,7 +2391,6 @@ function ChatPane({ focused, width, height, close }: PaneProps) {
       width={width}
       height={height}
       focused={focused}
-      close={close}
       channelId={channelId}
       onChannelChange={setChannelId}
     />

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -290,7 +290,7 @@ function EconDetailView({ event, width, height, focused }: EconDetailViewProps) 
   // For "change" mode, compute m/m or q/q percent change from consecutive observations
   const descObs = [...observations].reverse();
   const ascObs = observations; // already ascending from FRED
-  const tableRows = descObs.slice(0, 12).map((obs, i) => {
+  const tableRows = descObs.slice(0, 12).map((obs) => {
     if (mapping.displayMode !== "change" || obs.value == null) {
       return { date: obs.date, display: obs.value != null ? obs.value.toLocaleString("en-US", { maximumFractionDigits: 1 }) : "—" };
     }

--- a/src/plugins/builtin/news-wire/news-table.test.tsx
+++ b/src/plugins/builtin/news-wire/news-table.test.tsx
@@ -1,7 +1,7 @@
 import { TextAttributes } from "@opentui/core";
 import { afterEach, describe, expect, test } from "bun:test";
 import { act } from "react";
-import { Box, Text } from "../../../ui";
+import { Box } from "../../../ui";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import {
   AppContext,

--- a/src/plugins/builtin/options.tsx
+++ b/src/plugins/builtin/options.tsx
@@ -65,7 +65,7 @@ const OPTION_COLUMNS: Array<Omit<OptionColumn, "headerColor">> = [
   { id: "putOpenInterest", label: "P OI", width: 6, align: "right" },
 ];
 
-export function OptionsView({ width, height, focused, onCapture = () => {} }: OptionsViewProps) {
+export function OptionsView({ width, focused, onCapture = () => {} }: OptionsViewProps) {
   const { ticker, financials } = usePaneTicker();
   const [expIdx, setExpIdx] = useState(0);
   const [strikeIdx, setStrikeIdx] = useState(0);

--- a/src/plugins/builtin/portfolio-list/pane.tsx
+++ b/src/plugins/builtin/portfolio-list/pane.tsx
@@ -74,7 +74,7 @@ function visibleWarmupKey(kind: "quote" | "snapshot", ticker: TickerRecord): str
   return `${kind}:${ticker.metadata.ticker}:${ticker.metadata.exchange ?? ""}`;
 }
 
-function needsVisibleQuoteWarmup(ticker: TickerRecord, financials: TickerFinancials | undefined, now = Date.now()): boolean {
+function needsVisibleQuoteWarmup(financials: TickerFinancials | undefined, now = Date.now()): boolean {
   return !financials?.quote || isQuoteStaleForCurrentSession(financials.quote, now);
 }
 
@@ -482,7 +482,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       const financials = financialsMap.get(ticker.metadata.ticker);
       const quoteKey = visibleWarmupKey("quote", ticker);
       if (
-        needsVisibleQuoteWarmup(ticker, financials, nowTimestamp)
+        needsVisibleQuoteWarmup(financials, nowTimestamp)
         && !warmupInFlightRef.current.has(quoteKey)
         && nowTimestamp - (warmupAttemptRef.current.get(quoteKey) ?? 0) >= VISIBLE_FINANCIAL_REFRESH_COOLDOWN_MS
       ) {

--- a/src/plugins/builtin/ticker-detail/chart-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/chart-tab.tsx
@@ -24,7 +24,6 @@ export function ChartTab({
   interactive,
   axisMode,
   onActivate,
-  symbol,
   ticker,
   financials,
 }: {
@@ -34,7 +33,6 @@ export function ChartTab({
   interactive: boolean;
   axisMode: ChartAxisMode;
   onActivate?: () => void;
-  symbol: string | null;
   ticker: TickerRecord | null;
   financials: TickerFinancials | null;
 }) {

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -297,12 +297,10 @@ function PositionTable({ rows, width }: { rows: PositionTableRow[]; width: numbe
 
 export function OverviewTab({
   width,
-  symbol,
   ticker,
   financials,
 }: {
   width?: number;
-  symbol: string | null;
   ticker: TickerRecord | null;
   financials: TickerFinancials | null;
 }) {

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -60,7 +60,7 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
   const dispatch = useAppDispatch();
   const config = useAppSelector((state) => state.config);
   const paneInstance = usePaneInstance();
-  const { symbol, ticker, financials } = usePaneTicker();
+  const { ticker, financials } = usePaneTicker();
   const streamingTarget = quoteSubscriptionTargetFromTicker(ticker, ticker?.metadata.ticker, "provider");
   const streamingTargets = useMemo(() => (
     streamingTarget
@@ -230,7 +230,6 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
             <PaneFooterScope active={resolvedTabId === "overview"}>
               <OverviewTab
                 width={width}
-                symbol={symbol}
                 ticker={ticker}
                 financials={financials}
               />
@@ -273,7 +272,6 @@ export function TickerDetailPane({ focused, width, height }: PaneProps) {
                 interactive={chartInteractive}
                 axisMode={paneSettings.chartAxisMode}
                 onActivate={() => setChartInteractiveEager(true)}
-                symbol={symbol}
                 ticker={ticker}
                 financials={financials}
               />

--- a/src/plugins/builtin/ticker-detail/quote-monitor.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor.tsx
@@ -17,7 +17,7 @@ import { formatPercentRaw } from "../../../utils/format";
 import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../../utils/market-format";
 import { getActiveQuoteDisplay } from "../../../utils/market-status";
 import { EmptyState } from "../../../components";
-import { useQuoteFlashDirection, type QuoteFlashDirection } from "../../../components/quote-flash";
+import { useQuoteFlashDirection } from "../../../components/quote-flash";
 import {
   PriceAreaSparklineBackground,
   PriceSparkline,
@@ -430,7 +430,7 @@ export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) 
           height: "100%",
         }}
       >
-        {symbols.map((symbol, index) => {
+        {symbols.map((symbol) => {
           const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
           return (
             <QuoteMonitorCard

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -37,7 +37,7 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
 
   const fetchGenRef = useRef(0);
 
-  const load = useCallback(async (force = false) => {
+  const load = useCallback(async () => {
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
     setLoading(true);
@@ -62,7 +62,7 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
   useShortcut((ev) => {
     if (!focused) return;
     if (ev.name === "r") {
-      load(true);
+      load();
     }
   });
 
@@ -76,7 +76,7 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => load(true) }],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => load() }],
   }), [bp, error, inverted, load, loading]);
 
   if (loading && points.length === 0) {

--- a/src/plugins/ibkr/gateway-service-native.ts
+++ b/src/plugins/ibkr/gateway-service-native.ts
@@ -959,7 +959,6 @@ export class IbkrGatewayService {
       const contract = await withTimeout(this.resolveContract(ticker, exchange, instrument ?? null), IBKR_DATA_TIMEOUT, "resolveContract");
       const details = await withTimeout(this.getPrimaryContractDetails(contract), IBKR_DATA_TIMEOUT, "getContractDetails");
       const marketData = await this.withMarketDataFallback(
-        config,
         () => withTimeout(this.api!.getMarketDataSnapshot(contract, "", false), IBKR_DATA_TIMEOUT, "getMarketDataSnapshot"),
       );
       const quote = this.marketDataToQuote(contract, details, marketData);
@@ -1089,7 +1088,6 @@ export class IbkrGatewayService {
       const detailsPromise = withTimeout(this.getPrimaryContractDetails(contract), IBKR_DATA_TIMEOUT, "getContractDetails")
         .catch(() => undefined);
       const bars = await this.withMarketDataFallback(
-        config,
         () => withTimeout(this.api!.getHistoricalData(
           contract,
           "",
@@ -1150,7 +1148,6 @@ export class IbkrGatewayService {
       const detailsPromise = withTimeout(this.getPrimaryContractDetails(contract), IBKR_DATA_TIMEOUT, "getContractDetails")
         .catch(() => undefined);
       const bars = await this.withMarketDataFallback(
-        config,
         () => withTimeout(this.api!.getHistoricalData(
           contract,
           "",
@@ -1208,7 +1205,6 @@ export class IbkrGatewayService {
       else durationStr = `${Math.ceil(spanDays / 365)} Y`;
 
       const bars = await this.withMarketDataFallback(
-        config,
         () => withTimeout(this.api!.getHistoricalData(
           contract,
           endDateTime,
@@ -1316,7 +1312,7 @@ export class IbkrGatewayService {
         resolve();
       };
 
-      const onOrderStatus = (incomingOrderId: number, status: string) => {
+      const onOrderStatus = (incomingOrderId: number) => {
         if (incomingOrderId !== orderId) return;
         cleanup();
         resolve();
@@ -1378,7 +1374,7 @@ export class IbkrGatewayService {
         resolve();
       };
 
-      const onOrderStatus = (incomingOrderId: number, status: string) => {
+      const onOrderStatus = (incomingOrderId: number) => {
         if (incomingOrderId !== orderId) return;
         cleanup();
         resolve();
@@ -1744,7 +1740,7 @@ export class IbkrGatewayService {
       return;
     }
 
-    const seededQuote = await this.loadSeedQuote(contract, details, config).catch(() => null);
+    const seededQuote = await this.loadSeedQuote(contract, details).catch(() => null);
     if (seededQuote) {
       stream.lastQuote = seededQuote;
       for (const [listener, listenerTarget] of stream.listeners.entries()) {
@@ -1869,11 +1865,9 @@ export class IbkrGatewayService {
   private async loadSeedQuote(
     contract: Contract,
     details: ContractDetails,
-    config: IbkrGatewayConfig,
   ): Promise<Quote | null> {
     try {
       const marketData = await this.withMarketDataFallback(
-        config,
         () => withTimeout(this.api!.getMarketDataSnapshot(contract, "", false), IBKR_DATA_TIMEOUT, "getMarketDataSnapshot"),
       );
       const quote = this.marketDataToQuote(contract, details, marketData);
@@ -1930,10 +1924,7 @@ export class IbkrGatewayService {
     };
   }
 
-  private async withMarketDataFallback<T>(
-    config: IbkrGatewayConfig,
-    operation: () => Promise<T>,
-  ): Promise<T> {
+  private async withMarketDataFallback<T>(operation: () => Promise<T>): Promise<T> {
     try {
       return await operation();
     } catch (error: any) {

--- a/src/plugins/ibkr/gateway-service.test.ts
+++ b/src/plugins/ibkr/gateway-service.test.ts
@@ -434,7 +434,7 @@ describe("IbkrGatewayService", () => {
     (service as any).connect = async () => {};
     (service as any).resolveContract = async () => ({ symbol: "AAPL", exchange: "SMART", currency: "USD" });
     (service as any).getPrimaryContractDetails = async () => undefined;
-    (service as any).withMarketDataFallback = async (_config: unknown, task: () => Promise<unknown>) => task();
+    (service as any).withMarketDataFallback = async (task: () => Promise<unknown>) => task();
     (service as any).api = {
       getHistoricalData: async (_contract: unknown, _end: string, duration: string, barSize: string) => {
         requestArgs = { duration, barSize };

--- a/src/plugins/pane-manager.ts
+++ b/src/plugins/pane-manager.ts
@@ -240,7 +240,7 @@ function normalizeDetachedEntries(layout: LayoutConfig) {
     .map((entry) => ({ ...entry }));
 }
 
-function captureDockedMemory(layout: LayoutConfig, dockRoot: DockLayoutNode | null): Map<string, DockedPlacementMemory> {
+function captureDockedMemory(dockRoot: DockLayoutNode | null): Map<string, DockedPlacementMemory> {
   const memory = new Map<string, DockedPlacementMemory>();
   const leaves = collectDockLeafRefs(dockRoot);
 
@@ -274,7 +274,7 @@ function captureDockedMemory(layout: LayoutConfig, dockRoot: DockLayoutNode | nu
 }
 
 function capturePlacementMemory(layout: LayoutConfig): LayoutConfig {
-  const dockedMemory = captureDockedMemory(layout, layout.dockRoot);
+  const dockedMemory = captureDockedMemory(layout.dockRoot);
   const floatingById = new Map(layout.floating.map((entry) => [entry.instanceId, entry] as const));
   const detachedById = new Map((layout.detached ?? []).map((entry) => [entry.instanceId, entry] as const));
 
@@ -384,31 +384,6 @@ function insertRelativeToSubtreePath(
     ...base,
     dockRoot: replaceNodeAtPath(base.dockRoot, candidatePath, replacement),
   });
-}
-
-function scoreDirectionalCandidate(
-  current: DockLeafLayout,
-  candidate: DockLeafLayout,
-  direction: DockTarget["position"],
-): number | null {
-  const currentCenterX = current.rect.x + Math.floor(current.rect.width / 2);
-  const currentCenterY = current.rect.y + Math.floor(current.rect.height / 2);
-  const candidateCenterX = candidate.rect.x + Math.floor(candidate.rect.width / 2);
-  const candidateCenterY = candidate.rect.y + Math.floor(candidate.rect.height / 2);
-
-  if (direction === "left" && candidateCenterX >= currentCenterX) return null;
-  if (direction === "right" && candidateCenterX <= currentCenterX) return null;
-  if (direction === "above" && candidateCenterY >= currentCenterY) return null;
-  if (direction === "below" && candidateCenterY <= currentCenterY) return null;
-
-  const primaryDelta = direction === "left" || direction === "right"
-    ? Math.abs(currentCenterX - candidateCenterX)
-    : Math.abs(currentCenterY - candidateCenterY);
-  const secondaryDelta = direction === "left" || direction === "right"
-    ? Math.abs(currentCenterY - candidateCenterY)
-    : Math.abs(currentCenterX - candidateCenterX);
-
-  return primaryDelta * 1000 + secondaryDelta;
 }
 
 function resolveSplitSizes(total: number, ratio: number, minSize: number, precise = false): [number, number] {

--- a/src/plugins/prediction-markets/detail/outcomes.tsx
+++ b/src/plugins/prediction-markets/detail/outcomes.tsx
@@ -46,7 +46,7 @@ export function PredictionMarketOutcomesView({
         </Box>
       </Box>
 
-      {sortedOutcomes.map((market, index) => {
+      {sortedOutcomes.map((market) => {
         const selected = market.key === selectedMarketKey;
         return (
           <Box

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -28,7 +28,6 @@ import { registerElectrobunCoreCapabilities } from "./core-capabilities";
 import { setNativeIbkrGatewayModuleLoader } from "../../../plugins/ibkr/gateway-service";
 import { apiClient, type PersistedAuthUser } from "../../../utils/api-client";
 import {
-  checkElectrobunDesktopUpdate,
   runElectrobunDesktopUpdate,
 } from "./desktop-update";
 import {
@@ -817,11 +816,7 @@ async function initialize(
   };
 }
 
-async function handleDesktop(
-  rpc: DesktopRpc,
-  method: string,
-  payload: Record<string, unknown>,
-) {
+async function handleDesktop(method: string, payload: Record<string, unknown>) {
   const workspace = requireDesktopWorkspace();
   switch (method) {
     case "desktop.syncMainState": {
@@ -937,7 +932,7 @@ async function handleBackendRequest(
   if (method === "init") return initialize(rpc, payload);
   if (method === "http.fetch") return handleHttpFetch(payload);
   if (method.startsWith("capability.")) return handleCapability(rpc, method, payload);
-  if (method.startsWith("desktop.")) return handleDesktop(rpc, method, payload);
+  if (method.startsWith("desktop.")) return handleDesktop(method, payload);
 
   switch (method) {
     case "update.check":

--- a/src/renderers/electrobun/view/build-assets.ts
+++ b/src/renderers/electrobun/view/build-assets.ts
@@ -1,0 +1,116 @@
+import { readFile, writeFile } from "fs/promises";
+import { join, relative } from "path";
+import { TITLEBAR_OVERLAY_HEIGHT_PX } from "../../../components/layout/titlebar-overlay";
+
+type AliasRule = readonly [string, string] | readonly [string, string, string];
+type PageOptions = {
+  entrypoint: string;
+  outdir: string;
+  pluginName: string;
+  extraAliasRules?: AliasRule[];
+  failureMessage: string;
+  missingEntryMessage: string;
+  title: string;
+  loadingText: string;
+  bootstrapScript: string;
+};
+
+const ELECTROBUN_VIEW_DIR = join(process.cwd(), "src", "renderers", "electrobun", "view");
+const COMMON_ALIAS_RULES: AliasRule[] = [
+  ["notes-files", "notes-files.ts"],
+  ["native/kitty-support", "native-stubs/chart-kitty-support.ts"],
+  ["./kitty-support", "components/chart/native/renderer-selection.ts", "native-stubs/chart-kitty-support.ts"],
+  ["native/surface-manager", "native-stubs/chart-surface-manager.ts"],
+  ["native/surface-sync", "native-stubs/chart-surface-sync.ts"],
+];
+
+export function electrobunViewPath(...parts: string[]): string {
+  return join(ELECTROBUN_VIEW_DIR, ...parts);
+}
+
+export async function writeElectrobunViewPage(options: PageOptions): Promise<string> {
+  const { entrySrc, stylesheet } = await buildElectrobunViewBundle(options);
+  const htmlPath = join(options.outdir, "index.html");
+  await writeFile(htmlPath, renderElectrobunViewHtml({ ...options, stylesheet, entrySrc }));
+  return htmlPath;
+}
+
+async function buildElectrobunViewBundle({
+  entrypoint,
+  outdir,
+  pluginName,
+  extraAliasRules = [],
+  failureMessage,
+  missingEntryMessage,
+}: PageOptions): Promise<{ entrySrc: string; stylesheet: string }> {
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    outdir,
+    target: "browser",
+    format: "esm",
+    splitting: false,
+    sourcemap: "external",
+    minify: true,
+    define: {
+      "process.env.NODE_ENV": "\"production\"",
+    },
+    plugins: [
+      {
+        name: pluginName,
+        setup(build) {
+          const aliasRules = [...extraAliasRules, ...COMMON_ALIAS_RULES];
+          build.onResolve({ filter: /.*/ }, (args) => resolveAlias(args, aliasRules));
+        },
+      },
+    ],
+  });
+
+  if (!result.success) {
+    const details = result.logs.map((log) => log.message).filter(Boolean).join("\n");
+    throw new Error(details ? `${failureMessage}\n${details}` : failureMessage);
+  }
+
+  const entry = result.outputs.find((output) => output.kind === "entry-point" && output.path.endsWith(".js"));
+  if (!entry) throw new Error(missingEntryMessage);
+
+  return {
+    entrySrc: `./${relative(outdir, entry.path).replaceAll("\\", "/")}`,
+    stylesheet: (await readFile(electrobunViewPath("styles.css"), "utf8"))
+      .replaceAll("__TITLEBAR_OVERLAY_HEIGHT_PX__", String(TITLEBAR_OVERLAY_HEIGHT_PX)),
+  };
+}
+
+function renderElectrobunViewHtml({
+  title,
+  loadingText,
+  stylesheet,
+  bootstrapScript,
+  entrySrc,
+}: PageOptions & { stylesheet: string; entrySrc: string }): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${title}</title>
+    <style>${stylesheet}</style>
+  </head>
+  <body style="margin:0;background:#000;">
+    <div id="root"><div class="gloom-loading">${loadingText}</div></div>
+    <script>
+${bootstrapScript}
+    </script>
+    <script type="module" src="${entrySrc}"></script>
+  </body>
+</html>
+`;
+}
+
+function resolveAlias(args: { path: string; importer?: string }, aliasRules: AliasRule[]) {
+  for (const rule of aliasRules) {
+    const target = rule.length === 2
+      ? args.path.endsWith(rule[0]) && rule[1]
+      : args.path === rule[0] && args.importer?.endsWith(rule[1]) && rule[2];
+    if (target) return { path: electrobunViewPath(target) };
+  }
+}

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -16,9 +16,9 @@ import { setSharedMarketDataForTests } from "../../../plugins/registry";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../../../plugins/plugin-runtime";
 import { FloatingPaneWrapper } from "../../../components/layout/floating-pane";
 import { PaneContent } from "../../../components/layout/pane-content";
-import { getNativePaneBodyHeight, getNativePaneBodyWidth } from "../../../components/layout/pane-sizing";
+import { resolvePaneBodyFrame } from "../../../components/layout/pane-sizing";
 import { getPaneDisplayTitle } from "../../../components/layout/pane-title";
-import type { AppConfig, PaneInstanceConfig } from "../../../types/config";
+import type { AppConfig } from "../../../types/config";
 import type { CachedFinancialsTarget, DataProvider, QuoteSubscriptionTarget } from "../../../types/data-provider";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
@@ -326,8 +326,12 @@ function ShotPane({ payload }: { payload: CliPaneShotPayload }) {
   const title = getPaneDisplayTitle(titleState, instance, pane);
   const width = payload.widthCells;
   const height = payload.heightCells;
-  const bodyWidth = getNativePaneBodyWidth(width);
-  const bodyHeight = getNativePaneBodyHeight(height, false);
+  const bodyFrame = resolvePaneBodyFrame({
+    width,
+    height,
+    nativePaneChrome: true,
+    reserveFooter: false,
+  });
 
   return (
     <FloatingPaneWrapper
@@ -347,8 +351,8 @@ function ShotPane({ payload }: { payload: CliPaneShotPayload }) {
         paneId={instance.instanceId}
         paneType={instance.paneId}
         focused
-        width={bodyWidth}
-        height={bodyHeight}
+        width={bodyFrame.width ?? 1}
+        height={bodyFrame.height ?? 1}
       />
     </FloatingPaneWrapper>
   );

--- a/src/sources/gloomberb-cloud.ts
+++ b/src/sources/gloomberb-cloud.ts
@@ -481,16 +481,6 @@ function unwrapRequiredCloudResponse<T>(response: CloudMarketResponse<T>, messag
   throw new Error(response.reasonCode ?? message);
 }
 
-function unwrapOptionalCloudResponse<T>(response: CloudMarketResponse<T>): T | null {
-  if ((response.status === "success" || response.status === "partial") && response.data != null) {
-    return response.data;
-  }
-  if (isEmptyCloudStatus(response.status)) {
-    return null;
-  }
-  throw new Error(response.reasonCode ?? "Cloud data request failed");
-}
-
 export class GloomberbCloudProvider implements AssetDataProvider {
   readonly id = providerId;
   readonly name = "Gloomberb Cloud";

--- a/src/sources/provider-router.test.ts
+++ b/src/sources/provider-router.test.ts
@@ -5,14 +5,17 @@ import { join } from "path";
 import { AppPersistence } from "../data/app-persistence";
 import { AssetDataRouter } from "./provider-router";
 import { assetDataProvider } from "../capabilities";
+import type { PluginRegistry } from "../plugins/registry";
 import type { BrokerAdapter } from "../types/broker";
 import type { DataProvider, QuoteSubscriptionTarget } from "../types/data-provider";
 import type { CapabilityRouteSource } from "../types/capability-route-source";
 import type { NewsArticle } from "../news/types";
-import { cloneLayout, CURRENT_CONFIG_VERSION, DEFAULT_LAYOUT, type AppConfig } from "../types/config";
+import { cloneLayout, createDefaultConfig, DEFAULT_LAYOUT, type AppConfig } from "../types/config";
+import type { Quote, TickerFinancials } from "../types/financials";
 
 const originalConsoleError = console.error;
 const tempPaths: string[] = [];
+type BrokerInstance = AppConfig["brokerInstances"][number];
 
 function createTempDbPath(name: string): string {
   const path = join(tmpdir(), `gloomberb-provider-router-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
@@ -31,17 +34,10 @@ const fallbackProvider: DataProvider = {
   id: "fallback",
   name: "Fallback",
   async getTickerFinancials() {
-    return { annualStatements: [], quarterlyStatements: [], priceHistory: [] };
+    return makeFinancials();
   },
   async getQuote() {
-    return {
-      symbol: "AAPL",
-      price: 100,
-      currency: "USD",
-      change: 0,
-      changePercent: 0,
-      lastUpdated: Date.now(),
-    };
+    return makeQuote();
   },
   async getExchangeRate() {
     return 1;
@@ -56,6 +52,27 @@ const fallbackProvider: DataProvider = {
     return [];
   },
 };
+
+function makeFinancials(overrides: Partial<TickerFinancials> = {}): TickerFinancials {
+  return {
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: [],
+    ...overrides,
+  };
+}
+
+function makeQuote(overrides: Partial<Quote> = {}): Quote {
+  return {
+    symbol: "AAPL",
+    price: 100,
+    currency: "USD",
+    change: 0,
+    changePercent: 0,
+    lastUpdated: Date.now(),
+    ...overrides,
+  };
+}
 
 function makeArticle(id: string): NewsArticle {
   return {
@@ -80,6 +97,47 @@ function makeArticle(id: string): NewsArticle {
     isBreaking: false,
     isDeveloping: false,
   };
+}
+
+function brokerInstance(overrides: Partial<BrokerInstance> = {}): BrokerInstance {
+  return {
+    id: "ibkr-work",
+    brokerType: "ibkr",
+    label: "Work",
+    connectionMode: "gateway",
+    config: {},
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function createBrokerConfig(brokerInstances: BrokerInstance[]): AppConfig {
+  const layout = cloneLayout(DEFAULT_LAYOUT);
+  return {
+    ...createDefaultConfig(""),
+    portfolios: [],
+    watchlists: [],
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+    brokerInstances,
+  };
+}
+
+function attachTestRegistry(
+  router: AssetDataRouter,
+  options: {
+    brokers?: Array<[string, BrokerAdapter]>;
+    getEnabledCapabilities?: PluginRegistry["getEnabledCapabilities"];
+  } = {},
+): void {
+  router.attachRegistry({
+    brokers: new Map(options.brokers ?? []),
+    getEnabledCapabilities: options.getEnabledCapabilities ?? (() => []),
+  } as unknown as PluginRegistry);
+}
+
+function setBrokerInstances(router: AssetDataRouter, brokerInstances: BrokerInstance[]): void {
+  router.setConfigAccessor(() => createBrokerConfig(brokerInstances));
 }
 
 describe("AssetDataRouter", () => {
@@ -358,38 +416,12 @@ describe("AssetDataRouter", () => {
       },
     };
 
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [
+      brokerInstance({
         config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+      }),
+    ]);
 
     const quote = await router.getQuote("AAPL", "NASDAQ", { brokerId: "ibkr", brokerInstanceId: "ibkr-work" });
     expect(quote.price).toBe(123.45);
@@ -444,38 +476,12 @@ describe("AssetDataRouter", () => {
         },
       };
 
-      router.attachRegistry({
-        brokers: new Map([["ibkr", broker]]),
-        getEnabledCapabilities: () => [],
-      } as any);
-      router.setConfigAccessor(() => ({
-        dataDir: "",
-        configVersion: CURRENT_CONFIG_VERSION,
-        baseCurrency: "USD",
-        refreshIntervalMinutes: 30,
-        portfolios: [],
-        watchlists: [],
-        layout: cloneLayout(DEFAULT_LAYOUT),
-        layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-        activeLayoutIndex: 0,
-        brokerInstances: [{
-          id: "ibkr-work",
-          brokerType: "ibkr",
-          label: "Work",
-          connectionMode: "gateway",
+      attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+      setBrokerInstances(router, [
+        brokerInstance({
           config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
-          enabled: true,
-        }],
-        disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-        theme: "amber",
-        chartPreferences: {
-          defaultRenderMode: "area",
-          renderer: "auto",
-        },
-        recentTickers: [],
-      }));
+        }),
+      ]);
 
       const quote = await router.getQuote("285A.T", "TSEJ", { brokerId: "ibkr", brokerInstanceId: "ibkr-work" });
       expect(quote.providerId).toBe("yahoo");
@@ -513,48 +519,17 @@ describe("AssetDataRouter", () => {
       },
     };
 
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [
-        {
-          id: "ibkr-work",
-          brokerType: "ibkr",
-          label: "Work",
-          connectionMode: "gateway",
-          config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
-          enabled: true,
-        },
-        {
-          id: "ibkr-personal",
-          brokerType: "ibkr",
-          label: "Personal",
-          connectionMode: "gateway",
-          config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4003, clientId: 2 } },
-          enabled: true,
-        },
-      ],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [
+      brokerInstance({
+        config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
+      }),
+      brokerInstance({
+        id: "ibkr-personal",
+        label: "Personal",
+        config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4003, clientId: 2 } },
+      }),
+    ]);
 
     const results = await router.search("AAPL", { preferBroker: true, brokerInstanceId: "ibkr-work" });
     expect(results[0]?.brokerInstanceId).toBe("ibkr-work");
@@ -607,38 +582,12 @@ describe("AssetDataRouter", () => {
     };
     const router = new AssetDataRouter(fallbackProvider, [provider]);
 
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [
+      brokerInstance({
         config: { connectionMode: "gateway", gateway: { host: "127.0.0.1", port: 4002, clientId: 1 } },
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+      }),
+    ]);
 
     const results = await router.search("AAPL", { preferBroker: true, brokerInstanceId: "ibkr-work" });
     expect(results).toHaveLength(1);
@@ -648,10 +597,7 @@ describe("AssetDataRouter", () => {
 
   test("ignores disabled plugin sources when the registry filters them out", async () => {
     const router = new AssetDataRouter(fallbackProvider);
-    router.attachRegistry({
-      brokers: new Map(),
-      getEnabledCapabilities: () => [],
-    } as any);
+    attachTestRegistry(router);
 
     const quote = await router.getQuote("AAPL", "NASDAQ");
     expect(quote.price).toBe(100);
@@ -709,12 +655,11 @@ describe("AssetDataRouter", () => {
       },
     };
     const router = new AssetDataRouter(fallbackProvider);
-    router.attachRegistry({
-      brokers: new Map(),
+    attachTestRegistry(router, {
       getEnabledCapabilities: (kind?: string) => (
         kind === "asset-data" ? [assetDataProvider(cloudProvider)] : []
       ),
-    } as any);
+    });
 
     const quote = await router.getQuote("AAPL", "NASDAQ");
     expect(quote.price).toBe(125);
@@ -848,38 +793,8 @@ describe("AssetDataRouter", () => {
     };
 
     const router = new AssetDataRouter(fallbackProvider, [streamingProvider]);
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
-        config: {},
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [brokerInstance()]);
 
     const seenSymbols: string[] = [];
     const unsubscribe = router.subscribeQuotes([
@@ -951,38 +866,8 @@ describe("AssetDataRouter", () => {
     };
 
     const router = new AssetDataRouter(fallbackProvider, [streamingProvider]);
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
-        config: {},
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [brokerInstance()]);
 
     const unsubscribe = router.subscribeQuotes([{
       symbol: "AAPL",
@@ -1012,22 +897,20 @@ describe("AssetDataRouter", () => {
     const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
-        return { annualStatements: [], quarterlyStatements: [], priceHistory: [] };
+        return makeFinancials();
       },
       async getQuote(ticker) {
-        return {
+        return makeQuote({
           symbol: ticker,
           price: 252.375,
-          currency: "USD",
           change: 1.5,
           changePercent: 0.6,
           bid: 250.25,
           ask: 254.5,
           mark: 252.375,
-          lastUpdated: Date.now(),
           providerId: "gloomberb-cloud",
           dataSource: "delayed",
-        };
+        });
       },
     });
 
@@ -1047,12 +930,11 @@ describe("AssetDataRouter", () => {
       ...fallbackProvider,
       async getTickerFinancials() {
         providerCalls.fallback += 1;
-        return {
+        return makeFinancials({
           annualStatements: [{ date: "2025-12-31", totalRevenue: 1000 }],
           quarterlyStatements: [{ date: "2025-12-31", totalRevenue: 250 }],
-          priceHistory: [],
           fundamentals: { revenue: 1000, netIncome: 200 },
-        };
+        });
       },
     }, [], persistence.resources);
     const broker: BrokerAdapter = {
@@ -1067,55 +949,19 @@ describe("AssetDataRouter", () => {
       },
       async getTickerFinancials() {
         providerCalls.broker += 1;
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
-          quote: {
-            symbol: "AAPL",
+        return makeFinancials({
+          quote: makeQuote({
             price: 125,
-            currency: "USD",
             change: 2,
             changePercent: 1.6,
-            lastUpdated: Date.now(),
-          },
+          }),
           fundamentals: {},
-        };
+        });
       },
     };
 
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
-        config: {},
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [brokerInstance()]);
 
     const merged = await router.getTickerFinancials("AAPL", "NASDAQ", {
       brokerId: "ibkr",
@@ -1141,22 +987,19 @@ describe("AssetDataRouter", () => {
     const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
+        return makeFinancials({
           priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 0.245 }],
-          quote: {
+          quote: makeQuote({
             symbol: "IQE.L",
             providerId: "yahoo",
             price: 0.245,
             currency: "GBP",
             change: -0.021,
             changePercent: -7.89,
-            lastUpdated: Date.now(),
             dataSource: "delayed",
-          },
+          }),
           fundamentals: { revenue: 1000 },
-        };
+        });
       },
     });
     const broker: BrokerAdapter = {
@@ -1170,57 +1013,24 @@ describe("AssetDataRouter", () => {
         return [];
       },
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
+        return makeFinancials({
           priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 24.5 }],
-          quote: {
+          quote: makeQuote({
             symbol: "IQE",
             providerId: "ibkr",
             price: 24.5,
             currency: "GBP",
             change: -2.1,
             changePercent: -7.89,
-            lastUpdated: Date.now(),
             dataSource: "live",
-          },
+          }),
           fundamentals: { netIncome: 200 },
-        };
+        });
       },
     };
 
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
-        config: {},
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [brokerInstance()]);
 
     const merged = await router.getTickerFinancials("IQE", "LSE", {
       brokerId: "ibkr",
@@ -1237,16 +1047,13 @@ describe("AssetDataRouter", () => {
     const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
+        return makeFinancials({
           profile: {
             description: "Builds hardware and software.",
             sector: "Technology",
             industry: "Consumer Electronics",
           },
-        };
+        });
       },
     });
     const broker: BrokerAdapter = {
@@ -1260,47 +1067,14 @@ describe("AssetDataRouter", () => {
         return [];
       },
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
+        return makeFinancials({
           fundamentals: { revenue: 1000, netIncome: 200 },
-        };
+        });
       },
     };
 
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
-        config: {},
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [brokerInstance()]);
 
     const merged = await router.getTickerFinancials("AAPL", "NASDAQ", {
       brokerId: "ibkr",
@@ -1318,22 +1092,16 @@ describe("AssetDataRouter", () => {
       name: "Cloud",
       priority: 100,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
-          quote: {
-            symbol: "AAPL",
+        return makeFinancials({
+          quote: makeQuote({
             price: 125,
-            currency: "USD",
             change: 2,
             changePercent: 1.6,
-            lastUpdated: Date.now(),
-          },
+          }),
           fundamentals: {
             trailingPE: 25,
           },
-        };
+        });
       },
     };
     let yahooCalls = 0;
@@ -1344,23 +1112,20 @@ describe("AssetDataRouter", () => {
       priority: 1000,
       async getTickerFinancials() {
         yahooCalls += 1;
-        return {
+        return makeFinancials({
           annualStatements: [{ date: "2025-12-31", totalRevenue: 391035000000 }],
           quarterlyStatements: [{ date: "2026-03-31", totalRevenue: 95359000000 }],
           priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 124 }],
-          quote: {
-            symbol: "AAPL",
+          quote: makeQuote({
             price: 124,
-            currency: "USD",
             change: 1,
             changePercent: 0.8,
             marketCap: 2_000_000_000,
-            lastUpdated: Date.now(),
-          },
+          }),
           fundamentals: {
             forwardPE: 22,
           },
-        };
+        });
       },
     };
 
@@ -1384,19 +1149,15 @@ describe("AssetDataRouter", () => {
       name: "Cloud",
       priority: 100,
       async getTickerFinancials() {
-        return {
+        return makeFinancials({
           annualStatements: [{ date: "2025-12-31", totalRevenue: 1000 }],
-          quarterlyStatements: [],
-          priceHistory: [],
-          quote: {
+          quote: makeQuote({
             symbol: "AMD",
             price: 125,
-            currency: "USD",
             change: 2,
             changePercent: 1.6,
-            lastUpdated: Date.now(),
-          },
-        };
+          }),
+        });
       },
     };
     let yahooCalls = 0;
@@ -1407,16 +1168,14 @@ describe("AssetDataRouter", () => {
       priority: 1000,
       async getTickerFinancials() {
         yahooCalls += 1;
-        return {
+        return makeFinancials({
           annualStatements: [{
             date: "2025-12-31",
             totalRevenue: 900,
             accountsReceivable: 250,
             inventory: 125,
           }],
-          quarterlyStatements: [],
-          priceHistory: [],
-        };
+        });
       },
     };
 
@@ -1443,25 +1202,19 @@ describe("AssetDataRouter", () => {
       name: "Cloud",
       priority: 100,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
-          quote: {
-            symbol: "AAPL",
+        return makeFinancials({
+          quote: makeQuote({
             price: 125,
-            currency: "USD",
             change: 2,
             changePercent: 1.6,
-            lastUpdated: Date.now(),
-          },
+          }),
           fundamentals: {
             trailingPE: 25,
           },
           profile: {
             sector: "Technology",
           },
-        };
+        });
       },
     };
     const yahooProvider: DataProvider = {
@@ -1470,23 +1223,18 @@ describe("AssetDataRouter", () => {
       name: "Yahoo",
       priority: 1000,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
+        return makeFinancials({
           priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 124 }],
-          quote: {
-            symbol: "AAPL",
+          quote: makeQuote({
             price: 124,
-            currency: "USD",
             change: 1,
             changePercent: 0.8,
             marketCap: 2_000_000_000,
-            lastUpdated: Date.now(),
-          },
+          }),
           fundamentals: {
             forwardPE: 22,
           },
-        };
+        });
       },
     };
 
@@ -1540,58 +1288,21 @@ describe("AssetDataRouter", () => {
         return [];
       },
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
+        return makeFinancials({
           fundamentals: { revenue: 1000, netIncome: 200 },
-        };
+        });
       },
     };
 
-    const config: AppConfig = {
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [{
-        id: "ibkr-work",
-        brokerType: "ibkr",
-        label: "Work",
-        connectionMode: "gateway",
-        config: {},
-        enabled: true,
-      }],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    };
+    const config = createBrokerConfig([brokerInstance()]);
 
     const seedRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
-        };
+        return makeFinancials();
       },
     }, [], persistence.resources);
-    seedRouter.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
+    attachTestRegistry(seedRouter, { brokers: [["ibkr", broker]] });
     seedRouter.setConfigAccessor(() => config);
 
     const seeded = await seedRouter.getTickerFinancials("PSTG", "NYSE", {
@@ -1603,22 +1314,16 @@ describe("AssetDataRouter", () => {
     const refreshedRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
+        return makeFinancials({
           profile: {
             description: "Provides enterprise data storage platforms.",
             sector: "Technology",
             industry: "Computer Hardware",
           },
-        };
+        });
       },
     }, [], persistence.resources);
-    refreshedRouter.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
+    attachTestRegistry(refreshedRouter, { brokers: [["ibkr", broker]] });
     refreshedRouter.setConfigAccessor(() => config);
 
     const refreshed = await refreshedRouter.getTickerFinancials("PSTG", "NYSE", {
@@ -1637,21 +1342,15 @@ describe("AssetDataRouter", () => {
     const router = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
-          quote: {
+        return makeFinancials({
+          quote: makeQuote({
             symbol: "IQE.L",
             providerId: "yahoo",
             price: 0.245,
             currency: "GBP",
-            change: 0,
-            changePercent: 0,
-            lastUpdated: Date.now(),
             dataSource: "delayed",
-          },
-        };
+          }),
+        });
       },
     }, [], persistence.resources);
     const broker: BrokerAdapter = {
@@ -1668,66 +1367,23 @@ describe("AssetDataRouter", () => {
         if (instance.id === "ibkr-flex") {
           throw new Error("Gateway mode is required for broker market data");
         }
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
-          priceHistory: [],
-          quote: {
+        return makeFinancials({
+          quote: makeQuote({
             symbol: "IQE",
             providerId: "ibkr",
             price: 24.5,
             currency: "GBP",
-            change: 0,
-            changePercent: 0,
-            lastUpdated: Date.now(),
             dataSource: "live",
-          },
-        };
+          }),
+        });
       },
     };
 
-    router.attachRegistry({
-      brokers: new Map([["ibkr", broker]]),
-      getEnabledCapabilities: () => [],
-    } as any);
-    router.setConfigAccessor(() => ({
-      dataDir: "",
-      configVersion: CURRENT_CONFIG_VERSION,
-      baseCurrency: "USD",
-      refreshIntervalMinutes: 30,
-      portfolios: [],
-      watchlists: [],
-      layout: cloneLayout(DEFAULT_LAYOUT),
-      layouts: [{ name: "Default", layout: cloneLayout(DEFAULT_LAYOUT) }],
-      activeLayoutIndex: 0,
-      brokerInstances: [
-        {
-          id: "ibkr-flex",
-          brokerType: "ibkr",
-          label: "Flex",
-          connectionMode: "flex",
-          config: {},
-          enabled: true,
-        },
-        {
-          id: "ibkr-live",
-          brokerType: "ibkr",
-          label: "Live",
-          connectionMode: "gateway",
-          config: {},
-          enabled: true,
-        },
-      ],
-      disabledPlugins: [],
-      disabledSources: [],
-      pluginConfig: {},
-      theme: "amber",
-      chartPreferences: {
-        defaultRenderMode: "area",
-        renderer: "auto",
-      },
-      recentTickers: [],
-    }));
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [
+      brokerInstance({ id: "ibkr-flex", label: "Flex", connectionMode: "flex" }),
+      brokerInstance({ id: "ibkr-live", label: "Live" }),
+    ]);
 
     const live = await router.getTickerFinancials("IQE", "LSE", {
       brokerId: "ibkr",
@@ -1765,11 +1421,8 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=LSE",
         sourceKey: "provider:gloomberb-cloud",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "IQE",
           price: 23.1,
           currency: "GBp",
@@ -1778,11 +1431,11 @@ describe("AssetDataRouter", () => {
           previousClose: 24.5,
           lastUpdated: now,
           dataSource: "delayed",
-        },
+        }),
         profile: {
           description: "Cloud profile",
         },
-      },
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -1796,11 +1449,8 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=LSE",
         sourceKey: "provider:yahoo",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "IQE.L",
           providerId: "yahoo",
           price: 0.231,
@@ -1810,11 +1460,11 @@ describe("AssetDataRouter", () => {
           previousClose: 0.245,
           lastUpdated: now,
           dataSource: "delayed",
-        },
+        }),
         fundamentals: {
           revenue: 1000,
         },
-      },
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -1872,11 +1522,8 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=FWB2",
         sourceKey: "provider:gloomberb-cloud",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "HY9H",
           price: 528,
           currency: "EUR",
@@ -1888,14 +1535,14 @@ describe("AssetDataRouter", () => {
           listingExchangeName: "FWB2",
           providerId: "gloomberb-cloud",
           dataSource: "delayed",
-        },
+        }),
         fundamentals: {
           revenue: 1234,
         },
         profile: {
           description: "Cloud profile",
         },
-      },
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -1909,11 +1556,8 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=FWB2",
         sourceKey: "provider:yahoo",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "HY9H.F",
           price: 596,
           currency: "EUR",
@@ -1925,8 +1569,8 @@ describe("AssetDataRouter", () => {
           listingExchangeName: "FWB2",
           providerId: "yahoo",
           dataSource: "delayed",
-        },
-      },
+        }),
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -1976,14 +1620,10 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=NASDAQ",
         sourceKey: "provider:gloomberb-cloud",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "AMD",
           price: 221.53,
-          currency: "USD",
           change: 1.35,
           changePercent: 0.61,
           lastUpdated: now,
@@ -1992,8 +1632,8 @@ describe("AssetDataRouter", () => {
           listingExchangeName: "NASDAQ",
           providerId: "gloomberb-cloud",
           dataSource: "delayed",
-        },
-      },
+        }),
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -2007,14 +1647,10 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=NASDAQ",
         sourceKey: "provider:yahoo",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "AMD",
           price: 221.53,
-          currency: "USD",
           change: 1.35,
           changePercent: 0.61,
           lastUpdated: now,
@@ -2026,8 +1662,8 @@ describe("AssetDataRouter", () => {
           listingExchangeName: "NASDAQ",
           providerId: "yahoo",
           dataSource: "delayed",
-        },
-      },
+        }),
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -2075,14 +1711,10 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=NASDAQ",
         sourceKey: "provider:gloomberb-cloud",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "OLD",
           price: 42,
-          currency: "USD",
           change: -1,
           changePercent: -2.33,
           lastUpdated: Date.UTC(2020, 0, 2),
@@ -2091,11 +1723,11 @@ describe("AssetDataRouter", () => {
           listingExchangeName: "NASDAQ",
           providerId: "gloomberb-cloud",
           dataSource: "delayed",
-        },
+        }),
         fundamentals: {
           trailingPE: 12,
         },
-      },
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -2138,14 +1770,10 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=NASDAQ",
         sourceKey: "provider:gloomberb-cloud",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "AMD",
           price: 445.38,
-          currency: "USD",
           change: -2.91,
           changePercent: -0.65,
           lastUpdated: now,
@@ -2154,11 +1782,11 @@ describe("AssetDataRouter", () => {
           listingExchangeName: "NASDAQ",
           providerId: "gloomberb-cloud",
           dataSource: "delayed",
-        },
+        }),
         fundamentals: {
           sharesOutstanding: 1_630_000_000,
         },
-      },
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
@@ -2197,11 +1825,8 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=JPX",
         sourceKey: "provider:yahoo",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "4092.T",
           providerId: "yahoo",
           price: 3770,
@@ -2212,8 +1837,8 @@ describe("AssetDataRouter", () => {
           marketState: "CLOSED",
           exchangeName: "JPX",
           listingExchangeName: "JPX",
-        },
-      },
+        }),
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: old,
@@ -2227,11 +1852,8 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=JPX",
         sourceKey: "provider:yahoo",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "4092.T",
           providerId: "yahoo",
           price: 3925,
@@ -2242,8 +1864,8 @@ describe("AssetDataRouter", () => {
           marketState: "CLOSED",
           exchangeName: "JPX",
           listingExchangeName: "JPX",
-        },
-      },
+        }),
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: now,
@@ -2290,11 +1912,8 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=JPX",
         sourceKey: "provider:yahoo",
       },
-      {
-        annualStatements: [],
-        quarterlyStatements: [],
-        priceHistory: [],
-        quote: {
+      makeFinancials({
+        quote: makeQuote({
           symbol: "6315.T",
           providerId: "yahoo",
           price: 3380,
@@ -2305,12 +1924,12 @@ describe("AssetDataRouter", () => {
           marketState: "CLOSED",
           exchangeName: "JPX",
           listingExchangeName: "JPX",
-        },
+        }),
         fundamentals: {
           sharesOutstanding: 75_000_462,
           trailingPE: 37.2,
         },
-      },
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: old,
@@ -2324,7 +1943,7 @@ describe("AssetDataRouter", () => {
         variantKey: "exchange=JPX",
         sourceKey: "provider:yahoo",
       },
-      {
+      makeQuote({
         symbol: "6315.T",
         providerId: "yahoo",
         price: 2688,
@@ -2335,7 +1954,7 @@ describe("AssetDataRouter", () => {
         marketState: "CLOSED",
         exchangeName: "JPX",
         listingExchangeName: "JPX",
-      },
+      }),
       {
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: now,
@@ -2457,8 +2076,8 @@ describe("AssetDataRouter", () => {
         sourceKey: "provider:yahoo",
       },
       [
-        { date: null as any, close: 101 },
-        { date: null as any, close: 102 },
+        { date: null, close: 101 },
+        { date: null, close: 102 },
       ],
       {
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
@@ -2494,19 +2113,14 @@ describe("AssetDataRouter", () => {
     const seedRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getTickerFinancials() {
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
+        return makeFinancials({
           priceHistory: [{ date: new Date("2026-03-27T00:00:00Z"), close: 101 }],
-          quote: {
-            symbol: "AAPL",
+          quote: makeQuote({
             price: 101,
-            currency: "USD",
             change: 1,
             changePercent: 1,
-            lastUpdated: Date.now(),
-          },
-        };
+          }),
+        });
       },
     }, [], persistence.resources);
     await seedRouter.getTickerFinancials("AAPL", "NASDAQ");
@@ -2516,19 +2130,14 @@ describe("AssetDataRouter", () => {
       ...fallbackProvider,
       async getTickerFinancials() {
         providerCalls += 1;
-        return {
-          annualStatements: [],
-          quarterlyStatements: [],
+        return makeFinancials({
           priceHistory: [{ date: new Date("2026-03-28T00:00:00Z"), close: 202 }],
-          quote: {
-            symbol: "AAPL",
+          quote: makeQuote({
             price: 202,
-            currency: "USD",
             change: 2,
             changePercent: 1,
-            lastUpdated: Date.now(),
-          },
-        };
+          }),
+        });
       },
     }, [], persistence.resources);
 

--- a/src/sources/provider-router.ts
+++ b/src/sources/provider-router.ts
@@ -536,7 +536,7 @@ export class AssetDataRouter implements DataProvider {
 
     targets.forEach((target, index) => {
       const context = target.context;
-      const entityKey = this.getEntityKey(target.symbol, target.exchange, context?.instrument);
+      const entityKey = this.getEntityKey(target.symbol, context?.instrument);
       const variantKeys = this.getTickerVariantCandidates(target.exchange);
       const sourceKeys = [
         ...this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate)),
@@ -570,7 +570,7 @@ export class AssetDataRouter implements DataProvider {
         const key = this.quoteBatchKey(item.target);
         const sourceKey = this.providerSourceKey(batchProvider);
         for (const entry of providerIndexes.get(key) ?? []) {
-          const entityKey = this.getEntityKey(entry.target.symbol, entry.target.exchange, entry.target.context?.instrument);
+          const entityKey = this.getEntityKey(entry.target.symbol, entry.target.context?.instrument);
           const variantKey = this.getTickerVariantCandidates(entry.target.exchange)[0] ?? "";
           this.cacheResource("quote", entityKey, variantKey, sourceKey, item.quote, this.resolveProviderPolicy("quote", batchProvider));
           results[entry.index] = { target: entry.target, quote: item.quote };
@@ -631,7 +631,7 @@ export class AssetDataRouter implements DataProvider {
         if (!value) continue;
         const sourceKey = this.providerSourceKey(batchProvider);
         for (const entry of providerIndexes.get(key) ?? []) {
-          const entityKey = this.getEntityKey(entry.target.symbol, entry.target.exchange, entry.target.instrument ?? undefined);
+          const entityKey = this.getEntityKey(entry.target.symbol, entry.target.instrument ?? undefined);
           const variantKey = this.getTickerVariantCandidates(entry.target.exchange)[0] ?? "";
           this.cacheResource("financials", entityKey, variantKey, sourceKey, value, this.resolveProviderPolicy("financials", batchProvider));
           results[entry.index] = { target: entry.target, financials: value };
@@ -708,7 +708,7 @@ export class AssetDataRouter implements DataProvider {
   }
 
   async getQuote(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<Quote> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
     const sourceKeys = [
       ...this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate)),
@@ -872,12 +872,12 @@ export class AssetDataRouter implements DataProvider {
   }
 
   async getHolders(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<HolderData> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
     const cached = this.selectCachedResource<HolderData>("holders", entityKey, variantKeys, this.getProviderSourceKeys(), false);
     const forceRefresh = context?.cacheMode === "refresh";
     if (cached && !forceRefresh) {
-      this.scheduleRevalidation(this.makeRevalidationKey("holders", ticker, exchange, context), async () => {
+      this.scheduleRevalidation(this.makeRevalidationKey("holders", ticker, context), async () => {
         await this.revalidateHolders(ticker, exchange, context);
       });
       return cached.value;
@@ -890,12 +890,12 @@ export class AssetDataRouter implements DataProvider {
   }
 
   async getAnalystResearch(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<AnalystResearchData> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
     const cached = this.selectCachedAnalystResearch(entityKey, variantKeys, this.getProviderSourceKeys(), false);
     const forceRefresh = context?.cacheMode === "refresh";
     if (cached && !forceRefresh && !isAnalystResearchMissingRatingTargets(cached.value)) {
-      this.scheduleRevalidation(this.makeRevalidationKey("analystResearch", ticker, exchange, context), async () => {
+      this.scheduleRevalidation(this.makeRevalidationKey("analystResearch", ticker, context), async () => {
         await this.revalidateAnalystResearch(ticker, exchange, context);
       });
       return cached.value;
@@ -908,12 +908,12 @@ export class AssetDataRouter implements DataProvider {
   }
 
   async getCorporateActions(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<CorporateActionsData> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
     const cached = this.selectCachedResource<CorporateActionsData>("corporateActions", entityKey, variantKeys, this.getProviderSourceKeys(), false);
     const forceRefresh = context?.cacheMode === "refresh";
     if (cached && !forceRefresh) {
-      this.scheduleRevalidation(this.makeRevalidationKey("corporateActions", ticker, exchange, context), async () => {
+      this.scheduleRevalidation(this.makeRevalidationKey("corporateActions", ticker, context), async () => {
         await this.revalidateCorporateActions(ticker, exchange, context);
       });
       return cached.value;
@@ -926,7 +926,7 @@ export class AssetDataRouter implements DataProvider {
   }
 
   async getSecFilings(ticker: string, count = 15, exchange?: string, context?: MarketDataRequestContext): Promise<SecFilingItem[]> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = [
       buildVariantKey([["exchange", canonicalExchange(exchange)], ["count", count]]),
       buildVariantKey([["count", count]]),
@@ -934,7 +934,7 @@ export class AssetDataRouter implements DataProvider {
     ];
     const cached = this.selectCachedResource<SecFilingItem[]>("sec-filings", entityKey, variantKeys, this.getProviderSourceKeys(), false);
     if (cached) {
-      this.scheduleRevalidation(this.makeRevalidationKey("sec-filings", ticker, exchange, context, count), async () => {
+      this.scheduleRevalidation(this.makeRevalidationKey("sec-filings", ticker, context, count), async () => {
         await this.revalidateSecFilings(ticker, count, exchange, context);
       });
       return cached.value;
@@ -986,7 +986,7 @@ export class AssetDataRouter implements DataProvider {
   }
 
   async getPriceHistory(ticker: string, exchange: string, range: TimeRange, context?: MarketDataRequestContext): Promise<PricePoint[]> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = [
       buildVariantKey([["exchange", canonicalExchange(exchange)], ["range", range]]),
       buildVariantKey([["range", range]]),
@@ -1024,7 +1024,7 @@ export class AssetDataRouter implements DataProvider {
     resolution: ManualChartResolution,
     context?: MarketDataRequestContext,
   ): Promise<PricePoint[]> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = [
       buildVariantKey([["exchange", canonicalExchange(exchange)], ["range", bufferRange], ["resolution", resolution]]),
       buildVariantKey([["range", bufferRange], ["resolution", resolution]]),
@@ -1085,7 +1085,7 @@ export class AssetDataRouter implements DataProvider {
     barSize: string,
     context?: MarketDataRequestContext,
   ): Promise<PricePoint[]> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = [
       buildVariantKey([["exchange", canonicalExchange(exchange)], ["start", compactDate(startDate)], ["end", compactDate(endDate)], ["bar", barSize]]),
       buildVariantKey([["start", compactDate(startDate)], ["end", compactDate(endDate)], ["bar", barSize]]),
@@ -1114,7 +1114,7 @@ export class AssetDataRouter implements DataProvider {
   }
 
   async getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, context?: MarketDataRequestContext): Promise<OptionsChain> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = [
       buildVariantKey([["exchange", canonicalExchange(exchange)], ["expiration", expirationDate ?? "default"]]),
       buildVariantKey([["expiration", expirationDate ?? "default"]]),
@@ -1126,7 +1126,7 @@ export class AssetDataRouter implements DataProvider {
     ];
     const cached = this.selectCachedResource<OptionsChain>("options-chain", entityKey, variantKeys, sourceKeys, false);
     if (cached) {
-      this.scheduleRevalidation(this.makeRevalidationKey("options-chain", ticker, exchange, context, expirationDate ?? "default"), async () => {
+      this.scheduleRevalidation(this.makeRevalidationKey("options-chain", ticker, context, expirationDate ?? "default"), async () => {
         await this.revalidateOptionsChain(ticker, exchange, expirationDate, context);
       });
       return cached.value;
@@ -1142,10 +1142,10 @@ export class AssetDataRouter implements DataProvider {
     return providerChain.value;
   }
 
-  private makeRevalidationKey(kind: string, ticker: string, exchange?: string, context?: MarketDataRequestContext, extra?: string | number): string {
+  private makeRevalidationKey(kind: string, ticker: string, context?: MarketDataRequestContext, extra?: string | number): string {
     return [
       kind,
-      this.getEntityKey(ticker, exchange, context?.instrument),
+      this.getEntityKey(ticker, context?.instrument),
       extra != null ? String(extra) : "",
     ].join("|");
   }
@@ -1160,7 +1160,7 @@ export class AssetDataRouter implements DataProvider {
     this.revalidationInFlight.set(key, promise);
   }
 
-  private getEntityKey(ticker: string, exchange?: string, instrument?: BrokerContractRef | null): string {
+  private getEntityKey(ticker: string, instrument?: BrokerContractRef | null): string {
     if (instrument?.conId != null) return `contract:${instrument.conId}`;
     if (instrument?.localSymbol) return `contract:${instrument.localSymbol.toUpperCase()}`;
     if (instrument?.symbol) return `contract:${instrument.symbol.toUpperCase()}`;
@@ -1303,7 +1303,7 @@ export class AssetDataRouter implements DataProvider {
     allowExpired = false,
     options: CachedFinancialsReadOptions = {},
   ): CachedFinancialsSelection {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKeys = this.getTickerVariantCandidates(exchange);
     const brokerSourceKeys = this.getBrokerCandidatesForContext(context, false).map((candidate) => this.brokerSourceKey(candidate));
     const brokerRecord = brokerSourceKeys.length > 0
@@ -1548,7 +1548,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<TickerFinancials> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getTickerFinancials) continue;
@@ -1582,7 +1582,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<TickerFinancials> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     let primaryResult: SourceResult<TickerFinancials> | null = null;
 
@@ -1634,7 +1634,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<Quote> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getQuote) continue;
@@ -1666,7 +1666,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<Quote> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     for (const provider of this.providersInPriorityOrder()) {
       try {
@@ -1690,7 +1690,7 @@ export class AssetDataRouter implements DataProvider {
     range: TimeRange,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<PricePoint[]> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["range", range]]);
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getPriceHistory) continue;
@@ -1726,7 +1726,7 @@ export class AssetDataRouter implements DataProvider {
     resolution: ManualChartResolution,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<PricePoint[]> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["range", bufferRange], ["resolution", resolution]]);
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getPriceHistoryForResolution) continue;
@@ -1762,7 +1762,7 @@ export class AssetDataRouter implements DataProvider {
     range: TimeRange,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<PricePoint[]> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["range", range]]);
     let firstEmptyResult: SourceResult<PricePoint[]> | null = null;
 
@@ -1800,7 +1800,7 @@ export class AssetDataRouter implements DataProvider {
     resolution: ManualChartResolution,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<PricePoint[]> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["range", bufferRange], ["resolution", resolution]]);
     let firstEmptyResult: SourceResult<PricePoint[]> | null = null;
 
@@ -1897,7 +1897,7 @@ export class AssetDataRouter implements DataProvider {
     barSize: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<PricePoint[]> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["start", compactDate(startDate)], ["end", compactDate(endDate)], ["bar", barSize]]);
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getDetailedPriceHistory) continue;
@@ -1936,7 +1936,7 @@ export class AssetDataRouter implements DataProvider {
     barSize: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<PricePoint[]> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["start", compactDate(startDate)], ["end", compactDate(endDate)], ["bar", barSize]]);
     let firstEmptyResult: SourceResult<PricePoint[]> | null = null;
 
@@ -1974,7 +1974,7 @@ export class AssetDataRouter implements DataProvider {
     expirationDate?: number,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<OptionsChain> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["expiration", expirationDate ?? "default"]]);
     for (const candidate of this.getBrokerCandidatesForContext(context, false)) {
       if (!candidate.broker.getOptionsChain) continue;
@@ -2008,7 +2008,7 @@ export class AssetDataRouter implements DataProvider {
     expirationDate?: number,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<OptionsChain> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["expiration", expirationDate ?? "default"]]);
     const result = await this.firstProvider(async (provider) => {
       if (!provider.getOptionsChain) return null;
@@ -2027,7 +2027,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<HolderData> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     let firstEmptyResult: SourceResult<HolderData> | null = null;
     let lastError: unknown = null;
@@ -2058,7 +2058,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<AnalystResearchData> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     let firstEmptyResult: SourceResult<AnalystResearchData> | null = null;
     let firstIncompleteResult: SourceResult<AnalystResearchData> | null = null;
@@ -2097,7 +2097,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<CorporateActionsData> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = this.getTickerVariantCandidates(exchange)[0] ?? "";
     let firstEmptyResult: SourceResult<CorporateActionsData> | null = null;
     let lastError: unknown = null;
@@ -2129,7 +2129,7 @@ export class AssetDataRouter implements DataProvider {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<SecFilingItem[]> | null> {
-    const entityKey = this.getEntityKey(ticker, exchange, context?.instrument);
+    const entityKey = this.getEntityKey(ticker, context?.instrument);
     const variantKey = buildVariantKey([["exchange", canonicalExchange(exchange)], ["count", count]]);
     let lastError: unknown = null;
 

--- a/src/sources/yahoo-finance.test.ts
+++ b/src/sources/yahoo-finance.test.ts
@@ -124,7 +124,7 @@ describe("YahooFinanceClient exchange aliases", () => {
     const provider = new YahooFinanceClient() as any;
     let requestUrl = "";
     provider.getSymbolsToTry = () => ["AMD"];
-    provider.fetchJsonWithCrumb = async (_label: string, url: string) => {
+    provider.fetchJsonWithCrumb = async (url: string) => {
       requestUrl = url;
       return {
         quoteSummary: {

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -826,8 +826,8 @@ export class YahooFinanceClient implements DataProvider {
   }
 
   /** Fetch JSON from a Yahoo endpoint that requires crumb authentication. */
-  private async fetchJsonWithCrumb<T>(label: string, url: string): Promise<T> {
-    return this.withRetry(label, async () => {
+  private async fetchJsonWithCrumb<T>(url: string): Promise<T> {
+    return this.withRetry(async () => {
       await this.ensureCrumb();
       const separator = url.includes("?") ? "&" : "?";
       const fullUrl = `${url}${separator}crumb=${encodeURIComponent(this.crumb!)}`;
@@ -846,7 +846,7 @@ export class YahooFinanceClient implements DataProvider {
     });
   }
 
-  private async withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  private async withRetry<T>(fn: () => Promise<T>): Promise<T> {
     let lastError: any;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
@@ -861,8 +861,8 @@ export class YahooFinanceClient implements DataProvider {
     throw lastError;
   }
 
-  private async fetchJson<T>(label: string, url: string): Promise<T> {
-    return this.withRetry(label, async () => {
+  private async fetchJson<T>(url: string): Promise<T> {
+    return this.withRetry(async () => {
       const resp = await fetch(url, {
         headers: this.defaultHeaders(),
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -946,7 +946,7 @@ export class YahooFinanceClient implements DataProvider {
   private async fetchChart(symbol: string, range: string, interval = "1d", includePrePost = false) {
     const params = new URLSearchParams({ interval, range, includePrePost: String(includePrePost), events: "div,split" });
     const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?${params}`;
-    const data = await this.fetchJson<ChartResponse>(`chart ${symbol}`, url);
+    const data = await this.fetchJson<ChartResponse>(url);
     const result = data.chart?.result?.[0];
     if (!result?.timestamp?.length) throw new Error(data.chart?.error?.description || `No chart data for ${symbol}`);
     const quote = result.indicators?.quote?.[0];
@@ -969,14 +969,14 @@ export class YahooFinanceClient implements DataProvider {
   }
 
   /** Fetch extended hours data using 1d intraday chart with pre/post market included */
-  private async fetchExtendedHoursData(symbol: string, regularPrice: number, meta: NonNullable<ChartResult["meta"]>): Promise<ExtendedHoursData> {
+  private async fetchExtendedHoursData(symbol: string, meta: NonNullable<ChartResult["meta"]>): Promise<ExtendedHoursData> {
     const marketState = deriveMarketState(meta);
     if (marketState !== "PRE" && marketState !== "POST") return {};
 
     try {
       const params = new URLSearchParams({ interval: "5m", range: "1d", includePrePost: "true" });
       const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?${params}`;
-      const data = await this.fetchJson<ChartResponse>(`ext-hours ${symbol}`, url);
+      const data = await this.fetchJson<ChartResponse>(url);
       const result = data.chart?.result?.[0];
       if (!result?.timestamp?.length) return {};
       const closes = result.indicators?.quote?.[0]?.close || [];
@@ -991,14 +991,14 @@ export class YahooFinanceClient implements DataProvider {
     const p2 = Math.floor(Date.now() / 1000);
     const params = new URLSearchParams({ type: types.join(","), period1: String(p1), period2: String(p2) });
     const url = `https://query1.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries/${encodeURIComponent(symbol)}?${params}`;
-    const data = await this.fetchJson<TimeseriesResponse>(`timeseries ${symbol}`, url);
+    const data = await this.fetchJson<TimeseriesResponse>(url);
     return data.timeseries?.result || [];
   }
 
   private async fetchAssetProfile(symbol: string): Promise<CompanyProfile | undefined> {
     const params = new URLSearchParams({ modules: "assetProfile" });
     const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
-    const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(`asset profile ${symbol}`, url);
+    const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(url);
     const profile = data.quoteSummary?.result?.[0]?.assetProfile;
     if (!profile) return undefined;
 
@@ -1018,7 +1018,7 @@ export class YahooFinanceClient implements DataProvider {
     try {
       const params = new URLSearchParams({ modules: "summaryDetail" });
       const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
-      const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(`quote supplement ${symbol}`, url);
+      const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(url);
       const summaryDetail = data.quoteSummary?.result?.[0]?.summaryDetail;
       if (!summaryDetail) return {};
 
@@ -1136,7 +1136,7 @@ export class YahooFinanceClient implements DataProvider {
     const changePct = prev ? (change / prev) * 100 : 0;
 
     const marketState = deriveMarketState(meta);
-    const extHours = await this.fetchExtendedHoursData(symbol, currentPrice, meta);
+    const extHours = await this.fetchExtendedHoursData(symbol, meta);
 
     // Normalize extended hours prices too
     if (currencyDivisor !== 1) {
@@ -1430,7 +1430,7 @@ export class YahooFinanceClient implements DataProvider {
         const change = prev != null ? price - prev : 0;
 
         const marketState = deriveMarketState(meta);
-        const extHours = await this.fetchExtendedHoursData(symbol, price, meta);
+        const extHours = await this.fetchExtendedHoursData(symbol, meta);
 
         if (currencyDivisor !== 1) {
           if (extHours.preMarketPrice != null) extHours.preMarketPrice /= currencyDivisor;
@@ -1543,7 +1543,7 @@ export class YahooFinanceClient implements DataProvider {
           modules: "price,majorHoldersBreakdown,institutionOwnership",
         });
         const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
-        const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(`holders ${symbol}`, url);
+        const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(url);
         const result = data.quoteSummary?.result?.[0];
         if (!result) throw new Error(`No holder data for ${symbol}`);
 
@@ -1606,7 +1606,7 @@ export class YahooFinanceClient implements DataProvider {
           modules: "price,financialData,recommendationTrend,upgradeDowngradeHistory,earningsTrend",
         });
         const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
-        const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(`analyst research ${symbol}`, url);
+        const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(url);
         const result = data.quoteSummary?.result?.[0];
         if (!result) throw new Error(`No analyst data for ${symbol}`);
 
@@ -1634,7 +1634,7 @@ export class YahooFinanceClient implements DataProvider {
           modules: "price,quoteType,calendarEvents,earningsHistory",
         });
         const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
-        const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(`corporate actions ${symbol}`, url);
+        const data = await this.fetchJsonWithCrumb<QuoteSummaryResponse>(url);
         const result = data.quoteSummary?.result?.[0];
         if (!result) throw new Error(`No corporate actions for ${symbol}`);
 
@@ -1798,7 +1798,7 @@ export class YahooFinanceClient implements DataProvider {
               }>;
             }>;
           };
-        }>("options " + symbol, url);
+        }>(url);
 
         const result = data.optionChain?.result?.[0];
         if (!result) throw new Error("No options data");
@@ -1885,7 +1885,7 @@ export class YahooFinanceClient implements DataProvider {
                 };
               }>;
             };
-          }>(`earnings ${symbol}`, url);
+          }>(url);
 
           const mod = data.quoteSummary?.result?.[0];
           if (!mod) return null;

--- a/src/state/app-context.test.ts
+++ b/src/state/app-context.test.ts
@@ -3,7 +3,6 @@ import { appReducer, createInitialState, resolveCollectionForPane, resolveTicker
 import { cloneLayout, createDefaultConfig, createPaneInstance } from "../types/config";
 import type { AppSessionSnapshot } from "../core/state/session-persistence";
 import { buildBrokerPortfolioId } from "../utils/broker-instances";
-import type { DesktopSharedStateSnapshot } from "../types/desktop-window";
 
 describe("resolveTickerForPane", () => {
   test("uses a portfolio pane cursor for inspector follow panes", () => {

--- a/src/utils/market-format.ts
+++ b/src/utils/market-format.ts
@@ -1,5 +1,3 @@
-import { formatCurrency } from "./format";
-
 export type AssetDisplayKind = "cash" | "crypto" | "equity" | "contract" | "other";
 
 export interface AssetDisplayContext {


### PR DESCRIPTION
Extracts the command bar’s layout, list, and workflow rendering responsibilities into focused modules while preserving the existing command flow.

Shares pane-frame sizing/chrome and Electrobun view build helpers so desktop rendering paths use the same plumbing.

Removes low-value static assertions, duplicate provider-router fixtures, and unused symbols across providers, plugins, and UI surfaces.