### PR TITLE
Fix Mac app Command-Q quit

### DIFF
--- a/src/renderers/electrobun/bun/application-menu/click.test.ts
+++ b/src/renderers/electrobun/bun/application-menu/click.test.ts
@@ -30,6 +30,15 @@ describe("applicationMenuCommand", () => {
     })).toEqual({ type: "open-devtools" });
   });
 
+  test("parses the native quit command", () => {
+    expect(applicationMenuCommand({
+      data: {
+        action: ELECTROBUN_APPLICATION_MENU_ACTION,
+        data: { type: "quit" },
+      },
+    })).toEqual({ type: "quit" });
+  });
+
   test("ignores unknown command types", () => {
     expect(applicationMenuCommand({
       data: {

--- a/src/renderers/electrobun/bun/application-menu/click.ts
+++ b/src/renderers/electrobun/bun/application-menu/click.ts
@@ -45,6 +45,7 @@ function normalizeApplicationMenuCommand(value: unknown): ElectrobunApplicationM
     case "layout-redo":
     case "layout-gridlock":
     case "open-devtools":
+    case "quit":
       return { type: command.type };
     default:
       return null;

--- a/src/renderers/electrobun/bun/application-menu/index.test.ts
+++ b/src/renderers/electrobun/bun/application-menu/index.test.ts
@@ -9,4 +9,13 @@ describe("desktop application menu", () => {
   test("keeps the native application menu on macOS", () => {
     expect(buildDesktopApplicationMenu("darwin")).toEqual(buildApplicationMenu());
   });
+
+  test("routes macOS quit through an explicit command item", () => {
+    const appMenu = buildApplicationMenu()[0]?.submenu;
+    expect(appMenu?.at(-1)).toMatchObject({
+      label: "Quit Gloomberb",
+      accelerator: "CmdOrCtrl+Q",
+      data: { type: "quit" },
+    });
+  });
 });

--- a/src/renderers/electrobun/bun/application-menu/index.ts
+++ b/src/renderers/electrobun/bun/application-menu/index.ts
@@ -6,7 +6,8 @@ const GITHUB_ISSUE_URL = "https://github.com/vincelwt/gloomberb/issues/new/choos
 
 export type ElectrobunApplicationMenuCommand =
   | DesktopApplicationMenuCommand
-  | { type: "open-devtools" };
+  | { type: "open-devtools" }
+  | { type: "quit" };
 
 function commandItem(
   label: string,
@@ -38,7 +39,7 @@ export function buildApplicationMenu(): ApplicationMenuItemConfig[] {
         { role: "hideOthers" },
         { role: "showAll" },
         { type: "divider" },
-        { role: "quit" },
+        commandItem("Quit Gloomberb", { type: "quit" }, { accelerator: "CmdOrCtrl+Q" }),
       ],
     },
     {

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -281,6 +281,15 @@ function closeAllDetachedWindows(): void {
   detachedWindowManager.closeAll();
 }
 
+function quitDesktopApp(): void {
+  closeAllDetachedWindows();
+  teardownServices();
+  const window = mainWindow;
+  mainWindow = null;
+  window?.close();
+  Utils.quit();
+}
+
 function controlWindowForRpcKey(windowKey: string | undefined, action: DesktopWindowControlAction): boolean {
   const targetWindow = windowKey === MAIN_WINDOW_RPC_KEY
     ? mainWindow
@@ -444,6 +453,10 @@ ApplicationMenu.on("application-menu-clicked", (event: unknown) => {
   if (!command) return;
   if (command.type === "open-devtools") {
     openMainWindowDevTools();
+    return;
+  }
+  if (command.type === "quit") {
+    quitDesktopApp();
     return;
   }
   if (!isWindowRpcReady(MAIN_WINDOW_RPC_KEY)) return;


### PR DESCRIPTION
## Summary
- Route the macOS Quit menu item through an explicit application-menu command with CmdOrCtrl+Q.
- Handle the quit command in the Electrobun desktop process so it closes detached windows, tears down services, closes the main window, and exits.
- Add focused menu builder and click parser coverage for the quit command.

## Root cause
The menu relied on Electrobun's native quit role, which no longer reliably invoked the app shutdown path. The new explicit command bypasses role handling and works even before the main window RPC is ready.

## Validation
- bun test src/renderers/electrobun/bun/application-menu/index.test.ts src/renderers/electrobun/bun/application-menu/click.test.ts
- bun run desktop:build
- Launched the built Mac app, sent Command-Q, and confirmed the app process exited
- git diff --check