### PR TITLE
Add compact price return summaries

### DIFF
--- a/scripts/verify-windows-desktop.ps1
+++ b/scripts/verify-windows-desktop.ps1
@@ -652,6 +652,22 @@ function Stop-ProcessIds {
   }
 }
 
+function Disable-InstalledDesktopUpdates {
+  param([string]$InstallDir)
+
+  $VersionPath = Join-Path $InstallDir "Resources\version.json"
+  if (-not (Test-Path $VersionPath)) {
+    throw "Installed desktop version metadata was not found: $VersionPath"
+  }
+
+  $VersionInfo = Get-Content $VersionPath -Raw | ConvertFrom-Json
+  $VersionInfo.channel = "dev"
+  $VersionInfo.baseUrl = ""
+  $VersionInfo |
+    ConvertTo-Json -Depth 8 |
+    Set-Content -Path $VersionPath -Encoding UTF8
+}
+
 function Write-JsonFile {
   param(
     [string]$Path,
@@ -887,6 +903,8 @@ try {
   if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
   }
+
+  Disable-InstalledDesktopUpdates -InstallDir $InstallDir
 
   Capture-OnboardingScreenshot `
     -InstallDir $InstallDir `

--- a/src/components/chart/comparison-stock-chart/helpers.ts
+++ b/src/components/chart/comparison-stock-chart/helpers.ts
@@ -2,8 +2,6 @@ import type { PricePoint } from "../../../types/financials";
 import type { LocalPlotPointer } from "../core/pointer";
 import type { ComparisonChartRenderMode } from "../core/types";
 import type { projectComparisonChartData } from "../comparison/data";
-import { formatPercentRaw } from "../../../utils/format";
-import { formatMarketPriceWithCurrency } from "../../../market-data/market/format";
 
 export function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -40,36 +38,6 @@ export function buildComparisonNativeBitmapKey(
     marketSessionKey,
     fingerprint,
   ].join("::");
-}
-
-export function getLegendColumns(width: number): number {
-  if (width >= 110) return 3;
-  if (width >= 72) return 2;
-  return 1;
-}
-
-export function clipText(text: string, width: number): string {
-  if (width <= 0) return "";
-  if (text.length <= width) return text.padEnd(width);
-  if (width <= 3) return text.slice(0, width);
-  return `${text.slice(0, width - 3)}...`;
-}
-
-export function formatLegendSummary(
-  symbol: string,
-  rawValue: number | null,
-  baseValue: number | null,
-  currency: string,
-  priceRange: number | undefined,
-): string {
-  if (rawValue === null) return `${symbol} waiting`;
-  const price = formatMarketPriceWithCurrency(rawValue, currency, {
-    minimumFractionDigits: 2,
-    precisionOffset: 1,
-    priceRange,
-  });
-  if (baseValue === null || baseValue === 0) return `${symbol} ${price}`;
-  return `${symbol} ${price} ${formatPercentRaw(((rawValue - baseValue) / baseValue) * 100)}`;
 }
 
 export function getInitialComparisonMode(mode: string | undefined): ComparisonChartRenderMode {

--- a/src/components/chart/comparison-stock-chart/layout-metrics.ts
+++ b/src/components/chart/comparison-stock-chart/layout-metrics.ts
@@ -1,5 +1,4 @@
 import type { ChartAxisMode } from "../core/types";
-import { getLegendColumns } from "./helpers";
 
 export interface ComparisonChartLayoutMetrics {
   axisGap: number;
@@ -36,15 +35,16 @@ export function resolveComparisonChartLayoutMetrics({
   const controlRows = 2;
   const timeAxisRows = 1;
   const helpRows = 0;
-  const legendColumns = getLegendColumns(width);
-  const legendNeededRows = symbolCount > 0 ? Math.ceil(symbolCount / legendColumns) : 0;
-  const legendRows = legendNeededRows > 0
-    ? Math.min(4, Math.max(Math.min(height - (headerRows + controlRows + timeAxisRows + helpRows + 4), legendNeededRows), 1))
+  const legendColumns = 1;
+  const legendNeededRows = symbolCount > 0 ? symbolCount + 1 : 0;
+  const legendAvailableRows = Math.max(height - (headerRows + controlRows + timeAxisRows + helpRows + 6), 0);
+  const legendRows = legendNeededRows > 0 && legendAvailableRows > 0
+    ? Math.min(5, Math.max(2, Math.min(legendAvailableRows, legendNeededRows)))
     : 0;
   const chartHeight = Math.max(height - headerRows - controlRows - timeAxisRows - helpRows - legendRows, 4);
   const minChartWidth = 20;
   const measurementChartWidth = Math.max(width - axisSectionWidthBudget - axisGap, minChartWidth);
-  const legendItemWidth = Math.max(Math.floor((width - Math.max(legendColumns - 1, 0)) / legendColumns), 20);
+  const legendItemWidth = Math.max(width, 20);
 
   return {
     axisGap,

--- a/src/components/chart/comparison-stock-chart/legend.tsx
+++ b/src/components/chart/comparison-stock-chart/legend.tsx
@@ -1,73 +1,70 @@
-import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
-import { blendHex, colors } from "../../../theme/colors";
 import type { ComparisonChartProjection } from "../comparison/data";
-import { clipText, formatLegendSummary } from "./helpers";
+import { PriceReturnTable, type PriceReturnTableRow } from "../../price-performance";
+import type { PriceReturnField } from "../../../market-data/performance";
 
 interface ComparisonChartLegendProps {
   legendActiveIndex: number | null;
-  legendColumns: number;
   legendItemWidth: number;
   legendRows: number;
   onOpenSymbol: (symbol: string) => void;
   onSelectSymbol: (symbol: string) => void;
+  performanceBySymbol: ReadonlyMap<string, PriceReturnField[]>;
   projection: ComparisonChartProjection;
   selectedSymbol: string | null;
   symbols: string[];
-  visiblePriceRange: number | undefined;
+}
+
+function buildRangeReturnField(
+  item: ComparisonChartProjection["series"][number] | null,
+  legendActiveIndex: number | null,
+): PriceReturnField {
+  const activeRaw = legendActiveIndex !== null
+    ? item?.points[legendActiveIndex]?.rawValue ?? null
+    : item?.latestRawValue ?? null;
+  const baseValue = item?.baseValue ?? null;
+  const value = activeRaw != null && baseValue != null && baseValue !== 0
+    ? (activeRaw - baseValue) / baseValue
+    : null;
+  return {
+    id: "RNG",
+    label: "Rng",
+    value,
+  };
 }
 
 export function ComparisonChartLegend({
   legendActiveIndex,
-  legendColumns,
   legendItemWidth,
   legendRows,
   onOpenSymbol,
   onSelectSymbol,
+  performanceBySymbol,
   projection,
   selectedSymbol,
   symbols,
-  visiblePriceRange,
 }: ComparisonChartLegendProps) {
   if (legendRows <= 0) return null;
 
-  const legendRowsData = Array.from({ length: Math.ceil(symbols.length / legendColumns) }, (_, rowIndex) => (
-    symbols.slice(rowIndex * legendColumns, rowIndex * legendColumns + legendColumns)
-  ));
+  const rows: PriceReturnTableRow[] = symbols.map((symbol) => {
+    const item = projection.series.find((entry) => entry.symbol === symbol) ?? null;
+    return {
+      symbol,
+      color: item?.color ?? "#888888",
+      fields: [
+        buildRangeReturnField(item, legendActiveIndex),
+        ...(performanceBySymbol.get(symbol) ?? []),
+      ],
+      selected: selectedSymbol === symbol,
+    };
+  });
 
   return (
-    <ScrollBox height={legendRows} scrollY>
-      <Box flexDirection="column">
-        {legendRowsData.map((legendRow, rowIndex) => (
-          <Box key={`legend-row:${rowIndex}`} flexDirection="row" gap={1}>
-            {legendRow.map((symbol) => {
-              const item = projection.series.find((entry) => entry.symbol === symbol) ?? null;
-              const isSelected = selectedSymbol === symbol;
-              const activeRaw = legendActiveIndex !== null
-                ? item?.points[legendActiveIndex]?.rawValue ?? null
-                : item?.latestRawValue ?? null;
-              const currency = item?.currency ?? "USD";
-              const summary = formatLegendSummary(symbol, activeRaw, item?.baseValue ?? null, currency, visiblePriceRange);
-
-              return (
-                <Box
-                  key={symbol}
-                  width={legendItemWidth}
-                  backgroundColor={isSelected ? blendHex(colors.panel, colors.borderFocused, 0.18) : colors.panel}
-                  onMouseMove={() => onSelectSymbol(symbol)}
-                  onMouseDown={() => {
-                    onSelectSymbol(symbol);
-                    onOpenSymbol(symbol);
-                  }}
-                >
-                  <Text fg={item?.color ?? colors.textDim} attributes={isSelected ? TextAttributes.BOLD : 0}>
-                    {clipText(`${isSelected ? ">" : " "} ${summary}`, legendItemWidth)}
-                  </Text>
-                </Box>
-              );
-            })}
-          </Box>
-        ))}
-      </Box>
-    </ScrollBox>
+    <PriceReturnTable
+      height={legendRows}
+      onOpenSymbol={onOpenSymbol}
+      onSelectSymbol={onSelectSymbol}
+      rows={rows}
+      width={legendItemWidth}
+    />
   );
 }

--- a/src/components/chart/comparison-stock-chart/view.tsx
+++ b/src/components/chart/comparison-stock-chart/view.tsx
@@ -5,6 +5,11 @@ import { blendHex, colors } from "../../../theme/colors";
 import { useThemeColors } from "../../../theme/theme-context";
 import { usePaneSettingValue } from "../../../state/app/context";
 import { useQuoteStreaming } from "../../../state/hooks/quote-streaming";
+import {
+  appendQuoteToPriceReturnHistory,
+  buildPriceReturnFields,
+  type PriceReturnField,
+} from "../../../market-data/performance";
 import type { QuoteSubscriptionTarget } from "../../../types/data-provider";
 import {
   type ChartRendererPreference,
@@ -170,6 +175,27 @@ function useComparisonChartQuoteStreaming({
   useQuoteStreaming(streamingTargets);
 }
 
+function getOneYearReturn(fields: readonly PriceReturnField[]): number | null {
+  return fields.find((field) => field.id === "1Y")?.value ?? null;
+}
+
+function sortSymbolsByOneYearReturn(
+  symbols: readonly string[],
+  performanceBySymbol: ReadonlyMap<string, PriceReturnField[]>,
+): string[] {
+  const originalIndex = new Map(symbols.map((symbol, index) => [symbol, index]));
+  return [...symbols].sort((left, right) => {
+    const leftReturn = getOneYearReturn(performanceBySymbol.get(left) ?? []);
+    const rightReturn = getOneYearReturn(performanceBySymbol.get(right) ?? []);
+    if (leftReturn != null && rightReturn != null && leftReturn !== rightReturn) {
+      return rightReturn - leftReturn;
+    }
+    if (leftReturn != null && rightReturn == null) return -1;
+    if (leftReturn == null && rightReturn != null) return 1;
+    return (originalIndex.get(left) ?? 0) - (originalIndex.get(right) ?? 0);
+  });
+}
+
 function ComparisonStockChartView({
   paneId,
   width,
@@ -250,6 +276,22 @@ function ComparisonStockChartView({
     symbolSources,
     viewState,
   });
+  const performanceBySymbol = useMemo(() => {
+    const bySymbol = new Map<string, PriceReturnField[]>();
+    for (const source of symbolSources) {
+      const sourceHistory = appendQuoteToPriceReturnHistory(source.priceHistory, source.quote);
+      const fallbackHistory = series.find((entry) => entry.symbol === source.symbol)?.points ?? [];
+      bySymbol.set(
+        source.symbol,
+        buildPriceReturnFields(sourceHistory.length >= 2 ? sourceHistory : fallbackHistory),
+      );
+    }
+    return bySymbol;
+  }, [series, symbolSources]);
+  const summarySymbols = useMemo(
+    () => sortSymbolsByOneYearReturn(symbols, performanceBySymbol),
+    [performanceBySymbol, symbols],
+  );
 
   useEffect(() => {
     if (symbols.includes(viewState.selectedSymbol ?? "")) return;
@@ -311,7 +353,7 @@ function ComparisonStockChartView({
     cursorY: viewState.cursorY,
     renderer,
     setViewState,
-    symbols,
+    symbols: summarySymbols,
   });
   const {
     activePreset,
@@ -352,7 +394,6 @@ function ComparisonStockChartView({
     result,
     staticScene,
     timeAxisLabel,
-    visiblePriceRange,
   } = useComparisonChartRenderOutput({
     axisMode,
     chartColors,
@@ -386,7 +427,7 @@ function ComparisonStockChartView({
     setResolution,
     setViewState,
     supportMap,
-    symbols,
+    symbols: summarySymbols,
     updateDisplayCursorTarget,
     viewState,
     visibleDateWindow,
@@ -479,15 +520,14 @@ function ComparisonStockChartView({
       legend={(
         <ComparisonChartLegend
           legendActiveIndex={legendActiveIndex}
-          legendColumns={legendColumns}
           legendItemWidth={legendItemWidth}
           legendRows={legendRows}
           onOpenSymbol={onOpenSymbol}
           onSelectSymbol={setSelectedSymbol}
+          performanceBySymbol={performanceBySymbol}
           projection={projection}
           selectedSymbol={viewState.selectedSymbol}
-          symbols={symbols}
-          visiblePriceRange={visiblePriceRange}
+          symbols={summarySymbols}
         />
       )}
       plotBitmaps={plotBitmaps}

--- a/src/components/price-performance.tsx
+++ b/src/components/price-performance.tsx
@@ -1,0 +1,175 @@
+import { Box, ScrollBox, Text } from "../ui";
+import { blendHex, colors, priceColor } from "../theme/colors";
+import { displayWidth, formatPercent, padTo } from "../utils/format";
+import type { PriceReturnField } from "../market-data/performance";
+
+const STRIP_COLUMN_GAP = 1;
+const RETURN_CELL_MIN_WIDTH = 7;
+const SYMBOL_COLUMN_MIN_WIDTH = 6;
+const SYMBOL_COLUMN_MAX_WIDTH = 12;
+
+export interface PriceReturnTableRow {
+  symbol: string;
+  color: string;
+  fields: PriceReturnField[];
+  selected: boolean;
+}
+
+function formatReturnValue(value: number | null): string {
+  return value == null ? "-" : formatPercent(value);
+}
+
+function returnValueColor(value: number | null): string {
+  return value == null ? colors.textMuted : priceColor(value);
+}
+
+function hasAnyReturn(fields: readonly PriceReturnField[]): boolean {
+  return fields.some((field) => field.value != null);
+}
+
+function chunkFields<T>(fields: readonly T[], size: number): T[][] {
+  const rows: T[][] = [];
+  for (let index = 0; index < fields.length; index += size) {
+    rows.push(fields.slice(index, index + size));
+  }
+  return rows;
+}
+
+export function PriceReturnStrip({
+  fields,
+  width,
+}: {
+  fields: PriceReturnField[];
+  width: number;
+}) {
+  if (!hasAnyReturn(fields)) return null;
+
+  const columnCount = width >= 72
+    ? Math.min(6, fields.length)
+    : width >= 54
+      ? Math.min(4, fields.length)
+      : width >= 36
+        ? Math.min(3, fields.length)
+        : Math.min(2, fields.length);
+  const availableWidth = Math.max(width - STRIP_COLUMN_GAP * Math.max(columnCount - 1, 0), columnCount);
+  const cellWidth = Math.max(RETURN_CELL_MIN_WIDTH, Math.floor(availableWidth / columnCount));
+  const rows = chunkFields(fields, columnCount);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      {rows.map((row, rowIndex) => (
+        <Box key={rowIndex} flexDirection="row" height={1}>
+          {row.map((field, columnIndex) => {
+            const labelWidth = Math.min(3, Math.max(2, displayWidth(field.label)));
+            const valueWidth = Math.max(1, cellWidth - labelWidth);
+            return (
+              <Box key={field.id} flexDirection="row">
+                {columnIndex > 0 && <Box width={STRIP_COLUMN_GAP} />}
+                <Box flexDirection="row" width={cellWidth}>
+                  <Text fg={colors.textDim}>{padTo(field.label, labelWidth)}</Text>
+                  <Box width={valueWidth} overflow="hidden">
+                    <Text fg={returnValueColor(field.value)}>{padTo(formatReturnValue(field.value), valueWidth, "right")}</Text>
+                  </Box>
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function getFieldById(fields: readonly PriceReturnField[], id: string): PriceReturnField | null {
+  return fields.find((field) => field.id === id) ?? null;
+}
+
+function chooseComparisonFieldIds(width: number, availableIds: readonly string[]): string[] {
+  const preferred = width >= 86
+    ? ["RNG", "1M", "3M", "6M", "1Y", "3Y", "5Y"]
+    : width >= 72
+      ? ["RNG", "1M", "3M", "1Y", "3Y", "5Y"]
+      : width >= 58
+        ? ["RNG", "1M", "1Y", "3Y", "5Y"]
+        : width >= 44
+          ? ["RNG", "1M", "1Y", "5Y"]
+          : ["1Y", "5Y"];
+  const available = new Set(availableIds);
+  return preferred.filter((id) => available.has(id));
+}
+
+export function PriceReturnTable({
+  height,
+  onOpenSymbol,
+  onSelectSymbol,
+  rows,
+  width,
+}: {
+  height: number;
+  onOpenSymbol: (symbol: string) => void;
+  onSelectSymbol: (symbol: string) => void;
+  rows: PriceReturnTableRow[];
+  width: number;
+}) {
+  if (height <= 0 || rows.length === 0) return null;
+
+  const availableIds = rows[0]?.fields.map((field) => field.id) ?? [];
+  const fieldIds = chooseComparisonFieldIds(width, availableIds);
+  if (fieldIds.length === 0) return null;
+
+  const valueWidth = Math.max(
+    RETURN_CELL_MIN_WIDTH,
+    Math.floor((width - SYMBOL_COLUMN_MIN_WIDTH - fieldIds.length) / Math.max(fieldIds.length, 1)),
+  );
+  const symbolWidth = Math.min(
+    SYMBOL_COLUMN_MAX_WIDTH,
+    Math.max(SYMBOL_COLUMN_MIN_WIDTH, width - fieldIds.length * (valueWidth + 1)),
+  );
+  const fieldsById = rows[0]?.fields ?? [];
+
+  return (
+    <ScrollBox height={height} scrollY>
+      <Box flexDirection="column" width={width}>
+        <Box flexDirection="row" height={1}>
+          <Text fg={colors.textDim}>{padTo("Sym", symbolWidth)}</Text>
+          {fieldIds.map((fieldId) => {
+            const field = getFieldById(fieldsById, fieldId);
+            return (
+              <Box key={fieldId} flexDirection="row">
+                <Text fg={colors.textDim}>{" "}</Text>
+                <Text fg={colors.textDim}>{padTo(field?.label ?? fieldId, valueWidth, "right")}</Text>
+              </Box>
+            );
+          })}
+        </Box>
+
+        {rows.map((row) => (
+          <Box
+            key={row.symbol}
+            flexDirection="row"
+            height={1}
+            width={width}
+            backgroundColor={row.selected ? blendHex(colors.panel, colors.borderFocused, 0.18) : colors.panel}
+            onMouseMove={() => onSelectSymbol(row.symbol)}
+            onMouseDown={() => {
+              onSelectSymbol(row.symbol);
+              onOpenSymbol(row.symbol);
+            }}
+          >
+            <Text fg={row.color}>{padTo(`${row.selected ? ">" : " "} ${row.symbol}`, symbolWidth)}</Text>
+            {fieldIds.map((fieldId) => {
+              const field = getFieldById(row.fields, fieldId);
+              const value = field?.value ?? null;
+              return (
+                <Box key={fieldId} flexDirection="row">
+                  <Text fg={colors.textDim}>{" "}</Text>
+                  <Text fg={returnValueColor(value)}>{padTo(formatReturnValue(value), valueWidth, "right")}</Text>
+                </Box>
+              );
+            })}
+          </Box>
+        ))}
+      </Box>
+    </ScrollBox>
+  );
+}

--- a/src/market-data/performance.test.ts
+++ b/src/market-data/performance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appendQuoteToPriceReturnHistory,
+  buildPriceReturnFields,
+  computePriceReturnForHorizon,
+  PRICE_RETURN_HORIZONS,
+} from "./performance";
+import type { PricePoint } from "../types/financials";
+
+function point(date: string, close: number): PricePoint {
+  return { date: new Date(`${date}T00:00:00Z`), close };
+}
+
+describe("price performance", () => {
+  test("computes horizon return from the closest prior baseline", () => {
+    const history = [
+      point("2025-12-31", 100),
+      point("2026-01-02", 102),
+      point("2026-01-31", 110),
+      point("2026-02-01", 120),
+    ];
+
+    const oneMonth = PRICE_RETURN_HORIZONS.find((horizon) => horizon.id === "1M")!;
+
+    expect(computePriceReturnForHorizon(history, oneMonth)).toBeCloseTo(20 / 100);
+  });
+
+  test("leaves fixed horizons empty when history does not reach the baseline date", () => {
+    const history = [
+      point("2026-01-15", 100),
+      point("2026-02-01", 110),
+    ];
+
+    const fields = buildPriceReturnFields(history);
+
+    expect(fields.find((field) => field.id === "1M")?.value).toBeNull();
+    expect(fields.find((field) => field.id === "1Y")?.value).toBeNull();
+  });
+
+  test("can include a newer live quote as the latest return point", () => {
+    const history = [
+      point("2025-01-31", 100),
+      point("2026-01-31", 120),
+    ];
+    const withQuote = appendQuoteToPriceReturnHistory(history, {
+      price: 150,
+      lastUpdated: Date.parse("2026-02-01T15:30:00Z"),
+    });
+    const oneYear = PRICE_RETURN_HORIZONS.find((horizon) => horizon.id === "1Y")!;
+
+    expect(withQuote).toHaveLength(3);
+    expect(computePriceReturnForHorizon(withQuote, oneYear)).toBeCloseTo(50 / 100);
+  });
+});

--- a/src/market-data/performance.ts
+++ b/src/market-data/performance.ts
@@ -1,0 +1,109 @@
+import type { PricePoint, Quote } from "../types/financials";
+
+export interface PriceReturnHorizon {
+  id: string;
+  label: string;
+  amount: number;
+  unit: "month" | "year";
+}
+
+export interface PriceReturnField {
+  id: string;
+  label: string;
+  value: number | null;
+}
+
+export const PRICE_RETURN_HORIZONS: PriceReturnHorizon[] = [
+  { id: "1M", label: "1M", amount: 1, unit: "month" },
+  { id: "3M", label: "3M", amount: 3, unit: "month" },
+  { id: "6M", label: "6M", amount: 6, unit: "month" },
+  { id: "1Y", label: "1Y", amount: 1, unit: "year" },
+  { id: "3Y", label: "3Y", amount: 3, unit: "year" },
+  { id: "5Y", label: "5Y", amount: 5, unit: "year" },
+];
+
+function coercePointDate(value: Date | string | number): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+export function normalizePriceReturnHistory(points: readonly PricePoint[]): PricePoint[] {
+  const byTimestamp = new Map<number, PricePoint>();
+  for (const point of points) {
+    const date = coercePointDate(point.date as Date | string | number);
+    if (!date || !Number.isFinite(point.close)) continue;
+    byTimestamp.set(date.getTime(), { ...point, date });
+  }
+  return [...byTimestamp.entries()]
+    .sort((left, right) => left[0] - right[0])
+    .map(([, point]) => point);
+}
+
+export function appendQuoteToPriceReturnHistory(
+  points: readonly PricePoint[],
+  quote: Pick<Quote, "price" | "lastUpdated"> | null | undefined,
+): PricePoint[] {
+  const history = normalizePriceReturnHistory(points);
+  if (!quote || !Number.isFinite(quote.price) || !Number.isFinite(quote.lastUpdated)) {
+    return history;
+  }
+
+  const quoteDate = new Date(quote.lastUpdated);
+  if (!Number.isFinite(quoteDate.getTime())) return history;
+
+  const latestHistoryTime = history.at(-1)?.date.getTime() ?? Number.NEGATIVE_INFINITY;
+  if (quoteDate.getTime() <= latestHistoryTime) return history;
+
+  return [
+    ...history,
+    {
+      date: quoteDate,
+      close: quote.price,
+    },
+  ];
+}
+
+function subtractHorizon(date: Date, horizon: PriceReturnHorizon): Date {
+  const target = new Date(date);
+  if (horizon.unit === "month") {
+    target.setMonth(target.getMonth() - horizon.amount);
+  } else {
+    target.setFullYear(target.getFullYear() - horizon.amount);
+  }
+  return target;
+}
+
+export function computePriceReturnForHorizon(
+  points: readonly PricePoint[],
+  horizon: PriceReturnHorizon,
+): number | null {
+  const history = normalizePriceReturnHistory(points);
+  if (history.length < 2) return null;
+
+  const latest = history.at(-1)!;
+  const cutoff = subtractHorizon(latest.date, horizon);
+  let baseline: PricePoint | null = null;
+
+  for (const point of history) {
+    if (point.date.getTime() <= cutoff.getTime()) {
+      baseline = point;
+    } else {
+      break;
+    }
+  }
+
+  if (!baseline || !Number.isFinite(baseline.close) || baseline.close === 0) return null;
+  if (!Number.isFinite(latest.close)) return null;
+  return (latest.close - baseline.close) / baseline.close;
+}
+
+export function buildPriceReturnFields(
+  points: readonly PricePoint[],
+  horizons: readonly PriceReturnHorizon[] = PRICE_RETURN_HORIZONS,
+): PriceReturnField[] {
+  return horizons.map((horizon) => ({
+    id: horizon.id,
+    label: horizon.label,
+    value: computePriceReturnForHorizon(points, horizon),
+  }));
+}

--- a/src/plugins/builtin/comparison-chart/index.test.tsx
+++ b/src/plugins/builtin/comparison-chart/index.test.tsx
@@ -68,6 +68,28 @@ function makeFinancials(symbol: string, currency: string, closes: number[]): Tic
   };
 }
 
+function makeDatedFinancials(symbol: string, currency: string, closes: Array<[string, number]>): TickerFinancials {
+  const latest = closes.at(-1);
+  const latestClose = latest?.[1] ?? 0;
+  const latestDate = latest ? Date.parse(`${latest[0]}T00:00:00Z`) : Date.now();
+  return {
+    annualStatements: [],
+    quarterlyStatements: [],
+    quote: {
+      symbol,
+      price: latestClose,
+      currency,
+      change: latestClose - (closes[0]?.[1] ?? latestClose),
+      changePercent: closes[0]?.[1] ? ((latestClose - closes[0]![1]) / closes[0]![1]) * 100 : 0,
+      lastUpdated: latestDate,
+    },
+    priceHistory: closes.map(([date, close]) => ({
+      date: new Date(`${date}T00:00:00Z`),
+      close,
+    })),
+  };
+}
+
 function createProvider(historyBySymbol: Record<string, number[]>, currencyBySymbol: Record<string, string>): DataProvider {
   return {
     id: "test-provider",
@@ -99,6 +121,22 @@ function createProvider(historyBySymbol: Record<string, number[]>, currencyBySym
       close,
     })),
   };
+}
+
+function createDatedProvider(financialsBySymbol: Record<string, TickerFinancials>): DataProvider {
+  const provider = createProvider({}, {});
+  provider.getTickerFinancials = async (symbol) => financialsBySymbol[symbol] ?? makeDatedFinancials(symbol, "USD", []);
+  provider.getQuote = async (symbol) => financialsBySymbol[symbol]?.quote ?? {
+    symbol,
+    price: 0,
+    currency: "USD",
+    change: 0,
+    changePercent: 0,
+    lastUpdated: Date.now(),
+  };
+  provider.getPriceHistory = async (symbol) => financialsBySymbol[symbol]?.priceHistory ?? [];
+  provider.getPriceHistoryForResolution = async (symbol) => financialsBySymbol[symbol]?.priceHistory ?? [];
+  return provider;
 }
 
 function createRegistrySpy(spy: { selected: string[]; focused: string[] }): PluginRegistry {
@@ -314,7 +352,7 @@ describe("comparisonChartPlugin", () => {
     expect(frame).not.toContain("side by side");
   });
 
-  test("updates every legend value from the crosshair position", async () => {
+  test("updates every return summary range value from the crosshair position", async () => {
     const provider = createProvider({
       AAPL: [100, 102, 104],
       MSFT: [200, 202, 204],
@@ -343,8 +381,12 @@ describe("comparisonChartPlugin", () => {
 
     let frame = testSetup!.captureCharFrame();
     expect(frame).not.toContain("AAPL - 1D");
-    expect(frame).toContain("AAPL $104.00 +4.00%");
-    expect(frame).toContain("MSFT $204.00 +2.00%");
+    expect(frame).toContain("Sym");
+    expect(frame).toContain("Rng");
+    expect(frame).toContain("1Y");
+    expect(frame).toContain("5Y");
+    expect(frame).toMatch(/> AAPL\s+\+4\.00%/);
+    expect(frame).toMatch(/MSFT\s+\+2\.00%/);
 
     await act(async () => {
       await testSetup!.mockMouse.moveTo(2, 4);
@@ -353,8 +395,45 @@ describe("comparisonChartPlugin", () => {
     await flushFrames();
 
     frame = testSetup!.captureCharFrame();
-    expect(frame).toContain("AAPL $100.00 0.00%");
-    expect(frame).toContain("MSFT $200.00 0.00%");
+    expect(frame).toMatch(/> AAPL\s+0\.00%/);
+    expect(frame).toMatch(/MSFT\s+0\.00%/);
+  });
+
+  test("sorts comparison summary rows by one-year return", async () => {
+    const rows = {
+      SLOW: makeDatedFinancials("SLOW", "USD", [["2025-01-02", 100], ["2026-01-02", 105]]),
+      FAST: makeDatedFinancials("FAST", "USD", [["2025-01-02", 100], ["2026-01-02", 150]]),
+      MID: makeDatedFinancials("MID", "USD", [["2025-01-02", 100], ["2026-01-02", 125]]),
+    };
+    const provider = createDatedProvider(rows);
+    setSharedMarketDataForTests(provider);
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedRegistryForTests(createRegistrySpy({ selected: [], focused: [] }));
+
+    await mountComparisonHarness({
+      axisMode: "percent",
+      symbols: ["SLOW", "FAST", "MID"],
+      symbolsText: "SLOW, FAST, MID",
+    }, [
+      makeTicker("SLOW", "USD"),
+      makeTicker("FAST", "USD"),
+      makeTicker("MID", "USD"),
+    ], Object.entries(rows));
+
+    await flushFrames();
+
+    const frame = testSetup!.captureCharFrame();
+    const table = frame.slice(frame.indexOf("Sym"));
+    const fastIndex = table.indexOf("FAST");
+    const midIndex = table.indexOf("MID");
+    const slowIndex = table.indexOf("SLOW");
+
+    expect(fastIndex).toBeGreaterThanOrEqual(0);
+    expect(midIndex).toBeGreaterThanOrEqual(0);
+    expect(slowIndex).toBeGreaterThanOrEqual(0);
+    expect(fastIndex).toBeLessThan(midIndex);
+    expect(midIndex).toBeLessThan(slowIndex);
   });
 
   test("extends lagging comparison histories with the latest quote", async () => {
@@ -406,11 +485,11 @@ describe("comparisonChartPlugin", () => {
     await flushFrames();
 
     const frame = testSetup!.captureCharFrame();
-    expect(frame).toContain("AAPL $150.00 +");
-    expect(frame).toContain("MSFT $250.00 +");
+    expect(frame).toMatch(/> AAPL\s+\+47\.06%/);
+    expect(frame).toMatch(/MSFT\s+\+23\.76%/);
   });
 
-  test("updates comparison legends from chart-owned quote streams", async () => {
+  test("updates comparison return summary from chart-owned quote streams", async () => {
     let emitQuote: ((symbol: string, price: number) => void) | null = null;
     const provider = createProvider({
       AAPL: [100, 102],
@@ -464,7 +543,7 @@ describe("comparisonChartPlugin", () => {
     await flushFrames();
 
     const frame = testSetup!.captureCharFrame();
-    expect(frame).toContain("AAPL $155.00 +");
+    expect(frame).toMatch(/> AAPL\s+\+51\.96%/);
   });
 
   test("does not refetch resolution support when only comparison prices update", async () => {

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -15,6 +15,11 @@ import {
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { EmptyState } from "../../../components";
 import { ResolvedStockChart } from "../../../components/chart/stock-chart";
+import { PriceReturnStrip } from "../../../components/price-performance";
+import {
+  appendQuoteToPriceReturnHistory,
+  buildPriceReturnFields,
+} from "../../../market-data/performance";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import {
@@ -96,6 +101,19 @@ export function OverviewTab({
     baseCurrency,
     toBase,
   });
+  const performanceFields = buildPriceReturnFields(
+    appendQuoteToPriceReturnHistory(financials?.priceHistory ?? [], quote),
+  ).map((field) => {
+    if (field.value != null) return field;
+    if (field.id === "1Y" && fundamentals?.return1Y != null) {
+      return { ...field, value: fundamentals.return1Y };
+    }
+    if (field.id === "3Y" && fundamentals?.return3Y != null) {
+      return { ...field, value: fundamentals.return3Y };
+    }
+    return field;
+  });
+  const hasPerformance = performanceFields.some((field) => field.value != null);
   const positionRows = buildPositionRows({
     ticker,
     quote,
@@ -208,6 +226,13 @@ export function OverviewTab({
             ticker={ticker}
             financials={financials}
           />
+        )}
+
+        {hasPerformance && (
+          <Box flexDirection="column">
+            <SectionHeader title="Price Return" />
+            <PriceReturnStrip fields={performanceFields} width={contentWidth} />
+          </Box>
         )}
 
         {stats.length > 0 && (

--- a/src/plugins/builtin/ticker-detail/overview/model.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.ts
@@ -90,20 +90,6 @@ export function buildOverviewStats({
       valueColor: priceColor(fundamentals.revenueGrowth),
     });
   }
-  if (fundamentals?.return1Y != null) {
-    stats.push({
-      label: "1Y Return",
-      value: formatPercent(fundamentals.return1Y),
-      valueColor: priceColor(fundamentals.return1Y),
-    });
-  }
-  if (fundamentals?.return3Y != null) {
-    stats.push({
-      label: "3Y Return",
-      value: formatPercent(fundamentals.return3Y),
-      valueColor: priceColor(fundamentals.return3Y),
-    });
-  }
   if (fundamentals?.enterpriseValue) {
     stats.push({ label: "EV", value: formatCompact(fundamentals.enterpriseValue) });
   }


### PR DESCRIPTION
## Summary
- add shared price-return calculations for 1M, 3M, 6M, 1Y, 3Y, and 5Y horizons
- show compact price-return summaries in ticker overview and comparison chart rows
- sort comparison summary rows by 1Y return with unavailable values last
- prevent Windows desktop smoke tests from self-updating the installed test copy mid-run

## Validation
- bun test src/market-data/performance.test.ts src/plugins/builtin/comparison-chart/index.test.tsx src/plugins/builtin/ticker-detail/index.test.tsx
- tmux smoke test of the app launch
- GitHub Verify Windows checks