### PR TITLE
Fix desktop data table resize crash

### DIFF
--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -145,15 +145,16 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     const nextValue = element ? toCellX(element.clientWidth) : 0;
     setViewportWidth((current) => current === nextValue ? current : nextValue);
   }, []);
+  const scheduleViewportWidthMeasure = useRafCallback(measureViewportWidth);
 
   useEffect(() => {
     measureViewportWidth();
     const element = bodyElementRef.current;
     if (!element || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(measureViewportWidth);
+    const observer = new ResizeObserver(scheduleViewportWidthMeasure);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [measureViewportWidth]);
+  }, [measureViewportWidth, scheduleViewportWidthMeasure]);
 
   useEffect(() => {
     if (scrollToIndex == null || items.length === 0) return;


### PR DESCRIPTION
Defers desktop data-table width measurement from the ResizeObserver callback into the next animation frame.

This keeps horizontal overflow recalculation intact while avoiding the ResizeObserver delivery loop notification that could surface as a desktop crash during window resizing.