### PR TITLE
Fix changelog table navigation

### DIFF
--- a/src/plugins/builtin/changelog/index.tsx
+++ b/src/plugins/builtin/changelog/index.tsx
@@ -16,11 +16,16 @@ import { fetchChangelogReleases, type ChangelogRelease } from "../../../updater/
 import { colors } from "../../../theme/colors";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { isPlainKey } from "../../../utils/keyboard";
-import { usePluginPaneState } from "../../runtime";
+import {
+  DEFAULT_CHANGELOG_SORT,
+  nextChangelogSortPreference,
+  resolveSelectedReleaseIndex,
+  sortChangelogReleases,
+  type ChangelogColumnId,
+} from "./model";
 
 const CHANGELOG_LIMIT = 40;
 
-type ChangelogColumnId = "date" | "version" | "title";
 type ChangelogColumn = DataTableColumn & { id: ChangelogColumnId };
 type LoadStatus = "idle" | "loading" | "loaded" | "error";
 
@@ -103,7 +108,8 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
   const [releases, setReleases] = useState<ChangelogRelease[]>([]);
   const [status, setStatus] = useState<LoadStatus>("idle");
   const [error, setError] = useState<string | null>(null);
-  const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
+  const [selectedReleaseId, setSelectedReleaseId] = useState<string | null>(null);
+  const [sortPreference, setSortPreference] = useState(DEFAULT_CHANGELOG_SORT);
   const [openReleaseId, setOpenReleaseId] = useState<string | null>(null);
   const detailScrollRef = useRef<ScrollBoxRenderable>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -143,11 +149,18 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
     };
   }, [loadReleases]);
 
+  const sortedReleases = useMemo(
+    () => sortChangelogReleases(releases, sortPreference),
+    [releases, sortPreference],
+  );
+  const activeSelectedIdx = resolveSelectedReleaseIndex(sortedReleases, selectedReleaseId);
+  const activeSelectedReleaseId = sortedReleases[activeSelectedIdx]?.id ?? null;
+
   useEffect(() => {
-    if (releases.length > 0 && selectedIdx >= releases.length) {
-      setSelectedIdx(Math.max(0, releases.length - 1));
+    if (activeSelectedReleaseId !== selectedReleaseId) {
+      setSelectedReleaseId(activeSelectedReleaseId);
     }
-  }, [releases.length, selectedIdx, setSelectedIdx]);
+  }, [activeSelectedReleaseId, selectedReleaseId]);
 
   const openRelease = useMemo(
     () =>
@@ -177,9 +190,6 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
   });
 
   const columns = useMemo(() => buildColumns(width, releases), [releases, width]);
-  const activeSelectedIdx = releases.length > 0
-    ? Math.max(0, Math.min(selectedIdx, releases.length - 1))
-    : -1;
 
   const scrollDetailBy = useCallback((delta: number) => {
     const scrollBox = detailScrollRef.current;
@@ -237,6 +247,14 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
     }
   }, []);
 
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextChangelogSortPreference(current, columnId));
+  }, []);
+
+  const selectRelease = useCallback((release: ChangelogRelease) => {
+    setSelectedReleaseId(release.id);
+  }, []);
+
   const footerInfo = useMemo<PaneFooterSegment[]>(() => {
     const segments: PaneFooterSegment[] = [];
     if (status === "loading") {
@@ -251,17 +269,8 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
         parts: [{ text: "error", tone: "warning" }],
       });
     }
-    if (releases.length > 0) {
-      segments.push({
-        id: "versions",
-        parts: [
-          { text: "versions", tone: "label" },
-          { text: String(releases.length), tone: "value" },
-        ],
-      });
-    }
     return segments;
