### PR TITLE
Improve CLI automation surface

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -67,7 +67,7 @@ For external plugins, create a directory in `~/.gloomberb/plugins/`:
 
 ## What plugins can do
 
-Use `setup()` for interactive runtime registration, and `cliCommands` for root-level CLI commands that should be discoverable without running plugin setup.
+Use `setup()` for interactive runtime registration, `capabilities` for reusable headless services, and `cli.commands` for root-level CLI commands that should be discoverable without rendering panes. The older `cliCommands` array still works, but new plugins should prefer the typed `cli.commands` descriptor because it exposes summaries, input/output shape, formats, safety notes, and side-effect level to `gloomberb help`, `gloomberb catalog --json`, and `gloomberb api list`.
 
 ## Renderer-neutral UI
 
@@ -137,7 +137,7 @@ Commands registered with `ctx.registerCommand({ shortcut, shortcutArg })` and pa
 
 ### CLI commands
 
-Plugins can also declare root CLI commands directly on the plugin object:
+Plugins can declare root CLI commands directly on the plugin object. Prefer `cli.commands` for new commands; keep `cliCommands` only for compatibility with older plugins.
 
 ```typescript
 import type { GloomPlugin } from "gloomberb/types/plugin";
@@ -146,39 +146,50 @@ export const myPlugin: GloomPlugin = {
   id: "my-plugin",
   name: "My Plugin",
   version: "1.0.0",
-  cliCommands: [
-    {
-      name: "my-plugin",
-      aliases: ["mp"],
-      description: "Run a plugin-owned CLI command",
-      help: {
-        usage: ["my-plugin [action]"],
-        sections: [{
-          title: "My Plugin CLI",
-          columns: [
-            { header: "Action" },
-            { header: "Example" },
-          ],
-          rows: [
-            ["run", "gloomberb my-plugin run"],
-          ],
-        }],
+  cli: {
+    commands: [
+      {
+        name: "my-plugin",
+        aliases: ["mp"],
+        summary: "Run a plugin-owned CLI command",
+        inputShape: "my-plugin run [--limit N]",
+        outputShape: "rows: [{ id, label }]",
+        formats: ["text", "json", "csv", "ndjson"],
+        sideEffectLevel: "none",
+        examples: ["gloomberb my-plugin run --json"],
+        async execute(args, ctx) {
+          if (args[0] !== "run") {
+            ctx.fail("Usage: gloomberb my-plugin run");
+          }
+
+          const services = await ctx.initServices();
+          try {
+            ctx.printResult(
+              {
+                data: [
+                  { id: "demo", label: `Using data dir ${services.config.dataDir}` },
+                ],
+              },
+              {
+                columns: [
+                  { key: "id", header: "ID" },
+                  { key: "label", header: "Label" },
+                ],
+              },
+            );
+          } finally {
+            services.close();
+          }
+        },
       },
-      async execute(args, ctx) {
-        if (args[0] === "run") {
-          const { config, persistence } = await ctx.initConfigData();
-          console.log(`Using data dir ${config.dataDir}`);
-          persistence.close();
-          return;
-        }
-        ctx.fail("Usage: gloomberb my-plugin run");
-      },
-    },
-  ],
+    ],
+  },
 };
 ```
 
-Each CLI command owns one root namespace and parses its own subactions internally.
+Each CLI command owns one root namespace and parses its own subactions internally. Commands should call shared service/model code or capabilities, not pane React components. Only explicit visual commands such as screenshots should route through pane rendering.
+
+For automation, prefer returning the richest useful structured model in `ctx.printResult({ data })` and use `rows`/`columns` render options to keep text, CSV, and NDJSON compact. JSON output preserves `data` and includes display-column metadata, so agents can inspect both the full model and the human/table projection without scraping terminal text.
 
 Available CLI context helpers:
 
@@ -186,6 +197,9 @@ Available CLI context helpers:
 |------|---------------|
 | `ctx.initConfigData()` | Load config, persistence, and ticker storage |
 | `ctx.initMarketData()` | Load config plus the plugin-aware asset-data router |
+| `ctx.initServices()` | Load the full headless service set, including config, persistence, ticker repository, asset-data router, news service, plugin registry, and capability registry |
+| `ctx.cliOptions` | Parsed global flags such as output format, `--limit`, `--refresh`, `--dry-run`, and `--yes` |
+| `ctx.printResult(...)` | Render text, JSON, CSV, or NDJSON through the shared CLI result contract |
 | `ctx.fail(...)` | Print an error and exit |
 | `ctx.closeAndFail(...)` | Close persistence, then print an error and exit |
 | `ctx.output.*` | CLI formatting helpers (`cliStyles`, `renderSection`, `renderTable`, `renderStat`, `colorBySign`) |
@@ -222,6 +236,27 @@ Plugins contribute data and services through capabilities. A capability declares
 - `asset-data` for quotes, financials, search, FX, price history, options, filings, holders, analyst research, corporate actions, earnings calendars, article summaries, and quote streams.
 - `news` for ticker and global news feeds.
 - `plugin-service` for narrow renderer-safe service escape hatches.
+
+Capability operations can also include CLI manifest metadata. This is what makes the operation understandable to automation without plugin-specific documentation:
+
+```typescript
+{
+  kind: "query",
+  rendererSafe: true,
+  cli: {
+    summary: "Fetch a custom research report",
+    inputShape: "{ symbol: string }",
+    outputShape: "{ symbol, rating, notes }",
+    formats: ["text", "json"],
+    sideEffectLevel: "none",
+    requirements: ["enabled plugin"],
+    examples: ['gloomberb api invoke my-plugin.research \'{"symbol":"AAPL"}\' --json'],
+  },
+  handler: async (input) => ({ symbol: input.symbol, rating: "watch", notes: [] }),
+}
+```
+
+Use `sideEffectLevel: "local-write"` for local mutations, `"network-write"` for remote writes, `"external-trade"` for order placement/cancel/modify, and `"external-side-effect"` for other irreversible external actions. Mutating CLI commands should support `--dry-run` where practical and require `--yes` for dangerous operations.
 
 ```typescript
 import { assetDataProvider, newsProvider } from "gloomberb/capabilities";

--- a/README.md
+++ b/README.md
@@ -70,21 +70,42 @@ Open command mode with `Ctrl+P`, then type a command. Press `` ` `` to open tick
 
 ## CLI
 
-Running `gloomberb` with no arguments launches the terminal UI. Use `gloomberb help` to see the full command list.
+Running `gloomberb` with no arguments launches the terminal UI. Normal commands run through a headless CLI path; use `gloomberb launch-ui` when a script should explicitly open the UI.
+
+Human-readable output is the default. Automation can opt into structured output with `--json`, `--csv`, or `--ndjson`. JSON output favors the richest fetched model available and includes display-column metadata when a command has table columns; CSV and NDJSON use the command's tabular row view. Common global flags include `--limit`, `--refresh`, `--quiet`, `--no-color`, `--dry-run`, and `--yes`.
 
 | Command | Use |
 |---------|-----|
 | `gloomberb` | Launch the terminal UI |
+| `gloomberb launch-ui` | Explicitly launch the terminal UI |
 | `gloomberb help` | Show all CLI commands |
-| `gloomberb search <query>` | Search tickers and company names |
+| `gloomberb api list|get|invoke|subscribe` | Inspect and call plugin capabilities directly |
+| `gloomberb quote <symbols>` | Fetch current quotes |
+| `gloomberb search <query>` / `provider-search <query>` | Search tickers and provider symbols |
 | `gloomberb ticker <symbol>` | Show quote, ownership, and financials |
+| `gloomberb history|financials|fundamentals|options <symbol>` | Fetch research data |
+| `gloomberb news|filings|holders|insider|13f|analyst|events|valuation <symbol>` | Fetch company research feeds |
+| `gloomberb movers|indices|sectors|fx|fear-greed|earnings` | Fetch market overview data |
+| `gloomberb econ|fred|yield-curve` | Fetch macro data |
+| `gloomberb compare|correlation|relationship <symbols>` | Compare securities |
 | `gloomberb portfolio [action]` | Manage manual portfolios |
 | `gloomberb watchlist [action]` | Manage watchlists |
+| `gloomberb notes|alerts [action]` | Manage local notes and alerts |
+| `gloomberb broker|ibkr [action]` | Inspect broker integrations; trading actions require explicit account/profile and `--yes` |
+| `gloomberb ai providers|ask|screen` | Use configured AI providers and screeners |
+| `gloomberb rss fetch <url>` | Fetch an RSS feed |
+| `gloomberb buildout|congress|substack|x-feed|tweets` | Access cloud and social data sources when an existing session is available |
+| `gloomberb provider status` | Inspect enabled data providers |
+| `gloomberb config|cache|plugin|layout|pane|debug|doctor|version|changelog` | Inspect and manage local app state |
+| `gloomberb fn [...]` | Run a pane-backed report command |
+| `gloomberb shot [...]` | Capture a pane-backed screenshot |
 | `gloomberb predictions [...]` | Launch Prediction Markets |
 | `gloomberb plugins` | List installed plugins |
 | `gloomberb install <user/repo>` | Install a plugin from GitHub |
 | `gloomberb remove <name>` | Remove an installed plugin |
 | `gloomberb update [name]` | Update plugins |
+
+Commands that need a signed-in cloud session may return `auth_required`; sign-in, account management, and chat workflows are still handled in the app UI for now.
 
 ## Plugins
 

--- a/bin/gloomberb
+++ b/bin/gloomberb
@@ -1,3 +1,3 @@
 #!/usr/bin/env bun
 
