### PR TITLE
Fix TUI window edit target cycling

### DIFF
--- a/src/components/layout/shell/active-drag.ts
+++ b/src/components/layout/shell/active-drag.ts
@@ -4,6 +4,7 @@ import {
   getRememberedFloatingRect,
   resizeSplitAtPath,
   simulateDrop,
+  type DockGeometryOptions,
   type DockLeafLayout,
   type DropTarget,
   type LayoutBounds,
@@ -32,6 +33,7 @@ interface UseShellActiveDragOptions {
   bounds: LayoutBounds;
   contentHeight: number;
   dispatch: Dispatch<AppAction>;
+  dockGeometryOptions: DockGeometryOptions;
   dockLeafLayouts: DockLeafLayout[];
   dragRuntime: ShellDragRuntimeState;
   focusPane: (paneId: string) => void;
@@ -51,6 +53,7 @@ export function useShellActiveDrag({
   bounds,
   contentHeight,
   dispatch,
+  dockGeometryOptions,
   dockLeafLayouts,
   dragRuntime,
   focusPane,
@@ -117,7 +120,7 @@ export function useShellActiveDrag({
           const hoveredCell = hoveredOverlay.cells.find((cell) => pointInRect(cell.rect, hitX, hitShellY));
           if (hoveredCell) {
             const target: DropTarget = { kind: "leaf", targetId: hoveredOverlay.targetId, position: hoveredCell.position };
-            const simulation = simulateDrop(baseLayout, drag.paneId, target, bounds);
+            const simulation = simulateDrop(baseLayout, drag.paneId, target, bounds, dockGeometryOptions);
             if (simulation.previewRect) {
               updateDockPreview({ kind: "dock", target, rect: simulation.previewRect });
             } else {
@@ -199,6 +202,7 @@ export function useShellActiveDrag({
     bounds,
     contentHeight,
     dispatch,
+    dockGeometryOptions,
     dividerPreviewRef,
     dockLeafLayouts,
     dockPreviewRef,

--- a/src/components/layout/shell/drag/runtime.ts
+++ b/src/components/layout/shell/drag/runtime.ts
@@ -8,6 +8,7 @@ import {
 } from "react";
 import {
   type DockDividerLayout,
+  type DockGeometryOptions,
   type DockLeafLayout,
   type FloatingRect,
   type LayoutBounds,
@@ -146,6 +147,7 @@ interface UseShellPointerRuntimeOptions {
   closePaneMenu: () => void;
   contentHeight: number;
   dispatch: Dispatch<AppAction>;
+  dockGeometryOptions: DockGeometryOptions;
   dockDividerLayouts: DockDividerLayout[];
   dockLeafLayouts: DockLeafLayout[];
   dragRuntime: ShellDragRuntimeState;
@@ -179,6 +181,7 @@ export function useShellPointerRuntime({
   closePaneMenu,
   contentHeight,
   dispatch,
+  dockGeometryOptions,
   dockDividerLayouts,
   dockLeafLayouts,
   dragRuntime,
@@ -206,6 +209,7 @@ export function useShellPointerRuntime({
     bounds,
     contentHeight,
     dispatch,
+    dockGeometryOptions,
     dockLeafLayouts,
     focusPane,
     dragRuntime,

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -333,6 +333,7 @@ export function Shell({
     closePaneMenu,
     contentHeight,
     dispatch,
+    dockGeometryOptions,
     dockDividerLayouts,
     dockLeafLayouts,
     dragRuntime,

--- a/src/components/layout/shell/window-mode/index.ts
+++ b/src/components/layout/shell/window-mode/index.ts
@@ -13,6 +13,7 @@ import {
   applyWindowEditDirection,
   cycleWindowEditFocus,
   cycleWindowEditPane,
+  cycleWindowEditTarget,
   directionFromWindowEditKey,
   getWindowEditPaneIds,
   normalizeWindowEditFocus,
@@ -72,7 +73,10 @@ export function useShellWindowMode({
   );
   const windowModePaneId = windowMode?.paneId;
   const activeLayout = windowMode?.previewLayout ?? visibleLayout;
-  const windowModePaneIds = useMemo(() => getWindowEditPaneIds(activeLayout), [activeLayout]);
+  const windowModePaneIds = useMemo(
+    () => getWindowEditPaneIds(activeLayout, bounds, dockGeometryOptions),
+    [activeLayout, bounds, dockGeometryOptions],
+  );
   const windowModeDockMovePreview = useMemo(
     () => resolveWindowEditDockMovePreview(windowMode, bounds, dockGeometryOptions),
     [bounds, dockGeometryOptions, windowMode],
@@ -210,12 +214,16 @@ export function useShellWindowMode({
       }
     } else if (name === "w") {
       setWindowMode((current) => current
-        ? cycleWindowEditPane(current, windowModePaneIds, bounds, dockGeometryOptions, event.shift ? -1 : 1)
+        ? current.mode === "move" && current.focus.kind === "dock-move"
+          ? cycleWindowEditTarget(current, bounds, dockGeometryOptions, event.shift ? -1 : 1)
+          : cycleWindowEditPane(current, windowModePaneIds, bounds, dockGeometryOptions, event.shift ? -1 : 1)
         : current);
     } else if (name === "tab") {
       setWindowMode((current) => current
         ? current.mode === "move"
-          ? cycleWindowEditPane(current, windowModePaneIds, bounds, dockGeometryOptions, event.shift ? -1 : 1)
+          ? current.focus.kind === "dock-move"
+            ? cycleWindowEditTarget(current, bounds, dockGeometryOptions, event.shift ? -1 : 1)
+            : cycleWindowEditPane(current, windowModePaneIds, bounds, dockGeometryOptions, event.shift ? -1 : 1)
           : {
               ...current,
               focus: cycleWindowEditFocus(

--- a/src/components/layout/shell/window-mode/overlays.tsx
+++ b/src/components/layout/shell/window-mode/overlays.tsx
@@ -40,6 +40,13 @@ interface ShellWindowModeOverlaysProps {
   windowModeDockMovePreview: WindowEditDockMovePreview | null;
 }
 
+function getHighlightedPaneId(windowMode: WindowEditState | null, focusedPaneId: string | null): string | null {
+  if (windowMode?.mode === "move" && windowMode.focus.kind === "dock-move") {
+    return windowMode.focus.targetId;
+  }
+  return windowMode?.paneId ?? focusedPaneId;
+}
+
 function windowModeBannerKey(windowMode: WindowEditState): string {
   const focusKey = windowMode.focus.kind === "dock-move"
     ? `${windowMode.focus.targetId}:${windowMode.focus.position}`
@@ -69,7 +76,7 @@ export function ShellWindowModeOverlays({
   windowMode,
   windowModeDockMovePreview,
 }: ShellWindowModeOverlaysProps) {
-  const highlightedPaneId = windowMode?.paneId ?? focusedPaneId;
+  const highlightedPaneId = getHighlightedPaneId(windowMode, focusedPaneId);
   const highlightedFloatingPane = highlightedPaneId
     ? visibleFloatingPanes.find((entry) => entry.pane.instance.instanceId === highlightedPaneId)
     : null;

--- a/src/components/layout/window-edit/mode.test.ts
+++ b/src/components/layout/window-edit/mode.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { LayoutConfig } from "../../../types/config";
-import { cycleWindowEditPane, getWindowEditPaneIds, type WindowEditState } from "./mode";
+import {
+  cycleWindowEditPane,
+  cycleWindowEditTarget,
+  getWindowEditPaneIds,
+  type WindowEditState,
+} from "./mode";
+import { resolveWindowEditDockMovePreview } from "./presentation";
 
 const bounds = { x: 0, y: 0, width: 120, height: 40 };
 
@@ -38,18 +44,83 @@ describe("window edit mode", () => {
       dirty: false,
     };
 
-    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout), bounds, {}, 1);
+    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout, bounds, {}), bounds, {}, 1);
     expect(state.paneId).toBe("dock-b");
 
-    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout), bounds, {}, 1);
+    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout, bounds, {}), bounds, {}, 1);
     expect(state.paneId).toBe("float-a");
     expect(state.previewLayout.floating.find((entry) => entry.instanceId === "float-a")?.zIndex)
       .toBeGreaterThan(state.previewLayout.floating.find((entry) => entry.instanceId === "float-b")?.zIndex ?? 0);
 
-    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout), bounds, {}, 1);
+    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout, bounds, {}), bounds, {}, 1);
     expect(state.paneId).toBe("float-b");
 
-    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout), bounds, {}, 1);
+    state = cycleWindowEditPane(state, getWindowEditPaneIds(state.previewLayout, bounds, {}), bounds, {}, 1);
     expect(state.paneId).toBe("dock-a");
+  });
+
+  test("cycles dock move targets without changing the selected window", () => {
+    const layout: LayoutConfig = {
+      dockRoot: {
+        kind: "split",
+        axis: "horizontal",
+        ratio: 0.5,
+        first: { kind: "pane", instanceId: "source" },
+        second: {
+          kind: "split",
+          axis: "vertical",
+          ratio: 0.5,
+          first: { kind: "pane", instanceId: "target-a" },
+          second: { kind: "pane", instanceId: "target-b" },
+        },
+      },
+      instances: [
+        pane("source"),
+        pane("target-a"),
+        pane("target-b"),
+      ],
+      floating: [],
+      detached: [],
+    };
+    const state: WindowEditState = {
+      paneId: "source",
+      previewLayout: layout,
+      mode: "move",
+      focus: { kind: "dock-move", targetId: "target-a", position: "right" },
+      dirty: false,
+    };
+
+    const next = cycleWindowEditTarget(state, bounds, { reserveDividerGutters: true }, 1);
+
+    expect(next.paneId).toBe("source");
+    expect(next.focus).toEqual({ kind: "dock-move", targetId: "target-b", position: "right" });
+  });
+
+  test("uses dock geometry options for dock move preview rectangles", () => {
+    const layout: LayoutConfig = {
+      dockRoot: {
+        kind: "split",
+        axis: "horizontal",
+        ratio: 0.5,
+        first: { kind: "pane", instanceId: "left" },
+        second: { kind: "pane", instanceId: "right" },
+      },
+      instances: [
+        pane("left"),
+        pane("right"),
+      ],
+      floating: [],
+      detached: [],
+    };
+    const state: WindowEditState = {
+      paneId: "left",
+      previewLayout: layout,
+      mode: "move",
+      focus: { kind: "dock-move", targetId: "right", position: "right" },
+      dirty: false,
+    };
+
+    expect(resolveWindowEditDockMovePreview(state, bounds, { reserveDividerGutters: true })?.rect)
+      .toEqual({ x: 61, y: 0, width: 59, height: 40 });
   });
 });

--- a/src/components/layout/window-edit/mode.ts
+++ b/src/components/layout/window-edit/mode.ts
@@ -226,10 +226,55 @@ export function cycleWindowEditFocus(
   return targets[(currentIndex + delta + targets.length) % targets.length] ?? targets[0]!;
 }
 
-export function getWindowEditPaneIds(layout: LayoutConfig): string[] {
-  const dockedIds = getDockLeafLayouts(layout, { x: 0, y: 0, width: 120, height: 40 }).map((entry) => entry.instanceId);
+function getWindowEditDockPaneIds(
+  layout: LayoutConfig,
+  bounds: LayoutBounds,
+  dockGeometryOptions: DockGeometryOptions,
+): string[] {
+  return getDockLeafLayouts(layout, bounds, dockGeometryOptions).map((entry) => entry.instanceId);
+}
+
+export function getWindowEditPaneIds(
+  layout: LayoutConfig,
+  bounds: LayoutBounds,
+  dockGeometryOptions: DockGeometryOptions,
+): string[] {
+  const dockedIds = getWindowEditDockPaneIds(layout, bounds, dockGeometryOptions);
   const floatingIds = layout.floating.map((entry) => entry.instanceId);
   return [...dockedIds, ...floatingIds];
+}
+
+export function cycleWindowEditTarget(
+  state: WindowEditState,
+  bounds: LayoutBounds,
+  dockGeometryOptions: DockGeometryOptions,
+  delta: 1 | -1,
+): WindowEditState {
+  if (state.mode !== "move" || state.focus.kind !== "dock-move") {
+    return state;
+  }
+
+  const targetIds = getWindowEditDockPaneIds(state.previewLayout, bounds, dockGeometryOptions)
+    .filter((paneId) => paneId !== state.paneId);
+  if (targetIds.length === 0) {
+    return {
+      ...state,
+      focus: normalizeWindowEditFocus({ kind: "move" }, state.previewLayout, state.paneId, state.mode, bounds, dockGeometryOptions),
+    };
+  }
+
+  const currentIndex = targetIds.indexOf(state.focus.targetId);
+  const startIndex = currentIndex >= 0
+    ? currentIndex
+    : delta === 1
+      ? -1
+      : 0;
+  const targetId = targetIds[(startIndex + delta + targetIds.length) % targetIds.length] ?? targetIds[0]!;
+  return {
+    ...state,
+    focus: normalizeWindowEditFocus({ ...state.focus, targetId }, state.previewLayout, state.paneId, state.mode, bounds, dockGeometryOptions),
+    notice: undefined,
+  };
 }
 
 export function raiseWindowEditPane(layout: LayoutConfig, paneId: string): LayoutConfig {

--- a/src/components/layout/window-edit/presentation.ts
+++ b/src/components/layout/window-edit/presentation.ts
@@ -73,7 +73,7 @@ export function windowEditStatusLine(
 export function windowEditHelpText(state: WindowEditState): string {
   if (state.mode === "move") {
     if (state.focus.kind === "dock-move") {
-      return "arrows/hjkl choose side  m retarget  Tab/w window  d float  r resize  Enter commit/exit  Esc exit/cancel";
+      return "arrows/hjkl choose side  Tab/w target  m window  d float  r resize  Enter commit/exit  Esc exit/cancel";
     }
     return "Tab/w window  d dock/float  r resize  arrows/hjkl target/move  Shift fast  Enter commit/exit  Esc exit/cancel";
   }
@@ -100,6 +100,7 @@ export function resolveWindowEditDockMovePreview(
     state.paneId,
     leafDropTarget(focus.targetId, focus.position),
     bounds,
+    dockGeometryOptions,
   );
   if (!simulation.previewRect) return null;
   return {

--- a/src/plugins/pane-manager/docking.ts
+++ b/src/plugins/pane-manager/docking.ts
@@ -6,6 +6,7 @@ import {
   findDockLeaf,
   getNodeAtPath,
   replaceNodeAtPath,
+  type DockGeometryOptions,
   type DockTarget,
   type LayoutBounds,
 } from "./dock-tree";
@@ -116,11 +117,17 @@ export function applyDrop(layout: LayoutConfig, draggedId: string, dropTarget: D
   return insertRelativeToLeaf(layout, draggedId, dropTarget.targetId, direction);
 }
 
-export function simulateDrop(layout: LayoutConfig, draggedId: string, dropTarget: DropTarget, bounds: LayoutBounds): LayoutSimulation {
+export function simulateDrop(
+  layout: LayoutConfig,
+  draggedId: string,
+  dropTarget: DropTarget,
+  bounds: LayoutBounds,
+  options?: DockGeometryOptions,
+): LayoutSimulation {
   const nextLayout = applyDrop(layout, draggedId, dropTarget);
   return {
     layout: nextLayout,
-    previewRect: getLeafRect(nextLayout, draggedId, bounds),
+    previewRect: getLeafRect(nextLayout, draggedId, bounds, options),
   };
 }
 

--- a/src/plugins/pane-manager/queries.ts
+++ b/src/plugins/pane-manager/queries.ts
@@ -10,6 +10,7 @@ import {
   countColumnsFromGeometry,
   findDockLeaf,
   getDockLeafLayouts,
+  type DockGeometryOptions,
   type LayoutBounds,
 } from "./dock-tree";
 
@@ -20,8 +21,13 @@ export interface ResolvedPane {
   path?: Array<0 | 1>;
 }
 
-export function getLeafRect(layout: LayoutConfig, instanceId: string, bounds: LayoutBounds): LayoutBounds | null {
-  return getDockLeafLayouts(layout, bounds).find((entry) => entry.instanceId === instanceId)?.rect ?? null;
+export function getLeafRect(
+  layout: LayoutConfig,
+  instanceId: string,
+  bounds: LayoutBounds,
+  options?: DockGeometryOptions,
+): LayoutBounds | null {
+  return getDockLeafLayouts(layout, bounds, options).find((entry) => entry.instanceId === instanceId)?.rect ?? null;
 }
 
 export function resolveDocked(


### PR DESCRIPTION
## Summary
- Compute window edit pane order from the live shell bounds and dock geometry options instead of a fixed 120x40 layout model.
- Let Tab/W cycle dock move targets after choosing a side, while keeping the moved window fixed and highlighting the active target pane.
- Thread dock geometry options through drop preview simulation so keyboard and pointer previews match rendered divider gutters.

## Validation
- bun test
- bun run build
- tmux smoke: started the TUI at 120x40, opened WIN move, verified the WINDOW MOVE banner, then killed the session

Closes #289
