### PR TITLE
Fix terminal chat URL wrapping

### DIFF
--- a/src/plugins/builtin/chat/chat.test.tsx
+++ b/src/plugins/builtin/chat/chat.test.tsx
@@ -868,6 +868,36 @@ describe("ChatContent", () => {
     expect(frame).toContain("https://example.com/story.");
   });
 
+  test("keeps long link query strings from spilling into following terminal rows", async () => {
+    const controller = createController({
+      messages: [{
+        id: "m1",
+        channelId: "everyone",
+        content: "again:\nhttps://github.com/houmain/keymapper/issues?weird_one=the_rest_of the query parameters got lost entirely :)",
+        replyToId: null,
+        createdAt: "2026-03-28T00:00:00.000Z",
+        user: { id: "u1", username: "vince", displayName: "Vince" },
+      }],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 60,
+        height: 12,
+      }), {
+        width: 60,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    const frame = setup().captureCharFrame();
+    expect(frame).toContain("https://github.com/houmain/keymapper/issues?weird_one=");
+    expect(frame).toContain("the_rest_of the query parameters got lost entirely :)");
+    expect(frame).not.toContain("therquery=parametersfgot");
+  });
+
   test("shows a saved-login read-only footer when a session token is cached", async () => {
     const controller = createController({
       sessionToken: "token-123",

--- a/src/plugins/builtin/chat/layout.ts
+++ b/src/plugins/builtin/chat/layout.ts
@@ -30,6 +30,10 @@ export function formatInlinePreview(text: string, width: number) {
   return truncateWithEllipsis(normalizeInlinePreview(text), width);
 }
 
+export type ChatBodyInlineToken = InlineContentToken;
+
+export type ChatBodyLine = ChatBodyInlineToken[];
+
 function wrapTextLines(text: string, width: number) {
   const safeWidth = Math.max(width, 1);
   const lines: string[] = [];
@@ -78,50 +82,106 @@ function inlineTokenWidth(
   return Math.max(baseWidth, hoverWidth);
 }
 
+function tokenWithValue(token: InlineContentToken, value: string): InlineContentToken {
+  if (token.kind === "link") return { ...token, value };
+  if (token.kind === "username") return { ...token, value };
+  if (token.kind === "ticker") return { ...token, value };
+  return { kind: "text", value };
+}
+
+function firstDisplayWidthChunk(value: string, width: number): string {
+  return splitLongTextSegmentByDisplayWidth(value, Math.max(width, 1))[0] ?? "";
+}
+
+function trimLineEnd(line: ChatBodyLine): ChatBodyLine {
+  const next = [...line];
+  while (next.length > 0) {
+    const last = next[next.length - 1]!;
+    if (last.kind !== "text") break;
+    const trimmed = last.value.trimEnd();
+    if (trimmed) {
+      next[next.length - 1] = { ...last, value: trimmed };
+      break;
+    }
+    next.pop();
+  }
+  return next;
+}
+
 function wrapInlineContentLine(
   text: string,
   width: number,
   catalog: Record<string, InlineTickerCatalogEntry>,
-): string[] {
+): ChatBodyLine[] {
   const safeWidth = Math.max(width, 1);
-  const lines: string[] = [];
-  let current = "";
+  const lines: ChatBodyLine[] = [];
+  let current: ChatBodyLine = [];
   let currentWidth = 0;
 
   const finishLine = () => {
-    lines.push(current.trimEnd());
-    current = "";
+    lines.push(trimLineEnd(current));
+    current = [];
     currentWidth = 0;
   };
 
-  const appendTextPart = (rawPart: string) => {
-    let part = currentWidth === 0 ? rawPart.trimStart() : rawPart;
-    if (!part) return;
+  const appendSegment = (token: InlineContentToken, rawValue: string, trimStartOnWrap: boolean) => {
+    let value = currentWidth === 0 && trimStartOnWrap ? rawValue.trimStart() : rawValue;
+    if (!value) return;
 
-    while (part) {
-      const partWidth = displayWidth(part);
-      if (currentWidth > 0 && currentWidth + partWidth > safeWidth) {
+    while (value) {
+      const tokenWidth = token.kind === "ticker"
+        ? inlineTokenWidth(tokenWithValue(token, value), catalog)
+        : displayWidth(value);
+      const available = safeWidth - currentWidth;
+
+      if (currentWidth > 0 && tokenWidth > available) {
+        if (available <= 0) {
+          finishLine();
+          if (trimStartOnWrap) value = value.trimStart();
+          continue;
+        }
+
+        if (token.kind === "ticker") {
+          finishLine();
+          continue;
+        }
+
+        const chunk = firstDisplayWidthChunk(value, Math.max(available, 1));
+        if (chunk) {
+          current.push(tokenWithValue(token, chunk));
+          currentWidth += displayWidth(chunk);
+          value = value.slice(chunk.length);
+        }
         finishLine();
-        part = part.trimStart();
-        if (!part) return;
+        if (trimStartOnWrap) value = value.trimStart();
         continue;
       }
 
-      if (partWidth <= safeWidth - currentWidth) {
-        current += part;
-        currentWidth += partWidth;
+      if (tokenWidth <= safeWidth - currentWidth || token.kind === "ticker") {
+        current.push(tokenWithValue(token, value));
+        currentWidth += tokenWidth;
         return;
       }
 
-      const available = Math.max(safeWidth - currentWidth, 1);
-      const [chunk = "", ...rest] = splitLongTextSegmentByDisplayWidth(part, available);
+      const chunk = firstDisplayWidthChunk(value, Math.max(safeWidth - currentWidth, 1));
       if (chunk) {
-        current += chunk;
+        current.push(tokenWithValue(token, chunk));
         currentWidth += displayWidth(chunk);
+        value = value.slice(chunk.length);
       }
       finishLine();
-      part = rest.join("").trimStart();
+      if (trimStartOnWrap) value = value.trimStart();
     }
+  };
+
+  const appendTextPart = (rawPart: string) => {
+    let part = rawPart;
+    const partWidth = displayWidth(part);
+    if (currentWidth > 0 && partWidth > safeWidth - currentWidth && partWidth <= safeWidth) {
+      finishLine();
+      part = part.trimStart();
+    }
+    appendSegment({ kind: "text", value: part }, part, true);
   };
 
   const appendText = (value: string) => {
@@ -134,8 +194,7 @@ function wrapInlineContentLine(
   const appendInlineToken = (token: InlineContentToken) => {
     const tokenWidth = inlineTokenWidth(token, catalog);
     if (currentWidth > 0 && currentWidth + tokenWidth > safeWidth) finishLine();
-    current += token.value;
-    currentWidth += tokenWidth;
+    appendSegment(token, token.value, false);
   };
 
   for (const token of tokenizeInlineContent(text)) {
@@ -146,24 +205,24 @@ function wrapInlineContentLine(
     appendInlineToken(token);
   }
 
-  if (current || lines.length === 0) lines.push(current.trimEnd());
+  if (current.length > 0 || lines.length === 0) lines.push(trimLineEnd(current));
   return lines;
 }
 
-function wrapInlineContentLines(
+export function getMessageBodyTokenLines(
   text: string,
   width: number,
   catalog: Record<string, InlineTickerCatalogEntry>,
-): string[] {
-  const lines: string[] = [];
+): ChatBodyLine[] {
+  const lines: ChatBodyLine[] = [];
   for (const paragraph of text.split("\n")) {
     if (!paragraph) {
-      lines.push("");
+      lines.push([]);
       continue;
     }
     lines.push(...wrapInlineContentLine(paragraph, width, catalog));
   }
-  return lines.length > 0 ? lines : [""];
+  return lines.length > 0 ? lines : [[]];
 }
 
 export function getMessageBodyLines(
@@ -172,7 +231,7 @@ export function getMessageBodyLines(
   catalog?: Record<string, InlineTickerCatalogEntry>,
 ) {
   const contentLineWidth = Math.max(width - 4, 1);
-  if (catalog) return wrapInlineContentLines(message.content, contentLineWidth, catalog);
+  if (catalog) return getMessageBodyTokenLines(message.content, contentLineWidth, catalog).map((line) => line.map((token) => token.value).join(""));
   return wrapTextLines(message.content, contentLineWidth);
 }
 
@@ -183,7 +242,11 @@ export function estimateMessageHeight(
   catalog?: Record<string, InlineTickerCatalogEntry>,
 ) {
   const headerHeight = grouped ? 0 : 1;
-  return headerHeight + (message.replyTo ? 1 : 0) + getMessageBodyLines(message, width, catalog).length;
+  const contentLineWidth = Math.max(width - 4, 1);
+  const bodyLineCount = catalog
+    ? getMessageBodyTokenLines(message.content, contentLineWidth, catalog).length
+    : getMessageBodyLines(message, width, catalog).length;
+  return headerHeight + (message.replyTo ? 1 : 0) + bodyLineCount;
 }
 
 export function estimateComposerHeight(text: string, width: number) {

--- a/src/plugins/builtin/chat/message/inline-tokens.tsx
+++ b/src/plugins/builtin/chat/message/inline-tokens.tsx
@@ -6,10 +6,12 @@ import { TickerBadge } from "../../../../components/ticker/badge";
 import type { InlineTickerCatalogEntry } from "../../../../state/hooks/inline-tickers";
 import { blendHex, colors } from "../../../../theme/colors";
 import type { ChatUserSummary } from "../../../../api-client";
-import { tokenizeInlineContent } from "../../../../utils/inline-content-tokenizer";
+import { tokenizeInlineContent, type InlineContentToken } from "../../../../utils/inline-content-tokenizer";
 
 export function ResponsiveTickerBadgeText({
-  text,
+  text = "",
+  tokens: providedTokens,
+  prewrapped = false,
   catalog,
   textColor,
   openTicker,
@@ -17,7 +19,9 @@ export function ResponsiveTickerBadgeText({
   onUserHover,
   onUserHoverEnd,
 }: {
-  text: string;
+  text?: string;
+  tokens?: readonly InlineContentToken[];
+  prewrapped?: boolean;
   catalog: Record<string, InlineTickerCatalogEntry>;
   textColor: string;
   openTicker: (symbol: string) => void;
@@ -26,19 +30,21 @@ export function ResponsiveTickerBadgeText({
   onUserHoverEnd?: () => void;
 }) {
   const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
-  const tokens = useMemo(() => tokenizeInlineContent(text), [text]);
+  const tokens = useMemo(() => providedTokens ?? tokenizeInlineContent(text), [providedTokens, text]);
   const renderTextToken = (value: string, tokenIndex: number) => {
     if (!value) return null;
     return (
       <Text
         key={`text:${tokenIndex}`}
         fg={textColor}
-        wrapText
-        style={{
-          minWidth: 0,
-          whiteSpace: "pre-wrap",
-          overflowWrap: "anywhere",
-        }}
+        wrapText={!prewrapped}
+        style={prewrapped
+          ? undefined
+          : {
+            minWidth: 0,
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+          }}
       >
         {value}
       </Text>

--- a/src/plugins/builtin/chat/message/terminal.tsx
+++ b/src/plugins/builtin/chat/message/terminal.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "../../../../ui";
-import { MESSAGE_ACTION_WIDTH, formatInlinePreview, getMessageBodyLines } from "../layout";
+import { MESSAGE_ACTION_WIDTH, formatInlinePreview, getMessageBodyTokenLines } from "../layout";
 import { ChatActionChip } from "./action-chip";
 import { ResponsiveTickerBadgeText } from "./inline-tokens";
 import { getChatMessageRenderState } from "./render-state";
@@ -30,7 +30,7 @@ export function TerminalChatMessage({
   setHoveredIdx,
 }: TerminalChatMessageProps) {
   const state = getChatMessageRenderState({ msg, index, messages, selectedIdx, hoveredIdx, canSend });
-  const bodyLines = getMessageBodyLines(msg, contentWidth, catalog);
+  const bodyLines = getMessageBodyTokenLines(msg.content, messageBodyWidth, catalog);
   const showInlineReplyAction = !state.grouped && state.showReplyAction;
   const showGroupedReplyAction = state.grouped && state.showReplyAction;
   const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));
@@ -106,7 +106,8 @@ export function TerminalChatMessage({
         >
           <Box width={messageBodyWidth} height={1}>
             <ResponsiveTickerBadgeText
-              text={line}
+              tokens={line}
+              prewrapped
               catalog={catalog}
               textColor={state.bodyColor}
               openTicker={openTicker}


### PR DESCRIPTION
Terminal chat now pre-wraps inline message tokens before fixed-height rows render, so long links split cleanly instead of bleeding into the next line. Link chunks keep the original URL target, and desktop chat/raw inline text rendering keeps its existing wrapping behavior. Adds a regression case for a narrow chat pane with a long query-string link.