### PR TITLE
Focus comparison chart mouse interactions

### DIFF
--- a/src/components/chart/comparison-stock-chart/interactions.ts
+++ b/src/components/chart/comparison-stock-chart/interactions.ts
@@ -28,6 +28,7 @@ import {
   resolveCursorMotionKind,
   type ChartMouseEvent,
   type DisplayCursorState,
+  type MouseInteractionEvent,
 } from "../core/pointer";
 import type {
   ComparisonChartSeries,
@@ -48,6 +49,7 @@ interface UseComparisonChartPointerInteractionsOptions {
   chartWidth: number;
   commitSelectionCursor: (next: { cursorX: number | null; cursorY: number | null }) => void;
   expandBufferRange: (action: PendingExpansionAction) => boolean;
+  focusPaneForMouseInteraction: (event: MouseInteractionEvent | null | undefined) => void;
   mouseCrosshairDisabledRef: MutableRefObject<boolean>;
   plotRef: RefObject<BoxRenderable | null>;
   pointCount: number;
@@ -65,6 +67,7 @@ export function useComparisonChartPointerInteractions({
   chartWidth,
   commitSelectionCursor,
   expandBufferRange,
+  focusPaneForMouseInteraction,
   mouseCrosshairDisabledRef,
   plotRef,
   pointCount,
@@ -113,13 +116,14 @@ export function useComparisonChartPointerInteractions({
 
   const handlePlotDown = useCallback((event: ChartMouseEvent) => {
     consumeChartMouseEvent(event);
+    focusPaneForMouseInteraction(null);
     mouseCrosshairDisabledRef.current = false;
     if (!syncPointerCursor(event)) return;
     dragRef.current = {
       startGlobalX: getGlobalMouseX(event, renderer),
       startWindow: visibleDateWindow,
     };
-  }, [mouseCrosshairDisabledRef, renderer, syncPointerCursor, visibleDateWindow]);
+  }, [focusPaneForMouseInteraction, mouseCrosshairDisabledRef, renderer, syncPointerCursor, visibleDateWindow]);
 
   const handlePlotDrag = useCallback((event: ChartMouseEvent) => {
     consumeChartMouseEvent(event);
@@ -147,6 +151,7 @@ export function useComparisonChartPointerInteractions({
 
   const handlePlotScroll = useCallback((event: ChartMouseEvent) => {
     consumeChartMouseEvent(event);
+    focusPaneForMouseInteraction(null);
     const direction = event.scroll?.direction;
     if (!direction) return;
     const scrollPan = consumeScrollPanMovement(
@@ -179,6 +184,7 @@ export function useComparisonChartPointerInteractions({
     chartWidth,
     dateBounds,
     expandBufferRange,
+    focusPaneForMouseInteraction,
     scrollPanCellRemainderRef,
     series,
     seriesDates,

--- a/src/components/chart/comparison-stock-chart/legend.tsx
+++ b/src/components/chart/comparison-stock-chart/legend.tsx
@@ -1,11 +1,13 @@
 import type { ComparisonChartProjection } from "../comparison/data";
 import { PriceReturnTable, type PriceReturnTableRow } from "../../price-performance";
 import type { PriceReturnField } from "../../../market-data/performance";
+import type { MouseInteractionEvent } from "../core/pointer";
 
 interface ComparisonChartLegendProps {
   legendActiveIndex: number | null;
   legendItemWidth: number;
   legendRows: number;
+  onFocusInteraction: (event: MouseInteractionEvent | null | undefined) => void;
   onOpenSymbol: (symbol: string) => void;
   onSelectSymbol: (symbol: string) => void;
   performanceBySymbol: ReadonlyMap<string, PriceReturnField[]>;
@@ -36,6 +38,7 @@ export function ComparisonChartLegend({
   legendActiveIndex,
   legendItemWidth,
   legendRows,
+  onFocusInteraction,
   onOpenSymbol,
   onSelectSymbol,
   performanceBySymbol,
@@ -61,6 +64,7 @@ export function ComparisonChartLegend({
   return (
     <PriceReturnTable
       height={legendRows}
+      onFocusInteraction={onFocusInteraction}
       onOpenSymbol={onOpenSymbol}
       onSelectSymbol={onSelectSymbol}
       rows={rows}

--- a/src/components/chart/comparison-stock-chart/selection-runtime.ts
+++ b/src/components/chart/comparison-stock-chart/selection-runtime.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import { useCallback, useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import type { BoxRenderable, NativeRendererHost } from "../../../ui";
-import { buildDisplayCursorState } from "../core/pointer";
+import { useAppDispatch, usePaneInstanceId } from "../../../state/app/context";
+import { buildDisplayCursorState, type MouseInteractionEvent } from "../core/pointer";
 import type { ComparisonChartViewState } from "../core/types";
 import { useChartDisplayCursor, useChartDisplayCursorLayoutRemap } from "../display-cursor";
 import { clamp } from "./helpers";
@@ -10,6 +11,7 @@ interface UseComparisonChartSelectionRuntimeOptions {
   chartWidth: number;
   cursorX: number | null;
   cursorY: number | null;
+  focused: boolean;
   renderer: NativeRendererHost;
   setViewState: Dispatch<SetStateAction<ComparisonChartViewState>>;
   symbols: string[];
@@ -20,6 +22,7 @@ export function useComparisonChartSelectionRuntime({
   chartWidth,
   cursorX: viewCursorX,
   cursorY: viewCursorY,
+  focused,
   renderer,
   setViewState,
   symbols,
@@ -28,6 +31,7 @@ export function useComparisonChartSelectionRuntime({
   displayCursor: ReturnType<typeof useChartDisplayCursor>["displayCursor"];
   displayCursorX: number | null;
   displayCursorY: number | null;
+  focusPaneForMouseInteraction: (event: MouseInteractionEvent | null | undefined) => void;
   mouseCrosshairDisabledRef: MutableRefObject<boolean>;
   plotRef: MutableRefObject<BoxRenderable | null>;
   scrollPanCellRemainderRef: MutableRefObject<number>;
@@ -35,6 +39,8 @@ export function useComparisonChartSelectionRuntime({
   setSelectedSymbol: (symbol: string) => void;
   updateDisplayCursorTarget: ReturnType<typeof useChartDisplayCursor>["updateDisplayCursorTarget"];
 } {
+  const dispatch = useAppDispatch();
+  const paneId = usePaneInstanceId();
   const plotRef = useRef<BoxRenderable | null>(null);
   const mouseCrosshairDisabledRef = useRef(false);
   const scrollPanCellRemainderRef = useRef(0);
@@ -51,6 +57,16 @@ export function useComparisonChartSelectionRuntime({
   const cursorY = viewCursorY !== null ? clamp(viewCursorY, 0, chartHeight - 1) : null;
   const displayCursorX = displayCursor.cellX !== null ? clamp(displayCursor.cellX, 0, chartWidth - 1) : null;
   const displayCursorY = displayCursor.cellY !== null ? clamp(displayCursor.cellY, 0, chartHeight - 1) : null;
+
+  const focusPaneForMouseInteraction = useCallback((
+    event: MouseInteractionEvent | null | undefined,
+  ) => {
+    event?.stopPropagation?.();
+    event?.preventDefault?.();
+    if (!focused) {
+      dispatch({ type: "FOCUS_PANE", paneId });
+    }
+  }, [dispatch, focused, paneId]);
 
   const setSelectedSymbol = (symbol: string) => {
     setViewState((current) => (
@@ -101,6 +117,7 @@ export function useComparisonChartSelectionRuntime({
     displayCursor,
     displayCursorX,
     displayCursorY,
+    focusPaneForMouseInteraction,
     mouseCrosshairDisabledRef,
     plotRef,
     scrollPanCellRemainderRef,

--- a/src/components/chart/comparison-stock-chart/toolbar.tsx
+++ b/src/components/chart/comparison-stock-chart/toolbar.tsx
@@ -12,6 +12,7 @@ import {
   type ComparisonChartRenderMode,
   type TimeRange,
 } from "../core/types";
+import type { MouseInteractionEvent } from "../core/pointer";
 
 const MODE_CHIPS: Record<ComparisonChartRenderMode, string> = {
   area: "A",
@@ -22,6 +23,7 @@ interface ComparisonChartToolbarProps {
   activePreset: TimeRange | null;
   availableManualResolutions: ManualChartResolution[];
   effectiveResolution: ChartResolution;
+  focusPaneForMouseInteraction: (event: MouseInteractionEvent | null | undefined) => void;
   isUpdating: boolean;
   onRangeSelect: (range: TimeRange) => void;
   onRenderModeSelect: (mode: ComparisonChartRenderMode) => void;
@@ -36,6 +38,7 @@ export function ComparisonChartToolbar({
   activePreset,
   availableManualResolutions,
   effectiveResolution,
+  focusPaneForMouseInteraction,
   isUpdating,
   onRangeSelect,
   onRenderModeSelect,
@@ -54,7 +57,8 @@ export function ComparisonChartToolbar({
               key={range}
               fg={activePreset === range ? colors.textBright : (isRangePresetSupported(range, availableManualResolutions) ? colors.textDim : colors.textMuted)}
               attributes={activePreset === range ? TextAttributes.BOLD : 0}
-              onMouseDown={() => {
+              onMouseDown={(event: any) => {
+                focusPaneForMouseInteraction(event);
                 if (isRangePresetSupported(range, availableManualResolutions)) {
                   onRangeSelect(range);
                 }
@@ -73,7 +77,10 @@ export function ComparisonChartToolbar({
               key={resolution}
               fg={effectiveResolution === resolution ? colors.textBright : colors.textDim}
               attributes={effectiveResolution === resolution ? TextAttributes.BOLD : 0}
-              onMouseDown={() => onResolutionSelect(resolution)}
+              onMouseDown={(event: any) => {
+                focusPaneForMouseInteraction(event);
+                onResolutionSelect(resolution);
+              }}
             >
               {getChartResolutionLabel(resolution)}
             </Text>
@@ -89,7 +96,10 @@ export function ComparisonChartToolbar({
               key={mode}
               fg={renderMode === mode ? colors.textBright : colors.textDim}
               attributes={renderMode === mode ? TextAttributes.BOLD : 0}
-              onMouseDown={() => onRenderModeSelect(mode)}
+              onMouseDown={(event: any) => {
+                focusPaneForMouseInteraction(event);
+                onRenderModeSelect(mode);
+              }}
             >
               {MODE_CHIPS[mode]}
             </Text>

--- a/src/components/chart/comparison-stock-chart/view.tsx
+++ b/src/components/chart/comparison-stock-chart/view.tsx
@@ -345,6 +345,7 @@ function ComparisonStockChartView({
     displayCursor,
     displayCursorX,
     displayCursorY,
+    focusPaneForMouseInteraction,
     mouseCrosshairDisabledRef,
     plotRef,
     scrollPanCellRemainderRef,
@@ -356,6 +357,7 @@ function ComparisonStockChartView({
     chartWidth,
     cursorX: viewState.cursorX,
     cursorY: viewState.cursorY,
+    focused,
     renderer,
     setViewState,
     symbols: summarySymbols,
@@ -449,6 +451,7 @@ function ComparisonStockChartView({
     chartWidth,
     commitSelectionCursor,
     expandBufferRange,
+    focusPaneForMouseInteraction,
     mouseCrosshairDisabledRef,
     plotRef,
     pointCount: projection.dates.length,
@@ -527,6 +530,7 @@ function ComparisonStockChartView({
           legendActiveIndex={legendActiveIndex}
           legendItemWidth={legendItemWidth}
           legendRows={legendRows}
+          onFocusInteraction={focusPaneForMouseInteraction}
           onOpenSymbol={onOpenSymbol}
           onSelectSymbol={setSelectedSymbol}
           performanceBySymbol={performanceBySymbol}
@@ -547,6 +551,7 @@ function ComparisonStockChartView({
           activePreset={activePreset}
           availableManualResolutions={availableManualResolutions}
           effectiveResolution={effectiveResolution}
+          focusPaneForMouseInteraction={focusPaneForMouseInteraction}
           isUpdating={isUpdating}
           onRangeSelect={setRangePreset}
           onRenderModeSelect={(mode) => setViewState((current) => ({ ...current, renderMode: mode }))}

--- a/src/components/chart/core/pointer.ts
+++ b/src/components/chart/core/pointer.ts
@@ -31,6 +31,8 @@ export interface ChartMouseEvent {
   };
 }
 
+export type MouseInteractionEvent = Pick<ChartMouseEvent, "stopPropagation" | "preventDefault">;
+
 export function consumeChartMouseEvent(event: Pick<ChartMouseEvent, "stopPropagation" | "preventDefault">): void {
   event.stopPropagation?.();
   event.preventDefault?.();

--- a/src/components/price-performance.tsx
+++ b/src/components/price-performance.tsx
@@ -3,6 +3,11 @@ import { blendHex, colors, priceColor } from "../theme/colors";
 import { displayWidth, formatPercent, padTo } from "../utils/format";
 import type { PriceReturnField } from "../market-data/performance";
 
+type MouseInteractionEvent = {
+  stopPropagation?: () => void;
+  preventDefault?: () => void;
+};
+
 const STRIP_COLUMN_GAP = 1;
 const RETURN_CELL_MIN_WIDTH = 7;
 const SYMBOL_COLUMN_MIN_WIDTH = 6;
@@ -100,12 +105,14 @@ function chooseComparisonFieldIds(width: number, availableIds: readonly string[]
 
 export function PriceReturnTable({
   height,
+  onFocusInteraction,
   onOpenSymbol,
   onSelectSymbol,
   rows,
   width,
 }: {
   height: number;
+  onFocusInteraction?: (event: MouseInteractionEvent | null | undefined) => void;
   onOpenSymbol: (symbol: string) => void;
   onSelectSymbol: (symbol: string) => void;
   rows: PriceReturnTableRow[];
@@ -151,7 +158,8 @@ export function PriceReturnTable({
             width={width}
             backgroundColor={row.selected ? blendHex(colors.panel, colors.borderFocused, 0.18) : colors.panel}
             onMouseMove={() => onSelectSymbol(row.symbol)}
-            onMouseDown={() => {
+            onMouseDown={(event: any) => {
+              onFocusInteraction?.(event);
               onSelectSymbol(row.symbol);
               onOpenSymbol(row.symbol);
             }}

--- a/src/plugins/builtin/comparison-chart/index.test.tsx
+++ b/src/plugins/builtin/comparison-chart/index.test.tsx
@@ -6,6 +6,7 @@ import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../
 import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane/footer";
 import {
   AppContext,
+  type AppAction,
   createInitialState,
   PaneInstanceProvider,
 } from "../../../state/app/context";
@@ -29,6 +30,12 @@ let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | undefined;
 let root: ReturnType<typeof createRoot> | undefined;
 let sharedCoordinator: MarketDataCoordinator | null = null;
 const actEnvironment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+interface ComparisonHarnessOptions {
+  dispatch?: (action: AppAction) => void;
+  focused?: boolean;
+  focusedPaneId?: string | null;
+}
 
 function makeTicker(symbol: string, currency: string): TickerRecord {
   return {
@@ -202,7 +209,13 @@ function createComparisonHarness(
   tickers: TickerRecord[],
   financials: Array<[string, TickerFinancials]>,
   runtime: PluginRuntimeAccess,
+  options: ComparisonHarnessOptions = {},
 ) {
+  const {
+    dispatch = () => {},
+    focused = true,
+    focusedPaneId = focused ? TEST_PANE_ID : null,
+  } = options;
   const config = createDefaultConfig("/tmp/gloomberb-compare");
   const layout = {
     dockRoot: { kind: "pane" as const, instanceId: TEST_PANE_ID },
@@ -220,7 +233,7 @@ function createComparisonHarness(
     layouts: [{ name: "Default", layout: cloneLayout(layout) }],
   };
   const state = createInitialState(nextConfig);
-  state.focusedPaneId = TEST_PANE_ID;
+  state.focusedPaneId = focusedPaneId;
   state.tickers = new Map(tickers.map((ticker) => [ticker.metadata.ticker, ticker]));
   state.financials = new Map(financials);
 
@@ -233,7 +246,7 @@ function createComparisonHarness(
   }) => ReactElement;
 
   return (
-    <AppContext value={{ state, dispatch: () => {} }}>
+    <AppContext value={{ state, dispatch }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
         <PluginRenderProvider pluginId="comparison-chart" runtime={runtime}>
           <PaneFooterProvider>
@@ -242,11 +255,11 @@ function createComparisonHarness(
                 <ComparisonPane
                   paneId={TEST_PANE_ID}
                   paneType="comparison-chart"
-                  focused
+                  focused={focused}
                   width={120}
                   height={19}
                 />
-                <PaneFooterBar footer={footer} focused width={120} />
+                <PaneFooterBar footer={footer} focused={focused} width={120} />
               </Box>
             )}
           </PaneFooterProvider>
@@ -272,13 +285,14 @@ async function mountComparisonHarness(
   tickers: TickerRecord[],
   financials: Array<[string, TickerFinancials]>,
   spy: { selected: string[]; focused: string[]; settings?: string[] } = { selected: [], focused: [] },
+  options: ComparisonHarnessOptions = {},
 ) {
   actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
   testSetup = await createTestRenderer({ width: 120, height: 20 });
   root = createRoot(testSetup.renderer);
   await act(async () => {
     root!.render(
-      createComparisonHarness(settings, tickers, financials, createRuntimeSpy(spy)),
+      createComparisonHarness(settings, tickers, financials, createRuntimeSpy(spy), options),
     );
     await Promise.resolve();
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -428,6 +442,45 @@ describe("comparisonChartPlugin", () => {
     frame = testSetup!.captureCharFrame();
     expect(frame).toMatch(/> AAPL\s+0\.00%/);
     expect(frame).toMatch(/MSFT\s+0\.00%/);
+  });
+
+  test("focuses the pane when an unfocused comparison plot is clicked", async () => {
+    const dispatched: AppAction[] = [];
+    const provider = createProvider({
+      AAPL: [100, 102, 104],
+      MSFT: [200, 202, 204],
+    }, {
+      AAPL: "USD",
+      MSFT: "USD",
+    });
+    setSharedMarketDataForTests(provider);
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+    setSharedRegistryForTests(createRegistrySpy({ selected: [], focused: [] }));
+
+    await mountComparisonHarness({
+      axisMode: "percent",
+      symbols: ["AAPL", "MSFT"],
+      symbolsText: "AAPL, MSFT",
+    }, [
+      makeTicker("AAPL", "USD"),
+      makeTicker("MSFT", "USD"),
+    ], [
+      ["AAPL", makeFinancials("AAPL", "USD", [100, 102, 104])],
+      ["MSFT", makeFinancials("MSFT", "USD", [200, 202, 204])],
+    ], { selected: [], focused: [] }, {
+      dispatch: (action) => { dispatched.push(action); },
+      focused: false,
+      focusedPaneId: "ticker-detail:main",
+    });
+
+    await flushFrames();
+    await act(async () => {
+      await testSetup!.mockMouse.click(20, 8);
+      await testSetup!.renderOnce();
+    });
+
+    expect(dispatched).toContainEqual({ type: "FOCUS_PANE", paneId: TEST_PANE_ID });
   });
 
   test("keeps fixed return horizons independent from the selected chart range", async () => {


### PR DESCRIPTION
## Summary
- Focus the comparison chart pane from plot click/scroll, toolbar controls, and legend row clicks using the same pane-focus dispatch pattern as the stock chart.
- Thread the focus helper through comparison chart runtime wiring without changing renderer selection or kitty support.
- Add a regression test for clicking an unfocused comparison plot.

## Validation
- `bun test src/plugins/builtin/comparison-chart/index.test.tsx`
- `bun run build`
- tmux smoke: started `bun run start` in `gloomberb-422-smoke`, confirmed the TUI rendered, then killed the session
- `bun test`

Closes #422