### PR TITLE
Add authenticated Substack reader plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Open the command bar with `Ctrl+P` or `` ` ``, then type a command.
 ## What It Does
 
 - Research companies with quotes, charts, financials, filings, holders, insiders, options, analyst ratings, events, and relative valuation.
-- Follow markets with top stories, breaking news, sector feeds, global indices, FX, macro events, yield curves, market movers, and fear/greed.
+- Follow markets with top stories, breaking news, sector feeds, Substack subscriptions, global indices, FX, macro events, yield curves, market movers, and fear/greed.
 - Track portfolios and watchlists, connect brokers, set alerts, keep notes, run AI screens, browse prediction markets, and use Gloom Cloud chat.
 
 ## CLI
@@ -94,7 +94,7 @@ Core plugin areas include:
 
 - Portfolios, watchlists, manual entry, and broker connections
 - Ticker details, quotes, charts, options, filings, holders, insiders, and research
-- News, market movers, global indices, sectors, FX, earnings, macro data, and yield curves
+- News, Substack reader feeds, market movers, global indices, sectors, FX, earnings, macro data, and yield curves
 - Prediction markets, alerts, notes, chat, AI screeners, and external plugins
 
 See [PLUGINS.md](PLUGINS.md) for the plugin API and the shared UI surface available through `gloomberb/components`.
@@ -155,11 +155,15 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 |----------|----------|
 | `TOP` | Ranked market stories |
 | `MOST` | Top gainers, losers, most active, and trending tickers |
+| `PM <query>` | Polymarket and Kalshi prediction data |
 | `N` | News feed |
 | `CN <ticker>` | Ticker news |
 | `NI` | Sector news |
+| `SUB` | Authenticated Substack reader feed |
 | `FIRST` | Breaking news |
 | `TWIT <query>` | Ticker-related market posts |
+| `TBO` | TheBuildout infrastructure intelligence |
+| `CG` | Congress trading disclosures |
 | `WEI` | Global equity indices |
 | `ECON` | Economic events and releases |
 | `GC` | Yield curve |
@@ -176,13 +180,10 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 | `PORT` | Portfolio risk and sector exposure |
 | `ALRT` | Price alerts |
 | `SA <symbol condition price>` | Create a price alert |
-| `PM <query>` | Polymarket and Kalshi prediction data |
 | `AI <prompt>` | AI screener |
 | `CHAT [channel]` | Gloom Cloud chat |
 | `DM @user [@user...]` | Open or start a direct or group chat |
 | `ACM` | Gloom Cloud account settings |
-| `TBO` | TheBuildout infrastructure intelligence |
-| `CG` | Congress trading disclosures |
 | `NOTE` | Notes |
 | `IBKR` | IBKR trading pane |
 | `BR` | Broker connections |

--- a/src/components/ui/remote-image.tsx
+++ b/src/components/ui/remote-image.tsx
@@ -1,6 +1,5 @@
 import { Box, ImageSurface, Text } from "../../ui";
 import { colors } from "../../theme/colors";
-import { ExternalLinkText } from "./external-link";
 import { normalizedHttpUrl } from "../../utils/url";
 
 export interface RemoteImageProps {
@@ -9,13 +8,6 @@ export interface RemoteImageProps {
   width: number;
   height?: number;
   label?: string;
-}
-
-function truncate(value: string, width: number): string {
-  if (width <= 0) return "";
-  if (value.length <= width) return value;
-  if (width <= 3) return value.slice(0, width);
-  return `${value.slice(0, width - 3)}...`;
 }
 
 export function RemoteImage({
@@ -37,13 +29,8 @@ export function RemoteImage({
       height={Math.max(4, height)}
       objectFit="contain"
     >
-      <Box flexDirection="column" gap={1}>
+      <Box flexDirection="column">
         <Text fg={colors.textDim}>{label}</Text>
-        <ExternalLinkText
-          url={imageUrl}
-          label={truncate(imageUrl, resolvedWidth)}
-          color={colors.textBright}
-        />
       </Box>
     </ImageSurface>
   );

--- a/src/plugins/builtin/substack/api.test.ts
+++ b/src/plugins/builtin/substack/api.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
+import {
+  attachSubstackPersistence,
+  resetSubstackPersistence,
+  setSubstackFetchTransportForTests,
+} from "./api/store";
+import {
+  completeSubstackMagicLink,
+  completeSubstackOtpLogin,
+  parseCookiesFromSetCookie,
+  splitSetCookieHeader,
+} from "./api/auth";
+import {
+  getCachedSubstackArticleDetail,
+  getCachedSubstackHome,
+  getCachedSubstackPublicationFeed,
+} from "./api/cache";
+import {
+  loadSubstackArticleDetail,
+  loadSubstackHome,
+  loadSubstackPublicationFeed,
+} from "./api/loaders";
+import type { SubstackArticleSummary, SubstackPublication } from "./types";
+
+const EMAIL = "reader@example.com";
+const LOGIN_URL = "https://substack.com/login-token";
+
+afterEach(() => {
+  setSubstackFetchTransportForTests(null);
+  resetSubstackPersistence();
+});
+
+function publication(overrides: Partial<SubstackPublication> = {}): SubstackPublication {
+  return {
+    id: "alpha",
+    name: "Alpha Research",
+    subdomain: null,
+    baseUrl: "https://alpha.example",
+    description: null,
+    logoUrl: null,
+    latestPublishedAt: null,
+    ...overrides,
+  };
+}
+
+function article(overrides: Partial<SubstackArticleSummary> = {}): SubstackArticleSummary {
+  const pub = publication();
+  return {
+    id: "1",
+    title: "Markets and $SPY",
+    publicationId: pub.id,
+    publicationName: pub.name,
+    publicationSubdomain: pub.subdomain,
+    publicationBaseUrl: pub.baseUrl,
+    url: `${pub.baseUrl}/p/markets`,
+    slug: "markets",
+    publishedAt: "2026-06-05T10:00:00Z",
+    subtitle: null,
+    previewText: null,
+    bodyHtml: null,
+    imageUrls: [],
+    wordCount: 220,
+    readMinutes: 1,
+    ...overrides,
+  };
+}
+
+function installAuthenticatedTransport(
+  handler: (url: string, init?: RequestInit) => Response | undefined | Promise<Response | undefined>,
+): string[] {
+  const requests: string[] = [];
+  setSubstackFetchTransportForTests(async (url, init) => {
+    requests.push(url);
+    if (url === LOGIN_URL) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: "/reader",
+          "set-cookie": "substack.sid=sid123; Path=/; HttpOnly",
+        },
+      });
+    }
+    if (url === "https://substack.com/reader") {
+      return new Response("ok", { status: 200 });
+    }
+    return await handler(url, init) ?? new Response(`unexpected ${url}`, { status: 500 });
+  });
+  return requests;
+}
+
+describe("Substack auth", () => {
+  test("parses combined cookie headers and follows OTP redirects for the session cookie", async () => {
+    const headers = splitSetCookieHeader(
+      "foo=bar; Expires=Wed, 21 Oct 2026 07:28:00 GMT; Path=/, substack.sid=sid123; Path=/; HttpOnly, substack.lli=1; Path=/",
+    );
+    expect(parseCookiesFromSetCookie(headers).get("substack.sid")).toBe("sid123");
+
+    attachSubstackPersistence(new MemoryPluginPersistence());
+    const requests: string[] = [];
+    setSubstackFetchTransportForTests(async (url, init) => {
+      requests.push(url);
+      if (url === "https://substack.com/api/v1/email-otp-login/complete") {
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toMatchObject({ code: "123456", email: EMAIL });
+        return Response.json({ redirect: "/reader" });
+      }
+      if (url === "https://substack.com/reader") {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: "/home",
+            "set-cookie": "substack.sid=sid789; Path=/; HttpOnly",
+          },
+        });
+      }
+      if (url === "https://substack.com/home") {
+        return new Response("ok", {
+          headers: { "set-cookie": "substack.lli=1; Path=/" },
+        });
+      }
+      return new Response(`unexpected ${url}`, { status: 500 });
+    });
+
+    const auth = await completeSubstackOtpLogin("123456", EMAIL);
+
+    expect(auth).toMatchObject({ sid: "sid789", lli: "1", email: EMAIL });
+    expect(requests).toEqual([
+      "https://substack.com/api/v1/email-otp-login/complete",
+      "https://substack.com/reader",
+      "https://substack.com/home",
+    ]);
+  });
+});
+
+describe("Substack cached data loading", () => {
+  test("loads subscriptions plus paginated feed and reuses the cached result", async () => {
+    attachSubstackPersistence(new MemoryPluginPersistence());
+    const feedUrls: string[] = [];
+    const requests = installAuthenticatedTransport((url) => {
+      if (url === "https://substack.com/api/v1/subscriptions/page_v2") {
+        return Response.json({
+          result: {
+            subscriptions: [{ id: "sub-alpha", publication_id: "alpha" }],
+            publicationMap: {
+              alpha: { id: "alpha", name: "Alpha Research", base_url: "https://alpha.example" },
+            },
+          },
+        });
+      }
+      if (url.startsWith("https://substack.com/api/v1/reader/feed?")) {
+        feedUrls.push(url);
+        const parsed = new URL(url);
+        return Response.json(parsed.searchParams.has("cursor")
+          ? { items: [{ post: { id: "second", title: "Second", post_date: "2026-06-05T11:00:00Z", publication: { id: "alpha", name: "Alpha Research", base_url: "https://alpha.example" } } }] }
+          : {
+            items: [
+              { type: "comment", comment: { id: 1, body: "not a post" } },
+              { post: { id: "first", title: "First", post_date: "2026-06-05T10:00:00Z", publication: { id: "alpha", name: "Alpha Research", base_url: "https://alpha.example" } } },
+            ],
+            nextCursor: "cursor-2",
+          });
+      }
+    });
+
+    await completeSubstackMagicLink(LOGIN_URL, EMAIL);
+    const first = await loadSubstackHome(false);
+    const requestCountAfterFirstLoad = requests.length;
+    const second = await loadSubstackHome(false);
+
+    expect(first.subscriptions.map((item) => item.name)).toEqual(["Alpha Research"]);
+    expect(first.feed.map((item) => item.id)).toEqual(["first", "second"]);
+    expect(second.feed.map((item) => item.id)).toEqual(["first", "second"]);
+    expect(feedUrls).toHaveLength(2);
+    expect(new URL(feedUrls[1]!).searchParams.get("cursor")).toBe("cursor-2");
+    expect(requests).toHaveLength(requestCountAfterFirstLoad);
+  });
+
+  test("hydrates cached home, merged publication pages, and article detail synchronously", () => {
+    const persistence = new MemoryPluginPersistence();
+    attachSubstackPersistence(persistence);
+    const pub = publication({ name: "Alpha" });
+    const firstArticle = article({ id: "1", title: "Archive one", publicationName: "Alpha" });
+    const secondArticle = article({
+      id: "2",
+      title: "Archive two",
+      publicationName: "Alpha",
+      url: "https://alpha.example/p/archive-two",
+      slug: "archive-two",
+      publishedAt: "2026-06-04T10:00:00Z",
+      readMinutes: 2,
+      wordCount: 440,
+    });
+    const cacheOptions = { sourceKey: "substack", schemaVersion: 3 };
+
+    persistence.seedResource("subscriptions", "me", [pub], cacheOptions);
+    persistence.seedResource("feed", "subscribed", [firstArticle], cacheOptions);
+    persistence.seedResource("publication", "https://alpha.example:offset:0", {
+      items: [firstArticle],
+      nextOffset: 12,
+      hasMore: true,
+    }, cacheOptions);
+    persistence.seedResource("publication", "https://alpha.example:offset:12", {
+      items: [secondArticle],
+      nextOffset: null,
+      hasMore: false,
+    }, cacheOptions);
+    persistence.seedResource("post", "1", {
+      ...firstArticle,
+      bodyHtml: "<p>Cached body</p>",
+      contentText: "Cached body",
+      contentBlocks: [{ type: "paragraph", text: "Cached body" }],
+      linkUrls: [],
+    }, cacheOptions);
+
+    expect(getCachedSubstackHome()?.feed.map((item) => item.title)).toEqual(["Archive one"]);
+    expect(getCachedSubstackPublicationFeed(pub)?.data.items.map((item) => item.title)).toEqual([
+      "Archive one",
+      "Archive two",
+    ]);
+    expect(getCachedSubstackArticleDetail({ id: "1" })?.data.contentText).toBe("Cached body");
+  });
+});
+
+describe("Substack publication archive loading", () => {
+  test("uses archive page limits and offset pagination", async () => {
+    attachSubstackPersistence(new MemoryPluginPersistence());
+    const requests = installAuthenticatedTransport((url) => {
+      if (url === "https://alpha.example/api/v1/archive?sort=new&limit=12") {
+        return Response.json(Array.from({ length: 12 }, (_, index) => ({
+          id: index + 1,
+          title: `Archive ${index + 1}`,
+          post_date: "2026-06-05T10:00:00Z",
+          slug: `archive-${index + 1}`,
+        })));
+      }
+      if (url === "https://alpha.example/api/v1/archive?sort=new&limit=12&offset=12") {
+        return Response.json(Array.from({ length: 3 }, (_, index) => ({
+          id: index + 13,
+          title: `Archive ${index + 13}`,
+          post_date: "2026-06-05T10:00:00Z",
+          slug: `archive-${index + 13}`,
+        })));
+      }
+    });
+
+    await completeSubstackMagicLink(LOGIN_URL, EMAIL);
+    const first = await loadSubstackPublicationFeed(publication(), false);
+    const second = await loadSubstackPublicationFeed(publication(), false, first.data.nextOffset ?? 0);
+
+    expect(first.data).toMatchObject({ hasMore: true, nextOffset: 12 });
+    expect(first.data.items).toHaveLength(12);
+    expect(second.data.items.map((item) => item.id)).toEqual(["13", "14", "15"]);
+    expect(second.data.hasMore).toBe(false);
+    expect(requests).toContain("https://alpha.example/api/v1/archive?sort=new&limit=12");
+    expect(requests).toContain("https://alpha.example/api/v1/archive?sort=new&limit=12&offset=12");
+  });
+});
+
+describe("Substack article detail loading", () => {
+  test("prefers the Substack origin post endpoint over custom-domain teaser content", async () => {
+    attachSubstackPersistence(new MemoryPluginPersistence());
+    const requests = installAuthenticatedTransport((url) => {
+      if (url === "https://substack.com/api/v1/posts/by-id/42") {
+        return Response.json({
+          id: 42,
+          title: "Full post",
+          body_html: "<p>Preview.</p><p>Paid section with $NVDA and more detail.</p>",
+          publication: { id: "alpha", name: "Alpha", base_url: "https://alpha.example" },
+        });
+      }
+      if (url === "https://alpha.example/api/v1/posts/by-id/42") {
+        return Response.json({
+          id: 42,
+          title: "Full post",
+          body_html: "<p>Preview.</p>",
+          publication: { id: "alpha", name: "Alpha", base_url: "https://alpha.example" },
+        });
+      }
+    });
+
+    await completeSubstackMagicLink(LOGIN_URL, EMAIL);
+    const detail = await loadSubstackArticleDetail(article({
+      id: "42",
+      title: "Full post",
+      url: "https://alpha.example/p/full-post",
+      slug: "full-post",
+      previewText: "Preview.",
+      bodyHtml: "<p>Preview.</p>",
+      wordCount: 1,
+    }));
+
+    expect(detail.data.contentText).toContain("Paid section");
+    expect(detail.data.wordCount).toBeGreaterThan(1);
+    expect(requests).toContain("https://substack.com/api/v1/posts/by-id/42");
+    expect(requests).not.toContain("https://alpha.example/api/v1/posts/by-id/42");
+  });
+});

--- a/src/plugins/builtin/substack/api/auth.ts
+++ b/src/plugins/builtin/substack/api/auth.ts
@@ -1,0 +1,185 @@
+import type { SubstackAuthState } from "./types";
+import {
+  parseErrorText,
+  resolveSubstackUrl,
+  storeSubstackAuth,
+  substackFetch,
+  SUBSTACK_ORIGIN,
+} from "./store";
+
+export async function requestSubstackMagicLink(email: string): Promise<void> {
+  const normalizedEmail = email.trim();
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalizedEmail)) {
+    throw new Error("Enter a valid email address");
+  }
+  const response = await substackFetch(`${SUBSTACK_ORIGIN}/api/v1/email-login`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email: normalizedEmail }),
+  });
+  if (!response.ok) {
+    const detail = await parseErrorText(response);
+    throw new Error(`Substack login link failed (${response.status})${detail ? `: ${detail}` : ""}`);
+  }
+}
+
+export function splitSetCookieHeader(header: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let inExpires = false;
+  for (let i = 0; i < header.length; i += 1) {
+    const char = header[i];
+    if (char === ",") {
+      const fragment = header.slice(start, i);
+      inExpires = /expires=/i.test(fragment) && !/;\s*(?:max-age|domain|path|secure|httponly|samesite)\b/i.test(fragment);
+      if (!inExpires) {
+        parts.push(fragment.trim());
+        start = i + 1;
+      }
+    } else if (char === ";") {
+      inExpires = false;
+    }
+  }
+  const tail = header.slice(start).trim();
+  if (tail) parts.push(tail);
+  return parts;
+}
+
+function getSetCookieHeaders(headers: Headers): string[] {
+  const withGetSetCookie = headers as Headers & { getSetCookie?: () => string[] };
+  const direct = withGetSetCookie.getSetCookie?.();
+  if (direct && direct.length > 0) return direct;
+  const header = headers.get("set-cookie");
+  return header ? splitSetCookieHeader(header) : [];
+}
+
+export function parseCookiesFromSetCookie(headers: string[]): Map<string, string> {
+  const cookies = new Map<string, string>();
+  for (const header of headers) {
+    const first = header.split(";")[0] ?? "";
+    const eq = first.indexOf("=");
+    if (eq <= 0) continue;
+    const name = first.slice(0, eq).trim();
+    const value = first.slice(eq + 1).trim();
+    if (!name) continue;
+    cookies.set(name, value);
+  }
+  return cookies;
+}
+
+function cookieHeaderFromJar(jar: Map<string, string>): string {
+  return [...jar.entries()].map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+function mergeSetCookies(cookieJar: Map<string, string>, response: Response): void {
+  for (const [name, value] of parseCookiesFromSetCookie(getSetCookieHeaders(response.headers))) {
+    cookieJar.set(name, value);
+  }
+}
+
+async function followRedirectsForCookies(startUrl: string, cookieJar: Map<string, string>): Promise<void> {
+  let currentUrl = startUrl;
+  for (let redirectCount = 0; redirectCount < 8; redirectCount += 1) {
+    const response = await substackFetch(currentUrl, {
+      method: "GET",
+      redirect: "manual",
+      headers: cookieJar.size > 0 ? { cookie: cookieHeaderFromJar(cookieJar) } : undefined,
+    });
+    mergeSetCookies(cookieJar, response);
+
+    if (response.status < 300 || response.status >= 400) break;
+    const location = response.headers.get("location");
+    if (!location) break;
+    const nextUrl = resolveSubstackUrl(location, currentUrl);
+    if (!nextUrl) break;
+    currentUrl = nextUrl;
+  }
+}
+
+export async function completeSubstackMagicLink(link: string, email: string): Promise<SubstackAuthState> {
+  const currentUrl = resolveSubstackUrl(link);
+  if (!currentUrl) throw new Error("Paste the full Substack magic-link URL");
+
+  const cookieJar = new Map<string, string>();
+  await followRedirectsForCookies(currentUrl, cookieJar);
+
+  const sid = cookieJar.get("substack.sid");
+  if (!sid) {
+    throw new Error("Substack did not return a session cookie. Request a new login link and paste the full URL.");
+  }
+  const auth: SubstackAuthState = {
+    email: email.trim(),
+    sid,
+    lli: cookieJar.get("substack.lli") ?? "1",
+    loggedInAt: Date.now(),
+  };
+  storeSubstackAuth(auth);
+  return auth;
+}
+
+export async function completeSubstackOtpLogin(code: string, email: string): Promise<SubstackAuthState> {
+  const normalizedCode = code.trim();
+  const normalizedEmail = email.trim();
+  if (!/^\d{6}$/.test(normalizedCode)) {
+    throw new Error("Enter the 6-digit Substack email code");
+  }
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalizedEmail)) {
+    throw new Error("Enter a valid email address");
+  }
+
+  const cookieJar = new Map<string, string>();
+  const response = await substackFetch(`${SUBSTACK_ORIGIN}/api/v1/email-otp-login/complete`, {
+    method: "POST",
+    redirect: "manual",
+    credentials: "include",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      code: normalizedCode,
+      email: normalizedEmail,
+      redirect: "",
+      for_pub: null,
+      island_magic_signin: false,
+    }),
+  });
+  mergeSetCookies(cookieJar, response);
+
+  const isRedirect = response.status >= 300 && response.status < 400;
+  if (!response.ok && !isRedirect) {
+    const detail = await parseErrorText(response);
+    throw new Error(`Substack code login failed (${response.status})${detail ? `: ${detail}` : ""}`);
+  }
+
+  let redirectUrl = resolveSubstackUrl(response.headers.get("location"));
+  if (!redirectUrl && response.ok) {
+    try {
+      const payload = await response.clone().json() as { redirect?: unknown };
+      redirectUrl = resolveSubstackUrl(payload.redirect);
+    } catch {
+      redirectUrl = null;
+    }
+  }
+
+  if (!cookieJar.get("substack.sid") && redirectUrl) {
+    await followRedirectsForCookies(redirectUrl, cookieJar);
+  }
+
+  const sid = cookieJar.get("substack.sid");
+  if (!sid) {
+    const capturedCookieNames = [...cookieJar.keys()];
+    throw new Error(
+      `Substack accepted the code but did not return a session cookie. status=${response.status} redirect=${redirectUrl ? "yes" : "no"} cookies=${capturedCookieNames.length ? capturedCookieNames.join(",") : "none"}`,
+    );
+  }
+  const auth: SubstackAuthState = {
+    email: normalizedEmail,
+    sid,
+    lli: cookieJar.get("substack.lli") ?? "1",
+    loggedInAt: Date.now(),
+  };
+  storeSubstackAuth(auth);
+  return auth;
+}

--- a/src/plugins/builtin/substack/api/cache.ts
+++ b/src/plugins/builtin/substack/api/cache.ts
@@ -1,0 +1,78 @@
+import type { PersistedResourceValue } from "../../../../types/persistence";
+import {
+  sortSubscriptionsByLatest,
+} from "../normalize";
+import type {
+  SubstackArticleDetail,
+  SubstackArticleSummary,
+  SubstackPublication,
+} from "../types";
+import type { SubstackCachedData, SubstackHomeData, SubstackPublicationFeedPage } from "./types";
+import { readResource } from "./store";
+
+const PUBLICATION_ARCHIVE_MAX_CACHED_PAGES = 20;
+
+export function publicationCacheKey(publication: SubstackPublication, offset: number): string {
+  return `${publication.baseUrl ?? publication.subdomain ?? publication.id}:offset:${offset}`;
+}
+
+function cachedDataFromResource<T>(entry: PersistedResourceValue<T> | null): SubstackCachedData<T> | null {
+  if (!entry) return null;
+  return {
+    data: entry.value,
+    fetchedAt: entry.fetchedAt,
+    stale: Boolean(entry.stale),
+  };
+}
+
+export function getCachedSubstackHome(): SubstackHomeData | null {
+  const subscriptionsEntry = readResource<SubstackPublication[]>("subscriptions", "me", false);
+  const feedEntry = readResource<SubstackArticleSummary[]>("feed", "subscribed", false);
+  if (!subscriptionsEntry || !feedEntry) return null;
+  return {
+    subscriptions: sortSubscriptionsByLatest(subscriptionsEntry.value, feedEntry.value),
+    feed: feedEntry.value,
+    fetchedAt: Math.max(subscriptionsEntry.fetchedAt, feedEntry.fetchedAt),
+    stale: Boolean(subscriptionsEntry.stale) || Boolean(feedEntry.stale),
+  };
+}
+
+export function getCachedSubstackPublicationFeed(
+  publication: SubstackPublication,
+): SubstackCachedData<SubstackPublicationFeedPage> | null {
+  let offset: number | null = 0;
+  let pageCount = 0;
+  let merged: SubstackPublicationFeedPage | null = null;
+  let fetchedAt = 0;
+  let stale = false;
+
+  while (offset != null && pageCount < PUBLICATION_ARCHIVE_MAX_CACHED_PAGES) {
+    const entry: PersistedResourceValue<SubstackPublicationFeedPage> | null = readResource<SubstackPublicationFeedPage>(
+      "publication",
+      publicationCacheKey(publication, offset),
+      false,
+    );
+    if (!entry) break;
+    const itemsById = new Map<string, SubstackArticleSummary>();
+    for (const article of merged?.items ?? []) itemsById.set(article.id, article);
+    for (const article of entry.value.items) itemsById.set(article.id, article);
+    merged = {
+      items: [...itemsById.values()],
+      nextOffset: entry.value.nextOffset,
+      hasMore: entry.value.hasMore,
+    };
+    fetchedAt = Math.max(fetchedAt, entry.fetchedAt);
+    stale = stale || Boolean(entry.stale);
+    offset = entry.value.nextOffset;
+    pageCount += 1;
+  }
+
+  if (!merged) return null;
+  return { data: merged, fetchedAt, stale };
+}
+
+export function getCachedSubstackArticleDetail(
+  article: Pick<SubstackArticleSummary, "id">,
+): SubstackCachedData<SubstackArticleDetail> | null {
+  return cachedDataFromResource(readResource<SubstackArticleDetail>("post", article.id, false));
+}

--- a/src/plugins/builtin/substack/api/loaders.ts
+++ b/src/plugins/builtin/substack/api/loaders.ts
@@ -1,0 +1,146 @@
+import {
+  normalizeFeedItems,
+  normalizePostDetail,
+  normalizeSubscriptions,
+  sortSubscriptionsByLatest,
+} from "../normalize";
+import type {
+  SubstackArticleSummary,
+  SubstackPublication,
+} from "../types";
+import { SubstackAuthError, type SubstackCachedData, type SubstackHomeData, type SubstackPublicationFeedPage } from "./types";
+import { publicationCacheKey } from "./cache";
+import {
+  fetchJsonAuthenticated,
+  loadCachedResource,
+  requireAuth,
+  SUBSTACK_ORIGIN,
+} from "./store";
+
+const READER_FEED_TARGET_ITEMS = 50;
+const READER_FEED_MAX_PAGES = 12;
+const PUBLICATION_ARCHIVE_PAGE_LIMIT = 12;
+
+export async function loadSubstackHome(force = false): Promise<SubstackHomeData> {
+  const auth = requireAuth();
+  const [subscriptionsEntry, feedEntry] = await Promise.all([
+    loadCachedResource("subscriptions", "me", force, async () => {
+      const payload = await fetchJsonAuthenticated<unknown>(`${SUBSTACK_ORIGIN}/api/v1/subscriptions/page_v2`, auth);
+      return normalizeSubscriptions(payload);
+    }),
+    loadCachedResource("feed", "subscribed", force, async () => {
+      return fetchReaderFeedItems(auth, "subscribed");
+    }),
+  ]);
+  return {
+    subscriptions: sortSubscriptionsByLatest(subscriptionsEntry.data, feedEntry.data),
+    feed: feedEntry.data,
+    fetchedAt: Math.max(subscriptionsEntry.fetchedAt, feedEntry.fetchedAt),
+    stale: subscriptionsEntry.stale || feedEntry.stale,
+  };
+}
+
+function payloadCursor(payload: unknown): string | null {
+  const record = payload && typeof payload === "object" && !Array.isArray(payload)
+    ? payload as Record<string, unknown>
+    : null;
+  const cursor = record?.nextCursor ?? record?.next_cursor;
+  return typeof cursor === "string" && cursor.trim() ? cursor : null;
+}
+
+async function fetchReaderFeedItems(auth: ReturnType<typeof requireAuth>, tab: string): Promise<SubstackArticleSummary[]> {
+  const collected = new Map<string, SubstackArticleSummary>();
+  let cursor: string | null = null;
+  for (let page = 0; page < READER_FEED_MAX_PAGES && collected.size < READER_FEED_TARGET_ITEMS; page += 1) {
+    const url = new URL(`${SUBSTACK_ORIGIN}/api/v1/reader/feed`);
+    url.searchParams.set("tab", tab);
+    if (cursor) url.searchParams.set("cursor", cursor);
+    const payload = await fetchJsonAuthenticated<unknown>(url.toString(), auth);
+    for (const article of normalizeFeedItems(payload)) {
+      collected.set(article.id, article);
+      if (collected.size >= READER_FEED_TARGET_ITEMS) break;
+    }
+    const nextCursor = payloadCursor(payload);
+    if (!nextCursor || nextCursor === cursor) break;
+    cursor = nextCursor;
+  }
+  return [...collected.values()];
+}
+
+export async function loadSubstackPublicationFeed(
+  publication: SubstackPublication,
+  force = false,
+  offset = 0,
+): Promise<SubstackCachedData<SubstackPublicationFeedPage>> {
+  const auth = requireAuth();
+  const baseUrl = publication.baseUrl;
+  if (!baseUrl) {
+    return {
+      data: { items: [], nextOffset: null, hasMore: false },
+      fetchedAt: Date.now(),
+      stale: false,
+    };
+  }
+  return loadCachedResource("publication", publicationCacheKey(publication, offset), force, async () => {
+    const url = new URL("/api/v1/archive", baseUrl);
+    url.searchParams.set("sort", "new");
+    url.searchParams.set("limit", String(PUBLICATION_ARCHIVE_PAGE_LIMIT));
+    if (offset > 0) url.searchParams.set("offset", String(offset));
+    const payload = await fetchJsonAuthenticated<unknown>(url.toString(), auth);
+    const items = normalizeFeedItems(payload, publication);
+    const hasMore = items.length >= PUBLICATION_ARCHIVE_PAGE_LIMIT;
+    return {
+      items,
+      nextOffset: hasMore ? offset + PUBLICATION_ARCHIVE_PAGE_LIMIT : null,
+      hasMore,
+    };
+  });
+}
+
+function detailCandidateUrls(article: SubstackArticleSummary): string[] {
+  const urls: string[] = [];
+  if (/^\d+$/.test(article.id)) {
+    urls.push(new URL(`/api/v1/posts/by-id/${article.id}`, SUBSTACK_ORIGIN).toString());
+  }
+  const baseUrl = article.publicationBaseUrl
+    ?? (article.url ? new URL(article.url).origin : null);
+  if (baseUrl) {
+    if (/^\d+$/.test(article.id)) {
+      urls.push(new URL(`/api/v1/posts/by-id/${article.id}`, baseUrl).toString());
+    }
+    if (article.slug) {
+      urls.push(new URL(`/api/v1/posts/${article.slug}`, baseUrl).toString());
+    }
+    if (article.url) {
+      try {
+        const pathSlug = new URL(article.url).pathname.match(/\/p\/([^/?#]+)/)?.[1];
+        if (pathSlug) urls.push(new URL(`/api/v1/posts/${decodeURIComponent(pathSlug)}`, baseUrl).toString());
+      } catch {
+        // Ignore malformed article URLs; the direct post id/slug paths above still apply.
+      }
+    }
+  }
+  return [...new Set(urls)];
+}
+
+export async function loadSubstackArticleDetail(
+  article: SubstackArticleSummary,
+  force = false,
+): Promise<SubstackCachedData<ReturnType<typeof normalizePostDetail>>> {
+  const auth = requireAuth();
+  return loadCachedResource("post", article.id, force, async () => {
+    const urls = detailCandidateUrls(article);
+    const errors: string[] = [];
+    for (const url of urls) {
+      try {
+        const payload = await fetchJsonAuthenticated<unknown>(url, auth);
+        return normalizePostDetail(payload, article);
+      } catch (error) {
+        if (error instanceof SubstackAuthError) throw error;
+        errors.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+    if (article.bodyHtml || urls.length === 0) return normalizePostDetail(article, article);
+    throw new Error(errors[0] ?? "Substack post content unavailable");
+  });
+}

--- a/src/plugins/builtin/substack/api/store.ts
+++ b/src/plugins/builtin/substack/api/store.ts
@@ -1,0 +1,186 @@
+import type { PluginPersistence } from "../../../../types/plugin";
+import type { CachePolicy, PersistedResourceValue } from "../../../../types/persistence";
+import { createThrottledFetch, type ThrottledFetchTransport } from "../../../../utils/throttled-fetch";
+import { normalizedHttpUrl } from "../../../../utils/url";
+import { SubstackAuthError, type SubstackAuthState, type SubstackCachedData } from "./types";
+
+export const SUBSTACK_ORIGIN = "https://substack.com";
+
+const AUTH_STATE_KEY = "auth";
+const AUTH_SCHEMA_VERSION = 1;
+export const CACHE_SOURCE = "substack";
+export const CACHE_SCHEMA_VERSION = 3;
+const DEFAULT_HEADERS = {
+  accept: "application/json,text/plain,*/*",
+  "accept-language": "en-US,en;q=0.9",
+  "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+};
+const CACHE_POLICIES = {
+  subscriptions: { staleMs: 30 * 60 * 1000, expireMs: 14 * 24 * 60 * 60 * 1000 },
+  feed: { staleMs: 5 * 60 * 1000, expireMs: 3 * 24 * 60 * 60 * 1000 },
+  publication: { staleMs: 10 * 60 * 1000, expireMs: 7 * 24 * 60 * 60 * 1000 },
+  post: { staleMs: 30 * 24 * 60 * 60 * 1000, expireMs: 365 * 24 * 60 * 60 * 1000 },
+} satisfies Record<string, CachePolicy>;
+
+let substackPersistence: PluginPersistence | null = null;
+let substackClient = createThrottledFetch({
+  requestsPerMinute: 60,
+  maxRetries: 1,
+  timeoutMs: 15_000,
+  defaultHeaders: DEFAULT_HEADERS,
+  dedupeGetRequests: false,
+});
+const activeFetches = new Map<string, Promise<SubstackCachedData<unknown>>>();
+
+export function attachSubstackPersistence(persistence: PluginPersistence): void {
+  substackPersistence = persistence;
+}
+
+export function resetSubstackPersistence(): void {
+  substackPersistence = null;
+  activeFetches.clear();
+}
+
+export function setSubstackFetchTransportForTests(transport: ThrottledFetchTransport | null): void {
+  substackClient = createThrottledFetch({
+    requestsPerMinute: 10_000,
+    maxRetries: 0,
+    timeoutMs: 15_000,
+    defaultHeaders: DEFAULT_HEADERS,
+    dedupeGetRequests: false,
+    transport: transport ?? undefined,
+  });
+  activeFetches.clear();
+}
+
+function isAuthState(value: unknown): value is SubstackAuthState {
+  const record = value as Partial<SubstackAuthState> | null;
+  return !!record
+    && typeof record === "object"
+    && typeof record.email === "string"
+    && typeof record.sid === "string"
+    && record.sid.length > 0
+    && typeof record.loggedInAt === "number";
+}
+
+export function getStoredSubstackAuth(): SubstackAuthState | null {
+  const auth = substackPersistence?.getState<unknown>(AUTH_STATE_KEY, { schemaVersion: AUTH_SCHEMA_VERSION });
+  return isAuthState(auth) ? auth : null;
+}
+
+export function storeSubstackAuth(auth: SubstackAuthState): void {
+  substackPersistence?.setState(AUTH_STATE_KEY, auth, { schemaVersion: AUTH_SCHEMA_VERSION });
+}
+
+export function clearSubstackAuth(): void {
+  substackPersistence?.deleteState(AUTH_STATE_KEY);
+}
+
+export function requireAuth(): SubstackAuthState {
+  const auth = getStoredSubstackAuth();
+  if (!auth) throw new SubstackAuthError();
+  return auth;
+}
+
+function authHeaders(auth: SubstackAuthState): Record<string, string> {
+  return {
+    cookie: `substack.sid=${auth.sid}; substack.lli=${auth.lli?.trim() || "1"}`,
+  };
+}
+
+export async function parseErrorText(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.replace(/\s+/g, " ").trim().slice(0, 240);
+  } catch {
+    return "";
+  }
+}
+
+export async function substackFetch(url: string, init?: RequestInit): Promise<Response> {
+  return substackClient.fetch(url, init);
+}
+
+export async function fetchJsonAuthenticated<T = unknown>(url: string, auth: SubstackAuthState): Promise<T> {
+  const response = await substackClient.fetch(url, {
+    headers: authHeaders(auth),
+  });
+  if (response.status === 401 || response.status === 403) {
+    clearSubstackAuth();
+    throw new SubstackAuthError("Substack session expired");
+  }
+  if (!response.ok) {
+    const detail = await parseErrorText(response);
+    throw new Error(`Substack HTTP ${response.status}${detail ? `: ${detail}` : ""}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export function readResource<T>(kind: string, key: string, allowExpired = false): PersistedResourceValue<T> | null {
+  return substackPersistence?.getResource<T>(kind, key, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    allowExpired,
+  }) ?? null;
+}
+
+function writeResource<T>(kind: string, key: string, value: T, cachePolicy: CachePolicy): PersistedResourceValue<T> | null {
+  return substackPersistence?.setResource<T>(kind, key, value, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    cachePolicy,
+  }) ?? null;
+}
+
+export async function loadCachedResource<T>(
+  kind: keyof typeof CACHE_POLICIES,
+  key: string,
+  force: boolean,
+  loader: () => Promise<T>,
+): Promise<SubstackCachedData<T>> {
+  const fresh = readResource<T>(kind, key, false);
+  if (!force && fresh && !fresh.stale) {
+    return { data: fresh.value, fetchedAt: fresh.fetchedAt, stale: false };
+  }
+
+  const activeKey = `${kind}:${key}`;
+  const active = activeFetches.get(activeKey);
+  if (active) return active as Promise<SubstackCachedData<T>>;
+
+  const fallback = fresh ?? readResource<T>(kind, key, true);
+  const promise = loader()
+    .then((data) => {
+      const record = writeResource(kind, key, data, CACHE_POLICIES[kind]);
+      return {
+        data,
+        fetchedAt: record?.fetchedAt ?? Date.now(),
+        stale: false,
+      };
+    })
+    .catch((error) => {
+      if (fallback) {
+        return {
+          data: fallback.value,
+          fetchedAt: fallback.fetchedAt,
+          stale: true,
+        };
+      }
+      throw error;
+    })
+    .finally(() => {
+      activeFetches.delete(activeKey);
+    });
+  activeFetches.set(activeKey, promise as Promise<SubstackCachedData<unknown>>);
+  return promise;
+}
+
+export function resolveSubstackUrl(value: unknown, baseUrl = SUBSTACK_ORIGIN): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const direct = normalizedHttpUrl(value);
+  if (direct) return direct;
+  try {
+    return normalizedHttpUrl(new URL(value, baseUrl).toString());
+  } catch {
+    return null;
+  }
+}

