### PR TITLE
Fix DM chat labels and pane titles

### DIFF
--- a/src/components/layout/pane/title.ts
+++ b/src/components/layout/pane/title.ts
@@ -11,7 +11,11 @@ export function getPaneDisplayTitle(
     const channelId = typeof instance.settings?.channelId === "string" && instance.settings.channelId.trim()
       ? instance.settings.channelId.trim()
       : "everyone";
-    return instance.title ?? `#${channelId}`;
+    const title = typeof instance.title === "string" ? instance.title.trim() : "";
+    const displayTitle = title && !title.startsWith("dm:") && !title.startsWith("group:") ? title : undefined;
+    if (channelId.startsWith("dm:")) return displayTitle ?? "DM";
+    if (channelId.startsWith("group:")) return displayTitle ?? "Group";
+    return displayTitle ?? `#${channelId}`;
   }
 
   if (instance.paneId === TICKER_RESEARCH_PANE_ID) {

--- a/src/plugins/builtin/chat/channels.test.ts
+++ b/src/plugins/builtin/chat/channels.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatChannel } from "../../../api-client";
+import {
+  channelPrefix,
+  formatChannelLabel,
+  formatChatPaneTitle,
+} from "./channels";
+
+describe("chat channel labels", () => {
+  test("formats direct-message labels and titles with one mention prefix", () => {
+    const channel: ChatChannel = {
+      id: "dm:c7f89ce26f9da83d6be08a4838738074",
+      name: "@risto",
+      kind: "direct",
+      created_at: "2026-05-27T10:30:03.712Z",
+      dmUser: { id: "u2", username: "@risto", displayName: "Risto" },
+    };
+
+    expect(formatChannelLabel(channel, channel.id)).toBe("@risto");
+    expect(channelPrefix(channel, true)).toBe(" ");
+    expect(formatChatPaneTitle(channel, channel.id)).toBe("@risto");
+    expect(formatChatPaneTitle(undefined, channel.id)).toBe("DM");
+  });
+});

--- a/src/plugins/builtin/chat/channels.ts
+++ b/src/plugins/builtin/chat/channels.ts
@@ -46,15 +46,55 @@ export function getPreferredChatOpenChannelId(
   return normalizeChannelId(unreadConversation?.channelId ?? unreadStates[0]?.channelId ?? getLastVisitedChatChannelId(config));
 }
 
+function normalizeMentionUsername(username: string | null | undefined): string | null {
+  const normalized = username?.trim().replace(/^@+/, "");
+  return normalized || null;
+}
+
+function formatMentionUsername(username: string | null | undefined): string | null {
+  const normalized = normalizeMentionUsername(username);
+  return normalized ? `@${normalized}` : null;
+}
+
+function formatDirectChannelLabel(channel: ChatChannel, fallbackId: string) {
+  const usernameLabel = formatMentionUsername(channel.dmUser?.username);
+  if (usernameLabel) return usernameLabel;
+
+  const displayName = channel.dmUser?.displayName?.trim();
+  if (displayName) return displayName;
+
+  const channelName = channel.name?.trim();
+  if (channelName && channelName !== channel.id) {
+    return channelName.startsWith("@")
+      ? formatMentionUsername(channelName) ?? channelName
+      : channelName;
+  }
+
+  return fallbackId.startsWith("dm:") ? "DM" : fallbackId;
+}
+
 export function formatChannelLabel(channel: ChatChannel | undefined, fallbackId: string) {
   if (!channel) return fallbackId;
   if (channel.kind === "direct") {
-    return channel.dmUser?.username ? `@${channel.dmUser.username}` : channel.dmUser?.displayName ?? "DM";
+    return formatDirectChannelLabel(channel, fallbackId);
   }
   if (channel.kind === "group") {
     return channel.name?.trim() || "Group";
   }
   return channel.name?.trim() || fallbackId;
+}
+
+export function formatChatPaneTitle(channel: ChatChannel | undefined, fallbackId: string) {
+  const normalizedFallbackId = normalizeChannelId(fallbackId);
+  if (channel?.kind === "direct") {
+    return formatChannelLabel(channel, normalizedFallbackId);
+  }
+  if (channel?.kind === "group") {
+    return formatChannelLabel(channel, normalizedFallbackId);
+  }
+  if (!channel && normalizedFallbackId.startsWith("dm:")) return "DM";
+  if (!channel && normalizedFallbackId.startsWith("group:")) return "Group";
+  return `#${formatChannelLabel(channel, normalizedFallbackId)}`;
 }
 
 function conversationDetail(channel: ChatChannel): string {
@@ -168,7 +208,7 @@ export function buildDmCommandResults(ctx: GloomPluginContext, arg: string): Com
 }
 
 export function channelPrefix(channel: ChatChannel | undefined, active: boolean) {
-  if (channel?.kind === "direct") return active ? "@" : " ";
+  if (channel?.kind === "direct") return " ";
   if (channel?.kind === "group") return active ? "+" : " ";
   return active ? "#" : " ";
 }

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "../layout";
 import {
   DEFAULT_CHAT_CHANNEL_ID,
+  formatChatPaneTitle,
   normalizeChannelId,
 } from "../channels";
 import { ChatComposerArea } from "./composer";
