### PR TITLE
Fix ticker tab arrow navigation

### DIFF
--- a/src/plugins/builtin/ticker-detail/index.test.tsx
+++ b/src/plugins/builtin/ticker-detail/index.test.tsx
@@ -41,6 +41,7 @@ let detailHarnessState: ReturnType<typeof createInitialState> | null = null;
 let sharedCoordinator: MarketDataCoordinator | null = null;
 
 const runtime = createTestPluginRuntime();
+const TICKER_TAB_SETTLE_MS = 160;
 
 const DetailPane = tickerDetailPlugin.panes![0]!.component as (props: {
   paneId: string;
@@ -280,6 +281,13 @@ async function flushFrame() {
   });
 }
 
+async function settleTickerTabCommit() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, TICKER_TAB_SETTLE_MS));
+    await testSetup!.renderOnce();
+  });
+}
+
 async function clickFrameText(text: string) {
   const lines = testSetup!.captureCharFrame().split("\n");
   const row = lines.findIndex((line) => line.includes(text));
@@ -506,6 +514,7 @@ describe("TickerResearchPane", () => {
     });
     await flushFrame();
 
+    await settleTickerTabCommit();
     expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("fundamental-graphs");
 
     await act(async () => {
@@ -514,6 +523,7 @@ describe("TickerResearchPane", () => {
     });
     await flushFrame();
 
+    await settleTickerTabCommit();
     expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("financials");
   });
 

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -14,12 +14,15 @@ import { useQuoteStreaming } from "../../../state/hooks/quote-streaming";
 import { getCollectionName, getCollectionTickerCount } from "../../../state/selectors";
 import { getSharedRegistry } from "../../registry";
 import { EmptyState, PaneFooterScope, Tabs } from "../../../components";
+import { useThrottledCommitValue } from "../../../react/use-throttled-commit-value";
 import { resolveOptionsTarget } from "../../../utils/options";
 import {
   buildVisibleTickerResearchTabs,
   getTickerResearchPaneSettings,
   resolveLockedTabId,
 } from "./settings";
+
+const TICKER_RESEARCH_TAB_COMMIT_DELAY_MS = 120;
 
 function sameStringSet(left: Set<string>, right: Set<string>): boolean {
   if (left.size !== right.size) return false;
@@ -79,7 +82,16 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
   useQuoteStreaming(streamingTargets);
 
   const { collectionId } = usePaneCollection();
-  const [activeTabId, setActiveTabId] = usePaneStateValue<string>("activeTabId", "overview");
+  const [committedActiveTabId, setCommittedActiveTabId] = usePaneStateValue<string>("activeTabId", "overview");
+  const {
+    value: activeTabId,
+    setValue: setActiveTabId,
+  } = useThrottledCommitValue(
+    committedActiveTabId,
+    setCommittedActiveTabId,
+    TICKER_RESEARCH_TAB_COMMIT_DELAY_MS,
+    { commitPendingOnUnmount: true },
+  );
   const [pluginCaptured, setPluginCaptured] = useState(false);
   const [mountedTabIds, setMountedTabIds] = useState<Set<string>>(() => new Set());
   const paneSettings = getTickerResearchPaneSettings(paneInstance?.settings);

--- a/src/react/use-throttled-commit-value.ts
+++ b/src/react/use-throttled-commit-value.ts
@@ -4,6 +4,7 @@ export function useThrottledCommitValue<T>(
   committedValue: T,
   commitValue: (value: T) => void,
   delayMs: number,
+  options?: { commitPendingOnUnmount?: boolean },
 ) {
   const [value, setValueState] = useState<T>(committedValue);
   const valueRef = useRef<T>(committedValue);
@@ -12,10 +13,15 @@ export function useThrottledCommitValue<T>(
   const pendingValueRef = useRef<T>(committedValue);
   const appliedValueRef = useRef<T>(committedValue);
   const commitValueRef = useRef(commitValue);
+  const optionsRef = useRef(options);
 
   useEffect(() => {
     commitValueRef.current = commitValue;
   }, [commitValue]);
+
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
 
   const clearPendingCommit = useCallback(() => {
     if (commitTimerRef.current) {
@@ -84,8 +90,18 @@ export function useThrottledCommitValue<T>(
   }, [clearPendingCommit, committedValue]);
 
   useEffect(() => () => {
+    const pending = hasPendingCommitRef.current;
+    const pendingValue = pendingValueRef.current;
     if (commitTimerRef.current) {
       clearTimeout(commitTimerRef.current);
+    }
+    if (
+      optionsRef.current?.commitPendingOnUnmount
+      && pending
+      && !Object.is(appliedValueRef.current, pendingValue)
+    ) {
+      appliedValueRef.current = pendingValue;
+      commitValueRef.current(pendingValue);
     }
   }, []);
 


### PR DESCRIPTION
Ticker research tabs now update their visible active tab immediately while coalescing persisted pane-state writes.

This removes the controlled-state lag/race that made rapid left/right arrow navigation feel slow. The shared throttled commit helper can now preserve a pending final value when the pane unmounts, so selected tab state is not lost.