-import "../src/index.tsx"
+import "../src/cli/entry.ts"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -107,7 +107,7 @@ async function build(targetConfig: BuildTarget) {
   const target = `bun-${bunOs}-${arch}`;
   console.log(`Building ${target}...`);
   await runProcess(
-    ["bun", "build", "--compile", `--target=${target}`, "src/index.tsx", `--outfile=${outfile}`],
+    ["bun", "build", "--compile", `--target=${target}`, "src/cli/entry.ts", `--outfile=${outfile}`],
     `Failed to build ${target}`,
     { env: { ...process.env, GLOOMBERB_API_URL: "https://api.gloom.sh" } },
   );

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -58,6 +58,7 @@ export class CapabilityRegistry {
           id,
           kind: operation.kind,
           rendererSafe: operation.rendererSafe === true,
+          ...operation.cli,
         }));
       return {
         id: capability.id,

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -3,6 +3,7 @@ import type { AssetDataProvider } from "../types/data-provider";
 import type { NewsDataProvider } from "../types/capability-route-source";
 
 type CapabilityOperationKind = "read" | "query" | "action" | "stream";
+type CapabilitySideEffectLevel = "none" | "local-write" | "network-write" | "external-trade" | "external-side-effect";
 
 type CapabilityKind =
   | "asset-data"
@@ -20,9 +21,22 @@ interface CapabilityHandlerContext {
 
 type CapabilityStreamEmit<T = unknown> = (event: T) => void;
 
+export interface CapabilityOperationCliManifest {
+  summary?: string;
+  inputShape?: string;
+  outputShape?: string;
+  examples?: string[];
+  sideEffectLevel?: CapabilitySideEffectLevel;
+  requirements?: string[];
+  batch?: boolean;
+  formats?: Array<"text" | "json" | "csv" | "ndjson">;
+  safety?: string[];
+}
+
 export interface CapabilityOperation<I = unknown, O = unknown, E = unknown> {
   kind: CapabilityOperationKind;
   rendererSafe?: boolean;
+  cli?: CapabilityOperationCliManifest;
   input?: CapabilitySchema<I>;
   output?: CapabilitySchema<O>;
   cachePolicy?: CachePolicyMap[keyof CachePolicyMap];
@@ -55,6 +69,15 @@ export interface CapabilityOperationManifest {
   id: string;
   kind: CapabilityOperationKind;
   rendererSafe: boolean;
+  summary?: string;
+  inputShape?: string;
+  outputShape?: string;
+  examples?: string[];
+  sideEffectLevel?: CapabilitySideEffectLevel;
+  requirements?: string[];
+  batch?: boolean;
+  formats?: Array<"text" | "json" | "csv" | "ndjson">;
+  safety?: string[];
 }
 
 export interface CapabilityManifest {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -22,6 +22,7 @@ const originalHome = process.env.HOME;
 
 afterEach(async () => {
   process.env.HOME = originalHome;
+  process.exitCode = 0;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -96,12 +97,12 @@ async function captureConsole<T>(fn: () => Promise<T> | T): Promise<{ result: T;
   }
 }
 
-async function captureConsoleFailure(fn: () => Promise<unknown> | unknown): Promise<{ stdout: string; stderr: string; error: unknown }> {
+async function captureConsoleFailure(fn: () => Promise<unknown> | unknown): Promise<{ stdout: string; stderr: string; exitCode: string | number | undefined }> {
   const logs: string[] = [];
   const errors: string[] = [];
   const originalLog = console.log;
   const originalError = console.error;
-  const originalExit = process.exit;
+  const originalExitCode = process.exitCode;
 
   console.log = (...args: unknown[]) => {
     logs.push(args.map(String).join(" "));
@@ -109,23 +110,22 @@ async function captureConsoleFailure(fn: () => Promise<unknown> | unknown): Prom
   console.error = (...args: unknown[]) => {
     errors.push(args.map(String).join(" "));
   };
-  process.exit = ((code?: number) => {
-    throw new Error(`process.exit:${code ?? 0}`);
-  }) as typeof process.exit;
+  process.exitCode = undefined;
 
   try {
     await fn();
-    throw new Error("Expected command to fail.");
-  } catch (error) {
+    if (process.exitCode == null || process.exitCode === 0) {
+      throw new Error("Expected command to fail.");
+    }
     return {
       stdout: logs.join("\n"),
       stderr: errors.join("\n"),
-      error,
+      exitCode: process.exitCode,
     };
   } finally {
     console.log = originalLog;
     console.error = originalError;
-    process.exit = originalExit;
+    process.exitCode = originalExitCode ?? 0;
   }
 }
 
@@ -226,7 +226,7 @@ describe("CLI portfolio commands", () => {
     });
 
     const result = await captureConsoleFailure(() => runCli(["portfolio", "create", "Research"]));
-    expect(String(result.error)).toContain("process.exit:1");
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Portfolio "Research" already exists.');
   });
 
@@ -370,7 +370,7 @@ describe("CLI portfolio commands", () => {
     });
 
     const result = await captureConsoleFailure(() => runCli(["portfolio", "add", "IBKR Account", "NVDA"]));
-    expect(String(result.error)).toContain("process.exit:1");
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Portfolio "IBKR Account" is broker-managed and cannot be modified manually.');
   });
 });

--- a/src/cli/commands/api.ts
+++ b/src/cli/commands/api.ts
@@ -1,0 +1,119 @@
+import type { CliCommandDef } from "../../types/plugin";
+import { parseJsonPayload, requireArg, takeOption } from "./command-utils";
+
+function splitOperationTarget(target: string): { capabilityId: string; operationId: string } {
+  const separator = target.lastIndexOf(".");
+  if (separator <= 0 || separator === target.length - 1) {
+    throw new Error("Use <capability-id>.<operation-id>.");
+  }
+  return {
+    capabilityId: target.slice(0, separator),
+    operationId: target.slice(separator + 1),
+  };
+}
+
+function parseOperationTarget(target: string, ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  try {
+    return splitOperationTarget(target);
+  } catch (error) {
+    ctx.fail("Invalid capability operation target.", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export const apiCliCommand: CliCommandDef = {
+  name: "api",
+  description: "List, inspect, invoke, or subscribe to plugin capabilities",
+  help: {
+    usage: [
+      "api list [--kind kind]",
+      "api get <capability-id>",
+      "api invoke <capability.operation> [json-payload]",
+      "api subscribe <capability.operation> [json-payload] [--limit n]",
+    ],
+  },
+  execute: async (rawArgs, ctx) => {
+    const action = rawArgs[0] ?? "list";
+    const args = rawArgs.slice(1);
+    const services = await ctx.initServices();
+
+    try {
+      if (action === "list") {
+        const kind = takeOption(args, "--kind");
+        const manifests = services.services.pluginRegistry.capabilities
+          .manifests()
+          .filter((manifest) => !kind || manifest.kind === kind);
+        ctx.printResult({ data: manifests }, {
+          rows: (data) => data.map((manifest) => ({
+            id: manifest.id,
+            kind: manifest.kind,
+            name: manifest.name,
+            operations: manifest.operations.map((operation) => operation.id).join(", "),
+          })),
+          columns: [
+            { key: "id", header: "Capability" },
+            { key: "kind", header: "Kind" },
+            { key: "name", header: "Name" },
+            { key: "operations", header: "Operations" },
+          ],
+        });
+        return;
+      }
+
+      if (action === "get") {
+        const capabilityId = requireArg(args[0], "Usage: gloomberb api get <capability-id>", ctx);
+        const manifest = services.services.pluginRegistry.capabilities
+          .manifests()
+          .find((entry) => entry.id === capabilityId);
+        if (!manifest) ctx.fail(`Capability "${capabilityId}" is not available.`);
+        ctx.printResult({ data: manifest });
+        return;
+      }
+
+      if (action === "invoke") {
+        const target = requireArg(args[0], "Usage: gloomberb api invoke <capability.operation> [json-payload]", ctx);
+        const operationTarget = parseOperationTarget(target, ctx);
+        const payload = parseJsonPayload(args[1], ctx);
+        const data = await services.services.pluginRegistry.capabilities.invoke(
+          operationTarget.capabilityId,
+          operationTarget.operationId,
+          payload,
+        );
+        ctx.printResult({ data });
+        return;
+      }
+
+      if (action === "subscribe") {
+        const target = requireArg(args[0], "Usage: gloomberb api subscribe <capability.operation> [json-payload] [--limit n]", ctx);
+        const operationTarget = parseOperationTarget(target, ctx);
+        const limit = ctx.cliOptions.limit ?? 10;
+        const payload = parseJsonPayload(args[1], ctx);
+        let count = 0;
+        let subscriptionId: string | null = null;
+        await new Promise<void>(async (resolve, reject) => {
+          try {
+            subscriptionId = await services.services.pluginRegistry.capabilities.subscribe(
+              operationTarget.capabilityId,
+              operationTarget.operationId,
+              payload,
+              (event) => {
+                count += 1;
+                ctx.printResult({ data: event });
+                if (count >= limit && subscriptionId) {
+                  services.services.pluginRegistry.capabilities.unsubscribe(subscriptionId);
+                  resolve();
+                }
+              },
+            );
+          } catch (error) {
+            reject(error);
+          }
+        });
+        return;
+      }
+
+      ctx.fail("Usage: gloomberb api list|get|invoke|subscribe");
+    } finally {
+      services.destroy();
+    }
+  },
+};

--- a/src/cli/commands/automation.ts
+++ b/src/cli/commands/automation.ts
@@ -1,0 +1,173 @@
+import { detectProviders, getAiProvider } from "../../plugins/builtin/ai/providers";
+import { runAiPrompt } from "../../plugins/builtin/ai/runner";
+import { createRssNewsCapability } from "../../plugins/builtin/news/wire/rss/source";
+import type { CliCommandDef } from "../../types/plugin";
+import { requireArg, takeOption } from "./command-utils";
+
+function deferredResult(command: string, code: "auth_required" | "not_implemented", message: string) {
+  return {
+    command,
+    status: code,
+    code,
+    message,
+  };
+}
+
+export const brokerCliCommand: CliCommandDef = {
+  name: "broker",
+  aliases: ["brokers"],
+  description: "Inspect broker profiles and guarded broker operations",
+  help: { usage: ["broker list", "broker status", "broker add|edit|remove|connect|sync"] },
+  execute: async (args, ctx) => {
+    const action = args[0] ?? "list";
+    const services = await ctx.initServices();
+    try {
+      if (action === "list" || action === "status") {
+        const rows = services.config.brokerInstances.map((instance) => ({
+          id: instance.id,
+          type: instance.brokerType,
+          label: instance.label,
+          enabled: instance.enabled !== false,
+          connectionMode: instance.connectionMode ?? "",
+          lastSyncedAt: instance.lastSyncedAt ? new Date(instance.lastSyncedAt).toISOString() : "",
+        }));
+        ctx.printResult({ data: rows });
+        return;
+      }
+
+      ctx.printResult({
+        data: deferredResult("broker", "not_implemented", "Broker mutation and connection commands need shared non-UI broker service extraction before they can safely run headless."),
+      });
+    } finally {
+      services.destroy();
+    }
+  },
+};
+
+export const ibkrCliCommand: CliCommandDef = {
+  name: "ibkr",
+  description: "Guarded IBKR account, order preview, and order action commands",
+  help: { usage: ["ibkr accounts|positions|orders|preview|place|cancel"] },
+  execute: async (args, ctx) => {
+    const action = args[0] ?? "status";
+    const profile = takeOption(args, "--profile");
+    const account = takeOption(args, "--account");
+    if ((action === "place" || action === "cancel") && (!profile || !account || !ctx.cliOptions.yes)) {
+      ctx.fail(`ibkr ${action} requires --profile, --account, and --yes.`);
+    }
+    const services = await ctx.initServices();
+    try {
+      const ibkrProfiles = services.config.brokerInstances.filter((instance) => instance.brokerType === "ibkr");
+      if (action === "accounts" || action === "status") {
+        ctx.printResult({ data: ibkrProfiles.map((instance) => ({
+          id: instance.id,
+          label: instance.label,
+          enabled: instance.enabled !== false,
+          connectionMode: instance.connectionMode ?? "",
+          lastSyncedAt: instance.lastSyncedAt ? new Date(instance.lastSyncedAt).toISOString() : "",
+        })) });
+        return;
+      }
+      ctx.printResult({
+        data: {
+          ...deferredResult("ibkr", "not_implemented", "IBKR trading commands are registered with safety gates, but headless order/account service extraction is still required."),
+          action,
+          profile: profile ?? null,
+          account: account ?? null,
+          dryRun: ctx.cliOptions.dryRun,
+          confirmed: ctx.cliOptions.yes,
+        },
+      });
+    } finally {
+      services.destroy();
+    }
+  },
+};
+
+export const aiCliCommand: CliCommandDef = {
+  name: "ai",
+  description: "Inspect AI providers and run guarded headless AI prompts",
+  help: { usage: ["ai providers", "ai ask [--provider id] <prompt>", "ai screen list|show|delete|refresh|export"] },
+  execute: async (args, ctx) => {
+    const action = args[0] ?? "providers";
+    if (action === "providers") {
+      ctx.printResult({ data: detectProviders().map((provider) => ({
+        id: provider.id,
+        name: provider.name,
+        command: provider.command,
+        available: provider.available,
+      })) });
+      return;
+    }
+    if (action === "ask") {
+      const rawArgs = args.slice(1);
+      const providerId = takeOption(rawArgs, "--provider") ?? detectProviders().find((provider) => provider.available)?.id;
+      const provider = getAiProvider(providerId);
+      if (!provider) ctx.fail("Unknown AI provider.");
+      const selectedProvider = provider;
+      if (!selectedProvider.available) ctx.fail(`${selectedProvider.name} is not installed or not available in PATH.`);
+      const prompt = rawArgs.join(" ").trim();
+      if (!prompt) ctx.fail("Usage: gloomberb ai ask [--provider id] <prompt>");
+      const controller = runAiPrompt({ provider: selectedProvider, prompt, cwd: process.cwd() });
+      const text = await controller.done;
+      ctx.printResult({ data: { provider: selectedProvider.id, text } });
+      return;
+    }
+    if (action === "screen") {
+      ctx.printResult({
+        data: deferredResult("ai screen", "not_implemented", "AI screener tabs are still pane-state backed; expose them through a shared non-UI screener store before headless mutation."),
+      });
+      return;
+    }
+    ctx.fail("Usage: gloomberb ai providers|ask|screen");
+  },
+};
+
+export const rssCliCommand: CliCommandDef = {
+  name: "rss",
+  description: "Fetch an RSS feed as news rows",
+  help: { usage: ["rss fetch <url> [--name label]"] },
+  execute: async (args, ctx) => {
+    const action = args[0] ?? "fetch";
+    if (action !== "fetch") ctx.fail("Usage: gloomberb rss fetch <url> [--name label]");
+    const rawArgs = args.slice(1);
+    const name = takeOption(rawArgs, "--name") ?? "RSS";
+    const url = requireArg(rawArgs[0], "Usage: gloomberb rss fetch <url> [--name label]", ctx);
+    const capability = createRssNewsCapability([{
+      id: "cli-feed",
+      url,
+      name,
+      category: "cli",
+      authority: 50,
+      enabled: true,
+    }]);
+    const articles = await capability.provider.fetchNews({ feed: "latest", limit: ctx.cliOptions.limit ?? 20 });
+    ctx.printResult({ data: articles.map((article) => ({
+      title: article.title,
+      source: article.source,
+      publishedAt: article.publishedAt.toISOString(),
+      url: article.url,
+      summary: article.summary ?? "",
+    })) });
+  },
+};
+
+function cloudCommand(name: string, description: string): CliCommandDef {
+  return {
+    name,
+    description,
+    execute: (_args, ctx) => {
+      ctx.printResult({
+        data: deferredResult(name, "auth_required", "This command needs an existing cloud/session token. New auth/account/chat CLI workflows are deferred in this pass."),
+      });
+    },
+  };
+}
+
+export const cloudCliCommands: CliCommandDef[] = [
+  cloudCommand("buildout", "Fetch Buildout company data through an existing cloud session"),
+  cloudCommand("congress", "Fetch congressional trade data through an existing cloud session"),
+  cloudCommand("substack", "Fetch Substack reader data through an existing session"),
+  cloudCommand("x-feed", "Fetch X/Twitter feed data through an existing cloud session"),
+  cloudCommand("tweets", "Alias for x-feed"),
+];

--- a/src/cli/commands/command-utils.ts
+++ b/src/cli/commands/command-utils.ts
@@ -1,0 +1,53 @@
+import type { CliCommandContext } from "../../types/plugin";
+
+export function takeOption(args: string[], name: string): string | undefined {
+  const equalsPrefix = `${name}=`;
+  const equalsIndex = args.findIndex((arg) => arg.startsWith(equalsPrefix));
+  if (equalsIndex >= 0) {
+    const [value] = args.splice(equalsIndex, 1);
+    return value!.slice(equalsPrefix.length);
+  }
+
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  args.splice(index, value == null ? 1 : 2);
+  return value;
+}
+
+export function takeFlag(args: string[], name: string): boolean {
+  const index = args.indexOf(name);
+  if (index < 0) return false;
+  args.splice(index, 1);
+  return true;
+}
+
+export function parseJsonPayload(value: string | undefined, ctx: CliCommandContext): unknown {
+  if (!value) return {};
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    ctx.fail("Payload must be valid JSON.", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function parsePositiveInt(value: string | undefined, fallback: number, label: string, ctx: CliCommandContext): number {
+  if (value == null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    ctx.fail(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+export function requireArg(value: string | undefined, usage: string, ctx: CliCommandContext): string {
+  if (!value) ctx.fail(usage);
+  return value;
+}
+
+export function isoDate(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") return new Date(value).toISOString();
+  if (typeof value === "string") return value;
+  return "";
+}

--- a/src/cli/commands/market.ts
+++ b/src/cli/commands/market.ts
@@ -1,0 +1,527 @@
+import type { CliCommandDef } from "../../types/plugin";
+import type { TimeRange } from "../../components/chart/core/types";
+import type { EarningsEvent, QuoteBatchResult, SecFilingItem } from "../../types/data-provider";
+import type { NewsArticle, NewsFeed, NewsQuery } from "../../news/types";
+import type {
+  AnalystResearchData,
+  CorporateActionsData,
+  HolderData,
+  OptionsChain,
+  PricePoint,
+  TickerFinancials,
+} from "../../types/financials";
+import { formatMarketPriceWithCurrency } from "../../market-data/market/format";
+import { formatCompact } from "../../utils/format";
+import { isoDate, parsePositiveInt, requireArg, takeOption } from "./command-utils";
+
+const VALID_RANGES = new Set<TimeRange>(["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"]);
+const VALID_NEWS_FEEDS = new Set<NewsFeed>(["latest", "top", "breaking", "ticker", "sector", "topic"]);
+
+type QuoteCliRecord = Omit<QuoteBatchResult, "error"> & { error: string | null };
+type FinancialsCliData = TickerFinancials & {
+  symbol: string;
+  exchange: string;
+  providerId: string | null;
+};
+
+function parseRange(value: string | undefined): TimeRange {
+  const range = (value ?? "1Y").toUpperCase() as TimeRange;
+  return VALID_RANGES.has(range) ? range : "1Y";
+}
+
+function parseNewsFeed(value: string | undefined): NewsQuery["feed"] | undefined {
+  return value && VALID_NEWS_FEEDS.has(value as NewsFeed) ? value as NewsQuery["feed"] : undefined;
+}
+
+function normalizeSymbols(args: string[]): string[] {
+  return args
+    .flatMap((arg) => arg.split(","))
+    .map((symbol) => symbol.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function quoteColumns() {
+  return [
+    { key: "symbol", header: "Symbol" },
+    { key: "name", header: "Name" },
+    { key: "price", header: "Last", align: "right" as const },
+    { key: "changePercent", header: "Chg%", align: "right" as const },
+    { key: "currency", header: "Cur" },
+    { key: "source", header: "Source" },
+    { key: "updatedAt", header: "Updated" },
+  ];
+}
+
+function errorMessage(error: unknown): string | null {
+  if (error == null) return null;
+  return error instanceof Error ? error.message : String(error);
+}
+
+function quoteRows(results: QuoteCliRecord[]) {
+  return results.map((result) => {
+    const quote = result.quote;
+    return {
+      symbol: result.target.symbol,
+      name: quote?.name ?? "",
+      price: quote ? formatMarketPriceWithCurrency(quote.price, quote.currency) : "",
+      rawPrice: quote?.price ?? null,
+      change: quote?.change ?? null,
+      changePercent: quote?.changePercent == null ? null : Number(quote.changePercent.toFixed(2)),
+      currency: quote?.currency ?? "",
+      providerId: quote?.providerId ?? "",
+      source: quote?.dataSource ?? quote?.providerId ?? "",
+      updatedAt: quote?.lastUpdated ? new Date(quote.lastUpdated).toISOString() : "",
+      error: result.error ?? "",
+    };
+  });
+}
+
+function historyRows(points: PricePoint[]) {
+  return points.map((point) => ({
+    date: isoDate(point.date).slice(0, 10),
+    open: point.open ?? null,
+    high: point.high ?? null,
+    low: point.low ?? null,
+    close: point.close,
+    volume: point.volume ?? null,
+  }));
+}
+
+function financialStatementRows(financials: FinancialsCliData) {
+  return financials.annualStatements.slice(0, 8).map((statement) => ({
+    date: statement.date,
+    revenue: statement.totalRevenue ?? statement.operatingRevenue ?? null,
+    grossProfit: statement.grossProfit ?? null,
+    operatingIncome: statement.operatingIncome ?? null,
+    netIncome: statement.netIncome ?? statement.netIncomeCommonStockholders ?? null,
+    eps: statement.eps ?? statement.basicEps ?? null,
+  }));
+}
+
+function newsRows(articles: NewsArticle[]) {
+  return articles.map((article) => ({
+    title: article.title,
+    source: article.source,
+    publishedAt: isoDate(article.publishedAt),
+    topic: article.topic,
+    tickers: article.tickers.join(","),
+    url: article.url,
+    importance: article.importance,
+    breaking: article.isBreaking,
+  }));
+}
+
+function filingRows(filings: SecFilingItem[]) {
+  return filings.map((filing) => ({
+    form: filing.form,
+    filingDate: isoDate(filing.filingDate).slice(0, 10),
+    companyName: filing.companyName ?? "",
+    accessionNumber: filing.accessionNumber,
+    url: filing.primaryDocumentUrl ?? filing.filingUrl,
+  }));
+}
+
+function holderRows(data: HolderData, ownerTypes?: Set<string>) {
+  const holders = ownerTypes
+    ? data.holders.filter((holder) => ownerTypes.has(holder.ownerType))
+    : data.holders;
+  return holders.map((holder) => ({
+    type: holder.ownerType,
+    name: holder.name,
+    reportDate: holder.reportDate ?? "",
+    shares: holder.shares ?? null,
+    value: holder.value ?? null,
+    percentHeld: holder.percentHeld ?? null,
+    changeShares: holder.changeShares ?? null,
+  }));
+}
+
+function analystRows(data: AnalystResearchData) {
+  return data.ratings.map((rating) => ({
+    date: rating.date,
+    firm: rating.firm,
+    action: rating.action ?? "",
+    current: rating.current ?? "",
+    prior: rating.prior ?? "",
+    target: rating.currentPriceTarget ?? null,
+  }));
+}
+
+function corporateActionRows(data: CorporateActionsData) {
+  return [
+    ...data.earnings.map((event) => ({
+      type: "earnings",
+      date: event.date,
+      detail: event.epsActual == null ? `est ${event.epsEstimate ?? ""}` : `eps ${event.epsActual}`,
+    })),
+    ...data.dividends.map((event) => ({
+      type: "dividend",
+      date: event.exDate,
+      detail: String(event.amount),
+    })),
+    ...data.splits.map((event) => ({
+      type: "split",
+      date: event.date,
+      detail: event.description ?? `${event.fromFactor ?? ""}:${event.toFactor ?? ""}`,
+    })),
+  ].sort((left, right) => right.date.localeCompare(left.date));
+}
+
+function optionRows(chain: OptionsChain) {
+  return [...chain.calls.map((contract) => ({ side: "call", ...contract })), ...chain.puts.map((contract) => ({ side: "put", ...contract }))]
+    .map((contract) => ({
+      side: contract.side,
+      contract: contract.contractSymbol,
+      strike: contract.strike,
+      last: contract.lastPrice,
+      bid: contract.bid,
+      ask: contract.ask,
+      volume: contract.volume,
+      openInterest: contract.openInterest,
+      iv: contract.impliedVolatility,
+      expiration: new Date(contract.expiration * 1000).toISOString().slice(0, 10),
+    }));
+}
+
+function earningsRows(events: EarningsEvent[]) {
+  return events.map((event) => ({
+    symbol: event.symbol,
+    name: event.name,
+    date: isoDate(event.earningsDate).slice(0, 10),
+    timing: event.timing,
+    epsEstimate: event.epsEstimate,
+    epsActual: event.epsActual,
+    revenueEstimate: event.revenueEstimate,
+    revenueActual: event.revenueActual,
+  }));
+}
+
+async function runQuote(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const args = [...rawArgs];
+  const exchange = takeOption(args, "--exchange") ?? "";
+  const symbols = normalizeSymbols(args);
+  if (symbols.length === 0) ctx.fail("Usage: gloomberb quote <symbol...>");
+
+  const market = await ctx.initMarketData();
+  try {
+    const results = await market.dataProvider.getQuotesBatch(
+      symbols.map((symbol) => ({ symbol, exchange })),
+      { forceRefresh: ctx.cliOptions.refresh },
+    );
+    const data = results.map((result) => ({
+      target: result.target,
+      quote: result.quote,
+      error: errorMessage(result.error),
+    }));
+    ctx.printResult({ data }, { rows: quoteRows, columns: quoteColumns() });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runHistory(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const args = [...rawArgs];
+  const range = parseRange(takeOption(args, "--range"));
+  const requestedExchange = takeOption(args, "--exchange") ?? "";
+  const symbol = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb history <symbol> [--range 1Y]", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const localTicker = requestedExchange ? null : await market.store.loadTicker(symbol);
+    const exchange = requestedExchange || localTicker?.metadata.exchange || "";
+    const points = await market.dataProvider.getPriceHistory(symbol, exchange, range);
+    const data = historyRows(points);
+    ctx.printResult({ data, metadata: { symbol, range, exchange } }, {
+      columns: [
+        { key: "date", header: "Date" },
+        { key: "open", header: "Open", align: "right" },
+        { key: "high", header: "High", align: "right" },
+        { key: "low", header: "Low", align: "right" },
+        { key: "close", header: "Close", align: "right" },
+        { key: "volume", header: "Volume", align: "right" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runFinancials(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1], fundamentalsOnly = false) {
+  const args = [...rawArgs];
+  const exchange = takeOption(args, "--exchange") ?? "";
+  const symbol = requireArg(args[0]?.toUpperCase(), fundamentalsOnly ? "Usage: gloomberb fundamentals <symbol>" : "Usage: gloomberb financials <symbol>", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const financials = await market.dataProvider.getTickerFinancials(symbol, exchange, {
+      cacheMode: ctx.cliOptions.refresh ? "refresh" : "default",
+    });
+    const data: FinancialsCliData = {
+      symbol,
+      exchange,
+      providerId: financials.quote?.providerId ?? null,
+      ...financials,
+    };
+    if (fundamentalsOnly) {
+      ctx.printResult({ data });
+      return;
+    }
+    ctx.printResult({
+      data,
+      metadata: {
+        symbol,
+        providerId: financials.quote?.providerId,
+        annualStatements: financials.annualStatements.length,
+        quarterlyStatements: financials.quarterlyStatements.length,
+        fundamentals: financials.fundamentals,
+        profile: financials.profile,
+      },
+    }, {
+      rows: financialStatementRows,
+      columns: [
+        { key: "date", header: "Date" },
+        { key: "revenue", header: "Revenue", align: "right", value: (row) => row.revenue == null ? "" : formatCompact(Number(row.revenue)) },
+        { key: "grossProfit", header: "Gross", align: "right", value: (row) => row.grossProfit == null ? "" : formatCompact(Number(row.grossProfit)) },
+        { key: "operatingIncome", header: "Op Inc", align: "right", value: (row) => row.operatingIncome == null ? "" : formatCompact(Number(row.operatingIncome)) },
+        { key: "netIncome", header: "Net Inc", align: "right", value: (row) => row.netIncome == null ? "" : formatCompact(Number(row.netIncome)) },
+        { key: "eps", header: "EPS", align: "right" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runNews(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const args = [...rawArgs];
+  const feed = parseNewsFeed(takeOption(args, "--feed"));
+  const ticker = args[0]?.toUpperCase();
+  const market = await ctx.initMarketData();
+  try {
+    const limit = ctx.cliOptions.limit ?? 20;
+    const articles = await market.dataProvider.getNews({
+      feed: feed ?? (ticker ? "ticker" : "latest"),
+      scope: ticker ? "ticker" : "global",
+      ticker,
+      limit,
+    });
+    ctx.printResult({ data: articles, metadata: { ticker: ticker ?? null, feed: feed ?? null } }, {
+      rows: newsRows,
+      columns: [
+        { key: "publishedAt", header: "Published" },
+        { key: "source", header: "Source" },
+        { key: "title", header: "Title" },
+        { key: "tickers", header: "Tickers" },
+        { key: "url", header: "URL" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runFilings(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const args = [...rawArgs];
+  const count = parsePositiveInt(takeOption(args, "--count"), ctx.cliOptions.limit ?? 15, "Count", ctx);
+  const exchange = takeOption(args, "--exchange") ?? "";
+  const symbol = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb filings <symbol>", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const filings = await market.dataProvider.getSecFilings(symbol, count, exchange);
+    ctx.printResult({ data: filings, metadata: { symbol } }, {
+      rows: filingRows,
+      columns: [
+        { key: "filingDate", header: "Date" },
+        { key: "form", header: "Form" },
+        { key: "companyName", header: "Company" },
+        { key: "url", header: "URL" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runHolders(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1], ownerTypes?: Set<string>) {
+  const args = [...rawArgs];
+  const exchange = takeOption(args, "--exchange") ?? "";
+  const symbol = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb holders <symbol>", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const data = await market.dataProvider.getHolders(symbol, exchange);
+    ctx.printResult({ data, metadata: { symbol, summary: data.summary } }, {
+      rows: (holderData) => holderRows(holderData, ownerTypes),
+      columns: [
+        { key: "type", header: "Type" },
+        { key: "name", header: "Holder" },
+        { key: "reportDate", header: "Date" },
+        { key: "shares", header: "Shares", align: "right" },
+        { key: "value", header: "Value", align: "right", value: (row) => row.value == null ? "" : formatCompact(Number(row.value)) },
+        { key: "percentHeld", header: "% Held", align: "right" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runAnalyst(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const args = [...rawArgs];
+  const exchange = takeOption(args, "--exchange") ?? "";
+  const symbol = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb analyst <symbol>", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const data = await market.dataProvider.getAnalystResearch(symbol, exchange);
+    ctx.printResult({
+      data,
+      metadata: {
+        symbol,
+        recommendationRating: data.recommendationRating,
+        priceTarget: data.priceTarget,
+        recommendations: data.recommendations,
+      },
+    }, {
+      rows: analystRows,
+      columns: [
+        { key: "date", header: "Date" },
+        { key: "firm", header: "Firm" },
+        { key: "action", header: "Action" },
+        { key: "current", header: "Current" },
+        { key: "target", header: "Target", align: "right" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runEvents(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const args = [...rawArgs];
+  const exchange = takeOption(args, "--exchange") ?? "";
+  const symbol = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb events <symbol>", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const data = await market.dataProvider.getCorporateActions(symbol, exchange);
+    ctx.printResult({ data, metadata: { symbol } }, {
+      rows: corporateActionRows,
+      columns: [
+        { key: "date", header: "Date" },
+        { key: "type", header: "Type" },
+        { key: "detail", header: "Detail" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runOptions(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const args = [...rawArgs];
+  const expiration = takeOption(args, "--expiration");
+  const exchange = takeOption(args, "--exchange") ?? "";
+  const symbol = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb options <symbol>", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const chain = await market.dataProvider.getOptionsChain(
+      symbol,
+      exchange,
+      expiration == null ? undefined : Number(expiration),
+    );
+    ctx.printResult({ data: chain, metadata: { symbol, expirations: chain.expirationDates } }, {
+      rows: optionRows,
+      columns: [
+        { key: "side", header: "Side" },
+        { key: "contract", header: "Contract" },
+        { key: "expiration", header: "Expiry" },
+        { key: "strike", header: "Strike", align: "right" },
+        { key: "last", header: "Last", align: "right" },
+        { key: "bid", header: "Bid", align: "right" },
+        { key: "ask", header: "Ask", align: "right" },
+        { key: "volume", header: "Vol", align: "right" },
+        { key: "openInterest", header: "OI", align: "right" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runFx(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const currency = requireArg(rawArgs[0]?.toUpperCase(), "Usage: gloomberb fx <currency>", ctx);
+  const market = await ctx.initMarketData();
+  try {
+    const rate = await market.dataProvider.getExchangeRate(currency);
+    ctx.printResult({ data: [{ currency, baseCurrency: market.config.baseCurrency, rate }] }, {
+      columns: [
+        { key: "currency", header: "Currency" },
+        { key: "baseCurrency", header: "Base" },
+        { key: "rate", header: "Rate", align: "right" },
+      ],
+    });
+  } finally {
+    market.persistence.close();
+  }
+}
+
+async function runEarnings(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const symbols = normalizeSymbols([...rawArgs]);
+  if (symbols.length === 0) ctx.fail("Usage: gloomberb earnings <symbol...>");
+  const services = await ctx.initServices();
+  try {
+    let events: EarningsEvent[] = [];
+    for (const { capability } of services.services.pluginRegistry.capabilities.list("asset-data")) {
+      if (!capability.operations.getEarningsCalendar?.handler) continue;
+      try {
+        events = await services.services.pluginRegistry.capabilities.invoke<EarningsEvent[]>(
+          capability.id,
+          "getEarningsCalendar",
+          { symbols },
+        );
+      } catch {
+        continue;
+      }
+      if (events.length > 0) break;
+    }
+    ctx.printResult({ data: events }, {
+      rows: earningsRows,
+      columns: [
+        { key: "date", header: "Date" },
+        { key: "symbol", header: "Symbol" },
+        { key: "name", header: "Name" },
+        { key: "timing", header: "Timing" },
+        { key: "epsEstimate", header: "EPS Est", align: "right" },
+        { key: "epsActual", header: "EPS", align: "right" },
+      ],
+    });
+  } finally {
+    services.destroy();
+  }
+}
+
+export const marketDataCliCommands: CliCommandDef[] = [
+  { name: "quote", description: "Fetch one or more quotes", help: { usage: ["quote <symbol...>"] }, execute: runQuote },
+  { name: "provider-search", description: "Search provider instruments", help: { usage: ["provider-search <query>"] }, execute: async (args, ctx) => {
+    const query = args.join(" ");
+    if (!query) ctx.fail("Usage: gloomberb provider-search <query>");
+    const market = await ctx.initMarketData();
+    try {
+      const results = await market.dataProvider.search(query);
+      ctx.printResult({ data: results.slice(0, ctx.cliOptions.limit ?? results.length) });
+    } finally {
+      market.persistence.close();
+    }
+  } },
+  { name: "history", description: "Fetch historical prices", help: { usage: ["history <symbol> [--range 1Y]"] }, execute: runHistory },
+  { name: "financials", description: "Fetch annual financial statements", help: { usage: ["financials <symbol>"] }, execute: (args, ctx) => runFinancials(args, ctx, false) },
+  { name: "fundamentals", description: "Fetch fundamentals and profile data", help: { usage: ["fundamentals <symbol>"] }, execute: (args, ctx) => runFinancials(args, ctx, true) },
+  { name: "news", description: "Fetch market or ticker news", help: { usage: ["news [symbol] [--feed latest|top|ticker]"] }, execute: runNews },
+  { name: "filings", description: "Fetch SEC filings", help: { usage: ["filings <symbol>"] }, execute: runFilings },
+  { name: "holders", description: "Fetch holder data", help: { usage: ["holders <symbol>"] }, execute: (args, ctx) => runHolders(args, ctx) },
+  { name: "insider", description: "Fetch insider holder rows", help: { usage: ["insider <symbol>"] }, execute: (args, ctx) => runHolders(args, ctx, new Set(["insider", "direct"])) },
+  { name: "13f", description: "Fetch institutional and fund holder rows", help: { usage: ["13f <symbol>"] }, execute: (args, ctx) => runHolders(args, ctx, new Set(["institution", "fund"])) },
+  { name: "analyst", description: "Fetch analyst research and ratings", help: { usage: ["analyst <symbol>"] }, execute: runAnalyst },
+  { name: "events", description: "Fetch dividends, splits, and earnings events", help: { usage: ["events <symbol>"] }, execute: runEvents },
+  { name: "valuation", description: "Fetch valuation-related fundamentals", help: { usage: ["valuation <symbol>"] }, execute: (args, ctx) => runFinancials(args, ctx, true) },
+  { name: "options", description: "Fetch options chain rows", help: { usage: ["options <symbol> [--expiration unix]"] }, execute: runOptions },
+  { name: "compare", description: "Compare quotes for several symbols", help: { usage: ["compare <symbol...>"] }, execute: runQuote },
+  { name: "fx", description: "Fetch exchange rate into the configured base currency", help: { usage: ["fx <currency>"] }, execute: runFx },
+  { name: "earnings", description: "Fetch earnings calendar entries for symbols", help: { usage: ["earnings <symbol...>"] }, execute: runEarnings },
+];

--- a/src/cli/commands/overview.ts
+++ b/src/cli/commands/overview.ts
@@ -1,0 +1,222 @@
+import { apiClient } from "../../api-client";
+import type { CliCommandDef } from "../../types/plugin";
+import { formatCompact } from "../../utils/format";
+import { attachFearGreedPersistence, loadFearGreed, resetFearGreedPersistence } from "../../plugins/builtin/fear-greed/cache";
+import { createPluginPersistence } from "../../plugins/plugin-persistence";
+import {
+  fetchScreener,
+  fetchTrending,
+  MARKET_SUMMARY_SYMBOLS,
+  type ScreenerCategory,
+} from "../../plugins/builtin/market-movers/screener";
+import { loadCalendar, matchesCountry, matchesImpact, type CountryFilter, type ImpactFilter } from "../../plugins/builtin/econ/calendar-model";
+import { isoDate, requireArg, takeOption } from "./command-utils";
+
+const SECTOR_ETFS = [
+  "XLC", "XLY", "XLP", "XLE", "XLF", "XLV", "XLI", "XLK", "XLB", "XLRE", "XLU",
+];
+
+function screenerCategory(value: string | undefined): ScreenerCategory | "trending" {
+  if (value === "losers") return "day_losers";
+  if (value === "active" || value === "most-active") return "most_actives";
+  if (value === "trending") return "trending";
+  return "day_gainers";
+}
+
+function quoteRows(results: Awaited<ReturnType<NonNullable<import("../../types/data-provider").AssetDataProvider["getQuotesBatch"]>>>) {
+  return results.map((result) => {
+    const quote = result.quote;
+    return {
+      symbol: result.target.symbol,
+      name: quote?.name ?? "",
+      price: quote?.price ?? null,
+      change: quote?.change ?? null,
+      changePercent: quote?.changePercent == null ? null : Number(quote.changePercent.toFixed(2)),
+      currency: quote?.currency ?? "",
+      providerId: quote?.providerId ?? "",
+      marketCap: quote?.marketCap ?? null,
+    };
+  });
+}
+
+async function runMoverCommand(args: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const category = screenerCategory(args[0]);
+  const limit = ctx.cliOptions.limit ?? 25;
+  if (category === "trending") {
+    const services = await ctx.initServices();
+    try {
+      const trending = await fetchTrending(limit, undefined, { forceRefresh: ctx.cliOptions.refresh });
+      const results = await services.dataProvider.getQuotesBatch(
+        trending.map(({ symbol }) => ({ symbol, exchange: "" })),
+        { forceRefresh: ctx.cliOptions.refresh },
+      );
+      ctx.printResult({ data: quoteRows(results), metadata: { category } });
+    } finally {
+      services.destroy();
+    }
+    return;
+  }
+
+  const rows = await fetchScreener(category, limit, undefined, { forceRefresh: ctx.cliOptions.refresh });
+  ctx.printResult({ data: rows }, {
+    columns: [
+      { key: "symbol", header: "Symbol" },
+      { key: "name", header: "Name" },
+      { key: "price", header: "Last", align: "right" },
+      { key: "changePercent", header: "Chg%", align: "right" },
+      { key: "volume", header: "Volume", align: "right", value: (row) => formatCompact(Number(row.volume)) },
+      { key: "marketCap", header: "Mkt Cap", align: "right", value: (row) => row.marketCap == null ? "" : formatCompact(Number(row.marketCap)) },
+    ],
+  });
+}
+
+async function runQuoteBasket(symbols: string[], ctx: Parameters<CliCommandDef["execute"]>[1], metadata: Record<string, unknown>) {
+  const services = await ctx.initServices();
+  try {
+    const results = await services.dataProvider.getQuotesBatch(
+      symbols.map((symbol) => ({ symbol, exchange: "" })),
+      { forceRefresh: ctx.cliOptions.refresh },
+    );
+    ctx.printResult({ data: quoteRows(results), metadata }, {
+      columns: [
+        { key: "symbol", header: "Symbol" },
+        { key: "name", header: "Name" },
+        { key: "price", header: "Last", align: "right" },
+        { key: "changePercent", header: "Chg%", align: "right" },
+        { key: "marketCap", header: "Mkt Cap", align: "right", value: (row) => row.marketCap == null ? "" : formatCompact(Number(row.marketCap)) },
+      ],
+    });
+  } finally {
+    services.destroy();
+  }
+}
+
+async function runFearGreed(_args: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const context = await ctx.initConfigData();
+  attachFearGreedPersistence(createPluginPersistence(
+    context.persistence.pluginState,
+    context.persistence.resources,
+    "plugin:fear-greed",
+    "fear-greed",
+  ));
+  try {
+    const data = await loadFearGreed(ctx.cliOptions.refresh);
+    ctx.printResult({
+      data: [{
+        score: data.overall.score,
+        rating: data.overall.rating,
+        updatedAt: data.overall.updatedAt?.toISOString() ?? "",
+        previousClose: data.overall.previousClose,
+        previousWeek: data.overall.previousWeek,
+        previousMonth: data.overall.previousMonth,
+        previousYear: data.overall.previousYear,
+      }],
+      metadata: { indicators: data.indicators.map((indicator) => ({ id: indicator.definition.id, score: indicator.score, rating: indicator.rating })) },
+    });
+  } finally {
+    resetFearGreedPersistence();
+    context.persistence.close();
+  }
+}
+
+async function runEcon(args: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const rawArgs = [...args];
+  const country = (takeOption(rawArgs, "--country") ?? "all") as CountryFilter;
+  const impact = (takeOption(rawArgs, "--impact") ?? "all") as ImpactFilter;
+  const services = await ctx.initServices();
+  try {
+    const events = await loadCalendar(ctx.cliOptions.refresh);
+    const rows = events
+      .filter((event) => matchesCountry(event, country) && matchesImpact(event, impact))
+      .sort((left, right) => left.date.getTime() - right.date.getTime())
+      .slice(0, ctx.cliOptions.limit ?? 50)
+      .map((event) => ({
+        date: isoDate(event.date),
+        time: event.time,
+        country: event.country,
+        impact: event.impact,
+        event: event.event,
+        actual: event.actual ?? "",
+        forecast: event.forecast ?? "",
+        prior: event.prior ?? "",
+      }));
+    ctx.printResult({ data: rows, metadata: { country, impact } }, {
+      columns: [
+        { key: "date", header: "Date" },
+        { key: "time", header: "Time" },
+        { key: "country", header: "Country" },
+        { key: "impact", header: "Impact" },
+        { key: "event", header: "Event" },
+        { key: "actual", header: "Actual" },
+        { key: "forecast", header: "Forecast" },
+        { key: "prior", header: "Prior" },
+      ],
+    });
+  } finally {
+    services.destroy();
+  }
+}
+
+async function runFred(args: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const seriesId = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb fred <series-id>", ctx);
+  const startDate = takeOption(args, "--start") ?? "2021-01-01";
+  const sortOrder = (takeOption(args, "--sort") ?? "desc") as "asc" | "desc";
+  const data = await apiClient.getCloudFredSeries(seriesId, { startDate, sortOrder });
+  const rows = data.observations.slice(0, ctx.cliOptions.limit ?? data.observations.length);
+  ctx.printResult({ data: rows, metadata: { info: data.info, seriesId, startDate, sortOrder } });
+}
+
+async function runYieldCurve(args: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const startDate = takeOption(args, "--start") ?? "2021-01-01";
+  const series = ["DGS3MO", "DGS2", "DGS10", "DGS30"];
+  const results = await Promise.all(series.map(async (seriesId) => {
+    const data = await apiClient.getCloudFredSeries(seriesId, { startDate, sortOrder: "desc" });
+    const latest = data.observations[0];
+    return {
+      seriesId,
+      date: latest?.date ?? "",
+      value: latest?.value ?? null,
+      title: data.info?.title ?? "",
+    };
+  }));
+  ctx.printResult({ data: results, metadata: { startDate } });
+}
+
+async function runCorrelation(args: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
+  const left = requireArg(args[0]?.toUpperCase(), "Usage: gloomberb correlation <symbol-a> <symbol-b>", ctx);
+  const right = requireArg(args[1]?.toUpperCase(), "Usage: gloomberb correlation <symbol-a> <symbol-b>", ctx);
+  const services = await ctx.initServices();
+  try {
+    const [leftHistory, rightHistory] = await Promise.all([
+      services.dataProvider.getPriceHistory(left, "", "1Y"),
+      services.dataProvider.getPriceHistory(right, "", "1Y"),
+    ]);
+    const rightByDate = new Map(rightHistory.map((point) => [isoDate(point.date).slice(0, 10), point.close]));
+    const pairs = leftHistory
+      .map((point) => [point.close, rightByDate.get(isoDate(point.date).slice(0, 10))] as const)
+      .filter((pair): pair is readonly [number, number] => pair[1] != null);
+    const leftMean = pairs.reduce((sum, pair) => sum + pair[0], 0) / Math.max(1, pairs.length);
+    const rightMean = pairs.reduce((sum, pair) => sum + pair[1], 0) / Math.max(1, pairs.length);
+    const numerator = pairs.reduce((sum, pair) => sum + ((pair[0] - leftMean) * (pair[1] - rightMean)), 0);
+    const leftVariance = pairs.reduce((sum, pair) => sum + ((pair[0] - leftMean) ** 2), 0);
+    const rightVariance = pairs.reduce((sum, pair) => sum + ((pair[1] - rightMean) ** 2), 0);
+    const correlation = leftVariance > 0 && rightVariance > 0
+      ? numerator / Math.sqrt(leftVariance * rightVariance)
+      : null;
+    ctx.printResult({ data: [{ left, right, samples: pairs.length, correlation }] });
+  } finally {
+    services.destroy();
+  }
+}
+
+export const overviewCliCommands: CliCommandDef[] = [
+  { name: "movers", description: "Fetch gainers, losers, active, or trending market movers", help: { usage: ["movers [gainers|losers|active|trending]"] }, execute: runMoverCommand },
+  { name: "indices", description: "Fetch major US index quotes", execute: (args, ctx) => runQuoteBasket([...MARKET_SUMMARY_SYMBOLS], ctx, { group: "indices" }) },
+  { name: "sectors", description: "Fetch SPDR sector ETF quotes", execute: (args, ctx) => runQuoteBasket(SECTOR_ETFS, ctx, { group: "sectors" }) },
+  { name: "fear-greed", description: "Fetch CNN Fear & Greed gauge data", execute: runFearGreed },
+  { name: "econ", description: "Fetch economic calendar events", help: { usage: ["econ [--country US|G7|EU|all] [--impact high|medium|low|all]"] }, execute: runEcon },
+  { name: "fred", description: "Fetch a FRED series through the configured cloud session", help: { usage: ["fred <series-id> [--start yyyy-mm-dd]"] }, execute: runFred },
+  { name: "yield-curve", description: "Fetch standard Treasury yield FRED series", help: { usage: ["yield-curve [--start yyyy-mm-dd]"] }, execute: runYieldCurve },
+  { name: "correlation", description: "Compute 1Y close-price correlation for two symbols", help: { usage: ["correlation <symbol-a> <symbol-b>"] }, execute: runCorrelation },
+  { name: "relationship", description: "Alias for correlation", help: { usage: ["relationship <symbol-a> <symbol-b>"] }, execute: runCorrelation },
+];

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -12,10 +12,12 @@ import {
 import { initMarketData } from "../context";
 import { fail } from "../errors";
 import type { MarketContext } from "../types";
+import type { CliCommandContext } from "../../types/plugin";
 
 interface SearchCommandDependencies {
   initMarketData?: () => Promise<MarketContext>;
   fail?: (message: string, details?: string) => never;
+  printResult?: CliCommandContext["printResult"];
 }
 
 export async function searchCandidatesForCli({
@@ -52,6 +54,28 @@ export async function searchCandidatesForCli({
 
 function resolveSearchName(candidate: TickerSearchCandidate): string {
   return candidate.detail.split(" | ")[0] || candidate.detail || "—";
+}
+
+function searchCandidateRows(candidates: TickerSearchCandidate[]) {
+  return candidates.map((candidate) => ({
+    category: candidate.category,
+    symbol: candidate.label,
+    name: resolveSearchName(candidate),
+    exchange: candidate.result?.exchange
+      || candidate.result?.primaryExchange
+      || candidate.ticker?.metadata.exchange
+      || candidate.right
+      || "",
+    type: candidate.result?.type
+      || candidate.result?.brokerContract?.secType
+      || candidate.ticker?.metadata.assetCategory
+      || "",
+    source: candidate.kind === "ticker"
+      ? "Saved"
+      : candidate.result?.brokerLabel || candidate.result?.providerId || "Provider",
+    providerId: candidate.result?.providerId ?? "",
+    saved: candidate.kind === "ticker",
+  }));
 }
 
 export function buildSearchReport({
@@ -118,6 +142,21 @@ export async function search(query: string, dependencies: SearchCommandDependenc
     tickers,
     dataProvider,
   });
+
+  if (dependencies.printResult) {
+    dependencies.printResult({ data: searchCandidateRows(candidates), metadata: { query: trimmedQuery } }, {
+      columns: [
+        { key: "category", header: "Category" },
+        { key: "symbol", header: "Symbol" },
+        { key: "name", header: "Name" },
+        { key: "exchange", header: "Exchange" },
+        { key: "type", header: "Type" },
+        { key: "source", header: "Source" },
+      ],
+    });
+    persistence.close();
+    return;
+  }
 
   console.log(buildSearchReport({
     query: trimmedQuery,

--- a/src/cli/commands/system.ts
+++ b/src/cli/commands/system.ts
@@ -1,0 +1,553 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { VERSION } from "../../version";
+import { saveConfig } from "../../data/config/store";
+import { NotesFiles } from "../../plugins/builtin/notes/files";
+import { createAlert, deserializeAlerts, serializeAlerts } from "../../plugins/builtin/alerts/alert-engine";
+import type { AlertCondition } from "../../plugins/builtin/alerts/types";
+import type { CliCommandDef } from "../../types/plugin";
+import { debugLog, type LogLevel } from "../../utils/debug-log";
+import { parsePositiveInt, requireArg, takeOption } from "./command-utils";
+
+const ALERTS_PLUGIN_ID = "alerts";
+const ALERTS_KEY = "alerts";
+const LOG_LEVELS = new Set<LogLevel>(["debug", "info", "warn", "error"]);
+
+function commandRows(commands: CliCommandDef[]) {
+  return commands.map((command) => ({
+    name: command.name,
+    aliases: command.aliases?.join(",") ?? "",
+    description: command.description,
+  }));
+}
+
+function parseLogLevel(value: string | undefined): LogLevel | undefined {
+  return value && LOG_LEVELS.has(value as LogLevel) ? value as LogLevel : undefined;
+}
+
+function resourceCacheStats(services: Awaited<ReturnType<Parameters<CliCommandDef["execute"]>[1]["initServices"]>>) {
+  const row = services.persistence.database.connection
+    .query<{ count: number; size: number; expired: number; stale: number }, []>(
+      `SELECT COUNT(*) as count,
+              COALESCE(SUM(size_bytes), 0) as size,
+              SUM(CASE WHEN expires_at < strftime('%s','now') * 1000 THEN 1 ELSE 0 END) as expired,
+              SUM(CASE WHEN stale_at < strftime('%s','now') * 1000 THEN 1 ELSE 0 END) as stale
+       FROM resource_cache`,
+    )
+    .get();
+  return {
+    entries: row?.count ?? 0,
+    sizeBytes: row?.size ?? 0,
+    staleEntries: row?.stale ?? 0,
+    expiredEntries: row?.expired ?? 0,
+  };
+}
+
+export function createSystemCliCommands(allCommands: () => CliCommandDef[]): CliCommandDef[] {
+  const versionCommand: CliCommandDef = {
+    name: "version",
+    aliases: ["--version", "-v"],
+    description: "Print version and runtime information",
+    execute: async (_args, ctx) => {
+      let dataDir: string | null = null;
+      try {
+        const config = await ctx.initConfigData();
+        dataDir = config.dataDir;
+        config.persistence.close();
+      } catch {
+        dataDir = null;
+      }
+      ctx.printResult({
+        data: [{
+          version: VERSION,
+          bun: typeof Bun === "undefined" ? null : Bun.version,
+          platform: process.platform,
+          arch: process.arch,
+          dataDir,
+        }],
+      });
+    },
+  };
+
+  const doctorCommand: CliCommandDef = {
+    name: "doctor",
+    description: "Check local CLI runtime, config, plugins, and capability health",
+    execute: async (_args, ctx) => {
+      const checks: Array<{ check: string; status: string; detail: string }> = [];
+      let services: Awaited<ReturnType<typeof ctx.initServices>> | null = null;
+      try {
+        services = await ctx.initServices();
+        checks.push({ check: "config", status: "ok", detail: services.dataDir });
+        checks.push({ check: "database", status: "ok", detail: join(services.dataDir, ".gloomberb-cache.db") });
+        checks.push({ check: "plugins", status: "ok", detail: String(services.services.pluginRegistry.allPlugins.size) });
+        checks.push({ check: "capabilities", status: "ok", detail: String(services.services.pluginRegistry.capabilities.manifests().length) });
+      } catch (error) {
+        checks.push({ check: "runtime", status: "error", detail: error instanceof Error ? error.message : String(error) });
+      } finally {
+        services?.destroy();
+      }
+      ctx.printResult({ data: checks }, {
+        columns: [
+          { key: "check", header: "Check" },
+          { key: "status", header: "Status" },
+          { key: "detail", header: "Detail" },
+        ],
+      });
+    },
+  };
+
+  const configCommand: CliCommandDef = {
+    name: "config",
+    description: "Inspect and update local configuration",
+    help: { usage: ["config list", "config get <key>", "config set <key> <value>"] },
+    execute: async (args, ctx) => {
+      const action = args[0] ?? "list";
+      const context = await ctx.initConfigData();
+      try {
+        const safeConfig: Record<string, unknown> = {
+          dataDir: context.config.dataDir,
+          baseCurrency: context.config.baseCurrency,
+          refreshIntervalMinutes: context.config.refreshIntervalMinutes,
+          theme: context.config.theme,
+          disabledPlugins: context.config.disabledPlugins,
+          disabledSources: context.config.disabledSources,
+          portfolios: context.config.portfolios.length,
+          watchlists: context.config.watchlists.length,
+          brokerInstances: context.config.brokerInstances.length,
+        };
+
+        if (action === "list") {
+          ctx.printResult({ data: safeConfig });
+          return;
+        }
+        if (action === "get") {
+          const key = requireArg(args[1], "Usage: gloomberb config get <key>", ctx);
+          ctx.printResult({
+            data: {
+              key,
+              value: Object.prototype.hasOwnProperty.call(safeConfig, key) ? safeConfig[key] : null,
+            },
+          });
+          return;
+        }
+        if (action === "set") {
+          const key = requireArg(args[1], "Usage: gloomberb config set <key> <value>", ctx);
+          const value = requireArg(args[2], "Usage: gloomberb config set <key> <value>", ctx);
+          const editable = new Set(["baseCurrency", "refreshIntervalMinutes", "theme", "valueFlashingEnabled"]);
+          if (!editable.has(key)) ctx.fail(`Config key "${key}" is not editable from the CLI.`);
+          const parsedValue = key === "refreshIntervalMinutes"
+            ? Number(value)
+            : key === "valueFlashingEnabled"
+              ? value === "true"
+              : value;
+          const nextConfig = { ...context.config, [key]: parsedValue };
+          if (!ctx.cliOptions.dryRun) await saveConfig(nextConfig);
+          ctx.printResult({ data: { changed: !ctx.cliOptions.dryRun, dryRun: ctx.cliOptions.dryRun, key, value: parsedValue } });
+          return;
+        }
+        ctx.fail("Usage: gloomberb config list|get|set");
+      } finally {
+        context.persistence.close();
+      }
+    },
+  };
+
+  const cacheCommand: CliCommandDef = {
+    name: "cache",
+    description: "Inspect or clear the resource cache",
+    help: { usage: ["cache status", "cache clear [namespace]"] },
+    execute: async (args, ctx) => {
+      const action = args[0] ?? "status";
+      const services = await ctx.initServices();
+      try {
+        if (action === "status") {
+          ctx.printResult({ data: [resourceCacheStats(services)] });
+          return;
+        }
+        if (action === "clear") {
+          const namespace = args[1];
+          const before = resourceCacheStats(services);
+          if (!ctx.cliOptions.dryRun) services.persistence.resources.clear(namespace);
+          const after = ctx.cliOptions.dryRun ? before : resourceCacheStats(services);
+          ctx.printResult({ data: [{ changed: !ctx.cliOptions.dryRun, dryRun: ctx.cliOptions.dryRun, namespace: namespace ?? "all", before: before.entries, after: after.entries }] });
+          return;
+        }
+        ctx.fail("Usage: gloomberb cache status|clear");
+      } finally {
+        services.destroy();
+      }
+    },
+  };
+
+  const providerCommand: CliCommandDef = {
+    name: "provider",
+    aliases: ["providers"],
+    description: "Inspect provider/source capability status",
+    help: { usage: ["provider status"] },
+    execute: async (_args, ctx) => {
+      const services = await ctx.initServices();
+      try {
+        const disabledSources = new Set(services.config.disabledSources ?? []);
+        const rows = services.services.pluginRegistry.capabilities.manifests().map((manifest) => ({
+          id: manifest.sourceId ?? manifest.id,
+          capability: manifest.id,
+          kind: manifest.kind,
+          enabled: !disabledSources.has(manifest.sourceId ?? manifest.id),
+          operations: manifest.operations.map((operation) => operation.id).join(","),
+        }));
+        ctx.printResult({ data: rows }, {
+          columns: [
+            { key: "id", header: "Source" },
+            { key: "kind", header: "Kind" },
+            { key: "enabled", header: "Enabled" },
+            { key: "operations", header: "Operations" },
+          ],
+        });
+      } finally {
+        services.destroy();
+      }
+    },
+  };
+
+  const pluginCommand: CliCommandDef = {
+    name: "plugin",
+    description: "Inspect, enable, disable, or doctor plugins",
+    help: { usage: ["plugin list", "plugin info <id>", "plugin enable <id>", "plugin disable <id>", "plugin doctor"] },
+    execute: async (args, ctx) => {
+      const action = args[0] ?? "list";
+      const services = await ctx.initServices();
+      try {
+        const pluginRows = () => [...services.services.pluginRegistry.allPlugins.values()].map((plugin) => ({
+          id: plugin.id,
+          name: plugin.name,
+          version: plugin.version,
+          enabled: !services.config.disabledPlugins.includes(plugin.id),
+          panes: services.services.pluginRegistry.getPluginPaneIds(plugin.id).length,
+          templates: services.services.pluginRegistry.getPluginPaneTemplateIds(plugin.id).length,
+          capabilities: services.services.pluginRegistry.capabilities.manifests().filter((manifest) => (
+            services.services.pluginRegistry.getCapabilityPluginId(manifest.id) === plugin.id
+          )).length,
+        }));
+
+        if (action === "list" || action === "doctor") {
+          ctx.printResult({ data: pluginRows() });
+          return;
+        }
+        if (action === "info") {
+          const id = requireArg(args[1], "Usage: gloomberb plugin info <id>", ctx);
+          const row = pluginRows().find((plugin) => plugin.id === id);
+          if (!row) ctx.fail(`Plugin "${id}" is not available.`);
+          ctx.printResult({ data: row });
+          return;
+        }
+        if (action === "enable" || action === "disable") {
+          const id = requireArg(args[1], `Usage: gloomberb plugin ${action} <id>`, ctx);
+          const disabled = new Set(services.config.disabledPlugins ?? []);
+          const before = disabled.has(id);
+          if (action === "enable") disabled.delete(id);
+          else disabled.add(id);
+          const nextConfig = { ...services.config, disabledPlugins: [...disabled] };
+          if (!ctx.cliOptions.dryRun) await saveConfig(nextConfig);
+          ctx.printResult({ data: { changed: before !== disabled.has(id) && !ctx.cliOptions.dryRun, dryRun: ctx.cliOptions.dryRun, id, enabled: !disabled.has(id) } });
+          return;
+        }
+        ctx.fail("Usage: gloomberb plugin list|info|enable|disable|doctor");
+      } finally {
+        services.destroy();
+      }
+    },
+  };
+
+  const layoutCommand: CliCommandDef = {
+    name: "layout",
+    description: "Inspect saved layouts",
+    execute: async (_args, ctx) => {
+      const config = await ctx.initConfigData();
+      try {
+        const rows = config.config.layouts.map((layout, index) => ({
+          index,
+          active: index === config.config.activeLayoutIndex,
+          name: layout.name,
+          panes: layout.layout.instances.length,
+          floating: layout.layout.floating.length,
+          detached: layout.layout.detached.length,
+        }));
+        ctx.printResult({ data: rows });
+      } finally {
+        config.persistence.close();
+      }
+    },
+  };
+
+  const paneCommand: CliCommandDef = {
+    name: "pane",
+    description: "Inspect pane and pane-template inventory",
+    help: { usage: ["pane list"] },
+    execute: async (_args, ctx) => {
+      const services = await ctx.initServices();
+      try {
+        const rows = [
+          ...[...services.services.pluginRegistry.panes.entries()].map(([id, pane]) => ({
+            kind: "pane",
+            id,
+            name: pane.name,
+            owner: "",
+          })),
+          ...[...services.services.pluginRegistry.paneTemplates.entries()].map(([id, template]) => ({
+            kind: "template",
+            id,
+            name: template.label,
+            owner: services.services.pluginRegistry.getPaneTemplatePluginId(id) ?? "",
+          })),
+        ];
+        ctx.printResult({ data: rows }, {
+          columns: [
+            { key: "kind", header: "Kind" },
+            { key: "id", header: "ID" },
+            { key: "name", header: "Name" },
+            { key: "owner", header: "Owner" },
+          ],
+        });
+      } finally {
+        services.destroy();
+      }
+    },
+  };
+
+  const notesCommand: CliCommandDef = {
+    name: "notes",
+    description: "Read and mutate ticker or quick notes",
+    help: { usage: ["notes show <symbol>", "notes set <symbol> TEXT", "notes delete <symbol>", "notes quick list"] },
+    execute: async (args, ctx) => {
+      const config = await ctx.initConfigData();
+      const notes = new NotesFiles(config.dataDir);
+      try {
+        const action = args[0] ?? "list";
+        if (action === "quick") {
+          const subaction = args[1] ?? "list";
+          if (subaction !== "list") ctx.fail("Usage: gloomberb notes quick list");
+          const entries = await notes.loadQuickNotesIndex();
+          ctx.printResult({ data: entries });
+          return;
+        }
+        if (action === "show") {
+          const symbol = requireArg(args[1]?.toUpperCase(), "Usage: gloomberb notes show <symbol>", ctx);
+          ctx.printResult({ data: { symbol, text: await notes.load(symbol) } });
+          return;
+        }
+        if (action === "set") {
+          const symbol = requireArg(args[1]?.toUpperCase(), "Usage: gloomberb notes set <symbol> TEXT", ctx);
+          const text = args.slice(2).join(" ");
+          if (!ctx.cliOptions.dryRun) await notes.save(symbol, text);
+          ctx.printResult({ data: { changed: !ctx.cliOptions.dryRun, dryRun: ctx.cliOptions.dryRun, symbol, bytes: text.length } });
+          return;
+        }
+        if (action === "delete" || action === "rm") {
+          const symbol = requireArg(args[1]?.toUpperCase(), "Usage: gloomberb notes delete <symbol>", ctx);
+          if (!ctx.cliOptions.dryRun) await notes.delete(symbol);
+          ctx.printResult({ data: { changed: !ctx.cliOptions.dryRun, dryRun: ctx.cliOptions.dryRun, symbol } });
+          return;
+        }
+        ctx.fail("Usage: gloomberb notes show|set|delete|quick");
+      } finally {
+        config.persistence.close();
+      }
+    },
+  };
+
+  const alertsCommand: CliCommandDef = {
+    name: "alerts",
+    aliases: ["alert"],
+    description: "List and manage price alerts",
+    help: { usage: ["alerts list", "alerts add <symbol> <above|below|crosses> <price>", "alerts delete <id>", "alerts rearm <id>"] },
+    execute: async (args, ctx) => {
+      const action = args[0] ?? "list";
+      const config = await ctx.initConfigData();
+      try {
+        const raw = config.config.pluginConfig[ALERTS_PLUGIN_ID]?.[ALERTS_KEY];
+        const alerts = deserializeAlerts(typeof raw === "string" ? raw : "[]");
+        const saveAlerts = async (nextAlerts: typeof alerts) => {
+          const nextConfig = {
+            ...config.config,
+            pluginConfig: {
+              ...config.config.pluginConfig,
+              [ALERTS_PLUGIN_ID]: {
+                ...(config.config.pluginConfig[ALERTS_PLUGIN_ID] ?? {}),
+                [ALERTS_KEY]: serializeAlerts(nextAlerts),
+              },
+            },
+          };
+          if (!ctx.cliOptions.dryRun) await saveConfig(nextConfig);
+        };
+
+        if (action === "list") {
+          ctx.printResult({ data: alerts });
+          return;
+        }
+        if (action === "add") {
+          const symbol = requireArg(args[1]?.toUpperCase(), "Usage: gloomberb alerts add <symbol> <above|below|crosses> <price>", ctx);
+          const condition = requireArg(args[2], "Usage: gloomberb alerts add <symbol> <above|below|crosses> <price>", ctx) as AlertCondition;
+          if (!["above", "below", "crosses"].includes(condition)) ctx.fail("Condition must be above, below, or crosses.");
+          const price = Number(requireArg(args[3], "Usage: gloomberb alerts add <symbol> <above|below|crosses> <price>", ctx));
+          if (!Number.isFinite(price)) ctx.fail("Alert price must be a finite number.");
+          const alert = createAlert(symbol, condition, price);
+          await saveAlerts([...alerts, alert]);
+          ctx.printResult({ data: { changed: !ctx.cliOptions.dryRun, dryRun: ctx.cliOptions.dryRun, alert } });
+          return;
+        }
+        if (action === "delete" || action === "rm") {
+          const id = requireArg(args[1], "Usage: gloomberb alerts delete <id>", ctx);
+          const next = alerts.filter((alert) => alert.id !== id);
+          await saveAlerts(next);
+          ctx.printResult({ data: { changed: !ctx.cliOptions.dryRun && next.length !== alerts.length, dryRun: ctx.cliOptions.dryRun, id } });
+          return;
+        }
+        if (action === "rearm") {
+          const id = requireArg(args[1], "Usage: gloomberb alerts rearm <id>", ctx);
+          const next = alerts.map((alert) => alert.id === id ? { ...alert, status: "active" as const, triggeredAt: undefined } : alert);
+          await saveAlerts(next);
+          ctx.printResult({ data: { changed: !ctx.cliOptions.dryRun, dryRun: ctx.cliOptions.dryRun, id } });
+          return;
+        }
+        ctx.fail("Usage: gloomberb alerts list|add|delete|rearm");
+      } finally {
+        config.persistence.close();
+      }
+    },
+  };
+
+  const debugCommand: CliCommandDef = {
+    name: "debug",
+    description: "Inspect, export, clear, or tail in-memory debug logs",
+    help: { usage: ["debug logs", "debug export [--output path]", "debug clear", "debug tail [--limit n]"] },
+    execute: async (rawArgs, ctx) => {
+      const args = [...rawArgs];
+      const action = args[0] ?? "logs";
+      const source = takeOption(args, "--source");
+      const level = parseLogLevel(takeOption(args, "--level"));
+      if (action === "clear") {
+        debugLog.clear();
+        ctx.printResult({ data: { changed: true } });
+        return;
+      }
+      if (action === "export") {
+        const output = takeOption(args, "--output");
+        const text = debugLog.exportAsText({ source, level });
+        if (output) writeFileSync(output, text);
+        ctx.printResult({ data: { output: output ?? null, bytes: text.length, text: output ? undefined : text } });
+        return;
+      }
+      const entries = debugLog.getEntries({ source, level }).slice(-(ctx.cliOptions.limit ?? 50));
+      ctx.printResult({ data: entries }, {
+        columns: [
+          { key: "id", header: "ID", align: "right" },
+          { key: "timestamp", header: "Time", value: (row) => new Date(Number(row.timestamp)).toISOString() },
+          { key: "level", header: "Level" },
+          { key: "source", header: "Source" },
+          { key: "message", header: "Message" },
+        ],
+      });
+    },
+  };
+
+  const changelogCommand: CliCommandDef = {
+    name: "changelog",
+    description: "Print local changelog or release notes when available",
+    execute: async (args, ctx) => {
+      const limit = parsePositiveInt(args[0], ctx.cliOptions.limit ?? 80, "Line count", ctx);
+      const candidates = ["CHANGELOG.md", "CHANGELOG", "RELEASE_NOTES.md", "README.md"];
+      const found = candidates.find((candidate) => existsSync(candidate));
+      const text = found ? readFileSync(found, "utf8").split("\n").slice(0, limit).join("\n") : "";
+      ctx.printResult({ data: { path: found ?? null, text, version: VERSION } });
+    },
+  };
+
+  const commandCatalogCommand: CliCommandDef = {
+    name: "command",
+    aliases: ["commands"],
+    description: "List registered first-class CLI commands",
+    execute: (_args, ctx) => {
+      ctx.printResult({ data: commandRows(allCommands()) }, {
+        columns: [
+          { key: "name", header: "Command" },
+          { key: "aliases", header: "Aliases" },
+          { key: "description", header: "Description" },
+        ],
+      });
+    },
+  };
+
+  const coverageCommand: CliCommandDef = {
+    name: "coverage",
+    description: "Show CLI coverage for panes, templates, capabilities, and deferred exceptions",
+    execute: async (_args, ctx) => {
+      const commandNames = new Set(allCommands().map((command) => command.name));
+      const services = await ctx.initServices();
+      try {
+        const rows = [
+          ...[...services.services.pluginRegistry.panes.entries()].map(([id, pane]) => ({
+            surface: "pane",
+            id,
+            label: pane.name,
+            coverage: commandNames.has(id) ? "first-class" : "visual-only",
+            command: commandNames.has(id) ? id : "fn/shot",
+          })),
+          ...[...services.services.pluginRegistry.paneTemplates.entries()].map(([id, template]) => {
+            const direct = [id, template.paneId, template.shortcut?.prefix?.toLowerCase()]
+              .filter((value): value is string => !!value)
+              .find((value) => commandNames.has(value));
+            return {
+              surface: "template",
+              id,
+              label: template.label,
+              coverage: direct ? "first-class" : "visual-only",
+              command: direct ?? "fn/shot",
+            };
+          }),
+          ...services.services.pluginRegistry.capabilities.manifests().map((manifest) => ({
+            surface: "capability",
+            id: manifest.id,
+            label: manifest.name,
+            coverage: "api",
+            command: "api list|get|invoke|subscribe",
+          })),
+          ...["auth", "account-management", "chat"].map((id) => ({
+            surface: "deferred",
+            id,
+            label: id,
+            coverage: "deferred",
+            command: "",
+          })),
+        ];
+        ctx.printResult({ data: rows }, {
+          columns: [
+            { key: "surface", header: "Surface" },
+            { key: "id", header: "ID" },
+            { key: "coverage", header: "Coverage" },
+            { key: "command", header: "Command" },
+            { key: "label", header: "Label" },
+          ],
+        });
+      } finally {
+        services.destroy();
+      }
+    },
+  };
+
+  return [
+    versionCommand,
+    doctorCommand,
+    configCommand,
+    cacheCommand,
+    providerCommand,
+    pluginCommand,
+    layoutCommand,
+    paneCommand,
+    notesCommand,
+    alertsCommand,
+    debugCommand,
+    changelogCommand,
+    commandCatalogCommand,
+    coverageCommand,
+  ];
+}

--- a/src/cli/commands/ticker.ts
+++ b/src/cli/commands/ticker.ts
@@ -17,6 +17,7 @@ import type { FinancialStatement, TickerFinancials } from "../../types/financial
 import type { SecFilingItem } from "../../types/data-provider";
 import type { NewsArticle } from "../../news/types";
 import type { TickerRecord } from "../../types/ticker";
+import type { CliCommandContext } from "../../types/plugin";
 import { createBaseConverter } from "../base-converter";
 import { initMarketData } from "../context";
 import { closeAndFail } from "../errors";
@@ -40,6 +41,7 @@ const SEC_FILING_LIMIT = 5;
 interface TickerCommandDependencies {
   initMarketData?: () => Promise<MarketContext>;
   closeAndFail?: typeof closeAndFail;
+  printResult?: CliCommandContext["printResult"];
 }
 
 function appendMetricSection(lines: string[], title: string, metrics: Array<[string, string]>) {
@@ -367,6 +369,78 @@ export async function buildTickerReport({
   return lines.join("\n");
 }
 
+function buildTickerStructuredData({
+  symbol,
+  tickerFile,
+  financials,
+  config,
+  notes,
+  recentNews,
+  recentSecFilings,
+}: {
+  symbol: string;
+  tickerFile: TickerRecord | null;
+  financials: TickerFinancials;
+  config: AppConfig;
+  notes: string;
+  recentNews: NewsArticle[];
+  recentSecFilings: SecFilingItem[];
+}) {
+  const quote = financials.quote;
+  return {
+    symbol,
+    quote: quote ? {
+      symbol: quote.symbol,
+      name: quote.name,
+      price: quote.price,
+      change: quote.change,
+      changePercent: quote.changePercent,
+      currency: quote.currency,
+      marketCap: quote.marketCap ?? null,
+      volume: quote.volume ?? null,
+      exchangeName: quote.exchangeName ?? "",
+      fullExchangeName: quote.fullExchangeName ?? "",
+      marketState: quote.marketState ?? "",
+      dataSource: quote.dataSource ?? "",
+      providerId: quote.providerId ?? "",
+      lastUpdated: quote.lastUpdated ? new Date(quote.lastUpdated).toISOString() : "",
+    } : null,
+    ticker: tickerFile ? {
+      ticker: tickerFile.metadata.ticker,
+      name: tickerFile.metadata.name ?? "",
+      exchange: tickerFile.metadata.exchange ?? "",
+      assetCategory: tickerFile.metadata.assetCategory ?? "",
+      sector: tickerFile.metadata.sector ?? "",
+      industry: tickerFile.metadata.industry ?? "",
+      portfolios: formatPortfolioNames(config, tickerFile.metadata.portfolios),
+      watchlists: formatWatchlistNames(config, tickerFile.metadata.watchlists),
+      positions: tickerFile.metadata.positions,
+    } : null,
+    fundamentals: financials.fundamentals,
+    profile: financials.profile,
+    latestAnnual: financials.annualStatements.at(-1) ?? null,
+    latestQuarter: financials.quarterlyStatements.at(-1) ?? null,
+    annualStatementCount: financials.annualStatements.length,
+    quarterlyStatementCount: financials.quarterlyStatements.length,
+    notes,
+    recentNews: recentNews.map((item) => ({
+      title: item.title,
+      source: item.source,
+      publishedAt: item.publishedAt instanceof Date ? item.publishedAt.toISOString() : item.publishedAt,
+      url: item.url,
+      summary: item.summary ?? "",
+    })),
+    recentSecFilings: recentSecFilings.map((filing) => ({
+      form: filing.form,
+      filingDate: filing.filingDate instanceof Date ? filing.filingDate.toISOString() : filing.filingDate,
+      accessionNumber: filing.accessionNumber,
+      filingUrl: filing.filingUrl,
+      primaryDocumentUrl: filing.primaryDocumentUrl ?? "",
+      description: getFilingDescription(filing) ?? "",
+    })),
+  };
+}
+
 export async function ticker(symbol: string, dependencies: TickerCommandDependencies = {}) {
   const initMarketDataFn = dependencies.initMarketData ?? initMarketData;
   const closeAndFailCommand = dependencies.closeAndFail ?? closeAndFail;
@@ -379,8 +453,12 @@ export async function ticker(symbol: string, dependencies: TickerCommandDependen
   let financials: TickerFinancials | null = null;
   try {
     financials = await dataProvider.getTickerFinancials(normalized, exchange);
-  } catch (err: any) {
-    closeAndFailCommand(persistence, `Failed to fetch data for ${normalized}.`, err?.message);
+  } catch (error) {
+    closeAndFailCommand(
+      persistence,
+      `Failed to fetch data for ${normalized}.`,
+      error instanceof Error ? error.message : String(error),
+    );
   }
 
   if (!financials?.quote) {
@@ -409,16 +487,30 @@ export async function ticker(symbol: string, dependencies: TickerCommandDependen
   const recentNews = newsResult.status === "fulfilled" ? newsResult.value : [];
   const recentSecFilings = secFilingsResult.status === "fulfilled" ? secFilingsResult.value : [];
 
-  console.log(await buildTickerReport({
-    symbol: normalized,
-    tickerFile,
-    financials: resolvedFinancials,
-    config,
-    toBase,
-    notes,
-    recentNews,
-    recentSecFilings,
-  }));
+  if (dependencies.printResult) {
+    dependencies.printResult({
+      data: buildTickerStructuredData({
+        symbol: normalized,
+        tickerFile,
+        financials: resolvedFinancials,
+        config,
+        notes,
+        recentNews,
+        recentSecFilings,
+      }),
+    });
+  } else {
+    console.log(await buildTickerReport({
+      symbol: normalized,
+      tickerFile,
+      financials: resolvedFinancials,
+      config,
+      toBase,
+      notes,
+      recentNews,
+      recentSecFilings,
+    }));
+  }
 
   persistence.close();
 }

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -4,15 +4,22 @@ import { getDataDir, loadConfig } from "../data/config/store";
 import { AppPersistence } from "../data/app-persistence";
 import { TickerRepository } from "../data/ticker-repository";
 import { AssetDataRouter } from "../sources/provider-router";
+import { createAppServices } from "../core/app-services";
 import type { PluginCapability } from "../capabilities";
 import type { AppConfig } from "../types/config";
 import type { GloomPlugin } from "../types/plugin";
 import { getLoadablePlugins } from "../plugins/catalog";
+import type { PluginRegistry } from "../plugins/registry";
+import type { LoadedExternalPlugin } from "../plugins/loader";
 import { fail } from "./errors";
 import type { ConfigContext, MarketContext } from "./types";
 
 interface CliContextOptions {
   plugins?: GloomPlugin[];
+}
+
+interface CliServicesOptions {
+  externalPlugins?: LoadedExternalPlugin[];
 }
 
 function resolveCliCapabilities(config: AppConfig, plugins: GloomPlugin[]): PluginCapability[] {
@@ -55,9 +62,35 @@ export async function initMarketData(options: CliContextOptions = {}): Promise<M
   const plugins = options.plugins ?? getLoadablePlugins();
   const capabilities = resolveCliCapabilities(context.config, plugins);
   const dataProvider = new AssetDataRouter(null, [], context.persistence.resources);
-  dataProvider.attachRegistry({
+  const registryAdapter: Pick<PluginRegistry, "brokers" | "getEnabledCapabilities"> = {
     brokers: new Map(),
     getEnabledCapabilities: (kind?: string) => capabilities.filter((capability) => !kind || capability.kind === kind),
-  } as any);
+  };
+  dataProvider.attachRegistry(registryAdapter as PluginRegistry);
+  dataProvider.setConfigAccessor(() => context.config);
   return { ...context, dataProvider };
+}
+
+export async function initCliServices(options: CliServicesOptions = {}) {
+  const dataDir = await getDataDir();
+  if (!dataDir || !existsSync(dataDir)) {
+    fail("No data directory configured.", "Run gloomberb once to initialize your local data.");
+  }
+
+  const config = await loadConfig(dataDir);
+  const services = createAppServices({
+    config,
+    externalPlugins: options.externalPlugins ?? [],
+  });
+  services.providerRouter.setConfigAccessor(() => config);
+  await services.ready;
+  return {
+    config,
+    dataDir,
+    services,
+    dataProvider: services.providerRouter,
+    persistence: services.persistence,
+    store: services.tickerRepository,
+    destroy: () => services.destroy(),
+  };
 }

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -1,0 +1,51 @@
+import { dispatchCli } from "./index";
+import { fail, inferCliErrorOptions, printCliError } from "./errors";
+import { loadExternalPlugins } from "../plugins/loader";
+import type { CliLaunchRequest } from "../types/plugin";
+
+async function launchOpenTuiApp(options: {
+  externalPlugins: Awaited<ReturnType<typeof loadExternalPlugins>>;
+  cliLaunchRequest?: CliLaunchRequest | null;
+  cliArgs?: string[];
+}): Promise<void> {
+  const { startOpenTuiApp } = await import("../renderers/opentui/start");
+  await startOpenTuiApp({
+    externalPlugins: options.externalPlugins,
+    cliArgs: options.cliArgs ?? [],
+    skipCliDispatch: true,
+    cliLaunchRequest: options.cliLaunchRequest ?? null,
+  });
+}
+
+export async function runCliEntrypoint(rawArgs = process.argv.slice(2)): Promise<void> {
+  const externalPlugins = await loadExternalPlugins();
+  const command = rawArgs[0];
+
+  if (!command) {
+    await launchOpenTuiApp({ externalPlugins });
+    return;
+  }
+
+  if (command === "launch-ui" || command === "ui") {
+    await launchOpenTuiApp({ externalPlugins, cliArgs: rawArgs.slice(1) });
+    return;
+  }
+
+  const dispatchResult = await dispatchCli(rawArgs, { externalPlugins });
+  if (dispatchResult.kind === "handled") return;
+  if (dispatchResult.kind === "launch-ui") {
+    await launchOpenTuiApp({
+      externalPlugins,
+      cliLaunchRequest: dispatchResult.request,
+      cliArgs: [],
+    });
+    return;
+  }
+
+  fail(`Unknown command "${command}".`, "Run gloomberb help to list available commands.");
+}
+
+runCliEntrypoint().catch((error) => {
+  printCliError(error, inferCliErrorOptions(process.argv.slice(2)));
+  process.exitCode = 1;
+});

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,13 +1,64 @@
-import { cliStyles } from "../utils/cli-output";
 import type { AppPersistence } from "../data/app-persistence";
+import { DEFAULT_CLI_OPTIONS, type CliGlobalOptions } from "./options";
+import { serializeCliError, type CliErrorObject } from "./result";
 
-export function fail(message: string, details?: string): never {
-  console.error(cliStyles.danger(message));
-  if (details) console.error(cliStyles.muted(details));
-  process.exit(1);
+export class CliFailure extends Error {
+  readonly code: string;
+  readonly details?: unknown;
+  readonly retryable?: boolean;
+
+  constructor(message: string, details?: unknown, code = "cli_error", retryable?: boolean) {
+    super(message);
+    this.name = "CliFailure";
+    this.code = code;
+    this.details = details;
+    this.retryable = retryable;
+  }
+}
+
+export function fail(message: string, details?: unknown, code?: string): never {
+  throw new CliFailure(message, details, code);
 }
 
 export function closeAndFail(persistence: AppPersistence, message: string, details?: string): never {
   persistence.close();
   fail(message, details);
+}
+
+export function isCliFailure(error: unknown): error is CliFailure {
+  return error instanceof CliFailure;
+}
+
+export function cliErrorObject(error: unknown): CliErrorObject {
+  if (isCliFailure(error)) {
+    return {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+      retryable: error.retryable,
+    };
+  }
+  return {
+    code: "unexpected_error",
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export function inferCliErrorOptions(rawArgs: string[]): CliGlobalOptions {
+  const options: CliGlobalOptions = { ...DEFAULT_CLI_OPTIONS };
+  for (const arg of rawArgs) {
+    if (arg === "--") break;
+    if (arg === "--json") options.format = "json";
+    if (arg === "--csv") options.format = "csv";
+    if (arg === "--ndjson") options.format = "ndjson";
+    if (arg === "--quiet" || arg === "-q") options.quiet = true;
+    if (arg === "--no-color") options.color = false;
+    if (arg === "--color") options.color = true;
+  }
+  return options;
+}
+
+export function printCliError(error: unknown, options: CliGlobalOptions): void {
+  if (options.quiet && options.format === "text") return;
+  console.error(serializeCliError(cliErrorObject(error), options));
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,8 @@
 import { VERSION } from "../version";
-import type { CliCommandDef, CliDispatchResult } from "../types/plugin";
+import type { CliCommandDef, CliDispatchResult, CliLaunchRequest } from "../types/plugin";
 import type { LoadedExternalPlugin } from "../plugins/loader";
 import { loadCliConfigIfAvailable } from "./context";
+import { parseCliGlobalArgs } from "./options";
 import {
   buildCliCommandRegistry,
   createCliCommandContext,
@@ -10,9 +11,21 @@ import {
   renderCliHelp,
   type CliCommandRegistry,
 } from "./registry";
-import { fail } from "./errors";
+import { fail, inferCliErrorOptions, printCliError } from "./errors";
+import { setCliColorEnabledOverride } from "../utils/cli-output";
 import { search, searchCandidatesForCli, buildSearchReport } from "./commands/search";
 import { ticker, buildTickerReport } from "./commands/ticker";
+import { apiCliCommand } from "./commands/api";
+import { marketDataCliCommands } from "./commands/market";
+import { overviewCliCommands } from "./commands/overview";
+import { createSystemCliCommands } from "./commands/system";
+import {
+  aiCliCommand,
+  brokerCliCommand,
+  cloudCliCommands,
+  ibkrCliCommand,
+  rssCliCommand,
+} from "./commands/automation";
 import {
   installPlugin,
   listPlugins,
@@ -22,7 +35,11 @@ import {
 import { runPaneCatalog, runPaneFunction, runPaneScreenshot } from "./pane-functions";
 
 function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
-  return [
+  let commands: CliCommandDef[] = [];
+  const launchUiRequest: CliLaunchRequest = {
+    applyConfig: (config) => ({ config }),
+  };
+  commands = [
     {
       name: "help",
       aliases: ["--help", "-h"],
@@ -30,9 +47,27 @@ function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
       help: {
         usage: ["help"],
       },
-      execute: () => {
-        console.log(renderHelp());
+      execute: (_args, ctx) => {
+        if (ctx.cliOptions.format === "text") {
+          console.log(renderHelp());
+          return;
+        }
+        ctx.printResult({ data: commands.map((command) => ({
+          name: command.name,
+          aliases: command.aliases ?? [],
+          description: command.description,
+          usage: command.help?.usage ?? [],
+        })) });
       },
+    },
+    {
+      name: "launch-ui",
+      aliases: ["ui"],
+      description: "Launch the terminal UI explicitly",
+      help: {
+        usage: ["launch-ui"],
+      },
+      execute: () => ({ kind: "launch-ui", request: launchUiRequest }),
     },
     {
       name: "search",
@@ -45,6 +80,7 @@ function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
         await search(query, {
           initMarketData: ctx.initMarketData,
           fail: ctx.fail,
+          ...(ctx.cliOptions.format === "text" ? {} : { printResult: ctx.printResult }),
         });
       },
     },
@@ -62,6 +98,7 @@ function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
         await ticker(symbol!, {
           initMarketData: ctx.initMarketData,
           closeAndFail: ctx.closeAndFail,
+          ...(ctx.cliOptions.format === "text" ? {} : { printResult: ctx.printResult }),
         });
       },
     },
@@ -148,7 +185,17 @@ function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
         listPlugins();
       },
     },
+    apiCliCommand,
+    ...marketDataCliCommands,
+    ...overviewCliCommands,
+    ...createSystemCliCommands(() => commands),
+    brokerCliCommand,
+    ibkrCliCommand,
+    aiCliCommand,
+    rssCliCommand,
+    ...cloudCliCommands,
   ];
+  return commands;
 }
 
 export interface DispatchCliOptions {
@@ -170,7 +217,16 @@ async function createRegistry(options: DispatchCliOptions = {}): Promise<CliComm
 export { buildSearchReport, buildTickerReport, searchCandidatesForCli };
 
 export async function dispatchCli(args: string[], options: DispatchCliOptions = {}): Promise<CliDispatchResult> {
-  const command = args[0];
+  let parsed;
+  try {
+    parsed = parseCliGlobalArgs(args);
+  } catch (error) {
+    printCliError(error, inferCliErrorOptions(args));
+    process.exitCode = 1;
+    return { kind: "handled" };
+  }
+  setCliColorEnabledOverride(parsed.options.color);
+  const command = parsed.args[0];
   if (!command) {
     return { kind: "unhandled" };
   }
@@ -181,11 +237,17 @@ export async function dispatchCli(args: string[], options: DispatchCliOptions = 
     return { kind: "unhandled" };
   }
 
-  const result = await resolved.command.execute(
-    args.slice(1),
-    createCliCommandContext(resolved.ownerId, registry.plugins),
-  );
-  return normalizeCliDispatchResult(result);
+  try {
+    const result = await resolved.command.execute(
+      parsed.args.slice(1),
+      createCliCommandContext(resolved.ownerId, registry, parsed.options),
+    );
+    return normalizeCliDispatchResult(result);
+  } catch (error) {
+    printCliError(error, parsed.options);
+    process.exitCode = 1;
+    return { kind: "handled" };
+  }
 }
 
 export async function runCli(args: string[], options: DispatchCliOptions = {}): Promise<boolean> {

--- a/src/cli/options.test.ts
+++ b/src/cli/options.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { parseCliGlobalArgs } from "./options";
+
+describe("parseCliGlobalArgs", () => {
+  test("extracts global output and execution flags anywhere before --", () => {
+    const parsed = parseCliGlobalArgs([
+      "quote",
+      "--json",
+      "AAPL",
+      "--limit",
+      "2",
+      "--refresh",
+      "--dry-run",
+      "--yes",
+      "--no-color",
+    ]);
+
+    expect(parsed.args).toEqual(["quote", "AAPL"]);
+    expect(parsed.options).toMatchObject({
+      format: "json",
+      limit: 2,
+      refresh: true,
+      dryRun: true,
+      yes: true,
+      color: false,
+    });
+  });
+
+  test("leaves arguments after -- untouched", () => {
+    const parsed = parseCliGlobalArgs(["ai", "ask", "--", "--json"]);
+    expect(parsed.args).toEqual(["ai", "ask", "--json"]);
+    expect(parsed.options.format).toBe("text");
+  });
+
+  test("rejects invalid limits", () => {
+    expect(() => parseCliGlobalArgs(["quote", "AAPL", "--limit=0"])).toThrow("--limit");
+  });
+});

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,0 +1,95 @@
+export type CliOutputFormat = "text" | "json" | "csv" | "ndjson";
+
+export interface CliGlobalOptions {
+  format: CliOutputFormat;
+  quiet: boolean;
+  color: boolean | null;
+  limit?: number;
+  refresh: boolean;
+  dryRun: boolean;
+  yes: boolean;
+}
+
+export interface ParsedCliArgs {
+  args: string[];
+  options: CliGlobalOptions;
+}
+
+export const DEFAULT_CLI_OPTIONS: CliGlobalOptions = {
+  format: "text",
+  quiet: false,
+  color: null,
+  refresh: false,
+  dryRun: false,
+  yes: false,
+};
+
+function parseLimit(value: string | undefined): number {
+  if (!value) throw new Error("Missing value for --limit.");
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error("--limit must be a positive integer.");
+  }
+  return parsed;
+}
+
+export function parseCliGlobalArgs(rawArgs: string[]): ParsedCliArgs {
+  const options: CliGlobalOptions = { ...DEFAULT_CLI_OPTIONS };
+  const args: string[] = [];
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index]!;
+    if (arg === "--") {
+      args.push(...rawArgs.slice(index + 1));
+      break;
+    }
+    if (arg === "--json") {
+      options.format = "json";
+      continue;
+    }
+    if (arg === "--csv") {
+      options.format = "csv";
+      continue;
+    }
+    if (arg === "--ndjson") {
+      options.format = "ndjson";
+      continue;
+    }
+    if (arg === "--quiet" || arg === "-q") {
+      options.quiet = true;
+      continue;
+    }
+    if (arg === "--no-color") {
+      options.color = false;
+      continue;
+    }
+    if (arg === "--color") {
+      options.color = true;
+      continue;
+    }
+    if (arg === "--refresh") {
+      options.refresh = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--yes" || arg === "-y") {
+      options.yes = true;
+      continue;
+    }
+    if (arg === "--limit") {
+      index += 1;
+      options.limit = parseLimit(rawArgs[index]);
+      continue;
+    }
+    if (arg.startsWith("--limit=")) {
+      options.limit = parseLimit(arg.slice("--limit=".length));
+      continue;
+    }
+    args.push(arg);
+  }
+
+  return { args, options };
+}

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -76,11 +76,20 @@ export async function runPaneScreenshot(args: string[], ctx: CliCommandContext) 
 export async function runPaneCatalog(args: string[], ctx: CliCommandContext) {
   await runPaneCliCommand(ctx, async () => {
     const parsed = parsePaneCatalogArgs(args);
+    const effectiveParsed = {
+      ...parsed,
+      limit: ctx.cliOptions.limit ?? parsed.limit,
+    };
     const context = await ctx.initMarketData();
     const registry = await createPaneCatalog(context, ctx.plugins);
     try {
       const entries = await buildPaneCatalogEntries(registry, context);
-      console.log(renderPaneCatalogReport(filterPaneCatalogEntries(entries, parsed.query), parsed));
+      const filtered = filterPaneCatalogEntries(entries, parsed.query);
+      if (ctx.cliOptions.format === "text") {
+        console.log(renderPaneCatalogReport(filtered, effectiveParsed));
+      } else {
+        ctx.printResult({ data: filtered.slice(0, effectiveParsed.limit) });
+      }
     } finally {
       registry.destroy();
       context.persistence.close();

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -18,6 +18,7 @@ const originalHome = process.env.HOME;
 
 afterEach(async () => {
   process.env.HOME = originalHome;
+  process.exitCode = 0;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -180,6 +181,45 @@ describe("CLI dispatch", () => {
 
     expect(result).toEqual({ kind: "handled" });
     expect(stdout).toContain("ok:hello world");
+  });
+
+  test("renders plugin command failures through structured output", async () => {
+    process.env.HOME = await createTempHome("gloomberb-cli-registry-failure-home-");
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      const { result, stderr } = await captureConsole(() => dispatchCli(
+        ["fail-example", "--json"],
+        {
+          externalPlugins: [{
+            plugin: {
+              id: "failing-cli",
+              name: "Failing CLI",
+              version: "1.0.0",
+              cliCommands: [{
+                name: "fail-example",
+                description: "Fail on purpose",
+                execute: (_args, ctx) => ctx.fail("Synthetic failure.", "Synthetic details."),
+              }],
+            },
+            path: "/tmp/failing-cli",
+          }],
+        },
+      ));
+
+      expect(result).toEqual({ kind: "handled" });
+      expect(process.exitCode).toBe(1);
+      expect(JSON.parse(stderr)).toEqual({
+        ok: false,
+        error: {
+          code: "cli_error",
+          message: "Synthetic failure.",
+          details: "Synthetic details.",
+        },
+      });
+    } finally {
+      process.exitCode = originalExitCode ?? 0;
+    }
   });
 
   test("routes prediction market commands and aliases through launch-ui requests", async () => {

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -1,9 +1,17 @@
 import type { AppConfig } from "../types/config";
-import type { CliCommandContext, CliCommandDef, CliDispatchResult, GloomPlugin } from "../types/plugin";
+import type {
+  CliCommandContext,
+  CliCommandDef,
+  CliDispatchResult,
+  GloomPlugin,
+  PluginCliCommandDescriptor,
+} from "../types/plugin";
 import type { LoadedExternalPlugin } from "../plugins/loader";
 import { getPluginCatalog } from "../plugins/catalog";
-import { initConfigData, initMarketData } from "./context";
+import { initCliServices, initConfigData, initMarketData } from "./context";
 import { closeAndFail, fail } from "./errors";
+import { DEFAULT_CLI_OPTIONS, type CliGlobalOptions } from "./options";
+import { printCliResult } from "./result";
 import {
   cliStyles,
   colorBySign,
@@ -26,6 +34,8 @@ export interface CliCommandRegistry {
   lookup: ReadonlyMap<string, RegisteredCliCommand>;
   config: AppConfig | null;
   plugins: GloomPlugin[];
+  externalPlugins: LoadedExternalPlugin[];
+  descriptors: Array<{ pluginId: string; descriptor: PluginCliCommandDescriptor }>;
 }
 
 interface BuildCliCommandRegistryOptions {
@@ -59,6 +69,19 @@ export function normalizeCliDispatchResult(result: void | CliDispatchResult): Cl
 
 function getCommandUsageLabel(command: CliCommandDef): string {
   return command.help?.usage?.[0] ?? command.name;
+}
+
+function descriptorToCommand(descriptor: PluginCliCommandDescriptor): CliCommandDef | null {
+  if (!descriptor.execute) return null;
+  return {
+    name: descriptor.name,
+    aliases: descriptor.aliases,
+    description: descriptor.summary,
+    help: descriptor.examples?.length
+      ? { usage: descriptor.examples }
+      : undefined,
+    execute: descriptor.execute,
+  };
 }
 
 function renderHelpSections(registry: CliCommandRegistry): string[] {
@@ -149,6 +172,7 @@ export function buildCliCommandRegistry({
   }
 
   const loadablePlugins: GloomPlugin[] = [];
+  const descriptors: Array<{ pluginId: string; descriptor: PluginCliCommandDescriptor }> = [];
   for (const entry of catalog) {
     if (entry.error) {
       registryLog.warn(`Skipping external plugin "${entry.plugin.id}" for CLI registration.`, {
@@ -160,6 +184,11 @@ export function buildCliCommandRegistry({
     loadablePlugins.push(entry.plugin);
     for (const command of entry.plugin.cliCommands ?? []) {
       registerCommand(command, entry.plugin.id, "plugin");
+    }
+    for (const descriptor of entry.plugin.cli?.commands ?? []) {
+      descriptors.push({ pluginId: entry.plugin.id, descriptor });
+      const command = descriptorToCommand(descriptor);
+      if (command) registerCommand(command, entry.plugin.id, "plugin");
     }
   }
 
@@ -180,14 +209,25 @@ export function buildCliCommandRegistry({
     lookup,
     config,
     plugins: loadablePlugins,
+    externalPlugins,
+    descriptors,
   };
 }
 
-export function createCliCommandContext(ownerId: string, plugins: GloomPlugin[]): CliCommandContext {
+export function createCliCommandContext(
+  ownerId: string,
+  registryOrPlugins: Pick<CliCommandRegistry, "plugins" | "externalPlugins"> | GloomPlugin[],
+  cliOptions: CliGlobalOptions = DEFAULT_CLI_OPTIONS,
+): CliCommandContext {
+  const registry = Array.isArray(registryOrPlugins)
+    ? { plugins: registryOrPlugins, externalPlugins: [] }
+    : registryOrPlugins;
   return {
     initConfigData,
-    initMarketData: () => initMarketData({ plugins }),
-    plugins,
+    initMarketData: () => initMarketData({ plugins: registry.plugins }),
+    initServices: () => initCliServices({ externalPlugins: registry.externalPlugins }),
+    cliOptions,
+    plugins: registry.plugins,
     fail,
     closeAndFail,
     output: {
@@ -197,6 +237,7 @@ export function createCliCommandContext(ownerId: string, plugins: GloomPlugin[])
       renderStat,
       renderTable,
     },
+    printResult: (result, options) => printCliResult(result, cliOptions, options),
     log: debugLog.createLogger(ownerId === "core" ? "cli" : ownerId),
   };
 }

--- a/src/cli/result.test.ts
+++ b/src/cli/result.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { serializeCliError, serializeCliResult } from "./result";
+import type { CliGlobalOptions } from "./options";
+
+const baseOptions: CliGlobalOptions = {
+  format: "text",
+  quiet: false,
+  color: null,
+  refresh: false,
+  dryRun: false,
+  yes: false,
+};
+
+describe("serializeCliResult", () => {
+  test("renders limited JSON result envelopes", () => {
+    const output = serializeCliResult(
+      { data: [{ symbol: "AAPL" }, { symbol: "MSFT" }] },
+      { ...baseOptions, format: "json", limit: 1 },
+    );
+    expect(JSON.parse(output)).toEqual({
+      ok: true,
+      data: [{ symbol: "AAPL" }],
+    });
+  });
+
+  test("includes display column metadata in JSON envelopes", () => {
+    const output = serializeCliResult(
+      { data: [{ quote: { symbol: "AAPL", price: 123 } }] },
+      { ...baseOptions, format: "json" },
+      {
+        rows: (data) => data.map((row) => row.quote),
+        columns: [
+          { key: "symbol", header: "Symbol" },
+          { key: "price", header: "Last", align: "right" },
+        ],
+      },
+    );
+    expect(JSON.parse(output)).toEqual({
+      ok: true,
+      data: [{ quote: { symbol: "AAPL", price: 123 } }],
+      columns: [
+        { key: "symbol", header: "Symbol" },
+        { key: "price", header: "Last", align: "right" },
+      ],
+    });
+  });
+
+  test("renders CSV with provided column order", () => {
+    const output = serializeCliResult(
+      { data: [{ symbol: "AAPL", name: "Apple, Inc." }] },
+      { ...baseOptions, format: "csv" },
+      {
+        columns: [
+          { key: "symbol", header: "Symbol" },
+          { key: "name", header: "Name" },
+        ],
+      },
+    );
+    expect(output).toBe('Symbol,Name\nAAPL,"Apple, Inc."');
+  });
+
+  test("renders NDJSON rows", () => {
+    const output = serializeCliResult(
+      { data: [{ symbol: "AAPL" }, { symbol: "MSFT" }] },
+      { ...baseOptions, format: "ndjson" },
+    );
+    expect(output).toBe('{"symbol":"AAPL"}\n{"symbol":"MSFT"}');
+  });
+});
+
+describe("serializeCliError", () => {
+  test("renders stable structured errors for JSON", () => {
+    const output = serializeCliError(
+      { code: "auth_required", message: "Sign in first.", retryable: true },
+      { ...baseOptions, format: "json" },
+    );
+    expect(JSON.parse(output)).toEqual({
+      ok: false,
+      error: { code: "auth_required", message: "Sign in first.", retryable: true },
+    });
+  });
+});

--- a/src/cli/result.ts
+++ b/src/cli/result.ts
@@ -1,0 +1,149 @@
+import type { CliGlobalOptions } from "./options";
+import { renderTable, type CliTableColumn } from "../utils/cli-output";
+
+export interface CliResult<T = unknown> {
+  data: T;
+  metadata?: Record<string, unknown>;
+  warnings?: string[];
+}
+
+export interface CliErrorObject {
+  code: string;
+  message: string;
+  details?: unknown;
+  retryable?: boolean;
+}
+
+export interface CliResultColumn<Row = Record<string, unknown>> extends CliTableColumn {
+  key: string;
+  value?: (row: Row) => unknown;
+}
+
+export interface CliResultRenderOptions<T = unknown, Row = Record<string, unknown>> {
+  text?: (data: T) => string;
+  columns?: CliResultColumn<Row>[];
+  rows?: (data: T) => Row[];
+}
+
+interface CliResultJsonEnvelope<T> extends CliResult<T> {
+  ok: true;
+  columns?: Array<Pick<CliResultColumn, "key" | "header" | "align" | "width">>;
+}
+
+function applyLimit<T>(data: T, limit?: number): T {
+  if (!Array.isArray(data) || limit == null) return data;
+  return data.slice(0, limit) as T;
+}
+
+function asRows<T, Row>(data: T, limit?: number, rows?: (data: T) => Row[]): Row[] {
+  const resolvedRows = rows ? rows(data) : (Array.isArray(data) ? data : [data]) as Row[];
+  return limit == null ? resolvedRows : resolvedRows.slice(0, limit);
+}
+
+function normalizeCell(value: unknown): string {
+  if (value == null) return "";
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function inferColumns(rows: Record<string, unknown>[]): CliResultColumn<Record<string, unknown>>[] {
+  const keys = new Set<string>();
+  for (const row of rows) {
+    if (row && typeof row === "object" && !Array.isArray(row)) {
+      for (const key of Object.keys(row)) keys.add(key);
+    }
+  }
+  return [...keys].map((key) => ({ key, header: key }));
+}
+
+function csvEscape(value: string): string {
+  if (!/[",\n\r]/.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function serializeColumns<Row>(columns?: CliResultColumn<Row>[]) {
+  return columns?.map((column) => ({
+    key: column.key,
+    header: column.header,
+    ...(column.align ? { align: column.align } : {}),
+    ...(column.width ? { width: column.width } : {}),
+  }));
+}
+
+function renderCsv<Row extends Record<string, unknown>>(
+  rows: Row[],
+  columns?: CliResultColumn<Row>[],
+): string {
+  const resolvedColumns = columns && columns.length > 0
+    ? columns
+    : inferColumns(rows as Record<string, unknown>[]) as CliResultColumn<Row>[];
+  const header = resolvedColumns.map((column) => csvEscape(column.header)).join(",");
+  const body = rows.map((row) => resolvedColumns
+    .map((column) => csvEscape(normalizeCell(column.value ? column.value(row) : row[column.key])))
+    .join(","));
+  return [header, ...body].join("\n");
+}
+
+function renderTextTable<Row extends Record<string, unknown>>(
+  rows: Row[],
+  columns?: CliResultColumn<Row>[],
+): string {
+  const resolvedColumns = columns && columns.length > 0
+    ? columns
+    : inferColumns(rows as Record<string, unknown>[]) as CliResultColumn<Row>[];
+  return renderTable(
+    resolvedColumns.map((column) => ({
+      header: column.header,
+      align: column.align,
+      width: column.width,
+    })),
+    rows.map((row) => resolvedColumns.map((column) => normalizeCell(column.value ? column.value(row) : row[column.key]))),
+  );
+}
+
+export function serializeCliResult<T, Row extends Record<string, unknown> = Record<string, unknown>>(
+  result: CliResult<T>,
+  options: CliGlobalOptions,
+  renderOptions: CliResultRenderOptions<T, Row> = {},
+): string {
+  if (options.format === "json") {
+    const columns = serializeColumns(renderOptions.columns);
+    const envelope: CliResultJsonEnvelope<T> = {
+      ok: true,
+      ...result,
+      data: applyLimit(result.data, options.limit),
+      ...(columns?.length ? { columns } : {}),
+    };
+    return JSON.stringify(envelope, null, 2);
+  }
+
+  const rows = asRows(result.data, options.limit, renderOptions.rows);
+  if (options.format === "ndjson") {
+    return rows.map((row) => JSON.stringify(row)).join("\n");
+  }
+  if (options.format === "csv") {
+    return renderCsv(rows as Row[], renderOptions.columns);
+  }
+  if (renderOptions.text) {
+    return renderOptions.text(result.data);
+  }
+  return renderTextTable(rows as Row[], renderOptions.columns);
+}
+
+export function printCliResult<T, Row extends Record<string, unknown> = Record<string, unknown>>(
+  result: CliResult<T>,
+  options: CliGlobalOptions,
+  renderOptions: CliResultRenderOptions<T, Row> = {},
+): void {
+  if (options.quiet && options.format === "text") return;
+  const output = serializeCliResult(result, options, renderOptions);
+  if (output) console.log(output);
+}
+
+export function serializeCliError(error: CliErrorObject, options: CliGlobalOptions): string {
+  if (options.format === "json" || options.format === "ndjson") {
+    return JSON.stringify({ ok: false, error }, null, options.format === "json" ? 2 : 0);
+  }
+  return error.details == null ? error.message : `${error.message}\n${String(error.details)}`;
+}

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -2,6 +2,7 @@ import type { AppConfig } from "../types/config";
 import { AppPersistence } from "../data/app-persistence";
 import { TickerRepository } from "../data/ticker-repository";
 import { AssetDataRouter } from "../sources/provider-router";
+import type { AppServices } from "../core/app-services";
 
 export type ConfigContext = {
   config: AppConfig;
@@ -12,4 +13,14 @@ export type ConfigContext = {
 
 export type MarketContext = ConfigContext & {
   dataProvider: AssetDataRouter;
+};
+
+export type CliServicesContext = {
+  config: AppConfig;
+  dataDir: string;
+  services: AppServices;
+  dataProvider: AssetDataRouter;
+  persistence: AppPersistence;
+  store: TickerRepository;
+  destroy(): void;
 };

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -12,7 +12,7 @@ import { assetDataProvider, newsProvider } from "../capabilities";
 import type { AppConfig } from "../types/config";
 import type { DataProvider } from "../types/data-provider";
 import { debugLog } from "../utils/debug-log";
-import { measurePerf } from "../utils/perf-marks";
+import { measurePerf, measurePerfAsync } from "../utils/perf-marks";
 import { setIbkrPortfolioPerformanceResourceStore } from "../plugins/ibkr/portfolio-performance";
 
 const servicesLog = debugLog.createLogger("services");
@@ -25,6 +25,7 @@ export interface AppServices {
   marketData: MarketDataCoordinator;
   pluginRegistry: PluginRegistry;
   newsService: NewsService;
+  ready: Promise<void>;
   destroy(): void;
 }
 
@@ -68,10 +69,11 @@ export function createAppServices({
   setSharedMarketDataCoordinator(marketData);
 
   const plugins = getLoadablePlugins(externalPlugins);
+  const pluginReadyPromises: Promise<void>[] = [];
   for (const plugin of plugins) {
-    measurePerf("startup.services.register-plugin", () => {
-      void pluginRegistry.register(plugin);
-    }, { pluginId: plugin.id });
+    pluginReadyPromises.push(measurePerfAsync("startup.services.register-plugin", () => (
+      pluginRegistry.register(plugin)
+    ), { pluginId: plugin.id }));
   }
   measurePerf("startup.services.news-start", () => {
     newsService.start();
@@ -86,6 +88,7 @@ export function createAppServices({
     marketData,
     pluginRegistry,
     newsService,
+    ready: Promise.all(pluginReadyPromises).then(() => {}),
     destroy() {
       setSharedMarketDataCoordinator(null);
       setSharedNewsService(null);

--- a/src/data/config/store/index.ts
+++ b/src/data/config/store/index.ts
@@ -21,8 +21,7 @@ export function setConfigStoreHost(host: ConfigStoreHost | null): void {
 
 async function loadNodeHost(): Promise<ConfigStoreHost> {
   if (!nodeHostPromise) {
-    const modulePath = "./node";
-    nodeHostPromise = import(modulePath) as Promise<ConfigStoreHost>;
+    nodeHostPromise = import("./node") as Promise<ConfigStoreHost>;
   }
   return nodeHostPromise;
 }

--- a/src/plugins/builtin/portfolio-list/cli/portfolio-command.ts
+++ b/src/plugins/builtin/portfolio-list/cli/portfolio-command.ts
@@ -1,4 +1,5 @@
 import { saveConfig } from "../../../../data/config/store";
+import { countCollectionTickers } from "../../../../cli/helpers";
 import { resolveTickerForCli } from "../../../../cli/ticker-resolution";
 import { cliStyles, renderStat } from "../../../../utils/cli-output";
 import { formatMarketCostWithCurrency, formatMarketQuantity } from "../../../../market-data/market/format";
@@ -17,6 +18,28 @@ import { parseFiniteNumber, requireManualPortfolio } from "./shared";
 async function listCollections(ctx: CliCommandContext) {
   const { config, store, persistence } = await ctx.initConfigData();
   const tickers = await store.loadAllTickers();
+  if (ctx.cliOptions.format !== "text") {
+    ctx.printResult({
+      data: {
+        portfolios: config.portfolios.map((portfolio) => ({
+          id: portfolio.id,
+          name: portfolio.name,
+          currency: portfolio.currency,
+          brokerId: portfolio.brokerId ?? "",
+          brokerInstanceId: portfolio.brokerInstanceId ?? "",
+          brokerAccountId: portfolio.brokerAccountId ?? "",
+          tickerCount: countCollectionTickers(tickers, "portfolios", portfolio.id),
+        })),
+        watchlists: config.watchlists.map((watchlist) => ({
+          id: watchlist.id,
+          name: watchlist.name,
+          tickerCount: countCollectionTickers(tickers, "watchlists", watchlist.id),
+        })),
+      },
+    });
+    persistence.close();
+    return;
+  }
   console.log(renderCollectionOverview(config, tickers));
   persistence.close();
 }

--- a/src/plugins/builtin/portfolio-list/cli/watchlist-command.ts
+++ b/src/plugins/builtin/portfolio-list/cli/watchlist-command.ts
@@ -129,6 +129,23 @@ async function removeTickerFromWatchlist(watchlistName: string, symbol: string, 
 async function listWatchlists(ctx: CliCommandContext) {
   const { config, store, persistence } = await ctx.initConfigData();
   const tickers = await store.loadAllTickers();
+  const rows = config.watchlists.map((watchlist) => ({
+    id: watchlist.id,
+    name: watchlist.name,
+    tickerCount: countCollectionTickers(tickers, "watchlists", watchlist.id),
+  }));
+
+  if (ctx.cliOptions.format !== "text") {
+    ctx.printResult({ data: rows }, {
+      columns: [
+        { key: "name", header: "Watchlist" },
+        { key: "id", header: "ID" },
+        { key: "tickerCount", header: "Tickers", align: "right" },
+      ],
+    });
+    persistence.close();
+    return;
+  }
 
   console.log(renderSection("Watchlists"));
   if (config.watchlists.length === 0) {
@@ -143,10 +160,10 @@ async function listWatchlists(ctx: CliCommandContext) {
       { header: "ID" },
       { header: "Tickers", align: "right" },
     ],
-    config.watchlists.map((watchlist) => [
+    rows.map((watchlist) => [
       watchlist.name,
       watchlist.id,
-      String(countCollectionTickers(tickers, "watchlists", watchlist.id)),
+      String(watchlist.tickerCount),
     ]),
   ));
   persistence.close();

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -7,7 +7,7 @@ import type { AppServices } from "../../../core/app-services";
 import type { AppConfig } from "../../../types/config";
 import { newsProvider } from "../../../capabilities";
 import { debugLog } from "../../../utils/debug-log";
-import { measurePerf } from "../../../utils/perf-marks";
+import { measurePerf, measurePerfAsync } from "../../../utils/perf-marks";
 import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 import { createRemoteAssetDataClient } from "./remote/asset-data-client";
 import { RemotePersistence } from "./remote/persistence";
@@ -47,10 +47,11 @@ export function createAppServices({ config }: { config: AppConfig }): AppService
   }));
 
   const plugins = getRendererBuiltinPlugins();
+  const pluginReadyPromises: Promise<void>[] = [];
   for (const plugin of plugins) {
-    measurePerf("startup.services.register-plugin", () => {
-      void pluginRegistry.register(plugin);
-    }, { pluginId: plugin.id });
+    pluginReadyPromises.push(measurePerfAsync("startup.services.register-plugin", () => (
+      pluginRegistry.register(plugin)
+    ), { pluginId: plugin.id }));
   }
   measurePerf("startup.services.news-start", () => {
     newsService.start();
@@ -65,6 +66,7 @@ export function createAppServices({ config }: { config: AppConfig }): AppService
     marketData,
     pluginRegistry,
     newsService,
+    ready: Promise.all(pluginReadyPromises).then(() => {}),
     destroy() {
       setSharedMarketDataCoordinator(null);
       setSharedNewsService(null);

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -16,18 +16,26 @@ import { ToastHostProvider } from "../../ui/toast";
 import { colors } from "../../theme/colors";
 import { startMainThreadMonitor } from "../../utils/main-thread-monitor";
 import { measurePerfAsync } from "../../utils/perf-marks";
+import type { CliLaunchRequest } from "../../types/plugin";
 
-export async function startOpenTuiApp(): Promise<void> {
+export interface StartOpenTuiAppOptions {
+  externalPlugins?: Awaited<ReturnType<typeof loadExternalPlugins>>;
+  cliArgs?: string[];
+  skipCliDispatch?: boolean;
+  cliLaunchRequest?: CliLaunchRequest | null;
+}
+
+export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Promise<void> {
   setConfigStoreHost(nodeConfigStoreHost);
   debugLog.interceptConsole();
 
   const appLog = debugLog.createLogger("app");
   appLog.info("Gloomberb starting");
 
-  const cliArgs = process.argv.slice(2);
-  const externalPlugins = await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins());
-  let cliLaunchRequest = null;
-  if (cliArgs.length > 0) {
+  const cliArgs = options.cliArgs ?? process.argv.slice(2);
+  const externalPlugins = options.externalPlugins ?? await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins());
+  let cliLaunchRequest = options.cliLaunchRequest ?? null;
+  if (!options.skipCliDispatch && cliArgs.length > 0) {
     const dispatchResult = await dispatchCli(cliArgs, { externalPlugins });
     if (dispatchResult.kind === "handled") return;
     if (dispatchResult.kind === "launch-ui") {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -4,6 +4,8 @@ import type { PluginEvents } from "../plugins/event-bus";
 import type { PluginLogger } from "../utils/debug-log";
 import type { BrokerAdapter } from "./broker";
 import type { PluginCapability } from "../capabilities";
+import type { CliGlobalOptions } from "../cli/options";
+import type { CliResult, CliResultRenderOptions } from "../cli/result";
 import type { ContextMenuContext, ContextMenuItem } from "./context-menu";
 import type {
   AppConfig,
@@ -245,6 +247,8 @@ export type CliDispatchResult =
 export interface CliCommandContext {
   initConfigData(): Promise<import("../cli/types").ConfigContext>;
   initMarketData(): Promise<import("../cli/types").MarketContext>;
+  initServices(): Promise<import("../cli/types").CliServicesContext>;
+  cliOptions: CliGlobalOptions;
   plugins: GloomPlugin[];
   fail(message: string, details?: string): never;
   closeAndFail(
@@ -259,6 +263,10 @@ export interface CliCommandContext {
     renderStat: typeof import("../utils/cli-output").renderStat;
     renderTable: typeof import("../utils/cli-output").renderTable;
   };
+  printResult<T, Row extends Record<string, unknown> = Record<string, unknown>>(
+    result: CliResult<T>,
+    options?: CliResultRenderOptions<T, Row>,
+  ): void;
   log: PluginLogger;
 }
 
@@ -268,6 +276,25 @@ export interface CliCommandDef {
   description: string;
   help?: CliCommandHelp;
   execute(args: string[], ctx: CliCommandContext): void | CliDispatchResult | Promise<void | CliDispatchResult>;
+}
+
+export interface PluginCliCommandDescriptor {
+  name: string;
+  aliases?: string[];
+  summary: string;
+  inputShape?: string;
+  outputShape?: string;
+  examples?: string[];
+  sideEffectLevel?: "none" | "local-write" | "network-write" | "external-trade" | "external-side-effect";
+  requirements?: string[];
+  batch?: boolean;
+  formats?: Array<"text" | "json" | "csv" | "ndjson">;
+  safety?: string[];
+  execute?: CliCommandDef["execute"];
+}
+
+export interface PluginCliDescriptor {
+  commands?: PluginCliCommandDescriptor[];
 }
 
 export interface CommandDef {
@@ -489,6 +516,7 @@ export interface GloomPlugin {
   toggleable?: boolean;
   order?: number;
   cliCommands?: CliCommandDef[];
+  cli?: PluginCliDescriptor;
 
   setup?(ctx: GloomPluginContext): void | Promise<void>;
   dispose?(): void;

--- a/src/utils/cli-output.ts
+++ b/src/utils/cli-output.ts
@@ -8,9 +8,15 @@ export interface CliTableColumn {
 }
 
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+let colorEnabledOverride: boolean | null = null;
 
 function colorEnabled(): boolean {
+  if (colorEnabledOverride != null) return colorEnabledOverride;
   return !!process.stdout.isTTY && process.env.NO_COLOR !== "1" && process.env.TERM !== "dumb";
+}
+
+export function setCliColorEnabledOverride(value: boolean | null): void {
+  colorEnabledOverride = value;
 }
 
 function applyAnsi(text: string, code: string): string {


### PR DESCRIPTION
## Summary
- Split normal CLI commands onto a headless entry path while keeping no-arg and `launch-ui` flows UI-backed.
- Add shared CLI output primitives, global output/execution flags, structured errors, and expert `api list|get|invoke|subscribe` capability access.
- Make JSON the richer automation surface by preserving fetched data models and emitting display-column metadata, while text/CSV/NDJSON stay row-oriented.
- Expand first-class CLI coverage for market data, overview/macro, local state/config, provider/plugin/system, selected cloud/social, broker/IBKR safety stubs, AI, and RSS commands.
- Update README and plugin docs for the new CLI/capability descriptor model while keeping auth, account, and chat commands deferred.

## Validation
- `bun test src/cli/options.test.ts src/cli/result.test.ts src/cli/registry.test.ts src/cli.test.ts src/architecture/import-boundaries.test.ts`
- `bun test` (passes with existing React `act(...)` warnings)
- `bun build --target=bun src/cli/entry.ts --outdir=/tmp/gloomberb-entry-build`
- Smoke: `command`, `api list`, `quote`, `history`, `news`, `provider status`, `plugin list`, `portfolio list`, `watchlist list`, and `doctor` with JSON output.
- Rich JSON smoke: `quote`, `financials`, `news`, and `holders` expose full fetched models plus display columns.
- Broader command matrix was exercised earlier for the new read-only/local command groups; destructive broker/cache/debug/config actions were limited to guarded or dry-run paths.