@@ -37,6 +38,7 @@ interface ChatContentProps {
   focused: boolean;
   channelId?: string;
   onChannelChange?: (channelId: string) => void;
+  onChannelTitleChange?: (title: string) => void;
   controller?: ChatContentController;
 }
 
@@ -46,6 +48,7 @@ export function ChatContent({
   focused,
   channelId: rawChannelId,
   onChannelChange,
+  onChannelTitleChange,
   controller = chatController,
 }: ChatContentProps) {
   const dispatch = useAppDispatch();
@@ -140,6 +143,8 @@ export function ChatContent({
   const messageContents = useMemo(() => messages.map((message) => message.content), [messages]);
   const { catalog, openTicker } = useInlineTickers(messageContents);
   const userByUsername = useMemo(() => buildChatUserByUsername(channels, messages), [channels, messages]);
+  const activeChannel = useMemo(() => channels.find((channel) => channel.id === channelId), [channelId, channels]);
+  const activeChannelTitle = useMemo(() => formatChatPaneTitle(activeChannel, channelId), [activeChannel, channelId]);
   const {
     cancelProfilePopoverClose,
     closeProfilePopover,
@@ -152,6 +157,10 @@ export function ChatContent({
     setInputFocused(false);
     dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
   }, [dispatch]);
+
+  useEffect(() => {
+    onChannelTitleChange?.(activeChannelTitle);
+  }, [activeChannelTitle, onChannelTitleChange]);
 
   const {
     moveMessageSelection,

--- a/src/plugins/builtin/chat/pane.tsx
+++ b/src/plugins/builtin/chat/pane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { setPaneSetting } from "../../../pane-settings";
+import { updatePaneInstance } from "../../../pane-settings";
 import {
   syncConfigActiveLayoutState,
   useAppDispatch,
@@ -12,6 +12,7 @@ import { scheduleConfigSave } from "../../../state/config-save-scheduler";
 import type { PaneProps } from "../../../types/plugin";
 import {
   DEFAULT_CHAT_CHANNEL_ID,
+  formatChatPaneTitle,
   LAST_VISITED_CHAT_CHANNEL_KEY,
   normalizeChannelId,
 } from "./channels";
@@ -22,6 +23,7 @@ interface ChatPaneContentProps {
   focused: boolean;
   channelId?: string;
   onChannelChange?: (channelId: string) => void;
+  onChannelTitleChange?: (title: string) => void;
 }
 
 export function createChatPane(ChatContent: (props: ChatPaneContentProps) => ReactNode) {
@@ -37,9 +39,30 @@ export function createChatPane(ChatContent: (props: ChatPaneContentProps) => Rea
     ));
     const initialChannelIdRef = useRef(normalizeChannelId(rawPaneChannelId ?? lastVisitedChannelId));
     const persistedChannelId = normalizeChannelId(rawPaneChannelId ?? initialChannelIdRef.current);
-    const persistChannelId = useCallback((nextChannelId: string) => {
+    const persistChatPaneState = useCallback((nextChannelId: string, nextTitle?: string) => {
       const currentState = stateRef.current;
-      const layout = setPaneSetting(currentState.config.layout, paneId, "channelId", nextChannelId);
+      const currentPane = currentState.config.layout.instances.find((instance) => instance.instanceId === paneId);
+      const nextTitleValue = nextTitle?.trim() || undefined;
+      const currentPaneChannelId = typeof currentPane?.settings?.channelId === "string"
+        ? normalizeChannelId(currentPane.settings.channelId)
+        : null;
+      const currentLastVisitedChannelId = currentState.config.pluginConfig["gloomberb-cloud"]?.[LAST_VISITED_CHAT_CHANNEL_KEY];
+      if (
+        currentPaneChannelId === nextChannelId
+        && (!nextTitleValue || currentPane?.title === nextTitleValue)
+        && currentLastVisitedChannelId === nextChannelId
+      ) {
+        return;
+      }
+
+      const layout = updatePaneInstance(currentState.config.layout, paneId, (instance) => ({
+        ...instance,
+        title: nextTitleValue ?? instance.title,
+        settings: {
+          ...(instance.settings ?? {}),
+          channelId: nextChannelId,
+        },
+      }));
       const pluginConfig = {
         ...currentState.config.pluginConfig,
         "gloomberb-cloud": {
@@ -66,8 +89,8 @@ export function createChatPane(ChatContent: (props: ChatPaneContentProps) => Rea
 
     useEffect(() => {
       if (rawPaneChannelId) return;
-      persistChannelId(initialChannelIdRef.current);
-    }, [persistChannelId, rawPaneChannelId]);
+      persistChatPaneState(initialChannelIdRef.current, formatChatPaneTitle(undefined, initialChannelIdRef.current));
+    }, [persistChatPaneState, rawPaneChannelId]);
 
     useEffect(() => {
       const normalizedPersisted = normalizeChannelId(persistedChannelId);
@@ -84,8 +107,12 @@ export function createChatPane(ChatContent: (props: ChatPaneContentProps) => Rea
       const normalized = normalizeChannelId(nextChannelId);
       pendingChannelIdRef.current = normalized;
       setLocalChannelId((current) => (current === normalized ? current : normalized));
-      persistChannelId(normalized);
-    }, [persistChannelId]);
+      persistChatPaneState(normalized, formatChatPaneTitle(undefined, normalized));
+    }, [persistChatPaneState]);
+
+    const setChannelTitle = useCallback((nextTitle: string) => {
+      persistChatPaneState(channelId, nextTitle);
+    }, [channelId, persistChatPaneState]);
 
     return (
       <ChatContent
@@ -94,6 +121,7 @@ export function createChatPane(ChatContent: (props: ChatPaneContentProps) => Rea
         focused={focused}
         channelId={channelId}
         onChannelChange={setChannelId}
+        onChannelTitleChange={setChannelTitle}
       />
     );
   };

--- a/src/plugins/builtin/chat/sidebar.test.tsx
+++ b/src/plugins/builtin/chat/sidebar.test.tsx
@@ -442,6 +442,7 @@ describe("ChatContent channel sidebar", () => {
       await flushFrame();
 
       expect(findPaneInstance(latestState.config.layout, paneInstanceId)?.settings?.channelId).toBe("options");
+      expect(findPaneInstance(latestState.config.layout, paneInstanceId)?.title).toBe("#options");
       expect(latestState.config.pluginConfig["gloomberb-cloud"]?.lastChatChannelId).toBe("options");
       expect(setup().captureCharFrame()).toContain("#options");
     } finally {

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -13,6 +13,7 @@ import {
 import { registerTwitterFeedFeature } from "../cloud-tweets";
 import {
   buildDmCommandResults,
+  formatChatPaneTitle,
   getLastVisitedChatChannelId,
   hasOnlyDmUsernameArgs,
   normalizeShortcutChannelId,
@@ -50,8 +51,10 @@ export function createGloomberbCloudPlugin({
           const channelId = options?.arg
             ? await chatController.resolveRequiredChannelId(normalizeShortcutChannelId(options.arg))
             : await chatController.resolvePreferredChannelId(getLastVisitedChatChannelId(context.config));
+          const channel = chatController.getChannels().find((entry) => entry.id === channelId);
           return {
             placement: "floating",
+            title: formatChatPaneTitle(channel, channelId),
             settings: { channelId },
           };
         },


### PR DESCRIPTION
Fixes DM channel display so direct-message rows show a single @username and chat panes use participant or group titles instead of raw channel ids. Chat panes now persist the resolved channel title when opened or switched, including legacy saved panes whose title is still a raw dm/group id.