### PR TITLE
Fix terminal chat ticker badge wrapping

### DIFF
--- a/src/components/ticker/badge/format.ts
+++ b/src/components/ticker/badge/format.ts
@@ -1,0 +1,42 @@
+import { formatMarketPriceWithCurrency } from "../../../market-data/market/format";
+import type { Quote } from "../../../types/financials";
+import { displayWidth } from "../../../utils/format";
+
+export type TickerBadgeStatus = "loading" | "ready";
+
+export function formatTickerBadgeChange(changePercent: number): string {
+  const rounded = Math.round(changePercent * 10) / 10;
+  const normalized = Object.is(rounded, -0) ? 0 : rounded;
+  if (normalized === 0) return "0%";
+  const abs = Math.abs(normalized);
+  const body = Number.isInteger(abs) ? abs.toFixed(0) : abs.toFixed(1);
+  return `${normalized > 0 ? "+" : "-"}${body}%`;
+}
+
+export function getTickerBadgeText({
+  symbol,
+  status,
+  quote,
+  liveQuote = true,
+  hovered = false,
+}: {
+  symbol: string;
+  status: TickerBadgeStatus;
+  quote: Quote | null;
+  liveQuote?: boolean;
+  hovered?: boolean;
+}): string {
+  const quoteForDisplay = liveQuote ? quote : null;
+  const quoteLabel = hovered && quoteForDisplay
+    ? `${symbol} ${formatMarketPriceWithCurrency(quoteForDisplay.price, quoteForDisplay.currency, { minimumFractionDigits: 2 })}`
+    : status === "ready" && quoteForDisplay
+      ? formatTickerBadgeChange(quoteForDisplay.changePercent)
+      : "\u2026";
+  return liveQuote
+    ? hovered && quoteForDisplay ? quoteLabel : `${symbol} ${quoteLabel}`
+    : symbol;
+}
+
+export function getTickerBadgeCellWidth(options: Parameters<typeof getTickerBadgeText>[0]): number {
+  return displayWidth(getTickerBadgeText(options)) + 3;
+}

--- a/src/components/ticker/badge/index.tsx
+++ b/src/components/ticker/badge/index.tsx
@@ -2,8 +2,8 @@ import { Box, Text, useTickerContextMenu, useUiCapabilities } from "../../../ui"
 import { TextAttributes } from "../../../ui";
 import { colors, priceColor } from "../../../theme/colors";
 import { getSharedRegistry } from "../../../plugins/registry";
-import { formatMarketPriceWithCurrency } from "../../../market-data/market/format";
 import type { Quote } from "../../../types/financials";
