### PR TITLE
Fix comparison performance range returns

### DIFF
--- a/src/components/chart/comparison-stock-chart/render-data.ts
+++ b/src/components/chart/comparison-stock-chart/render-data.ts
@@ -3,7 +3,8 @@ import {
   DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
   useChartQueries,
 } from "../../../market-data/hooks";
-import { buildChartKey } from "../../../market-data/selectors";
+import type { ChartRequest, InstrumentRef } from "../../../market-data/request-types";
+import { buildChartKey, resolveEntryData } from "../../../market-data/selectors";
 import { getSharedMarketData } from "../../../plugins/registry";
 import { blendHex, colors, getComparisonSeriesColor } from "../../../theme/colors";
 import type { BrokerContractRef } from "../../../types/instrument";
@@ -24,6 +25,8 @@ import type {
   ComparisonChartViewState,
 } from "../core/types";
 
+const COMPARISON_PERFORMANCE_RANGE = "5Y" as const;
+
 export interface ComparisonChartSymbolSource {
   symbol: string;
   currency: string | undefined;
@@ -38,6 +41,16 @@ export interface ComparisonChartSymbolSource {
 interface UseComparisonChartRenderDataOptions {
   symbolSources: ComparisonChartSymbolSource[];
   viewState: ComparisonChartViewState;
+}
+
+function instrumentFromSymbolSource(source: ComparisonChartSymbolSource): InstrumentRef {
+  return {
+    symbol: source.symbol,
+    exchange: source.exchange,
+    brokerId: source.brokerId,
+    brokerInstanceId: source.brokerInstanceId,
+    instrument: source.instrument,
+  };
 }
 
 export function useComparisonChartRenderData({
@@ -143,19 +156,23 @@ export function useComparisonChartRenderData({
   );
   const chartRequests = useMemo(() => (
     symbolSources.map((source) => ({
-      instrument: {
-        symbol: source.symbol,
-        exchange: source.exchange,
-        brokerId: source.brokerId,
-        brokerInstanceId: source.brokerInstanceId,
-        instrument: source.instrument,
-      },
+      instrument: instrumentFromSymbolSource(source),
       bufferRange: viewState.bufferRange,
       granularity: effectiveResolution === "auto" ? "range" as const : "resolution" as const,
       resolution: effectiveResolution === "auto" ? undefined : effectiveResolution,
     }))
   ), [effectiveResolution, symbolSources, viewState.bufferRange]);
+  const performanceRequests = useMemo<ChartRequest[]>(() => (
+    symbolSources.map((source) => ({
+      instrument: instrumentFromSymbolSource(source),
+      bufferRange: COMPARISON_PERFORMANCE_RANGE,
+      granularity: "range",
+    }))
+  ), [symbolSources]);
   const chartEntries = useChartQueries(chartRequests, {
+    refreshIntervalMs: DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
+  });
+  const performanceEntries = useChartQueries(performanceRequests, {
     refreshIntervalMs: DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
   });
   const entryStates = useMemo(() => chartRequests.map((request) => (
@@ -182,6 +199,17 @@ export function useComparisonChartRenderData({
       points,
     };
   }), [chartEntries, chartRequests, symbolSources]);
+  const performanceHistoryBySymbol = useMemo(() => {
+    const bySymbol = new Map<string, PricePoint[]>();
+    symbolSources.forEach((source, index) => {
+      const request = performanceRequests[index];
+      const history = request ? resolveEntryData(performanceEntries.get(buildChartKey(request))) : null;
+      if (history?.length) {
+        bySymbol.set(source.symbol, history);
+      }
+    });
+    return bySymbol;
+  }, [performanceEntries, performanceRequests, symbolSources]);
 
   return {
     availableManualResolutions,
@@ -192,6 +220,7 @@ export function useComparisonChartRenderData({
     isUpdating,
     resolutionChips,
     selectionSupportMap,
+    performanceHistoryBySymbol,
     series,
     supportMap,
   };

--- a/src/components/chart/comparison-stock-chart/sources.ts
+++ b/src/components/chart/comparison-stock-chart/sources.ts
@@ -24,17 +24,21 @@ export function useComparisonChartSymbolSources(symbols: string[]): {
   const marketFinancials = useTickerFinancialsMap(stableTickers);
   const symbolSources = useMemo<ComparisonChartSymbolSource[]>(() => stableSymbols.map((symbol) => {
     const ticker = tickers.get(symbol) ?? null;
-    const financial = marketFinancials.get(symbol) ?? financials.get(symbol) ?? null;
+    const marketFinancial = marketFinancials.get(symbol) ?? null;
+    const storedFinancial = financials.get(symbol) ?? null;
     const instrument = ticker?.metadata.broker_contracts?.[0] ?? null;
+    const quote = marketFinancial?.quote ?? storedFinancial?.quote;
     return {
       symbol,
-      currency: financial?.quote?.currency ?? ticker?.metadata.currency,
-      quote: financial?.quote,
+      currency: quote?.currency ?? ticker?.metadata.currency,
+      quote,
       exchange: ticker?.metadata.exchange ?? "",
       brokerId: instrument?.brokerId,
       brokerInstanceId: instrument?.brokerInstanceId,
       instrument,
-      priceHistory: financial?.priceHistory ?? [],
+      priceHistory: marketFinancial?.priceHistory?.length
+        ? marketFinancial.priceHistory
+        : storedFinancial?.priceHistory ?? [],
     };
   }), [financials, marketFinancials, stableSymbols, tickers]);
 

--- a/src/components/chart/comparison-stock-chart/view.tsx
+++ b/src/components/chart/comparison-stock-chart/view.tsx
@@ -270,6 +270,7 @@ function ComparisonStockChartView({
     isUpdating,
     resolutionChips,
     selectionSupportMap,
+    performanceHistoryBySymbol,
     series,
     supportMap,
   } = useComparisonChartRenderData({
@@ -279,7 +280,11 @@ function ComparisonStockChartView({
   const performanceBySymbol = useMemo(() => {
     const bySymbol = new Map<string, PriceReturnField[]>();
     for (const source of symbolSources) {
-      const sourceHistory = appendQuoteToPriceReturnHistory(source.priceHistory, source.quote);
+      const baselineHistory = performanceHistoryBySymbol.get(source.symbol) ?? [];
+      const sourceHistory = appendQuoteToPriceReturnHistory(
+        baselineHistory.length >= 2 ? baselineHistory : source.priceHistory,
+        source.quote,
+      );
       const fallbackHistory = series.find((entry) => entry.symbol === source.symbol)?.points ?? [];
       bySymbol.set(
         source.symbol,
@@ -287,7 +292,7 @@ function ComparisonStockChartView({
       );
     }
     return bySymbol;
-  }, [series, symbolSources]);
+  }, [performanceHistoryBySymbol, series, symbolSources]);
   const summarySymbols = useMemo(
     () => sortSymbolsByOneYearReturn(symbols, performanceBySymbol),
     [performanceBySymbol, symbols],

--- a/src/plugins/builtin/comparison-chart/index.test.tsx
+++ b/src/plugins/builtin/comparison-chart/index.test.tsx
@@ -13,7 +13,7 @@ import { Box } from "../../../ui";
 import { cloneLayout, createDefaultConfig } from "../../../types/config";
 import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
 import type { DataProvider } from "../../../types/data-provider";
-import type { TickerFinancials } from "../../../types/financials";
+import type { PricePoint, TickerFinancials } from "../../../types/financials";
 import type { PluginRegistry } from "../../registry";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
 import { setSharedMarketDataForTests, setSharedRegistryForTests } from "../../registry";
@@ -90,6 +90,13 @@ function makeDatedFinancials(symbol: string, currency: string, closes: Array<[st
   };
 }
 
+function makeDatedPriceHistory(closes: Array<[string, number]>): PricePoint[] {
+  return closes.map(([date, close]) => ({
+    date: new Date(`${date}T00:00:00Z`),
+    close,
+  }));
+}
+
 function createProvider(historyBySymbol: Record<string, number[]>, currencyBySymbol: Record<string, string>): DataProvider {
   return {
     id: "test-provider",
@@ -136,6 +143,30 @@ function createDatedProvider(financialsBySymbol: Record<string, TickerFinancials
   };
   provider.getPriceHistory = async (symbol) => financialsBySymbol[symbol]?.priceHistory ?? [];
   provider.getPriceHistoryForResolution = async (symbol) => financialsBySymbol[symbol]?.priceHistory ?? [];
+  return provider;
+}
+
+function createRangeAwareDatedProvider({
+  fullHistoryBySymbol,
+  shortHistoryBySymbol,
+}: {
+  fullHistoryBySymbol: Record<string, Array<[string, number]>>;
+  shortHistoryBySymbol: Record<string, Array<[string, number]>>;
+}): DataProvider {
+  const financialsBySymbol = Object.fromEntries(
+    Object.entries(shortHistoryBySymbol).map(([symbol, history]) => [
+      symbol,
+      makeDatedFinancials(symbol, "USD", history),
+    ]),
+  );
+  const provider = createDatedProvider(financialsBySymbol);
+  const resolveHistory = (symbol: string, range: string) => makeDatedPriceHistory(
+    range === "5Y"
+      ? fullHistoryBySymbol[symbol] ?? shortHistoryBySymbol[symbol] ?? []
+      : shortHistoryBySymbol[symbol] ?? [],
+  );
+  provider.getPriceHistory = async (symbol, _exchange, range) => resolveHistory(symbol, range);
+  provider.getPriceHistoryForResolution = async (symbol, _exchange, range) => resolveHistory(symbol, range);
   return provider;
 }
 
@@ -397,6 +428,46 @@ describe("comparisonChartPlugin", () => {
     frame = testSetup!.captureCharFrame();
     expect(frame).toMatch(/> AAPL\s+0\.00%/);
     expect(frame).toMatch(/MSFT\s+0\.00%/);
+  });
+
+  test("keeps fixed return horizons independent from the selected chart range", async () => {
+    const shortHistory = {
+      AAPL: [["2025-01-02", 180], ["2026-01-02", 200]],
+      MSFT: [["2025-01-02", 300], ["2026-01-02", 330]],
+    } satisfies Record<string, Array<[string, number]>>;
+    const fullHistory = {
+      AAPL: [["2021-01-02", 100], ["2023-01-02", 150], ["2025-01-02", 180], ["2026-01-02", 200]],
+      MSFT: [["2021-01-02", 220], ["2023-01-02", 270], ["2025-01-02", 300], ["2026-01-02", 330]],
+    } satisfies Record<string, Array<[string, number]>>;
+    const provider = createRangeAwareDatedProvider({
+      fullHistoryBySymbol: fullHistory,
+      shortHistoryBySymbol: shortHistory,
+    });
+    setSharedMarketDataForTests(provider);
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedRegistryForTests(createRegistrySpy({ selected: [], focused: [] }));
+
+    await mountComparisonHarness({
+      axisMode: "percent",
+      rangePreset: "1Y",
+      chartResolution: "1d",
+      symbols: ["AAPL", "MSFT"],
+      symbolsText: "AAPL, MSFT",
+    }, [
+      makeTicker("AAPL", "USD"),
+      makeTicker("MSFT", "USD"),
+    ], [
+      ["AAPL", makeDatedFinancials("AAPL", "USD", shortHistory.AAPL)],
+      ["MSFT", makeDatedFinancials("MSFT", "USD", shortHistory.MSFT)],
+    ]);
+
+    await flushFrames(8);
+
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("5Y");
+    expect(frame).toMatch(/> AAPL\s+\+11\.11%[^\n]*\+100\.00%/);
+    expect(frame).toMatch(/MSFT\s+\+10\.00%[^\n]*\+50\.00%/);
   });
 
   test("sorts comparison summary rows by one-year return", async () => {


### PR DESCRIPTION
## Summary
- compute comparison fixed-horizon returns from an independent 5Y performance history
- keep the range return tied to the selected chart window
- preserve stored quotes when coordinator snapshots only contain chart history

## Validation
- bun test src/plugins/builtin/comparison-chart/index.test.tsx src/market-data/performance.test.ts
- bun run build
- bun test