### PR TITLE
Fix chart indicator colors

### DIFF
--- a/src/components/chart/stock-chart.test.ts
+++ b/src/components/chart/stock-chart.test.ts
@@ -9,6 +9,7 @@ import {
   resolveChartKeyboardKey,
   resolveIndicatorBufferRange,
 } from "./stock-chart";
+import { colors, getChartIndicatorColor } from "../../theme/colors";
 import {
   getLocalPlotPointer,
   projectCellCursorToLocalPixels,
@@ -358,6 +359,11 @@ describe("stock chart indicator helpers", () => {
     expect(overlays.smaLines[0]?.points[0]?.index).toBe(0);
     expect(overlays.smaLines[0]?.points.at(-1)?.index).toBe(projected.length - 1);
     expect(overlays.bollinger?.upper[0]?.index).toBe(0);
+    expect(overlays.smaLines[0]?.color).toBe(getChartIndicatorColor(0));
+    expect(overlays.bollinger?.color).toBe(getChartIndicatorColor(1));
+    expect(new Set([overlays.smaLines[0]?.color, overlays.bollinger?.color]).size).toBe(2);
+    expect([colors.positive, colors.negative]).not.toContain(overlays.smaLines[0]?.color);
+    expect([colors.positive, colors.negative]).not.toContain(overlays.bollinger?.color);
   });
 
   test("widens the data buffer enough for selected indicator warmup periods", () => {

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch, useAppSelector, usePaneInstance, usePaneInstanceId, use
 import { usePaneFooter, type PaneFooterSegment, type PaneHint } from "../layout/pane-footer";
 import { ShortcutHint } from "../ui";
 import { getSharedMarketData } from "../../plugins/registry";
-import { colors } from "../../theme/colors";
+import { colors, getChartIndicatorColor } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
 import { formatCompact } from "../../utils/format";
 import { formatMarketPriceWithCurrency } from "../../utils/market-format";
@@ -929,19 +929,6 @@ function resolveSelectionCursor(
   };
 }
 
-function getIndicatorColor(index: number): string {
-  const indicatorColors = [
-    colors.negative,
-    colors.positive,
-    colors.borderFocused,
-    colors.warning,
-    colors.textBright,
-    colors.neutral,
-    colors.textMuted,
-  ];
-  return indicatorColors[((index % indicatorColors.length) + indicatorColors.length) % indicatorColors.length]!;
-}
-
 function getIndicatorWarmupPeriod(config: IndicatorConfig): number {
   const periods = [
     ...(config.sma ?? []),
@@ -1056,7 +1043,7 @@ function computeIndicatorOverlays(
   config: IndicatorConfig,
 ): ChartIndicatorOverlays {
   let colorIdx = 0;
-  const nextColor = () => getIndicatorColor(colorIdx++);
+  const nextColor = () => getChartIndicatorColor(colorIdx++);
 
   const smaLines = (config.sma ?? []).map((period) => ({
     period,

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -89,6 +89,28 @@ export function getComparisonSeriesColor(index: number): string {
   return seriesColors[((index % seriesColors.length) + seriesColors.length) % seriesColors.length]!;
 }
 
+export function getChartIndicatorColor(index: number): string {
+  const accent = higherContrast(colors.warning, colors.borderFocused, colors.bg);
+  const indicatorColors = [
+    colors.warning,
+    blendHex(colors.borderFocused, colors.warning, 0.38),
+    blendHex(colors.warning, colors.textBright, 0.42),
+    blendHex(colors.borderFocused, colors.textBright, 0.38),
+    colors.neutral,
+    blendHex(colors.warning, colors.neutral, 0.52),
+    blendHex(colors.borderFocused, colors.neutral, 0.46),
+  ];
+  const candidate = indicatorColors[((index % indicatorColors.length) + indicatorColors.length) % indicatorColors.length]!;
+  const color = blendForContrast(
+    candidate,
+    colors.bg,
+    higherContrast(accent, colors.textBright, colors.bg),
+    3.6,
+  );
+  if (![colors.positive, colors.negative, colors.text].includes(color)) return color;
+  return blendForContrast(blendHex(color, accent, 0.55), colors.bg, colors.textBright, 3.6);
+}
+
 /** Returns a hover background color derived from bg and selected */
 export function hoverBg(): string {
   return blendHex(colors.bg, colors.selected, 0.5);

--- a/src/theme/themes.test.ts
+++ b/src/theme/themes.test.ts
@@ -8,7 +8,9 @@ import {
   commandBarSelectedText,
   commandBarSubtleText,
   commandBarText,
+  colors,
   floatingPaneTitleBg,
+  getChartIndicatorColor,
   paneTitleBg,
   paneTitleText,
 } from "./colors";
@@ -64,6 +66,19 @@ describe("theme contrast", () => {
       assertMinContrast(id, "commandBarHeadingText/bg", commandBarHeadingText(), commandBarBg(), SUBTLE_TEXT_MIN);
       assertMinContrast(id, "commandBarSubtleText/panel", commandBarSubtleText(), commandBarPanelBg(), SUBTLE_TEXT_MIN);
       assertMinContrast(id, "commandBarSelectedText/selected", commandBarSelectedText(), commandBarSelectedBg(), BODY_TEXT_MIN);
+    }
+  });
+
+  test("keeps chart indicator colors readable and separate from price line colors", () => {
+    for (const id of Object.keys(themes)) {
+      applyTheme(id);
+      for (const indicatorIndex of [0, 1, 2]) {
+        const color = getChartIndicatorColor(indicatorIndex);
+        assertMinContrast(id, `chartIndicator${indicatorIndex}/bg`, color, colors.bg, SUBTLE_TEXT_MIN);
+        if ([colors.positive, colors.negative, colors.text].includes(color)) {
+          throw new Error(`${id} chartIndicator${indicatorIndex} reuses a price line color`);
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- Add a dedicated chart indicator color palette that avoids price trend green/red colors.
- Route stock-chart SMA, EMA, and Bollinger overlays through the shared indicator palette.
- Add focused chart and theme tests for distinct, readable indicator colors.

Fixes #400

## Tests
- bun test src/components/chart/stock-chart.test.ts src/theme/themes.test.ts
- bun run build
- tmux smoke: bun run start