--- a/src/plugins/builtin/substack/api/types.ts
+++ b/src/plugins/builtin/substack/api/types.ts
@@ -1,0 +1,40 @@
+import type {
+  SubstackArticleDetail,
+  SubstackArticleSummary,
+  SubstackPublication,
+} from "../types";
+
+export interface SubstackAuthState {
+  email: string;
+  sid: string;
+  lli: string | null;
+  loggedInAt: number;
+}
+
+export interface SubstackHomeData {
+  subscriptions: SubstackPublication[];
+  feed: SubstackArticleSummary[];
+  fetchedAt: number;
+  stale: boolean;
+}
+
+export interface SubstackPublicationFeedPage {
+  items: SubstackArticleSummary[];
+  nextOffset: number | null;
+  hasMore: boolean;
+}
+
+export interface SubstackCachedData<T> {
+  data: T;
+  fetchedAt: number;
+  stale: boolean;
+}
+
+export class SubstackAuthError extends Error {
+  constructor(message = "Substack login required") {
+    super(message);
+    this.name = "SubstackAuthError";
+  }
+}
+
+export type { SubstackArticleDetail, SubstackArticleSummary, SubstackPublication };

--- a/src/plugins/builtin/substack/article-detail.tsx
+++ b/src/plugins/builtin/substack/article-detail.tsx
@@ -1,0 +1,359 @@
+import { useCallback, type RefObject } from "react";
+import { Box, ScrollBox, Text, TextAttributes, useRendererHost, type ScrollBoxRenderable } from "../../../ui";
+import { Spinner } from "../../../components";
+import { RemoteImage } from "../../../components/ui";
+import { TickerBadgeText } from "../../../components/ticker/badge/text";
+import { useInlineTickers } from "../../../state/hooks/inline-tickers";
+import { colors } from "../../../theme/colors";
+import type {
+  SubstackArticleDetail,
+  SubstackArticleSummary,
+  SubstackContentBlock,
+} from "./types";
+
+function articleBlockText(block: SubstackContentBlock): string {
+  switch (block.type) {
+    case "heading":
+    case "paragraph":
+    case "quote":
+    case "listItem":
+      return block.text;
+    case "embed":
+      return [block.text, block.url].filter(Boolean).join("\n");
+    default:
+      return "";
+  }
+}
+
+function wrappedTextProps(width: number) {
+  return {
+    width,
+    wrapText: true,
+    wrapMode: "word",
+    style: {
+      minWidth: 0,
+      whiteSpace: "pre-wrap",
+      overflowWrap: "anywhere",
+    },
+  } as const;
+}
+
+function normalizedTwitterUsername(username: string | null | undefined): string | null {
+  const normalized = username?.trim().replace(/^@/, "") ?? "";
+  return /^[A-Za-z0-9_]{1,15}$/.test(normalized) ? normalized : null;
+}
+
+function TweetEmbedView({
+  block,
+  lineWidth,
+  imageWidth,
+  imageHeight,
+  catalog,
+  openTicker,
+  openLink,
+  openUsername,
+}: {
+  block: Extract<SubstackContentBlock, { type: "embed"; kind: "tweet" }>;
+  lineWidth: number;
+  imageWidth: number;
+  imageHeight: number;
+  catalog: ReturnType<typeof useInlineTickers>["catalog"];
+  openTicker: ReturnType<typeof useInlineTickers>["openTicker"];
+  openLink: (url: string) => void;
+  openUsername: (username: string) => void;
+}) {
+  const username = normalizedTwitterUsername(block.username);
+  const contentWidth = Math.max(1, lineWidth - 3);
+
+  return (
+    <Box flexDirection="column" width={lineWidth} paddingX={1}>
+      <Box flexDirection="row" width={Math.max(1, lineWidth - 2)}>
+        <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>Tweet</Text>
+        {username ? (
+          <Text
+            fg={colors.borderFocused}
+            onMouseDown={() => openUsername(username)}
+          >
+            {` @${username}`}
+          </Text>
+        ) : null}
+        {block.dateLabel ? <Text fg={colors.textDim}>{` | ${block.dateLabel}`}</Text> : null}
+      </Box>
+      <Box flexDirection="row" width={Math.max(1, lineWidth - 2)}>
+        <Text fg={colors.borderFocused}>| </Text>
+        <Box width={contentWidth}>
+          <TickerBadgeText
+            text={block.text}
+            lineWidth={contentWidth}
+            catalog={catalog}
+            textColor={colors.text}
+            openTicker={openTicker}
+            openLink={openLink}
+            openUsername={openUsername}
+          />
+        </Box>
+      </Box>
+      {block.imageUrls.length > 0 ? (
+        <Box flexDirection="column" paddingLeft={2}>
+          {block.imageUrls.slice(0, 2).map((url, index) => (
+            <RemoteImage
+              key={url}
+              src={url}
+              alt={`Tweet image ${index + 1}`}
+              width={Math.max(1, imageWidth - 2)}
+              height={Math.max(4, Math.min(imageHeight, 10))}
+              label={block.imageUrls.length > 1 ? `tweet image ${index + 1}` : "tweet image"}
+            />
+          ))}
+        </Box>
+      ) : null}
+      {block.url ? (
+        <Text
+          fg={colors.borderFocused}
+          onMouseDown={() => openLink(block.url!)}
+        >
+          open tweet
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+function ArticleBlockView({
+  block,
+  lineWidth,
+  imageWidth,
+  imageHeight,
+  catalog,
+  openTicker,
+  openLink,
+  openUsername,
+}: {
+  block: SubstackContentBlock;
+  lineWidth: number;
+  imageWidth: number;
+  imageHeight: number;
+  catalog: ReturnType<typeof useInlineTickers>["catalog"];
+  openTicker: ReturnType<typeof useInlineTickers>["openTicker"];
+  openLink: (url: string) => void;
+  openUsername: (username: string) => void;
+}) {
+  switch (block.type) {
+    case "heading":
+      return (
+        <Text
+          fg={colors.textBright}
+          attributes={TextAttributes.BOLD}
+          {...wrappedTextProps(lineWidth)}
+        >
+          {block.text}
+        </Text>
+      );
+    case "quote":
+      return (
+        <Box flexDirection="row" width={lineWidth}>
+          <Text fg={colors.warning}>| </Text>
+          <Box width={Math.max(1, lineWidth - 2)}>
+            <TickerBadgeText
+              text={block.text}
+              lineWidth={Math.max(1, lineWidth - 2)}
+              catalog={catalog}
+              textColor={colors.textDim}
+              openTicker={openTicker}
+              openLink={openLink}
+              openUsername={openUsername}
+            />
+          </Box>
+        </Box>
+      );
+    case "listItem":
+      return (
+        <Box flexDirection="row" width={lineWidth}>
+          <Text fg={colors.textDim}>- </Text>
+          <Box width={Math.max(1, lineWidth - 2)}>
+            <TickerBadgeText
+              text={block.text}
+              lineWidth={Math.max(1, lineWidth - 2)}
+              catalog={catalog}
+              textColor={colors.text}
+              openTicker={openTicker}
+              openLink={openLink}
+              openUsername={openUsername}
+            />
+          </Box>
+        </Box>
+      );
+    case "image":
+      return (
+        <RemoteImage
+          src={block.url}
+          alt={block.alt ?? "Substack image"}
+          width={imageWidth}
+          height={imageHeight}
+          label={block.alt ?? "image"}
+        />
+      );
+    case "embed":
+      if (block.kind === "tweet") {
+        return (
+          <TweetEmbedView
+            block={block}
+            lineWidth={lineWidth}
+            imageWidth={imageWidth}
+            imageHeight={imageHeight}
+            catalog={catalog}
+            openTicker={openTicker}
+            openLink={openLink}
+            openUsername={openUsername}
+          />
+        );
+      }
+      return (
+        <Box flexDirection="column" width={lineWidth} paddingX={1}>
+          <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+            {block.kind === "media" ? "Media" : "Link"}
+          </Text>
+          <TickerBadgeText
+            text={block.text}
+            lineWidth={Math.max(1, lineWidth - 2)}
+            catalog={catalog}
+            textColor={colors.text}
+            openTicker={openTicker}
+            openLink={openLink}
+            openUsername={openUsername}
+          />
+          {block.url ? (
+            <Text
+              fg={colors.borderFocused}
+              onMouseDown={() => openLink(block.url!)}
+              {...wrappedTextProps(Math.max(1, lineWidth - 2))}
+            >
+              {block.url}
+            </Text>
+          ) : null}
+        </Box>
+      );
+    case "divider":
+      return <Text fg={colors.border}>{"-".repeat(Math.max(1, Math.min(lineWidth, 96)))}</Text>;
+    case "paragraph":
+    default:
+      return (
+        <TickerBadgeText
+          text={block.text}
+          lineWidth={lineWidth}
+          catalog={catalog}
+          textColor={colors.text}
+          openTicker={openTicker}
+          openLink={openLink}
+          openUsername={openUsername}
+        />
+      );
+  }
+}
+
+function ArticleRichContent({
+  blocks,
+  fallbackText,
+  fallbackImageUrls,
+  articleTitle,
+  lineWidth,
+  imageWidth,
+  imageHeight,
+}: {
+  blocks: SubstackContentBlock[];
+  fallbackText: string;
+  fallbackImageUrls: string[];
+  articleTitle: string;
+  lineWidth: number;
+  imageWidth: number;
+  imageHeight: number;
+}) {
+  const rendererHost = useRendererHost();
+  const resolvedBlocks = blocks.length > 0
+    ? blocks
+    : [
+      ...(fallbackText ? [{ type: "paragraph" as const, text: fallbackText }] : []),
+      ...fallbackImageUrls.map((url): SubstackContentBlock => ({ type: "image", url, alt: articleTitle })),
+    ];
+  const tickerText = resolvedBlocks.map(articleBlockText).filter(Boolean).join("\n");
+  const { catalog, openTicker } = useInlineTickers([tickerText], { liveQuotes: false });
+  const openLink = useCallback((url: string) => {
+    void rendererHost.openExternal(url);
+  }, [rendererHost]);
+  const openUsername = useCallback((username: string) => {
+    const normalized = normalizedTwitterUsername(username);
+    if (!normalized) return;
+    void rendererHost.openExternal(`https://x.com/${normalized}`);
+  }, [rendererHost]);
+
+  if (resolvedBlocks.length === 0) {
+    return <Text fg={colors.textDim}>No article text returned.</Text>;
+  }
+
+  return (
+    <Box flexDirection="column" width={lineWidth} gap={1}>
+      {resolvedBlocks.map((block, index) => (
+        <ArticleBlockView
+          key={`${block.type}:${index}:${articleBlockText(block).slice(0, 32)}`}
+          block={block}
+          lineWidth={lineWidth}
+          imageWidth={imageWidth}
+          imageHeight={imageHeight}
+          catalog={catalog}
+          openTicker={openTicker}
+          openLink={openLink}
+          openUsername={openUsername}
+        />
+      ))}
+    </Box>
+  );
+}
+
+export function ArticleDetail({
+  article,
+  detail,
+  width,
+  loading,
+  error,
+  scrollRef,
+  onOpenArticle,
+}: {
+  article: SubstackArticleSummary;
+  detail: SubstackArticleDetail | null;
+  width: number;
+  loading: boolean;
+  error: string | null;
+  scrollRef: RefObject<ScrollBoxRenderable | null>;
+  onOpenArticle: () => void;
+}) {
+  const resolved = detail ?? null;
+  const text = resolved?.contentText || article.previewText || article.subtitle || "";
+  const blocks = resolved?.contentBlocks ?? [];
+  const fallbackImageUrls = resolved?.imageUrls.length ? resolved.imageUrls : article.imageUrls;
+  const lineWidth = Math.max(1, width - 2);
+  const imageWidth = Math.min(lineWidth, 86);
+  const imageHeight = Math.max(6, Math.min(14, Math.floor(imageWidth * 0.32)));
+
+  return (
+    <ScrollBox ref={scrollRef} scrollY focusable={false} flexGrow={1} paddingX={1}>
+      <Box flexDirection="column" width={lineWidth} gap={1}>
+        {loading && !resolved ? <Spinner label="Loading article..." /> : null}
+        {error ? <Text fg={colors.negative}>{error}</Text> : null}
+        <ArticleRichContent
+          blocks={blocks}
+          fallbackText={text}
+          fallbackImageUrls={fallbackImageUrls}
+          articleTitle={article.title}
+          lineWidth={lineWidth}
+          imageWidth={imageWidth}
+          imageHeight={imageHeight}
+        />
+        {article.url ? (
+          <Box height={1}>
+            <Text fg={colors.textDim} onMouseDown={onOpenArticle}>Open source: O</Text>
+          </Box>
+        ) : null}
+      </Box>
+    </ScrollBox>
+  );
+}

--- a/src/plugins/builtin/substack/article-stack.tsx
+++ b/src/plugins/builtin/substack/article-stack.tsx
@@ -1,0 +1,129 @@
+import { useCallback, type ReactNode, type RefObject } from "react";
+import { Box, Text, TextAttributes, type ScrollBoxRenderable } from "../../../ui";
+import {
+  DataTableStackView,
+  type DataTableCell,
+  type DataTableKeyEvent,
+} from "../../../components";
+import { colors } from "../../../theme/colors";
+import {
+  formatPublishedAt,
+  formatReadTime,
+} from "./table";
+import type {
+  SubstackArticleSummary,
+  SubstackColumn,
+  SubstackPublication,
+  SubstackSortColumnId,
+  SubstackSortDirection,
+} from "./types";
+import type { ActiveFeedState } from "./pane-state";
+
+export function SubstackArticleStack({
+  focused,
+  detailOpen,
+  selectedArticle,
+  selectedArticleId,
+  detailContent,
+  activePublication,
+  activeFeedState,
+  sortedRows,
+  sort,
+  columns,
+  tableScrollRef,
+  width,
+  height,
+  onBack,
+  onActivate,
+  onSelectionChange,
+  onRootKeyDown,
+  onDetailKeyDown,
+  onBodyScrollActivity,
+  onHeaderClick,
+}: {
+  focused: boolean;
+  detailOpen: boolean;
+  selectedArticle: SubstackArticleSummary | null;
+  selectedArticleId: string | null;
+  detailContent: ReactNode;
+  activePublication: SubstackPublication | null;
+  activeFeedState: ActiveFeedState;
+  sortedRows: SubstackArticleSummary[];
+  sort: { columnId: SubstackSortColumnId; direction: SubstackSortDirection };
+  columns: SubstackColumn[];
+  tableScrollRef: RefObject<ScrollBoxRenderable | null>;
+  width: number;
+  height: number;
+  onBack: () => void;
+  onActivate: (article: SubstackArticleSummary) => void;
+  onSelectionChange: (id: string) => void;
+  onRootKeyDown: (event: DataTableKeyEvent) => boolean;
+  onDetailKeyDown: (event: DataTableKeyEvent) => boolean;
+  onBodyScrollActivity: () => void;
+  onHeaderClick: (columnId: string) => void;
+}) {
+  const renderCell = useCallback((
+    article: SubstackArticleSummary,
+    column: SubstackColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+    switch (column.id) {
+      case "published":
+        return { text: formatPublishedAt(article.publishedAt), color: selectedColor ?? colors.textDim };
+      case "publication":
+        return { text: article.publicationName ?? "-", color: selectedColor ?? colors.textBright };
+      case "title":
+        return {
+          text: article.title,
+          color: selectedColor ?? colors.text,
+          attributes: TextAttributes.BOLD,
+        };
+      case "read":
+        return {
+          text: formatReadTime(article.readMinutes),
+          color: selectedColor ?? colors.textDim,
+        };
+    }
+  }, []);
+
+  const bodyAfter = activePublication && sortedRows.length > 0 && (activeFeedState.loading || activeFeedState.loadingMore) ? (
+    <Box height={1} paddingX={1}>
+      <Text fg={colors.textDim}>{activeFeedState.loadingMore ? "Loading more..." : "Loading archive..."}</Text>
+    </Box>
+  ) : null;
+
+  return (
+    <DataTableStackView<SubstackArticleSummary, SubstackColumn>
+      focused={focused}
+      detailOpen={detailOpen}
+      onBack={onBack}
+      detailTitle={selectedArticle?.title}
+      detailContent={detailContent}
+      selection={{
+        kind: "id",
+        selectedId: selectedArticleId,
+        getId: (article) => article.id,
+        onChange: onSelectionChange,
+      }}
+      onActivate={onActivate}
+      onRootKeyDown={onRootKeyDown}
+      onDetailKeyDown={onDetailKeyDown}
+      onBodyScrollActivity={onBodyScrollActivity}
+      scrollRef={tableScrollRef}
+      bodyAfter={bodyAfter}
+      rootWidth={width}
+      rootHeight={Math.max(1, height - 1)}
+      columns={columns}
+      items={sortedRows}
+      sortColumnId={sort.columnId}
+      sortDirection={sort.direction}
+      onHeaderClick={onHeaderClick}
+      getItemKey={(article) => article.id}
+      renderCell={renderCell}
+      emptyStateTitle={activeFeedState.loading ? "Loading articles..." : activeFeedState.error ?? "No Substack posts"}
+      emptyStateHint={activePublication ? activePublication.name : "Authenticated reader feed"}
+    />
+  );
+}

--- a/src/plugins/builtin/substack/content.ts
+++ b/src/plugins/builtin/substack/content.ts
@@ -1,0 +1,478 @@
+import { decodeHtmlEntities } from "../../../utils/html-entities";
+import type { ExtractedArticleContent, SubstackContentBlock } from "./types";
+import {
+  asRecord,
+  extractAttribute,
+  firstString,
+  normalizeUrl,
+  parseDateIso,
+  rawStringValue,
+  stringValue,
+  uniqueStrings,
+  type JsonRecord,
+} from "./utils";
+
+const WORDS_PER_MINUTE = 220;
+
+export function wordCount(text: string): number {
+  return text.match(/[\p{L}\p{N}]+(?:['.-][\p{L}\p{N}]+)*/gu)?.length ?? 0;
+}
+
+export function estimateReadingMinutes(wordsOrText: number | string | null | undefined): number {
+  const words = typeof wordsOrText === "number"
+    ? wordsOrText
+    : typeof wordsOrText === "string"
+      ? wordCount(wordsOrText)
+      : 0;
+  return Math.max(1, Math.ceil(Math.max(0, words) / WORDS_PER_MINUTE));
+}
+
+function bestSrcsetUrl(srcset: string | null, baseUrl?: string | null): string | null {
+  if (!srcset) return null;
+  const candidates = srcset
+    .split(",")
+    .map((entry) => entry.trim().split(/\s+/)[0] ?? "")
+    .map((entry) => normalizeUrl(decodeHtmlEntities(entry), baseUrl))
+    .filter((entry): entry is string => !!entry);
+  return candidates.at(-1) ?? null;
+}
+
+export function extractImageUrlsFromHtml(html: string, baseUrl?: string | null): string[] {
+  const urls: Array<string | null> = [];
+  for (const match of html.matchAll(/<(img|source)\b[^>]*>/gi)) {
+    const tag = match[0];
+    urls.push(
+      normalizeUrl(decodeHtmlEntities(extractAttribute(tag, "src") ?? ""), baseUrl),
+      normalizeUrl(decodeHtmlEntities(extractAttribute(tag, "data-src") ?? ""), baseUrl),
+      bestSrcsetUrl(decodeHtmlEntities(extractAttribute(tag, "srcset") ?? ""), baseUrl),
+      bestSrcsetUrl(decodeHtmlEntities(extractAttribute(tag, "data-srcset") ?? ""), baseUrl),
+    );
+  }
+  return uniqueStrings(urls);
+}
+
+interface ExtractedLink {
+  url: string;
+  label: string;
+}
+
+function extractLinksFromHtml(html: string, baseUrl?: string | null): ExtractedLink[] {
+  const links: ExtractedLink[] = [];
+  for (const match of html.matchAll(/<a\b[^>]*>/gi)) {
+    const tag = match[0];
+    const url = normalizeUrl(decodeHtmlEntities(extractAttribute(tag, "href") ?? ""), baseUrl);
+    if (!url) continue;
+    const closeIndex = html.indexOf("</a>", match.index + tag.length);
+    const label = closeIndex >= 0
+      ? plainFragment(html.slice(match.index + tag.length, closeIndex))
+      : url;
+    links.push({ url, label: label || url });
+  }
+  const seen = new Set<string>();
+  return links.filter((link) => {
+    if (seen.has(link.url)) return false;
+    seen.add(link.url);
+    return true;
+  });
+}
+
+function extractLinkUrlsFromHtml(html: string, baseUrl?: string | null): string[] {
+  return extractLinksFromHtml(html, baseUrl).map((link) => link.url);
+}
+
+function plainFragment(html: string): string {
+  return decodeHtmlEntities(html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim());
+}
+
+function textFragment(html: string, baseUrl?: string | null): string {
+  const withReadableLinks = html.replace(
+    /<a\b([^>]*)>([\s\S]*?)<\/a>/gi,
+    (_match, attrs: string, inner: string) => {
+      const href = normalizeUrl(decodeHtmlEntities(extractAttribute(attrs, "href") ?? ""), baseUrl);
+      const label = plainFragment(inner);
+      if (label) return label;
+      return href ?? "";
+    },
+  );
+  return plainFragment(
+    withReadableLinks
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/(p|div|section|article|blockquote|h[1-6]|li|tr|ul|ol)>/gi, "\n"),
+  );
+}
+
+function normalizeArticleText(text: string): string {
+  return decodeHtmlEntities(text)
+    .replace(/\r/g, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n[ \t]+/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+/g, " ").trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function isSocialUrl(url: string | null | undefined): boolean {
+  return !!url && /\b(?:twitter\.com|x\.com|t\.co)\b/i.test(url);
+}
+
+function twitterUsernameFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const match = url.match(/\b(?:twitter\.com|x\.com)\/([A-Za-z0-9_]{1,15})\/status\//i);
+  return match?.[1] ?? null;
+}
+
+function socialEmbedUrl(links: ExtractedLink[]): string | null {
+  return links.find((link) => isSocialUrl(link.url))?.url ?? null;
+}
+
+function isSocialEmbed(attrs: string, inner: string, links: ExtractedLink[]): boolean {
+  return /twitter|tweet|x\.com/i.test(attrs)
+    || /twitter-tweet|tweet|platform\.twitter|x\.com|twitter\.com/i.test(inner)
+    || links.some((link) => isSocialUrl(link.url));
+}
+
+function formatTweetDateLabel(value: unknown): string | null {
+  const parsed = parseDateIso(value);
+  if (!parsed) return stringValue(value);
+  return new Date(parsed).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function isLikelyImageUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  const decoded = decodeURIComponent(url);
+  return /\/image\/fetch\//i.test(decoded)
+    || /\.(?:avif|gif|jpe?g|png|svg|webp)(?:[?#]|$)/i.test(decoded);
+}
+
+function textMatchesImageLink(text: string, links: ExtractedLink[], imageUrls: string[]): boolean {
+  const normalizedText = normalizeArticleText(text);
+  if (!normalizedText) return false;
+  const directUrl = normalizeUrl(normalizedText);
+  if (isLikelyImageUrl(directUrl)) return true;
+
+  const imageLinkLabels = links
+    .filter((link) => isLikelyImageUrl(link.url))
+    .flatMap((link) => [link.label, link.url])
+    .map(normalizeArticleText);
+  if (imageLinkLabels.includes(normalizedText)) return true;
+
+  return imageUrls.some((url) => normalizedText === url || normalizedText.includes(url));
+}
+
+function buildTweetEmbedBlock(
+  text: string,
+  links: ExtractedLink[],
+  url: string | null,
+): SubstackContentBlock {
+  const sourceLink = links.find((link) => link.url === url) ?? links.find((link) => isSocialUrl(link.url));
+  const dateLabel = sourceLink && sourceLink.label !== sourceLink.url ? sourceLink.label : null;
+  let body = normalizeArticleText(text);
+  if (dateLabel && body.endsWith(dateLabel)) {
+    body = normalizeArticleText(body.slice(0, -dateLabel.length));
+  }
+
+  let username = twitterUsernameFromUrl(url);
+  let authorName: string | null = null;
+  const authorMatch = body.match(/\s+[\u2014-]\s*([^@\n]+?)\s*\(@([A-Za-z0-9_]{1,15})\)\s*$/);
+  if (authorMatch?.index != null) {
+    authorName = normalizeArticleText(authorMatch[1] ?? "") || null;
+    username = username ?? authorMatch[2] ?? null;
+    body = normalizeArticleText(body.slice(0, authorMatch.index));
+  }
+
+  return {
+    type: "embed",
+    kind: "tweet",
+    text: body || "Tweet",
+    url,
+    username,
+    authorName,
+    dateLabel,
+    imageUrls: [],
+  };
+}
+
+function tweetTextFromRecord(record: JsonRecord | null): string | null {
+  const raw = rawStringValue(record?.full_text) ?? rawStringValue(record?.text);
+  if (!raw) return null;
+  const withReadableLinks = raw.replace(
+    /<a\b([^>]*)>([\s\S]*?)<\/a>/gi,
+    (_match, attrs: string, inner: string) => {
+      const href = normalizeUrl(decodeHtmlEntities(extractAttribute(attrs, "href") ?? ""));
+      const label = plainFragment(inner);
+      if (label) return label;
+      return href ?? "";
+    },
+  );
+  return normalizeArticleText(decodeHtmlEntities(withReadableLinks)
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " "));
+}
+
+function tweetImageUrlsFromRecord(record: JsonRecord | null): string[] {
+  const photos = Array.isArray(record?.photos) ? record.photos : [];
+  return uniqueStrings(photos.map((photo) => (
+    normalizeUrl(firstString(asRecord(photo), ["img_url", "url", "src"]))
+  )));
+}
+
+function tweetEmbedBlockFromAttrs(attrs: string): SubstackContentBlock | null {
+  const rawAttrs = extractAttribute(attrs, "data-attrs");
+  if (!rawAttrs) return null;
+  let record: JsonRecord | null = null;
+  try {
+    record = asRecord(JSON.parse(decodeHtmlEntities(rawAttrs)));
+  } catch {
+    return null;
+  }
+  if (!record) return null;
+
+  const url = normalizeUrl(firstString(record, ["url", "expanded_url"]));
+  const quoted = asRecord(record.quoted_tweet);
+  const text = [
+    tweetTextFromRecord(record),
+    tweetTextFromRecord(quoted) ? `Quoted: ${tweetTextFromRecord(quoted)}` : null,
+  ].filter(Boolean).join("\n\n");
+
+  return {
+    type: "embed",
+    kind: "tweet",
+    text: text || "Tweet",
+    url,
+    username: firstString(record, ["username"]) ?? twitterUsernameFromUrl(url),
+    authorName: firstString(record, ["name"]),
+    dateLabel: formatTweetDateLabel(record.date),
+    imageUrls: tweetImageUrlsFromRecord(record),
+  };
+}
+
+function pushTextBlock(
+  blocks: SubstackContentBlock[],
+  block: SubstackContentBlock,
+): void {
+  const text = "text" in block ? normalizeArticleText(block.text) : "";
+  if ("text" in block && !text) return;
+  const normalizedBlock = "text" in block ? { ...block, text } : block;
+  const previous = blocks.at(-1);
+  if (
+    previous
+    && "text" in previous
+    && "text" in normalizedBlock
+    && previous.type === normalizedBlock.type
+    && previous.text === normalizedBlock.text
+  ) {
+    return;
+  }
+  blocks.push(normalizedBlock);
+}
+
+function stripDuplicateLeadingTitleFromBlocks(
+  blocks: SubstackContentBlock[],
+  title: string | null | undefined,
+): SubstackContentBlock[] {
+  const normalizedTitle = (title ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+  if (!normalizedTitle) return blocks;
+  const index = blocks.findIndex((block) => "text" in block && block.text.trim().length > 0);
+  if (index < 0) return blocks;
+  const block = blocks[index]!;
+  if (!("text" in block)) return blocks;
+  const firstText = block.text.replace(/\s+/g, " ").trim().toLowerCase();
+  if (firstText !== normalizedTitle) return blocks;
+  return [...blocks.slice(0, index), ...blocks.slice(index + 1)];
+}
+
+function articleTextFromBlocks(blocks: SubstackContentBlock[]): string {
+  return normalizeArticleText(blocks
+    .map((block) => {
+      switch (block.type) {
+        case "heading":
+        case "paragraph":
+        case "quote":
+        case "listItem":
+          return block.text;
+        case "embed":
+          return [block.text, block.url].filter(Boolean).join("\n");
+        default:
+          return "";
+      }
+    })
+    .filter(Boolean)
+    .join("\n\n"));
+}
+
+function imageBlocksFromHtml(
+  html: string,
+  baseUrl: string | null,
+  seenImages: Set<string>,
+): SubstackContentBlock[] {
+  const blocks: SubstackContentBlock[] = [];
+  for (const match of html.matchAll(/<img\b[^>]*>/gi)) {
+    const tag = match[0];
+    const url = normalizeUrl(decodeHtmlEntities(extractAttribute(tag, "src") ?? ""), baseUrl)
+      ?? normalizeUrl(decodeHtmlEntities(extractAttribute(tag, "data-src") ?? ""), baseUrl)
+      ?? bestSrcsetUrl(decodeHtmlEntities(extractAttribute(tag, "srcset") ?? ""), baseUrl)
+      ?? bestSrcsetUrl(decodeHtmlEntities(extractAttribute(tag, "data-srcset") ?? ""), baseUrl);
+    if (!url || seenImages.has(url)) continue;
+    seenImages.add(url);
+    blocks.push({
+      type: "image",
+      url,
+      alt: stringValue(extractAttribute(tag, "alt")),
+    });
+  }
+  return blocks;
+}
+
+export function extractArticleContentBlocks(
+  bodyHtml: string | null | undefined,
+  options: { baseUrl?: string | null; imageUrls?: string[]; title?: string | null } = {},
+): SubstackContentBlock[] {
+  const baseUrl = options.baseUrl ?? null;
+  const html = (bodyHtml ?? "")
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<noscript\b[\s\S]*?<\/noscript>/gi, " ");
+  const blocks: SubstackContentBlock[] = [];
+  const seenImages = new Set<string>();
+  const blockPattern = /<div\b(?=[^>]*twitter-embed)([\s\S]*?)>\s*<\/div>|<(h[1-6]|p|blockquote|li|figure|iframe)\b([^>]*)>([\s\S]*?)<\/\2>|<(img|hr)\b([^>]*)\/?>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = blockPattern.exec(html)) !== null) {
+    const twitterAttrs = match[1] ?? "";
+    const pairedTag = match[2]?.toLowerCase();
+    const selfClosingTag = match[5]?.toLowerCase();
+    const tag = twitterAttrs ? "twitterEmbed" : pairedTag ?? selfClosingTag;
+    const attrs = twitterAttrs || match[3] || match[6] || "";
+    const inner = match[4] ?? "";
+
+    if (!tag) continue;
+
+    if (tag === "twitterEmbed") {
+      const tweetBlock = tweetEmbedBlockFromAttrs(attrs);
+      if (tweetBlock) pushTextBlock(blocks, tweetBlock);
+      continue;
+    }
+
+    if (tag === "img") {
+      for (const block of imageBlocksFromHtml(match[0], baseUrl, seenImages)) blocks.push(block);
+      continue;
+    }
+    if (tag === "hr") {
+      if (blocks.at(-1)?.type !== "divider") blocks.push({ type: "divider" });
+      continue;
+    }
+    if (tag === "iframe") {
+      const src = normalizeUrl(decodeHtmlEntities(extractAttribute(attrs, "src") ?? ""), baseUrl);
+      pushTextBlock(blocks, {
+        type: "embed",
+        kind: /youtube|youtu\.be|vimeo|video/i.test(src ?? "") ? "media" : "link",
+        text: src ? "Embedded media" : "Embedded content",
+        url: src,
+      });
+      continue;
+    }
+
+    const links = extractLinksFromHtml(inner, baseUrl);
+    const text = textFragment(inner, baseUrl);
+
+    if (tag === "figure") {
+      const socialUrl = socialEmbedUrl(links);
+      if (isSocialEmbed(attrs, inner, links)) {
+        pushTextBlock(blocks, buildTweetEmbedBlock(text || "Tweet", links, socialUrl ?? links.at(-1)?.url ?? null));
+        continue;
+      }
+      const imageUrls = extractImageUrlsFromHtml(inner, baseUrl);
+      for (const block of imageBlocksFromHtml(inner, baseUrl, seenImages)) blocks.push(block);
+      if (text && !textMatchesImageLink(text, links, imageUrls)) {
+        pushTextBlock(blocks, { type: "paragraph", text });
+      }
+      continue;
+    }
+
+    if (tag.startsWith("h")) {
+      const level = Number(tag.slice(1));
+      pushTextBlock(blocks, { type: "heading", level, text });
+      continue;
+    }
+    if (tag === "blockquote") {
+      const socialUrl = socialEmbedUrl(links);
+      pushTextBlock(blocks, isSocialEmbed(attrs, inner, links)
+        ? buildTweetEmbedBlock(text || "Tweet", links, socialUrl ?? links.at(-1)?.url ?? null)
+        : { type: "quote", text });
+      continue;
+    }
+    if (tag === "li") {
+      pushTextBlock(blocks, { type: "listItem", text });
+      continue;
+    }
+
+    if (text && textMatchesImageLink(text, links, [])) {
+      continue;
+    }
+    if (links.length === 1 && text && text === links[0]!.label && links[0]!.url !== text) {
+      pushTextBlock(blocks, { type: "embed", kind: "link", text, url: links[0]!.url });
+      continue;
+    }
+    pushTextBlock(blocks, { type: "paragraph", text });
+  }
+
+  if (blocks.length === 0) {
+    const fallback = normalizeArticleText(textFragment(html, baseUrl));
+    if (fallback) {
+      for (const paragraph of fallback.split(/\n{2,}/)) {
+        pushTextBlock(blocks, { type: "paragraph", text: paragraph });
+      }
+    }
+  }
+
+  for (const url of options.imageUrls ?? []) {
+    const normalized = normalizeUrl(url, baseUrl);
+    if (!normalized || seenImages.has(normalized)) continue;
+    seenImages.add(normalized);
+    blocks.push({ type: "image", url: normalized, alt: null });
+  }
+
+  return stripDuplicateLeadingTitleFromBlocks(blocks, options.title);
+}
+
+export function extractArticleContent(
+  bodyHtml: string | null | undefined,
+  options: { baseUrl?: string | null; imageUrls?: string[]; title?: string | null } = {},
+): ExtractedArticleContent {
+  const html = bodyHtml ?? "";
+  const baseUrl = options.baseUrl ?? null;
+  const imageUrls = uniqueStrings([
+    ...(options.imageUrls ?? []),
+    ...extractImageUrlsFromHtml(html, baseUrl),
+  ].map((url) => normalizeUrl(url, baseUrl)));
+  const linkUrls = extractLinkUrlsFromHtml(html, baseUrl).filter((url) => !isLikelyImageUrl(url));
+  const blocks = extractArticleContentBlocks(bodyHtml, options);
+  const text = stripDuplicateLeadingTitle(articleTextFromBlocks(blocks), options.title);
+  const words = wordCount(text);
+  return {
+    text,
+    blocks,
+    imageUrls,
+    linkUrls,
+    wordCount: words,
+    readMinutes: estimateReadingMinutes(words),
+  };
+}
+
+function stripDuplicateLeadingTitle(text: string, title: string | null | undefined): string {
+  const normalizedTitle = (title ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+  if (!normalizedTitle || !text) return text;
+  const lines = text.split("\n");
+  const firstContentIndex = lines.findIndex((line) => line.trim().length > 0);
+  if (firstContentIndex < 0) return text;
+  const firstLine = lines[firstContentIndex]!.replace(/\s+/g, " ").trim().toLowerCase();
+  if (firstLine !== normalizedTitle) return text;
+  const nextLines = [...lines.slice(0, firstContentIndex), ...lines.slice(firstContentIndex + 1)];
+  return normalizeArticleText(nextLines.join("\n"));
+}

--- a/src/plugins/builtin/substack/feed-tabs.tsx
+++ b/src/plugins/builtin/substack/feed-tabs.tsx
@@ -1,0 +1,41 @@
+import { Box } from "../../../ui";
+import { Tabs } from "../../../components";
+import { tabIdForPublication } from "./table";
+import {
+  SUBSTACK_FEED_TAB_ID,
+  type SubstackPublication,
+} from "./types";
+import { tabLabel } from "./pane-state";
+
+export function SubstackFeedTabs({
+  subscriptions,
+  activeTab,
+  focused,
+  detailOpen,
+  onSelect,
+}: {
+  subscriptions: SubstackPublication[];
+  activeTab: string;
+  focused: boolean;
+  detailOpen: boolean;
+  onSelect: (tabId: string) => void;
+}) {
+  return (
+    <Box height={1}>
+      <Tabs
+        tabs={[
+          { label: "Feed", value: SUBSTACK_FEED_TAB_ID },
+          ...subscriptions.map((publication) => ({
+            label: tabLabel(publication.name),
+            value: tabIdForPublication(publication),
+          })),
+        ]}
+        activeValue={activeTab}
+        onSelect={onSelect}
+        compact
+        variant="pill"
+        focused={focused && !detailOpen}
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/substack/index.tsx
+++ b/src/plugins/builtin/substack/index.tsx
@@ -1,0 +1,49 @@
+import type { GloomPlugin } from "../../../types/plugin";
+import {
+  attachSubstackPersistence,
+  resetSubstackPersistence,
+} from "./api/store";
+import {
+  SUBSTACK_PANE_ID,
+  SUBSTACK_PLUGIN_ID,
+} from "./types";
+import { SubstackPane } from "./pane";
+
+export const substackPlugin: GloomPlugin = {
+  id: SUBSTACK_PLUGIN_ID,
+  name: "Substack",
+  version: "1.0.0",
+  description: "Authenticated Substack reader feed and subscriptions",
+  toggleable: true,
+
+  setup(ctx) {
+    attachSubstackPersistence(ctx.persistence);
+  },
+
+  dispose() {
+    resetSubstackPersistence();
+  },
+
+  panes: [
+    {
+      id: SUBSTACK_PANE_ID,
+      name: "Substack",
+      icon: "S",
+      component: SubstackPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 104, height: 32 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "substack-pane",
+      paneId: SUBSTACK_PANE_ID,
+      label: "Substack",
+      description: "Open the authenticated Substack reader feed.",
+      keywords: ["substack", "newsletter", "feed", "reader", "subscription"],
+      shortcut: { prefix: "SUB" },
+    },
+  ],
+};

--- a/src/plugins/builtin/substack/login-view.tsx
+++ b/src/plugins/builtin/substack/login-view.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Box, Text, TextAttributes, type InputRenderable } from "../../../ui";
+import { Button, TextField } from "../../../components";
+import { colors } from "../../../theme/colors";
+import {
+  completeSubstackMagicLink,
+  completeSubstackOtpLogin,
+  requestSubstackMagicLink,
+} from "./api/auth";
+import type {
+  SubstackAuthState,
+} from "./api/types";
+import { errorMessage } from "./pane-state";
+
+export function SubstackLoginView({
+  width,
+  height,
+  focused,
+  onLogin,
+}: {
+  width: number;
+  height: number;
+  focused: boolean;
+  onLogin: (auth: SubstackAuthState) => void;
+}) {
+  const [email, setEmail] = useState("");
+  const [loginToken, setLoginToken] = useState("");
+  const [phase, setPhase] = useState<"email" | "link">("email");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const emailRef = useRef<InputRenderable | null>(null);
+  const linkRef = useRef<InputRenderable | null>(null);
+  const panelWidth = Math.max(32, Math.min(72, width - 4));
+
+  useEffect(() => {
+    if (!focused) return;
+    const input = phase === "email" ? emailRef.current : linkRef.current;
+    input?.focus?.();
+  }, [focused, phase]);
+
+  const requestLink = useCallback(() => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    requestSubstackMagicLink(email)
+      .then(() => {
+        setPhase("link");
+      })
+      .catch((requestError) => setError(errorMessage(requestError)))
+      .finally(() => setBusy(false));
+  }, [busy, email]);
+
+  const completeLogin = useCallback(() => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    const token = loginToken.trim();
+    const login = /^\d{6}$/.test(token)
+      ? completeSubstackOtpLogin(token, email)
+      : completeSubstackMagicLink(token, email);
+    login
+      .then(onLogin)
+      .catch((loginError) => setError(errorMessage(loginError)))
+      .finally(() => setBusy(false));
+  }, [busy, email, loginToken, onLogin]);
+
+  return (
+    <Box width={width} height={height} justifyContent="center" alignItems="center">
+      <Box width={panelWidth} flexDirection="column" gap={1}>
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Substack login</Text>
+        {phase === "email" ? (
+          <>
+            <TextField
+              label="Email"
+              value={email}
+              placeholder="you@example.com"
+              width={panelWidth}
+              inputRef={emailRef}
+              focused={focused}
+              onChange={setEmail}
+              onSubmit={requestLink}
+            />
+            <Button
+              label={busy ? "Sending..." : "Send magic link"}
+              variant="primary"
+              disabled={busy || !email.trim()}
+              onPress={requestLink}
+            />
+          </>
+        ) : (
+          <>
+            <Text fg={colors.textDim}>Paste the 6-digit code or full URL from Substack's email.</Text>
+            <TextField
+              label="Code or magic link"
+              value={loginToken}
+              placeholder="123456 or https://substack.com/..."
+              width={panelWidth}
+              inputRef={linkRef}
+              focused={focused}
+              onChange={setLoginToken}
+              onSubmit={completeLogin}
+            />
+            <Box flexDirection="row" gap={1}>
+              <Button
+                label={busy ? "Logging in..." : "Log in"}
+                variant="primary"
+                disabled={busy || !loginToken.trim()}
+                onPress={completeLogin}
+              />
+              <Button
+                label="Change email"
+                variant="ghost"
+                disabled={busy}
+                onPress={() => {
+                  setPhase("email");
+                  setLoginToken("");
+                }}
+              />
+            </Box>
+          </>
+        )}
+        {error ? <Text fg={colors.negative}>{error}</Text> : null}
+      </Box>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/substack/model.test.ts
+++ b/src/plugins/builtin/substack/model.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { extractArticleContent } from "./content";
+import {
+  articleMatchesPublication,
+  normalizeFeedItems,
+  normalizePostDetail,
+  normalizeSubscriptions,
+  sortSubscriptionsByLatest,
+} from "./normalize";
+
+describe("Substack article extraction", () => {
+  test("keeps article structure while removing chrome and image-only links", () => {
+    const attrs = JSON.stringify({
+      url: "https://x.com/jukan05/status/2062809398284812532?s=46",
+      full_text: "* Important: SK hynix has no plans to add any new NAND flash capacity.\n\n=&gt; Pure-play NAND manufacturers add capacity.",
+      username: "jukan05",
+      name: "Jukan @COMPUTEX",
+      date: "2026-06-05T08:11:00.000Z",
+      photos: [{ img_url: "https://pbs.substack.com/media/HKCSNYaa8AAq-06.jpg" }],
+      quoted_tweet: {
+        full_text: "[Exclusive] Jensen Huang asked Hynix to make more.",
+        username: "jukan05",
+      },
+    }).replace(/"/g, "&quot;");
+    const content = extractArticleContent(`
+      <article>
+        <script>window.bad = true</script>
+        <h1>Ignored detail title</h1>
+        <h2>Victory Giant: -11% as US weighs subsidies</h2>
+        <p>We bought <a href="/p/company">$NVDA</a> after earnings.</p>
+        <div class="twitter-embed" data-attrs="${attrs}" data-component-name="Twitter2ToDOM"></div>
+        <blockquote>Seems very knee jerkish - subsidies seem very small.</blockquote>
+        <figure>
+          <a href="https://substackcdn.com/image/fetch/$s_!abc/f_auto,q_auto:good/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fchart.png">image</a>
+          <img src="/company-card.png" alt="CQME chart" />
+        </figure>
+        <p>See <a href="https://example.com/report">the report</a>.</p>
+      </article>
+    `, {
+      baseUrl: "https://collyerbridge.substack.com",
+      title: "Ignored detail title",
+    });
+
+    expect(content.text).toContain("$NVDA");
+    expect(content.text).toContain("Seems very knee jerkish");
+    expect(content.text).not.toContain("Ignored detail title");
+    expect(content.text).not.toContain("window.bad");
+    expect(content.text).not.toContain("substackcdn.com/image/fetch");
+    expect(content.imageUrls).toEqual(["https://collyerbridge.substack.com/company-card.png"]);
+    expect(content.linkUrls).toEqual([
+      "https://collyerbridge.substack.com/p/company",
+      "https://example.com/report",
+    ]);
+    expect(content.blocks.map((block) => block.type)).toEqual([
+      "heading",
+      "paragraph",
+      "embed",
+      "quote",
+      "image",
+      "paragraph",
+    ]);
+    expect(content.blocks[2]).toEqual({
+      type: "embed",
+      kind: "tweet",
+      text: "* Important: SK hynix has no plans to add any new NAND flash capacity.\n\n=> Pure-play NAND manufacturers add capacity.\n\nQuoted: [Exclusive] Jensen Huang asked Hynix to make more.",
+      url: "https://x.com/jukan05/status/2062809398284812532?s=46",
+      username: "jukan05",
+      authorName: "Jukan @COMPUTEX",
+      dateLabel: "Jun 5, 2026",
+      imageUrls: ["https://pbs.substack.com/media/HKCSNYaa8AAq-06.jpg"],
+    });
+  });
+});
+
+describe("Substack feed normalization", () => {
+  test("normalizes reader rows and orders subscriptions by newest matching post", () => {
+    const subscriptions = normalizeSubscriptions({
+      result: {
+        subscriptions: [
+          { id: "sa", publication_id: "a" },
+          { id: "sb", publication_id: "b" },
+        ],
+        publicationMap: {
+          a: { id: "a", name: "Alpha", base_url: "https://alpha.example" },
+          b: { id: "b", name: "Beta", base_url: "https://beta.example" },
+        },
+      },
+    });
+    const feed = normalizeFeedItems({
+      items: [
+        {
+          post: {
+            id: "older",
+            title: "Older",
+            post_date: "2026-06-01T10:00:00Z",
+            publication: { id: "a", name: "Alpha", base_url: "https://alpha.example" },
+          },
+        },
+        {
+          post: {
+            id: "newer",
+            title: "Semis and $NVDA",
+            subtitle: "A quick note",
+            post_date: "2026-06-05T10:00:00Z",
+            canonical_url: "https://beta.example/p/nvda",
+            slug: "nvda",
+            wordcount: 560,
+            publication: { id: "b", name: "Beta", base_url: "https://beta.example" },
+          },
+        },
+      ],
+    });
+
+    const sorted = sortSubscriptionsByLatest(subscriptions, feed);
+    expect(feed[1]).toMatchObject({
+      id: "newer",
+      title: "Semis and $NVDA",
+      publicationName: "Beta",
+      publicationBaseUrl: "https://beta.example",
+      url: "https://beta.example/p/nvda",
+      readMinutes: 3,
+    });
+    expect(sorted.map((publication) => publication.name)).toEqual(["Beta", "Alpha"]);
+    expect(articleMatchesPublication(feed[1]!, sorted[0]!)).toBe(true);
+  });
+
+  test("merges fetched post body into an existing summary", () => {
+    const summary = normalizeFeedItems({
+      items: [
+        {
+          post: {
+            id: 99,
+            title: "Macro Links",
+            post_date: "2026-06-05T10:00:00Z",
+            publication: { id: "macro", name: "Macro", base_url: "https://macro.example" },
+          },
+        },
+      ],
+    })[0]!;
+
+    const detail = normalizePostDetail({
+      id: 99,
+      title: "Macro Links",
+      body_html: "<p>$SPY broke higher. <a href=\"/p/chart\">Chart</a></p>",
+      publication: { id: "macro", name: "Macro", base_url: "https://macro.example" },
+    }, summary);
+
+    expect(detail.contentText).toContain("$SPY");
+    expect(detail.linkUrls).toEqual(["https://macro.example/p/chart"]);
+    expect(detail.contentBlocks).toEqual([
+      { type: "paragraph", text: "$SPY broke higher. Chart" },
+    ]);
+    expect(detail.id).toBe("99");
+  });
+});

--- a/src/plugins/builtin/substack/normalize.ts
+++ b/src/plugins/builtin/substack/normalize.ts
@@ -1,0 +1,343 @@
+import {
+  estimateReadingMinutes,
+  extractArticleContent,
+  wordCount,
+} from "./content";
+import type {
+  SubstackArticleDetail,
+  SubstackArticleSummary,
+  SubstackPublication,
+} from "./types";
+import {
+  asRecord,
+  firstNumber,
+  firstRawString,
+  firstRecord,
+  firstString,
+  firstValue,
+  maxIso,
+  normalizeUrl,
+  parseDateIso,
+  timestamp,
+  uniqueStrings,
+  type JsonRecord,
+} from "./utils";
+
+function extractPayloadArray(payload: unknown, preferredKeys: string[]): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  const record = asRecord(payload);
+  if (!record) return [];
+  for (const key of preferredKeys) {
+    const value = record[key];
+    if (Array.isArray(value)) return value;
+  }
+  const data = asRecord(record.data);
+  if (data) {
+    for (const key of preferredKeys) {
+      const value = data[key];
+      if (Array.isArray(value)) return value;
+    }
+  }
+  const result = asRecord(record.result);
+  if (result) {
+    for (const key of preferredKeys) {
+      const value = result[key];
+      if (Array.isArray(value)) return value;
+    }
+  }
+  return [];
+}
+
+export function normalizePublication(raw: unknown): SubstackPublication | null {
+  const record = asRecord(raw);
+  if (!record) return null;
+  const subdomain = firstString(record, ["subdomain", "handle", "slug"]);
+  const customDomain = firstString(record, ["custom_domain", "customDomain", "domain"]);
+  const baseUrl = normalizeUrl(firstRawString(record, ["base_url", "baseUrl", "url", "web_url", "canonical_url"]))
+    ?? (customDomain ? `https://${customDomain}` : null)
+    ?? (subdomain ? `https://${subdomain}.substack.com` : null);
+  const idValue = firstValue(record, ["id", "publication_id", "publicationId", "subdomain"]);
+  const name = firstString(record, ["name", "publication_name", "publicationName", "title"]) ?? subdomain ?? "Substack";
+  const id = String(idValue ?? baseUrl ?? name).trim();
+  return {
+    id,
+    name,
+    subdomain,
+    baseUrl,
+    description: firstString(record, ["description", "hero_text", "heroText", "author_bio"]),
+    logoUrl: normalizeUrl(firstRawString(record, ["logo_url", "logoUrl", "logo", "cover_image", "coverImage"]), baseUrl),
+    latestPublishedAt: parseDateIso(firstValue(record, [
+      "latestPublishedAt",
+      "last_published_at",
+      "last_post_date",
+      "lastPostDate",
+      "updated_at",
+    ])),
+  };
+}
+
+export function normalizeSubscriptions(payload: unknown): SubstackPublication[] {
+  const rows = extractPayloadArray(payload, [
+    "subscriptions",
+    "publications",
+    "results",
+    "items",
+  ]);
+  const rootRecord = asRecord(payload);
+  const publicationLookup = buildPublicationLookup(rootRecord);
+  const deduped = new Map<string, SubstackPublication>();
+  for (const row of rows) {
+    const record = asRecord(row);
+    const publication = normalizePublication(
+      record?.publication
+        ?? record?.pub
+        ?? (record ? publicationLookup.get(String(record.publication_id ?? record.publicationId ?? "")) : null)
+        ?? row,
+    );
+    if (!publication) continue;
+    const key = publicationKey(publication);
+    const existing = deduped.get(key);
+    if (!existing) {
+      deduped.set(key, publication);
+      continue;
+    }
+    deduped.set(key, {
+      ...existing,
+      latestPublishedAt: maxIso(existing.latestPublishedAt, publication.latestPublishedAt),
+    });
+  }
+  return [...deduped.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function buildPublicationLookup(record: JsonRecord | null): Map<string, unknown> {
+  const lookup = new Map<string, unknown>();
+  if (!record) return lookup;
+  const maps = [
+    asRecord(record.publicationMap),
+    asRecord(record.publication_map),
+    asRecord(asRecord(record.result)?.publicationMap),
+    asRecord(asRecord(record.result)?.publication_map),
+  ];
+  for (const map of maps) {
+    if (!map) continue;
+    for (const [key, value] of Object.entries(map)) {
+      lookup.set(key, value);
+    }
+  }
+  const arrays = [
+    record.publications,
+    asRecord(record.result)?.publications,
+  ];
+  for (const array of arrays) {
+    if (!Array.isArray(array)) continue;
+    for (const publication of array) {
+      const normalized = normalizePublication(publication);
+      if (!normalized) continue;
+      lookup.set(normalized.id, publication);
+    }
+  }
+  return lookup;
+}
+
+function articlePostRecord(row: unknown): JsonRecord | null {
+  const record = asRecord(row);
+  return firstRecord(
+    record?.post,
+    record?.item,
+    record?.entity,
+    record?.object,
+    record,
+  );
+}
+
+function articlePublicationRecord(row: JsonRecord | null, post: JsonRecord | null): JsonRecord | null {
+  return firstRecord(
+    post?.publication,
+    post?.pub,
+    row?.publication,
+    row?.pub,
+  );
+}
+
+function buildArticleUrl(post: JsonRecord | null, publication: SubstackPublication | null): string | null {
+  const direct = normalizeUrl(firstRawString(post, ["canonical_url", "canonicalUrl", "url", "web_url"]), publication?.baseUrl);
+  if (direct) return direct;
+  const slug = firstString(post, ["slug"]);
+  if (!slug || !publication?.baseUrl) return null;
+  return normalizeUrl(`/p/${slug}`, publication.baseUrl);
+}
+
+function normalizeArticle(row: unknown, sourcePublication?: SubstackPublication | null): SubstackArticleSummary | null {
+  const rowRecord = asRecord(row);
+  const post = articlePostRecord(row);
+  if (!post) return null;
+  const publication = normalizePublication(articlePublicationRecord(rowRecord, post)) ?? sourcePublication ?? null;
+  const title = firstString(post, ["title", "name", "social_title", "email_subject"]) ?? firstString(rowRecord, ["title"]);
+  const subtitle = firstString(post, ["subtitle", "description", "search_engine_description", "social_description"]);
+  const bodyHtml = firstRawString(post, ["body_html", "bodyHtml", "body"]);
+  const coverImage = normalizeUrl(firstRawString(post, [
+    "cover_image",
+    "coverImage",
+    "cover_image_url",
+    "coverImageUrl",
+    "thumbnail_url",
+    "thumbnailUrl",
+    "image",
+  ]), publication?.baseUrl);
+  const extracted = bodyHtml
+    ? extractArticleContent(bodyHtml, { baseUrl: publication?.baseUrl, imageUrls: coverImage ? [coverImage] : [], title })
+    : { text: "", blocks: [], imageUrls: uniqueStrings([coverImage]), linkUrls: [], wordCount: 0, readMinutes: 1 };
+  const previewText = firstString(post, [
+    "truncated_body_text",
+    "body_preview",
+    "preview",
+    "subtitle",
+    "description",
+    "search_engine_description",
+  ]) ?? (extracted.text ? extracted.text.slice(0, 500) : null);
+  const rawWordCount = firstNumber(post, ["wordcount", "word_count", "words"]);
+  const words = Math.max(0, Math.round(rawWordCount ?? extracted.wordCount ?? wordCount(previewText ?? "")));
+  const rawReadMinutes = firstNumber(post, [
+    "reading_time_minutes",
+    "read_time_minutes",
+    "readMinutes",
+    "readingTime",
+  ]);
+  const publishedAt = parseDateIso(firstValue(post, [
+    "post_date",
+    "published_at",
+    "publish_date",
+    "date",
+    "created_at",
+    "updated_at",
+  ]) ?? firstValue(rowRecord, ["published_at", "timestamp", "date"]));
+  const url = buildArticleUrl(post, publication);
+  const slug = firstString(post, ["slug"]);
+  const rawId = firstValue(post, ["id", "post_id", "postId", "canonical_slug"]) ?? firstValue(rowRecord, ["id", "post_id"]);
+  const id = String(rawId ?? url ?? `${publication?.id ?? "substack"}:${slug ?? title ?? publishedAt ?? Math.random()}`).trim();
+
+  if (!title && !url && !bodyHtml) return null;
+
+  return {
+    id,
+    title: title ?? "Untitled",
+    publicationId: publication?.id ?? null,
+    publicationName: publication?.name ?? null,
+    publicationSubdomain: publication?.subdomain ?? null,
+    publicationBaseUrl: publication?.baseUrl ?? null,
+    url,
+    slug,
+    publishedAt,
+    subtitle,
+    previewText,
+    bodyHtml,
+    imageUrls: extracted.imageUrls,
+    wordCount: words,
+    readMinutes: rawReadMinutes != null ? Math.max(1, Math.ceil(rawReadMinutes)) : estimateReadingMinutes(words || extracted.text),
+  };
+}
+
+export function normalizeFeedItems(payload: unknown, sourcePublication?: SubstackPublication | null): SubstackArticleSummary[] {
+  const rows = extractPayloadArray(payload, ["items", "posts", "results", "feed"]);
+  const items = rows
+    .map((row) => normalizeArticle(row, sourcePublication))
+    .filter((row): row is SubstackArticleSummary => !!row);
+  const deduped = new Map<string, SubstackArticleSummary>();
+  for (const item of items) {
+    const existing = deduped.get(item.id);
+    if (!existing || timestamp(item.publishedAt) > timestamp(existing.publishedAt)) {
+      deduped.set(item.id, item);
+    }
+  }
+  return [...deduped.values()];
+}
+
+export function normalizePostDetail(
+  payload: unknown,
+  fallback: SubstackArticleSummary,
+): SubstackArticleDetail {
+  const post = articlePostRecord(payload) ?? asRecord(payload);
+  const normalized = normalizeArticle(post ?? payload, {
+    id: fallback.publicationId ?? fallback.publicationBaseUrl ?? fallback.publicationName ?? "substack",
+    name: fallback.publicationName ?? "Substack",
+    subdomain: fallback.publicationSubdomain,
+    baseUrl: fallback.publicationBaseUrl,
+    description: null,
+    logoUrl: null,
+    latestPublishedAt: null,
+  }) ?? fallback;
+  const bodyHtml = normalized.bodyHtml ?? fallback.bodyHtml;
+  const extracted = extractArticleContent(bodyHtml, {
+    baseUrl: normalized.publicationBaseUrl ?? fallback.publicationBaseUrl,
+    imageUrls: uniqueStrings([...fallback.imageUrls, ...normalized.imageUrls]),
+    title: normalized.title || fallback.title,
+  });
+  const contentText = extracted.text || normalized.previewText || fallback.previewText || "";
+  const words = Math.max(normalized.wordCount, extracted.wordCount, wordCount(contentText));
+  return {
+    ...fallback,
+    ...normalized,
+    id: fallback.id,
+    title: normalized.title || fallback.title,
+    url: normalized.url ?? fallback.url,
+    bodyHtml,
+    imageUrls: uniqueStrings([...normalized.imageUrls, ...fallback.imageUrls, ...extracted.imageUrls]),
+    contentText,
+    contentBlocks: extracted.blocks,
+    linkUrls: extracted.linkUrls,
+    wordCount: words,
+    readMinutes: estimateReadingMinutes(words || contentText),
+  };
+}
+
+export function publicationKey(publication: Pick<SubstackPublication, "id" | "name" | "baseUrl" | "subdomain">): string {
+  return (
+    publication.baseUrl
+      ?? publication.subdomain
+      ?? publication.id
+      ?? publication.name
+  ).toLowerCase();
+}
+
+function articlePublicationKeys(article: SubstackArticleSummary): string[] {
+  return uniqueStrings([
+    article.publicationBaseUrl?.toLowerCase(),
+    article.publicationSubdomain?.toLowerCase(),
+    article.publicationId?.toLowerCase(),
+    article.publicationName?.toLowerCase(),
+  ]);
+}
+
+export function articleMatchesPublication(
+  article: SubstackArticleSummary,
+  publication: SubstackPublication,
+): boolean {
+  const keys = new Set(articlePublicationKeys(article));
+  return [
+    publication.baseUrl,
+    publication.subdomain,
+    publication.id,
+    publication.name,
+  ].some((value) => !!value && keys.has(value.toLowerCase()));
+}
+
+export function sortSubscriptionsByLatest(
+  subscriptions: SubstackPublication[],
+  feedItems: SubstackArticleSummary[],
+): SubstackPublication[] {
+  return [...subscriptions]
+    .map((publication) => {
+      const latestFeedAt = feedItems
+        .filter((article) => articleMatchesPublication(article, publication))
+        .reduce<string | null>((latest, article) => maxIso(latest, article.publishedAt), null);
+      return {
+        publication,
+        latestAt: maxIso(publication.latestPublishedAt, latestFeedAt),
+      };
+    })
+    .sort((a, b) => {
+      const byDate = timestamp(b.latestAt) - timestamp(a.latestAt);
+      return byDate !== 0 ? byDate : a.publication.name.localeCompare(b.publication.name);
+    })
+    .map((entry) => ({ ...entry.publication, latestPublishedAt: entry.latestAt }));
+}

--- a/src/plugins/builtin/substack/pane-footer.ts
+++ b/src/plugins/builtin/substack/pane-footer.ts
@@ -1,0 +1,71 @@
+import { usePaneFooter } from "../../../components";
+import type { SubstackAuthState } from "./api/types";
+import {
+  formatReadTime,
+  formatWordCount,
+} from "./table";
+import {
+  SUBSTACK_PANE_ID,
+  type SubstackArticleSummary,
+} from "./types";
+import { cacheStatusLabel, type ActiveFeedState, type DetailState } from "./pane-state";
+
+export function useSubstackPaneFooter({
+  auth,
+  detailOpen,
+  activeFeedState,
+  activeDetail,
+  selectedArticle,
+  refreshActive,
+  openSelectedArticle,
+}: {
+  auth: SubstackAuthState | null;
+  detailOpen: boolean;
+  activeFeedState: ActiveFeedState;
+  activeDetail: DetailState;
+  selectedArticle: SubstackArticleSummary | null;
+  refreshActive: () => void;
+  openSelectedArticle: () => void;
+}) {
+  const statusLabel = cacheStatusLabel(activeFeedState.fetchedAt, activeFeedState.stale);
+  const articleMetaLabel = detailOpen && selectedArticle
+    ? [
+      selectedArticle.publicationName,
+      formatReadTime(activeDetail.data?.readMinutes ?? selectedArticle.readMinutes),
+      formatWordCount(activeDetail.data?.wordCount ?? selectedArticle.wordCount),
+    ].filter(Boolean).join("  |  ")
+    : null;
+
+  usePaneFooter(SUBSTACK_PANE_ID, () => ({
+    info: [
+      ...(!auth ? [{ id: "auth", parts: [{ text: "login required", tone: "warning" as const }] }] : []),
+      ...(articleMetaLabel ? [{ id: "article-meta", parts: [{ text: articleMetaLabel, tone: "muted" as const }] }] : []),
+      ...(activeFeedState.loading || activeFeedState.loadingMore ? [{ id: "loading", parts: [{ text: activeFeedState.loadingMore ? "loading more" : "loading", tone: "muted" as const }] }] : []),
+      ...(activeDetail.loading && detailOpen ? [{ id: "detail-loading", parts: [{ text: "loading article", tone: "muted" as const }] }] : []),
+      ...(statusLabel && auth ? [{ id: "cache", parts: [{ text: statusLabel, tone: activeFeedState.stale ? "warning" as const : "muted" as const }] }] : []),
+      ...(activeFeedState.error ? [{ id: "error", parts: [{ text: activeFeedState.error, tone: "warning" as const }] }] : []),
+      ...(activeDetail.error && detailOpen ? [{ id: "detail-error", parts: [{ text: activeDetail.error, tone: "warning" as const }] }] : []),
+    ],
+    hints: auth ? [
+      { id: "refresh", key: "r", label: "efresh", onPress: refreshActive },
+      { id: "open", key: "o", label: "pen", onPress: openSelectedArticle, disabled: !selectedArticle?.url },
+    ] : [],
+  }), [
+    activeDetail.error,
+    activeDetail.loading,
+    activeDetail.data?.readMinutes,
+    activeDetail.data?.wordCount,
+    activeFeedState.error,
+    activeFeedState.fetchedAt,
+    activeFeedState.loading,
+    activeFeedState.loadingMore,
+    activeFeedState.stale,
+    articleMetaLabel,
+    auth,
+    detailOpen,
+    openSelectedArticle,
+    refreshActive,
+    selectedArticle?.url,
+    statusLabel,
+  ]);
+}

--- a/src/plugins/builtin/substack/pane-state.ts
+++ b/src/plugins/builtin/substack/pane-state.ts
@@ -1,0 +1,170 @@
+import { formatTimeAgo } from "../../../utils/format";
+import {
+  getCachedSubstackArticleDetail,
+  getCachedSubstackHome,
+  getCachedSubstackPublicationFeed,
+} from "./api/cache";
+import type {
+  SubstackHomeData,
+  SubstackPublicationFeedPage,
+} from "./api/types";
+import { articleMatchesPublication } from "./normalize";
+import type {
+  SubstackArticleDetail,
+  SubstackArticleSummary,
+  SubstackPublication,
+} from "./types";
+
+export interface LoadState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  fetchedAt: number | null;
+  stale: boolean;
+}
+
+export type PublicationFeedState = LoadState<SubstackPublicationFeedPage> & {
+  loadingMore: boolean;
+};
+
+export type DetailState = LoadState<SubstackArticleDetail>;
+
+export type ActiveFeedState = LoadState<SubstackArticleSummary[]> & {
+  loadingMore?: boolean;
+  hasMore?: boolean;
+  nextOffset?: number | null;
+};
+
+export function emptyLoadState<T>(): LoadState<T> {
+  return {
+    data: null,
+    loading: false,
+    error: null,
+    fetchedAt: null,
+    stale: false,
+  };
+}
+
+export function emptyPublicationFeedState(): PublicationFeedState {
+  return {
+    ...emptyLoadState<SubstackPublicationFeedPage>(),
+    loadingMore: false,
+  };
+}
+
+export function mergePublicationFeedPages(
+  current: SubstackPublicationFeedPage | null,
+  next: SubstackPublicationFeedPage,
+): SubstackPublicationFeedPage {
+  if (!current) return next;
+  const articlesById = new Map<string, SubstackArticleSummary>();
+  for (const article of current.items) articlesById.set(article.id, article);
+  for (const article of next.items) articlesById.set(article.id, article);
+  return {
+    items: [...articlesById.values()],
+    nextOffset: next.nextOffset,
+    hasMore: next.hasMore,
+  };
+}
+
+export function homeLoadStateFromCache(): LoadState<SubstackHomeData> {
+  const cached = getCachedSubstackHome();
+  if (!cached) return emptyLoadState<SubstackHomeData>();
+  return {
+    data: cached,
+    loading: false,
+    error: null,
+    fetchedAt: cached.fetchedAt,
+    stale: cached.stale,
+  };
+}
+
+export function publicationLoadStateFromCache(publication: SubstackPublication): PublicationFeedState | null {
+  const cached = getCachedSubstackPublicationFeed(publication);
+  if (!cached) return null;
+  return {
+    data: cached.data,
+    loading: false,
+    loadingMore: false,
+    error: null,
+    fetchedAt: cached.fetchedAt,
+    stale: cached.stale,
+  };
+}
+
+export function detailLoadStateFromCache(article: SubstackArticleSummary): DetailState | null {
+  const cached = getCachedSubstackArticleDetail(article);
+  if (!cached) return null;
+  return {
+    data: cached.data,
+    loading: false,
+    error: null,
+    fetchedAt: cached.fetchedAt,
+    stale: cached.stale,
+  };
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function tabLabel(label: string): string {
+  const compact = label.replace(/\s+/g, " ").trim();
+  return compact.length <= 24 ? compact : `${compact.slice(0, 21)}...`;
+}
+
+export function cacheStatusLabel(fetchedAt: number | null, stale: boolean): string | null {
+  if (!fetchedAt) return null;
+  return `${stale ? "stale " : "updated "}${formatTimeAgo(new Date(fetchedAt))}`;
+}
+
+export function activeFeedStateFromSources({
+  activePublication,
+  activePublicationTabId,
+  publicationFeeds,
+  home,
+}: {
+  activePublication: SubstackPublication | null;
+  activePublicationTabId: string | null;
+  publicationFeeds: Record<string, PublicationFeedState>;
+  home: LoadState<SubstackHomeData>;
+}): ActiveFeedState {
+  if (!activePublication || !activePublicationTabId) {
+    return {
+      data: home.data?.feed ?? null,
+      loading: home.loading,
+      error: home.error,
+      fetchedAt: home.fetchedAt,
+      stale: home.stale,
+      loadingMore: false,
+      hasMore: false,
+      nextOffset: null,
+    };
+  }
+
+  const publicationEntry = publicationFeeds[activePublicationTabId];
+  if (publicationEntry?.data) {
+    return {
+      data: publicationEntry.data.items,
+      loading: publicationEntry.loading,
+      loadingMore: publicationEntry.loadingMore,
+      hasMore: publicationEntry.data.hasMore,
+      nextOffset: publicationEntry.data.nextOffset,
+      error: publicationEntry.error,
+      fetchedAt: publicationEntry.fetchedAt,
+      stale: publicationEntry.stale,
+    };
+  }
+
+  const publicationFallbackRows = home.data?.feed.filter((article) => articleMatchesPublication(article, activePublication)) ?? [];
+  return {
+    data: publicationFallbackRows.length > 0 ? publicationFallbackRows : null,
+    loading: publicationEntry?.loading ?? false,
+    loadingMore: publicationEntry?.loadingMore ?? false,
+    hasMore: false,
+    nextOffset: null,
+    error: publicationEntry?.error ?? null,
+    fetchedAt: publicationEntry?.fetchedAt ?? home.fetchedAt,
+    stale: publicationEntry?.stale ?? home.stale,
+  };
+}

--- a/src/plugins/builtin/substack/pane.tsx
+++ b/src/plugins/builtin/substack/pane.tsx
@@ -1,0 +1,500 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, useRendererHost, type ScrollBoxRenderable } from "../../../ui";
+import {
+  EmptyState,
+  Spinner,
+  type DataTableKeyEvent,
+} from "../../../components";
+import type { PaneProps } from "../../../types/plugin";
+import { isPlainKey } from "../../../utils/keyboard";
+import { useDebouncedPluginPaneState, usePluginPaneState } from "../../runtime";
+import {
+  clearSubstackAuth,
+  getStoredSubstackAuth,
+} from "./api/store";
+import {
+  loadSubstackArticleDetail,
+  loadSubstackHome,
+  loadSubstackPublicationFeed,
+} from "./api/loaders";
+import {
+  SubstackAuthError,
+  type SubstackAuthState,
+  type SubstackCachedData,
+  type SubstackHomeData,
+  type SubstackPublicationFeedPage,
+} from "./api/types";
+import { ArticleDetail } from "./article-detail";
+import { SubstackArticleStack } from "./article-stack";
+import { SubstackFeedTabs } from "./feed-tabs";
+import { SubstackLoginView } from "./login-view";
+import {
+  buildSubstackColumns,
+  isSubstackSortColumnId,
+  nextSubstackSort,
+  publicationFromTabId,
+  sortedSubstackArticles,
+  tabIdForPublication,
+} from "./table";
+import {
+  SUBSTACK_FEED_TAB_ID,
+  type SubstackArticleDetail,
+  type SubstackArticleSummary,
+  type SubstackPublication,
+  type SubstackSortColumnId,
+  type SubstackSortDirection,
+} from "./types";
+import { useSubstackPaneFooter } from "./pane-footer";
+import {
+  activeFeedStateFromSources,
+  detailLoadStateFromCache,
+  emptyLoadState,
+  emptyPublicationFeedState,
+  errorMessage,
+  homeLoadStateFromCache,
+  mergePublicationFeedPages,
+  publicationLoadStateFromCache,
+  type DetailState,
+  type LoadState,
+  type PublicationFeedState,
+} from "./pane-state";
+
+const PUBLICATION_LOAD_MORE_THRESHOLD_ROWS = 8;
+
+export function SubstackPane({ focused, width, height }: PaneProps) {
+  const rendererHost = useRendererHost();
+  const [auth, setAuth] = useState<SubstackAuthState | null>(() => getStoredSubstackAuth());
+  const [home, setHome] = useState<LoadState<SubstackHomeData>>(homeLoadStateFromCache);
+  const [publicationFeeds, setPublicationFeeds] = useState<Record<string, PublicationFeedState>>({});
+  const [details, setDetails] = useState<Record<string, DetailState>>({});
+  const [activeTab, setActiveTab] = usePluginPaneState<string>("activeTab", SUBSTACK_FEED_TAB_ID);
+  const [selectedArticleId, setSelectedArticleId] = useDebouncedPluginPaneState<string | null>("selectedArticleId", null);
+  const [detailOpen, setDetailOpen] = usePluginPaneState<boolean>("detailOpen", false);
+  const [sort, setSort] = useState<{ columnId: SubstackSortColumnId; direction: SubstackSortDirection }>({
+    columnId: "published",
+    direction: "desc",
+  });
+  const homeFetchGenRef = useRef(0);
+  const publicationFetchGenRef = useRef<Record<string, number>>({});
+  const detailFetchGenRef = useRef(0);
+  const tableScrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const detailScrollRef = useRef<ScrollBoxRenderable | null>(null);
+
+  const handleAuthFailure = useCallback((error: unknown) => {
+    if (!(error instanceof SubstackAuthError)) return false;
+    clearSubstackAuth();
+    setAuth(null);
+    setDetailOpen(false);
+    setHome((current) => ({
+      ...current,
+      loading: false,
+      error: error.message,
+    }));
+    return true;
+  }, []);
+
+  const loadHome = useCallback((force = false) => {
+    if (!auth) return;
+    homeFetchGenRef.current += 1;
+    const gen = homeFetchGenRef.current;
+    setHome((current) => ({
+      ...current,
+      loading: !current.data || force,
+      error: null,
+    }));
+    loadSubstackHome(force)
+      .then((data) => {
+        if (homeFetchGenRef.current !== gen) return;
+        setHome({
+          data,
+          loading: false,
+          error: null,
+          fetchedAt: data.fetchedAt,
+          stale: data.stale,
+        });
+      })
+      .catch((loadError) => {
+        if (homeFetchGenRef.current !== gen) return;
+        if (handleAuthFailure(loadError)) return;
+        setHome((current) => ({
+          ...current,
+          loading: false,
+          error: errorMessage(loadError),
+        }));
+      });
+  }, [auth, handleAuthFailure]);
+
+  useEffect(() => {
+    if (!auth) return;
+    loadHome(false);
+  }, [auth, loadHome]);
+
+  const subscriptions = home.data?.subscriptions ?? [];
+  const activePublication = useMemo(
+    () => publicationFromTabId(activeTab, subscriptions),
+    [activeTab, subscriptions],
+  );
+  const activePublicationTabId = activePublication ? tabIdForPublication(activePublication) : null;
+
+  useEffect(() => {
+    if (!home.data || activeTab === SUBSTACK_FEED_TAB_ID) return;
+    if (!publicationFromTabId(activeTab, subscriptions)) {
+      setActiveTab(SUBSTACK_FEED_TAB_ID);
+      setDetailOpen(false);
+    }
+  }, [activeTab, home.data, setActiveTab, setDetailOpen, subscriptions]);
+
+  const loadPublication = useCallback((publication: SubstackPublication, force = false, offset = 0) => {
+    const tabId = tabIdForPublication(publication);
+    const isLoadMore = offset > 0 && !force;
+    const gen = (publicationFetchGenRef.current[tabId] ?? 0) + 1;
+    publicationFetchGenRef.current[tabId] = gen;
+    setPublicationFeeds((current) => ({
+      ...current,
+      [tabId]: {
+        ...(current[tabId] ?? emptyPublicationFeedState()),
+        loading: !isLoadMore,
+        loadingMore: isLoadMore,
+        error: null,
+      },
+    }));
+    loadSubstackPublicationFeed(publication, force, offset)
+      .then((entry: SubstackCachedData<SubstackPublicationFeedPage>) => {
+        if (publicationFetchGenRef.current[tabId] !== gen) return;
+        setPublicationFeeds((current) => ({
+          ...current,
+          [tabId]: (() => {
+            const previous = current[tabId] ?? emptyPublicationFeedState();
+            return {
+              data: isLoadMore ? mergePublicationFeedPages(previous.data, entry.data) : entry.data,
+              loading: false,
+              loadingMore: false,
+              error: null,
+              fetchedAt: entry.fetchedAt,
+              stale: entry.stale,
+            };
+          })(),
+        }));
+      })
+      .catch((loadError) => {
+        if (publicationFetchGenRef.current[tabId] !== gen) return;
+        if (handleAuthFailure(loadError)) return;
+        setPublicationFeeds((current) => ({
+          ...current,
+          [tabId]: {
+            ...(current[tabId] ?? emptyPublicationFeedState()),
+            loading: false,
+            loadingMore: false,
+            error: errorMessage(loadError),
+          },
+        }));
+      });
+  }, [handleAuthFailure]);
+
+  useEffect(() => {
+    if (!activePublication || !activePublicationTabId) return;
+    const entry = publicationFeeds[activePublicationTabId];
+    if (entry?.data || entry?.loading || entry?.loadingMore || entry?.error) return;
+    const cached = publicationLoadStateFromCache(activePublication);
+    if (cached) {
+      setPublicationFeeds((current) => ({
+        ...current,
+        [activePublicationTabId]: cached,
+      }));
+      return;
+    }
+    loadPublication(activePublication, false);
+  }, [activePublication, activePublicationTabId, loadPublication, publicationFeeds]);
+
+  const activeFeedState = activeFeedStateFromSources({
+    activePublication,
+    activePublicationTabId,
+    publicationFeeds,
+    home,
+  });
+
+  const loadMoreActivePublicationRows = useCallback(() => {
+    if (!activePublication || !activePublicationTabId || detailOpen) return;
+    const entry = publicationFeeds[activePublicationTabId];
+    const page = entry?.data;
+    if (!page || entry.loading || entry.loadingMore || entry.error || !page.hasMore || page.nextOffset == null) return;
+    const scrollBox = tableScrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const visibleBottom = scrollBox.scrollTop + scrollBox.viewport.height;
+    const remainingRows = page.items.length - visibleBottom;
+    if (remainingRows > PUBLICATION_LOAD_MORE_THRESHOLD_ROWS) return;
+    loadPublication(activePublication, false, page.nextOffset);
+  }, [activePublication, activePublicationTabId, detailOpen, loadPublication, publicationFeeds]);
+
+  const sortedRows = useMemo(() => (
+    sortedSubstackArticles(activeFeedState.data ?? [], sort)
+  ), [activeFeedState.data, sort]);
+
+  useEffect(() => {
+    loadMoreActivePublicationRows();
+  }, [loadMoreActivePublicationRows, sortedRows.length]);
+
+  const selectedIndex = selectedArticleId
+    ? sortedRows.findIndex((article) => article.id === selectedArticleId)
+    : -1;
+  const selectedArticle = sortedRows[selectedIndex >= 0 ? selectedIndex : 0] ?? null;
+
+  useEffect(() => {
+    if (sortedRows.length === 0) {
+      if (!home.loading && !activeFeedState.loading && !activeFeedState.loadingMore) {
+        if (selectedArticleId !== null) setSelectedArticleId(null);
+        setDetailOpen(false);
+      }
+      return;
+    }
+    if (!selectedArticleId || selectedIndex < 0) {
+      setSelectedArticleId(sortedRows[0]!.id);
+    }
+  }, [
+    activeFeedState.loading,
+    activeFeedState.loadingMore,
+    home.loading,
+    selectedArticleId,
+    selectedIndex,
+    setDetailOpen,
+    setSelectedArticleId,
+    sortedRows,
+  ]);
+
+  const loadSelectedDetail = useCallback((article: SubstackArticleSummary, force = false) => {
+    detailFetchGenRef.current += 1;
+    const gen = detailFetchGenRef.current;
+    setDetails((current) => ({
+      ...current,
+      [article.id]: {
+        ...(current[article.id] ?? emptyLoadState<SubstackArticleDetail>()),
+        loading: true,
+        error: null,
+      },
+    }));
+    loadSubstackArticleDetail(article, force)
+      .then((entry) => {
+        if (detailFetchGenRef.current !== gen) return;
+        setDetails((current) => ({
+          ...current,
+          [article.id]: {
+            data: entry.data,
+            loading: false,
+            error: null,
+            fetchedAt: entry.fetchedAt,
+            stale: entry.stale,
+          },
+        }));
+      })
+      .catch((loadError) => {
+        if (detailFetchGenRef.current !== gen) return;
+        if (handleAuthFailure(loadError)) return;
+        setDetails((current) => ({
+          ...current,
+          [article.id]: {
+            ...(current[article.id] ?? emptyLoadState<SubstackArticleDetail>()),
+            loading: false,
+            error: errorMessage(loadError),
+          },
+        }));
+      });
+  }, [handleAuthFailure]);
+
+  useEffect(() => {
+    if (!detailOpen || !selectedArticle) return;
+    const existing = details[selectedArticle.id];
+    if (existing?.data || existing?.loading) return;
+    const cached = detailLoadStateFromCache(selectedArticle);
+    if (cached) {
+      setDetails((current) => ({
+        ...current,
+        [selectedArticle.id]: cached,
+      }));
+      if (!cached.stale) return;
+    }
+    loadSelectedDetail(selectedArticle, false);
+  }, [detailOpen, details, loadSelectedDetail, selectedArticle]);
+
+  useEffect(() => {
+    if (!detailOpen) return;
+    if (detailScrollRef.current) detailScrollRef.current.scrollTop = 0;
+  }, [detailOpen, selectedArticle?.id]);
+
+  const selectTab = useCallback((tabId: string) => {
+    setActiveTab(tabId);
+    setDetailOpen(false);
+  }, [setActiveTab, setDetailOpen]);
+
+  const refreshActive = useCallback(() => {
+    if (activePublication) {
+      loadPublication(activePublication, true);
+      return;
+    }
+    loadHome(true);
+  }, [activePublication, loadHome, loadPublication]);
+
+  const openSelectedArticle = useCallback(() => {
+    if (!selectedArticle?.url) return;
+    void rendererHost.openExternal(selectedArticle.url);
+  }, [rendererHost, selectedArticle]);
+
+  const handleLogin = useCallback((nextAuth: SubstackAuthState) => {
+    setAuth(nextAuth);
+    setActiveTab(SUBSTACK_FEED_TAB_ID);
+  }, [setActiveTab]);
+
+  const handleHeaderClick = useCallback((columnId: string) => {
+    if (!isSubstackSortColumnId(columnId)) return;
+    setSort((current) => nextSubstackSort(current, columnId));
+  }, []);
+
+  const scrollDetailBy = useCallback((delta: number) => {
+    const scrollBox = detailScrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const maxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
+    scrollBox.scrollTop = Math.max(0, Math.min(maxScrollTop, scrollBox.scrollTop + delta));
+  }, []);
+
+  const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refreshActive();
+      return true;
+    }
+    if (isPlainKey(event, "o")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      openSelectedArticle();
+      return true;
+    }
+    return false;
+  }, [openSelectedArticle, refreshActive]);
+
+  const handleDetailKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (isPlainKey(event, "j", "down")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      scrollDetailBy(1);
+      return true;
+    }
+    if (isPlainKey(event, "k", "up")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      scrollDetailBy(-1);
+      return true;
+    }
+    if (isPlainKey(event, "o")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      openSelectedArticle();
+      return true;
+    }
+    if (isPlainKey(event, "r") && selectedArticle) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      loadSelectedDetail(selectedArticle, true);
+      return true;
+    }
+    return false;
+  }, [loadSelectedDetail, openSelectedArticle, scrollDetailBy, selectedArticle]);
+
+  const includePublication = !activePublication;
+  const columns = useMemo(() => buildSubstackColumns(width, includePublication), [includePublication, width]);
+  const activeDetail = selectedArticle ? details[selectedArticle.id] ?? emptyLoadState<SubstackArticleDetail>() : emptyLoadState<SubstackArticleDetail>();
+  useSubstackPaneFooter({
+    auth,
+    detailOpen,
+    activeFeedState,
+    activeDetail,
+    selectedArticle,
+    refreshActive,
+    openSelectedArticle,
+  });
+
+  if (!auth) {
+    return (
+      <SubstackLoginView
+        width={width}
+        height={height}
+        focused={focused}
+        onLogin={handleLogin}
+      />
+    );
+  }
+
+  const tabs = (
+    <SubstackFeedTabs
+      subscriptions={subscriptions}
+      activeTab={activeTab}
+      focused={focused}
+      detailOpen={detailOpen}
+      onSelect={selectTab}
+    />
+  );
+
+  if (home.loading && !home.data) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Spinner label="Loading Substack..." />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (home.error && !home.data) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box padding={1}>
+          <EmptyState title="Substack unavailable." message={home.error} hint="Press r to retry." />
+        </Box>
+      </Box>
+    );
+  }
+
+  const detailContent = selectedArticle ? (
+    <ArticleDetail
+      article={selectedArticle}
+      detail={activeDetail.data}
+      width={width}
+      loading={activeDetail.loading}
+      error={activeDetail.error}
+      scrollRef={detailScrollRef}
+      onOpenArticle={openSelectedArticle}
+    />
+  ) : null;
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      {tabs}
+      <SubstackArticleStack
+        focused={focused}
+        detailOpen={detailOpen}
+        onBack={() => setDetailOpen(false)}
+        selectedArticle={selectedArticle}
+        detailContent={detailContent}
+        selectedArticleId={selectedArticleId}
+        onActivate={(article) => {
+          setSelectedArticleId(article.id, { immediate: true });
+          setDetailOpen(true);
+        }}
+        onSelectionChange={(id) => setSelectedArticleId(id)}
+        onRootKeyDown={handleRootKeyDown}
+        onDetailKeyDown={handleDetailKeyDown}
+        onBodyScrollActivity={loadMoreActivePublicationRows}
+        tableScrollRef={tableScrollRef}
+        width={width}
+        height={height}
+        columns={columns}
+        sortedRows={sortedRows}
+        activePublication={activePublication}
+        activeFeedState={activeFeedState}
+        sort={sort}
+        onHeaderClick={handleHeaderClick}
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/substack/table.ts
+++ b/src/plugins/builtin/substack/table.ts
@@ -1,0 +1,111 @@
+import type {
+  SubstackArticleSummary,
+  SubstackColumn,
+  SubstackPublication,
+  SubstackSortColumnId,
+  SubstackSortDirection,
+} from "./types";
+import { publicationKey } from "./normalize";
+import { timestamp } from "./utils";
+
+export function isSubstackSortColumnId(value: string): value is SubstackSortColumnId {
+  return value === "published" || value === "publication" || value === "title" || value === "read";
+}
+
+export function nextSubstackSort(
+  current: { columnId: SubstackSortColumnId; direction: SubstackSortDirection },
+  columnId: SubstackSortColumnId,
+): { columnId: SubstackSortColumnId; direction: SubstackSortDirection } {
+  if (current.columnId === columnId) {
+    return { columnId, direction: current.direction === "desc" ? "asc" : "desc" };
+  }
+  return {
+    columnId,
+    direction: columnId === "title" || columnId === "publication" ? "asc" : "desc",
+  };
+}
+
+export function sortedSubstackArticles(
+  articles: SubstackArticleSummary[],
+  sort: { columnId: SubstackSortColumnId; direction: SubstackSortDirection },
+): SubstackArticleSummary[] {
+  const direction = sort.direction === "asc" ? 1 : -1;
+  return [...articles].sort((a, b) => {
+    let result = 0;
+    switch (sort.columnId) {
+      case "published":
+        result = timestamp(a.publishedAt) - timestamp(b.publishedAt);
+        break;
+      case "publication":
+        result = (a.publicationName ?? "").localeCompare(b.publicationName ?? "");
+        break;
+      case "title":
+        result = a.title.localeCompare(b.title);
+        break;
+      case "read":
+        result = a.readMinutes - b.readMinutes;
+        break;
+    }
+    return result === 0 ? timestamp(b.publishedAt) - timestamp(a.publishedAt) : result * direction;
+  });
+}
+
+export function formatPublishedAt(value: string | null): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  const now = new Date();
+  const sameYear = date.getFullYear() === now.getFullYear();
+  const datePart = date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "2-digit" as const }),
+  });
+  const timePart = date.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  return `${datePart} ${timePart}`;
+}
+
+export function formatReadTime(minutes: number): string {
+  return `${Math.max(1, Math.ceil(minutes))}m`;
+}
+
+export function formatWordCount(words: number): string {
+  if (words >= 1000) return `${(words / 1000).toFixed(words >= 10_000 ? 0 : 1)}k words`;
+  return `${Math.max(0, Math.round(words))} words`;
+}
+
+export function buildSubstackColumns(width: number, includePublication: boolean): SubstackColumn[] {
+  const publishedWidth = 13;
+  const readWidth = 5;
+  const publicationWidth = includePublication ? Math.max(12, Math.min(21, Math.floor(width * 0.18))) : 0;
+  const fixed = publishedWidth + readWidth + publicationWidth;
+  const titleWidth = Math.max(18, width - fixed - 4);
+  const columns: SubstackColumn[] = [
+    { id: "published", label: "Published", width: publishedWidth, align: "left" },
+  ];
+  if (includePublication) {
+    columns.push({ id: "publication", label: "Publication", width: publicationWidth, align: "left" });
+  }
+  columns.push(
+    { id: "title", label: "Title", width: titleWidth, align: "left", flexGrow: 1 },
+    { id: "read", label: "Read", width: readWidth, align: "right" },
+  );
+  return columns;
+}
+
+export function tabIdForPublication(publication: SubstackPublication): string {
+  return `pub:${publicationKey(publication)}`;
+}
+
+export function publicationFromTabId(
+  tabId: string,
+  publications: SubstackPublication[],
+): SubstackPublication | null {
+  if (!tabId.startsWith("pub:")) return null;
+  const key = tabId.slice(4);
+  return publications.find((publication) => publicationKey(publication) === key) ?? null;
+}

