### PR TITLE
Use data table for Congress member trades

### DIFF
--- a/src/plugins/builtin/congress-trades/detail.tsx
+++ b/src/plugins/builtin/congress-trades/detail.tsx
@@ -1,25 +1,35 @@
-import type { RefObject } from "react";
-import { Box, ScrollBox, Text, TextAttributes, type ScrollBoxRenderable } from "../../../ui";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, ScrollBox, Text, TextAttributes, useRendererHost } from "../../../ui";
+import {
+  DataTableView,
+  usePaneFooter,
+  type DataTableKeyEvent,
+} from "../../../components";
+import { useInlineTickerOpener } from "../../../state/hooks/inline-tickers";
 import { colors } from "../../../theme/colors";
 import { padTo } from "../../../utils/format";
+import { isPlainKey } from "../../../utils/keyboard";
 import type {
+  CloudCongressHousePayload,
   CloudCongressMemberPayload,
   CloudCongressTradePayload,
 } from "../../../api-client";
+import { apiClient } from "../../../api-client";
 import {
+  CONGRESS_MEMBER_FILING_LIMIT,
+  CONGRESS_MEMBER_TRADE_LIMIT,
+  CONGRESS_TRADES_PANE_ID,
+  buildMemberTradeColumns,
   formatAmountRange,
   formatLag,
-  formatShortDate,
+  nextSort,
+  sortedTrades,
   truncate,
+  type LoadStatus,
+  type TradeColumn,
+  type TradeColumnId,
 } from "./model";
