### PR TITLE
Fix chat conversation notification labels

### DIFF
--- a/src/plugins/builtin/chat/channel-labels.ts
+++ b/src/plugins/builtin/chat/channel-labels.ts
@@ -1,0 +1,53 @@
+import type { ChatChannel } from "../../../api-client";
+import { normalizeChannelId } from "./controller/state";
+
+function normalizeMentionUsername(username: string | null | undefined): string | null {
+  const normalized = username?.trim().replace(/^@+/, "");
+  return normalized || null;
+}
+
+function formatMentionUsername(username: string | null | undefined): string | null {
+  const normalized = normalizeMentionUsername(username);
+  return normalized ? `@${normalized}` : null;
+}
+
+function formatDirectChannelLabel(channel: ChatChannel, fallbackId: string) {
+  const usernameLabel = formatMentionUsername(channel.dmUser?.username);
+  if (usernameLabel) return usernameLabel;
+
+  const displayName = channel.dmUser?.displayName?.trim();
+  if (displayName) return displayName;
+
+  const channelName = channel.name?.trim();
+  if (channelName && channelName !== channel.id) {
+    return channelName.startsWith("@")
+      ? formatMentionUsername(channelName) ?? channelName
+      : channelName;
+  }
+
+  return fallbackId.startsWith("dm:") ? "DM" : fallbackId;
+}
+
+export function formatChannelLabel(channel: ChatChannel | undefined, fallbackId: string) {
+  if (!channel) return fallbackId;
+  if (channel.kind === "direct") {
+    return formatDirectChannelLabel(channel, fallbackId);
+  }
+  if (channel.kind === "group") {
+    return channel.name?.trim() || "Group";
+  }
+  return channel.name?.trim() || fallbackId;
+}
+
+export function formatChatPaneTitle(channel: ChatChannel | undefined, fallbackId: string) {
+  const normalizedFallbackId = normalizeChannelId(fallbackId);
+  if (channel?.kind === "direct") {
+    return formatChannelLabel(channel, normalizedFallbackId);
+  }
+  if (channel?.kind === "group") {
+    return formatChannelLabel(channel, normalizedFallbackId);
+  }
+  if (!channel && normalizedFallbackId.startsWith("dm:")) return "DM";
+  if (!channel && (normalizedFallbackId.startsWith("grp:") || normalizedFallbackId.startsWith("group:"))) return "Group";
+  return `#${formatChannelLabel(channel, normalizedFallbackId)}`;
+}

--- a/src/plugins/builtin/chat/channels.test.ts
+++ b/src/plugins/builtin/chat/channels.test.ts
@@ -21,4 +21,8 @@ describe("chat channel labels", () => {
     expect(formatChatPaneTitle(channel, channel.id)).toBe("@risto");
     expect(formatChatPaneTitle(undefined, channel.id)).toBe("DM");
   });
+
+  test("uses a neutral group title before private channel metadata loads", () => {
+    expect(formatChatPaneTitle(undefined, "grp:93f14c6b9827c30f")).toBe("Group");
+  });
 });

--- a/src/plugins/builtin/chat/channels.ts
+++ b/src/plugins/builtin/chat/channels.ts
@@ -2,6 +2,9 @@ import type { CommandResultDef, GloomPluginContext } from "../../../types/plugin
 import type { ChatChannel, ChatChannelState } from "../../../api-client";
 import type { AppConfig, PaneInstanceConfig } from "../../../types/config";
 import { chatController } from "./controller";
+import { formatChannelLabel } from "./channel-labels";
+
+export { formatChannelLabel, formatChatPaneTitle } from "./channel-labels";
 
 export const DEFAULT_CHAT_CHANNEL_ID = "everyone";
 export const LAST_VISITED_CHAT_CHANNEL_KEY = "lastChatChannelId";
@@ -44,57 +47,6 @@ export function getPreferredChatOpenChannelId(
     return kind === "direct" || kind === "group";
   });
   return normalizeChannelId(unreadConversation?.channelId ?? unreadStates[0]?.channelId ?? getLastVisitedChatChannelId(config));
