### PR TITLE
Open no-field pane templates directly

### DIFF
--- a/src/components/command-bar/pane-templates/workflow-route.ts
+++ b/src/components/command-bar/pane-templates/workflow-route.ts
@@ -16,7 +16,17 @@ import {
   getPaneTemplateDisplayLabel,
 } from "./items";
 
+function paneTemplateHasConfigFields(template: PaneTemplateDef): boolean {
+  if (template.wizard?.some((step) => step.type !== "info")) {
+    return true;
+  }
+  return !!buildGeneratedTemplateField(template, null).field;
+}
+
 export function shouldOpenPaneTemplateConfig(template: PaneTemplateDef, arg?: string): boolean {
+  if (!paneTemplateHasConfigFields(template)) {
+    return false;
+  }
   if (template.wizard && template.wizard.length > 0) {
     if (!arg?.trim()) {
       return true;

--- a/src/components/command-bar/surface/pane.test.tsx
+++ b/src/components/command-bar/surface/pane.test.tsx
@@ -117,6 +117,42 @@ function registerOptionalTextPane(pluginRegistry: MutablePaneRegistry): void {
   });
 }
 
+function registerQueryOnlyPane(pluginRegistry: MutablePaneRegistry): void {
+  mutableRegistryMap(pluginRegistry.panes).set("prediction-markets", {
+    id: "prediction-markets",
+    name: "Prediction Markets",
+    component: () => null,
+    defaultPosition: "left",
+    defaultMode: "floating",
+  });
+  mutableRegistryMap(pluginRegistry.paneTemplates).set("new-prediction-markets-pane", {
+    id: "new-prediction-markets-pane",
+    paneId: "prediction-markets",
+    label: "Prediction Markets",
+    description: "Open a new prediction markets browser pane",
+    keywords: ["prediction", "markets", "polymarket", "kalshi", "events"],
+    shortcut: { prefix: "PM", argPlaceholder: "query", argKind: "text" },
+  });
+}
+
+function registerShortcutOnlyPane(pluginRegistry: MutablePaneRegistry): void {
+  mutableRegistryMap(pluginRegistry.panes).set("top-news", {
+    id: "top-news",
+    name: "Top News",
+    component: () => null,
+    defaultPosition: "right",
+    defaultMode: "floating",
+  });
+  mutableRegistryMap(pluginRegistry.paneTemplates).set("top-news-pane", {
+    id: "top-news-pane",
+    paneId: "top-news",
+    label: "Top News",
+    description: "Curated top market stories ranked by importance",
+    keywords: ["top", "news", "headlines", "stories"],
+    shortcut: { prefix: "TOP" },
+  });
+}
+
 describe("CommandBar pane and layout routes", () => {
   const layoutModeConfig = (config: AppConfig): AppConfig => {
     const research = cloneLayout(config.layout);
@@ -270,6 +306,46 @@ describe("CommandBar pane and layout routes", () => {
     expect(created).toEqual([{ templateId: "optional-search-pane", options: undefined }]);
     expect(testSetup.captureCharFrame()).not.toContain("Create Pane");
   });
+
+  for (const scenario of [
+    {
+      query: "prediction markets",
+      register: registerQueryOnlyPane,
+      templateId: "new-prediction-markets-pane",
+    },
+    {
+      query: "top news",
+      register: registerShortcutOnlyPane,
+      templateId: "top-news-pane",
+    },
+  ] as const) {
+    test(`creates ${scenario.templateId} directly when it has no config fields`, async () => {
+      const created: CreatedPaneCall[] = [];
+
+      testSetup = await testRender(<CommandBarHarness
+        query={scenario.query}
+        live
+        configurePluginRegistry={(pluginRegistry) => {
+          scenario.register(pluginRegistry);
+          recordPaneCreations(pluginRegistry, created);
+        }}
+      />, {
+        width: 100,
+        height: 18,
+      });
+
+      await testSetup.renderOnce();
+
+      await act(async () => {
+        testSetup!.mockInput.pressEnter();
+        await Bun.sleep(0);
+        await testSetup!.renderOnce();
+      });
+
+      expect(created).toEqual([{ templateId: scenario.templateId, options: undefined }]);
+      expect(testSetup.captureCharFrame()).not.toContain("Create Pane");
+    });
+  }
 
   test("shows pane templates that share the same shortcut", async () => {
     testSetup = await testRender(<CommandBarHarness


### PR DESCRIPTION
## Summary
- Avoid opening pane-template workflows when the template has no visible config fields.
- Keep templates with real fields, such as ticker lists or AI prompt fields, on the workflow path.
- Add command-bar regressions for both free-text and shortcut-only no-field pane templates.

## Root cause
The command bar treated some pane templates as promptable even when the generated workflow had no fields to collect, leaving users on an empty confirmation step.

## Validation
- `bun test src/components/command-bar/surface/pane.test.tsx src/components/command-bar/surface/index.test.tsx src/components/command-bar/view-model.test.ts`
- Audited all 52 registered pane templates: 30 no-field templates direct, 22 templates prompt with fields, 0 empty-workflow risks.
- tmux smoke for `top news`: selected pane opened directly with no `Create Pane` step.