### PR TITLE
Fix shared portfolio settings

### DIFF
--- a/src/components/layout/pane/footer/index.test.tsx
+++ b/src/components/layout/pane/footer/index.test.tsx
@@ -123,6 +123,12 @@ describe("PaneFooterBar", () => {
     expect(col).toBeGreaterThanOrEqual(0);
 
     await act(async () => {
+      await testSetup!.mockMouse.release(col + 1, 0);
+      await testSetup!.renderOnce();
+    });
+    expect(refreshCount).toBe(0);
+
+    await act(async () => {
       await testSetup!.mockMouse.click(col + 1, 0);
       await testSetup!.renderOnce();
     });

--- a/src/components/layout/pane/footer/index.tsx
+++ b/src/components/layout/pane/footer/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Span, Text, TextAttributes, useUiCapabilities } from "../../../../ui";
+import { useRef } from "react";
 import { colors, blendHex } from "../../../../theme/colors";
 import { getShortcutHintWidth, ShortcutHint } from "../../../ui/shortcut-hint";
 import {
@@ -50,13 +51,24 @@ function stopMouseEvent(event?: { stopPropagation?: () => void; preventDefault?:
 function SegmentView({ segment }: { segment: PaneFooterSegment }) {
   const interactive = !!segment.onPress && !segment.disabled;
   const attributes = segment.parts.some((part) => part.bold) || interactive ? TextAttributes.BOLD : 0;
+  const triggerMouseDownRef = useRef(false);
+  const startSegmentPress = (event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
+    triggerMouseDownRef.current = true;
+    stopMouseEvent(event);
+  };
+  const finishSegmentPress = (event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
+    const startedOnTrigger = triggerMouseDownRef.current;
+    triggerMouseDownRef.current = false;
+    if (startedOnTrigger) segment.onPress?.();
+    else stopMouseEvent(event);
+  };
 
   return (
     <Text
       fg={segment.disabled ? colors.textMuted : colors.textDim}
       attributes={attributes}
-      onMouseDown={interactive ? stopMouseEvent : undefined}
-      onMouseUp={interactive ? segment.onPress : undefined}
+      onMouseDown={interactive ? startSegmentPress : undefined}
+      onMouseUp={interactive ? finishSegmentPress : undefined}
       {...(interactive ? { "data-gloom-interactive": "true" } : {})}
     >
       {segment.parts.map((part, index) => (

--- a/src/components/pane-settings-dialog/field-dialogs.tsx
+++ b/src/components/pane-settings-dialog/field-dialogs.tsx
@@ -61,7 +61,6 @@ export function TuiSelectFieldDialog(props: SelectFieldDialogProps) {
   return (
     <DialogFrame
       title={field.label}
-      footer="Use ↑↓ to choose · enter to apply · esc cancel"
     >
       <ListView
         items={field.options.map((option) => ({
@@ -158,7 +157,6 @@ function TuiTextFieldDialog(props: TextFieldDialogProps) {
   return (
     <DialogFrame
       title={field.label}
-      footer="Enter to apply · esc cancel"
     >
       <Box flexDirection="column" gap={1}>
         <TextField

--- a/src/components/pane-settings-dialog/tui.tsx
+++ b/src/components/pane-settings-dialog/tui.tsx
@@ -29,7 +29,7 @@ export function TuiPaneSettingsDialogBody({
   onActivate: (field: PaneSettingField | undefined) => void;
 }) {
   return (
-    <DialogFrame title={title} footer="Use ↑↓ to choose · enter to edit · esc cancel">
+    <DialogFrame title={title}>
       <ListView
         items={fields.map((field) => ({
           id: field.key,

--- a/src/components/ui/choice-dialog.tsx
+++ b/src/components/ui/choice-dialog.tsx
@@ -17,6 +17,7 @@ export interface ChoiceDialogChoice {
 export interface ChoiceDialogProps extends PromptContext<string> {
   title: string;
   choices: ChoiceDialogChoice[];
+  selectedChoiceId?: string;
   footer?: string;
   bgColor?: string;
 }
@@ -30,14 +31,23 @@ function getChoiceDescription(choice: ChoiceDialogChoice | undefined): string {
   return choice?.description ?? "";
 }
 
+function getInitialChoiceIndex(choices: ChoiceDialogChoice[], selectedChoiceId: string | undefined): number {
+  if (!selectedChoiceId) return 0;
+  const selectedIndex = choices.findIndex((choice) => choice.id === selectedChoiceId);
+  return selectedIndex >= 0 ? selectedIndex : 0;
+}
+
 export function ChoiceDialog({
   resolve,
   title,
   choices,
-  footer = "↑↓ choose · Enter/click select · Esc cancel",
+  selectedChoiceId,
+  footer,
   bgColor = colors.bg,
 }: ChoiceDialogProps) {
-  const [index, setIndex] = useState(() => clampChoiceIndex(0, choices.length));
+  const [index, setIndex] = useState(() =>
+    clampChoiceIndex(getInitialChoiceIndex(choices, selectedChoiceId), choices.length)
+  );
   const selectedIndex = clampChoiceIndex(index, choices.length);
   const selectedChoice = selectedIndex >= 0 ? choices[selectedIndex] : undefined;
   const items = useMemo<ListViewItem[]>(() => choices.map((choice) => ({

--- a/src/components/ui/multi-select/dialog.tsx
+++ b/src/components/ui/multi-select/dialog.tsx
@@ -2,7 +2,7 @@ import { Box, Text, useUiHost } from "../../../ui";
 import { TextAttributes } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import { type AlertContext, useDialog, useDialogKeyboard } from "../../../ui/dialog";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { colors } from "../../../theme/colors";
 import { isDetailBackNavigationKey } from "../../../utils/back-navigation";
 import { isPlainKey } from "../../../utils/keyboard";
@@ -253,6 +253,7 @@ export function MultiSelectDialogButton({
 }: MultiSelectDialogButtonProps) {
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const dialog = useDialog();
+  const triggerMouseDownRef = useRef(false);
   const summary = summarizeMultiSelectValues({ options, selectedValues, emptyLabel });
   const buttonLabel = `${label}: ${summary}`;
   const buttonText = ` ${buttonLabel} `;
@@ -311,6 +312,17 @@ export function MultiSelectDialogButton({
     );
   }
 
+  const startTriggerPress = (event?: DialogTriggerEvent) => {
+    triggerMouseDownRef.current = true;
+    stopMouseEvent(event);
+  };
+  const finishTriggerPress = (event?: DialogTriggerEvent) => {
+    const startedOnTrigger = triggerMouseDownRef.current;
+    triggerMouseDownRef.current = false;
+    if (startedOnTrigger) openDialog(event);
+    else stopMouseEvent(event);
+  };
+
   return (
     <Box
       id={idPrefix ? `${idPrefix}:button` : undefined}
@@ -318,14 +330,14 @@ export function MultiSelectDialogButton({
       width={buttonText.length}
       flexDirection="row"
       backgroundColor={disabled ? colors.panel : colors.selected}
-      onMouseDown={stopMouseEvent}
-      onMouseUp={openDialog}
+      onMouseDown={startTriggerPress}
+      onMouseUp={finishTriggerPress}
     >
       <Text
         fg={disabled ? colors.textMuted : colors.selectedText}
         attributes={TextAttributes.BOLD}
-        onMouseDown={stopMouseEvent}
-        onMouseUp={openDialog}
+        onMouseDown={startTriggerPress}
+        onMouseUp={finishTriggerPress}
       >
         {buttonText}
       </Text>

--- a/src/components/ui/shortcut-hint.tsx
+++ b/src/components/ui/shortcut-hint.tsx
@@ -1,5 +1,6 @@
 import { StyledText, Text, TextAttributes } from "../../ui";
 import { colors } from "../../theme/colors";
+import { useRef } from "react";
 
 type ShortcutHintMouseEvent = {
   stopPropagation?: () => void;
@@ -36,6 +37,17 @@ export function ShortcutHint({
   const keyColor = disabled ? colors.textMuted : colors.textBright;
   const labelColor = disabled ? colors.textMuted : colors.textDim;
   const keyText = `[${hotkey}]`;
+  const triggerMouseDownRef = useRef(false);
+  const startPress = (event?: ShortcutHintMouseEvent) => {
+    triggerMouseDownRef.current = true;
+    stopMouseEvent(event);
+  };
+  const finishPress = (event?: ShortcutHintMouseEvent) => {
+    const startedOnTrigger = triggerMouseDownRef.current;
+    triggerMouseDownRef.current = false;
+    if (startedOnTrigger) onPress?.(event);
+    else stopMouseEvent(event);
+  };
 
   return (
     <Text
@@ -47,8 +59,8 @@ export function ShortcutHint({
       ])}
       fg={disabled ? colors.textMuted : colors.textDim}
       attributes={interactive ? TextAttributes.BOLD : 0}
-      onMouseDown={interactive ? stopMouseEvent : undefined}
-      onMouseUp={interactive ? onPress : undefined}
+      onMouseDown={interactive ? startPress : undefined}
+      onMouseUp={interactive ? finishPress : undefined}
       {...(dataGloomRole ? { "data-gloom-role": dataGloomRole } : {})}
     />
   );

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -227,7 +227,7 @@ function MultiSelectDialogButtonHarness() {
   );
 }
 
-function ChoiceDialogHarness() {
+function ChoiceDialogHarness({ selectedChoiceId }: { selectedChoiceId?: string } = {}) {
   return (
     <ChoiceDialog
       title="Choose Account"
@@ -240,6 +240,7 @@ function ChoiceDialogHarness() {
         { id: "beta", label: "Beta", description: "Beta account" },
         { id: "gamma", label: "Gamma", description: "Gamma account" },
       ]}
+      selectedChoiceId={selectedChoiceId}
     />
   );
 }
@@ -411,6 +412,15 @@ describe("shared UI kit", () => {
     expect(button!.width).toBe(" IND: SMA ".length);
 
     await act(async () => {
+      await testSetup!.mockMouse.release(button!.x + 1, button!.y);
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).not.toContain("Chart Indicators");
+
+    await act(async () => {
       await testSetup!.mockMouse.click(button!.x + 1, button!.y);
       await Promise.resolve();
       await testSetup!.renderOnce();
@@ -471,6 +481,18 @@ describe("shared UI kit", () => {
       await testSetup!.renderOnce();
     });
     expect(resolvedChoice).toBe("gamma");
+  });
+
+  test("preselects the current choice in choice dialogs", async () => {
+    testSetup = await testRender(<ChoiceDialogHarness selectedChoiceId="beta" />, { width: 44, height: 10 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Beta account");
+    expect(frame).not.toContain("Alpha account");
   });
 
   test("cancels choice dialogs with escape", async () => {

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -90,10 +90,6 @@ export function PickerRow({
         event?.stopPropagation?.();
         event?.preventDefault?.();
         onFocus();
-      }}
-      onMouseUp={(event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
-        event?.stopPropagation?.();
-        event?.preventDefault?.();
         onOpen();
       }}
     >

--- a/src/plugins/builtin/account-management/model.test.ts
+++ b/src/plugins/builtin/account-management/model.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { Portfolio, TickerRecord } from "../../../types/ticker";
+import { buildPortfolioChoices, countPortfolioHoldings, NO_PORTFOLIO_VALUE } from "./model";
+
+function makeTicker(symbol: string, portfolios: string[]): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "XNAS",
+      currency: "USD",
+      name: symbol,
+      portfolios,
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+describe("account management model", () => {
+  test("counts portfolio holdings from app ticker state", () => {
+    const tickers = new Map([
+      ["AAPL", makeTicker("AAPL", ["main"])],
+      ["MSFT", makeTicker("MSFT", ["main", "income"])],
+      ["SPY", makeTicker("SPY", [])],
+    ]);
+
+    expect(countPortfolioHoldings(tickers)).toEqual({ main: 2, income: 1 });
+  });
+
+  test("describes public portfolio analytics in the shared portfolio picker", () => {
+    const portfolios: Portfolio[] = [
+      { id: "main", name: "Main Portfolio", currency: "USD" },
+    ];
+
+    const choices = buildPortfolioChoices(portfolios, { main: 2 });
+
+    expect(choices).toEqual([
+      {
+        id: NO_PORTFOLIO_VALUE,
+        label: "None",
+        detail: "Off",
+        description: "Do not show portfolio analytics on your public profile.",
+      },
+      {
+        id: "main",
+        label: "Main Portfolio",
+        detail: "2 tickers",
+        description: "Shares this portfolio's YTD % and SPY Beta on your public profile.",
+      },
+    ]);
+  });
+});

--- a/src/plugins/builtin/account-management/model.ts
+++ b/src/plugins/builtin/account-management/model.ts
@@ -1,6 +1,6 @@
 import type { ChoiceDialogChoice } from "../../../components";
 import type { AccountProfile } from "../../../api-client";
-import type { Portfolio } from "../../../types/ticker";
+import type { Portfolio, TickerRecord } from "../../../types/ticker";
 
 export type AccountFieldKey =
   | "username"
@@ -75,14 +75,24 @@ export function formatPlan(plan: AccountProfile["plan"] | null | undefined): str
   return plan === "pro" ? "Pro" : "Free";
 }
 
+export function countPortfolioHoldings(tickers: ReadonlyMap<string, TickerRecord>): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const record of tickers.values()) {
+    for (const portfolioId of record.metadata.portfolios) {
+      counts[portfolioId] = (counts[portfolioId] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
 export function buildPortfolioChoices(portfolios: Portfolio[], holdingCounts: Record<string, number>): ChoiceDialogChoice[] {
   return [
-    { id: NO_PORTFOLIO_VALUE, label: "None", detail: "Off", description: "No public analytics portfolio." },
+    { id: NO_PORTFOLIO_VALUE, label: "None", detail: "Off", description: "Do not show portfolio analytics on your public profile." },
     ...portfolios.map((portfolio) => ({
       id: portfolio.id,
       label: portfolio.name,
       detail: `${holdingCounts[portfolio.id] ?? 0} tickers`,
-      description: portfolio.description || `${portfolio.currency} portfolio`,
+      description: "Shares this portfolio's YTD % and SPY Beta on your public profile.",
     })),
   ];
 }

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -13,6 +13,7 @@ import {
   BASE_FIELD_ORDER,
   NO_PORTFOLIO_VALUE,
   buildPortfolioChoices,
+  countPortfolioHoldings,
   emptyToNull,
   portfolioOptionIds,
   profileToDraft,
@@ -49,15 +50,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const bodyHeight = Math.max(5, height);
   const fieldOrder = BASE_FIELD_ORDER;
 
-  const portfolioHoldingCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const record of Object.values(tickers)) {
-      for (const portfolioId of record.metadata.portfolios) {
-        counts[portfolioId] = (counts[portfolioId] ?? 0) + 1;
-      }
-    }
-    return counts;
-  }, [tickers]);
+  const portfolioHoldingCounts = useMemo(() => countPortfolioHoldings(tickers), [tickers]);
   const portfolioChoices = useMemo(
     () => buildPortfolioChoices(portfolios, portfolioHoldingCounts),
     [portfolioHoldingCounts, portfolios],
@@ -138,6 +131,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
 
   const openPortfolioDialog = useCallback(async () => {
     setActiveField("sharedPortfolioId");
+    const currentPortfolioChoiceId = draftRef.current.sharedPortfolioId || NO_PORTFOLIO_VALUE;
     const selected = await dialog.prompt<string>({
       closeOnClickOutside: false,
       content: (context: PromptContext<string>) => (
@@ -145,7 +139,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
           {...context}
           title="Shared Portfolio"
           choices={portfolioChoices}
-          footer="↑↓ choose · Enter/click select · Esc cancel"
+          selectedChoiceId={currentPortfolioChoiceId}
         />
       ),
     }).catch(() => "");
@@ -365,7 +359,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
           <PickerRow
             label="Profile Analytics"
             value={selectedPortfolioLabel(portfolios, draft.sharedPortfolioId)}
-            detail={draft.sharedPortfolioId ? "YTD% + beta source" : "No shared portfolio"}
+            detail={draft.sharedPortfolioId ? "Shares portfolio YTD % + SPY Beta" : "No public portfolio analytics"}
             active={activeField === "sharedPortfolioId"}
             width={formWidth}
             onFocus={() => setActiveField("sharedPortfolioId")}

--- a/src/plugins/builtin/account-management/password-dialog.tsx
+++ b/src/plugins/builtin/account-management/password-dialog.tsx
@@ -78,7 +78,7 @@ export function PasswordChangeDialog({
 
   const fieldWidth = 42;
   return (
-    <DialogFrame title="Change Password" footer="Esc cancel">
+    <DialogFrame title="Change Password">
       <Box flexDirection="column" gap={1}>
         <TextField
           label={activeField === "current" ? "> Current Password" : "  Current Password"}


### PR DESCRIPTION
Fixes the Gloom Cloud shared portfolio setting so it counts holdings from the app ticker map, reopens with the current portfolio selected, and clearly states that public analytics share portfolio YTD % and SPY Beta.

It removes obvious keyboard/click instruction footers from the account and pane settings dialogs.

It also guards shared mouse-up activation in multi-select buttons, pane footer segments, and shortcut hints so a dialog dismissal cannot trigger controls underneath.