--- a/src/plugins/builtin/substack/types.ts
+++ b/src/plugins/builtin/substack/types.ts
@@ -1,0 +1,71 @@
+import type { DataTableColumn } from "../../../components";
+
+export const SUBSTACK_PANE_ID = "substack";
+export const SUBSTACK_PLUGIN_ID = "substack";
+export const SUBSTACK_FEED_TAB_ID = "feed";
+
+export interface SubstackPublication {
+  id: string;
+  name: string;
+  subdomain: string | null;
+  baseUrl: string | null;
+  description: string | null;
+  logoUrl: string | null;
+  latestPublishedAt: string | null;
+}
+
+export interface ExtractedArticleContent {
+  text: string;
+  blocks: SubstackContentBlock[];
+  imageUrls: string[];
+  linkUrls: string[];
+  wordCount: number;
+  readMinutes: number;
+}
+
+export type SubstackContentBlock =
+  | { type: "heading"; text: string; level: number }
+  | { type: "paragraph"; text: string }
+  | { type: "quote"; text: string }
+  | { type: "listItem"; text: string }
+  | { type: "image"; url: string; alt: string | null }
+  | {
+    type: "embed";
+    kind: "tweet";
+    text: string;
+    url: string | null;
+    username: string | null;
+    authorName: string | null;
+    dateLabel: string | null;
+    imageUrls: string[];
+  }
+  | { type: "embed"; kind: "link" | "media"; text: string; url: string | null }
+  | { type: "divider" };
+
+export interface SubstackArticleSummary {
+  id: string;
+  title: string;
+  publicationId: string | null;
+  publicationName: string | null;
+  publicationSubdomain: string | null;
+  publicationBaseUrl: string | null;
+  url: string | null;
+  slug: string | null;
+  publishedAt: string | null;
+  subtitle: string | null;
+  previewText: string | null;
+  bodyHtml: string | null;
+  imageUrls: string[];
+  wordCount: number;
+  readMinutes: number;
+}
+
+export interface SubstackArticleDetail extends SubstackArticleSummary {
+  contentText: string;
+  contentBlocks: SubstackContentBlock[];
+  linkUrls: string[];
+}
+
+export type SubstackSortColumnId = "published" | "publication" | "title" | "read";
+export type SubstackSortDirection = "asc" | "desc";
+export type SubstackColumn = DataTableColumn & { id: SubstackSortColumnId };

