### PR TITLE
Fix X Feed search input capture

### DIFF
--- a/src/components/data-table/view.tsx
+++ b/src/components/data-table/view.tsx
@@ -26,6 +26,11 @@ export type DataTableKeyEvent = TableViewKeyEvent;
 
 const DATA_TABLE_SELECTION_COMMIT_DELAY_MS = 150;
 
+export interface DataTableRootKeyContext {
+  selectedIndex: number;
+  itemCount: number;
+}
+
 export type DataTableSelectionChangeReason =
   | "keyboard"
   | "pointer"
@@ -95,7 +100,10 @@ export interface DataTableViewProps<
   hoveredIdx?: number | null;
   setHoveredIdx?: (index: number | null) => void;
   keyboardNavigation?: boolean;
-  onRootKeyDown?: (event: DataTableKeyEvent) => boolean | void;
+  onRootKeyDown?: (
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => boolean | void;
   resetScrollKey?: unknown;
 }
 
@@ -486,7 +494,10 @@ export function DataTableView<
     if (event.defaultPrevented || event.propagationStopped) return;
     if (!focused || !keyboardNavigation) return;
 
-    if (onRootKeyDown?.(event)) return;
+    if (onRootKeyDown?.(event, {
+      selectedIndex: effectiveSelectedIndexRef.current,
+      itemCount: tableProps.items.length,
+    })) return;
     if (tableProps.items.length === 0) return;
 
     if (isNextTableRowKey(event)) {

--- a/src/components/feed-data-table/stack-view.tsx
+++ b/src/components/feed-data-table/stack-view.tsx
@@ -6,6 +6,7 @@ import { formatTimeAgo } from "../../utils/format";
 import { isPlainKey } from "../../utils/keyboard";
 import { toTimestampMillis } from "../../utils/timestamp";
 import { DataTableStackView } from "../data-table/stack-view";
+import type { DataTableRootKeyContext } from "../data-table/view";
 import {
   activeStackIndex,
   sortIndexedStackRows,
@@ -45,9 +46,16 @@ interface FeedDataTableStackViewProps {
   rootAfter?: ReactNode;
   onRootKeyDown?: (event: {
     name?: string;
+    sequence?: string;
+    ctrl?: boolean;
+    meta?: boolean;
+    super?: boolean;
+    alt?: boolean;
+    option?: boolean;
+    shift?: boolean;
     preventDefault?: () => void;
     stopPropagation?: () => void;
-  }) => boolean | void;
+  }, context: DataTableRootKeyContext) => boolean | void;
   sourceLabel?: string;
   titleLabel?: string;
   emptyStateTitle?: string;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,7 +8,7 @@ export type { TickerListVisibleRange } from "./ticker/list-table-view";
 export { TickerBadgeList } from "./ticker/badge/list";
 export { InputSearchBar } from "./input-search-bar";
 export { DataTableView } from "./data-table/view";
-export type { DataTableKeyEvent } from "./data-table/view";
+export type { DataTableKeyEvent, DataTableRootKeyContext } from "./data-table/view";
 export { DataTableStackView } from "./data-table/stack-view";
 export { FeedDataTableStackView } from "./feed-data-table/stack-view";
 export type { FeedDataTableItem } from "./feed-data-table/stack-view";

--- a/src/components/input-search-bar.test.tsx
+++ b/src/components/input-search-bar.test.tsx
@@ -18,7 +18,13 @@ afterEach(async () => {
   testSetup = undefined;
 });
 
-function Harness({ actions }: { actions: AppAction[] }) {
+function Harness({
+  actions,
+  onNavigateDown,
+}: {
+  actions: AppAction[];
+  onNavigateDown?: () => void;
+}) {
   const state = createInitialState(createDefaultConfig("/tmp/gloomberb-input-search-bar"));
   const inputRef = useRef<InputRenderable | null>(null);
   const [active, setActive] = useState(true);
@@ -38,6 +44,7 @@ function Harness({ actions }: { actions: AppAction[] }) {
         inputRef={inputRef}
         placeholder="search"
         debounceMs={100}
+        onNavigateDown={onNavigateDown}
         onFocus={() => {}}
         onBlur={() => {}}
         onQueryChange={() => {}}
@@ -67,5 +74,30 @@ describe("InputSearchBar", () => {
       { type: "SET_INPUT_CAPTURED", captured: true },
       { type: "SET_INPUT_CAPTURED", captured: false },
     ]);
+  });
+
+  test("moves from the active search input to the table with Down", async () => {
+    const actions: AppAction[] = [];
+    let navigatedDown = 0;
+
+    testSetup = await testRender(
+      <Harness
+        actions={actions}
+        onNavigateDown={() => {
+          navigatedDown += 1;
+        }}
+      />,
+      { width: 40, height: 4 },
+    );
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("down");
+      await testSetup!.renderOnce();
+    });
+
+    expect(navigatedDown).toBe(1);
   });
 });