-}
-
-function normalizeMentionUsername(username: string | null | undefined): string | null {
-  const normalized = username?.trim().replace(/^@+/, "");
-  return normalized || null;
-}
-
-function formatMentionUsername(username: string | null | undefined): string | null {
-  const normalized = normalizeMentionUsername(username);
-  return normalized ? `@${normalized}` : null;
-}
-
-function formatDirectChannelLabel(channel: ChatChannel, fallbackId: string) {
-  const usernameLabel = formatMentionUsername(channel.dmUser?.username);
-  if (usernameLabel) return usernameLabel;
-
-  const displayName = channel.dmUser?.displayName?.trim();
-  if (displayName) return displayName;
-
-  const channelName = channel.name?.trim();
-  if (channelName && channelName !== channel.id) {
-    return channelName.startsWith("@")
-      ? formatMentionUsername(channelName) ?? channelName
-      : channelName;
-  }
-
-  return fallbackId.startsWith("dm:") ? "DM" : fallbackId;
-}
-
-export function formatChannelLabel(channel: ChatChannel | undefined, fallbackId: string) {
-  if (!channel) return fallbackId;
-  if (channel.kind === "direct") {
-    return formatDirectChannelLabel(channel, fallbackId);
-  }
-  if (channel.kind === "group") {
-    return channel.name?.trim() || "Group";
-  }
-  return channel.name?.trim() || fallbackId;
-}
-
-export function formatChatPaneTitle(channel: ChatChannel | undefined, fallbackId: string) {
-  const normalizedFallbackId = normalizeChannelId(fallbackId);
-  if (channel?.kind === "direct") {
-    return formatChannelLabel(channel, normalizedFallbackId);
-  }
-  if (channel?.kind === "group") {
-    return formatChannelLabel(channel, normalizedFallbackId);
-  }
-  if (!channel && normalizedFallbackId.startsWith("dm:")) return "DM";
-  if (!channel && normalizedFallbackId.startsWith("group:")) return "Group";
-  return `#${formatChannelLabel(channel, normalizedFallbackId)}`;
 }
 
 function conversationDetail(channel: ChatChannel): string {

--- a/src/plugins/builtin/chat/chat.test.tsx
+++ b/src/plugins/builtin/chat/chat.test.tsx
@@ -9,7 +9,7 @@ import type { ChatMessage } from "../../../api-client";
 import { apiClient } from "../../../api-client";
 import { PluginRenderProvider } from "../../runtime";
 import { setSharedRegistryForTests } from "../../registry";
-import { ChatStatusWidget } from ".";
+import { ChatContent, ChatStatusWidget } from ".";
 import {
   cleanupChatTest,
   createChatTestControls,
@@ -55,6 +55,42 @@ afterEach(async () => {
 });
 
 describe("ChatContent", () => {
+  test("keeps a persisted DM selected while private channels refresh", async () => {
+    const controller = createController();
+    const dmChannelId = "dm:test";
+    installServerChannels(controller, [
+      { id: "everyone", name: "everyone", created_at: "2026-03-26T12:10:05.684Z" },
+    ]);
+    controller.refreshChannels = async () => {};
+    controller.refreshPresence = async () => {};
+    controller.refreshSession = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    const channelChanges: string[] = [];
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
+
+    await act(async () => {
+      testSetup = await testRender(
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PluginRenderProvider pluginId="gloomberb-cloud" runtime={createTestPluginRuntime()}>
+            <ChatContent
+              controller={controller}
+              width={60}
+              height={12}
+              focused
+              channelId={dmChannelId}
+              onChannelChange={(nextChannelId) => channelChanges.push(nextChannelId)}
+            />
+          </PluginRenderProvider>
+        </AppContext>,
+        { width: 60, height: 12 },
+      );
+    });
+
+    await flushFrame();
+
+    expect(channelChanges).toEqual([]);
+  });
+
   test("focuses the prompt on click and preserves typing order", async () => {
     const controller = createController();
 

--- a/src/plugins/builtin/chat/content/channel-navigation.ts
+++ b/src/plugins/builtin/chat/content/channel-navigation.ts
@@ -7,6 +7,10 @@ import {
 } from "../channels";
 import type { ChatContentController } from "./types";
 
+function isConversationChannelId(channelId: string): boolean {
+  return channelId.startsWith("dm:") || channelId.startsWith("grp:") || channelId.startsWith("group:");
+}
+
 export function useChatChannelNavigation({
   blurInput,
   channelId,
@@ -83,6 +87,8 @@ export function useChatChannelNavigation({
   useEffect(() => {
     if (!onChannelChange || channelsLoading || channels.length === 0) return;
     if (channels.some((channel) => channel.id === channelId)) return;
+    // DM/group panes can remount before the private channel catalog is refreshed.
+    if (isConversationChannelId(channelId)) return;
     const fallbackChannelId = channels.find((channel) => channel.id === DEFAULT_CHAT_CHANNEL_ID)?.id
       ?? channels[0]?.id;
     if (fallbackChannelId) {

--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -1219,6 +1219,65 @@ describe("ChatController", () => {
     }]);
   });
 
+  test("uses direct channel labels in server-issued notification subtitles", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const directChannel: ChatChannel = {
+      id: "dm:u2",
+      name: "u2",
+      kind: "direct",
+      created_at: "2026-03-28T00:00:00.000Z",
+      dmUser: { id: "u2", username: "bob", displayName: "Bob" },
+    };
+    const message: ChatMessage = {
+      id: "m1",
+      channelId: directChannel.id,
+      content: "ping",
+      replyToId: null,
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u2", username: "bob", displayName: "Bob" },
+    };
+
+    apiClient.getChatState = async () => ({
+      channels: [...SERVER_CHAT_CHANNELS, directChannel],
+      onlineCount: 0,
+      channelStates: [...SERVER_CHAT_CHANNELS, directChannel].map((channel) => ({
+        channelId: channel.id,
+        notificationsEnabled: false,
+        lastReadMessageId: null,
+        unreadCount: 0,
+      })),
+      notifications: [],
+    });
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    controller.setNotifier((entry) => {
+      notifications.push(entry);
+    });
+    controller.attachPersistence(persistence);
+    await controller.refreshChatState();
+
+    (controller as any).handleChatNotification({
+      id: "n1",
+      type: "channel",
+      channelId: directChannel.id,
+      messageId: "m1",
+      createdAt: "2026-03-28T00:00:00.000Z",
+      message,
+    } satisfies ChatNotification);
+
+    expect(notifications).toEqual([{
+      title: "Gloomberb chat",
+      subtitle: "@bob",
+      body: "@bob: ping",
+      type: "info",
+      desktop: "when-inactive",
+    }]);
+  });
+
   test("tracks unread channel messages and clears them when the channel opens", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -491,6 +491,7 @@ export class ChatController {
       options,
       ensureChannelState: (channelId) => this.ensureChannelState(channelId),
       mergeMessages: (channelId, messages, mergeOptions) => this.mergeMessages(channelId, messages, mergeOptions),
+      getChannel: (channelId) => this.channelCatalog.getChannels().find((channel) => channel.id === channelId),
       notifiedMessageIds: this.notifiedMessageIds,
       notify: this.notifyFn,
     });

--- a/src/plugins/builtin/chat/controller/notifications.ts
+++ b/src/plugins/builtin/chat/controller/notifications.ts
@@ -1,6 +1,7 @@
 import type { AppNotificationRequest } from "../../../../types/plugin";
-import { apiClient, type ChatMessage, type ChatNotification } from "../../../../api-client";
+import { apiClient, type ChatChannel, type ChatMessage, type ChatNotification } from "../../../../api-client";
 import type { ChannelRuntimeState, MergeMessagesOptions } from "./state";
+import { formatChatPaneTitle } from "../channel-labels";
 import {
   formatChannelToast,
   formatMentionToast,
@@ -9,23 +10,26 @@ import {
 
 function notifyChatServerMessage({
   notification,
+  channel,
   notifiedMessageIds,
   notify,
 }: {
   notification: ChatNotification;
+  channel: ChatChannel | undefined;
   notifiedMessageIds: Set<string>;
   notify: (notification: AppNotificationRequest) => void;
 }): void {
   if (notifiedMessageIds.has(notification.messageId)) return;
   notifiedMessageIds.add(notification.messageId);
+  const channelTitle = formatChatPaneTitle(channel, notification.channelId);
   const body = notification.type === "reply"
     ? formatReplyToast(notification.message)
     : notification.type === "mention"
       ? formatMentionToast(notification.message)
-      : formatChannelToast(notification.channelId, notification.message);
+      : formatChannelToast(channelTitle, notification.message, channel?.kind);
   notify({
     title: "Gloomberb chat",
-    subtitle: `#${notification.channelId}`,
+    subtitle: channelTitle,
     body,
     type: "info",
     desktop: "when-inactive",
@@ -37,6 +41,7 @@ export function handleChatNotification({
   options = {},
   ensureChannelState,
   mergeMessages,
+  getChannel,
   notifiedMessageIds,
   notify,
 }: {
@@ -44,13 +49,14 @@ export function handleChatNotification({
   options?: { countUnread?: boolean };
   ensureChannelState: (channelId: string) => ChannelRuntimeState;
   mergeMessages: (channelId: string, messages: ChatMessage[], options?: MergeMessagesOptions) => void;
+  getChannel: (channelId: string) => ChatChannel | undefined;
   notifiedMessageIds: Set<string>;
   notify: (notification: AppNotificationRequest) => void;
 }): void {
   mergeMessages(notification.channelId, [notification.message], { countUnread: options.countUnread });
   const channel = ensureChannelState(notification.channelId);
   if (channel.openViewCount === 0) {
-    notifyChatServerMessage({ notification, notifiedMessageIds, notify });
+    notifyChatServerMessage({ notification, channel: getChannel(notification.channelId), notifiedMessageIds, notify });
   }
   void apiClient.markChatNotificationsDelivered([notification.id]).catch(() => {});
 }

--- a/src/plugins/builtin/chat/controller/utils.ts
+++ b/src/plugins/builtin/chat/controller/utils.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from "../../../../api-client";
+import type { ChatChannel, ChatMessage } from "../../../../api-client";
 
 const ISO_TIMESTAMP_CURSOR = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
 const USERNAME_MENTION = /(^|[^A-Za-z0-9_])@([A-Za-z][A-Za-z0-9_]{2,29})(?![A-Za-z0-9_])/g;
@@ -42,10 +42,13 @@ export function formatReplyToast(message: ChatMessage): string {
   return `@${author} replied to you: ${snippet}`;
 }
 
-export function formatChannelToast(channelId: string, message: ChatMessage): string {
+export function formatChannelToast(channelTitle: string, message: ChatMessage, channelKind?: ChatChannel["kind"]): string {
   const author = message.user.username || "Someone";
   const snippet = formatMessageSnippet(message.content);
-  return snippet ? `#${channelId} @${author}: ${snippet}` : `#${channelId} @${author} sent a message.`;
+  if (channelKind === "direct") {
+    return snippet ? `@${author}: ${snippet}` : `@${author} sent a message.`;
+  }
+  return snippet ? `${channelTitle} @${author}: ${snippet}` : `${channelTitle} @${author} sent a message.`;
 }
 
 export function isLegacyTimestampCursor(cursor: string | null): boolean {


### PR DESCRIPTION
Chat notifications now resolve direct and group conversations through the shared channel label formatter before rendering toast or desktop copy, so raw `dm:`/`grp:` IDs are not exposed.
The same formatter is used for pane titles and notification subtitles, with neutral DM/Group fallbacks until private channel metadata loads.
Persisted conversation panes also stay on their DM/group channel during the private channel refresh instead of snapping back to a public channel.
