### PR TITLE
Fix TBO detail scrolling

### DIFF
--- a/src/plugins/builtin/buildout/detail/index.tsx
+++ b/src/plugins/builtin/buildout/detail/index.tsx
@@ -54,37 +54,52 @@ export function BuildoutDetail({
   ) : null;
 
   return (
-    <ScrollBox width={width} height={height}>
-      <Box flexDirection="column" paddingX={1} width={bodyWidth}>
-        {row.kind === "company" ? (
-          <CompanyDetail
-            company={row.item}
-            bodyWidth={bodyWidth}
-            catalog={catalog}
-            openTicker={openTicker}
-            favoriteToggle={favoriteToggle}
-          />
-        ) : null}
-        {row.kind === "site" ? (
-          <SiteDetail
-            site={row.item}
-            bodyWidth={bodyWidth}
-            height={height}
-            catalog={catalog}
-            openTicker={openTicker}
-            favoriteToggle={favoriteToggle}
-          />
-        ) : null}
-        {row.kind === "intel" ? (
-          <IntelDetail
-            item={row.item}
-            bodyWidth={bodyWidth}
-            height={height}
-            catalog={catalog}
-            openTicker={openTicker}
-          />
-        ) : null}
-      </Box>
-    </ScrollBox>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+    >
+      <ScrollBox
+        width={width}
+        flexGrow={1}
+        flexBasis={0}
+        minHeight={0}
+        scrollY
+        focusable={false}
+      >
+        <Box flexDirection="column" paddingX={1} width={bodyWidth}>
+          {row.kind === "company" ? (
+            <CompanyDetail
+              company={row.item}
+              bodyWidth={bodyWidth}
+              catalog={catalog}
+              openTicker={openTicker}
+              favoriteToggle={favoriteToggle}
+            />
+          ) : null}
+          {row.kind === "site" ? (
+            <SiteDetail
+              site={row.item}
+              bodyWidth={bodyWidth}
+              height={height}
+              catalog={catalog}
+              openTicker={openTicker}
+              favoriteToggle={favoriteToggle}
+            />
+          ) : null}
+          {row.kind === "intel" ? (
+            <IntelDetail
+              item={row.item}
+              bodyWidth={bodyWidth}
+              height={height}
+              catalog={catalog}
+              openTicker={openTicker}
+            />
+          ) : null}
+        </Box>
+      </ScrollBox>
+    </Box>
   );
 }


### PR DESCRIPTION
The TBO detail body was rendered as an unbounded scroll box without vertical scroll registration, so focused-pane arrow scrolling only worked after directly clicking the detail and desktop did not expose the expected scrollbar. This wraps company, site, and intel details in a bounded vertical scroll region that participates in focused-pane scrolling while preserving the existing detail content and footer actions.