-
-export function sideColor(side: CloudCongressTradePayload["side"], selected: boolean): string {
-  if (selected) return colors.selectedText;
-  if (side === "BUY") return colors.positive;
-  if (side === "SELL") return colors.negative;
-  if (side === "EXCHANGE") return colors.warning;
-  return colors.textDim;
-}
+import { renderCongressTradeCell } from "./table";
 
 function DetailLine({
   label,
@@ -86,69 +96,195 @@ export function TradeDetail({
   );
 }
 
-export function MemberTradeList({
+export function MemberTradesDetail({
   member,
-  trades,
+  initialTrades,
   width,
-  scrollRef,
+  focused,
+  filingLimit,
 }: {
   member: CloudCongressMemberPayload;
-  trades: CloudCongressTradePayload[];
+  initialTrades: CloudCongressTradePayload[];
   width: number;
-  scrollRef: RefObject<ScrollBoxRenderable | null>;
+  focused: boolean;
+  filingLimit: number;
 }) {
-  const lineWidth = Math.max(1, width - 2);
-  const filedWidth = 7;
-  const txWidth = 7;
-  const sideWidth = 5;
-  const tickerWidth = 10;
-  const amountWidth = 14;
-  const assetWidth = Math.max(16, lineWidth - filedWidth - txWidth - sideWidth - tickerWidth - amountWidth - 6);
-  return (
-    <ScrollBox ref={scrollRef} scrollY focusable={false} flexGrow={1} paddingX={1}>
-      <Box flexDirection="column" width={lineWidth}>
-        <Box height={1} flexDirection="row">
-          <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-            {truncate(`${member.memberName} ${member.stateDistrict}`, lineWidth)}
-          </Text>
-        </Box>
-        <Box height={1} flexDirection="row">
-          <Text fg={colors.textDim}>
-            {`${member.tradeCount} trades  ${member.buyCount} buys  ${member.sellCount} sells  ${formatAmountRange(member.estimatedLow, member.estimatedHigh)}`}
-          </Text>
-        </Box>
-        <Text>{" "}</Text>
-        <Box height={1} flexDirection="row">
-          <Text fg={colors.textDim}>{padTo("FILED", filedWidth)}</Text>
-          <Text fg={colors.textDim}> </Text>
-          <Text fg={colors.textDim}>{padTo("TX", txWidth)}</Text>
-          <Text fg={colors.textDim}> </Text>
-          <Text fg={colors.textDim}>{padTo("SIDE", sideWidth)}</Text>
-          <Text fg={colors.textDim}> </Text>
-          <Text fg={colors.textDim}>{padTo("TICKER", tickerWidth)}</Text>
-          <Text fg={colors.textDim}> </Text>
-          <Text fg={colors.textDim}>{padTo("AMOUNT", amountWidth, "right")}</Text>
-          <Text fg={colors.textDim}> </Text>
-          <Text fg={colors.textDim}>{padTo("ASSET", assetWidth)}</Text>
-        </Box>
-        {trades.map((trade) => (
-          <Box key={trade.id} height={1} flexDirection="row">
-            <Text fg={colors.textDim}>{padTo(formatShortDate(trade.filingDate), filedWidth)}</Text>
-            <Text fg={colors.textDim}> </Text>
-            <Text fg={colors.textDim}>{padTo(formatShortDate(trade.transactionDate), txWidth)}</Text>
-            <Text fg={colors.textDim}> </Text>
-            <Text fg={sideColor(trade.side, false)}>{padTo(trade.side, sideWidth)}</Text>
-            <Text fg={colors.textDim}> </Text>
-            <Text fg={trade.ticker ? colors.positive : colors.textDim} attributes={trade.ticker ? TextAttributes.BOLD : 0}>
-              {padTo(trade.ticker ?? "--", tickerWidth)}
-            </Text>
-            <Text fg={colors.textDim}> </Text>
-            <Text fg={colors.textBright}>{padTo(formatAmountRange(trade.amountLow, trade.amountHigh, trade.amount), amountWidth, "right")}</Text>
-            <Text fg={colors.textDim}> </Text>
-            <Text fg={colors.text}>{truncate(trade.assetName, assetWidth)}</Text>
-          </Box>
-        ))}
+  const rendererHost = useRendererHost();
+  const openTicker = useInlineTickerOpener();
+  const [trades, setTrades] = useState<CloudCongressTradePayload[]>(initialTrades);
+  const [detailPayload, setDetailPayload] = useState<CloudCongressHousePayload | null>(null);
+  const [status, setStatus] = useState<LoadStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedTradeId, setSelectedTradeId] = useState<string | null>(initialTrades[0]?.id ?? null);
+  const [sortPreference, setSortPreference] = useState<{ columnId: TradeColumnId; direction: "asc" | "desc" }>({
+    columnId: "filed",
+    direction: "desc",
+  });
+  const fetchGenRef = useRef(0);
+
+  const load = useCallback((refresh = false) => {
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setStatus("loading");
+    setError(null);
+    apiClient.getCloudCongressHouse({
+      member: member.memberName,
+      limit: CONGRESS_MEMBER_TRADE_LIMIT,
+      filingLimit: Math.max(CONGRESS_MEMBER_FILING_LIMIT, filingLimit),
+      refresh,
+    })
+      .then((payload) => {
+        if (fetchGenRef.current !== gen) return;
+        const exactMemberTrades = payload.trades.filter((trade) => (
+          trade.memberName === member.memberName
+          && trade.stateDistrict === member.stateDistrict
+        ));
+        setDetailPayload(payload);
+        setTrades(exactMemberTrades.length > 0 ? exactMemberTrades : payload.trades);
+        setStatus("loaded");
+      })
+      .catch((loadError) => {
+        if (fetchGenRef.current !== gen) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+        setStatus("error");
+      });
+  }, [filingLimit, member.memberName, member.stateDistrict]);
+
+  useEffect(() => {
+    fetchGenRef.current += 1;
+    setTrades(initialTrades);
+    setDetailPayload(null);
+    setStatus("loading");
+    setError(null);
+    setSelectedTradeId(initialTrades[0]?.id ?? null);
+  }, [member.id]);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  const sortedRows = useMemo(() => sortedTrades(trades, sortPreference), [sortPreference, trades]);
+  const columns = useMemo(() => buildMemberTradeColumns(width), [width]);
+  const selectedTrade = useMemo(() => (
+    sortedRows.find((trade) => trade.id === selectedTradeId) ?? sortedRows[0] ?? null
+  ), [selectedTradeId, sortedRows]);
+  const summaryMember = useMemo(() => (
+    detailPayload?.members.find((entry) => entry.id === member.id)
+    ?? detailPayload?.members.find((entry) => (
+      entry.memberName === member.memberName
+      && entry.stateDistrict === member.stateDistrict
+    ))
+    ?? member
+  ), [detailPayload?.members, member]);
+  const maybeTruncated = status === "loaded" && trades.length >= CONGRESS_MEMBER_TRADE_LIMIT;
+
+  useEffect(() => {
+    if (selectedTradeId && sortedRows.some((trade) => trade.id === selectedTradeId)) return;
+    setSelectedTradeId(sortedRows[0]?.id ?? null);
+  }, [selectedTradeId, sortedRows]);
+
+  const refresh = useCallback(() => {
+    load(true);
+  }, [load]);
+
+  const openSelectedTicker = useCallback(() => {
+    if (selectedTrade?.ticker) openTicker(selectedTrade.ticker);
+  }, [openTicker, selectedTrade?.ticker]);
+
+  const openSelectedSource = useCallback(() => {
+    if (selectedTrade?.sourceUrl) void rendererHost.openExternal(selectedTrade.sourceUrl);
+  }, [rendererHost, selectedTrade?.sourceUrl]);
+
+  const handleKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+      return true;
+    }
+    if (isPlainKey(event, "t") && selectedTrade?.ticker) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      openSelectedTicker();
+      return true;
+    }
+    if (isPlainKey(event, "o") && selectedTrade?.sourceUrl) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      openSelectedSource();
+      return true;
+    }
+    return false;
+  }, [openSelectedSource, openSelectedTicker, refresh, selectedTrade?.sourceUrl, selectedTrade?.ticker]);
+
+  usePaneFooter(`${CONGRESS_TRADES_PANE_ID}:member-detail`, () => ({
+    info: [
+      ...(status === "loading" ? [{ id: "member-loading", parts: [{ text: "loading member trades", tone: "muted" as const }] }] : []),
+      ...(error ? [{ id: "member-error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+      ...(maybeTruncated ? [{ id: "member-truncated", parts: [{ text: `limited to ${CONGRESS_MEMBER_TRADE_LIMIT} trades`, tone: "warning" as const }] }] : []),
+    ],
+    hints: [
+      { id: "member-refresh", key: "r", label: "efresh", onPress: refresh },
+      { id: "member-ticker", key: "t", label: "icker", onPress: openSelectedTicker, disabled: !selectedTrade?.ticker },
+      { id: "member-open", key: "o", label: "pen", onPress: openSelectedSource, disabled: !selectedTrade?.sourceUrl },
+    ],
+  }), [
+    error,
+    maybeTruncated,
+    openSelectedSource,
+    openSelectedTicker,
+    refresh,
+    selectedTrade?.sourceUrl,
+    selectedTrade?.ticker,
+    status,
+  ]);
+
+  const summary = (
+    <Box flexDirection="column" paddingX={1} paddingTop={1} paddingBottom={1}>
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.textDim}>
+          {`${summaryMember.stateDistrict || "--"}  ${summaryMember.tradeCount} trades  ${summaryMember.buyCount} buys  ${summaryMember.sellCount} sells  ${formatAmountRange(summaryMember.estimatedLow, summaryMember.estimatedHigh)}`}
+        </Text>
       </Box>
-    </ScrollBox>
+    </Box>
+  );
+  const emptyTitle = status === "loading"
+    ? "Loading member trades..."
+    : error ?? "No trades for this member.";
+
+  return (
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      <DataTableView<CloudCongressTradePayload, TradeColumn>
+        focused={focused}
+        selection={{
+          kind: "id",
+          selectedId: selectedTradeId,
+          getId: (trade) => trade.id,
+          onChange: (id) => setSelectedTradeId(id),
+        }}
+        onActivate={(trade) => {
+          if (trade.ticker) openTicker(trade.ticker);
+        }}
+        onRootKeyDown={handleKeyDown}
+        rootWidth={width}
+        rootBefore={summary}
+        resetScrollKey={member.id}
+        columns={columns}
+        items={sortedRows}
+        sortColumnId={sortPreference.columnId}
+        sortDirection={sortPreference.direction}
+        onHeaderClick={(columnId) => {
+          setSortPreference((current) => nextSort(
+            current,
+            columnId as TradeColumnId,
+            columnId === "ticker" || columnId === "asset" || columnId === "side" || columnId === "owner" ? "asc" : "desc",
+          ));
+        }}
+        getItemKey={(trade) => trade.id}
+        renderCell={renderCongressTradeCell}
+        emptyStateTitle={emptyTitle}
+        showHorizontalScrollbar={false}
+      />
+    </Box>
   );
 }

--- a/src/plugins/builtin/congress-trades/footer.ts
+++ b/src/plugins/builtin/congress-trades/footer.ts
@@ -7,11 +7,13 @@ import type {
 import {
   CONGRESS_TRADES_PANE_ID,
   type CongressTab,
+  type DetailMode,
   type LoadStatus,
 } from "./model";
 
 export function useCongressTradesFooter({
   activeTab,
+  detailMode,
   detailTrade,
   error,
   load,
@@ -23,6 +25,7 @@ export function useCongressTradesFooter({
   status,
 }: {
   activeTab: CongressTab;
+  detailMode: DetailMode;
   detailTrade: CloudCongressTradePayload | null;
   error: string | null;
   load: (refresh?: boolean) => void;
@@ -44,16 +47,19 @@ export function useCongressTradesFooter({
       ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-    hints: [
-      { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
-      ...(activeTab === "trades" ? [
-        { id: "member", key: "m", label: "ember", onPress: openSelectedTradeMember, disabled: !selectedTrade },
-        { id: "ticker", key: "t", label: "icker", onPress: openSelectedTicker, disabled: !(detailTrade?.ticker ?? selectedTrade?.ticker) },
-        { id: "open", key: "o", label: "pen", onPress: openSelectedTradeSource, disabled: !(detailTrade ?? selectedTrade)?.sourceUrl },
-      ] : []),
-    ],
+    hints: detailMode?.kind === "member"
+      ? []
+      : [
+          { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
+          ...(activeTab === "trades" ? [
+            { id: "member", key: "m", label: "ember", onPress: openSelectedTradeMember, disabled: !selectedTrade },
+            { id: "ticker", key: "t", label: "icker", onPress: openSelectedTicker, disabled: !(detailTrade?.ticker ?? selectedTrade?.ticker) },
+            { id: "open", key: "o", label: "pen", onPress: openSelectedTradeSource, disabled: !(detailTrade ?? selectedTrade)?.sourceUrl },
+          ] : []),
+        ],
   }), [
     activeTab,
+    detailMode,
     detailTrade,
     error,
     load,

--- a/src/plugins/builtin/congress-trades/keyboard.ts
+++ b/src/plugins/builtin/congress-trades/keyboard.ts
@@ -1,14 +1,12 @@
-import { useCallback, type RefObject } from "react";
+import { useCallback } from "react";
 import { type DataTableKeyEvent } from "../../../components";
 import { useShortcut } from "../../../react/input";
-import { type ScrollBoxRenderable } from "../../../ui";
 import { isPlainKey } from "../../../utils/keyboard";
 import type { CongressTab, DetailMode } from "./model";
 
 export function useCongressTradesKeyboard({
   activeTab,
   detailMode,
-  detailScrollRef,
   focused,
   load,
   openSelectedTicker,
@@ -18,7 +16,6 @@ export function useCongressTradesKeyboard({
 }: {
   activeTab: CongressTab;
   detailMode: DetailMode;
-  detailScrollRef: RefObject<ScrollBoxRenderable | null>;
   focused: boolean;
   load: (refresh?: boolean) => void;
   openSelectedTicker: () => void;
@@ -26,25 +23,9 @@ export function useCongressTradesKeyboard({
   openSelectedTradeSource: () => void;
   selectTab: (tab: string) => void;
 }) {
-  const scrollDetailBy = useCallback((delta: number) => {
-    const scrollBox = detailScrollRef.current;
-    if (!scrollBox?.viewport) return;
-    const maxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
-    scrollBox.scrollTop = Math.max(0, Math.min(maxScrollTop, scrollBox.scrollTop + delta));
-  }, [detailScrollRef]);
-
   const handleDetailKeyDown = useCallback((event: DataTableKeyEvent) => {
-    if (isPlainKey(event, "j", "down")) {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      scrollDetailBy(1);
-      return true;
-    }
-    if (isPlainKey(event, "k", "up")) {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      scrollDetailBy(-1);
-      return true;
+    if (detailMode?.kind === "member") {
+      return false;
     }
     if (isPlainKey(event, "o")) {
       event.preventDefault?.();
@@ -65,7 +46,7 @@ export function useCongressTradesKeyboard({
       return true;
     }
     return false;
-  }, [openSelectedTicker, openSelectedTradeMember, openSelectedTradeSource, scrollDetailBy]);
+  }, [detailMode?.kind, openSelectedTicker, openSelectedTradeMember, openSelectedTradeSource]);
 
   const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
     if (isPlainKey(event, "r")) {

--- a/src/plugins/builtin/congress-trades/model.ts
+++ b/src/plugins/builtin/congress-trades/model.ts
@@ -8,6 +8,8 @@ import type {
 export const CONGRESS_TRADES_PANE_ID = "congress-trades";
 export const CONGRESS_TRADE_LIMIT = 200;
 export const CONGRESS_FILING_LIMIT = 20;
+export const CONGRESS_MEMBER_TRADE_LIMIT = 2000;
+export const CONGRESS_MEMBER_FILING_LIMIT = 500;
 
 export type CongressTab = "trades" | "members";
 export type LoadStatus = "idle" | "loading" | "loaded" | "error";
@@ -25,6 +27,7 @@ export type TradeColumnId =
   | "side"
   | "ticker"
   | "amount"
+  | "asset"
   | "owner";
 export type TradeColumn = DataTableColumn & { id: TradeColumnId };
 export type MemberColumnId =
@@ -104,6 +107,8 @@ function compareTrade(
       return compareText(left.ticker ?? "", right.ticker ?? "");
     case "amount":
       return (left.amountHigh ?? left.amountLow ?? 0) - (right.amountHigh ?? right.amountLow ?? 0);
+    case "asset":
+      return compareText(left.assetName, right.assetName);
     case "owner":
       return compareText(left.owner, right.owner);
   }
@@ -169,6 +174,30 @@ export function buildTradeColumns(width: number): TradeColumn[] {
     { id: "ticker", label: "TICKER", width: tickerWidth, align: "left" },
     { id: "amount", label: "AMOUNT", width: amountWidth, align: "right" },
     { id: "owner", label: "OWNER", width: ownerWidth, align: "left" },
+  ];
+}
+
+export function buildMemberTradeColumns(width: number): TradeColumn[] {
+  const filedWidth = 7;
+  const txWidth = 7;
+  const sideWidth = 8;
+  const tickerWidth = 12;
+  const amountWidth = 14;
+  const ownerWidth = 8;
+  const lagWidth = 5;
+  const assetWidth = Math.max(
+    18,
+    width - filedWidth - txWidth - sideWidth - tickerWidth - amountWidth - ownerWidth - lagWidth - 9,
+  );
+  return [
+    { id: "filed", label: "FILED", width: filedWidth, align: "left" },
+    { id: "tx", label: "TX", width: txWidth, align: "left" },
+    { id: "side", label: "SIDE", width: sideWidth, align: "left" },
+    { id: "ticker", label: "TICKER", width: tickerWidth, align: "left" },
+    { id: "amount", label: "AMOUNT", width: amountWidth, align: "right" },
+    { id: "asset", label: "ASSET", width: assetWidth, align: "left" },
+    { id: "owner", label: "OWNER", width: ownerWidth, align: "left" },
+    { id: "lag", label: "LAG", width: lagWidth, align: "right" },
   ];
 }
 

--- a/src/plugins/builtin/congress-trades/pane.tsx
+++ b/src/plugins/builtin/congress-trades/pane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Box, useRendererHost, type ScrollBoxRenderable } from "../../../ui";
+import { Box, useRendererHost } from "../../../ui";
 import {
   DataTableStackView,
   EmptyState,
@@ -17,6 +17,7 @@ import {
 import type { PaneProps } from "../../../types/plugin";
 import {
   CONGRESS_FILING_LIMIT,
+  CONGRESS_MEMBER_FILING_LIMIT,
   CONGRESS_TRADE_LIMIT,
   CONGRESS_TRADES_PANE_ID,
   buildMemberColumns,
@@ -34,7 +35,7 @@ import {
   type TradeColumn,
   type TradeColumnId,
 } from "./model";
-import { MemberTradeList, TradeDetail } from "./detail";
+import { MemberTradesDetail, TradeDetail } from "./detail";
 import { useCongressTradesFooter } from "./footer";
 import { useCongressTradesKeyboard } from "./keyboard";
 import {
@@ -61,7 +62,6 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
     columnId: "trades",
     direction: "desc",
   });
-  const detailScrollRef = useRef<ScrollBoxRenderable | null>(null);
   const fetchGenRef = useRef(0);
 
   const load = useCallback((refresh = false) => {
@@ -142,12 +142,6 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
     if (detailMode?.kind === "member" && !detailMember) setDetailMode(null);
   }, [detailMember, detailMode, detailTrade]);
 
-  useEffect(() => {
-    if (!detailMode) return;
-    const scrollBox = detailScrollRef.current;
-    if (scrollBox) scrollBox.scrollTop = 0;
-  }, [detailMode]);
-
   const selectTab = useCallback((tab: string) => {
     setActiveTab(tab === "members" ? "members" : "trades");
     setDetailMode(null);
@@ -176,7 +170,6 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
   const { handleDetailKeyDown, handleRootKeyDown } = useCongressTradesKeyboard({
     activeTab,
     detailMode,
-    detailScrollRef,
     focused,
     load,
     openSelectedTicker,
@@ -187,6 +180,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
 
   useCongressTradesFooter({
     activeTab,
+    detailMode,
     detailTrade,
     error,
     load,
@@ -201,11 +195,12 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
   const detailContent = detailTrade ? (
     <TradeDetail trade={detailTrade} width={width} />
   ) : detailMember ? (
-    <MemberTradeList
+    <MemberTradesDetail
+      focused={focused}
       member={detailMember}
-      trades={detailMemberTrades}
+      initialTrades={detailMemberTrades}
       width={width}
-      scrollRef={detailScrollRef}
+      filingLimit={payload?.filingCount ?? CONGRESS_MEMBER_FILING_LIMIT}
     />
   ) : null;
   const detailTitle = detailTrade

--- a/src/plugins/builtin/congress-trades/table.tsx
+++ b/src/plugins/builtin/congress-trades/table.tsx
@@ -12,7 +12,14 @@ import {
   type MemberColumn,
   type TradeColumn,
 } from "./model";
-import { sideColor } from "./detail";
+
+export function sideColor(side: CloudCongressTradePayload["side"], selected: boolean): string {
+  if (selected) return colors.selectedText;
+  if (side === "BUY") return colors.positive;
+  if (side === "SELL") return colors.negative;
+  if (side === "EXCHANGE") return colors.warning;
+  return colors.textDim;
+}
 
 export function renderCongressTradeCell(
   trade: CloudCongressTradePayload,
@@ -51,6 +58,8 @@ export function renderCongressTradeCell(
         text: formatAmountRange(trade.amountLow, trade.amountHigh, trade.amount),
         color: selectedColor ?? colors.textBright,
       };
+    case "asset":
+      return { text: trade.assetName, color: selectedColor ?? colors.text };
     case "owner":
       return { text: trade.owner, color: selectedColor ?? colors.textDim };
   }


### PR DESCRIPTION
## Summary
- Replace the Congress member detail manual trade list with the shared data table.
- Fetch member-specific trades with higher scan limits so detail views can show more than the root table payload.
- Route member detail refresh, ticker, and source actions through the nested detail table/footer.

## Validation
- bun test
- bun build src/index.tsx --target=bun --outdir /tmp/gloomberb-congress-build
- tmux smoke test: opened the Congress pane via CG and verified member detail renders the nested trade table and loads member trades.