--- a/src/plugins/builtin/substack/utils.ts
+++ b/src/plugins/builtin/substack/utils.ts
@@ -1,0 +1,131 @@
+import { decodeHtmlEntities } from "../../../utils/html-entities";
+import { normalizedHttpUrl } from "../../../utils/url";
+
+export type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function asRecord(value: unknown): JsonRecord | null {
+  return isRecord(value) ? value : null;
+}
+
+export function stringValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = decodeHtmlEntities(value).replace(/\s+/g, " ").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function rawStringValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function numberValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function firstString(record: JsonRecord | null, keys: string[]): string | null {
+  if (!record) return null;
+  for (const key of keys) {
+    const value = stringValue(record[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+export function firstRawString(record: JsonRecord | null, keys: string[]): string | null {
+  if (!record) return null;
+  for (const key of keys) {
+    const value = rawStringValue(record[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+export function firstNumber(record: JsonRecord | null, keys: string[]): number | null {
+  if (!record) return null;
+  for (const key of keys) {
+    const value = numberValue(record[key]);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+export function firstValue(record: JsonRecord | null, keys: string[]): unknown {
+  if (!record) return null;
+  for (const key of keys) {
+    if (record[key] != null) return record[key];
+  }
+  return null;
+}
+
+export function firstRecord(...values: unknown[]): JsonRecord | null {
+  for (const value of values) {
+    const record = asRecord(value);
+    if (record) return record;
+  }
+  return null;
+}
+
+export function parseDateIso(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const ms = value > 10_000_000_000 ? value : value * 1000;
+    const date = new Date(ms);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  if (typeof value !== "string" || !value.trim()) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export function normalizeUrl(value: unknown, baseUrl?: string | null): string | null {
+  const raw = rawStringValue(value);
+  if (!raw) return null;
+  const direct = normalizedHttpUrl(raw);
+  if (direct) return direct;
+  if (!baseUrl) return null;
+  try {
+    const resolved = new URL(raw, baseUrl);
+    return normalizedHttpUrl(resolved.toString());
+  } catch {
+    return null;
+  }
+}
+
+export function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+export function timestamp(value: string | null | undefined): number {
+  if (!value) return 0;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+}
+
+export function maxIso(a: string | null, b: string | null): string | null {
+  if (!a) return b;
+  if (!b) return a;
+  return timestamp(a) >= timestamp(b) ? a : b;
+}
+
+export function extractAttribute(tag: string, name: string): string | null {
+  const pattern = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i");
+  const match = tag.match(pattern);
+  return rawStringValue(match?.[1] ?? match?.[2] ?? match?.[3] ?? null);
+}

--- a/src/plugins/catalog-ui.ts
+++ b/src/plugins/catalog-ui.ts
@@ -2,6 +2,7 @@ import type { GloomPlugin } from "../types/plugin";
 import { portfolioListPlugin } from "./builtin/portfolio-list";
 import { newsPlugin } from "./builtin/news";
 import { notesPlugin } from "./builtin/notes";
+import { substackPlugin } from "./builtin/substack";
 import { aiPlugin } from "./builtin/ai";
 import { gloomberbCloudPlugin } from "./builtin/cloud";
 import { changelogPlugin } from "./builtin/changelog";
@@ -26,6 +27,7 @@ export const uiBuiltinPlugins: GloomPlugin[] = [
   ibkrPlugin,
   layoutManagerPlugin,
   newsPlugin,
+  substackPlugin,
   notesPlugin,
   aiPlugin,
   changelogPlugin,

--- a/src/renderers/electrobun/bun/desktop/http-fetch.test.ts
+++ b/src/renderers/electrobun/bun/desktop/http-fetch.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { handleHttpFetch } from "./http-fetch";
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+
+afterEach(() => {
+  server?.stop(true);
+  server = null;
+});
+
+describe("handleHttpFetch", () => {
+  test("preserves manual redirects and Set-Cookie headers", async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/login") {
+          return new Response(null, {
+            status: 302,
+            headers: {
+              location: "/reader",
+              "set-cookie": "substack.sid=sid123; Path=/; HttpOnly",
+            },
+          });
+        }
+        if (url.pathname === "/reader") {
+          return new Response("reader");
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const response = await handleHttpFetch({
+      url: new URL("/login", server.url).toString(),
+      init: { redirect: "manual" },
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe("/reader");
+    expect(response.setCookie).toEqual(["substack.sid=sid123; Path=/; HttpOnly"]);
+  });
+});

--- a/src/renderers/electrobun/bun/desktop/http-fetch.ts
+++ b/src/renderers/electrobun/bun/desktop/http-fetch.ts
@@ -26,6 +26,10 @@ export async function handleHttpFetch(payload: Record<string, unknown>) {
     typeof init.method === "string" && init.method.trim().length > 0
       ? init.method.trim().toUpperCase()
       : "GET";
+  const redirect =
+    init.redirect === "manual" || init.redirect === "error" || init.redirect === "follow"
+      ? init.redirect
+      : undefined;
   const body =
     typeof init.body === "string" && method !== "GET" && method !== "HEAD"
       ? init.body
@@ -35,6 +39,7 @@ export async function handleHttpFetch(payload: Record<string, unknown>) {
     method,
     headers: normalizeHttpFetchHeaders(init.headers),
     body,
+    redirect,
   });
   const responseHeaders: Record<string, string> = {};
   response.headers.forEach((value, key) => {

--- a/src/renderers/electrobun/view/http-fetch.ts
+++ b/src/renderers/electrobun/view/http-fetch.ts
@@ -61,12 +61,18 @@ async function electrobunHttpFetch(url: string, init?: RequestInit): Promise<Res
   const requestPromise = requestBackendHttpFetch(url, init);
 
   const response = await withAbort(requestPromise, init?.signal);
-
-  return new Response(response.body, {
+  const headers = createResponseHeaders(response.headers, response.setCookie);
+  const fetchResponse = new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers,
   });
+
+  Object.defineProperty(fetchResponse, "headers", {
+    value: headers,
+    configurable: true,
+  });
+  return fetchResponse;
 }
 
 async function requestBackendHttpFetch(url: string, init?: RequestInit): Promise<ElectrobunHttpFetchResponse> {
@@ -76,6 +82,7 @@ async function requestBackendHttpFetch(url: string, init?: RequestInit): Promise
       method: init?.method,
       headers: normalizeHeaders(init?.headers),
       body: await serializeBody(init?.body),
+      redirect: init?.redirect,
     },
   });
 }


### PR DESCRIPTION
Adds a built-in Substack reader plugin with email-code and magic-link authentication, cached subscription/feed/archive loading, per-publication tabs, and article detail views.
Renders article content with images, headings, quotes, links, tickers, and embedded tweet data while keeping article metadata in the pane footer.
Extends the desktop HTTP fetch bridge so Substack auth flows can preserve manual redirects and Set-Cookie headers, and removes duplicate image URL display from rendered images.
Documents the `SUB` command and groups Substack, prediction markets, TheBuildout, and Congress disclosures under market/news/macro shortcuts.