-  }, [releases.length, status]);
+  }, [status]);
 
   const footerHints = useMemo<PaneHint[]>(() => [{
     id: "refresh",
@@ -296,7 +305,7 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
     );
   }
 
-  if (releases.length === 0) {
+  if (sortedReleases.length === 0) {
     return (
       <Box paddingX={1} paddingY={1}>
         <Text fg={colors.textDim}>No changelog entries found.</Text>
@@ -320,16 +329,19 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
       )}
       detailTitle={openRelease ? releaseDetailTitle(openRelease) : undefined}
       selectedIndex={activeSelectedIdx}
-      onSelectIndex={(index) => setSelectedIdx(index)}
+      onSelectIndex={(_index, release) => selectRelease(release)}
       onActivateIndex={(_index, release) => setOpenReleaseId(release.id)}
       onDetailKeyDown={handleDetailKeyDown}
       rootWidth={width}
       rootHeight={height}
       columns={columns}
-      items={releases}
+      items={sortedReleases}
+      sortColumnId={sortPreference.columnId}
+      sortDirection={sortPreference.direction}
+      onHeaderClick={handleHeaderClick}
       getItemKey={(release) => release.id}
-      isSelected={(_release, index) => index === activeSelectedIdx}
-      onSelect={(_release, index) => setSelectedIdx(index)}
+      isSelected={(release) => release.id === activeSelectedReleaseId}
+      onSelect={selectRelease}
       onActivate={(release) => setOpenReleaseId(release.id)}
       renderCell={renderCell}
       emptyStateTitle="No changelog entries."

--- a/src/plugins/builtin/changelog/model.test.ts
+++ b/src/plugins/builtin/changelog/model.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type { ChangelogRelease } from "../../../updater/github-releases";
+import {
+  DEFAULT_CHANGELOG_SORT,
+  nextChangelogSortPreference,
+  resolveSelectedReleaseIndex,
+  sortChangelogReleases,
+} from "./model";
+
+function release(
+  id: string,
+  version: string,
+  title: string,
+  publishedAt: string,
+): ChangelogRelease {
+  return {
+    id,
+    tagName: version,
+    version,
+    title,
+    publishedAt,
+    body: "",
+    url: "",
+  };
+}
+
+describe("changelog table model", () => {
+  const releases = [
+    release("8", "v0.8.0", "Desktop fixes", "2026-05-20T10:00:00Z"),
+    release("10", "v0.10.0", "Accounts", "2026-05-22T10:00:00Z"),
+    release("9", "v0.9.0", "Buildout", "2026-05-21T10:00:00Z"),
+  ];
+
+  test("sorts releases by newest date by default", () => {
+    expect(
+      sortChangelogReleases(releases, DEFAULT_CHANGELOG_SORT).map((entry) => entry.id),
+    )
+      .toEqual(["10", "9", "8"]);
+  });
+
+  test("sorts version tags numerically", () => {
+    expect(
+      sortChangelogReleases(
+        releases,
+        { columnId: "version", direction: "asc" },
+      ).map((entry) => entry.version),
+    )
+      .toEqual(["v0.8.0", "v0.9.0", "v0.10.0"]);
+  });
+
+  test("cycles header sort direction without returning an undefined handler state", () => {
+    const versionSort = nextChangelogSortPreference(DEFAULT_CHANGELOG_SORT, "version");
+    expect(versionSort).toEqual({ columnId: "version", direction: "desc" });
+    expect(nextChangelogSortPreference(versionSort, "version"))
+      .toEqual({ columnId: "version", direction: "asc" });
+  });
+
+  test("ignores unknown header ids instead of creating broken sort state", () => {
+    expect(nextChangelogSortPreference(DEFAULT_CHANGELOG_SORT, "missing"))
+      .toBe(DEFAULT_CHANGELOG_SORT);
+  });
+
+  test("resolves selected rows by stable release id after sorting", () => {
+    const sorted = sortChangelogReleases(
+      releases,
+      { columnId: "title", direction: "asc" },
+    );
+
+    expect(sorted.map((entry) => entry.id)).toEqual(["10", "9", "8"]);
+    expect(resolveSelectedReleaseIndex(sorted, "8")).toBe(2);
+  });
+
+  test("falls back to the first release when the selected id disappears", () => {
+    expect(resolveSelectedReleaseIndex(releases, "removed")).toBe(0);
+    expect(resolveSelectedReleaseIndex([], "removed")).toBe(-1);
+  });
+});

--- a/src/plugins/builtin/changelog/model.ts
+++ b/src/plugins/builtin/changelog/model.ts
@@ -1,0 +1,98 @@
+import type { ChangelogRelease } from "../../../updater/github-releases";
+import type { SortDirection } from "../../../utils/sort-values";
+
+export type ChangelogColumnId = "date" | "version" | "title";
+
+export interface ChangelogSortPreference {
+  columnId: ChangelogColumnId;
+  direction: SortDirection;
+}
+
+export const DEFAULT_CHANGELOG_SORT: ChangelogSortPreference = {
+  columnId: "date",
+  direction: "desc",
+};
+
+function isChangelogColumnId(columnId: string): columnId is ChangelogColumnId {
+  return columnId === "date" || columnId === "version" || columnId === "title";
+}
+
+function defaultDirection(columnId: ChangelogColumnId): SortDirection {
+  return columnId === "title" ? "asc" : "desc";
+}
+
+function releaseDateValue(release: ChangelogRelease): number {
+  const timestamp = Date.parse(release.publishedAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+function compareReleaseValue(
+  left: ChangelogRelease,
+  right: ChangelogRelease,
+  columnId: ChangelogColumnId,
+): number {
+  switch (columnId) {
+    case "date":
+      return releaseDateValue(left) - releaseDateValue(right);
+    case "version":
+      return compareText(left.version, right.version);
+    case "title":
+      return compareText(left.title, right.title);
+  }
+}
+
+export function sortChangelogReleases(
+  releases: ChangelogRelease[],
+  sortPreference: ChangelogSortPreference,
+): ChangelogRelease[] {
+  return releases
+    .map((release, index) => ({ release, index }))
+    .sort((left, right) => {
+      const comparison = compareReleaseValue(
+        left.release,
+        right.release,
+        sortPreference.columnId,
+      );
+      const directed = sortPreference.direction === "asc"
+        ? comparison
+        : -comparison;
+      return directed || left.index - right.index;
+    })
+    .map((entry) => entry.release);
+}
+
+export function nextChangelogSortPreference(
+  current: ChangelogSortPreference,
+  columnId: string,
+): ChangelogSortPreference {
+  if (!isChangelogColumnId(columnId)) return current;
+  const nextColumnId = columnId;
+  if (current.columnId !== nextColumnId) {
+    return {
+      columnId: nextColumnId,
+      direction: defaultDirection(nextColumnId),
+    };
+  }
+  return {
+    columnId: nextColumnId,
+    direction: current.direction === "asc" ? "desc" : "asc",
+  };
+}
+
+export function resolveSelectedReleaseIndex(
+  releases: ChangelogRelease[],
+  selectedReleaseId: string | null,
+): number {
+  const selectedIndex = selectedReleaseId
+    ? releases.findIndex((release) => release.id === selectedReleaseId)
+    : -1;
+  if (selectedIndex >= 0) return selectedIndex;
+  return releases.length > 0 ? 0 : -1;
+}


### PR DESCRIPTION
Fixes a changelog crash caused by missing table sort props by adding a dedicated sort model for the date, version, and title headers.

Selection now tracks release ids instead of persisted row indexes, keeping arrow navigation responsive and stable across sorting and reloads.

The changelog footer also drops the static versions count so it only reports live loading and error state.