### PR TITLE
Fix rapid chat channel navigation

### DIFF
--- a/src/plugins/builtin/chat/content/channel-navigation.ts
+++ b/src/plugins/builtin/chat/content/channel-navigation.ts
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { ChatChannel, ChatUserSummary } from "../../../../api-client";
+import { useThrottledCommitValue } from "../../../../react/use-throttled-commit-value";
 import {
   DEFAULT_CHAT_CHANNEL_ID,
   normalizeChannelId,
 } from "../channels";
 import type { ChatContentController } from "./types";
+
+const CHANNEL_NAVIGATION_COMMIT_DELAY_MS = 150;
 
 function isConversationChannelId(channelId: string): boolean {
   return channelId.startsWith("dm:") || channelId.startsWith("grp:") || channelId.startsWith("group:");
@@ -38,15 +41,16 @@ export function useChatChannelNavigation({
   resetTranscriptSelection: () => void;
   showChannelSidebar: boolean;
 }): {
-  changeChannel: (nextChannelId: string) => void;
   cycleChannel: (direction: 1 | -1) => boolean;
   directExpanded: boolean;
   focusChannelSidebar: () => boolean;
   focusChatContent: () => boolean;
   moveSidebarChannelSelection: (direction: "up" | "down") => boolean;
   openDirectMessage: (target: ChatUserSummary) => Promise<void>;
+  selectSidebarChannel: (channelId: string) => void;
   setDirectExpanded: Dispatch<SetStateAction<boolean>>;
   setSidebarFocused: (nextFocused: boolean) => void;
+  sidebarCursorChannelId: string;
   sidebarFocused: boolean;
   sidebarFocusedRef: MutableRefObject<boolean>;
 } {
@@ -70,6 +74,13 @@ export function useChatChannelNavigation({
     resetTranscriptSelection();
     onChannelChange?.(normalized);
   }, [channelIdRef, onChannelChange, resetTranscriptSelection]);
+  const {
+    value: sidebarCursorChannelId,
+    valueRef: sidebarCursorChannelIdRef,
+    setValue: setSidebarCursorChannelId,
+    flushValue: flushSidebarCursorChannelId,
+    replaceValue: replaceSidebarCursorChannelId,
+  } = useThrottledCommitValue(channelId, changeChannel, CHANNEL_NAVIGATION_COMMIT_DELAY_MS);
 
   const openDirectMessage = useCallback(async (target: ChatUserSummary) => {
     if (!target.id && !target.username) return;
@@ -79,10 +90,10 @@ export function useChatChannelNavigation({
         username: target.username ?? undefined,
       });
       setDirectExpanded(true);
-      changeChannel(channel.id);
+      setSidebarCursorChannelId(channel.id, { immediate: true });
       closeProfilePopover();
     } catch {}
-  }, [changeChannel, closeProfilePopover, controller]);
+  }, [closeProfilePopover, controller, setSidebarCursorChannelId]);
 
   useEffect(() => {
     if (!onChannelChange || channelsLoading || channels.length === 0) return;
@@ -109,9 +120,9 @@ export function useChatChannelNavigation({
     const nextIndex = (currentIndex + direction + channels.length) % channels.length;
     const nextChannel = channels[nextIndex];
     if (!nextChannel) return false;
-    changeChannel(nextChannel.id);
+    setSidebarCursorChannelId(nextChannel.id, { immediate: true });
     return true;
-  }, [changeChannel, channelIdRef, channels, onChannelChange]);
+  }, [channelIdRef, channels, onChannelChange, setSidebarCursorChannelId]);
 
   const focusChannelSidebar = useCallback(() => {
     if (!showChannelSidebar || !onChannelChange) return false;
@@ -119,28 +130,49 @@ export function useChatChannelNavigation({
       blurInput();
     }
     resetTranscriptSelection();
+    replaceSidebarCursorChannelId(channelId);
     setSidebarFocused(true);
     return true;
-  }, [blurInput, inputFocused, onChannelChange, resetTranscriptSelection, setSidebarFocused, showChannelSidebar]);
+  }, [
+    blurInput,
+    channelId,
+    inputFocused,
+    onChannelChange,
+    replaceSidebarCursorChannelId,
+    resetTranscriptSelection,
+    setSidebarFocused,
+    showChannelSidebar,
+  ]);
 
   const focusChatContent = useCallback(() => {
     if (!showChannelSidebar) return false;
+    flushSidebarCursorChannelId(sidebarCursorChannelIdRef.current);
     setSidebarFocused(false);
     return true;
-  }, [setSidebarFocused, showChannelSidebar]);
+  }, [flushSidebarCursorChannelId, setSidebarFocused, showChannelSidebar, sidebarCursorChannelIdRef]);
 
   const moveSidebarChannelSelection = useCallback((direction: "up" | "down") => {
     if (!showChannelSidebar || sidebarNavigationChannels.length <= 1 || !onChannelChange) return false;
-    const currentIndex = sidebarNavigationChannels.findIndex((channel) => channel.id === channelIdRef.current);
+    const currentIndex = sidebarNavigationChannels.findIndex((channel) => channel.id === sidebarCursorChannelIdRef.current);
     const baseIndex = currentIndex >= 0 ? currentIndex : 0;
     const nextIndex = direction === "down"
       ? Math.min(baseIndex + 1, sidebarNavigationChannels.length - 1)
       : Math.max(baseIndex - 1, 0);
     const nextChannel = sidebarNavigationChannels[nextIndex];
     if (!nextChannel || nextIndex === baseIndex) return true;
-    changeChannel(nextChannel.id);
+    setSidebarCursorChannelId(nextChannel.id);
     return true;
-  }, [changeChannel, channelIdRef, onChannelChange, showChannelSidebar, sidebarNavigationChannels]);
+  }, [
+    onChannelChange,
+    setSidebarCursorChannelId,
+    showChannelSidebar,
+    sidebarCursorChannelIdRef,
+    sidebarNavigationChannels,
+  ]);
+
+  const selectSidebarChannel = useCallback((nextChannelId: string) => {
+    setSidebarCursorChannelId(nextChannelId, { immediate: true });
+  }, [setSidebarCursorChannelId]);
 
   useEffect(() => {
     if (focused && showChannelSidebar) return;
@@ -148,15 +180,16 @@ export function useChatChannelNavigation({
   }, [focused, setSidebarFocused, showChannelSidebar]);
 
   return {
-    changeChannel,
     cycleChannel,
     directExpanded,
     focusChannelSidebar,
     focusChatContent,
     moveSidebarChannelSelection,
     openDirectMessage,
+    selectSidebarChannel,
     setDirectExpanded,
     setSidebarFocused,
+    sidebarCursorChannelId,
     sidebarFocused,
     sidebarFocusedRef,
   };

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -212,15 +212,16 @@ export function ChatContent({
   });
 
   const {
-    changeChannel,
     cycleChannel,
     directExpanded,
     focusChannelSidebar,
     focusChatContent,
     moveSidebarChannelSelection,
     openDirectMessage,
+    selectSidebarChannel,
     setDirectExpanded,
     setSidebarFocused,
+    sidebarCursorChannelId,
     sidebarFocused,
     sidebarFocusedRef,
   } = useChatChannelNavigation({
@@ -367,7 +368,7 @@ export function ChatContent({
         <ChannelSidebar
           channels={channels}
           channelStates={channelStates}
-          activeChannelId={channelId}
+          activeChannelId={sidebarFocused ? sidebarCursorChannelId : channelId}
           onlineCount={onlineCount}
           width={channelSidebarWidth}
           height={height}
@@ -376,7 +377,7 @@ export function ChatContent({
           loading={channelsLoading}
           canManageNotifications={!!user?.emailVerified}
           directExpanded={directExpanded}
-          onSelect={changeChannel}
+          onSelect={selectSidebarChannel}
           onFocusRequest={() => setSidebarFocused(true)}
           onToggleNotifications={(nextChannelId, enabled) => {
             controller.setChannelNotificationsEnabled(nextChannelId, enabled);
@@ -392,7 +393,7 @@ export function ChatContent({
         flexGrow={nativePaneChrome ? 1 : undefined}
         backgroundColor={chatContentBg}
         position="relative"
-        onMouseDown={() => setSidebarFocused(false)}
+        onMouseDown={() => focusChatContent()}
         style={nativeFillStyle}
       >
       {!nativePaneChrome && (

--- a/src/plugins/builtin/chat/content/shortcuts.ts
+++ b/src/plugins/builtin/chat/content/shortcuts.ts
@@ -75,6 +75,13 @@ export function useChatContentShortcuts({
     const isEnterKey = event.name === "return" || event.name === "enter";
 
     if (sidebarFocusedRef.current && showChannelSidebar) {
+      if (isEnterKey) {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        focusChatContent();
+        return;
+      }
+
       if (isPlainKey(event, "left")) {
         event.preventDefault?.();
         event.stopPropagation?.();

--- a/src/plugins/builtin/chat/sidebar.test.tsx
+++ b/src/plugins/builtin/chat/sidebar.test.tsx
@@ -9,6 +9,7 @@ import { PluginRenderProvider } from "../../runtime";
 import { gloomberbCloudPlugin } from "../cloud";
 import { ChatContent } from "../chat";
 import { chatController } from "./controller";
+import { useChatChannelNavigation } from "./content/channel-navigation";
 import {
   cleanupChatTest,
   createChatTestControls,
@@ -283,6 +284,76 @@ describe("ChatContent channel sidebar", () => {
     await emitKeypress({ name: "down", sequence: "\u001b[B" });
     await flushFrame();
     expect(setup().captureCharFrame()).toContain("#equities");
+  });
+
+  test("coalesces rapid sidebar navigation to the final channel", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    const channels = [
+      { id: "everyone", name: "everyone", created_at: "2026-03-26T12:10:05.684Z" },
+      { id: "equities", name: "equities", created_at: "2026-05-09T00:00:00.000Z" },
+      { id: "options", name: "options", created_at: "2026-05-09T00:00:00.000Z" },
+      { id: "macro", name: "macro", created_at: "2026-05-09T00:00:00.000Z" },
+      { id: "crypto", name: "crypto", created_at: "2026-05-09T00:00:00.000Z" },
+    ];
+    const channelChanges: string[] = [];
+    let navigation: ReturnType<typeof useChatChannelNavigation> | null = null;
+    let latestCursorChannelId = "";
+    let latestCommittedChannelId = "";
+
+    function NavigationHarness() {
+      const [channelId, setChannelId] = useState("equities");
+      const channelIdRef = useRef(channelId);
+      channelIdRef.current = channelId;
+      const handleChannelChange = useCallback((nextChannelId: string) => {
+        channelChanges.push(nextChannelId);
+        setChannelId(nextChannelId);
+      }, []);
+      navigation = useChatChannelNavigation({
+        blurInput: () => {},
+        channelId,
+        channelIdRef,
+        channels,
+        channelsLoading: false,
+        closeProfilePopover: () => {},
+        controller,
+        focused: true,
+        inputFocused: false,
+        onChannelChange: handleChannelChange,
+        resetTranscriptSelection: () => {},
+        showChannelSidebar: true,
+      });
+      latestCursorChannelId = navigation.sidebarCursorChannelId;
+      latestCommittedChannelId = channelId;
+
+      return null;
+    }
+
+    await act(async () => {
+      testSetup = await testRender(<NavigationHarness />, {
+        width: 90,
+        height: 12,
+      });
+    });
+
+    await act(async () => {
+      navigation?.focusChannelSidebar();
+      navigation?.moveSidebarChannelSelection("down");
+      navigation?.moveSidebarChannelSelection("down");
+      navigation?.moveSidebarChannelSelection("down");
+      await setup().renderOnce();
+    });
+
+    expect(latestCursorChannelId).toBe("crypto");
+    expect(latestCommittedChannelId).toBe("equities");
+    expect(channelChanges).toEqual([]);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 180));
+      await setup().renderOnce();
+    });
+
+    expect(channelChanges).toEqual(["crypto"]);
+    expect(latestCommittedChannelId).toBe("crypto");
   });
 
   test("keeps the channel sidebar visible while a channel loads", async () => {

--- a/src/plugins/builtin/portfolio-list/use-throttled-cursor-symbol.ts
+++ b/src/plugins/builtin/portfolio-list/use-throttled-cursor-symbol.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useThrottledCommitValue } from "../../../react/use-throttled-commit-value";
 
 const FOLLOW_CURSOR_THROTTLE_MS = 150;
 
@@ -7,75 +7,17 @@ export function useThrottledCursorSymbol(
   setCommittedCursorSymbol: (symbol: string | null) => void,
   throttleMs = FOLLOW_CURSOR_THROTTLE_MS,
 ) {
-  const [cursorSymbol, setCursorSymbolState] = useState<string | null>(committedCursorSymbol);
-  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hasPendingCommitRef = useRef(false);
-  const pendingCursorSymbolRef = useRef<string | null>(committedCursorSymbol);
-  const appliedCursorSymbolRef = useRef<string | null>(committedCursorSymbol);
-
-  const clearPendingCursorCommit = useCallback(() => {
-    if (commitTimerRef.current) {
-      clearTimeout(commitTimerRef.current);
-      commitTimerRef.current = null;
-    }
-    hasPendingCommitRef.current = false;
-  }, []);
-
-  const commitCursorSymbol = useCallback((nextCursorSymbol?: string | null) => {
-    const targetCursorSymbol = nextCursorSymbol ?? pendingCursorSymbolRef.current;
-    clearPendingCursorCommit();
-    pendingCursorSymbolRef.current = targetCursorSymbol;
-
-    if (Object.is(appliedCursorSymbolRef.current, targetCursorSymbol)) {
-      return;
-    }
-
-    appliedCursorSymbolRef.current = targetCursorSymbol;
-    setCommittedCursorSymbol(targetCursorSymbol);
-  }, [clearPendingCursorCommit, setCommittedCursorSymbol]);
-
-  const scheduleCursorSymbol = useCallback((nextCursorSymbol: string | null, options?: { immediate?: boolean }) => {
-    setCursorSymbolState((current) => (Object.is(current, nextCursorSymbol) ? current : nextCursorSymbol));
-    pendingCursorSymbolRef.current = nextCursorSymbol;
-
-    if (options?.immediate) {
-      commitCursorSymbol(nextCursorSymbol);
-      return;
-    }
-
-    clearPendingCursorCommit();
-
-    if (Object.is(appliedCursorSymbolRef.current, nextCursorSymbol)) {
-      return;
-    }
-
-    hasPendingCommitRef.current = true;
-    commitTimerRef.current = setTimeout(() => {
-      commitCursorSymbol();
-    }, throttleMs);
-  }, [clearPendingCursorCommit, commitCursorSymbol, throttleMs]);
-
-  useEffect(() => {
-    if (hasPendingCommitRef.current && Object.is(committedCursorSymbol, pendingCursorSymbolRef.current)) {
-      clearPendingCursorCommit();
-    }
-
-    if (!hasPendingCommitRef.current) {
-      appliedCursorSymbolRef.current = committedCursorSymbol;
-      setCursorSymbolState((current) => (Object.is(current, committedCursorSymbol) ? current : committedCursorSymbol));
-    }
-  }, [clearPendingCursorCommit, committedCursorSymbol]);
-
-  useEffect(() => () => {
-    if (commitTimerRef.current) {
-      clearTimeout(commitTimerRef.current);
-    }
-  }, []);
+  const {
+    value: cursorSymbol,
+    setValue,
+    flushValue,
+    cancelPendingValue,
+  } = useThrottledCommitValue(committedCursorSymbol, setCommittedCursorSymbol, throttleMs);
 
   return {
     cursorSymbol,
-    setCursorSymbol: scheduleCursorSymbol,
-    flushCursorSymbol: commitCursorSymbol,
-    cancelPendingCursorSymbol: clearPendingCursorCommit,
+    setCursorSymbol: setValue,
+    flushCursorSymbol: flushValue,
+    cancelPendingCursorSymbol: cancelPendingValue,
   };
 }

--- a/src/react/use-throttled-commit-value.ts
+++ b/src/react/use-throttled-commit-value.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useThrottledCommitValue<T>(
+  committedValue: T,
+  commitValue: (value: T) => void,
+  delayMs: number,
+) {
+  const [value, setValueState] = useState<T>(committedValue);
+  const valueRef = useRef<T>(committedValue);
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasPendingCommitRef = useRef(false);
+  const pendingValueRef = useRef<T>(committedValue);
+  const appliedValueRef = useRef<T>(committedValue);
+  const commitValueRef = useRef(commitValue);
+
+  useEffect(() => {
+    commitValueRef.current = commitValue;
+  }, [commitValue]);
+
+  const clearPendingCommit = useCallback(() => {
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+    hasPendingCommitRef.current = false;
+  }, []);
+
+  const flushValue = useCallback((...args: [] | [T]) => {
+    const targetValue = args.length === 0 ? pendingValueRef.current : args[0];
+    clearPendingCommit();
+    pendingValueRef.current = targetValue;
+    valueRef.current = targetValue;
+    setValueState((current) => (Object.is(current, targetValue) ? current : targetValue));
+
+    if (Object.is(appliedValueRef.current, targetValue)) {
+      return;
+    }
+
+    appliedValueRef.current = targetValue;
+    commitValueRef.current(targetValue);
+  }, [clearPendingCommit]);
+
+  const replaceValue = useCallback((nextValue: T) => {
+    clearPendingCommit();
+    appliedValueRef.current = nextValue;
+    pendingValueRef.current = nextValue;
+    valueRef.current = nextValue;
+    setValueState((current) => (Object.is(current, nextValue) ? current : nextValue));
+  }, [clearPendingCommit]);
+
+  const setValue = useCallback((nextValue: T, options?: { immediate?: boolean }) => {
+    valueRef.current = nextValue;
+    pendingValueRef.current = nextValue;
+    setValueState((current) => (Object.is(current, nextValue) ? current : nextValue));
+
+    if (options?.immediate) {
+      flushValue(nextValue);
+      return;
+    }
+
+    clearPendingCommit();
+
+    if (Object.is(appliedValueRef.current, nextValue)) {
+      return;
+    }
+
+    hasPendingCommitRef.current = true;
+    commitTimerRef.current = setTimeout(() => {
+      flushValue();
+    }, delayMs);
+  }, [clearPendingCommit, delayMs, flushValue]);
+
+  useEffect(() => {
+    if (hasPendingCommitRef.current && Object.is(committedValue, pendingValueRef.current)) {
+      clearPendingCommit();
+    }
+
+    if (!hasPendingCommitRef.current) {
+      appliedValueRef.current = committedValue;
+      pendingValueRef.current = committedValue;
+      valueRef.current = committedValue;
+      setValueState((current) => (Object.is(current, committedValue) ? current : committedValue));
+    }
+  }, [clearPendingCommit, committedValue]);
+
+  useEffect(() => () => {
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current);
+    }
+  }, []);
+
+  return {
+    value,
+    valueRef,
+    setValue,
+    flushValue,
+    replaceValue,
+    cancelPendingValue: clearPendingCommit,
+  };
+}


### PR DESCRIPTION
Rapid arrow movement in the chat channel sidebar now uses an immediate local cursor and commits only the final selected channel after a short debounce. That prevents pane persistence from briefly rewinding selection to an older channel while moving quickly. The shared throttled commit hook also keeps the portfolio cursor behavior on the same path instead of duplicating the state logic. Pressing Enter or returning focus to chat flushes any pending sidebar selection immediately.