### PR TITLE
Add floating pane cleanup and tabbed Help

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For the best terminal experience, use a [Kitty](https://sw.kovidgoyal.net/kitty/
 
 ## Start
 
-Open the command bar with `Ctrl+P` or `` ` ``, then type a command.
+Open command mode with `Ctrl+P`, then type a command. Press `` ` `` to open ticker search directly.
 
 | Try | Opens |
 |-----|-------|
@@ -103,7 +103,8 @@ See [PLUGINS.md](PLUGINS.md) for the plugin API and the shared UI surface availa
 
 | Key | Action |
 |-----|--------|
-| `Ctrl+P` or `` ` `` | Open command bar |
+| `Ctrl+P` | Open command mode |
+| `` ` `` | Open ticker search |
 | `Ctrl+,` | Open focused pane settings |
 | `Ctrl+W` | Close focused pane |
 | `Ctrl+Shift+M` | Move focused window (`WIN resize` starts resize mode) |

--- a/src/app/global-shortcuts.test.tsx
+++ b/src/app/global-shortcuts.test.tsx
@@ -44,26 +44,38 @@ function createRegistry(shortcutExecute?: () => void): PluginRegistry {
 
 function ShortcutHarness({
   dispatch,
+  focusedTickerSymbol = null,
   pluginRegistry,
+  refreshTicker = () => {},
   state,
 }: {
   dispatch: (action: AppAction) => void;
+  focusedTickerSymbol?: string | null;
   pluginRegistry: PluginRegistry;
+  refreshTicker?: (symbol: string, exchange?: string, tickerOverride?: any, priority?: number) => void;
   state: AppState;
 }) {
   useAppGlobalShortcuts({
     dispatch,
-    focusedTickerSymbol: null,
+    focusedTickerSymbol,
     isDetachedWindow: false,
     pluginRegistry,
-    refreshTicker: () => {},
+    refreshTicker,
     startUpdate: () => {},
     state,
   });
   return <text>ready</text>;
 }
 
-async function renderHarness(state: AppState, registry: PluginRegistry, dispatch: (action: AppAction) => void) {
+async function renderHarness(
+  state: AppState,
+  registry: PluginRegistry,
+  dispatch: (action: AppAction) => void,
+  options: {
+    focusedTickerSymbol?: string | null;
+    refreshTicker?: (symbol: string, exchange?: string, tickerOverride?: any, priority?: number) => void;
+  } = {},
+) {
   testSetup = await createTestRenderer({ width: 40, height: 8 });
   root = createRoot(testSetup.renderer);
   act(() => {
@@ -71,7 +83,9 @@ async function renderHarness(state: AppState, registry: PluginRegistry, dispatch
       <TestDialogProvider>
         <ShortcutHarness
           dispatch={dispatch}
+          focusedTickerSymbol={options.focusedTickerSymbol}
           pluginRegistry={registry}
+          refreshTicker={options.refreshTicker}
           state={state}
         />
       </TestDialogProvider>,
@@ -179,5 +193,24 @@ describe("useAppGlobalShortcuts", () => {
     }]);
     expect(event.defaultPrevented).toBe(true);
     expect(event.propagationStopped).toBe(true);
+  });
+
+  test("does not treat modified Shift-R as force refresh", async () => {
+    const refreshes: Array<{ symbol: string; priority?: number }> = [];
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-global-shortcuts-resize"));
+    state.tickers.set("AAPL", {
+      metadata: { ticker: "AAPL", exchange: "NASDAQ" },
+    } as any);
+    await renderHarness(state, createRegistry(), () => {}, {
+      refreshTicker: (symbol, _exchange, _ticker, priority) => {
+        refreshes.push({ symbol, priority });
+      },
+    });
+
+    const event = await emitKeypress({ name: "r", ctrl: true, shift: true });
+
+    expect(refreshes).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
+    expect(event.propagationStopped).toBe(false);
   });
 });

--- a/src/app/global-shortcuts.ts
+++ b/src/app/global-shortcuts.ts
@@ -101,18 +101,19 @@ export function useAppGlobalShortcuts({
 
     if (state.inputCaptured) return;
 
-    if (!isDetachedWindow && event.name === "q") {
+    const hasShortcutModifier = event.ctrl || event.meta || event.super || event.alt;
+    if (!hasShortcutModifier && !isDetachedWindow && event.name === "q") {
       rendererHost.requestExit();
-    } else if (event.name === "r") {
+    } else if (!hasShortcutModifier && event.name === "r") {
       if (focusedTickerSymbol) {
         const ticker = state.tickers.get(focusedTickerSymbol);
         if (ticker) refreshTicker(ticker.metadata.ticker, ticker.metadata.exchange, ticker, 0);
       }
-    } else if (event.name === "R" || (event.name === "r" && event.shift)) {
+    } else if (!hasShortcutModifier && (event.name === "R" || (event.name === "r" && event.shift))) {
       for (const ticker of state.tickers.values()) {
         refreshTicker(ticker.metadata.ticker, ticker.metadata.exchange, ticker, 1);
       }
-    } else if (event.name === "u" && state.updateAvailable && !state.updateProgress && !state.updateCheckInProgress && canSelfUpdate(state.updateAvailable)) {
+    } else if (!hasShortcutModifier && event.name === "u" && state.updateAvailable && !state.updateProgress && !state.updateCheckInProgress && canSelfUpdate(state.updateAvailable)) {
       startUpdate(state.updateAvailable);
     } else {
       const disabledPlugins = new Set(state.config.disabledPlugins || []);

--- a/src/components/command-bar/layout-items/current-layout.test.ts
+++ b/src/components/command-bar/layout-items/current-layout.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { createInitialState, type AppAction, type AppState } from "../../../state/app/context";
+import { cloneLayout, createDefaultConfig, type LayoutConfig } from "../../../types/config";
+import type { PluginRegistry } from "../../../plugins/registry";
+import type { CommandBarRoute } from "../workflow/types";
+import type { LayoutItemsContext } from "./types";
+import { buildCurrentLayoutItems } from "./current-layout";
+
+type InlineConfirmOptions = Parameters<LayoutItemsContext["openInlineConfirm"]>[0];
+
+function createFloatingLayoutFixture(): { layout: LayoutConfig; state: AppState } {
+  const config = createDefaultConfig("/tmp/gloomberb-layout-actions-test");
+  const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+  const firstDetailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+  if (!mainPane || !firstDetailPane) throw new Error("missing default panes");
+
+  const secondDetailPane = {
+    ...firstDetailPane,
+    instanceId: "ticker-detail:secondary",
+  };
+  const layout: LayoutConfig = {
+    dockRoot: { kind: "pane", instanceId: "portfolio-list:main" },
+    instances: [{ ...mainPane }, { ...firstDetailPane }, secondDetailPane],
+    floating: [
+      { instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 },
+      { instanceId: "ticker-detail:secondary", x: 8, y: 3, width: 30, height: 8 },
+    ],
+    detached: [],
+  };
+  const state = createInitialState({
+    ...config,
+    layout: cloneLayout(layout),
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  });
+  return { layout, state };
+}
+
+function createLayoutItemsContext(
+  options: {
+    confirmDangerousActions?: boolean;
+    layouts: LayoutConfig[];
+    confirmations: InlineConfirmOptions[];
+  },
+): LayoutItemsContext {
+  const { layout, state } = createFloatingLayoutFixture();
+  return {
+    closeAll: () => {},
+    currentLayout: layout,
+    dispatch: (_action: AppAction) => {},
+    duplicatePane: () => {},
+    focusedPaneId: state.focusedPaneId,
+    notifyGridlockRevert: () => {},
+    openBuiltInWorkflow: () => {},
+    openInlineConfirm: (confirmOptions) => {
+      options.confirmations.push(confirmOptions);
+    },
+    persistLayoutChange: (nextLayout) => {
+      options.layouts.push(nextLayout);
+    },
+    pluginRegistry: {
+      getTermSizeFn: () => ({ width: 80, height: 24 }),
+    } as PluginRegistry,
+    pushRoute: (_route: CommandBarRoute) => {},
+    state,
+    ...(options.confirmDangerousActions === undefined ? {} : { confirmDangerousActions: options.confirmDangerousActions }),
+  };
+}
+
+describe("buildCurrentLayoutItems", () => {
+  test("closes all floating panes from the current layout", () => {
+    const layouts: LayoutConfig[] = [];
+    const confirmations: InlineConfirmOptions[] = [];
+    const items = buildCurrentLayoutItems(createLayoutItemsContext({ layouts, confirmations }));
+
+    const item = items.find((entry) => entry.id === "layout-close-all-floating");
+    expect(item).toMatchObject({
+      label: "Close All Floating Panes",
+      disabled: false,
+    });
+
+    item?.action();
+
+    expect(confirmations).toEqual([]);
+    expect(layouts).toHaveLength(1);
+    expect(layouts[0]?.floating).toEqual([]);
+    expect(layouts[0]?.instances.map((instance) => instance.instanceId)).toEqual(["portfolio-list:main"]);
+    expect(layouts[0]?.dockRoot).toEqual({ kind: "pane", instanceId: "portfolio-list:main" });
+  });
+
+  test("confirms before closing all floating panes when dangerous actions are guarded", () => {
+    const layouts: LayoutConfig[] = [];
+    const confirmations: InlineConfirmOptions[] = [];
+    const items = buildCurrentLayoutItems(createLayoutItemsContext({
+      confirmDangerousActions: true,
+      layouts,
+      confirmations,
+    }));
+
+    items.find((entry) => entry.id === "layout-close-all-floating")?.action();
+
+    expect(layouts).toEqual([]);
+    expect(confirmations).toHaveLength(1);
+    expect(confirmations[0]).toMatchObject({
+      confirmId: "layout-close-all-floating",
+      title: "Close All Floating Panes",
+      confirmLabel: "Close Floating Panes",
+      tone: "danger",
+    });
+
+    confirmations[0]?.onConfirm();
+
+    expect(layouts).toHaveLength(1);
+    expect(layouts[0]?.floating).toEqual([]);
+  });
+});

--- a/src/components/command-bar/layout-items/current-layout.ts
+++ b/src/components/command-bar/layout-items/current-layout.ts
@@ -1,5 +1,6 @@
 import {
   gridlockAllPanes,
+  removeFloatingPanes,
 } from "../../../plugins/pane-manager";
 import {
   DEFAULT_LAYOUT,
@@ -21,6 +22,8 @@ export function buildCurrentLayoutItems({
   state,
 }: LayoutItemsContext): ResultItem[] {
   const layoutHistory = state.layoutHistory[state.config.activeLayoutIndex];
+  const floatingPaneCount = currentLayout.floating.length;
+  const floatingPaneLabel = floatingPaneCount === 1 ? "floating pane" : "floating panes";
 
   return [
     {
@@ -88,6 +91,36 @@ export function buildCurrentLayoutItems({
         notifyGridlockRevert();
         closeAll({ revertThemePreview: false });
       },
+    },
+    {
+      id: "layout-close-all-floating",
+      label: "Close All Floating Panes",
+      detail: floatingPaneCount > 0
+        ? `Remove ${floatingPaneCount} ${floatingPaneLabel} from the current layout`
+        : "No floating panes in the current layout",
+      category: "Current Layout",
+      kind: "action",
+      disabled: floatingPaneCount === 0,
+      action: confirmDangerousActions
+        ? () => {
+          if (floatingPaneCount === 0) return;
+          openInlineConfirm({
+            confirmId: "layout-close-all-floating",
+            title: "Close All Floating Panes",
+            body: [`Close ${floatingPaneCount} ${floatingPaneLabel}?`],
+            confirmLabel: "Close Floating Panes",
+            cancelLabel: "Back",
+            tone: "danger",
+            onConfirm: () => {
+              persistLayoutChange(removeFloatingPanes(currentLayout));
+            },
+          });
+        }
+        : () => {
+          if (floatingPaneCount === 0) return;
+          persistLayoutChange(removeFloatingPanes(currentLayout));
+          closeAll({ revertThemePreview: false });
+        },
     },
     {
       id: "layout-rename",

--- a/src/components/command-bar/surface/pane.test.tsx
+++ b/src/components/command-bar/surface/pane.test.tsx
@@ -158,6 +158,7 @@ describe("CommandBar pane and layout routes", () => {
     expect(frame).toContain("Float Pane");
     expect(frame).toContain("Undo Layout Change");
     expect(frame).toContain("Current Layout");
+    expect(frame).toContain("Close All Floating Panes");
   });
 
   test("runs layout actions directly from root search", async () => {

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -61,10 +61,11 @@ function createShellPluginRegistry(options?: {
   } as unknown as PluginRegistry;
 }
 
-async function emitKeypress(event: { name?: string; sequence?: string; ctrl?: boolean; meta?: boolean; shift?: boolean }) {
+async function emitKeypress(event: { name?: string; sequence?: string; ctrl?: boolean; meta?: boolean; shift?: boolean; alt?: boolean }) {
   await act(async () => {
     const keyEvent = {
       ctrl: false,
+      alt: false,
       meta: false,
       option: false,
       shift: false,
@@ -312,6 +313,7 @@ describe("Shell", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Settings");
     expect(frame).toContain("Ctrl+,");
+    expect(frame).not.toContain("Layout Actions");
     expect(frame).not.toContain("CmdOrCtrl");
   });
 
@@ -400,22 +402,90 @@ describe("Shell", () => {
     });
     await testSetup.renderOnce();
 
-    expect(testSetup.captureCharFrame()).toContain("Dock Pane");
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Dock Pane");
+    expect(frame).not.toContain("Layout Actions");
   });
 
   test("resolves pane management shortcuts", () => {
     const base = { ctrl: false, meta: true, super: true, shift: true, alt: false };
     expect(resolvePaneManagementShortcut({ ...base, name: ",", key: ",", shift: false })).toBe("settings");
     expect(resolvePaneManagementShortcut({ ...base, name: "w", key: "w", ctrl: true, meta: false, super: false, shift: false })).toBe("close");
+    expect(resolvePaneManagementShortcut({ ...base, name: "w", key: "w", shift: false, alt: true })).toBe("close-all-floating");
+    expect(resolvePaneManagementShortcut({ ...base, name: "W", key: "W", shift: false })).toBeNull();
     expect(resolvePaneManagementShortcut({ ...base, name: "D", key: "D" })).toBe("toggle-floating");
     expect(resolvePaneManagementShortcut({ ...base, name: "o", key: "o" })).toBe("pop-out");
     expect(resolvePaneManagementShortcut({ ...base, name: "c", key: "c" })).toBe("copy-screenshot");
     expect(resolvePaneManagementShortcut({ ...base, name: "l", key: "l" })).toBe("layout-actions");
     expect(resolvePaneManagementShortcut({ ...base, name: "g", key: "g" })).toBe("gridlock-all");
     expect(resolvePaneManagementShortcut({ ...base, name: "m", key: "m" })).toBe("window-mode");
+    expect(resolvePaneManagementShortcut({ ...base, name: "r", key: "r" })).toBe("window-resize-mode");
     expect(resolvePaneManagementShortcut({ ...base, name: "n", key: "n" })).toBeNull();
     expect(resolvePaneManagementShortcut({ ...base, name: "d", key: "d", alt: true })).toBeNull();
     expect(resolvePaneManagementShortcut({ ...base, name: "d", key: "d", meta: false, super: false })).toBeNull();
+  });
+
+  test("exits window mode on Enter without changes", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-window-mode-resize-shortcut-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    const dockedLayout = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        second: { kind: "pane" as const, instanceId: "ticker-detail:main" },
+      },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [],
+      detached: [],
+    };
+    const { actions } = await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, dockedLayout, "portfolio-list:main"),
+    );
+
+    await emitKeypress({ name: "m", ctrl: true, shift: true });
+    expect(testSetup.captureCharFrame()).toContain("WINDOW MOVE");
+
+    await emitKeypress({ name: "enter" });
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame()).not.toContain("WINDOW MOVE");
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+  });
+
+  test("starts resize mode directly from the resize shortcut", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-window-mode-resize-shortcut-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    const dockedLayout = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        second: { kind: "pane" as const, instanceId: "ticker-detail:main" },
+      },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [],
+      detached: [],
+    };
+    const { actions } = await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, dockedLayout, "portfolio-list:main"),
+    );
+
+    await emitKeypress({ name: "r", ctrl: true, shift: true });
+    expect(testSetup.captureCharFrame()).toContain("WINDOW RESIZE");
+
+    await emitKeypress({ name: "enter" });
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    const frame = testSetup.captureCharFrame();
+    expect(frame).not.toContain("WINDOW RESIZE");
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
   });
 
   test("moves a floating pane in window mode and commits once", async () => {
@@ -783,6 +853,54 @@ describe("Shell", () => {
     const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
     expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId)).toEqual(["portfolio-list:main"]);
     expect(updateLayout?.layout.floating).toEqual([]);
+  });
+
+  test("closes all floating panes with Ctrl+Alt+W", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    const firstDetailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+    if (!mainPane || !firstDetailPane) throw new Error("missing default panes");
+    const secondDetailPane = {
+      ...firstDetailPane,
+      instanceId: "ticker-detail:secondary",
+    };
+
+    const mixedLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane }, { ...firstDetailPane }, secondDetailPane],
+      floating: [
+        { instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 },
+        { instanceId: "ticker-detail:secondary", x: 8, y: 3, width: 30, height: 8 },
+      ],
+      detached: [],
+    };
+    const state = {
+      ...createInitialState({
+        ...config,
+        layout: cloneLayout(mixedLayout),
+        layouts: [{ name: "Default", layout: cloneLayout(mixedLayout) }],
+      }),
+      focusedPaneId: "portfolio-list:main",
+    };
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <TestDialogProvider>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 12 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "w", ctrl: true, alt: true });
+
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(actions).toContainEqual({ type: "PUSH_LAYOUT_HISTORY" });
+    expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId)).toEqual(["portfolio-list:main"]);
+    expect(updateLayout?.layout.floating).toEqual([]);
+    expect(updateLayout?.layout.dockRoot).toEqual({ kind: "pane", instanceId: "portfolio-list:main" });
   });
 
 });

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -186,6 +186,7 @@ export function Shell({
   });
 
   const {
+    closeAllFloatingPanes,
     closeFocusedPane,
     copyFocusedPaneScreenshot,
     copyPaneScreenshot,
@@ -213,6 +214,7 @@ export function Shell({
 
   useShellPaneManagementShortcuts({
     cancelActiveDrag,
+    closeAllFloatingPanes,
     closeFocusedPane,
     copyFocusedPaneScreenshot,
     focusedPaneId,

--- a/src/components/layout/shell/menu.ts
+++ b/src/components/layout/shell/menu.ts
@@ -101,14 +101,8 @@ export function menuForPane(
     {
       id: "window-resize-mode",
       label: "Resize Window...",
-      accelerator: "WIN resize",
+      accelerator: PANE_MANAGEMENT_ACCELERATORS.windowResizeMode,
       onSelect: () => pluginRegistry.openWindowMode(pane.instance.instanceId, "resize"),
-    },
-    {
-      id: "layout-actions",
-      label: "Layout Actions...",
-      accelerator: PANE_MANAGEMENT_ACCELERATORS.layoutActions,
-      onSelect: () => pluginRegistry.openCommandBar("LAY "),
     },
   );
 

--- a/src/components/layout/shell/pane/actions.ts
+++ b/src/components/layout/shell/pane/actions.ts
@@ -5,6 +5,7 @@ import {
   floatPane,
   gridlockAllPanes,
   isPaneInLayout,
+  removeFloatingPanes,
   removePane,
   type ResolvedPane,
 } from "../../../../plugins/pane-manager";
@@ -73,6 +74,12 @@ export function useShellPaneActions({
     return true;
   }, [focusedPaneId, persistLayout, visibleLayout]);
 
+  const closeAllFloatingPanes = useCallback(() => {
+    if (visibleLayout.floating.length === 0) return false;
+    persistLayout(removeFloatingPanes(visibleLayout));
+    return true;
+  }, [persistLayout, visibleLayout]);
+
   const copyFocusedPaneScreenshot = useCallback(() => {
     if (!focusedPaneId || !nativePaneChrome || !rendererHost.copyPngImage) return false;
     if (!paneMap.has(focusedPaneId)) return false;
@@ -115,6 +122,7 @@ export function useShellPaneActions({
   }, [persistLayout, visibleLayout]);
 
   return {
+    closeAllFloatingPanes,
     closeFocusedPane,
     copyFocusedPaneScreenshot,
     copyPaneScreenshot,

--- a/src/components/layout/shell/pane/management-shortcuts.ts
+++ b/src/components/layout/shell/pane/management-shortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useShortcut } from "../../../../react/input";
+import type { WindowEditMode } from "../../../../plugins/registry";
 import {
   createDoubleEscapeCloseState,
   recordDoubleEscapeClose,
@@ -12,6 +13,7 @@ import {
 
 interface ShellPaneManagementShortcutOptions {
   cancelActiveDrag(): void;
+  closeAllFloatingPanes(): boolean;
   closeFocusedPane(): boolean;
   copyFocusedPaneScreenshot(): boolean;
   focusedPaneId: string | null;
@@ -22,12 +24,13 @@ interface ShellPaneManagementShortcutOptions {
   openLayoutMenu(): void;
   overlayOpen: boolean;
   popOutFocusedPane(): boolean;
-  startWindowMode(): void;
+  startWindowMode(paneId?: string, mode?: WindowEditMode): void;
   toggleFocusedPaneFloating(): boolean;
 }
 
 export function useShellPaneManagementShortcuts({
   cancelActiveDrag,
+  closeAllFloatingPanes,
   closeFocusedPane,
   copyFocusedPaneScreenshot,
   focusedPaneId,
@@ -82,6 +85,9 @@ export function useShellPaneManagementShortcuts({
       case "close":
         handled = closeFocusedPane();
         break;
+      case "close-all-floating":
+        handled = closeAllFloatingPanes();
+        break;
       case "settings":
         handled = openFocusedPaneSettings();
         break;
@@ -102,7 +108,11 @@ export function useShellPaneManagementShortcuts({
         handled = gridlockVisiblePanes();
         break;
       case "window-mode":
-        startWindowMode();
+        startWindowMode(undefined, "move");
+        handled = true;
+        break;
+      case "window-resize-mode":
+        startWindowMode(undefined, "resize");
         handled = true;
         break;
     }

--- a/src/components/layout/shell/shortcuts.ts
+++ b/src/components/layout/shell/shortcuts.ts
@@ -6,9 +6,11 @@ export const PANE_MANAGEMENT_ACCELERATORS = {
   popOut: "CmdOrCtrl+Shift+O",
   copyScreenshot: "CmdOrCtrl+Shift+C",
   close: "CmdOrCtrl+W",
+  closeAllFloating: "CmdOrCtrl+Alt+W",
   layoutActions: "CmdOrCtrl+Shift+L",
   gridlockAll: "CmdOrCtrl+Shift+G",
   windowMode: "CmdOrCtrl+Shift+M",
+  windowResizeMode: "CmdOrCtrl+Shift+R",
 } as const;
 
 export type PaneManagementShortcut =
@@ -17,24 +19,30 @@ export type PaneManagementShortcut =
   | "pop-out"
   | "copy-screenshot"
   | "close"
+  | "close-all-floating"
   | "layout-actions"
   | "gridlock-all"
-  | "window-mode";
+  | "window-mode"
+  | "window-resize-mode";
 
 export function resolvePaneManagementShortcut(
   event: Pick<KeyEventLike, "name" | "key" | "ctrl" | "meta" | "super" | "shift" | "alt">,
 ): PaneManagementShortcut | null {
   if (!event.ctrl && !event.meta && !event.super) return null;
-  const name = (event.name ?? event.key ?? "").toLowerCase();
-  if (name === "w") return "close";
-  if (!event.shift && name === ",") return "settings";
-  if (!event.shift || event.alt) return null;
+  const rawName = event.name ?? event.key ?? "";
+  const name = rawName.toLowerCase();
+  const shifted = event.shift || rawName !== name;
+  if (!shifted && event.alt && name === "w") return "close-all-floating";
+  if (!shifted && name === "w") return "close";
+  if (!shifted && name === ",") return "settings";
+  if (!shifted || event.alt) return null;
   if (name === "c") return "copy-screenshot";
   if (name === "d") return "toggle-floating";
   if (name === "o") return "pop-out";
   if (name === "l") return "layout-actions";
   if (name === "g") return "gridlock-all";
   if (name === "m") return "window-mode";
+  if (name === "r") return "window-resize-mode";
   return null;
 }
 
@@ -42,6 +50,6 @@ export function inputCaptureAllowsPaneManagementShortcut(
   shortcut: PaneManagementShortcut,
   event: Pick<KeyEventLike, "meta" | "super" | "targetEditable">,
 ): boolean {
-  if (shortcut !== "close") return false;
+  if (shortcut !== "close" && shortcut !== "close-all-floating") return false;
   return event.meta || event.super || event.targetEditable !== true;
 }

--- a/src/components/layout/shell/window-mode/index.ts
+++ b/src/components/layout/shell/window-mode/index.ts
@@ -128,9 +128,13 @@ export function useShellWindowMode({
     if (!windowMode) return;
     const committedLayout = resolveWindowEditCommitLayout(windowMode, bounds, dockGeometryOptions);
     const hasPendingCommit = windowEditHasPendingCommit(windowMode, bounds, dockGeometryOptions);
-    if (hasPendingCommit) {
-      persistLayout(committedLayout);
+    if (!hasPendingCommit) {
+      focusPane(windowMode.paneId);
+      setWindowMode(null);
+      return;
     }
+
+    persistLayout(committedLayout);
     focusPane(windowMode.paneId);
     setWindowMode({
       paneId: windowMode.paneId,
@@ -138,7 +142,7 @@ export function useShellWindowMode({
       mode: "move",
       focus: normalizeWindowEditFocus({ kind: "move" }, committedLayout, windowMode.paneId, "move", bounds, dockGeometryOptions),
       dirty: false,
-      notice: hasPendingCommit ? "Committed" : "No changes",
+      notice: "Committed",
     });
   }, [bounds, dockGeometryOptions, focusPane, persistLayout, windowMode]);
 
@@ -166,6 +170,7 @@ export function useShellWindowMode({
 
   useShortcut((event) => {
     if (!windowMode) return;
+    if (event.ctrl || event.meta || event.super || event.alt) return;
     const name = (event.name ?? event.key ?? "").toLowerCase();
     let handled = true;
 

--- a/src/components/layout/window-edit/presentation.ts
+++ b/src/components/layout/window-edit/presentation.ts
@@ -73,14 +73,14 @@ export function windowEditStatusLine(
 export function windowEditHelpText(state: WindowEditState): string {
   if (state.mode === "move") {
     if (state.focus.kind === "dock-move") {
-      return "arrows/hjkl choose side  m retarget  Tab/w window  d float  r resize  Enter commit  Esc exit/cancel";
+      return "arrows/hjkl choose side  m retarget  Tab/w window  d float  r resize  Enter commit/exit  Esc exit/cancel";
     }
-    return "Tab/w window  d dock/float  r resize  arrows/hjkl target/move  Shift fast  Enter commit  Esc exit/cancel";
+    return "Tab/w window  d dock/float  r resize  arrows/hjkl target/move  Shift fast  Enter commit/exit  Esc exit/cancel";
   }
   if (state.focus.kind === "floating-resize") {
-    return "Tab corner  w window  m move  arrows/hjkl resize  Shift fast  Enter commit  Esc exit/cancel";
+    return "Tab corner  w window  m move  arrows/hjkl resize  Shift fast  Enter commit/exit  Esc exit/cancel";
   }
-  return "arrows/hjkl move divider  Tab divider  w window  m move  Shift fast  Enter commit  Esc exit/cancel";
+  return "arrows/hjkl move divider  Tab divider  w window  m move  Shift fast  Enter commit/exit  Esc exit/cancel";
 }
 
 export function resolveWindowEditDockMovePreview(

--- a/src/components/onboarding/onboarding-steps.tsx
+++ b/src/components/onboarding/onboarding-steps.tsx
@@ -101,7 +101,8 @@ export function ShortcutsStep({ pluginRegistry }: { pluginRegistry: PluginRegist
   const shortcutDisplayMode = getShortcutDisplayMode(uiHost.kind);
   const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform, shortcutDisplayMode);
   const keyboardShortcuts = [
-    { key: "Ctrl+P / `", desc: "Open the command bar" },
+    { key: "Ctrl+P", desc: "Open command mode" },
+    { key: "`", desc: "Open ticker search" },
     { key: "Tab", desc: "Switch between panels" },
     { key: platformShortcut("W"), desc: "Close the focused pane" },
     { key: platformShortcut(["Shift", "D"]), desc: "Dock or float the focused pane" },
@@ -155,7 +156,7 @@ export function ShortcutsStep({ pluginRegistry }: { pluginRegistry: PluginRegist
       </Box>
       <Box height={1} />
       <Box height={1}>
-        <Text fg={colors.textDim}>{"Type these in the command bar ("}<Span fg={colors.text}><Strong>{"Ctrl+P"}</Strong></Span>{" or "}<Span fg={colors.text}><Strong>{"`"}</Strong></Span>{"):"}</Text>
+        <Text fg={colors.textDim}>{"Type these in the command bar ("}<Span fg={colors.text}><Strong>{"Ctrl+P"}</Strong></Span>{"):"}</Text>
       </Box>
       <Box height={1} />
 

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -30,6 +30,7 @@ export interface TabsProps {
   onAdd?: () => void;
   focused?: boolean;
   keyboardNavigation?: boolean;
+  scrollable?: boolean;
 }
 
 const WHEEL_DELTA_PER_CELL = 8;
@@ -45,6 +46,7 @@ export function Tabs({
   onAdd,
   focused = false,
   keyboardNavigation = true,
+  scrollable = true,
 }: TabsProps) {
   const ui = useUiHost();
   const NativeTabs = ui.Tabs;
@@ -131,6 +133,7 @@ export function Tabs({
       closeMode={closeMode}
       addLabel={addLabel}
       onAdd={onAdd}
+      scrollable={scrollable}
       palette={palette}
     />
   );
@@ -154,6 +157,7 @@ function OpenTuiTabs({
   closeMode = "always",
   addLabel = "+",
   onAdd,
+  scrollable = true,
   palette,
 }: TabsProps & {
   palette: {
@@ -227,6 +231,96 @@ function OpenTuiTabs({
     scrollBox.scrollTo({ x: nextLeft, y: scrollBox.scrollTop });
   };
 
+  const tabRow = (
+    <Box flexDirection="row" width={totalWidth} height={1}>
+      {tabs.map((tab, index) => {
+        const active = tab.value === activeValue;
+        const hovered = hoveredValue === tab.value && !tab.disabled;
+        const tabWidth = tabWidths[index] ?? tab.label.length + 2;
+        const showClose = !!tab.onClose && (closeMode === "always" || active);
+        const attributes = (active ? TextAttributes.BOLD : 0)
+          | (variant === "underline" && !compact && (active || hovered) ? TextAttributes.UNDERLINE : 0);
+        const startHover = tab.disabled
+          ? undefined
+          : () => {
+              setHoveredValue((current) => (current === tab.value ? current : tab.value));
+            };
+        const endHover = tab.disabled
+          ? undefined
+          : () => {
+              setHoveredValue((current) => (current === tab.value ? null : current));
+            };
+        const selectTab = tab.disabled
+          ? undefined
+          : (event: TabPointerEvent) => {
+              if (event.button === 2 && tab.onContextMenu) {
+                event.preventDefault?.();
+                event.stopPropagation?.();
+                tab.onContextMenu(tab.value, event);
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation?.();
+              onSelect(tab.value);
+            };
+
+        return (
+          <Box
+            key={tab.value}
+            width={tabWidth}
+            height={1}
+            flexDirection="row"
+            backgroundColor={active && variant === "pill" ? palette.activeBg : hovered ? palette.hoverBg : undefined}
+            onMouseOver={startHover}
+            onMouseMove={startHover}
+            onMouseOut={endHover}
+            onMouseDown={selectTab}
+            onDoubleClick={tab.disabled || !tab.onDoubleClick ? undefined : () => tab.onDoubleClick?.(tab.value)}
+          >
+            <Text
+              fg={tab.disabled ? palette.disabledFg : active && variant === "pill" ? palette.activePillFg : active ? palette.activeFg : hovered ? palette.hoverFg : palette.inactiveFg}
+              attributes={attributes}
+              onMouseDown={selectTab}
+            >
+              {` ${tab.label} `}
+            </Text>
+            {showClose && (
+              <Text
+                fg={active && variant === "pill" ? palette.activePillFg : palette.closeFg}
+                onMouseDown={(event: any) => {
+                  event.preventDefault?.();
+                  event.stopPropagation?.();
+                  tab.onClose?.(tab.value);
+                }}
+              >
+                {"x "}
+              </Text>
+            )}
+          </Box>
+        );
+      })}
+      {onAdd && (
+        <Box
+          width={addWidth}
+          height={1}
+          backgroundColor={hoveredValue === "__add__" ? palette.hoverBg : undefined}
+          onMouseMove={() => setHoveredValue((current) => (current === "__add__" ? current : "__add__"))}
+          onMouseOut={() => setHoveredValue((current) => (current === "__add__" ? null : current))}
+          onMouseDown={(event: TabPointerEvent) => {
+            event.preventDefault();
+            onAdd();
+          }}
+        >
+          <Text fg={hoveredValue === "__add__" ? palette.hoverFg : palette.addFg}>
+            {` ${addLabel} `}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+
+  if (!scrollable) return tabRow;
+
   return (
     <ScrollBox
       ref={scrollRef}
@@ -237,86 +331,7 @@ function OpenTuiTabs({
       horizontalScrollbarOptions={{ visible: false }}
       onMouseScroll={handleMouseScroll}
     >
-      <Box flexDirection="row" width={totalWidth} height={1}>
-        {tabs.map((tab, index) => {
-          const active = tab.value === activeValue;
-          const hovered = hoveredValue === tab.value && !tab.disabled;
-          const tabWidth = tabWidths[index] ?? tab.label.length + 2;
-          const showClose = !!tab.onClose && (closeMode === "always" || active);
-          const attributes = (active ? TextAttributes.BOLD : 0)
-            | (variant === "underline" && !compact && (active || hovered) ? TextAttributes.UNDERLINE : 0);
-          const startHover = tab.disabled
-            ? undefined
-            : () => {
-                setHoveredValue((current) => (current === tab.value ? current : tab.value));
-              };
-          const endHover = tab.disabled
-            ? undefined
-            : () => {
-                setHoveredValue((current) => (current === tab.value ? null : current));
-              };
-
-          return (
-            <Box
-              key={tab.value}
-              width={tabWidth}
-              height={1}
-              flexDirection="row"
-              backgroundColor={active && variant === "pill" ? palette.activeBg : hovered ? palette.hoverBg : undefined}
-              onMouseOver={startHover}
-              onMouseMove={startHover}
-              onMouseOut={endHover}
-              onMouseDown={tab.disabled ? undefined : (event: TabPointerEvent) => {
-                if (event.button === 2 && tab.onContextMenu) {
-                  event.preventDefault?.();
-                  event.stopPropagation?.();
-                  tab.onContextMenu(tab.value, event);
-                  return;
-                }
-                event.preventDefault();
-                onSelect(tab.value);
-              }}
-              onDoubleClick={tab.disabled || !tab.onDoubleClick ? undefined : () => tab.onDoubleClick?.(tab.value)}
-            >
-              <Text
-                fg={tab.disabled ? palette.disabledFg : active && variant === "pill" ? palette.activePillFg : active ? palette.activeFg : hovered ? palette.hoverFg : palette.inactiveFg}
-                attributes={attributes}
-              >
-                {` ${tab.label} `}
-              </Text>
-              {showClose && (
-                <Text
-                  fg={active && variant === "pill" ? palette.activePillFg : palette.closeFg}
-                  onMouseDown={(event: any) => {
-                    event.preventDefault?.();
-                    event.stopPropagation?.();
-                    tab.onClose?.(tab.value);
-                  }}
-                >
-                  {"x "}
-                </Text>
-              )}
-            </Box>
-          );
-        })}
-        {onAdd && (
-          <Box
-            width={addWidth}
-            height={1}
-            backgroundColor={hoveredValue === "__add__" ? palette.hoverBg : undefined}
-            onMouseMove={() => setHoveredValue((current) => (current === "__add__" ? current : "__add__"))}
-            onMouseOut={() => setHoveredValue((current) => (current === "__add__" ? null : current))}
-            onMouseDown={(event: TabPointerEvent) => {
-              event.preventDefault();
-              onAdd();
-            }}
-          >
-            <Text fg={hoveredValue === "__add__" ? palette.hoverFg : palette.addFg}>
-              {` ${addLabel} `}
-            </Text>
-          </Box>
-        )}
-      </Box>
+      {tabRow}
     </ScrollBox>
   );
 }

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -360,6 +360,60 @@ describe("shared UI kit", () => {
     expect(lastSelected).toBe("chart");
   });
 
+  test("selects tabs by clicking their text labels", async () => {
+    let lastSelected = "overview";
+    const selectedValues: string[] = [];
+
+    function PointerTabsHarness() {
+      const [activeValue, setActiveValue] = useState("overview");
+      return (
+        <Tabs
+          tabs={[
+            { label: "Overview", value: "overview" },
+            { label: "News", value: "news" },
+            { label: "Chart", value: "chart" },
+          ]}
+          activeValue={activeValue}
+          onSelect={(value) => {
+            lastSelected = value;
+            selectedValues.push(value);
+            setActiveValue(value);
+          }}
+          scrollable={false}
+        />
+      );
+    }
+
+    testSetup = await testRender(<PointerTabsHarness />, { width: 40, height: 4 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    let frame = testSetup.captureCharFrame();
+    const newsCol = frame.split("\n")[0]!.indexOf("News");
+    expect(newsCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(newsCol + 1, 0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(lastSelected).toBe("news");
+
+    frame = testSetup.captureCharFrame();
+    const chartCol = frame.split("\n")[0]!.indexOf("Chart");
+    expect(chartCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(chartCol + 1, 0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(selectedValues).toEqual(["news", "chart"]);
+    expect(lastSelected).toBe("chart");
+  });
+
   test("renders tab actions for editable tab sets", async () => {
     testSetup = await testRender(
       <Tabs

--- a/src/plugins/builtin/help/components.tsx
+++ b/src/plugins/builtin/help/components.tsx
@@ -29,7 +29,7 @@ export function ShortcutRow({
   return (
     <Box flexDirection="row" gap={1}>
       <Box flexDirection="row" gap={1} flexShrink={0}>
-        {badges.map((badge) => <ShortcutBadge key={badge} label={badge} />)}
+        {badges.map((badge, index) => <ShortcutBadge key={`${badge}:${index}`} label={badge} />)}
       </Box>
       <Box flexGrow={1}>
         <Text fg={colors.text} wrapText>{description}</Text>

--- a/src/plugins/builtin/help/index.test.tsx
+++ b/src/plugins/builtin/help/index.test.tsx
@@ -35,7 +35,31 @@ async function renderHelpPane(
   );
 
   await testSetup.renderOnce();
+  await testSetup.renderOnce();
   return testSetup;
+}
+
+async function moveHelpTabRight(count = 1) {
+  await act(async () => {
+    for (let index = 0; index < count; index += 1) {
+      testSetup!.mockInput.pressArrow("right");
+    }
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+async function resetRenderedHelpPane(
+  runtime = createTestPluginRuntime(),
+  size = { width: 88, height: 36 },
+) {
+  if (testSetup) {
+    act(() => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+  return renderHelpPane(runtime, size);
 }
 
 function withoutScrollbar(line: string) {
@@ -44,22 +68,35 @@ function withoutScrollbar(line: string) {
 }
 
 describe("HelpPane", () => {
-  test("puts section spacing before headings instead of after them", async () => {
+  test("starts on basics and puts section spacing before headings instead of after them", async () => {
     await renderHelpPane(createTestPluginRuntime(), { width: 88, height: 80 });
 
     const lines = testSetup!.captureCharFrame().split("\n").map(withoutScrollbar);
     const commandBarRow = lines.findIndex((line) => line.includes("Command Bar"));
-    const templatesRow = lines.findIndex((line) => line.includes("Window Templates"));
+    const layoutRow = lines.findIndex((line) => line.includes("Layout Basics"));
 
+    expect(lines[0]).toContain("Basics");
+    expect(testSetup!.captureCharFrame()).toContain("Basics");
+    expect(testSetup!.captureCharFrame()).toContain("Functions");
+    expect(testSetup!.captureCharFrame()).toContain("Issues");
+    expect(testSetup!.captureCharFrame()).not.toContain("Issues/Debug");
+    expect(testSetup!.captureCharFrame()).not.toContain("Window Templates");
+    expect(testSetup!.captureCharFrame()).not.toContain("Search for a ticker or open the best matching security.");
     expect(commandBarRow).toBeGreaterThan(0);
-    expect(templatesRow).toBeGreaterThan(commandBarRow);
+    expect(layoutRow).toBeGreaterThan(commandBarRow);
     expect(lines[commandBarRow - 1]?.trim()).toBe("");
-    expect(lines[commandBarRow + 1]).toContain("Open or toggle the command bar");
-    expect(lines[templatesRow - 1]?.trim()).toBe("");
-    expect(lines[templatesRow + 1]?.trim()).not.toBe("");
+    expect(lines[commandBarRow + 1]).toContain("Open command mode");
+    expect(testSetup!.captureCharFrame()).toContain("Open ticker search directly.");
+    expect(testSetup!.captureCharFrame()).toContain("DES");
+    expect(testSetup!.captureCharFrame()).toContain("Clear command text.");
+    expect(testSetup!.captureCharFrame()).toContain("Delete the previous word");
+    expect(testSetup!.captureCharFrame()).toContain("Submit multiline command forms.");
+    expect(testSetup!.captureCharFrame()).toContain("close all floating panes");
+    expect(lines[layoutRow - 1]?.trim()).toBe("");
+    expect(lines[layoutRow + 1]?.trim()).not.toBe("");
   });
 
-  test("lists core, plugin command, template, and keyboard shortcuts", async () => {
+  test("separates functions from keyboard shortcuts", async () => {
     setSharedRegistryForTests({
       commands: new Map([[
         "set-alert",
@@ -106,24 +143,52 @@ describe("HelpPane", () => {
     } as any);
 
     await renderHelpPane(createTestPluginRuntime(), { width: 88, height: 80 });
+    await moveHelpTabRight();
 
-    const frame = testSetup!.captureCharFrame();
-    expect(frame).toMatch(/AW\s+<ticker>/);
-    expect(frame).toMatch(/SA\s+<symbol condition price>/);
-    expect(frame).toMatch(/QQ\s+<tickers>/);
-    expect(frame).toContain("Add Alert (Alerts)");
-    expect(frame).toContain("Shift+X");
-    expect(frame).toContain("Sync data (Gloom Cloud)");
-    expect(frame).toContain("Ctrl+W");
-    expect(frame).toContain("Ctrl+,");
-    expect(frame).not.toContain("Ctrl+Shift+O");
-    expect(frame).not.toContain("Pop the focused pane");
-    expect(frame).not.toContain("Cmd+W");
-    expect(frame).not.toContain("Cmd+,");
-    expect(frame).not.toContain("Cmd+K");
-    expect(frame).not.toContain("Cmd/Ctrl");
-    expect(frame).not.toContain("CmdOrCtrl");
-    expect(frame).not.toContain("Open ticker actions for the focused ticker.");
+    const functionsFrame = testSetup!.captureCharFrame();
+    expect(functionsFrame).toContain("Manage Plugins");
+    expect(functionsFrame).toMatch(/AW\s+<ticker>/);
+    expect(functionsFrame).toMatch(/SA\s+<symbol condition price>/);
+    expect(functionsFrame).toMatch(/QQ\s+<tickers>/);
+    expect(functionsFrame).toContain("Alerts");
+    expect(functionsFrame).toContain("Add Alert");
+    expect(functionsFrame).toContain("Shift+X");
+    expect(functionsFrame).toContain("Gloom Cloud");
+    expect(functionsFrame).toContain("Sync data");
+    expect(functionsFrame).toContain("Ticker Research");
+    expect(functionsFrame).toContain("Quote Monitor");
+    expect(functionsFrame).not.toContain("Add Alert (Alerts)");
+    expect(functionsFrame).not.toContain("Sync data (Gloom Cloud)");
+    expect(functionsFrame).not.toContain("Quote Monitor (Ticker Research)");
+    expect(functionsFrame).not.toContain("Ctrl+W");
+
+    await resetRenderedHelpPane(createTestPluginRuntime(), { width: 88, height: 80 });
+    await moveHelpTabRight(2);
+
+    const shortcutsFrame = testSetup!.captureCharFrame();
+    expect(shortcutsFrame).toContain("Ctrl+W");
+    expect(shortcutsFrame).toContain("Ctrl+Alt+W");
+    expect(shortcutsFrame).toContain("Ctrl+Shift+M");
+    expect(shortcutsFrame).toContain("Ctrl+Shift+R");
+    expect(shortcutsFrame).toContain("Ctrl+,");
+    expect(shortcutsFrame).toContain("Navigation");
+    expect(shortcutsFrame).toContain("Up/Down");
+    expect(shortcutsFrame).toContain("j/k");
+    expect(shortcutsFrame).toContain("Left/Right");
+    expect(shortcutsFrame).toContain("h/l");
+    expect(shortcutsFrame).toContain("PageUp/PageDown");
+    expect(shortcutsFrame).toContain("Window Mode");
+    expect(shortcutsFrame).toContain("h/j/k/l");
+    expect(shortcutsFrame).toContain("Close all floating panes.");
+    expect(shortcutsFrame).not.toContain("AW");
+    expect(shortcutsFrame).not.toContain("Ctrl+Shift+O");
+    expect(shortcutsFrame).not.toContain("Pop the focused pane");
+    expect(shortcutsFrame).not.toContain("Cmd+W");
+    expect(shortcutsFrame).not.toContain("Cmd+,");
+    expect(shortcutsFrame).not.toContain("Cmd+K");
+    expect(shortcutsFrame).not.toContain("Cmd/Ctrl");
+    expect(shortcutsFrame).not.toContain("CmdOrCtrl");
+    expect(shortcutsFrame).not.toContain("Open ticker actions for the focused ticker.");
   });
 
   test("keeps shortcuts and descriptions on the same row when narrow", async () => {
@@ -131,14 +196,18 @@ describe("HelpPane", () => {
 
     const lines = testSetup!.captureCharFrame().split("\n").map(withoutScrollbar);
     const closeCommandRow = lines.findIndex((line) => line.includes("Close the command bar."));
-    const securityDetailsRow = lines.findIndex((line) => line.includes("Open security details"));
 
     expect(closeCommandRow).toBeGreaterThanOrEqual(0);
     expect(lines[closeCommandRow]).toContain("Esc");
     expect(lines[closeCommandRow]).toContain("`");
+
+    await moveHelpTabRight();
+
+    const functionLines = testSetup!.captureCharFrame().split("\n").map(withoutScrollbar);
+    const securityDetailsRow = functionLines.findIndex((line) => line.includes("Open security details"));
     expect(securityDetailsRow).toBeGreaterThanOrEqual(0);
-    expect(lines[securityDetailsRow]).toContain("DES");
-    expect(lines[securityDetailsRow]).toContain("<ticker>");
+    expect(functionLines[securityDetailsRow]).toContain("DES");
+    expect(functionLines[securityDetailsRow]).toContain("<ticker>");
   });
 
   test("opens the debug log from the mouse action", async () => {
@@ -149,8 +218,14 @@ describe("HelpPane", () => {
     });
 
     await renderHelpPane(runtime);
+    await moveHelpTabRight(3);
 
-    const lines = testSetup!.captureCharFrame().split("\n");
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("GitHub Issues");
+    expect(frame).not.toContain("Issues/Debug");
+    expect(frame).not.toContain("plugin,\n");
+
+    const lines = frame.split("\n");
     const row = lines.findIndex((line) => line.includes("Open Debug Log"));
     const col = lines[row]?.indexOf("Open Debug Log") ?? -1;
 

--- a/src/plugins/builtin/help/index.tsx
+++ b/src/plugins/builtin/help/index.tsx
@@ -1,6 +1,8 @@
 import { Box, ScrollBox, Text, useUiHost } from "../../../ui";
 import { TextAttributes } from "../../../ui";
 import { useState } from "react";
+import { Tabs } from "../../../components";
+import { ExternalLinkText } from "../../../components/ui";
 import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import { getSharedRegistry } from "../../registry";
@@ -19,9 +21,20 @@ import {
   resolveWindowTemplates,
 } from "./shortcut-model";
 
-export function HelpPane({ width, height }: PaneProps) {
+const HELP_TABS = [
+  { label: "Basics", value: "basics" },
+  { label: "Functions", value: "functions" },
+  { label: "Shortcuts", value: "shortcuts" },
+  { label: "Issues", value: "issues" },
+] as const;
+
+type HelpTabId = typeof HELP_TABS[number]["value"];
+const GLOOMBERB_ISSUES_URL = "https://github.com/vincelwt/gloomberb/issues";
+
+export function HelpPane({ focused, width, height }: PaneProps) {
   const registry = getSharedRegistry();
   const { openCommandBar, showPane } = usePluginAppActions();
+  const [activeTabId, setActiveTabId] = useState<HelpTabId>("basics");
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
   const commandShortcuts = resolveCommandShortcuts(registry);
   const pluginShortcuts = resolvePluginShortcuts(registry);
@@ -32,14 +45,15 @@ export function HelpPane({ width, height }: PaneProps) {
   const shortcutDisplayMode = getShortcutDisplayMode(uiHost.kind);
   const platformShortcut = (keys: string | readonly string[]) => formatPrimaryShortcut(keys, shortcutPlatform, shortcutDisplayMode);
   const commandBarBadges = shortcutDisplayMode === "terminal"
-    ? ["Ctrl+P", "`"]
-    : ["Ctrl+P", platformShortcut("K"), "`"];
+    ? ["Ctrl+P"]
+    : ["Ctrl+P", platformShortcut("K")];
   const copyBadges = shortcutDisplayMode === "terminal"
     ? ["Ctrl+Shift+C"]
     : [platformShortcut("C")];
   const pasteBadges = shortcutDisplayMode === "terminal"
     ? ["Ctrl+Shift+V"]
     : [platformShortcut("V")];
+  const contentHeight = Math.max(0, height - 1);
 
   const openDebugLog = () => {
     showPane("debug");
@@ -53,94 +67,23 @@ export function HelpPane({ width, height }: PaneProps) {
     openCommandBar("PL ");
   };
 
-  return (
-    <Box flexDirection="column" width={width} height={height}>
-      <ScrollBox flexGrow={1} scrollY>
-        <Box flexDirection="column" padding={1}>
-          <Box flexDirection="column" gap={1}>
-            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>How To Use Gloomberb</Text>
-            <Box flexDirection="column">
-              <Text fg={colors.textDim}>Gloomberb is command-bar first.</Text>
-              <Text fg={colors.textDim}>Use the keyboard for speed, and the mouse for windows.</Text>
+  const renderContent = () => {
+    switch (activeTabId) {
+      case "functions":
+        return (
+          <>
+            <Box flexDirection="row" gap={1}>
+              <ActionButton
+                id="plugins"
+                label="Manage Plugins"
+                hovered={hoveredAction === "plugins"}
+                onHover={setHoveredAction}
+                onPress={openPluginManager}
+              />
             </Box>
-          </Box>
 
-          <Box flexDirection="row" gap={1}>
-            <ActionButton
-              id="debug"
-              label="Open Debug Log"
-              hovered={hoveredAction === "debug"}
-              onHover={setHoveredAction}
-              onPress={openDebugLog}
-            />
-            <ActionButton
-              id="layout"
-              label="Layout Actions"
-              hovered={hoveredAction === "layout"}
-              onHover={setHoveredAction}
-              onPress={openLayoutActions}
-            />
-            <ActionButton
-              id="plugins"
-              label="Manage Plugins"
-              hovered={hoveredAction === "plugins"}
-              onHover={setHoveredAction}
-              onPress={openPluginManager}
-            />
-          </Box>
-
-          <HelpSection title="Command Bar">
-            <ShortcutRow
-              badges={commandBarBadges}
-              description="Open or toggle the command bar from anywhere."
-            />
-            <ShortcutRow
-              badges={["<ticker>"]}
-              description="Search for a ticker or open the best matching security."
-            />
-            <ShortcutRow
-              badges={["Up/Down", "Ctrl+P/N"]}
-              description="Move through command bar results."
-            />
-            <ShortcutRow
-              badges={["Enter", "Shift+Enter"]}
-              description="Run the selected result or its secondary action."
-            />
-            <ShortcutRow
-              badges={["Tab"]}
-              description="Accept an inferred shortcut argument from the focused ticker."
-            />
-            <ShortcutRow
-              badges={["Esc", "`"]}
-              description="Close the command bar."
-            />
-          </HelpSection>
-
-          <HelpSection title="Command Prefixes">
-            {groupShortcutEntries(commandShortcuts).map((group) => (
-              <ShortcutGroup
-                key={group.title}
-                title={group.title}
-                entries={group.entries}
-              />
-            ))}
-          </HelpSection>
-
-          <HelpSection title="Window Templates">
-            {windowTemplates.length > 0 ? groupShortcutEntries(windowTemplates).map((group) => (
-              <ShortcutGroup
-                key={group.title}
-                title={group.title}
-                entries={group.entries}
-              />
-            )) : (
-              <Text fg={colors.textDim}>No shortcut window templates are currently registered.</Text>
-            )}
-          </HelpSection>
-
-          {pluginShortcuts.length > 0 && (
-            <HelpSection title="Plugin Shortcuts">
-              {groupShortcutEntries(pluginShortcuts).map((group) => (
+            <HelpSection title="Command Prefixes">
+              {groupShortcutEntries(commandShortcuts).map((group) => (
                 <ShortcutGroup
                   key={group.title}
                   title={group.title}
@@ -148,94 +91,307 @@ export function HelpPane({ width, height }: PaneProps) {
                 />
               ))}
             </HelpSection>
-          )}
 
-          <HelpSection title="Global Keys">
-            <ShortcutRow
-              badges={["Tab", "Shift+Tab"]}
-              description="Move focus between panes and floating windows."
-            />
-            <ShortcutRow
-              badges={["Ctrl+1-9"]}
-              description="Switch saved layouts by number."
-            />
-            <ShortcutRow
-              badges={["r", "Shift+R"]}
-              description="Refresh the focused ticker or refresh everything."
-            />
-            <ShortcutRow
-              badges={["q"]}
-              description="Quit the terminal app."
-            />
-            <ShortcutRow
-              badges={copyBadges}
-              description="Copy the active terminal selection."
-            />
-            <ShortcutRow
-              badges={pasteBadges}
-              description="Paste clipboard text into the active input."
-            />
-            <ShortcutRow
-              badges={["u"]}
-              description="Install an available app update when one is shown."
-            />
-          </HelpSection>
+            <HelpSection title="Window Templates">
+              {windowTemplates.length > 0 ? groupShortcutEntries(windowTemplates).map((group) => (
+                <ShortcutGroup
+                  key={group.title}
+                  title={group.title}
+                  entries={group.entries}
+                />
+              )) : (
+                <Text fg={colors.textDim}>No shortcut window templates are currently registered.</Text>
+              )}
+            </HelpSection>
 
-          <HelpSection title="Pane Management">
-            <ShortcutRow
-              badges={[platformShortcut("W")]}
-              description="Close the focused pane, docked or floating."
-            />
-            <ShortcutRow
-              badges={[platformShortcut(",")]}
-              description="Edit settings for the focused pane."
-            />
-            <ShortcutRow
-              badges={[platformShortcut(["Shift", "D"])]}
-              description="Dock or float the focused pane."
-            />
-            {isDesktopWeb && (
-              <ShortcutRow
-                badges={[platformShortcut(["Shift", "O"])]}
-                description="Pop the focused pane out to a desktop window."
-              />
+            {pluginShortcuts.length > 0 && (
+              <HelpSection title="Plugin Shortcuts">
+                {groupShortcutEntries(pluginShortcuts).map((group) => (
+                  <ShortcutGroup
+                    key={group.title}
+                    title={group.title}
+                    entries={group.entries}
+                  />
+                ))}
+              </HelpSection>
             )}
-            {isDesktopWeb && (
+          </>
+        );
+
+      case "shortcuts":
+        return (
+          <>
+            <HelpSection title="Navigation">
               <ShortcutRow
-                badges={[platformShortcut(["Shift", "C"])]}
-                description="Copy a screenshot of the focused pane."
+                badges={["Up/Down", "j/k"]}
+                description="Move through focused table and list rows."
               />
-            )}
-            <ShortcutRow
-              badges={[platformShortcut(["Shift", "L"])]}
-              description="Open layout actions."
-            />
-            <ShortcutRow
-              badges={[platformShortcut(["Shift", "G"])]}
-              description="Gridlock all windows."
-            />
-            <ShortcutRow
-              badges={["Esc"]}
-              description="Cancel an active pane drag."
-            />
-          </HelpSection>
+              <ShortcutRow
+                badges={["Enter"]}
+                description="Open or activate the selected row."
+              />
+              <ShortcutRow
+                badges={["Left/Right", "h/l"]}
+                description="Switch tabs when a tab bar is focused."
+              />
+              <ShortcutRow
+                badges={["Esc", "Backspace"]}
+                description="Go back from detail views that support back navigation."
+              />
+            </HelpSection>
 
-          <HelpSection title="Layout System">
-            <Text fg={colors.text}>Docked panes stay in the saved layout.</Text>
-            <Box flexDirection="column">
-              <Text fg={colors.text}>Floating panes can be dragged by the title bar</Text>
-              <Text fg={colors.text}>and resized from the lower-right corner.</Text>
-            </Box>
-            <Text fg={colors.text}>Use Layout Actions for split, move, duplicate, undo, redo, and layout presets.</Text>
-          </HelpSection>
+            <HelpSection title="Scrolling">
+              <ShortcutRow
+                badges={["PageUp/PageDown"]}
+                description="Scroll focused pane content by page."
+              />
+              <ShortcutRow
+                badges={["Home/End"]}
+                description="Scroll focused pane content to the start or end."
+              />
+            </HelpSection>
 
-          <HelpSection title="If There Is A Bug">
-            <Text fg={colors.text}>Open Debug Log, then run Export Debug Log from the command bar.</Text>
-            <Box flexDirection="column">
-              <Text fg={colors.text}>The file lands in ~/Downloads. Include steps, ticker or layout, plugin,</Text>
-              <Text fg={colors.text}>and a screenshot if it is visual.</Text>
+            <HelpSection title="Global Keys">
+              <ShortcutRow
+                badges={["Tab", "Shift+Tab"]}
+                description="Move focus between panes and floating windows."
+              />
+              <ShortcutRow
+                badges={["Ctrl+1-9"]}
+                description="Switch saved layouts by number."
+              />
+              <ShortcutRow
+                badges={["r", "Shift+R"]}
+                description="Refresh the focused ticker or refresh everything."
+              />
+              <ShortcutRow
+                badges={["q"]}
+                description="Quit the terminal app."
+              />
+              <ShortcutRow
+                badges={copyBadges}
+                description="Copy the active terminal selection."
+              />
+              <ShortcutRow
+                badges={pasteBadges}
+                description="Paste clipboard text into the active input."
+              />
+              <ShortcutRow
+                badges={["u"]}
+                description="Install an available app update when one is shown."
+              />
+            </HelpSection>
+
+            <HelpSection title="Pane Management">
+              <ShortcutRow
+                badges={[platformShortcut("W")]}
+                description="Close the focused pane, docked or floating."
+              />
+              <ShortcutRow
+                badges={[platformShortcut(["Alt", "W"])]}
+                description="Close all floating panes."
+              />
+              <ShortcutRow
+                badges={[platformShortcut(",")]}
+                description="Edit settings for the focused pane."
+              />
+              <ShortcutRow
+                badges={[platformShortcut(["Shift", "D"])]}
+                description="Dock or float the focused pane."
+              />
+              {isDesktopWeb && (
+                <ShortcutRow
+                  badges={[platformShortcut(["Shift", "O"])]}
+                  description="Pop the focused pane out to a desktop window."
+                />
+              )}
+              {isDesktopWeb && (
+                <ShortcutRow
+                  badges={[platformShortcut(["Shift", "C"])]}
+                  description="Copy a screenshot of the focused pane."
+                />
+              )}
+              <ShortcutRow
+                badges={[platformShortcut(["Shift", "L"])]}
+                description="Open layout actions."
+              />
+              <ShortcutRow
+                badges={[platformShortcut(["Shift", "G"])]}
+                description="Gridlock all windows."
+              />
+              <ShortcutRow
+                badges={[platformShortcut(["Shift", "M"])]}
+                description="Enter window move mode."
+              />
+              <ShortcutRow
+                badges={[platformShortcut(["Shift", "R"])]}
+                description="Enter window resize mode."
+              />
+              <ShortcutRow
+                badges={["Esc"]}
+                description="Cancel an active pane drag."
+              />
+              <ShortcutRow
+                badges={["Esc", "Esc"]}
+                description="Close the focused pane when nothing is being dragged."
+              />
+            </HelpSection>
+
+            <HelpSection title="Window Mode">
+              <ShortcutRow
+                badges={["m", "r"]}
+                description="Switch between move and resize."
+              />
+              <ShortcutRow
+                badges={["d"]}
+                description="Dock or float the selected window."
+              />
+              <ShortcutRow
+                badges={["Arrows", "h/j/k/l"]}
+                description="Move, resize, or choose a dock target."
+              />
+              <ShortcutRow
+                badges={["Shift"]}
+                description="Use larger move and resize steps with direction keys."
+              />
+              <ShortcutRow
+                badges={["Tab", "w"]}
+                description="Cycle windows or resize handles."
+              />
+              <ShortcutRow
+                badges={["Enter", "Esc"]}
+                description="Commit pending changes or exit window mode."
+              />
+            </HelpSection>
+          </>
+        );
+
+      case "issues":
+        return (
+          <>
+            <Box flexDirection="row" gap={1}>
+              <ActionButton
+                id="debug"
+                label="Open Debug Log"
+                hovered={hoveredAction === "debug"}
+                onHover={setHoveredAction}
+                onPress={openDebugLog}
+              />
+              <ExternalLinkText
+                url={GLOOMBERB_ISSUES_URL}
+                label="GitHub Issues"
+              />
             </Box>
-          </HelpSection>
+
+            <HelpSection title="If There Is A Bug">
+              <Text fg={colors.text} wrapText>Open Debug Log, then run Export Debug Log from the command bar.</Text>
+              <Text fg={colors.text} wrapText>The file lands in ~/Downloads. Include steps, ticker or layout, plugin, and a screenshot if it is visual.</Text>
+            </HelpSection>
+          </>
+        );
+
+      case "basics":
+      default:
+        return (
+          <>
+            <Box flexDirection="column" gap={1}>
+              <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>How To Use Gloomberb</Text>
+              <Box flexDirection="column">
+                <Text fg={colors.textDim}>Gloomberb is command-bar first.</Text>
+                <Text fg={colors.textDim}>Use the keyboard for speed, and the mouse for windows.</Text>
+              </Box>
+            </Box>
+
+            <Box flexDirection="row" gap={1}>
+              <ActionButton
+                id="layout"
+                label="Layout Actions"
+                hovered={hoveredAction === "layout"}
+                onHover={setHoveredAction}
+                onPress={openLayoutActions}
+              />
+            </Box>
+
+            <HelpSection title="Command Bar">
+              <ShortcutRow
+                badges={commandBarBadges}
+                description="Open command mode for actions, pane commands, and typed prefixes."
+              />
+              <ShortcutRow
+                badges={["`"]}
+                description="Open ticker search directly."
+              />
+              <ShortcutRow
+                badges={["DES", "<ticker>"]}
+                description="Open security details for a specific ticker."
+              />
+              <ShortcutRow
+                badges={["Up/Down", "Ctrl+P/N"]}
+                description="Move through command bar results."
+              />
+              <ShortcutRow
+                badges={["Enter", "Shift+Enter"]}
+                description="Run the selected result or its secondary action."
+              />
+              <ShortcutRow
+                badges={["Tab"]}
+                description="Accept a suggested command argument when one is available."
+              />
+              <ShortcutRow
+                badges={["Esc", "`"]}
+                description="Close the command bar."
+              />
+              <ShortcutRow
+                badges={["Ctrl+U"]}
+                description="Clear command text."
+              />
+              <ShortcutRow
+                badges={["Ctrl+W"]}
+                description="Delete the previous word in command text."
+              />
+              <ShortcutRow
+                badges={["Backspace"]}
+                description="Go back from a nested command screen when the query is empty."
+              />
+              <ShortcutRow
+                badges={["Space"]}
+                description="Toggle command-bar plugin rows, toggles, and multi-select choices."
+              />
+              <ShortcutRow
+                badges={["[", "]"]}
+                description="Reorder ordered multi-select choices."
+              />
+              <ShortcutRow
+                badges={["Ctrl+S"]}
+                description="Submit multiline command forms."
+              />
+            </HelpSection>
+
+            <HelpSection title="Layout Basics">
+              <Text fg={colors.text}>Docked panes stay in the saved layout.</Text>
+              <Text fg={colors.text} wrapText>Floating panes can be dragged by the title bar and resized from the lower-right corner.</Text>
+              <Text fg={colors.text} wrapText>Use Layout Actions for split, move, duplicate, close all floating panes, undo, redo, and layout presets.</Text>
+            </HelpSection>
+          </>
+        );
+    }
+  };
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <Box width={width} height={1} flexShrink={0}>
+        <Tabs
+          tabs={HELP_TABS}
+          activeValue={activeTabId}
+          onSelect={(value) => setActiveTabId(value as HelpTabId)}
+          focused={focused}
+          compact
+          scrollable={false}
+        />
+      </Box>
+      <ScrollBox key={activeTabId} width={width} height={contentHeight} scrollY>
+        <Box flexDirection="column" padding={1}>
+          {renderContent()}
         </Box>
       </ScrollBox>
     </Box>

--- a/src/plugins/builtin/help/shortcut-model.ts
+++ b/src/plugins/builtin/help/shortcut-model.ts
@@ -27,7 +27,7 @@ export function resolveWindowTemplates(registry: SharedRegistry): HelpShortcutEn
           shortcut.prefix,
           shortcut.argPlaceholder ? `<${shortcut.argPlaceholder}>` : null,
         ].filter((value): value is string => !!value),
-        description: pluginName ? `${template.label} (${pluginName})` : template.label,
+        description: template.label,
         category: pluginName ?? "Core Panes",
       };
     })
@@ -46,9 +46,8 @@ function formatPlaceholder(value: string | undefined): string | null {
   return value ? `<${value}>` : null;
 }
 
-function withPluginName(description: string | undefined, pluginName: string | null | undefined): string {
-  const base = description?.trim() || "Run command";
-  return pluginName ? `${base} (${pluginName})` : base;
+function formatShortcutDescription(description: string | undefined): string {
+  return description?.trim() || "Run command";
 }
 
 function sortShortcutEntries(left: HelpShortcutEntry, right: HelpShortcutEntry): number {
@@ -90,7 +89,7 @@ export function resolveCommandShortcuts(registry: SharedRegistry): HelpShortcutE
           command.shortcut!.toUpperCase(),
           formatPlaceholder(command.shortcutArg?.placeholder),
         ].filter((value): value is string => !!value),
-        description: withPluginName(command.label, pluginName),
+        description: formatShortcutDescription(command.label),
         category: pluginName ?? command.category,
       };
     })
@@ -126,7 +125,7 @@ export function resolvePluginShortcuts(registry: SharedRegistry): HelpShortcutEn
       return {
         id: `plugin-shortcut:${shortcut.id}`,
         badges: [formatShortcutKey(shortcut)],
-        description: withPluginName(shortcut.description, pluginName),
+        description: formatShortcutDescription(shortcut.description),
         category: pluginName ?? "Plugin Shortcuts",
       };
     })

--- a/src/plugins/pane-manager.ts
+++ b/src/plugins/pane-manager.ts
@@ -49,7 +49,7 @@ export {
   swapPanes,
 } from "./pane-manager/docking";
 
-export { removePane } from "./pane-manager/layout-state";
+export { removeFloatingPanes, removePane } from "./pane-manager/layout-state";
 export { gridlockAllPanes } from "./pane-manager/gridlock";
 export type {
   DropTarget,

--- a/src/plugins/pane-manager/layout-state.ts
+++ b/src/plugins/pane-manager/layout-state.ts
@@ -158,3 +158,14 @@ export function removePane(layout: LayoutConfig, instanceId: string): LayoutConf
     [instanceId],
   ));
 }
+
+export function removeFloatingPanes(layout: LayoutConfig): LayoutConfig {
+  if (layout.floating.length === 0) return layout;
+  return finalizeLayout(removePaneInstances(
+    {
+      ...layout,
+      floating: [],
+    },
+    layout.floating.map((entry) => entry.instanceId),
+  ));
+}


### PR DESCRIPTION
Adds a close-all-floating-panes path across layout actions, pane shortcuts, and layout-state cleanup so floating panes can be cleared without affecting docked panes.

Tightens pane/window keyboard handling with Ctrl+Alt+W for floating cleanup, Ctrl+Shift+M/R for move/resize mode, modified shortcut isolation, and Enter exiting window mode when there are no pending changes.

Reworks Help into Basics, Functions, Shortcuts, and Issues tabs using the shared tab UI, updates shortcut coverage and ticker-search copy, removes repeated plugin names, and adds the GitHub Issues link.

Updates onboarding and README shortcut docs to match the current command mode versus direct ticker-search flow.