### PR TITLE
Fix comparison chart gaps across market hours

### DIFF
--- a/src/components/chart/comparison/data.test.ts
+++ b/src/components/chart/comparison/data.test.ts
@@ -57,6 +57,60 @@ describe("projectComparisonChartData", () => {
     expect(projection.series[1]?.points.map((point) => point.rawValue)).toEqual([null, null, 20, 22]);
   });
 
+  test("carries the latest series value across shared timestamps from other markets", () => {
+    const projection = projectComparisonChartData([
+      makeSeries("DAX", "EUR", [
+        ["2024-01-02T08:00:00.000Z", 100],
+        ["2024-01-02T08:15:00.000Z", 101],
+        ["2024-01-03T08:00:00.000Z", 102],
+      ]),
+      makeSeries("AAPL", "USD", [
+        ["2024-01-02T14:30:00.000Z", 200],
+        ["2024-01-02T14:45:00.000Z", 201],
+      ]),
+    ], 8, {
+      panOffset: 0,
+      zoomLevel: 1,
+      renderMode: "line",
+    }, "price");
+
+    expect(projection.dates.map((date) => date.toISOString())).toEqual([
+      "2024-01-02T08:00:00.000Z",
+      "2024-01-02T08:15:00.000Z",
+      "2024-01-02T14:30:00.000Z",
+      "2024-01-02T14:45:00.000Z",
+      "2024-01-03T08:00:00.000Z",
+    ]);
+    expect(projection.series[0]?.points.map((point) => point.rawValue)).toEqual([100, 101, 101, 101, 102]);
+    expect(projection.series[1]?.points.map((point) => point.rawValue)).toEqual([null, null, 200, 201, 201]);
+  });
+
+  test("uses the same alternating close bucket selection as stock chart projection", () => {
+    const projection = projectComparisonChartData([
+      makeSeries("DAX", "EUR", [
+        ["2024-01-02T08:00:00.000Z", 100],
+        ["2024-01-02T08:15:00.000Z", 105],
+        ["2024-01-02T14:30:00.000Z", 101],
+        ["2024-01-02T14:45:00.000Z", 99],
+      ]),
+      makeSeries("AAPL", "USD", [
+        ["2024-01-02T14:30:00.000Z", 200],
+        ["2024-01-02T14:45:00.000Z", 201],
+      ]),
+    ], 2, {
+      panOffset: 0,
+      zoomLevel: 1,
+      renderMode: "line",
+    }, "price");
+
+    expect(projection.dates.map((date) => date.toISOString())).toEqual([
+      "2024-01-02T08:15:00.000Z",
+      "2024-01-02T14:45:00.000Z",
+    ]);
+    expect(projection.series[0]?.points.map((point) => point.rawValue)).toEqual([105, 99]);
+    expect(projection.series[1]?.points.map((point) => point.rawValue)).toEqual([null, 200]);
+  });
+
   test("normalizes percent mode from each series first visible point", () => {
     const projection = projectComparisonChartData([
       makeSeries("AAPL", "USD", [

--- a/src/components/chart/comparison/data.ts
+++ b/src/components/chart/comparison/data.ts
@@ -7,6 +7,11 @@ import type {
 } from "../core/types";
 import { buildVisibleDateWindowFromRange } from "../core/date-window";
 import { getVisiblePointCount } from "../core/viewport";
+import {
+  buildIndexProjectionBuckets,
+  selectRepresentativeCloseValue,
+  type IndexProjectionBucket,
+} from "../core/projection";
 
 export interface ComparisonProjectedPoint {
   date: Date;
@@ -37,6 +42,14 @@ interface ComparisonAxisModeResolution {
   effectiveAxisMode: ChartAxisMode;
   warning: string | null;
 }
+
+type ComparisonWindowViewState =
+  Pick<ComparisonChartViewState, "panOffset" | "zoomLevel">
+  & Partial<Pick<ComparisonChartViewState, "dateWindow">>;
+
+type ComparisonProjectionViewState =
+  ComparisonWindowViewState
+  & Pick<ComparisonChartViewState, "renderMode">;
 
 export interface ComparisonChartProjection {
   dates: Date[];
@@ -92,7 +105,7 @@ export function getMaxComparisonPanOffset(
 
 export function getVisibleComparisonWindow(
   series: ComparisonChartSeries[],
-  viewState: Pick<ComparisonChartViewState, "dateWindow" | "panOffset" | "zoomLevel">,
+  viewState: ComparisonWindowViewState,
 ): ComparisonVisibleWindow {
   const dates = getUniqueSortedDates(series);
 
@@ -138,10 +151,7 @@ function transformRawValue(rawValue: number | null, axisMode: ChartAxisMode, bas
 }
 
 function resolveRepresentativeValue(values: number[], index: number): number {
-  if (values.length === 1) return values[0]!;
-  return index % 2 === 0
-    ? Math.max(...values)
-    : Math.min(...values);
+  return selectRepresentativeCloseValue(values, index, (value) => value);
 }
 
 function buildSeriesMap(points: PricePoint[]): Map<number, number> {
@@ -153,6 +163,28 @@ function buildSeriesMap(points: PricePoint[]): Map<number, number> {
     map.set(timestamp, point.close);
   }
   return map;
+}
+
+function buildFilledRawValuesByDate(
+  rawByDate: ReadonlyMap<number, number>,
+  dates: readonly Date[],
+): Array<number | null> {
+  let latestRawValue: number | null = null;
+  return dates.map((date) => {
+    const timestamp = date.getTime();
+    if (rawByDate.has(timestamp)) {
+      latestRawValue = rawByDate.get(timestamp)!;
+      return latestRawValue;
+    }
+    return latestRawValue;
+  });
+}
+
+function getBucketDate(
+  dates: readonly Date[],
+  bucket: IndexProjectionBucket,
+): Date {
+  return dates[Math.max(bucket.end - 1, 0)] ?? dates[dates.length - 1] ?? new Date(0);
 }
 
 function resolveComparisonAxisMode(
@@ -194,7 +226,7 @@ function resolveComparisonAxisMode(
 export function projectComparisonChartData(
   series: ComparisonChartSeries[],
   chartWidth: number,
-  viewState: Pick<ComparisonChartViewState, "dateWindow" | "panOffset" | "zoomLevel" | "renderMode">,
+  viewState: ComparisonProjectionViewState,
   requestedAxisMode: ChartAxisMode,
 ): ComparisonChartProjection {
   const normalizedSeries = series.map((entry) => ({ ...entry, points: normalizeSeriesPoints(entry.points) }));
@@ -221,31 +253,26 @@ export function projectComparisonChartData(
       warning: axisResolution.warning,
     };
   }
-  const bucketCount = Math.min(Math.max(chartWidth, 1), Math.max(window.dates.length, 1));
-  const bucketSize = window.dates.length > 0 ? window.dates.length / bucketCount : 1;
+  const buckets = buildIndexProjectionBuckets(window.dates.length, chartWidth);
 
   const projectedSeries = normalizedSeries.map((entry) => {
     const rawByDate = buildSeriesMap(entry.points);
-    const visibleRawValues = window.dates
-      .map((date) => rawByDate.get(date.getTime()) ?? null)
+    const filledRawValues = buildFilledRawValuesByDate(rawByDate, window.dates);
+    const visibleRawValues = filledRawValues
       .filter((value): value is number => value !== null);
     const baseValue = visibleRawValues[0] ?? null;
     const latestRawValue = visibleRawValues[visibleRawValues.length - 1] ?? null;
 
-    const points = Array.from({ length: bucketCount }, (_, index) => {
-      const start = Math.floor(index * bucketSize);
-      const end = Math.min(window.dates.length, Math.max(Math.floor((index + 1) * bucketSize), start + 1));
-      const bucketDates = window.dates.slice(start, end);
-      const date = bucketDates[bucketDates.length - 1] ?? window.dates[window.dates.length - 1] ?? new Date(0);
-      const bucketRawValues = bucketDates
-        .map((bucketDate) => rawByDate.get(bucketDate.getTime()) ?? null)
+    const points = buckets.map((bucket) => {
+      const bucketRawValues = filledRawValues
+        .slice(bucket.start, bucket.end)
         .filter((value): value is number => value !== null);
       const rawValue = bucketRawValues.length > 0
-        ? resolveRepresentativeValue(bucketRawValues, index)
+        ? resolveRepresentativeValue(bucketRawValues, bucket.index)
         : null;
 
       return {
-        date,
+        date: getBucketDate(window.dates, bucket),
         rawValue,
         value: transformRawValue(rawValue, axisResolution.effectiveAxisMode, baseValue),
       };
@@ -264,11 +291,7 @@ export function projectComparisonChartData(
   });
 
   return {
-    dates: Array.from({ length: bucketCount }, (_, index) => {
-      const start = Math.floor(index * bucketSize);
-      const end = Math.min(window.dates.length, Math.max(Math.floor((index + 1) * bucketSize), start + 1));
-      return window.dates[Math.max(end - 1, 0)] ?? new Date(0);
-    }),
+    dates: buckets.map((bucket) => getBucketDate(window.dates, bucket)),
     series: projectedSeries,
     requestedMode,
     effectiveMode: requestedMode,

--- a/src/components/chart/core/projection.ts
+++ b/src/components/chart/core/projection.ts
@@ -24,6 +24,12 @@ export interface ProjectChartDataOptions {
   sourceIndexOffset?: number;
 }
 
+export interface IndexProjectionBucket {
+  index: number;
+  start: number;
+  end: number;
+}
+
 interface StableOhlcProjectionOptionsInput {
   pointCount: number;
   sourceIndexOffset: number;
@@ -131,6 +137,44 @@ function aggregateOhlcBucket(bucket: readonly ProjectedChartPoint[]): ProjectedC
   };
 }
 
+export function buildIndexProjectionBuckets(
+  itemCount: number,
+  targetWidth: number,
+): IndexProjectionBucket[] {
+  const normalizedItemCount = Math.max(Math.floor(itemCount), 0);
+  if (normalizedItemCount === 0) return [];
+
+  const bucketCount = Math.min(normalizedItemCount, Math.max(Math.floor(targetWidth), 1));
+  const bucketSize = normalizedItemCount / bucketCount;
+
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const start = Math.floor(index * bucketSize);
+    const end = Math.min(
+      normalizedItemCount,
+      Math.max(Math.floor((index + 1) * bucketSize), start + 1),
+    );
+    return { index, start, end };
+  });
+}
+
+export function selectRepresentativeCloseValue<T>(
+  bucket: readonly T[],
+  index: number,
+  getClose: (item: T) => number,
+): T {
+  let best = bucket[0] as T;
+  if (index % 2 === 0) {
+    for (const item of bucket) {
+      if (getClose(item) > getClose(best)) best = item;
+    }
+  } else {
+    for (const item of bucket) {
+      if (getClose(item) < getClose(best)) best = item;
+    }
+  }
+  return best;
+}
+
 function bucketOhlcBySourceIndex(
   normalizedPoints: readonly ProjectedChartPoint[],
   bucketSize: number,
@@ -202,33 +246,13 @@ function projectCloseSeries(
   targetWidth: number,
 ): ProjectedChartPoint[] {
   if (points.length === 0) return [];
-  if (points.length <= targetWidth) return points.map(normalizePoint);
-
-  const result: ProjectedChartPoint[] = [];
-  const bucketSize = points.length / targetWidth;
-
-  for (let i = 0; i < targetWidth; i++) {
-    const start = Math.floor(i * bucketSize);
-    const end = Math.min(points.length, Math.max(Math.floor((i + 1) * bucketSize), start + 1));
-    const bucket = points.slice(start, end);
-
-    if (bucket.length === 0) continue;
-
-    // Alternate bucket extremes to preserve line/area shape after downsampling.
-    let best = bucket[0]!;
-    if (i % 2 === 0) {
-      for (const point of bucket) {
-        if (point.close > best.close) best = point;
-      }
-    } else {
-      for (const point of bucket) {
-        if (point.close < best.close) best = point;
-      }
-    }
-    result.push(normalizePoint(best));
-  }
-
-  return result;
+  return buildIndexProjectionBuckets(points.length, targetWidth).map((bucket) => (
+    normalizePoint(selectRepresentativeCloseValue(
+      points.slice(bucket.start, bucket.end),
+      bucket.index,
+      (point) => point.close,
+    ))
+  ));
 }
 
 /**


### PR DESCRIPTION
Fixes #421.

Comparison charts now share the normal chart close-series bucket selection and carry the latest known value across shared timestamps after a series has visible data. This keeps line and area comparisons continuous across ordinary cross-market timestamp gaps, such as XETRA versus NYSE trading hours, while preserving leading gaps, percent normalization, and mixed-currency handling.