### PR TITLE
Fix ticker detail table navigation and sparklines

### DIFF
--- a/src/components/data-table/view.test.tsx
+++ b/src/components/data-table/view.test.tsx
@@ -22,6 +22,11 @@ const rows: Row[] = [
   { type: "row", id: "first", title: "First row" },
   { type: "row", id: "second", title: "Second row" },
 ];
+const largeRows: Row[] = Array.from({ length: 1_000 }, (_, index) => ({
+  type: "row",
+  id: `row-${index}`,
+  title: `Row ${index}`,
+}));
 
 const columns: Column[] = [
   { id: "title", label: "Title", width: 20, align: "left" },
@@ -76,6 +81,40 @@ function Harness() {
               <Text>{`selected=${selectedTitle} activated=${activatedTitle}`}</Text>
             </Box>
           }
+        />
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+function LargeSelectionHarness({
+  onIsSelected,
+}: {
+  onIsSelected: () => void;
+}) {
+  const state = createInitialState(
+    createDefaultConfig("/tmp/gloomberb-data-table-view-large-test"),
+  );
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId="data-table-view-large-test">
+        <DataTableView<Row, Column>
+          focused
+          selectedIndex={500}
+          columns={columns}
+          items={largeRows}
+          sortColumnId={null}
+          sortDirection="asc"
+          onHeaderClick={() => {}}
+          getItemKey={(row) => row.id}
+          isSelected={(_row, index) => {
+            onIsSelected();
+            return index === 500;
+          }}
+          onSelect={() => {}}
+          renderCell={(row): DataTableCell => ({ text: row.title })}
+          emptyStateTitle="No rows"
         />
       </PaneInstanceProvider>
     </AppContext>
@@ -150,4 +189,19 @@ describe("DataTableView", () => {
     expect(testSetup.captureCharFrame()).toContain("selected=Second row activated=First row");
   });
 
+  test("does not scan every row when the selected index is explicit", async () => {
+    let isSelectedCalls = 0;
+    testSetup = await testRender(
+      <LargeSelectionHarness
+        onIsSelected={() => {
+          isSelectedCalls += 1;
+        }}
+      />,
+      { width: 60, height: 12 },
+    );
+
+    await renderSettled();
+
+    expect(isSelectedCalls).toBeLessThan(150);
+  });
 });

--- a/src/components/data-table/view.tsx
+++ b/src/components/data-table/view.tsx
@@ -99,8 +99,10 @@ export function DataTableView<
     number | null
   >(null);
   const selectedIndexFromPredicate = useMemo(
-    () => tableProps.items.findIndex(tableProps.isSelected),
-    [tableProps.items, tableProps.isSelected],
+    () => selectedIndex == null
+      ? tableProps.items.findIndex(tableProps.isSelected)
+      : -1,
+    [selectedIndex, tableProps.items, tableProps.isSelected],
   );
   const usesFallbackSelection =
     selectedIndex == null && selectedIndexFromPredicate < 0;