+import { getTickerBadgeText } from "./format";
 
 export interface TickerBadgeProps {
   symbol: string;
@@ -33,15 +33,6 @@ function blendHex(base: string, accent: string, ratio: number): string {
   return `#${mix(br, ar)}${mix(bg, ag)}${mix(bb, ab)}`;
 }
 
-function formatBadgeChange(changePercent: number): string {
-  const rounded = Math.round(changePercent * 10) / 10;
-  const normalized = Object.is(rounded, -0) ? 0 : rounded;
-  if (normalized === 0) return "0%";
-  const abs = Math.abs(normalized);
-  const body = Number.isInteger(abs) ? abs.toFixed(0) : abs.toFixed(1);
-  return `${normalized > 0 ? "+" : "-"}${body}%`;
-}
-
 export function TickerBadge({
   symbol,
   status,
@@ -65,14 +56,7 @@ export function TickerBadge({
   const tone = status === "ready" && quoteForDisplay
     ? priceColor(quoteForDisplay.changePercent)
     : colors.borderFocused;
-  const quoteLabel = hovered && quoteForDisplay
-    ? `${symbol} ${formatMarketPriceWithCurrency(quoteForDisplay.price, quoteForDisplay.currency, { minimumFractionDigits: 2 })}`
-    : status === "ready" && quoteForDisplay
-      ? formatBadgeChange(quoteForDisplay.changePercent)
-      : "…";
-  const text = liveQuote
-    ? hovered && quoteForDisplay ? quoteLabel : `${symbol} ${quoteLabel}`
-    : symbol;
+  const text = getTickerBadgeText({ symbol, status, quote, liveQuote, hovered });
   const color = hovered ? colors.textBright : tone;
   const backgroundColor = hovered
     ? blendHex(colors.bg, tone, 0.42)

--- a/src/components/ticker/badge/text.tsx
+++ b/src/components/ticker/badge/text.tsx
@@ -5,6 +5,7 @@ import { ExternalLinkText, openUrl } from "../../ui";
 import { tokenizeInlineContent } from "../../../utils/inline-content-tokenizer";
 import type { InlineTickerCatalogEntry } from "../../../state/hooks/inline-tickers";
 import { displayWidth } from "../../../utils/format";
+import { splitLongTextSegmentByDisplayWidth } from "../../../utils/text-wrap";
 import { blendHex, colors } from "../../../theme/colors";
 
 export interface TickerBadgeTextProps {
@@ -54,28 +55,10 @@ function UsernameBadge({
   );
 }
 
-function splitLongTextSegment(value: string, lineWidth: number): string[] {
-  if (displayWidth(value) <= lineWidth) return [value];
-
-  const chunks: string[] = [];
-  let current = "";
-  for (const char of Array.from(value)) {
-    const next = `${current}${char}`;
-    if (current && displayWidth(next) > lineWidth) {
-      chunks.push(current);
-      current = char;
-      continue;
-    }
-    current = next;
-  }
-  if (current) chunks.push(current);
-  return chunks;
-}
-
 function splitTextForWrap(value: string, lineWidth: number): string[] {
   const width = Math.max(1, lineWidth);
   const segments = value.match(/\S+\s*|\s+/g) ?? [value];
-  return segments.flatMap((segment) => splitLongTextSegment(segment, width));
+  return segments.flatMap((segment) => splitLongTextSegmentByDisplayWidth(segment, width));
 }
 
 export function TickerBadgeText({

--- a/src/plugins/builtin/chat/chat.test.tsx
+++ b/src/plugins/builtin/chat/chat.test.tsx
@@ -779,6 +779,66 @@ describe("ChatContent", () => {
     expect(opened).toEqual(["TSLA"]);
   });
 
+  test("wraps ticker badges using their rendered width in terminal messages", async () => {
+    const controller = createController({
+      messages: [{
+        id: "m1",
+        channelId: "everyone",
+        content: "For example for $META it seems to look at Meta AI revenue, not mentioning the ad engine where revenues are most likely to translate",
+        replyToId: null,
+        createdAt: "2026-03-28T00:00:00.000Z",
+        user: { id: "u1", username: "vince", displayName: "Vince" },
+      }],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 60,
+        height: 12,
+        configureState(state) {
+          state.tickers = new Map([["META", {
+            metadata: {
+              ticker: "META",
+              exchange: "NASDAQ",
+              currency: "USD",
+              name: "Meta Platforms, Inc.",
+              portfolios: [],
+              watchlists: [],
+              positions: [],
+              custom: {},
+              tags: [],
+            },
+          }]]);
+          state.financials = new Map([["META", {
+            annualStatements: [],
+            quarterlyStatements: [],
+            priceHistory: [],
+            quote: {
+              symbol: "META",
+              price: 650,
+              currency: "USD",
+              change: -3.25,
+              changePercent: -0.5,
+              lastUpdated: Date.now(),
+            },
+          }]]);
+        },
+      }), {
+        width: 60,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    const frame = setup().captureCharFrame();
+    const normalizedFrame = frame.replace(/\s+/g, " ");
+    expect(normalizedFrame).toContain("For example for META -0.5%");
+    expect(normalizedFrame).toContain("it seems to look at Meta AI revenue, not");
+    expect(normalizedFrame).toContain("mentioning the ad engine where revenues");
+    expect(frame).not.toContain("mentioningttheoad");
+  });
+
   test("renders detected links in chat messages", async () => {
     const controller = createController({
       messages: [{

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -240,6 +240,7 @@ export function ChatContent({
     requestOlderMessagesIfNeeded,
   } = useChatScrollRuntime({
     channelId,
+    catalog,
     contentWidth,
     controller,
     focused,

--- a/src/plugins/builtin/chat/content/scroll.ts
+++ b/src/plugins/builtin/chat/content/scroll.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { ScrollBoxRenderable } from "../../../../ui";
 import type { ChatMessage } from "../../../../api-client";
+import type { InlineTickerCatalogEntry } from "../../../../state/hooks/inline-tickers";
 import type { ChatContentController } from "./types";
 import {
   estimateMessageHeight,
@@ -30,6 +31,7 @@ export interface ChatPrependAnchor {
 
 interface ChatScrollRuntimeArgs {
   channelId: string;
+  catalog: Record<string, InlineTickerCatalogEntry>;
   contentWidth: number;
   controller: ChatContentController;
   focused: boolean;
@@ -53,6 +55,7 @@ interface ChatScrollRuntimeArgs {
 
 export function useChatScrollRuntime({
   channelId,
+  catalog,
   contentWidth,
   controller,
   focused,
@@ -149,10 +152,11 @@ export function useChatScrollRuntime({
       if (nativePaneChrome && scrollElementIntoScrollBoxView(scrollRef.current, messageElementsRef.current.get(messageId))) return;
       const scrollBox = scrollRef.current;
       if (!scrollBox) return;
-      scrollBox.scrollTo(getMessageTopOffset(messages, targetIndex, contentWidth));
+      scrollBox.scrollTo(getMessageTopOffset(messages, targetIndex, contentWidth, catalog));
     });
     return true;
   }, [
+    catalog,
     contentWidth,
     messageElementsRef,
     messages,
@@ -210,7 +214,7 @@ export function useChatScrollRuntime({
       : -1;
     const exactPixels = nativePaneChrome === true && hasPixelScrollMetrics(scrollBox);
     const addedRows = !exactPixels && previousOldestIndex > 0
-      ? getMessageTopOffset(messages, previousOldestIndex, contentWidth)
+      ? getMessageTopOffset(messages, previousOldestIndex, contentWidth, catalog)
       : Math.max(0, getScrollHeight(scrollBox, exactPixels) - currentAnchor.scrollHeight);
     scrollToPosition(scrollBox, currentAnchor.scrollTop + addedRows, exactPixels);
     if (currentAnchor.selectedMessageId) {
@@ -224,7 +228,7 @@ export function useChatScrollRuntime({
         prependAnchorRef.current = null;
       }
     });
-  }, [contentWidth, loadingOlderMessages, messages, nativePaneChrome, prependAnchorRef, scrollRef, setSelectedIdx]);
+  }, [catalog, contentWidth, loadingOlderMessages, messages, nativePaneChrome, prependAnchorRef, scrollRef, setSelectedIdx]);
 
   useEffect(() => {
     if (!focused || !stickyTranscript) return;
@@ -241,8 +245,8 @@ export function useChatScrollRuntime({
       runAfterLayout(() => scrollElementIntoScrollBoxView(scrollRef.current, messageElementsRef.current.get(selectedMessageId)));
       return;
     }
-    const top = getMessageTopOffset(messages, selectedIdx, contentWidth);
-    const rowHeight = estimateMessageHeight(messages[selectedIdx]!, contentWidth, isGroupedWithPrevious(messages, selectedIdx));
+    const top = getMessageTopOffset(messages, selectedIdx, contentWidth, catalog);
+    const rowHeight = estimateMessageHeight(messages[selectedIdx]!, contentWidth, isGroupedWithPrevious(messages, selectedIdx), catalog);
     const nextScrollTop = getSelectedMessageScrollTop({
       scrollTop: sb.scrollTop,
       viewportHeight: sb.viewport?.height ?? 0,
@@ -253,6 +257,7 @@ export function useChatScrollRuntime({
       sb.scrollTo(nextScrollTop);
     }
   }, [
+    catalog,
     contentWidth,
     messageElementsRef,
     messages,

--- a/src/plugins/builtin/chat/layout.ts
+++ b/src/plugins/builtin/chat/layout.ts
@@ -1,6 +1,10 @@
 import type { ScrollBoxRenderable } from "../../../ui";
 import type { ChatMessage } from "../../../api-client";
-import { truncateWithEllipsis } from "../../../utils/text-wrap";
+import { splitLongTextSegmentByDisplayWidth, truncateWithEllipsis } from "../../../utils/text-wrap";
+import { tokenizeInlineContent, type InlineContentToken } from "../../../utils/inline-content-tokenizer";
+import { displayWidth } from "../../../utils/format";
+import { getTickerBadgeCellWidth } from "../../../components/ticker/badge/format";
+import type { InlineTickerCatalogEntry } from "../../../state/hooks/inline-tickers";
 
 const MESSAGE_GROUP_THRESHOLD_MS = 5 * 60 * 1000;
 const MESSAGE_SELECTION_BOTTOM_INSET = 1;
@@ -51,24 +55,150 @@ function wrapTextLines(text: string, width: number) {
   return lines.length > 0 ? lines : [""];
 }
 
-export function getMessageBodyLines(message: ChatMessage, width: number) {
+function inlineTokenWidth(
+  token: InlineContentToken,
+  catalog: Record<string, InlineTickerCatalogEntry>,
+): number {
+  if (token.kind !== "ticker") return displayWidth(token.value);
+
+  const entry = catalog[token.symbol];
+  if (!entry || entry.status === "missing") return displayWidth(token.value);
+
+  const baseWidth = getTickerBadgeCellWidth({
+    symbol: token.symbol,
+    status: entry.status,
+    quote: entry.quote,
+  });
+  const hoverWidth = getTickerBadgeCellWidth({
+    symbol: token.symbol,
+    status: entry.status,
+    quote: entry.quote,
+    hovered: true,
+  });
+  return Math.max(baseWidth, hoverWidth);
+}
+
+function wrapInlineContentLine(
+  text: string,
+  width: number,
+  catalog: Record<string, InlineTickerCatalogEntry>,
+): string[] {
+  const safeWidth = Math.max(width, 1);
+  const lines: string[] = [];
+  let current = "";
+  let currentWidth = 0;
+
+  const finishLine = () => {
+    lines.push(current.trimEnd());
+    current = "";
+    currentWidth = 0;
+  };
+
+  const appendTextPart = (rawPart: string) => {
+    let part = currentWidth === 0 ? rawPart.trimStart() : rawPart;
+    if (!part) return;
+
+    while (part) {
+      const partWidth = displayWidth(part);
+      if (currentWidth > 0 && currentWidth + partWidth > safeWidth) {
+        finishLine();
+        part = part.trimStart();
+        if (!part) return;
+        continue;
+      }
+
+      if (partWidth <= safeWidth - currentWidth) {
+        current += part;
+        currentWidth += partWidth;
+        return;
+      }
+
+      const available = Math.max(safeWidth - currentWidth, 1);
+      const [chunk = "", ...rest] = splitLongTextSegmentByDisplayWidth(part, available);
+      if (chunk) {
+        current += chunk;
+        currentWidth += displayWidth(chunk);
+      }
+      finishLine();
+      part = rest.join("").trimStart();
+    }
+  };
+
+  const appendText = (value: string) => {
+    const parts = value.match(/\S+\s*|\s+/g) ?? [value];
+    for (const part of parts) {
+      appendTextPart(part);
+    }
+  };
+
+  const appendInlineToken = (token: InlineContentToken) => {
+    const tokenWidth = inlineTokenWidth(token, catalog);
+    if (currentWidth > 0 && currentWidth + tokenWidth > safeWidth) finishLine();
+    current += token.value;
+    currentWidth += tokenWidth;
+  };
+
+  for (const token of tokenizeInlineContent(text)) {
+    if (token.kind === "text") {
+      appendText(token.value);
+      continue;
+    }
+    appendInlineToken(token);
+  }
+
+  if (current || lines.length === 0) lines.push(current.trimEnd());
+  return lines;
+}
+
+function wrapInlineContentLines(
+  text: string,
+  width: number,
+  catalog: Record<string, InlineTickerCatalogEntry>,
+): string[] {
+  const lines: string[] = [];
+  for (const paragraph of text.split("\n")) {
+    if (!paragraph) {
+      lines.push("");
+      continue;
+    }
+    lines.push(...wrapInlineContentLine(paragraph, width, catalog));
+  }
+  return lines.length > 0 ? lines : [""];
+}
+
+export function getMessageBodyLines(
+  message: ChatMessage,
+  width: number,
+  catalog?: Record<string, InlineTickerCatalogEntry>,
+) {
   const contentLineWidth = Math.max(width - 4, 1);
+  if (catalog) return wrapInlineContentLines(message.content, contentLineWidth, catalog);
   return wrapTextLines(message.content, contentLineWidth);
 }
 
-export function estimateMessageHeight(message: ChatMessage, width: number, grouped = false) {
+export function estimateMessageHeight(
+  message: ChatMessage,
+  width: number,
+  grouped = false,
+  catalog?: Record<string, InlineTickerCatalogEntry>,
+) {
   const headerHeight = grouped ? 0 : 1;
-  return headerHeight + (message.replyTo ? 1 : 0) + getMessageBodyLines(message, width).length;
+  return headerHeight + (message.replyTo ? 1 : 0) + getMessageBodyLines(message, width, catalog).length;
 }
 
 export function estimateComposerHeight(text: string, width: number) {
   return Math.max(1, Math.min(CHAT_COMPOSER_MAX_ROWS, wrapTextLines(text, width).length));
 }
 
-export function getMessageTopOffset(messages: ChatMessage[], index: number, width: number) {
+export function getMessageTopOffset(
+  messages: ChatMessage[],
+  index: number,
+  width: number,
+  catalog?: Record<string, InlineTickerCatalogEntry>,
+) {
   let offset = 0;
   for (let i = 0; i < index; i += 1) {
-    offset += estimateMessageHeight(messages[i]!, width, isGroupedWithPrevious(messages, i));
+    offset += estimateMessageHeight(messages[i]!, width, isGroupedWithPrevious(messages, i), catalog);
   }
   return offset;
 }

--- a/src/plugins/builtin/chat/message/terminal.tsx
+++ b/src/plugins/builtin/chat/message/terminal.tsx
@@ -30,7 +30,7 @@ export function TerminalChatMessage({
   setHoveredIdx,
 }: TerminalChatMessageProps) {
   const state = getChatMessageRenderState({ msg, index, messages, selectedIdx, hoveredIdx, canSend });
-  const bodyLines = getMessageBodyLines(msg, contentWidth);
+  const bodyLines = getMessageBodyLines(msg, contentWidth, catalog);
   const showInlineReplyAction = !state.grouped && state.showReplyAction;
   const showGroupedReplyAction = state.grouped && state.showReplyAction;
   const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));

--- a/src/utils/text-wrap.ts
+++ b/src/utils/text-wrap.ts
@@ -1,8 +1,28 @@
+import { displayWidth } from "./format";
+
 export function truncateWithEllipsis(text: string, width: number): string {
   if (width <= 0) return "";
   if (text.length <= width) return text;
   if (width <= 3) return text.slice(0, width);
   return `${text.slice(0, width - 3)}...`;
+}
+
+export function splitLongTextSegmentByDisplayWidth(value: string, lineWidth: number): string[] {
+  if (displayWidth(value) <= lineWidth) return [value];
+
+  const chunks: string[] = [];
+  let current = "";
+  for (const char of Array.from(value)) {
+    const next = `${current}${char}`;
+    if (current && displayWidth(next) > lineWidth) {
+      chunks.push(current);
+      current = char;
+      continue;
+    }
+    current = next;
+  }
+  if (current) chunks.push(current);
+  return chunks;
 }
 
 export function wrapTextLines(


### PR DESCRIPTION
Fixes terminal chat message wrapping when an inline ticker badge expands beyond the raw `$SYMBOL` token width.

The chat row height and scroll calculations now measure inline content using the rendered ticker badge width, including hover state, so following text gets reserved rows instead of painting over the next line.

Ticker badge text formatting is shared with layout measurement, and long display-width splitting is reused by badge text rendering.

A focused regression covers the screenshot-like `$META` message so the malformed joined text does not return.