--- a/src/components/input-search-bar.test.tsx
+++ b/src/components/input-search-bar.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useCallback, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { testRender } from "../renderers/opentui/test-utils";
+import { AppContext, createInitialState, type AppAction } from "../state/app/context";
+import { createDefaultConfig } from "../types/config";
+import type { InputRenderable } from "../ui";
+import { InputSearchBar } from "./input-search-bar";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let setSearchActive: Dispatch<SetStateAction<boolean>> | null = null;
+
+afterEach(async () => {
+  setSearchActive = null;
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+function Harness({ actions }: { actions: AppAction[] }) {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-input-search-bar"));
+  const inputRef = useRef<InputRenderable | null>(null);
+  const [active, setActive] = useState(true);
+  setSearchActive = setActive;
+  const dispatch = useCallback((action: AppAction) => {
+    actions.push(action);
+  }, [actions]);
+
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <InputSearchBar
+        value=""
+        focused
+        active={active}
+        width={30}
+        focusToken={0}
+        inputRef={inputRef}
+        placeholder="search"
+        debounceMs={100}
+        onFocus={() => {}}
+        onBlur={() => {}}
+        onQueryChange={() => {}}
+      />
+    </AppContext>
+  );
+}
+
+describe("InputSearchBar", () => {
+  test("captures app input while the search input is active", async () => {
+    const actions: AppAction[] = [];
+
+    testSetup = await testRender(<Harness actions={actions} />, { width: 40, height: 4 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions).toEqual([{ type: "SET_INPUT_CAPTURED", captured: true }]);
+    if (!setSearchActive) throw new Error("search setter was not registered");
+
+    await act(async () => {
+      setSearchActive(false);
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions).toEqual([
+      { type: "SET_INPUT_CAPTURED", captured: true },
+      { type: "SET_INPUT_CAPTURED", captured: false },
+    ]);
+  });
+});

--- a/src/components/input-search-bar.tsx
+++ b/src/components/input-search-bar.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState, type RefObject } from "react";
 import { Box, Input, Text, type InputRenderable } from "../ui";
 import { colors } from "../theme/colors";
 import { useAppInputCapture } from "../state/app/input-capture";
+import { useShortcut } from "../react/input";
+import { isPlainArrowDown, stopSearchFocusNavigation } from "../utils/search-focus-navigation";
 
 export function InputSearchBar({
   value,
@@ -13,6 +15,7 @@ export function InputSearchBar({
   placeholder,
   debounceMs,
   normalizeValue = identity,
+  onNavigateDown,
   onFocus,
   onBlur,
   onQueryChange,
@@ -26,12 +29,23 @@ export function InputSearchBar({
   placeholder: string;
   debounceMs: number;
   normalizeValue?: (value: string) => string;
+  onNavigateDown?: () => void;
   onFocus: () => void;
   onBlur: () => void;
   onQueryChange: (query: string) => void;
 }) {
   const [draft, setDraft] = useState(value);
   useAppInputCapture(focused && active);
+
+  useShortcut((event) => {
+    if (!onNavigateDown || !isPlainArrowDown(event)) return;
+    stopSearchFocusNavigation(event);
+    onNavigateDown();
+  }, {
+    allowEditable: true,
+    enabled: focused && active && !!onNavigateDown,
+    phase: "before",
+  });
 
   useEffect(() => {
     setDraft(value);

--- a/src/components/input-search-bar.tsx
+++ b/src/components/input-search-bar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
 import { Box, Input, Text, type InputRenderable } from "../ui";
 import { colors } from "../theme/colors";
+import { useAppInputCapture } from "../state/app/input-capture";
 
 export function InputSearchBar({
   value,
@@ -30,6 +31,7 @@ export function InputSearchBar({
   onQueryChange: (query: string) => void;
 }) {
   const [draft, setDraft] = useState(value);
+  useAppInputCapture(focused && active);
 
   useEffect(() => {
     setDraft(value);

--- a/src/plugins/builtin/cloud-tweets/pane.tsx
+++ b/src/plugins/builtin/cloud-tweets/pane.tsx
@@ -267,6 +267,7 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
       inputRef={searchInputRef}
       onFocus={focusSearch}
       onBlur={blurSearch}
+      onNavigateDown={blurSearch}
       onQueryChange={updateFeedQuery}
     />
   ) : null;
@@ -309,6 +310,7 @@ export function TwitterFeedPane({ focused, width, height }: PaneProps) {
           load={loadActiveFeed}
           onResult={markFeedResult}
           onError={markFeedError}
+          onFocusSearch={focusSearch}
           emptyStateTitle={searchEnabled ? "No tweets" : "Enter a search query"}
           emptyStateHint={searchEnabled ? activeFeedQuery : undefined}
         />

--- a/src/plugins/builtin/cloud-tweets/search-bar.tsx
+++ b/src/plugins/builtin/cloud-tweets/search-bar.tsx
@@ -15,6 +15,7 @@ export function TwitterFeedSearchBar({
   inputRef,
   onFocus,
   onBlur,
+  onNavigateDown,
   onQueryChange,
 }: {
   feed: TwitterFeed;
@@ -25,6 +26,7 @@ export function TwitterFeedSearchBar({
   inputRef: RefObject<InputRenderable | null>;
   onFocus: () => void;
   onBlur: () => void;
+  onNavigateDown?: () => void;
   onQueryChange: (feedId: string, query: string) => void;
 }) {
   const updateQuery = useCallback((value: string) => {
@@ -43,6 +45,7 @@ export function TwitterFeedSearchBar({
       debounceMs={TWEET_SEARCH_DEBOUNCE_MS}
       onFocus={onFocus}
       onBlur={onBlur}
+      onNavigateDown={onNavigateDown}
       onQueryChange={updateQuery}
     />
   );

--- a/src/plugins/builtin/cloud-tweets/table.tsx
+++ b/src/plugins/builtin/cloud-tweets/table.tsx
@@ -15,6 +15,7 @@ import type { CloudTweetPayload, CloudTweetSearchResponse } from "../../../api-c
 import { formatTimeAgo } from "../../../utils/format";
 import { colors } from "../../../theme/colors";
 import { CloudAuthNotice } from "../cloud/auth-actions";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import {
   buildTweetColumns,
   formatMetric,
@@ -152,6 +153,7 @@ export function TweetSearchTable({
   load,
   onResult,
   onError,
+  onFocusSearch,
   emptyStateTitle,
   emptyStateHint,
 }: {
@@ -165,6 +167,7 @@ export function TweetSearchTable({
   load: () => Promise<CloudTweetSearchResponse>;
   onResult?: (result: CloudTweetSearchResponse) => void;
   onError?: (message: string) => void;
+  onFocusSearch?: () => void;
   emptyStateTitle?: string;
   emptyStateHint?: string;
 }) {
@@ -220,12 +223,17 @@ export function TweetSearchTable({
   }, []);
 
   const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (onFocusSearch && activeIndex <= 0 && isPlainArrowUp(event)) {
+      stopSearchFocusNavigation(event);
+      onFocusSearch();
+      return true;
+    }
     if (event.name !== "r") return false;
     event.preventDefault?.();
     event.stopPropagation?.();
     reload();
     return true;
-  }, [reload]);
+  }, [activeIndex, onFocusSearch, reload]);
 
   const handleDetailKeyDown = useCallback((event: DataTableKeyEvent) => {
     if (event.name !== "o") return false;

--- a/src/plugins/builtin/cloud-tweets/table.tsx
+++ b/src/plugins/builtin/cloud-tweets/table.tsx
@@ -6,6 +6,7 @@ import {
   usePaneFooter,
   type DataTableCell,
   type DataTableKeyEvent,
+  type DataTableRootKeyContext,
 } from "../../../components";
 import { TickerBadgeText } from "../../../components/ticker/badge/text";
 import { RemoteImage } from "../../../components/ui";
@@ -222,8 +223,11 @@ export function TweetSearchTable({
     ));
   }, []);
 
-  const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
-    if (onFocusSearch && activeIndex <= 0 && isPlainArrowUp(event)) {
+  const handleRootKeyDown = useCallback((
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => {
+    if (onFocusSearch && context.selectedIndex <= 0 && isPlainArrowUp(event)) {
       stopSearchFocusNavigation(event);
       onFocusSearch();
       return true;
@@ -233,7 +237,7 @@ export function TweetSearchTable({
     event.stopPropagation?.();
     reload();
     return true;
-  }, [activeIndex, onFocusSearch, reload]);
+  }, [onFocusSearch, reload]);
 
   const handleDetailKeyDown = useCallback((event: DataTableKeyEvent) => {
     if (event.name !== "o") return false;

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -363,7 +363,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
                 activeValue={activeCollectionId}
                 onSelect={handleCollectionSelect}
                 compact
-                focused={focused}
+                focused={focused && !quickAddFocused}
               />
             </Box>
           </Box>

--- a/src/plugins/builtin/portfolio-list/quick-add/index.tsx
+++ b/src/plugins/builtin/portfolio-list/quick-add/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Input, Text, type InputRenderable } from "../../../../ui";
 import { useShortcut } from "../../../../react/input";
 import { useAppDispatch, useAppSelector } from "../../../../state/app/context";
+import { useAppInputCapture } from "../../../../state/app/input-capture";
 import { getSharedRegistry } from "../../../registry";
 import { usePluginAppActions } from "../../../runtime";
 import { colors, priceColor } from "../../../../theme/colors";
@@ -102,6 +103,7 @@ export function QuickAddTickerInput({
   const [inputValue, setInputValue] = useState("");
   const [validation, setValidation] = useState<QuickAddValidation>(IDLE_VALIDATION);
   const [submitting, setSubmitting] = useState(false);
+  useAppInputCapture(inputFocused && focused);
 
   const focusInput = useCallback(() => {
     if (!focused) return;
@@ -121,13 +123,6 @@ export function QuickAddTickerInput({
   useEffect(() => {
     onFocusChange?.(inputFocused && focused);
   }, [focused, inputFocused, onFocusChange]);
-
-  useEffect(() => {
-    if (inputFocused && focused) {
-      dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
-      return () => dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
-    }
-  }, [dispatch, focused, inputFocused]);
 
   useEffect(() => {
     if (!focused && inputFocused) {

--- a/src/plugins/builtin/thirteenf/pane.test.tsx
+++ b/src/plugins/builtin/thirteenf/pane.test.tsx
@@ -224,6 +224,32 @@ describe("ThirteenFPane", () => {
     ).toBeUndefined();
   });
 
+  test("moves from the first fund row to search with Up", async () => {
+    setHttpFetchTransport(async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith("/topfunds")) {
+        return json([
+          { cik: "1", name: "Alpha Capital", period_of_report: "2026-03-31", pnl: null },
+        ]);
+      }
+      return json([]);
+    });
+
+    await act(async () => {
+      testSetup = await testRender(<Harness />, { width: 100, height: 20 });
+    });
+    await renderFrames();
+
+    await emitKeypress({ name: "up", sequence: "\u001B[A" });
+    await act(async () => {
+      await testSetup!.mockInput.typeText("BRK");
+      await testSetup!.renderOnce();
+    });
+    await renderFrames(2);
+
+    expect(testSetup!.captureCharFrame()).toContain("BRK");
+  });
+
   test("rapid keyboard navigation activates the current rendered row", async () => {
     setHttpFetchTransport(async (url) => {
       const path = new URL(String(url)).pathname;

--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -15,6 +15,7 @@ import {
   Tabs,
   usePaneFooter,
   type DataTableKeyEvent,
+  type DataTableRootKeyContext,
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
 import { usePaneSettingValue } from "../../../state/app/context";
@@ -314,8 +315,11 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
     ? "Loading 13F funds..."
     : error ?? warning ?? "No 13F funds found.";
 
-  const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
-    if (selectedIndex <= 0 && isPlainArrowUp(event)) {
+  const handleRootKeyDown = useCallback((
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => {
+    if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
       stopSearchFocusNavigation(event);
       focusSearch();
       return true;
@@ -333,7 +337,7 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
       return true;
     }
     return false;
-  }, [focusSearch, refresh, selectedIndex]);
+  }, [focusSearch, refresh]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -23,6 +23,7 @@ import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import type { PaneProps } from "../../../types/plugin";
 import { isDetailBackNavigationKey } from "../../../utils/back-navigation";
 import { isPlainKey } from "../../../utils/keyboard";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { truncateWithEllipsis } from "../../../utils/text-wrap";
 import { usePluginPaneState, usePluginTickerActions } from "../../runtime";
 import { loadBrowserRows, loadFilingPositions, loadFundDetail } from "./data";
@@ -303,6 +304,7 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
         normalizeValue={trimSearchValue}
         onFocus={focusSearch}
         onBlur={blurSearch}
+        onNavigateDown={blurSearch}
         onQueryChange={updateQuery}
       />
     </Box>
@@ -313,6 +315,11 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
     : error ?? warning ?? "No 13F funds found.";
 
   const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (selectedIndex <= 0 && isPlainArrowUp(event)) {
+      stopSearchFocusNavigation(event);
+      focusSearch();
+      return true;
+    }
     if (event.name === "r") {
       event.preventDefault?.();
       event.stopPropagation?.();
@@ -326,7 +333,7 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
       return true;
     }
     return false;
-  }, [focusSearch, refresh]);
+  }, [focusSearch, refresh, selectedIndex]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/prediction-markets/controller/index.ts
+++ b/src/plugins/prediction-markets/controller/index.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type InputRenderable, type ScrollBoxRenderable } from "../../../ui";
 import { useViewport } from "../../../react/input";
+import { useAppInputCapture } from "../../../state/app/input-capture";
 import { usePaneInstance } from "../../../state/app/context";
 import {
   useDebouncedPluginPaneState,
@@ -101,6 +102,7 @@ export function usePredictionMarketsController({
   const [searchFocused, setSearchFocused] = useState(false);
   const [initialParamsApplied, setInitialParamsApplied] = useState(false);
   const appViewport = useViewport();
+  useAppInputCapture(focused && searchFocused);
 
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);

--- a/src/plugins/prediction-markets/controller/keyboard.ts
+++ b/src/plugins/prediction-markets/controller/keyboard.ts
@@ -1,6 +1,7 @@
 import { useCallback, type RefObject } from "react";
 import { type ScrollBoxRenderable } from "../../../ui";
 import { useShortcut } from "../../../react/input";
+import { isPlainArrowDown, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { getAdjacentPredictionCategoryId } from "../categories";
 import { resolvePredictionKeyboardCommand } from "../keyboard";
 import { getAdjacentPredictionVenueScope } from "../navigation";
@@ -16,6 +17,11 @@ import type {
 interface PredictionKeyboardEvent {
   name?: string;
   sequence?: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  super?: boolean;
+  alt?: boolean;
+  option?: boolean;
   shift?: boolean;
   preventDefault?: () => void;
   stopPropagation?: () => void;
@@ -102,6 +108,11 @@ export function usePredictionControllerKeyboard({
       const command = resolvePredictionKeyboardCommand(event);
 
       if (searchFocused) {
+        if (isPlainArrowDown(event)) {
+          stopSearchFocusNavigation(event);
+          blurSearch();
+          return;
+        }
         if (command === "escape") {
           event.stopPropagation?.();
           event.preventDefault?.();

--- a/src/plugins/prediction-markets/controller/keyboard.ts
+++ b/src/plugins/prediction-markets/controller/keyboard.ts
@@ -23,6 +23,8 @@ interface PredictionKeyboardEvent {
   alt?: boolean;
   option?: boolean;
   shift?: boolean;
+  defaultPrevented?: boolean;
+  propagationStopped?: boolean;
   preventDefault?: () => void;
   stopPropagation?: () => void;
 }
@@ -68,6 +70,25 @@ export function usePredictionControllerKeyboard({
   setVenue,
   toggleWatchlist,
 }: UsePredictionControllerKeyboardParams) {
+  const handleSearchNavigation = useCallback(
+    (event: PredictionKeyboardEvent) => {
+      if (!focused || !searchFocused) return;
+
+      if (isPlainArrowDown(event)) {
+        stopSearchFocusNavigation(event);
+        blurSearch();
+        return;
+      }
+
+      if (resolvePredictionKeyboardCommand(event) === "escape") {
+        event.stopPropagation?.();
+        event.preventDefault?.();
+        blurSearch();
+      }
+    },
+    [blurSearch, focused, searchFocused],
+  );
+
   const cycleDetailOutcome = useCallback(
     (direction: "previous" | "next") => {
       if (detailTab !== "overview" || sortedOutcomeMarkets.length === 0) {
@@ -104,20 +125,11 @@ export function usePredictionControllerKeyboard({
 
   const handleKeyboard = useCallback(
     (event: PredictionKeyboardEvent) => {
+      if (event.defaultPrevented || event.propagationStopped) return;
       if (!focused) return;
       const command = resolvePredictionKeyboardCommand(event);
 
       if (searchFocused) {
-        if (isPlainArrowDown(event)) {
-          stopSearchFocusNavigation(event);
-          blurSearch();
-          return;
-        }
-        if (command === "escape") {
-          event.stopPropagation?.();
-          event.preventDefault?.();
-          blurSearch();
-        }
         return;
       }
 
@@ -226,6 +238,12 @@ export function usePredictionControllerKeyboard({
       toggleWatchlist,
     ],
   );
+
+  useShortcut(handleSearchNavigation, {
+    allowEditable: true,
+    enabled: focused && searchFocused,
+    phase: "before",
+  });
 
   useShortcut(handleKeyboard);
 }

--- a/src/plugins/prediction-markets/pane.test.tsx
+++ b/src/plugins/prediction-markets/pane.test.tsx
@@ -265,6 +265,25 @@ describe("prediction markets pane interactions", () => {
     expect(frame).not.toContain("\u2190 Back");
   });
 
+  test("moves focus between search and the market table with arrows", async () => {
+    installPredictionMarketMocks();
+
+    testSetup = await testRender(<Harness />, { width: 120, height: 34 });
+    await flushFrames(testSetup);
+
+    await emitKeypress(testSetup, { name: "up", sequence: "\u001b[A" });
+    await flushFrames(testSetup);
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("? search markets");
+
+    await emitKeypress(testSetup, { name: "down", sequence: "\u001b[B" });
+    await flushFrames(testSetup);
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("/ search markets");
+  });
+
   test("supports detail outcome navigation and escape return from the keyboard", async () => {
     attachPredictionMarketsPersistence(new MemoryPersistence());
 

--- a/src/plugins/prediction-markets/pane.test.tsx
+++ b/src/plugins/prediction-markets/pane.test.tsx
@@ -271,13 +271,26 @@ describe("prediction markets pane interactions", () => {
     testSetup = await testRender(<Harness />, { width: 120, height: 34 });
     await flushFrames(testSetup);
 
+    await emitKeypress(testSetup, { name: "j", sequence: "j" });
+    await flushFrames(testSetup, 1);
+
     await emitKeypress(testSetup, { name: "up", sequence: "\u001b[A" });
     await flushFrames(testSetup);
 
     let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("/ search markets");
+
+    await emitKeypress(testSetup, { name: "up", sequence: "\u001b[A" });
+    await flushFrames(testSetup);
+
+    frame = testSetup.captureCharFrame();
     expect(frame).toContain("? search markets");
 
-    await emitKeypress(testSetup, { name: "down", sequence: "\u001b[B" });
+    await emitKeypress(testSetup, {
+      name: "down",
+      sequence: "\u001b[B",
+      targetEditable: true,
+    });
     await flushFrames(testSetup);
 
     frame = testSetup.captureCharFrame();

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -1,6 +1,12 @@
 import { Box, Input, Text } from "../../ui";
 import { useCallback, useMemo, useRef } from "react";
-import { DataTableStackView, Tabs, usePaneFooter, type DataTableKeyEvent } from "../../components";
+import {
+  DataTableStackView,
+  Tabs,
+  usePaneFooter,
+  type DataTableKeyEvent,
+  type DataTableRootKeyContext,
+} from "../../components";
 import { createRowValueCache } from "../../components/ui/row-value-cache";
 import type { PaneProps } from "../../types/plugin";
 import { colors } from "../../theme/colors";
@@ -218,14 +224,17 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
     watchlistedRowKeys,
   ]);
 
-  const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
-    if (controller.selectedIndex <= 0 && isPlainArrowUp(event)) {
+  const handleRootKeyDown = useCallback((
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => {
+    if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
       stopSearchFocusNavigation(event);
       controller.actions.focusSearch();
       return true;
     }
     return false;
-  }, [controller.actions.focusSearch, controller.selectedIndex]);
+  }, [controller.actions.focusSearch]);
 
   const detailContent =
     controller.selectedSummary && controller.selectedRow ? (

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -1,6 +1,6 @@
 import { Box, Input, Text } from "../../ui";
 import { useCallback, useMemo, useRef } from "react";
-import { DataTableStackView, Tabs, usePaneFooter } from "../../components";
+import { DataTableStackView, Tabs, usePaneFooter, type DataTableKeyEvent } from "../../components";
 import { createRowValueCache } from "../../components/ui/row-value-cache";
 import type { PaneProps } from "../../types/plugin";
 import { colors } from "../../theme/colors";
@@ -9,6 +9,7 @@ import { usePredictionMarketsController } from "./controller";
 import { PredictionMarketDetailPane } from "./detail/pane";
 import { getPredictionColumnValue } from "./metrics";
 import { BROWSE_TABS, VENUE_TABS } from "./navigation";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../utils/search-focus-navigation";
 import type {
   PredictionBrowseTab,
   PredictionCategoryId,
@@ -217,6 +218,15 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
     watchlistedRowKeys,
   ]);
 
+  const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (controller.selectedIndex <= 0 && isPlainArrowUp(event)) {
+      stopSearchFocusNavigation(event);
+      controller.actions.focusSearch();
+      return true;
+    }
+    return false;
+  }, [controller.actions.focusSearch, controller.selectedIndex]);
+
   const detailContent =
     controller.selectedSummary && controller.selectedRow ? (
       <Box
@@ -271,6 +281,7 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       }}
       onActivate={(row) =>
         controller.actions.openSelectedRow(row.key)}
+      onRootKeyDown={handleRootKeyDown}
       columns={controller.visibleColumns}
       items={controller.visibleRows}
       sortColumnId={controller.sortPreference.columnId}

--- a/src/plugins/prediction-markets/test-helpers.tsx
+++ b/src/plugins/prediction-markets/test-helpers.tsx
@@ -531,6 +531,7 @@ export async function emitKeypress(
   event: {
     name?: string;
     sequence?: string;
+    targetEditable?: boolean;
     shift?: boolean;
   },
 ) {

--- a/src/state/app/input-capture.ts
+++ b/src/state/app/input-capture.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useAppDispatch } from "./context";
+
+export function useAppInputCapture(captured: boolean) {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!captured) return;
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+    return () => dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+  }, [captured, dispatch]);
+}

--- a/src/utils/search-focus-navigation.ts
+++ b/src/utils/search-focus-navigation.ts
@@ -1,0 +1,24 @@
+import { isPlainKeyboardEvent, type KeyboardModifierEventLike } from "./keyboard";
+
+export interface SearchFocusNavigationEvent extends KeyboardModifierEventLike {
+  sequence?: string;
+  preventDefault?: () => void;
+  stopPropagation?: () => void;
+}
+
+export function isPlainArrowDown(event: SearchFocusNavigationEvent): boolean {
+  if (!isPlainKeyboardEvent(event)) return false;
+  const name = event.name?.toLowerCase();
+  return name === "down" || event.sequence === "\u001b[B" || event.sequence === "\u001bOB";
+}
+
+export function isPlainArrowUp(event: SearchFocusNavigationEvent): boolean {
+  if (!isPlainKeyboardEvent(event)) return false;
+  const name = event.name?.toLowerCase();
+  return name === "up" || event.sequence === "\u001b[A" || event.sequence === "\u001bOA";
+}
+
+export function stopSearchFocusNavigation(event: SearchFocusNavigationEvent): void {
+  event.preventDefault?.();
+  event.stopPropagation?.();
+}


### PR DESCRIPTION
## Summary
- Capture app input while shared search bars are active, so global plain-key shortcuts do not see query text.
- Reuse the same capture hook in portfolio quick add and keep collection tabs unfocused while quick add owns input.
- Add arrow-key handoff between search bars and their tables for X Feed, 13F, and Prediction Markets.
- Use the table's live cursor for Up-to-search handoff and make Prediction Markets search handle Down/Escape while the editable input is focused.

## Validation
- bun test src/components/input-search-bar.test.tsx src/app/global-shortcuts.test.tsx src/plugins/builtin/portfolio-list/pane/index.test.tsx
- bun test src/components/input-search-bar.test.tsx src/plugins/prediction-markets/pane.test.tsx src/plugins/builtin/thirteenf/pane.test.tsx src/app/global-shortcuts.test.tsx
- bun run build
- tmux smoke with a temporary X Feed pane: added a feed, typed q-containing query text without exiting, then verified Up focuses search and Down returns focus to the table.
- Desktop dev rebuild and relaunch with the final Prediction Markets search/table handoff patch.

Closes #350