@@ -110,9 +112,7 @@ export function DataTableView<
       : fallbackSelectedIndex ?? -1);
 
   const navigableIndices = useMemo(() => {
-    if (!isNavigable) {
-      return tableProps.items.map((_, index) => index);
-    }
+    if (!isNavigable) return null;
     return tableProps.items.reduce<number[]>((indices, item, index) => {
       if (isNavigable(item, index)) indices.push(index);
       return indices;
@@ -125,6 +125,18 @@ export function DataTableView<
       return;
     }
     if (fallbackSelectedIndex == null) return;
+    if (!navigableIndices) {
+      if (
+        fallbackSelectedIndex >= 0
+        && fallbackSelectedIndex < tableProps.items.length
+      ) {
+        return;
+      }
+      setFallbackSelectedIndex(tableProps.items.length > 0
+        ? Math.min(fallbackSelectedIndex, tableProps.items.length - 1)
+        : null);
+      return;
+    }
     if (navigableIndices.includes(fallbackSelectedIndex)) return;
 
     const nextIndex = navigableIndices.find(
@@ -133,7 +145,12 @@ export function DataTableView<
       ?? navigableIndices.at(-1)
       ?? null;
     setFallbackSelectedIndex(nextIndex);
-  }, [fallbackSelectedIndex, navigableIndices, usesFallbackSelection]);
+  }, [
+    fallbackSelectedIndex,
+    navigableIndices,
+    tableProps.items.length,
+    usesFallbackSelection,
+  ]);
 
   const handleBodyScrollActivity = useTableBodyScrollActivity({
     onBodyScrollActivity,
@@ -172,20 +189,53 @@ export function DataTableView<
   }, [isNavigable, onActivateIndex, tableProps]);
 
   const selectByOffset = useCallback((offset: -1 | 1) => {
+    if (!navigableIndices) {
+      if (tableProps.items.length === 0) return;
+      const nextIndex = effectiveSelectedIndex >= 0
+        ? Math.max(
+            0,
+            Math.min(effectiveSelectedIndex + offset, tableProps.items.length - 1),
+          )
+        : 0;
+      selectIndex(nextIndex);
+      return;
+    }
     if (navigableIndices.length === 0) return;
     const currentPosition = navigableIndices.indexOf(effectiveSelectedIndex);
     const nextPosition = currentPosition >= 0
-      ? Math.max(0, Math.min(currentPosition + offset, navigableIndices.length - 1))
+      ? Math.max(
+          0,
+          Math.min(currentPosition + offset, navigableIndices.length - 1),
+        )
       : 0;
     const nextIndex = navigableIndices[nextPosition];
     if (nextIndex !== undefined) selectIndex(nextIndex);
-  }, [effectiveSelectedIndex, navigableIndices, selectIndex]);
+  }, [
+    effectiveSelectedIndex,
+    navigableIndices,
+    selectIndex,
+    tableProps.items.length,
+  ]);
 
   const activateSelection = useCallback(() => {
+    if (!navigableIndices) {
+      if (tableProps.items.length === 0) return;
+      const selectedIndex = effectiveSelectedIndex >= 0
+        && effectiveSelectedIndex < tableProps.items.length
+        ? effectiveSelectedIndex
+        : 0;
+      activateIndex(selectedIndex);
+      return;
+    }
     if (navigableIndices.length === 0) return;
     const selectedIsNavigable = navigableIndices.includes(effectiveSelectedIndex);
     activateIndex(selectedIsNavigable ? effectiveSelectedIndex : navigableIndices[0]!);
-  }, [activateIndex, effectiveSelectedIndex, navigableIndices]);
+  }, [
+    activateIndex,
+    effectiveSelectedIndex,
+    navigableIndices,
+    tableProps.items.length,
+  ]);
 
   useShortcut((event) => {
     if (event.defaultPrevented || event.propagationStopped) return;

--- a/src/components/price-sparkline/view.tsx
+++ b/src/components/price-sparkline/view.tsx
@@ -149,6 +149,7 @@ export function PriceSparkline({
   area?: boolean;
 }) {
   useThemeColors();
+  const uiHost = useUiHost();
   const sparklineHistory = useMemo(() => resolveSparklineHistory(priceHistory ?? [], period), [period, priceHistory]);
   const values = useMemo(() => sparklineValues(sparklineHistory), [sparklineHistory]);
   if (values.length < 2) {
@@ -156,7 +157,7 @@ export function PriceSparkline({
   }
 
   const color = sparklineColor(values, trend);
-  return useUiHost().kind === "desktop-web"
+  return uiHost.kind === "desktop-web"
     ? <DesktopPriceSparkline values={values} width={width} height={height} color={color} />
     : <TerminalPriceSparkline priceHistory={sparklineHistory} values={values} width={width} height={height} color={color} area={area} />;
 }

--- a/src/plugins/builtin/shared/ticker-request.ts
+++ b/src/plugins/builtin/shared/ticker-request.ts
@@ -58,7 +58,9 @@ export function useTickerRequest<T>(
     load(false);
   }, [load]);
 
-  return { ...state, reload: () => load(true) };
+  const reload = useCallback(() => load(true), [load]);
+
+  return { ...state, reload };
 }
 
 export function formatDateTime(date: Date): string {

--- a/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
@@ -12,7 +12,11 @@ import type { PaneProps } from "../../../../types/plugin";
 import type { PricePoint } from "../../../../types/financials";
 import { colors, priceColor } from "../../../../theme/colors";
 import { formatCompact, formatNumber, formatPercent } from "../../../../utils/format";
-import { useAssetData, usePluginPaneState } from "../../../runtime";
+import {
+  useAssetData,
+  useDebouncedPluginPaneState,
+  usePluginPaneState,
+} from "../../../runtime";
 import { loadingErrorFooterInfo, refreshFooterHint, useClampSelectedIndex } from "../../shared/table-pane";
 import { formatDateTime, useBoundTicker, useTickerRequest } from "../../shared/ticker-request";
 
@@ -95,7 +99,7 @@ export function HistoricalPricesPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
   const { symbol, exchange } = useBoundTicker();
   const [range, setRange] = usePluginPaneState<TimeRange>("range", "ALL");
-  const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
+  const [selectedIdx, setSelectedIdx] = useDebouncedPluginPaneState<number>("selectedIdx", 0);
   const loader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
     if (!dataProvider) throw new Error("Market data unavailable");
     return dataProvider.getPriceHistory(

--- a/src/plugins/builtin/ticker-detail/financials/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/financials/pane.tsx
@@ -9,6 +9,7 @@ export function FinancialsResearchTab({ focused }: TickerResearchTabProps) {
     <ResolvedFinancialsTab
       focused={focused}
       financials={financials}
+      allowArrowSubTabNavigation={false}
     />
   );
 }

--- a/src/plugins/builtin/ticker-detail/financials/tab.tsx
+++ b/src/plugins/builtin/ticker-detail/financials/tab.tsx
@@ -45,10 +45,12 @@ export function FinancialsTab({
   focused,
   headerScrollId,
   bodyScrollId,
+  allowArrowSubTabNavigation = true,
 }: {
   focused: boolean;
   headerScrollId?: string;
   bodyScrollId?: string;
+  allowArrowSubTabNavigation?: boolean;
 }) {
   const { financials } = usePaneTicker();
   return (
@@ -57,6 +59,7 @@ export function FinancialsTab({
       financials={financials}
       headerScrollId={headerScrollId}
       bodyScrollId={bodyScrollId}
+      allowArrowSubTabNavigation={allowArrowSubTabNavigation}
     />
   );
 }
@@ -66,11 +69,13 @@ export function ResolvedFinancialsTab({
   financials,
   headerScrollId,
   bodyScrollId,
+  allowArrowSubTabNavigation = true,
 }: {
   focused: boolean;
   financials: ReturnType<typeof usePaneTicker>["financials"];
   headerScrollId?: string;
   bodyScrollId?: string;
+  allowArrowSubTabNavigation?: boolean;
 }) {
   const annualStatements = financials?.annualStatements ?? [];
   const quarterlyStatements = financials?.quarterlyStatements ?? [];
@@ -85,6 +90,7 @@ export function ResolvedFinancialsTab({
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
     () => new Set(collectDefaultCollapsedGroupIds(FINANCIAL_SUB_TABS.flatMap((tab) => tab.rows))),
   );
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
   const bodyScrollRef = useRef<ScrollBoxRenderable>(null);
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
   const resolvedPeriodForFooter = resolveFinancialPeriod(period, hasAnnualStatements, hasQuarterlyStatements);
@@ -102,6 +108,9 @@ export function ResolvedFinancialsTab({
     const boundedIndex = ((rawIndex % FINANCIAL_SUB_TABS.length) + FINANCIAL_SUB_TABS.length) % FINANCIAL_SUB_TABS.length;
     setStoredSubTab(FINANCIAL_SUB_TABS[boundedIndex]?.key ?? FINANCIAL_SUB_TABS[0]!.key);
   }, [setStoredSubTab, subTabIdx]);
+  const selectAdjacentSubTab = useCallback((direction: -1 | 1) => {
+    setSubTabIdx((current) => current + direction);
+  }, [setSubTabIdx]);
   const togglePeriod = useCallback(() => {
     if (!hasAnnualStatements && !hasQuarterlyStatements) return;
     setPeriod((current) => {
@@ -192,6 +201,7 @@ export function ResolvedFinancialsTab({
 
   useShortcut((event) => {
     if (!focused) return;
+    if (event.ctrl || event.meta || event.alt || event.super || event.targetEditable) return;
     const keyName = event.name || event.key || event.sequence;
     if (keyName === "p") {
       event.preventDefault();
@@ -209,6 +219,14 @@ export function ResolvedFinancialsTab({
       event.preventDefault();
       event.stopPropagation();
       setSubTabIdx(Number(keyName) - 1);
+    } else if (allowArrowSubTabNavigation && keyName === "left") {
+      event.preventDefault();
+      event.stopPropagation();
+      selectAdjacentSubTab(-1);
+    } else if (allowArrowSubTabNavigation && keyName === "right") {
+      event.preventDefault();
+      event.stopPropagation();
+      selectAdjacentSubTab(1);
     }
   }, { phase: "before" });
 
@@ -219,10 +237,6 @@ export function ResolvedFinancialsTab({
       setPeriod("annual");
     }
   }, [hasAnnualStatements, hasQuarterlyStatements, period]);
-
-  if (!financials || (!hasAnnualStatements && !hasQuarterlyStatements)) {
-    return <Text fg={colors.textDim}>No financial data available.</Text>;
-  }
 
   const resolvedPeriod = resolveFinancialPeriod(period, hasAnnualStatements, hasQuarterlyStatements);
   const isAnnual = resolvedPeriod === "annual";
@@ -256,6 +270,25 @@ export function ResolvedFinancialsTab({
     })),
   ];
   const rows = buildFinancialRows(subTab.rows, displayStatements, collapsedGroups);
+  const selectedIndex = selectedRowId
+    ? rows.findIndex((row) => row.id === selectedRowId)
+    : rows.length > 0 ? 0 : -1;
+  const effectiveSelectedIndex = selectedIndex >= 0
+    ? selectedIndex
+    : rows.length > 0 ? 0 : -1;
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      if (selectedRowId !== null) setSelectedRowId(null);
+      return;
+    }
+    if (selectedRowId && rows.some((row) => row.id === selectedRowId)) return;
+    setSelectedRowId(rows[0]!.id);
+  }, [rows, selectedRowId]);
+
+  if (!financials || (!hasAnnualStatements && !hasQuarterlyStatements)) {
+    return <Text fg={colors.textDim}>No financial data available.</Text>;
+  }
 
   const renderCell = (
     row: FinancialTableRow,
@@ -345,18 +378,22 @@ export function ResolvedFinancialsTab({
         bodyScrollId={bodyScrollId}
         columns={columns}
         items={rows}
+        selectedIndex={effectiveSelectedIndex}
+        onSelectIndex={(_index, row) => {
+          setSelectedRowId(row.id);
+        }}
         sortColumnId={null}
         sortDirection="desc"
         onHeaderClick={() => {}}
         getItemKey={(row) => row.id}
-        isSelected={() => false}
+        isSelected={(_row, index) => index === effectiveSelectedIndex}
         onSelect={(row) => {
+          setSelectedRowId(row.id);
           if (row.kind === "group" && row.toggleable) toggleGroup(row.id);
         }}
         onActivate={(row) => {
           if (row.kind === "group" && row.toggleable) toggleGroup(row.id);
         }}
-        isNavigable={(row) => row.kind === "group" && row.toggleable}
         getRowBackgroundColor={(row) => row.kind === "group" && row.depth === 0 ? colors.panel : undefined}
         renderCell={renderCell}
         emptyStateTitle="No financial data"

--- a/src/plugins/builtin/ticker-detail/index.test.tsx
+++ b/src/plugins/builtin/ticker-detail/index.test.tsx
@@ -36,6 +36,8 @@ const TEST_PANE_ID = "ticker-research:test";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let harnessDispatch: React.Dispatch<AppAction> | null = null;
+let financialsHarnessState: ReturnType<typeof createInitialState> | null = null;
+let detailHarnessState: ReturnType<typeof createInitialState> | null = null;
 let sharedCoordinator: MarketDataCoordinator | null = null;
 
 const runtime = createTestPluginRuntime();
@@ -78,7 +80,7 @@ function makeFinancials(overrides: Partial<TickerFinancials> = {}): TickerFinanc
   };
 }
 
-function createFinancialsTabHarness() {
+function FinancialsTabHarness() {
   const config = createDefaultConfig("/tmp/gloomberb-test");
   config.layout.instances = config.layout.instances.map((instance) => (
     instance.instanceId === "ticker-detail:main"
@@ -91,25 +93,27 @@ function createFinancialsTabHarness() {
   const financials: TickerFinancials = {
     annualStatements: [
       { date: "2021-12-31" },
-      { date: "2022-12-31", totalRevenue: 43.49e9, operatingIncome: 9.37e9, eps: 4.68, totalAssets: 64e9, currentAssets: 18e9, cashAndCashEquivalents: 3e9 },
-      { date: "2023-12-31", totalRevenue: 27.62e9, operatingIncome: -2.4e9, eps: -0.92, totalAssets: 67.89e9, currentAssets: 16.77e9, cashAndCashEquivalents: 3.93e9 },
-      { date: "2024-12-31", totalRevenue: 25.88e9, operatingIncome: -3.92e9, eps: -1.73, totalAssets: 69.23e9, currentAssets: 19.05e9, cashAndCashEquivalents: 3.79e9, accountsReceivable: 5.12e9 },
-      { date: "2025-12-31", totalRevenue: 28.88e9, operatingIncome: -3.7e9, eps: -1.77, totalAssets: 76.93e9, currentAssets: 26.95e9, cashAndCashEquivalents: 5.54e9, accountsReceivable: 7.45e9, inventory: 4.88e9 },
+      { date: "2022-12-31", totalRevenue: 43.49e9, operatingRevenue: 43.49e9, costOfRevenue: 20e9, grossProfit: 23.49e9, operatingIncome: 9.37e9, eps: 4.68, totalAssets: 64e9, currentAssets: 18e9, cashAndCashEquivalents: 3e9 },
+      { date: "2023-12-31", totalRevenue: 27.62e9, operatingRevenue: 27.62e9, costOfRevenue: 16e9, grossProfit: 11.62e9, operatingIncome: -2.4e9, eps: -0.92, totalAssets: 67.89e9, currentAssets: 16.77e9, cashAndCashEquivalents: 3.93e9 },
+      { date: "2024-12-31", totalRevenue: 25.88e9, operatingRevenue: 25.88e9, costOfRevenue: 15e9, grossProfit: 10.88e9, operatingIncome: -3.92e9, eps: -1.73, totalAssets: 69.23e9, currentAssets: 19.05e9, cashAndCashEquivalents: 3.79e9, accountsReceivable: 5.12e9 },
+      { date: "2025-12-31", totalRevenue: 28.88e9, operatingRevenue: 28.88e9, costOfRevenue: 17e9, grossProfit: 11.88e9, operatingIncome: -3.7e9, eps: -1.77, totalAssets: 76.93e9, currentAssets: 26.95e9, cashAndCashEquivalents: 5.54e9, accountsReceivable: 7.45e9, inventory: 4.88e9 },
     ],
     quarterlyStatements: [
-      { date: "2025-03-31", totalRevenue: 6e9, operatingIncome: -1e9, eps: -0.4 },
-      { date: "2025-06-30", totalRevenue: 6.5e9, operatingIncome: -1.1e9, eps: -0.42 },
-      { date: "2025-09-30", totalRevenue: 7e9, operatingIncome: -1.2e9, eps: -0.45 },
-      { date: "2025-12-31", totalRevenue: 7.08e9, operatingIncome: -1.01e9, eps: -0.5, totalAssets: 76.93e9, currentAssets: 26.95e9, cashAndCashEquivalents: 5.54e9, accountsReceivable: 7.45e9, inventory: 4.88e9 },
+      { date: "2025-03-31", totalRevenue: 6e9, operatingRevenue: 6e9, costOfRevenue: 3e9, grossProfit: 3e9, operatingIncome: -1e9, eps: -0.4 },
+      { date: "2025-06-30", totalRevenue: 6.5e9, operatingRevenue: 6.5e9, costOfRevenue: 3.3e9, grossProfit: 3.2e9, operatingIncome: -1.1e9, eps: -0.42 },
+      { date: "2025-09-30", totalRevenue: 7e9, operatingRevenue: 7e9, costOfRevenue: 3.5e9, grossProfit: 3.5e9, operatingIncome: -1.2e9, eps: -0.45 },
+      { date: "2025-12-31", totalRevenue: 7.08e9, operatingRevenue: 7.08e9, costOfRevenue: 3.7e9, grossProfit: 3.38e9, operatingIncome: -1.01e9, eps: -0.5, totalAssets: 76.93e9, currentAssets: 26.95e9, cashAndCashEquivalents: 5.54e9, accountsReceivable: 7.45e9, inventory: 4.88e9 },
     ],
     priceHistory: [],
   };
 
   state.tickers = new Map([["2337", ticker]]);
   state.financials = new Map([["2337", financials]]);
+  const [appState, dispatch] = useReducer(appReducer, state);
+  financialsHarnessState = appState;
 
   return (
-    <AppContext value={{ state, dispatch: () => {} }}>
+    <AppContext value={{ state: appState, dispatch }}>
       <PaneInstanceProvider paneId="ticker-detail:main">
         <FinancialsTab
           focused
@@ -119,6 +123,10 @@ function createFinancialsTabHarness() {
       </PaneInstanceProvider>
     </AppContext>
   );
+}
+
+function createFinancialsTabHarness() {
+  return <FinancialsTabHarness />;
 }
 
 function createFinancialsTabFooterHarness(width = 90, height = 18) {
@@ -246,6 +254,7 @@ function DetailHarness({
   const initialState = createDetailState(config, ticker, financials, activeTabId, exchangeRates);
   const [state, dispatch] = useReducer(appReducer, initialState);
   harnessDispatch = dispatch;
+  detailHarnessState = state;
 
   return (
     <AppContext value={{ state, dispatch }}>
@@ -277,6 +286,8 @@ afterEach(() => {
     testSetup = undefined;
   }
   harnessDispatch = null;
+  financialsHarnessState = null;
+  detailHarnessState = null;
   setSharedRegistryForTests(undefined);
   setOptionsProvider(undefined);
 });
@@ -304,6 +315,51 @@ describe("FinancialsTab", () => {
     frame = testSetup.captureCharFrame();
     expect(frame).toContain("Quarterly");
     expect(frame).toContain("[p]eriod");
+  });
+
+  test("moves selection with down without collapsing the selected financial group", async () => {
+    testSetup = await testRender(createFinancialsTabFooterHarness(100, 20), {
+      width: 100,
+      height: 20,
+    });
+
+    await flushFrame();
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).toContain("Operating Revenue");
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("down");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(testSetup.captureCharFrame()).toContain("Operating Revenue");
+  });
+
+  test("switches financial statement sections with left and right arrows", async () => {
+    testSetup = await testRender(createFinancialsTabFooterHarness(100, 20), {
+      width: 100,
+      height: 20,
+    });
+
+    await flushFrame();
+    await flushFrame();
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("right");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(financialsHarnessState?.paneState["ticker-detail:main"]?.financialSubTab).toBe("cashflow");
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("left");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(financialsHarnessState?.paneState["ticker-detail:main"]?.financialSubTab).toBe("income");
   });
 
 });
@@ -352,6 +408,42 @@ describe("TickerResearchPane", () => {
     await flushFrame();
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Financials");
+  });
+
+  test("lets ticker detail tab arrows leave the embedded financials tab", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setOptionsProvider(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={makeFinancials({
+          annualStatements: [{ date: "2024-12-31", totalRevenue: 1_000 }],
+        })}
+        activeTabId="financials"
+      />,
+      { width: 90, height: 24 },
+    );
+
+    await flushFrame();
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("financials");
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("right");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("fundamental-graphs");
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("left");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("financials");
   });
 
   test("shows Trade when an IBKR gateway profile exists", async () => {

--- a/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
@@ -1,7 +1,14 @@
+import { useMemo } from "react";
 import { Box, Text, TextAttributes, useUiCapabilities } from "../../../../ui";
 import type { TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
-import { useTickerFinancials } from "../../../../market-data/hooks";
+import {
+  DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
+  useChartQuery,
+  useTickerFinancials,
+} from "../../../../market-data/hooks";
+import { instrumentFromTicker } from "../../../../market-data/request-types";
+import { resolveEntryData } from "../../../../market-data/selectors";
 import { useDoubleClickActivation } from "../../../../components/use-double-click-activation";
 import { colors, priceColor } from "../../../../theme/colors";
 import { formatPercentRaw } from "../../../../utils/format";
@@ -47,6 +54,23 @@ export function QuoteMonitorCard({
   const { nativePaneChrome } = useUiCapabilities();
   const marketFinancials = useTickerFinancials(symbol, ticker);
   const financials = marketFinancials ?? cachedFinancials;
+  const chartRequest = useMemo(() => {
+    const instrument = instrumentFromTicker(ticker, symbol);
+    return instrument
+      ? {
+        instrument,
+        bufferRange: chartPeriod,
+        granularity: "range" as const,
+      }
+      : null;
+  }, [chartPeriod, symbol, ticker]);
+  const chartEntry = useChartQuery(chartRequest, {
+    refreshIntervalMs: DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
+  });
+  const queriedPriceHistory = resolveEntryData(chartEntry);
+  const priceHistory = queriedPriceHistory && queriedPriceHistory.length >= 2
+    ? queriedPriceHistory
+    : financials?.priceHistory;
   const flashDirection = useQuoteFlashDirection(financials, valueFlashingEnabled);
   const quote = financials?.quote;
   const display = getActiveQuoteDisplay(quote);
@@ -62,7 +86,7 @@ export function QuoteMonitorCard({
   const changeValueText = display ? formatSignedMarketPrice(display.change, { assetCategory: ticker?.metadata.assetCategory }) : "";
   const priceColumnWidth = Math.max(priceText.length, changePercentText.length + changeValueText.length + 1);
   const nameMaxWidth = Math.max(10, width - priceColumnWidth - (nativePaneChrome ? 5 : 3));
-  const sparklineRange = resolvePriceSparklineRange(financials?.priceHistory, chartPeriod);
+  const sparklineRange = resolvePriceSparklineRange(priceHistory, chartPeriod);
   const rangeLabel = sparklineRange
     ? `${chartPeriod} ${formatMarketPriceWithCurrency(sparklineRange.min, currency, { assetCategory: ticker?.metadata.assetCategory })}-${formatMarketPriceWithCurrency(sparklineRange.max, currency, { assetCategory: ticker?.metadata.assetCategory })}`
     : "";
@@ -124,7 +148,7 @@ export function QuoteMonitorCard({
       } : undefined}
     >
       {nativePaneChrome && display && (
-        <PriceAreaSparklineBackground priceHistory={financials?.priceHistory} trend={trend} period={chartPeriod} />
+        <PriceAreaSparklineBackground priceHistory={priceHistory} trend={trend} period={chartPeriod} />
       )}
       {!display ? (
         <Box flexDirection="column" flexGrow={1} justifyContent="center">
@@ -286,7 +310,7 @@ export function QuoteMonitorCard({
 
           <Box height={terminalSparklineHeight} flexDirection="row" alignItems="center" gap={1}>
             <PriceSparkline
-              priceHistory={financials?.priceHistory}
+              priceHistory={priceHistory}
               width={sparklineWidth}
               height={terminalSparklineHeight}
               trend={trend}

--- a/src/plugins/builtin/ticker-detail/quote-monitor/index.test.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/index.test.tsx
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act } from "react";
 import { testRender } from "../../../../renderers/opentui/test-utils";
-import type { TickerFinancials } from "../../../../types/financials";
+import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../../market-data/coordinator";
+import { createTestDataProvider } from "../../../../test-support/data-provider";
+import type { PricePoint, TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
-import { createDefaultConfig } from "../../../../types/config";
+import { createDefaultConfig, TICKER_RESEARCH_PANE_ID } from "../../../../types/config";
 import { AppContext, createInitialState, PaneInstanceProvider } from "../../../../state/app/context";
 import { QuoteMonitorPane } from "./index";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../../../runtime";
@@ -12,6 +14,7 @@ import type { PinTickerOptions } from "../../../../types/plugin";
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
 afterEach(() => {
+  setSharedMarketDataCoordinator(null);
   if (testSetup) {
     testSetup.renderer.destroy();
     testSetup = undefined;
@@ -79,7 +82,20 @@ function makeTicker(symbol: string, name: string): TickerRecord {
   };
 }
 
-function makeFinancials(symbol: string, price: number, change: number, changePercent: number): TickerFinancials {
+function makePriceHistory(price: number): PricePoint[] {
+  return Array.from({ length: 12 }, (_, index) => ({
+    date: new Date(Date.UTC(2026, 0, index + 1)),
+    close: price - 6 + index,
+  }));
+}
+
+function makeFinancials(
+  symbol: string,
+  price: number,
+  change: number,
+  changePercent: number,
+  priceHistory = makePriceHistory(price),
+): TickerFinancials {
   return {
     quote: {
       symbol,
@@ -91,15 +107,13 @@ function makeFinancials(symbol: string, price: number, change: number, changePer
     },
     annualStatements: [],
     quarterlyStatements: [],
-    priceHistory: Array.from({ length: 12 }, (_, index) => ({
-      date: new Date(Date.UTC(2026, 0, index + 1)),
-      close: price - 6 + index,
-    })),
+    priceHistory,
   };
 }
 
 function createQuoteMonitorHarness(options: {
   symbols?: string[];
+  financials?: Map<string, TickerFinancials>;
   pinCalls?: PinTickerCall[];
   settingsCalls?: Array<string | undefined>;
 } = {}) {
@@ -128,7 +142,7 @@ function createQuoteMonitorHarness(options: {
     makeTicker("AAPL", "Apple"),
   ];
   state.tickers = new Map(tickers.map((ticker) => [ticker.metadata.ticker, ticker]));
-  state.financials = new Map([
+  state.financials = options.financials ?? new Map([
     ["MSFT", makeFinancials("MSFT", 356.15, -9.82, -2.68)],
     ["AAPL", makeFinancials("AAPL", 202.12, 3.05, 1.53)],
   ]);
@@ -147,14 +161,40 @@ function createQuoteMonitorHarness(options: {
   );
 }
 
+async function renderHarness(
+  node: ReturnType<typeof createQuoteMonitorHarness>,
+  options: Parameters<typeof testRender>[1],
+) {
+  await act(async () => {
+    testSetup = await testRender(node, options);
+  });
+}
+
+async function renderOnce() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function flushFrames(count: number) {
+  for (let index = 0; index < count; index += 1) {
+    await act(async () => {
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+  }
+}
+
 describe("QuoteMonitorPane", () => {
   test("renders a compact quote card for the bound ticker", async () => {
-    testSetup = await testRender(createQuoteMonitorHarness(), {
+    await renderHarness(createQuoteMonitorHarness(), {
       width: 72,
       height: 7,
     });
 
-    await testSetup.renderOnce();
+    await renderOnce();
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("MSFT");
@@ -165,12 +205,12 @@ describe("QuoteMonitorPane", () => {
   });
 
   test("renders multiple configured tickers", async () => {
-    testSetup = await testRender(createQuoteMonitorHarness({ symbols: ["MSFT", "AAPL"] }), {
+    await renderHarness(createQuoteMonitorHarness({ symbols: ["MSFT", "AAPL"] }), {
       width: 72,
       height: 8,
     });
 
-    await testSetup.renderOnce();
+    await renderOnce();
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("MSFT");
@@ -181,12 +221,12 @@ describe("QuoteMonitorPane", () => {
 
   test("opens a Ticker Research pane on the second card click", async () => {
     const pinCalls: PinTickerCall[] = [];
-    testSetup = await testRender(createQuoteMonitorHarness({ pinCalls }), {
+    await renderHarness(createQuoteMonitorHarness({ pinCalls }), {
       width: 72,
       height: 7,
     });
 
-    await testSetup.renderOnce();
+    await renderOnce();
     const frame = testSetup.captureCharFrame();
     const row = frame.split("\n").findIndex((line) => line.includes("MSFT"));
     expect(row).toBeGreaterThanOrEqual(0);
@@ -200,18 +240,47 @@ describe("QuoteMonitorPane", () => {
 
     expect(pinCalls).toEqual([{
       symbol: "MSFT",
-      options: { paneType: "ticker-detail", floating: true },
+      options: { paneType: TICKER_RESEARCH_PANE_ID, floating: true },
     }]);
   });
 
-  test("opens pane settings when t is pressed", async () => {
-    const settingsCalls: Array<string | undefined> = [];
-    testSetup = await testRender(createQuoteMonitorHarness({ settingsCalls }), {
+  test("loads chart history for quote-only cards", async () => {
+    const loadCalls: Array<{ symbol: string; exchange: string; range: string }> = [];
+    const chartHistory = makePriceHistory(356.15);
+    setSharedMarketDataCoordinator(new MarketDataCoordinator(createTestDataProvider({
+      getTickerFinancials: async (symbol) => makeFinancials(symbol, 356.15, -9.82, -2.68, []),
+      getPriceHistory: async (symbol, exchange, range) => {
+        loadCalls.push({ symbol, exchange, range });
+        return chartHistory;
+      },
+    })));
+
+    await renderHarness(createQuoteMonitorHarness({
+      financials: new Map([
+        ["MSFT", makeFinancials("MSFT", 356.15, -9.82, -2.68, [])],
+      ]),
+    }), {
       width: 72,
       height: 7,
     });
 
-    await testSetup.renderOnce();
+    await renderOnce();
+    await flushFrames(3);
+
+    const frame = testSetup.captureCharFrame();
+    expect(loadCalls).toContainEqual({ symbol: "MSFT", exchange: "NASDAQ", range: "1M" });
+    expect(frame).toContain("MSFT");
+    expect(frame).toMatch(/[⠁-⣿]/);
+  });
+
+  test("opens pane settings when t is pressed", async () => {
+    const settingsCalls: Array<string | undefined> = [];
+    await renderHarness(createQuoteMonitorHarness({ settingsCalls }), {
+      width: 72,
+      height: 7,
+    });
+
+    await renderOnce();
 
     await act(async () => {
       testSetup!.mockInput.pressKey("t");

--- a/src/renderers/electrobun/view/data-table/row.tsx
+++ b/src/renderers/electrobun/view/data-table/row.tsx
@@ -38,6 +38,12 @@ function renderHeaderLabel<C extends DataTableColumn>(
   };
 }
 
+function contentJustifyForAlign(align: string | undefined): CSSProperties["justifyContent"] {
+  if (align === "right") return "flex-end";
+  if (align === "center") return "center";
+  return "flex-start";
+}
+
 export function WebDataTableHeader<C extends DataTableColumn>({
   columns,
   focusPane,
@@ -99,11 +105,14 @@ export function WebDataTableHeader<C extends DataTableColumn>({
           >
             <span
               title={text}
-              style={clippedCellTextStyle(
-                column,
-                isSorted ? CSS_TEXT : column.headerColor ?? CSS_TEXT_DIM,
-                TextAttributes.BOLD,
-              )}
+              style={{
+                ...clippedCellTextStyle(
+                  column,
+                  isSorted ? CSS_TEXT : column.headerColor ?? CSS_TEXT_DIM,
+                  TextAttributes.BOLD,
+                ),
+                whiteSpace: "pre",
+              }}
             >
               {text}
             </span>
@@ -293,6 +302,9 @@ function WebDataTableRowInner<
               <div
                 title={cell.text}
                 style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: contentJustifyForAlign(column.align),
                   width: "100%",
                   height: "100%",
                   minWidth: 0,


### PR DESCRIPTION
This fixes ticker detail data-table keyboard handling so financial statement rows can be selected without collapsing groups, while standalone financial panes can switch sections with left/right and embedded financial tabs let parent tab navigation handle those arrows.
It also restores quote-monitor sparklines for quote-only cards by loading chart history directly, debounces historical price row persistence, and keeps the price sparkline hook order stable.
On desktop, custom data-table cell content now aligns with its column, which keeps financial statement headers and figures lined up.
