### PR TITLE
Add chat message editing

### DIFF
--- a/src/api-client/chat.ts
+++ b/src/api-client/chat.ts
@@ -93,6 +93,14 @@ export class CloudChatApi {
     return normalizeChatMessage(message);
   }
 
+  async editMessage(channelId: string, messageId: string, content: string): Promise<ChatMessage> {
+    const message = await this.options.request<ChatMessage>(`/chat/channels/${channelId}/messages/${messageId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ content }),
+    });
+    return normalizeChatMessage(message);
+  }
+
   connectChannel(
     channelId: string,
     onMessage: (msg: ChatMessage) => void,

--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -379,6 +379,36 @@ describe("apiClient chat timestamps", () => {
     expect(sentMessage.createdAt).toBe("2026-04-08T07:29:27.625Z");
   });
 
+  test("edits a chat message and normalizes the edit timestamp", async () => {
+    const requests: Array<{ path: string; method: string; body: unknown }> = [];
+    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
+      requests.push({
+        path: new URL(String(input)).pathname,
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return createResponse({
+        id: "m2",
+        channelId: "everyone",
+        content: "hello edited",
+        replyToId: null,
+        createdAt: "2026-04-08 07:29:27.625",
+        editedAt: "2026-04-08 07:30:27.625",
+        user: { id: "u1", username: "alice", displayName: "Alice" },
+        replyTo: null,
+      });
+    });
+
+    const editedMessage = await apiClient.editMessage("everyone", "m2", "hello edited");
+
+    expect(requests).toEqual([{
+      path: "/chat/channels/everyone/messages/m2",
+      method: "PATCH",
+      body: { content: "hello edited" },
+    }]);
+    expect(editedMessage.editedAt).toBe("2026-04-08T07:30:27.625Z");
+  });
+
   test("normalizes websocket chat timestamps before notifying listeners", async () => {
     const seenCreatedAts: string[] = [];
     const channel = apiClient.connectChannel("everyone", (message) => {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -244,6 +244,10 @@ class GloomApiClient {
     return this.chat.sendMessage(channelId, content, replyToId, clientMessageId);
   }
 
+  async editMessage(channelId: string, messageId: string, content: string): Promise<ChatMessage> {
+    return this.chat.editMessage(channelId, messageId, content);
+  }
+
   connectChannel(
     channelId: string,
     onMessage: (msg: ChatMessage) => void,

--- a/src/api-client/normalizers.ts
+++ b/src/api-client/normalizers.ts
@@ -12,6 +12,7 @@ export function normalizeChatMessage(message: ChatMessage): ChatMessage {
   return {
     ...message,
     createdAt: normalizeTimestamp(message.createdAt),
+    ...(message.editedAt ? { editedAt: normalizeTimestamp(message.editedAt) } : {}),
   };
 }
 

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -28,6 +28,7 @@ export interface ChatMessage {
   content: string;
   replyToId: string | null;
   createdAt: string;
+  editedAt?: string | null;
   user: ChatUserSummary;
   replyTo?: { content: string; user: { id?: string; username: string } } | null;
   clientStatus?: "sending" | "failed";

--- a/src/plugins/builtin/chat/chat.test.tsx
+++ b/src/plugins/builtin/chat/chat.test.tsx
@@ -180,6 +180,86 @@ describe("ChatContent", () => {
     expect(bodyLine).not.toContain("Reply");
   });
 
+  test("shows the edit action next to reply for the latest own message", async () => {
+    const ownMessage: ChatMessage = {
+      id: "m-own",
+      channelId: "everyone",
+      content: "typo",
+      replyToId: null,
+      createdAt: "2026-03-30T00:00:03.000Z",
+      user: { id: "u0", username: "vince", displayName: "Vince" },
+    };
+    const controller = createController({
+      messages: [makeMessage(1), ownMessage],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 72,
+        height: 12,
+      }), {
+        width: 72,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    await emitKeypress({ name: "up", sequence: "\u001b[A" });
+    await flushFrame();
+
+    const lines = setup().captureCharFrame().split("\n");
+    const headerLine = lines.find((line) => line.includes("vince"));
+
+    expect(headerLine).toContain("Reply");
+    expect(headerLine).toContain("Edit");
+  });
+
+  test("up arrow from an empty focused composer edits the latest own message", async () => {
+    const ownMessage: ChatMessage = {
+      id: "m-own",
+      channelId: "everyone",
+      content: "typo",
+      replyToId: null,
+      createdAt: "2026-03-30T00:00:03.000Z",
+      user: { id: "u0", username: "vince", displayName: "Vince" },
+    };
+    const controller = createController({
+      messages: [makeMessage(1), ownMessage],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 72,
+        height: 12,
+      }), {
+        width: 72,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    const lines = setup().captureCharFrame().split("\n");
+    const inputRow = lines.findIndex((line) => line.includes("Type a message..."));
+    const inputCol = lines[inputRow]?.indexOf("Type a message...") ?? -1;
+    expect(inputRow).toBeGreaterThanOrEqual(0);
+    expect(inputCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await setup().mockMouse.click(inputCol + 1, inputRow);
+      await setup().renderOnce();
+      await setup().renderOnce();
+    });
+
+    await emitKeypress({ name: "up", sequence: "\u001b[A" });
+    await flushFrame();
+
+    const frame = setup().captureCharFrame();
+    expect(frame).toContain("editing");
+    expect(frame).toContain("> typo");
+  });
+
   test("down arrow from the newest selected message returns focus to the composer", async () => {
     const controller = createController({
       messages: [makeMessage(1), makeMessage(2)],

--- a/src/plugins/builtin/chat/chat.test.tsx
+++ b/src/plugins/builtin/chat/chat.test.tsx
@@ -30,6 +30,21 @@ function setup(): ChatTestSetup {
 }
 const { flushFrame, emitKeypress } = createChatTestControls(setup);
 
+function recentChatTimestamp(offsetMs = 60_000) {
+  return new Date(Date.now() - offsetMs).toISOString();
+}
+
+function makeOwnMessage(content = "typo", createdAt = recentChatTimestamp()): ChatMessage {
+  return {
+    id: "m-own",
+    channelId: "everyone",
+    content,
+    replyToId: null,
+    createdAt,
+    user: { id: "u0", username: "vince", displayName: "Vince" },
+  };
+}
+
 beforeEach(() => {
   installChatApiTestDefaults();
 });
@@ -181,14 +196,7 @@ describe("ChatContent", () => {
   });
 
   test("shows the edit action next to reply for the latest own message", async () => {
-    const ownMessage: ChatMessage = {
-      id: "m-own",
-      channelId: "everyone",
-      content: "typo",
-      replyToId: null,
-      createdAt: "2026-03-30T00:00:03.000Z",
-      user: { id: "u0", username: "vince", displayName: "Vince" },
-    };
+    const ownMessage = makeOwnMessage();
     const controller = createController({
       messages: [makeMessage(1), ownMessage],
     });
@@ -215,15 +223,36 @@ describe("ChatContent", () => {
     expect(headerLine).toContain("Edit");
   });
 
+  test("hides the edit action after the edit window expires", async () => {
+    const ownMessage = makeOwnMessage("typo", recentChatTimestamp(16 * 60_000));
+    const controller = createController({
+      messages: [makeMessage(1), ownMessage],
+    });
+
+    await act(async () => {
+      testSetup = await testRender(createHarness(controller, {
+        width: 72,
+        height: 12,
+      }), {
+        width: 72,
+        height: 12,
+      });
+    });
+
+    await flushFrame();
+
+    await emitKeypress({ name: "up", sequence: "\u001b[A" });
+    await flushFrame();
+
+    const lines = setup().captureCharFrame().split("\n");
+    const headerLine = lines.find((line) => line.includes("vince"));
+
+    expect(headerLine).toContain("Reply");
+    expect(headerLine).not.toContain("Edit");
+  });
+
   test("up arrow from an empty focused composer edits the latest own message", async () => {
-    const ownMessage: ChatMessage = {
-      id: "m-own",
-      channelId: "everyone",
-      content: "typo",
-      replyToId: null,
-      createdAt: "2026-03-30T00:00:03.000Z",
-      user: { id: "u0", username: "vince", displayName: "Vince" },
-    };
+    const ownMessage = makeOwnMessage();
     const controller = createController({
       messages: [makeMessage(1), ownMessage],
     });
@@ -258,6 +287,14 @@ describe("ChatContent", () => {
     const frame = setup().captureCharFrame();
     expect(frame).toContain("editing");
     expect(frame).toContain("> typo");
+
+    await act(async () => {
+      await setup().mockInput.typeText(" fix");
+      await setup().renderOnce();
+      await setup().renderOnce();
+    });
+
+    expect(setup().captureCharFrame()).toContain("> typo fix");
   });
 
   test("down arrow from the newest selected message returns focus to the composer", async () => {

--- a/src/plugins/builtin/chat/content/composer-runtime.ts
+++ b/src/plugins/builtin/chat/content/composer-runtime.ts
@@ -27,7 +27,10 @@ export function useChatComposerRuntime({
   inputValueRef,
   messages,
   onChannelChange,
+  editingMessage,
+  latestEditableMessageId,
   replyTo,
+  setEditingMessage,
   setDirectExpanded,
   setFollowMessages,
   setReplyTo,
@@ -49,7 +52,10 @@ export function useChatComposerRuntime({
   inputValueRef: MutableRef<string>;
   messages: ChatMessage[];
   onChannelChange?: (channelId: string) => void;
+  editingMessage: ChatMessage | null;
+  latestEditableMessageId: string | null;
   replyTo: ChatMessage | null;
+  setEditingMessage: Dispatch<SetStateAction<ChatMessage | null>>;
   setDirectExpanded: Dispatch<SetStateAction<boolean>>;
   setFollowMessages: Dispatch<SetStateAction<boolean>>;
   setReplyTo: Dispatch<SetStateAction<ChatMessage | null>>;
@@ -59,6 +65,9 @@ export function useChatComposerRuntime({
 }) {
   const replyToRef = useRef(replyTo);
   replyToRef.current = replyTo;
+  const editingMessageRef = useRef(editingMessage);
+  editingMessageRef.current = editingMessage;
+  const editSubmittingRef = useRef(false);
 
   const focusComposer = useCallback(() => {
     setSelectedIdx(-1);
@@ -75,10 +84,37 @@ export function useChatComposerRuntime({
     }
   }, [channelId, controller, setReplyTo, useDefaultControllerChannel]);
 
+  const persistDraft = useCallback((draft: string) => {
+    if (useDefaultControllerChannel) {
+      controller.setDraft(draft);
+    } else {
+      controller.setChannelDraft(channelId, draft);
+    }
+  }, [channelId, controller, useDefaultControllerChannel]);
+
+  const replaceLocalComposer = useCallback((draft: string) => {
+    inputValueRef.current = draft;
+    updateComposerRows(draft);
+    const textarea = inputRef.current;
+    if (textarea && textarea.editBuffer.getText() !== draft) {
+      applyingExternalDraftRef.current = true;
+      try {
+        textarea.setText(draft);
+      } finally {
+        applyingExternalDraftRef.current = false;
+      }
+    }
+  }, [applyingExternalDraftRef, inputRef, inputValueRef, updateComposerRows]);
+
   const beginReplyTo = useCallback((index: number, options?: { deferFocus?: boolean }) => {
     if (!canSend || index < 0 || index >= messages.length) return;
     const nextReplyTo = messages[index] ?? null;
     if (!nextReplyTo) return;
+    if (editingMessageRef.current) {
+      replaceLocalComposer("");
+      persistDraft("");
+    }
+    setEditingMessage(null);
     setSelectedIdx(index);
     setFollowMessages(index === messages.length - 1);
     setReplyTo(nextReplyTo);
@@ -98,11 +134,57 @@ export function useChatComposerRuntime({
     controller,
     focusInput,
     messages,
+    persistDraft,
+    replaceLocalComposer,
+    setEditingMessage,
     setFollowMessages,
     setReplyTo,
     setSelectedIdx,
     useDefaultControllerChannel,
   ]);
+
+  const beginEditMessage = useCallback((index: number, options?: { deferFocus?: boolean }) => {
+    if (!canSend || index < 0 || index >= messages.length) return false;
+    const message = messages[index] ?? null;
+    if (!message || message.id !== latestEditableMessageId) return false;
+    clearReplyTarget();
+    setEditingMessage(message);
+    setSelectedIdx(index);
+    setFollowMessages(index === messages.length - 1);
+    replaceLocalComposer(message.content);
+    persistDraft(message.content);
+    if (options?.deferFocus) {
+      queueMicrotask(() => focusInput());
+    } else {
+      focusInput();
+    }
+    return true;
+  }, [
+    canSend,
+    clearReplyTarget,
+    focusInput,
+    latestEditableMessageId,
+    messages,
+    persistDraft,
+    replaceLocalComposer,
+    setEditingMessage,
+    setFollowMessages,
+    setSelectedIdx,
+  ]);
+
+  const beginEditLatestMessage = useCallback((options?: { deferFocus?: boolean }) => {
+    if (!latestEditableMessageId) return false;
+    const index = messages.findIndex((message) => message.id === latestEditableMessageId);
+    return beginEditMessage(index, options);
+  }, [beginEditMessage, latestEditableMessageId, messages]);
+
+  const cancelEditMessage = useCallback(() => {
+    if (!editingMessageRef.current) return;
+    setEditingMessage(null);
+    replaceLocalComposer("");
+    persistDraft("");
+    focusInput();
+  }, [focusInput, persistDraft, replaceLocalComposer, setEditingMessage]);
 
   const returnToComposer = useCallback(() => {
     setSelectedIdx(-1);
@@ -113,22 +195,30 @@ export function useChatComposerRuntime({
   }, [canSend, focusInput, setFollowMessages, setSelectedIdx]);
 
   const clearLocalComposer = useCallback(() => {
-    inputValueRef.current = "";
-    updateComposerRows("");
-    const textarea = inputRef.current;
-    if (textarea && textarea.editBuffer.getText() !== "") {
-      applyingExternalDraftRef.current = true;
-      try {
-        textarea.setText("");
-      } finally {
-        applyingExternalDraftRef.current = false;
-      }
-    }
-  }, [applyingExternalDraftRef, inputRef, inputValueRef, updateComposerRows]);
+    replaceLocalComposer("");
+  }, [replaceLocalComposer]);
 
   const sendMessage = useCallback(() => {
     const content = inputValueRef.current.trim();
     if (!content) return;
+    const editing = editingMessageRef.current;
+    if (editing) {
+      if (editSubmittingRef.current) return;
+      const sendChannelId = useDefaultControllerChannel ? channelId : channelIdRef.current;
+      if (editing.channelId !== sendChannelId) return;
+      editSubmittingRef.current = true;
+      void controller.editChannelMessage(sendChannelId, editing.id, content).then((accepted) => {
+        if (!accepted) return;
+        setEditingMessage(null);
+        clearLocalComposer();
+        persistDraft("");
+        setSelectedIdx(-1);
+        setFollowMessages(true);
+      }).finally(() => {
+        editSubmittingRef.current = false;
+      });
+      return;
+    }
     const composerCommand = parseChatComposerCommand(content);
     if (composerCommand?.kind === "direct") {
       void controller.openDirectChannel({ username: composerCommand.username }).then((channel) => {
@@ -172,7 +262,9 @@ export function useChatComposerRuntime({
     controller,
     inputValueRef,
     onChannelChange,
+    persistDraft,
     setDirectExpanded,
+    setEditingMessage,
     setFollowMessages,
     setSelectedIdx,
     useDefaultControllerChannel,
@@ -182,16 +274,13 @@ export function useChatComposerRuntime({
     if (applyingExternalDraftRef.current) return;
     inputValueRef.current = draft;
     updateComposerRows(draft);
-    if (useDefaultControllerChannel) {
-      controller.setDraft(draft);
-    } else {
-      controller.setChannelDraft(channelId, draft);
-    }
+    persistDraft(draft);
   }, [
     applyingExternalDraftRef,
     channelId,
     controller,
     inputValueRef,
+    persistDraft,
     updateComposerRows,
     useDefaultControllerChannel,
   ]);
@@ -234,18 +323,33 @@ export function useChatComposerRuntime({
     clearReplyTarget();
   }, [canSend, clearReplyTarget, replyTo]);
 
+  useEffect(() => {
+    if (canSend || !editingMessage) return;
+    cancelEditMessage();
+  }, [canSend, cancelEditMessage, editingMessage]);
+
   const replyPreview = replyTo
     ? formatInlinePreview(
       replyTo.content,
       Math.max(contentWidth - ` replying to @${replyTo.user.username}: `.length - COMPOSER_ACTION_WIDTH - 1, 0),
     )
     : "";
-  const inputPlaceholder = replyTo ? `Reply to @${replyTo.user.username}...` : "Type a message...";
+  const editingPreview = editingMessage
+    ? formatInlinePreview(
+      editingMessage.content,
+      Math.max(contentWidth - " editing: ".length - COMPOSER_ACTION_WIDTH - 1, 0),
+    )
+    : "";
+  const inputPlaceholder = editingMessage ? "Edit message..." : replyTo ? `Reply to @${replyTo.user.username}...` : "Type a message...";
 
   return {
+    beginEditLatestMessage,
+    beginEditMessage,
     beginReplyTo,
+    cancelEditMessage,
     clearReplyTarget,
     commitLocalDraft,
+    editingPreview,
     focusComposer,
     inputPlaceholder,
     replyPreview,

--- a/src/plugins/builtin/chat/content/composer-runtime.ts
+++ b/src/plugins/builtin/chat/content/composer-runtime.ts
@@ -12,6 +12,26 @@ interface MutableRef<T> {
   current: T;
 }
 
+function moveComposerCursorToEnd(textarea: TextareaRenderable, draft: string) {
+  const offset = draft.length;
+  const editBuffer = textarea.editBuffer as typeof textarea.editBuffer & {
+    setCursorByOffset?: (offset: number) => void;
+  };
+  if (typeof editBuffer.setCursorByOffset === "function") {
+    editBuffer.setCursorByOffset(offset);
+    return;
+  }
+  if (typeof textarea.setCursorOffset === "function") {
+    textarea.setCursorOffset(offset);
+    return;
+  }
+  try {
+    textarea.cursorOffset = offset;
+  } catch {
+    // Some host renderers expose cursorOffset as read-only.
+  }
+}
+
 export function useChatComposerRuntime({
   applyingExternalDraftRef,
   blurInput,
@@ -100,9 +120,12 @@ export function useChatComposerRuntime({
       applyingExternalDraftRef.current = true;
       try {
         textarea.setText(draft);
+        moveComposerCursorToEnd(textarea, draft);
       } finally {
         applyingExternalDraftRef.current = false;
       }
+    } else if (textarea) {
+      moveComposerCursorToEnd(textarea, draft);
     }
   }, [applyingExternalDraftRef, inputRef, inputValueRef, updateComposerRows]);
 

--- a/src/plugins/builtin/chat/content/composer.tsx
+++ b/src/plugins/builtin/chat/content/composer.tsx
@@ -14,6 +14,7 @@ interface MutableRef<T> {
 
 interface ChatComposerAreaProps {
   canSend: boolean;
+  cancelEditMessage: () => void;
   clearReplyTarget: () => void;
   commitLocalDraft: (draft: string) => void;
   composerHeight: number;
@@ -27,6 +28,8 @@ interface ChatComposerAreaProps {
   inputRef: MutableRef<TextareaRenderable | null>;
   inputValueRef: MutableRef<string>;
   nativePaneChrome: boolean | undefined;
+  editingMessage: ChatMessage | null;
+  editingPreview: string;
   replyPreview: string;
   replyTo: ChatMessage | null;
   sendMessage: () => void;
@@ -35,6 +38,7 @@ interface ChatComposerAreaProps {
 
 export function ChatComposerArea({
   canSend,
+  cancelEditMessage,
   clearReplyTarget,
   commitLocalDraft,
   composerHeight,
@@ -48,6 +52,8 @@ export function ChatComposerArea({
   inputRef,
   inputValueRef,
   nativePaneChrome,
+  editingMessage,
+  editingPreview,
   replyPreview,
   replyTo,
   sendMessage,
@@ -89,7 +95,20 @@ export function ChatComposerArea({
         />
       )}
 
-      {replyTo && (
+      {editingMessage && (
+        <Box height={1} width={contentWidth} flexDirection="row">
+          <Text fg={colors.textMuted}> editing </Text>
+          <Text fg={colors.textDim}>{editingPreview ? `: ${editingPreview}` : ""}</Text>
+          <Box flexGrow={1} />
+          <ChatActionChip
+            label="Cancel"
+            width={COMPOSER_ACTION_WIDTH}
+            onPress={cancelEditMessage}
+          />
+        </Box>
+      )}
+
+      {!editingMessage && replyTo && (
         <Box height={1} width={contentWidth} flexDirection="row">
           <Text fg={colors.textMuted}> replying to </Text>
           <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{`@${replyTo.user.username}`}</Text>
@@ -135,14 +154,16 @@ export function ChatComposerArea({
 export function getChatComposerAreaHeight({
   canSend,
   composerHeight,
+  editingMessage,
   nativePaneChrome,
   replyTo,
 }: {
   canSend: boolean;
   composerHeight: number;
+  editingMessage: ChatMessage | null;
   nativePaneChrome: boolean | undefined;
   replyTo: ChatMessage | null;
 }) {
   if (!canSend) return 2;
-  return getMessageComposerBlockHeight({ height: composerHeight, nativePaneChrome }) + (replyTo ? 1 : 0);
+  return getMessageComposerBlockHeight({ height: composerHeight, nativePaneChrome }) + (editingMessage || replyTo ? 1 : 0);
 }

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -31,6 +31,7 @@ import {
 import { buildChatUserByUsername } from "./user-map";
 import { useChatComposerRuntime } from "./composer-runtime";
 import { useChatMessageSelection } from "./selection-runtime";
+import type { ChatMessage } from "../../../../api-client";
 
 interface ChatContentProps {
   width: number;
@@ -60,12 +61,14 @@ export function ChatContent({
   const [inputFocused, setInputFocused] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [editingMessage, setEditingMessage] = useState<ChatMessage | null>(null);
   const [followMessages, setFollowMessages] = useState(true);
   const inputRef = useRef<TextareaRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const messageElementsRef = useRef(new Map<string, unknown>());
   const applyingExternalDraftRef = useRef(false);
   const prependAnchorRef = useRef<ChatPrependAnchor | null>(null);
+  const previousEditingChannelIdRef = useRef(channelId);
   const useDefaultControllerChannel = channelId === DEFAULT_CHAT_CHANNEL_ID && !onChannelChange;
   const initialWidthMetrics = resolveChatContentWidthMetrics({
     width,
@@ -125,12 +128,20 @@ export function ChatContent({
   const selectionActive = selectedIdx >= 0 && selectedIdx < messages.length;
   const stickyTranscript = followMessages && !selectionActive;
   const latestMessageId = messages[messages.length - 1]?.id ?? null;
+  const latestEditableMessageId = useMemo(() => {
+    if (!user?.id) return null;
+    return [...messages]
+      .reverse()
+      .find((message) => message.user.id === user.id && !message.clientStatus)
+      ?.id ?? null;
+  }, [messages, user?.id]);
   const {
     composerHeight,
     messageAreaHeight,
   } = resolveChatContentHeightMetrics({
     canSend,
     composerRows,
+    editingMessage,
     height,
     nativePaneChrome,
     replyTo,
@@ -161,6 +172,12 @@ export function ChatContent({
   useEffect(() => {
     onChannelTitleChange?.(activeChannelTitle);
   }, [activeChannelTitle, onChannelTitleChange]);
+
+  useEffect(() => {
+    if (previousEditingChannelIdRef.current === channelId) return;
+    previousEditingChannelIdRef.current = channelId;
+    setEditingMessage(null);
+  }, [channelId]);
 
   const {
     moveMessageSelection,
@@ -209,9 +226,13 @@ export function ChatContent({
   }, [dispatch, setSidebarFocused]);
 
   const {
+    beginEditLatestMessage,
+    beginEditMessage,
     beginReplyTo,
+    cancelEditMessage,
     clearReplyTarget,
     commitLocalDraft,
+    editingPreview,
     focusComposer,
     inputPlaceholder,
     replyPreview,
@@ -232,7 +253,10 @@ export function ChatContent({
     inputValueRef,
     messages,
     onChannelChange,
+    editingMessage,
+    latestEditableMessageId,
     replyTo,
+    setEditingMessage,
     setDirectExpanded,
     setFollowMessages,
     setReplyTo,
@@ -272,9 +296,11 @@ export function ChatContent({
   });
 
   useChatContentShortcuts({
+    beginEditLatestMessage,
     beginReplyTo,
     blurInput,
     canSend,
+    cancelEditMessage,
     clearReplyTarget,
     cycleChannel,
     focusChannelSidebar,
@@ -289,6 +315,7 @@ export function ChatContent({
     moveMessageSelection,
     moveSidebarChannelSelection,
     nativePaneChrome,
+    editingMessage,
     replyTo,
     requestOlderMessages,
     requestOlderMessagesIfNeeded,
@@ -356,6 +383,7 @@ export function ChatContent({
 
       <ChatTranscript
         beginReplyTo={beginReplyTo}
+        beginEditMessage={beginEditMessage}
         canSend={canSend}
         catalog={catalog}
         cancelProfilePopoverClose={cancelProfilePopoverClose}
@@ -370,6 +398,7 @@ export function ChatContent({
         messageBodyWidth={messageBodyWidth}
         messages={messages}
         nativePaneChrome={nativePaneChrome}
+        latestEditableMessageId={latestEditableMessageId}
         openDirectMessage={openDirectMessage}
         openTicker={openTicker}
         profilePopoverUser={profilePopoverUser}
@@ -392,6 +421,7 @@ export function ChatContent({
 
       <ChatComposerArea
         canSend={canSend}
+        cancelEditMessage={cancelEditMessage}
         clearReplyTarget={clearReplyTarget}
         commitLocalDraft={commitLocalDraft}
         composerHeight={composerHeight}
@@ -405,6 +435,8 @@ export function ChatContent({
         inputRef={inputRef}
         inputValueRef={inputValueRef}
         nativePaneChrome={nativePaneChrome}
+        editingMessage={editingMessage}
+        editingPreview={editingPreview}
         replyPreview={replyPreview}
         replyTo={replyTo}
         sendMessage={sendMessage}

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -32,6 +32,10 @@ import { buildChatUserByUsername } from "./user-map";
 import { useChatComposerRuntime } from "./composer-runtime";
 import { useChatMessageSelection } from "./selection-runtime";
 import type { ChatMessage } from "../../../../api-client";
+import {
+  CHAT_MESSAGE_EDIT_WINDOW_MS,
+  findLatestEditableChatMessage,
+} from "../edit-window";
 
 interface ChatContentProps {
   width: number;
@@ -128,13 +132,29 @@ export function ChatContent({
   const selectionActive = selectedIdx >= 0 && selectedIdx < messages.length;
   const stickyTranscript = followMessages && !selectionActive;
   const latestMessageId = messages[messages.length - 1]?.id ?? null;
-  const latestEditableMessageId = useMemo(() => {
+  const [editWindowNowMs, setEditWindowNowMs] = useState(() => Date.now());
+  const latestOwnMessage = useMemo(() => {
     if (!user?.id) return null;
     return [...messages]
       .reverse()
-      .find((message) => message.user.id === user.id && !message.clientStatus)
-      ?.id ?? null;
+      .find((message) => message.user.id === user.id && !message.clientStatus) ?? null;
   }, [messages, user?.id]);
+
+  useEffect(() => {
+    if (!latestOwnMessage) return;
+    const createdMs = Date.parse(latestOwnMessage.createdAt);
+    if (!Number.isFinite(createdMs)) return;
+    const expiresInMs = createdMs + CHAT_MESSAGE_EDIT_WINDOW_MS - Date.now();
+    if (expiresInMs <= 0) return;
+    const timer = setTimeout(() => {
+      setEditWindowNowMs(Date.now());
+    }, Math.min(expiresInMs + 250, 60_000));
+    return () => clearTimeout(timer);
+  }, [editWindowNowMs, latestOwnMessage]);
+
+  const latestEditableMessageId = useMemo(() => {
+    return findLatestEditableChatMessage(messages, user?.id, editWindowNowMs)?.id ?? null;
+  }, [editWindowNowMs, messages, user?.id]);
   const {
     composerHeight,
     messageAreaHeight,

--- a/src/plugins/builtin/chat/content/layout-metrics.ts
+++ b/src/plugins/builtin/chat/content/layout-metrics.ts
@@ -42,12 +42,14 @@ export function resolveChatContentWidthMetrics({
 export function resolveChatContentHeightMetrics({
   canSend,
   composerRows,
+  editingMessage,
   height,
   nativePaneChrome,
   replyTo,
 }: {
   canSend: boolean;
   composerRows: number;
+  editingMessage: ChatMessage | null;
   height: number;
   nativePaneChrome: boolean | undefined;
   replyTo: ChatMessage | null;
@@ -57,7 +59,7 @@ export function resolveChatContentHeightMetrics({
       ? Math.min(CHAT_COMPOSER_MAX_ROWS + 1, Math.max(2, composerRows + 1))
       : composerRows
     : 0;
-  const inputAreaHeight = getChatComposerAreaHeight({ canSend, composerHeight, nativePaneChrome, replyTo });
+  const inputAreaHeight = getChatComposerAreaHeight({ canSend, composerHeight, editingMessage, nativePaneChrome, replyTo });
   const topSeparatorHeight = nativePaneChrome ? 0 : 1;
   const footerSeparatorHeight = !nativePaneChrome && !canSend ? 1 : 0;
   const messageAreaHeight = Math.max(1, height - topSeparatorHeight - footerSeparatorHeight - inputAreaHeight);

--- a/src/plugins/builtin/chat/content/shortcuts.ts
+++ b/src/plugins/builtin/chat/content/shortcuts.ts
@@ -6,9 +6,11 @@ import { isPlainKey } from "../../../../utils/keyboard";
 import { scrollToBottom } from "../layout";
 
 export function useChatContentShortcuts({
+  beginEditLatestMessage,
   beginReplyTo,
   blurInput,
   canSend,
+  cancelEditMessage,
   clearReplyTarget,
   cycleChannel,
   focusChannelSidebar,
@@ -23,6 +25,7 @@ export function useChatContentShortcuts({
   moveMessageSelection,
   moveSidebarChannelSelection,
   nativePaneChrome,
+  editingMessage,
   replyTo,
   requestOlderMessages,
   requestOlderMessagesIfNeeded,
@@ -35,9 +38,11 @@ export function useChatContentShortcuts({
   showChannelSidebar,
   sidebarFocusedRef,
 }: {
+  beginEditLatestMessage: (options?: { deferFocus?: boolean }) => boolean;
   beginReplyTo: (index: number, options?: { deferFocus?: boolean }) => void;
   blurInput: () => void;
   canSend: boolean;
+  cancelEditMessage: () => void;
   clearReplyTarget: () => void;
   cycleChannel: (direction: 1 | -1) => boolean;
   focusChannelSidebar: () => boolean;
@@ -52,6 +57,7 @@ export function useChatContentShortcuts({
   moveMessageSelection: (direction: "up" | "down") => boolean;
   moveSidebarChannelSelection: (direction: "up" | "down") => boolean;
   nativePaneChrome?: boolean;
+  editingMessage: ChatMessage | null;
   replyTo: ChatMessage | null;
   requestOlderMessages: () => void;
   requestOlderMessagesIfNeeded: () => void;
@@ -107,7 +113,9 @@ export function useChatContentShortcuts({
       if (event.name === "escape") {
         event.preventDefault?.();
         event.stopPropagation?.();
-        if (replyTo) {
+        if (editingMessage) {
+          cancelEditMessage();
+        } else if (replyTo) {
           clearReplyTarget();
         } else {
           blurInput();
@@ -116,6 +124,17 @@ export function useChatContentShortcuts({
       }
 
       const verticalDirection = event.name === "up" || event.name === "down" ? event.name : null;
+      if (
+        verticalDirection === "up"
+        && canSend
+        && isPlainKey(event, "up")
+        && inputValueRef.current.trim().length === 0
+        && beginEditLatestMessage({ deferFocus: true })
+      ) {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        return;
+      }
       if (verticalDirection && isPlainKey(event, "up", "down") && shouldLeaveComposerForSelection(verticalDirection)) {
         const moved = moveMessageSelection(verticalDirection);
         if (moved) {

--- a/src/plugins/builtin/chat/content/transcript.tsx
+++ b/src/plugins/builtin/chat/content/transcript.tsx
@@ -13,6 +13,7 @@ interface MutableRef<T> {
 
 interface ChatTranscriptProps {
   beginReplyTo: (index: number, options?: { deferFocus?: boolean }) => void;
+  beginEditMessage: (index: number, options?: { deferFocus?: boolean }) => boolean;
   canSend: boolean;
   catalog: Record<string, InlineTickerCatalogEntry>;
   cancelProfilePopoverClose: () => void;
@@ -27,6 +28,7 @@ interface ChatTranscriptProps {
   messageBodyWidth: number;
   messages: ChatMessage[];
   nativePaneChrome: boolean | undefined;
+  latestEditableMessageId: string | null;
   openDirectMessage: (target: ChatUserSummary) => void;
   openTicker: (symbol: string) => void;
   profilePopoverUser: ChatUserSummary | null;
@@ -43,6 +45,7 @@ interface ChatTranscriptProps {
 
 export function ChatTranscript({
   beginReplyTo,
+  beginEditMessage,
   canSend,
   catalog,
   cancelProfilePopoverClose,
@@ -57,6 +60,7 @@ export function ChatTranscript({
   messageBodyWidth,
   messages,
   nativePaneChrome,
+  latestEditableMessageId,
   openDirectMessage,
   openTicker,
   profilePopoverUser,
@@ -113,7 +117,9 @@ export function ChatTranscript({
               onUserHover={showProfilePopover}
               onUserHoverEnd={scheduleProfilePopoverClose}
               beginReplyTo={beginReplyTo}
+              beginEditMessage={beginEditMessage}
               jumpToMessage={jumpToMessage}
+              latestEditableMessageId={latestEditableMessageId}
               registerMessageElement={registerMessageElement}
             />
           ) : (
@@ -133,7 +139,9 @@ export function ChatTranscript({
               onUserHover={showProfilePopover}
               onUserHoverEnd={scheduleProfilePopoverClose}
               beginReplyTo={beginReplyTo}
+              beginEditMessage={beginEditMessage}
               jumpToMessage={jumpToMessage}
+              latestEditableMessageId={latestEditableMessageId}
               setHoveredIdx={setHoveredIdx}
             />
           )

--- a/src/plugins/builtin/chat/content/types.ts
+++ b/src/plugins/builtin/chat/content/types.ts
@@ -15,6 +15,7 @@ export type ChatContentController = Pick<
   | "refreshSession"
   | "send"
   | "sendToChannel"
+  | "editChannelMessage"
   | "openDirectChannel"
   | "openGroupChannel"
   | "setDraft"

--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -32,6 +32,10 @@ async function flushMicrotasks() {
   await Promise.resolve();
 }
 
+function recentChatTimestamp(offsetMs = 60_000) {
+  return new Date(Date.now() - offsetMs).toISOString();
+}
+
 class TrackingPersistence extends MemoryPersistence {
   stateWrites = 0;
 
@@ -727,7 +731,7 @@ describe("ChatController", () => {
       channelId: "everyone",
       content: "helo",
       replyToId: null,
-      createdAt: "2026-03-28T00:00:00.000Z",
+      createdAt: recentChatTimestamp(),
       user: { id: "u1", username: "vince", displayName: "Vince" },
     };
 
@@ -759,6 +763,42 @@ describe("ChatController", () => {
       content: "hello",
       editedAt: "2026-03-28T00:01:00.000Z",
     });
+  });
+
+  test("refuses to edit after the edit window expires", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const original: ChatMessage = {
+      id: "m1",
+      channelId: "everyone",
+      content: "old typo",
+      replyToId: null,
+      createdAt: recentChatTimestamp(16 * 60_000),
+      user: { id: "u1", username: "vince", displayName: "Vince" },
+    };
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    persistence.setResource(TRANSCRIPT_KIND, TRANSCRIPT_KEY, {
+      messages: [original],
+    }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+    controller.setNotifier((notification) => notifications.push(notification));
+    controller.attachPersistence(persistence);
+    apiClient.editMessage = async () => {
+      throw new Error("should not call server");
+    };
+
+    await expect(controller.editChannelMessage("everyone", "m1", "old fix")).resolves.toBe(false);
+
+    expect(controller.getSnapshot().messages[0]?.content).toBe("old typo");
+    expect(notifications).toEqual([{ body: "Messages can only be edited within 15 minutes.", type: "error" }]);
   });
 
   test("refuses to edit an older message from the current user", async () => {

--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -18,6 +18,7 @@ const originalUpdateChatChannelState = apiClient.updateChatChannelState.bind(api
 const originalMarkChatNotificationsDelivered = apiClient.markChatNotificationsDelivered.bind(apiClient);
 const originalSubscribeChatNotifications = apiClient.subscribeChatNotifications.bind(apiClient);
 const originalSubscribeChatPresence = apiClient.subscribeChatPresence.bind(apiClient);
+const originalEditMessage = apiClient.editMessage.bind(apiClient);
 
 const SERVER_CHAT_CHANNELS: ChatChannel[] = [
   { id: "everyone", name: "everyone", created_at: "2026-03-26T12:10:05.684Z" },
@@ -77,6 +78,7 @@ afterEach(() => {
   apiClient.markChatNotificationsDelivered = originalMarkChatNotificationsDelivered;
   apiClient.subscribeChatNotifications = originalSubscribeChatNotifications;
   apiClient.subscribeChatPresence = originalSubscribeChatPresence;
+  apiClient.editMessage = originalEditMessage;
 });
 
 describe("ChatController", () => {
@@ -715,6 +717,94 @@ describe("ChatController", () => {
 
     detachFirstView();
     detachSecondView();
+  });
+
+  test("edits the latest message from the current user", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const original: ChatMessage = {
+      id: "m1",
+      channelId: "everyone",
+      content: "helo",
+      replyToId: null,
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u1", username: "vince", displayName: "Vince" },
+    };
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    persistence.setResource(TRANSCRIPT_KIND, TRANSCRIPT_KEY, {
+      messages: [original],
+    }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+    controller.attachPersistence(persistence);
+    apiClient.editMessage = async (channelId, messageId, content) => ({
+      ...original,
+      channelId,
+      id: messageId,
+      content,
+      editedAt: "2026-03-28T00:01:00.000Z",
+    });
+
+    await expect(controller.editChannelMessage("everyone", "m1", "hello")).resolves.toBe(true);
+
+    const [edited] = controller.getSnapshot().messages;
+    expect(edited).toMatchObject({
+      id: "m1",
+      content: "hello",
+      editedAt: "2026-03-28T00:01:00.000Z",
+    });
+  });
+
+  test("refuses to edit an older message from the current user", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const messages: ChatMessage[] = [
+      {
+        id: "m1",
+        channelId: "everyone",
+        content: "older",
+        replyToId: null,
+        createdAt: "2026-03-28T00:00:00.000Z",
+        user: { id: "u1", username: "vince", displayName: "Vince" },
+      },
+      {
+        id: "m2",
+        channelId: "everyone",
+        content: "newer",
+        replyToId: null,
+        createdAt: "2026-03-28T00:01:00.000Z",
+        user: { id: "u1", username: "vince", displayName: "Vince" },
+      },
+    ];
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    persistence.setResource(TRANSCRIPT_KIND, TRANSCRIPT_KEY, {
+      messages,
+    }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+    controller.setNotifier((notification) => notifications.push(notification));
+    controller.attachPersistence(persistence);
+    apiClient.editMessage = async () => {
+      throw new Error("should not call server");
+    };
+
+    await expect(controller.editChannelMessage("everyone", "m1", "edited")).resolves.toBe(false);
+
+    expect(controller.getSnapshot().messages.map((message) => message.content)).toEqual(["older", "newer"]);
+    expect(notifications).toEqual([{ body: "Only your latest sent message can be edited.", type: "error" }]);
   });
 
   test("marks a pending message as failed when sending errors", async () => {

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -42,6 +42,10 @@ import {
 import {
   handleChatNotification as handleChatNotificationEvent,
 } from "./notifications";
+import {
+  CHAT_MESSAGE_EDIT_WINDOW_LABEL,
+  isWithinChatMessageEditWindow,
+} from "../edit-window";
 import { ChatControllerRealtime } from "./realtime";
 import { ChatControllerChannels } from "./channels";
 import { ChatControllerView } from "./view";
@@ -382,6 +386,10 @@ export class ChatController {
       ));
     if (!latestOwnMessage || latestOwnMessage.id !== messageId) {
       this.notifyFn({ body: "Only your latest sent message can be edited.", type: "error" });
+      return false;
+    }
+    if (!isWithinChatMessageEditWindow(latestOwnMessage)) {
+      this.notifyFn({ body: `Messages can only be edited within ${CHAT_MESSAGE_EDIT_WINDOW_LABEL}.`, type: "error" });
       return false;
     }
     if (latestOwnMessage.content === messageContent) return true;

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -367,6 +367,38 @@ export class ChatController {
     });
   }
 
+  async editChannelMessage(channelId: string, messageId: string, content: string): Promise<boolean> {
+    const normalizedChannelId = normalizeChannelId(channelId);
+    const channel = this.ensureChannelState(normalizedChannelId);
+    const messageContent = content.trim();
+    if (!messageContent) return false;
+    if (!this.session.user?.emailVerified || !this.session.sessionToken) return false;
+
+    const latestOwnMessage = [...getVisibleMessages(channel)]
+      .reverse()
+      .find((message) => (
+        message.user.id === this.session.user?.id
+        && !message.clientStatus
+      ));
+    if (!latestOwnMessage || latestOwnMessage.id !== messageId) {
+      this.notifyFn({ body: "Only your latest sent message can be edited.", type: "error" });
+      return false;
+    }
+    if (latestOwnMessage.content === messageContent) return true;
+
+    try {
+      const message = await apiClient.editMessage(normalizedChannelId, messageId, messageContent);
+      this.mergeMessages(normalizedChannelId, [message]);
+      return true;
+    } catch (error) {
+      const errorMessage = error instanceof Error && error.message
+        ? error.message
+        : "Failed to edit message.";
+      this.notifyFn({ body: errorMessage, type: "error" });
+      return false;
+    }
+  }
+
   ensureConnection(channelId = DEFAULT_CHAT_CHANNEL_ID): void {
     const normalizedChannelId = normalizeChannelId(channelId);
     const channel = this.ensureChannelState(normalizedChannelId);

--- a/src/plugins/builtin/chat/controller/messages.ts
+++ b/src/plugins/builtin/chat/controller/messages.ts
@@ -30,6 +30,24 @@ function mergeStoredMessages(channel: ChannelRuntimeState, messages: ChatMessage
     }
     merged.set(message.id, message);
   }
+  for (const message of messages) {
+    for (const [id, current] of merged) {
+      if (current.replyToId !== message.id || current.replyTo?.content === message.content) continue;
+      merged.set(id, {
+        ...current,
+        replyTo: current.replyTo
+          ? {
+            ...current.replyTo,
+            content: message.content,
+            user: {
+              id: message.user.id,
+              username: message.user.username ?? current.replyTo.user.username,
+            },
+          }
+          : current.replyTo,
+      });
+    }
+  }
   channel.messages = [...merged.values()]
     .sort(compareMessages);
   channel.lastCursor = channel.messages[channel.messages.length - 1]?.id ?? channel.lastCursor;

--- a/src/plugins/builtin/chat/edit-window.ts
+++ b/src/plugins/builtin/chat/edit-window.ts
@@ -1,0 +1,24 @@
+import type { ChatMessage } from "../../../api-client";
+
+export const CHAT_MESSAGE_EDIT_WINDOW_MS = 15 * 60_000;
+export const CHAT_MESSAGE_EDIT_WINDOW_LABEL = "15 minutes";
+
+export function isWithinChatMessageEditWindow(message: ChatMessage, nowMs = Date.now()): boolean {
+  const createdMs = Date.parse(message.createdAt);
+  return Number.isFinite(createdMs) && nowMs - createdMs <= CHAT_MESSAGE_EDIT_WINDOW_MS;
+}
+
+export function findLatestEditableChatMessage(
+  messages: ChatMessage[],
+  userId: string | null | undefined,
+  nowMs = Date.now(),
+): ChatMessage | null {
+  if (!userId) return null;
+  return [...messages]
+    .reverse()
+    .find((message) => (
+      message.user.id === userId
+      && !message.clientStatus
+      && isWithinChatMessageEditWindow(message, nowMs)
+    )) ?? null;
+}

--- a/src/plugins/builtin/chat/message/action-chip.tsx
+++ b/src/plugins/builtin/chat/message/action-chip.tsx
@@ -25,6 +25,7 @@ export function ChatActionChip({
       height={1}
       backgroundColor={emphasized ? colors.borderFocused : colors.panel}
       onMouseDown={handlePress}
+      style={{ cursor: "pointer" }}
     >
       <Text
         fg={emphasized ? colors.bg : colors.text}

--- a/src/plugins/builtin/chat/message/desktop.tsx
+++ b/src/plugins/builtin/chat/message/desktop.tsx
@@ -22,14 +22,20 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
   onUserHover,
   onUserHoverEnd,
   beginReplyTo,
+  beginEditMessage,
   jumpToMessage,
+  latestEditableMessageId,
   registerMessageElement,
 }: ChatMessageBaseProps & {
   registerMessageElement: (messageId: string, node: unknown | null) => void;
 }) {
   const state = getChatMessageRenderState({ msg, index, messages, selectedIdx, hoveredIdx, canSend });
+  const canEditMessage = msg.id === latestEditableMessageId;
   const showInlineReplyAction = !state.grouped && canSend;
+  const showInlineEditAction = !state.grouped && canSend && canEditMessage;
   const showGroupedReplyAction = state.grouped && canSend;
+  const showGroupedEditAction = state.grouped && canSend && canEditMessage;
+  const groupedActionWidth = MESSAGE_ACTION_WIDTH * Number(showGroupedReplyAction) + MESSAGE_ACTION_WIDTH * Number(showGroupedEditAction);
   const rowProps = {
     width: "100%",
     paddingRight: DESKTOP_MESSAGE_RIGHT_PADDING,
@@ -98,21 +104,37 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
             {msg.user.username ?? "anon"}
           </Text>
           <Text fg={state.headerStatusColor}> {state.headerStatus}</Text>
-          {showInlineReplyAction && (
+          {(showInlineReplyAction || showInlineEditAction) && (
             <>
               <Text fg={state.headerStatusColor}> </Text>
-              <Box
-                width={MESSAGE_ACTION_WIDTH}
-                height={1}
-                data-gloom-role="chat-message-reply-action"
-              >
-                <ChatActionChip
-                  label="Reply"
+              {showInlineReplyAction && (
+                <Box
                   width={MESSAGE_ACTION_WIDTH}
-                  emphasized={state.isSelected}
-                  onPress={() => beginReplyTo(index)}
-                />
-              </Box>
+                  height={1}
+                  data-gloom-role="chat-message-reply-action"
+                >
+                  <ChatActionChip
+                    label="Reply"
+                    width={MESSAGE_ACTION_WIDTH}
+                    emphasized={state.isSelected}
+                    onPress={() => beginReplyTo(index)}
+                  />
+                </Box>
+              )}
+              {showInlineEditAction && (
+                <Box
+                  width={MESSAGE_ACTION_WIDTH}
+                  height={1}
+                  data-gloom-role="chat-message-reply-action"
+                >
+                  <ChatActionChip
+                    label="Edit"
+                    width={MESSAGE_ACTION_WIDTH}
+                    emphasized={state.isSelected}
+                    onPress={() => beginEditMessage(index)}
+                  />
+                </Box>
+              )}
             </>
           )}
         </Box>
@@ -135,21 +157,32 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
             onUserHoverEnd={onUserHoverEnd}
           />
         </Box>
-        {showGroupedReplyAction && (
+        {(showGroupedReplyAction || showGroupedEditAction) && (
           <Box
             position="absolute"
             top={0}
             right={0}
-            width={MESSAGE_ACTION_WIDTH}
+            width={groupedActionWidth}
             height={1}
+            flexDirection="row"
             data-gloom-role="chat-message-reply-action"
           >
-            <ChatActionChip
-              label="Reply"
-              width={MESSAGE_ACTION_WIDTH}
-              emphasized={state.isSelected}
-              onPress={() => beginReplyTo(index)}
-            />
+            {showGroupedReplyAction && (
+              <ChatActionChip
+                label="Reply"
+                width={MESSAGE_ACTION_WIDTH}
+                emphasized={state.isSelected}
+                onPress={() => beginReplyTo(index)}
+              />
+            )}
+            {showGroupedEditAction && (
+              <ChatActionChip
+                label="Edit"
+                width={MESSAGE_ACTION_WIDTH}
+                emphasized={state.isSelected}
+                onPress={() => beginEditMessage(index)}
+              />
+            )}
           </Box>
         )}
       </Box>

--- a/src/plugins/builtin/chat/message/render-state.ts
+++ b/src/plugins/builtin/chat/message/render-state.ts
@@ -41,7 +41,11 @@ export function getChatMessageRenderState({
   const isSending = msg.clientStatus === "sending";
   const hasFailed = msg.clientStatus === "failed";
   const selectedTextColor = hasFailed ? colors.negative : colors.selectedText;
-  const headerStatus = isSending ? "sending..." : hasFailed ? "failed" : formatTimeAgo(msg.createdAt);
+  const headerStatus = isSending
+    ? "sending..."
+    : hasFailed
+      ? "failed"
+      : `${formatTimeAgo(msg.createdAt)}${msg.editedAt ? " edited" : ""}`;
 
   return {
     isSelected,

--- a/src/plugins/builtin/chat/message/terminal.tsx
+++ b/src/plugins/builtin/chat/message/terminal.tsx
@@ -26,13 +26,19 @@ export function TerminalChatMessage({
   onUserHover,
   onUserHoverEnd,
   beginReplyTo,
+  beginEditMessage,
   jumpToMessage,
+  latestEditableMessageId,
   setHoveredIdx,
 }: TerminalChatMessageProps) {
   const state = getChatMessageRenderState({ msg, index, messages, selectedIdx, hoveredIdx, canSend });
   const bodyLines = getMessageBodyLines(msg, contentWidth, catalog);
+  const canEditMessage = msg.id === latestEditableMessageId;
   const showInlineReplyAction = !state.grouped && state.showReplyAction;
+  const showInlineEditAction = !state.grouped && state.showReplyAction && canEditMessage;
   const showGroupedReplyAction = state.grouped && state.showReplyAction;
+  const showGroupedEditAction = state.grouped && state.showReplyAction && canEditMessage;
+  const groupedActionWidth = MESSAGE_ACTION_WIDTH * Number(showGroupedReplyAction) + MESSAGE_ACTION_WIDTH * Number(showGroupedEditAction);
   const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));
   const clearHovered = () => setHoveredIdx((current) => (current === index ? null : current));
   const messageRowProps = {
@@ -80,17 +86,29 @@ export function TerminalChatMessage({
             {msg.user.username ?? "anon"}
           </Text>
           <Text fg={state.headerStatusColor}> {state.headerStatus}</Text>
-          {showInlineReplyAction && (
+          {(showInlineReplyAction || showInlineEditAction) && (
             <>
               <Text fg={state.headerStatusColor}> </Text>
-              <Box width={MESSAGE_ACTION_WIDTH} height={1}>
-                <ChatActionChip
-                  label="Reply"
-                  width={MESSAGE_ACTION_WIDTH}
-                  emphasized={state.isSelected}
-                  onPress={() => beginReplyTo(index)}
-                />
-              </Box>
+              {showInlineReplyAction && (
+                <Box width={MESSAGE_ACTION_WIDTH} height={1}>
+                  <ChatActionChip
+                    label="Reply"
+                    width={MESSAGE_ACTION_WIDTH}
+                    emphasized={state.isSelected}
+                    onPress={() => beginReplyTo(index)}
+                  />
+                </Box>
+              )}
+              {showInlineEditAction && (
+                <Box width={MESSAGE_ACTION_WIDTH} height={1}>
+                  <ChatActionChip
+                    label="Edit"
+                    width={MESSAGE_ACTION_WIDTH}
+                    emphasized={state.isSelected}
+                    onPress={() => beginEditMessage(index)}
+                  />
+                </Box>
+              )}
             </>
           )}
         </Box>
@@ -115,14 +133,24 @@ export function TerminalChatMessage({
               onUserHoverEnd={onUserHoverEnd}
             />
           </Box>
-          {lineIndex === 0 && showGroupedReplyAction && (
-            <Box position="absolute" top={0} right={0} width={MESSAGE_ACTION_WIDTH} height={1}>
-              <ChatActionChip
-                label="Reply"
-                width={MESSAGE_ACTION_WIDTH}
-                emphasized={state.isSelected}
-                onPress={() => beginReplyTo(index)}
-              />
+          {lineIndex === 0 && (showGroupedReplyAction || showGroupedEditAction) && (
+            <Box position="absolute" top={0} right={0} width={groupedActionWidth} height={1} flexDirection="row">
+              {showGroupedReplyAction && (
+                <ChatActionChip
+                  label="Reply"
+                  width={MESSAGE_ACTION_WIDTH}
+                  emphasized={state.isSelected}
+                  onPress={() => beginReplyTo(index)}
+                />
+              )}
+              {showGroupedEditAction && (
+                <ChatActionChip
+                  label="Edit"
+                  width={MESSAGE_ACTION_WIDTH}
+                  emphasized={state.isSelected}
+                  onPress={() => beginEditMessage(index)}
+                />
+              )}
             </Box>
           )}
         </Box>

--- a/src/plugins/builtin/chat/message/types.ts
+++ b/src/plugins/builtin/chat/message/types.ts
@@ -14,5 +14,7 @@ export interface ChatMessageBaseProps {
   onUserHover: (user: ChatUserSummary) => void;
   onUserHoverEnd: () => void;
   beginReplyTo: (index: number, options?: { deferFocus?: boolean }) => void;
+  beginEditMessage: (index: number, options?: { deferFocus?: boolean }) => boolean;
   jumpToMessage: (messageId: string) => void;
+  latestEditableMessageId: string | null;
 }

--- a/src/plugins/builtin/chat/test-harness.tsx
+++ b/src/plugins/builtin/chat/test-harness.tsx
@@ -20,6 +20,7 @@ const originalConnectChannel = apiClient.connectChannel.bind(apiClient);
 const originalGetChannels = apiClient.getChannels.bind(apiClient);
 const originalGetChatPresence = apiClient.getChatPresence.bind(apiClient);
 const originalUpdateChatChannelState = apiClient.updateChatChannelState.bind(apiClient);
+const originalEditMessage = apiClient.editMessage.bind(apiClient);
 
 export type ChatTestSetup = Awaited<ReturnType<typeof testRender>>;
 
@@ -50,6 +51,7 @@ export async function cleanupChatTest(testSetup: ChatTestSetup | undefined): Pro
   apiClient.getChannels = originalGetChannels;
   apiClient.getChatPresence = originalGetChatPresence;
   apiClient.updateChatChannelState = originalUpdateChatChannelState;
+  apiClient.editMessage = originalEditMessage;
   apiClient.setSessionToken(null);
 
   if (testSetup) {

--- a/src/renderers/electrobun/view/host/input.tsx
+++ b/src/renderers/electrobun/view/host/input.tsx
@@ -53,6 +53,15 @@ function callTextHandler(handler: unknown, value: string): void {
   }
 }
 
+function applyDomCursorOffset(
+  element: HTMLInputElement | HTMLTextAreaElement | null,
+  offset: number,
+) {
+  if (!element) return;
+  const clampedOffset = Math.max(0, Math.min(offset, element.value.length));
+  element.setSelectionRange(clampedOffset, clampedOffset);
+}
+
 function useEditableValue(props: Record<string, unknown>) {
   const controlledValue = getStringProp(props, "value");
   const [internalValue, setInternalValue] = useState(getStringProp(props, "initialValue") ?? "");
@@ -142,6 +151,11 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
   const elementRef = useRef<HTMLInputElement | null>(null);
   const { value, valueRef, setValue } = useEditableValue(props);
   const [cursorOffset, setCursorOffset] = useState(value.length);
+  const applyCursorOffset = (offset: number) => {
+    setCursorOffset(offset);
+    queueMicrotask(() => applyDomCursorOffset(elementRef.current, offset));
+    globalThis.requestAnimationFrame?.(() => applyDomCursorOffset(elementRef.current, offset));
+  };
 
   useEffect(() => {
     if (props.focused === true) {
@@ -157,8 +171,9 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
     get cursorOffset() {
       return cursorOffset;
     },
+    setCursorOffset: applyCursorOffset,
     focus: () => elementRef.current?.focus(),
-  }), [cursorOffset, setValue, valueRef]);
+  }), [applyCursorOffset, cursorOffset, setValue, valueRef]);
 
   const handleValueChange = (nextValue: string) => {
     setValue(nextValue);
@@ -207,6 +222,11 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
   const elementRef = useRef<HTMLTextAreaElement | null>(null);
   const { value, valueRef, setValue } = useEditableValue(props);
   const [cursorOffset, setCursorOffset] = useState(value.length);
+  const applyCursorOffset = (offset: number) => {
+    setCursorOffset(offset);
+    queueMicrotask(() => applyDomCursorOffset(elementRef.current, offset));
+    globalThis.requestAnimationFrame?.(() => applyDomCursorOffset(elementRef.current, offset));
+  };
 
   useEffect(() => {
     if (props.focused === true) {
@@ -222,6 +242,7 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
     get cursorOffset() {
       return cursorOffset;
     },
+    setCursorOffset: applyCursorOffset,
     get virtualLineCount() {
       const metrics = textareaMetrics(
         valueRef.current,
@@ -248,7 +269,7 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
     syntaxStyle: null,
     addHighlight: () => {},
     clearLineHighlights: () => {},
-  }), [cursorOffset, props, setValue, valueRef]);
+  }), [applyCursorOffset, cursorOffset, props, setValue, valueRef]);
 
   const handleValueChange = (nextValue: string) => {
     setValue(nextValue);

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -122,6 +122,7 @@ export interface ScrollBoxRenderable {
 export interface InputRenderable {
   editBuffer: TextEditBuffer;
   cursorOffset?: number;
+  setCursorOffset?(offset: number): void;
   focus?(): void;
 }
 


### PR DESCRIPTION
Adds chat message editing for the current user's latest sent message from the composer with ArrowUp or the inline Edit action. Edits are limited to a 15-minute window, keep the cursor at the end when editing starts, and show an edited marker in the transcript. The client sends edits through the chat API and merges updated reply previews so quoted content stays current.