### PR TITLE
Fix root ticker search normalization

### DIFF
--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -165,6 +165,31 @@ describe("ticker-search utilities", () => {
     });
   });
 
+  test("tries canonical symbol aliases before raw lowercase provider searches", async () => {
+    const queries: string[] = [];
+    const results = await searchTickerCandidates({
+      query: "nvda",
+      tickers: new Map<string, TickerRecord>(),
+      dataProvider: createTestDataProvider({
+        id: "test",
+        search: async (query) => {
+          queries.push(query);
+          return query === "NVDA"
+            ? [makeSearchResult("NVDA", "NVIDIA Corporation")]
+            : [{ ...makeSearchResult("NVD", "GraniteShares 2x Short NVDA Daily ETF"), exchange: "NYSEArca", type: "ETF" }];
+        },
+      }),
+      totalLimit: 5,
+      includeOptionContracts: false,
+    });
+
+    expect(queries[0]).toBe("NVDA");
+    expect(results[0]).toMatchObject({
+      label: "NVDA",
+      category: "Primary Listing",
+    });
+  });
+
   test("upserts ticker records from provider search results", async () => {
     const saved: TickerRecord[] = [];
     const repository = {

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -234,9 +234,13 @@ function buildProviderSearchQueries(query: string): string[] {
   const trimmedQuery = query.trim();
   if (!trimmedQuery) return [];
 
-  const queries = new Set<string>([trimmedQuery]);
+  const symbolLike = /^[A-Za-z0-9.^=\-/]+$/.test(trimmedQuery);
+  const queries = new Set<string>();
+
+  if (!symbolLike) queries.add(trimmedQuery);
   for (const alias of buildSymbolAliases(trimmedQuery)) queries.add(alias);
   for (const alias of buildCompactShareClassAliases(trimmedQuery)) queries.add(alias);
+  queries.add(trimmedQuery);
   return [...queries].slice(0, 4);
 }
 


### PR DESCRIPTION
Plain root ticker searches now try canonical symbol aliases before the raw typed text, so lowercase symbols like nvda resolve NVIDIA ahead of loosely matched NVDA-related instruments while company-name search behavior stays unchanged.
