### PR TITLE
Fix Substack pane resize and fullscreen shortcut

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,7 @@ import { Header } from "./components/layout/header";
 import { StatusBar } from "./components/layout/status-bar";
 import { Shell } from "./components/layout/shell";
 import { DetachedPaneShell } from "./components/layout/detached-pane-shell";
+import { TransientLayoutProvider } from "./components/layout/transient-layout";
 import { CommandBar } from "./components/command-bar/surface";
 import { OnboardingWizard } from "./components/onboarding/onboarding-wizard";
 import { useDialog } from "./ui/dialog";
@@ -293,13 +294,15 @@ function AppInner({
     <ContextMenuProvider pluginRegistry={pluginRegistry}>
       <ThemedAppRoot>
         <Header />
-        <Shell
-          pluginRegistry={pluginRegistry}
-          desktopWindowBridge={desktopWindowBridge}
-          desktopDockPreview={desktopDockPreview}
-          commandBarNativeOccluder={commandBarNativeOccluder}
-        />
-        <StatusBar />
+        <TransientLayoutProvider>
+          <Shell
+            pluginRegistry={pluginRegistry}
+            desktopWindowBridge={desktopWindowBridge}
+            desktopDockPreview={desktopDockPreview}
+            commandBarNativeOccluder={commandBarNativeOccluder}
+          />
+          <StatusBar />
+        </TransientLayoutProvider>
         {state.commandBarOpen && (
           <CommandBar
             dataProvider={dataProvider}

--- a/src/components/layout/shell/drag/runtime.ts
+++ b/src/components/layout/shell/drag/runtime.ts
@@ -178,6 +178,7 @@ interface UseShellPointerRuntimeOptions {
   setHoveredMenuItemId: Dispatch<SetStateAction<string | null>>;
   setMenuState: Dispatch<SetStateAction<ActionMenuState | null>>;
   snapGuides: ReturnType<typeof makeSnapGuides>;
+  transientFocusActive: boolean;
   updateWindowModePreviewLayout: (nextLayout: LayoutConfig, paneId?: string) => void;
   visibleFloatingPanes: VisibleFloatingPane[];
   visibleLayout: LayoutConfig;
@@ -208,6 +209,7 @@ export function useShellPointerRuntime({
   setHoveredMenuItemId,
   setMenuState,
   snapGuides,
+  transientFocusActive,
   updateWindowModePreviewLayout,
   visibleFloatingPanes,
   visibleLayout,
@@ -251,6 +253,7 @@ export function useShellPointerRuntime({
     selectWindowModePane,
     setHoveredMenuItemId,
     setMenuState,
+    transientFocusActive,
     visibleFloatingPanes,
     width,
     windowMode,
@@ -268,6 +271,7 @@ export function useShellPointerRuntime({
     selectWindowModePane,
     setHoveredMenuItemId,
     setMenuState,
+    transientFocusActive,
     windowMode,
   });
 

--- a/src/components/layout/shell/drag/runtime.ts
+++ b/src/components/layout/shell/drag/runtime.ts
@@ -6,6 +6,7 @@ import {
   type MutableRefObject,
   type SetStateAction,
 } from "react";
+import { useRafCallback } from "../../../../react/use-raf-callback";
 import {
   type DockDividerLayout,
   type DockGeometryOptions,
@@ -92,17 +93,26 @@ export function useShellDragRuntimeState({
 }): ShellDragRuntimeState {
   const dragRef = useRef<DragMode | null>(null);
   const [dragFloatingRect, setDragFloatingRect] = useState<{ paneId: string; rect: FloatingRect } | null>(null);
+  const pendingDragFloatingRectRef = useRef<{ paneId: string; rect: FloatingRect } | null>(null);
   const [dragCursor, setDragCursor] = useState<{ x: number; y: number } | null>(null);
   const [dividerPreview, setDividerPreview] = useState<DividerPreviewState | null>(null);
   const [dockPreview, setDockPreview] = useState<DragPreview | null>(null);
   const dividerPreviewRef = useRef<DividerPreviewState | null>(null);
   const dockPreviewRef = useRef<DragPreview | null>(null);
+  const flushDragFloatingRect = useRafCallback(() => {
+    setDragFloatingRect(pendingDragFloatingRectRef.current);
+  });
 
   const updateDragFloatingRect = useCallback((next: { paneId: string; rect: FloatingRect } | null) => {
-    setDragFloatingRect(next
+    pendingDragFloatingRectRef.current = next
       ? { paneId: next.paneId, rect: constrainFloatingRectToBounds(next.rect, width, contentHeight) }
-      : null);
-  }, [contentHeight, width]);
+      : null;
+    if (!next) {
+      setDragFloatingRect(null);
+      return;
+    }
+    flushDragFloatingRect();
+  }, [contentHeight, flushDragFloatingRect, width]);
 
   const updateDividerPreview = useCallback((next: DividerPreviewState | null) => {
     dividerPreviewRef.current = next;

--- a/src/components/layout/shell/fullscreen.ts
+++ b/src/components/layout/shell/fullscreen.ts
@@ -1,20 +1,10 @@
 import { isPaneInLayout } from "../../../plugins/pane-manager";
 import { cloneLayout, type LayoutConfig } from "../../../types/config";
 
-export function resolvePaneFullscreenLayout(
+export function resolvePaneFocusSourceLayout(
   layout: LayoutConfig,
   paneId: string | null,
 ): LayoutConfig | null {
   if (!paneId || !isPaneInLayout(layout, paneId)) return null;
-  const source = cloneLayout(layout);
-  const pane = source.instances.find((instance) => instance.instanceId === paneId);
-  if (!pane) return null;
-
-  return {
-    ...source,
-    dockRoot: { kind: "pane", instanceId: paneId },
-    instances: [pane],
-    floating: [],
-    detached: [],
-  };
+  return cloneLayout(layout);
 }

--- a/src/components/layout/shell/fullscreen.ts
+++ b/src/components/layout/shell/fullscreen.ts
@@ -6,10 +6,14 @@ export function resolvePaneFullscreenLayout(
   paneId: string | null,
 ): LayoutConfig | null {
   if (!paneId || !isPaneInLayout(layout, paneId)) return null;
+  const source = cloneLayout(layout);
+  const pane = source.instances.find((instance) => instance.instanceId === paneId);
+  if (!pane) return null;
 
   return {
-    ...cloneLayout(layout),
+    ...source,
     dockRoot: { kind: "pane", instanceId: paneId },
+    instances: [pane],
     floating: [],
     detached: [],
   };

--- a/src/components/layout/shell/fullscreen.ts
+++ b/src/components/layout/shell/fullscreen.ts
@@ -1,0 +1,16 @@
+import { isPaneInLayout } from "../../../plugins/pane-manager";
+import { cloneLayout, type LayoutConfig } from "../../../types/config";
+
+export function resolvePaneFullscreenLayout(
+  layout: LayoutConfig,
+  paneId: string | null,
+): LayoutConfig | null {
+  if (!paneId || !isPaneInLayout(layout, paneId)) return null;
+
+  return {
+    ...cloneLayout(layout),
+    dockRoot: { kind: "pane", instanceId: paneId },
+    floating: [],
+    detached: [],
+  };
+}

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { TestDialogProvider, testRender } from "../../../renderers/opentui/test-utils";
 import { openTuiUiHost } from "../../../renderers/opentui/ui-host";
 import type { ReactNode } from "react";
-import { act, useReducer } from "react";
+import { act, useReducer, useState } from "react";
 import { AppContext, appReducer, createInitialState } from "../../../state/app/context";
 import { cloneLayout, createDefaultConfig, TICKER_RESEARCH_PANE_ID, type LayoutConfig } from "../../../types/config";
 import type { PluginRegistry } from "../../../plugins/registry";
@@ -14,7 +14,8 @@ import {
   resolveAppHeaderHeightCells,
   Shell,
 } from "./index";
-import { resolvePaneFullscreenLayout } from "./fullscreen";
+import { resolvePaneFocusSourceLayout } from "./fullscreen";
+import { TransientLayoutProvider, useTransientLayout, type TransientLayoutState } from "../transient-layout";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -132,6 +133,42 @@ async function renderShellForWindowModeTest(
   );
   await testSetup.renderOnce();
   return { actions, registry };
+}
+
+function CaptureTransientLayout({
+  controls,
+}: {
+  controls: { transientLayout: TransientLayoutState | null };
+}) {
+  const { transientLayout } = useTransientLayout();
+  controls.transientLayout = transientLayout;
+  return null;
+}
+
+function ShellTransientHarness({
+  initialState,
+  registry,
+  controls,
+}: {
+  initialState: ReturnType<typeof createInitialState>;
+  registry: PluginRegistry;
+  controls: {
+    dispatch?: (action: ShellTestAction) => void;
+    transientLayout: TransientLayoutState | null;
+  };
+}) {
+  const [state, dispatch] = useReducer(appReducer, initialState);
+  controls.dispatch = dispatch;
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <TransientLayoutProvider>
+        <TestDialogProvider>
+          <Shell pluginRegistry={registry} />
+        </TestDialogProvider>
+        <CaptureTransientLayout controls={controls} />
+      </TransientLayoutProvider>
+    </AppContext>
+  );
 }
 
 function findUpdateLayout(actions: ShellTestAction[]) {
@@ -467,20 +504,22 @@ describe("Shell", () => {
     expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
   });
 
-  test("builds fullscreen as a transient one-pane layout", () => {
+  test("captures the source layout for transient pane focus", () => {
     const config = createDefaultConfig("/tmp/gloomberb-shell-fullscreen-layout-test");
     const layout = cloneLayout(config.layout);
     layout.dockRoot = { kind: "pane", instanceId: "portfolio-list:main" };
     layout.floating = [{ instanceId: "ticker-detail:main", x: 8, y: 2, width: 32, height: 10, zIndex: 75 }];
 
-    const focusedLayout = resolvePaneFullscreenLayout(layout, "ticker-detail:main");
+    const focusedLayout = resolvePaneFocusSourceLayout(layout, "ticker-detail:main");
 
     expect(focusedLayout).toMatchObject({
-      dockRoot: { kind: "pane", instanceId: "ticker-detail:main" },
-      floating: [],
-      detached: [],
+      dockRoot: { kind: "pane", instanceId: "portfolio-list:main" },
+      floating: [{ instanceId: "ticker-detail:main", x: 8, y: 2, width: 32, height: 10, zIndex: 75 }],
     });
-    expect(focusedLayout?.instances.map((instance) => instance.instanceId)).toEqual(["ticker-detail:main"]);
+    expect(focusedLayout).not.toBe(layout);
+    expect(focusedLayout?.instances.map((instance) => instance.instanceId)).toEqual(
+      layout.instances.map((instance) => instance.instanceId),
+    );
   });
 
   test("locks layout-changing mouse drags while fullscreen is active", async () => {
@@ -515,6 +554,162 @@ describe("Shell", () => {
     expect(frame).toContain("Main Portfolio");
     expect(frame).not.toContain("Ticker Research Body");
     expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+  });
+
+  test("keeps focused pane local detail state when maximizing a floating pane", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-fullscreen-local-state-test");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    let openDetail: (() => void) | null = null;
+    const registry = createShellPluginRegistry({
+      tickerDetailComponent: () => {
+        const [detailOpen, setDetailOpen] = useState(false);
+        openDetail = () => setDetailOpen(true);
+        return <text>{detailOpen ? "Detail State" : "Table State"}</text>;
+      },
+    });
+    const floatingLayout = {
+      dockRoot: null,
+      instances: [{ ...detailPane }],
+      floating: [{ instanceId: "ticker-detail:main", x: 4, y: 2, width: 40, height: 10, zIndex: 50 }],
+      detached: [],
+    };
+    await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, floatingLayout, "ticker-detail:main"),
+      { registry, width: 80, height: 18 },
+    );
+
+    await act(async () => {
+      openDetail?.();
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame()).toContain("etail State");
+
+    await emitKeypress({ name: "f", ctrl: true, shift: true });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("etail State");
+    expect(frame).not.toContain("able State");
+  });
+
+  test("allows pane fullscreen shortcut while text input is captured on desktop", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-fullscreen-captured-input-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    const dockedLayout = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        second: { kind: "pane" as const, instanceId: "ticker-detail:main" },
+      },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [],
+      detached: [],
+    };
+    const { actions } = await renderShellForWindowModeTest(
+      {
+        ...createShellStateWithLayout(config, dockedLayout, "portfolio-list:main"),
+        inputCaptured: true,
+      },
+      { width: 80, height: 18 },
+    );
+
+    await emitKeypress({
+      name: "f",
+      key: "f",
+      meta: true,
+      super: true,
+      shift: true,
+      targetEditable: true,
+    } as any);
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Main Portfolio");
+    expect(frame).not.toContain("Ticker Research Body");
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+  });
+
+  test("keeps the transient focus layout available after switching saved layouts", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-transient-focus-layout-tab-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    const defaultLayout = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        second: { kind: "pane" as const, instanceId: "ticker-detail:main" },
+      },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [],
+      detached: [],
+    };
+    const monitorLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "ticker-detail:main" },
+      instances: [{ ...detailPane }],
+      floating: [],
+      detached: [],
+    };
+    config.layout = cloneLayout(defaultLayout);
+    config.layouts = [
+      { name: "Default", layout: cloneLayout(defaultLayout), focusedPaneId: "portfolio-list:main" },
+      { name: "Monitor", layout: cloneLayout(monitorLayout), focusedPaneId: "ticker-detail:main" },
+    ];
+    config.activeLayoutIndex = 0;
+
+    const initialState = {
+      ...createInitialState(config),
+      focusedPaneId: "portfolio-list:main",
+      statusBarVisible: true,
+    };
+    const registry = createShellPluginRegistry();
+    const controls: {
+      dispatch?: (action: ShellTestAction) => void;
+      transientLayout: TransientLayoutState | null;
+    } = { transientLayout: null };
+
+    testSetup = await testRender(
+      <ShellTransientHarness initialState={initialState} registry={registry} controls={controls} />,
+      { width: 100, height: 18 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "f", ctrl: true, shift: true });
+
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Main Portfolio");
+    expect(frame).not.toContain("Ticker Research Body");
+    expect(controls.transientLayout).toMatchObject({
+      id: "pane-focus",
+      active: true,
+    });
+
+    await act(async () => {
+      controls.transientLayout?.onDeactivate?.();
+      controls.dispatch?.({ type: "SWITCH_LAYOUT", index: 1 });
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(controls.transientLayout).toMatchObject({
+      id: "pane-focus",
+      active: false,
+    });
+
+    await act(async () => {
+      controls.transientLayout?.onActivate?.();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(controls.transientLayout).toMatchObject({
+      id: "pane-focus",
+      active: true,
+    });
   });
 
   test("exits window mode on Enter without changes", async () => {

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -417,12 +417,53 @@ describe("Shell", () => {
     expect(resolvePaneManagementShortcut({ ...base, name: "o", key: "o" })).toBe("pop-out");
     expect(resolvePaneManagementShortcut({ ...base, name: "c", key: "c" })).toBe("copy-screenshot");
     expect(resolvePaneManagementShortcut({ ...base, name: "l", key: "l" })).toBe("layout-actions");
+    expect(resolvePaneManagementShortcut({ ...base, name: "f", key: "f" })).toBe("toggle-fullscreen");
     expect(resolvePaneManagementShortcut({ ...base, name: "g", key: "g" })).toBe("gridlock-all");
     expect(resolvePaneManagementShortcut({ ...base, name: "m", key: "m" })).toBe("window-mode");
     expect(resolvePaneManagementShortcut({ ...base, name: "r", key: "r" })).toBe("window-resize-mode");
     expect(resolvePaneManagementShortcut({ ...base, name: "n", key: "n" })).toBeNull();
     expect(resolvePaneManagementShortcut({ ...base, name: "d", key: "d", alt: true })).toBeNull();
     expect(resolvePaneManagementShortcut({ ...base, name: "d", key: "d", meta: false, super: false })).toBeNull();
+  });
+
+  test("toggles the focused pane fullscreen without persisting layout", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-fullscreen-shortcut-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    const dockedLayout = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        second: { kind: "pane" as const, instanceId: "ticker-detail:main" },
+      },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [],
+      detached: [],
+    };
+    const { actions } = await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, dockedLayout, "portfolio-list:main"),
+      { width: 80, height: 18 },
+    );
+
+    expect(testSetup.captureCharFrame()).toContain("Main Portfolio");
+    expect(testSetup.captureCharFrame()).toContain("Ticker Research Body");
+
+    await emitKeypress({ name: "f", ctrl: true, shift: true });
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Main Portfolio");
+    expect(frame).not.toContain("Ticker Research Body");
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+
+    await emitKeypress({ name: "f", ctrl: true, shift: true });
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Main Portfolio");
+    expect(frame).toContain("Ticker Research Body");
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
   });
 
   test("exits window mode on Enter without changes", async () => {

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -14,6 +14,7 @@ import {
   resolveAppHeaderHeightCells,
   Shell,
 } from "./index";
+import { resolvePaneFullscreenLayout } from "./fullscreen";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -463,6 +464,56 @@ describe("Shell", () => {
     frame = testSetup.captureCharFrame();
     expect(frame).toContain("Main Portfolio");
     expect(frame).toContain("Ticker Research Body");
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+  });
+
+  test("builds fullscreen as a transient one-pane layout", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-fullscreen-layout-test");
+    const layout = cloneLayout(config.layout);
+    layout.dockRoot = { kind: "pane", instanceId: "portfolio-list:main" };
+    layout.floating = [{ instanceId: "ticker-detail:main", x: 8, y: 2, width: 32, height: 10, zIndex: 75 }];
+
+    const focusedLayout = resolvePaneFullscreenLayout(layout, "ticker-detail:main");
+
+    expect(focusedLayout).toMatchObject({
+      dockRoot: { kind: "pane", instanceId: "ticker-detail:main" },
+      floating: [],
+      detached: [],
+    });
+    expect(focusedLayout?.instances.map((instance) => instance.instanceId)).toEqual(["ticker-detail:main"]);
+  });
+
+  test("locks layout-changing mouse drags while fullscreen is active", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-fullscreen-drag-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    const dockedLayout = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+        second: { kind: "pane" as const, instanceId: "ticker-detail:main" },
+      },
+      instances: [{ ...mainPane }, { ...detailPane }],
+      floating: [],
+      detached: [],
+    };
+    const { actions } = await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, dockedLayout, "portfolio-list:main"),
+      { width: 80, height: 18 },
+    );
+
+    await emitKeypress({ name: "f", ctrl: true, shift: true });
+    await act(async () => {
+      await testSetup!.mockMouse.drag(4, 0, 32, 4);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Main Portfolio");
+    expect(frame).not.toContain("Ticker Research Body");
     expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
   });
 

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -59,7 +59,8 @@ import {
   useShellVisibleLayout,
 } from "./layout-state";
 import { useShellPaneActions } from "./pane/actions";
-import { resolvePaneFullscreenLayout } from "./fullscreen";
+import { resolvePaneFocusSourceLayout } from "./fullscreen";
+import { useTransientLayout } from "../transient-layout";
 
 export { resolveAppHeaderHeightCells } from "./chrome";
 export { buildNativeWindowState } from "./native/window-state";
@@ -70,6 +71,12 @@ interface ShellProps {
   desktopWindowBridge?: DesktopWindowBridge;
   desktopDockPreview?: DesktopDockPreviewState | null;
   commandBarNativeOccluder?: LayoutBounds | null;
+}
+
+interface TransientFocusLayoutState {
+  paneId: string;
+  layout: LayoutConfig;
+  active: boolean;
 }
 
 export function Shell({
@@ -88,6 +95,7 @@ export function Shell({
   const inputCaptured = useAppSelector((state) => state.inputCaptured);
   const statusBarVisible = useAppSelector(selectStatusBarVisible);
   const rendererHost = useRendererHost();
+  const { setTransientLayout } = useTransientLayout();
   const uiKind = useUiHost().kind;
   const shortcutDisplayMode = getShortcutDisplayMode(uiKind);
   const { nativePaneChrome = false, nativeContextMenu, precisePointer, titleBarOverlay, cellHeightPx } = useUiCapabilities();
@@ -105,9 +113,9 @@ export function Shell({
     setHoveredPaneId((current) => (current === paneId ? current : paneId));
   }, []);
   const [menuState, setMenuState] = useState<ActionMenuState | null>(null);
-  const [transientFocusPaneId, setTransientFocusPaneId] = useState<string | null>(null);
-  const transientFocusPaneIdRef = useRef<string | null>(null);
-  transientFocusPaneIdRef.current = transientFocusPaneId;
+  const [transientFocusLayoutState, setTransientFocusLayoutState] = useState<TransientFocusLayoutState | null>(null);
+  const transientFocusLayoutStateRef = useRef<TransientFocusLayoutState | null>(null);
+  transientFocusLayoutStateRef.current = transientFocusLayoutState;
   const [hoveredMenuItemId, setHoveredMenuItemId] = useState<string | null>(null);
   const closePaneMenu = useCallback(() => {
     setMenuState(null);
@@ -176,21 +184,17 @@ export function Shell({
     visibleLayout,
     width,
   });
-  const transientFocusLayout = useMemo(
-    () => (!windowMode && transientFocusPaneId
-      ? resolvePaneFullscreenLayout(visibleLayout, transientFocusPaneId)
-      : null),
-    [transientFocusPaneId, visibleLayout, windowMode],
-  );
-  const transientFocusActive = !!transientFocusLayout;
-  const activeLayout = transientFocusLayout ?? windowModeLayout;
+  const transientFocusActive = !windowMode && transientFocusLayoutState?.active === true;
+  const activeLayout = transientFocusActive && transientFocusLayoutState
+    ? transientFocusLayoutState.layout
+    : windowModeLayout;
+  const transientFocusPaneId = transientFocusActive ? transientFocusLayoutState?.paneId ?? null : null;
 
   useEffect(() => {
-    if (!transientFocusPaneId) return;
-    if (windowMode || !isPaneInLayout(visibleLayout, transientFocusPaneId)) {
-      setTransientFocusPaneId(null);
-    }
-  }, [transientFocusPaneId, visibleLayout, windowMode]);
+    if (!windowMode || !transientFocusLayoutState) return;
+    transientFocusLayoutStateRef.current = null;
+    setTransientFocusLayoutState(null);
+  }, [transientFocusLayoutState, windowMode]);
 
   const {
     dockedPanes,
@@ -231,19 +235,79 @@ export function Shell({
     visibleLayout,
     width,
   });
+  const setTransientFocusLayout = useCallback((next: TransientFocusLayoutState | null) => {
+    transientFocusLayoutStateRef.current = next;
+    setTransientFocusLayoutState(next);
+  }, []);
   const toggleFocusedPaneFullscreen = useCallback(() => {
-    if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) {
+    const current = transientFocusLayoutStateRef.current;
+    if (current?.active) {
+      setTransientFocusLayout(null);
+      return true;
+    }
+
+    if (current && current.paneId === focusedPaneId) {
+      setTransientFocusLayout({ ...current, active: true });
+      focusPane(current.paneId);
+      closePaneMenu();
+      return true;
+    }
+
+    const nextLayout = resolvePaneFocusSourceLayout(visibleLayout, focusedPaneId);
+    if (!focusedPaneId || !nextLayout) {
       pluginRegistry.notify({ body: "Focus a pane to make it fullscreen", type: "info" });
       return false;
     }
 
     closePaneMenu();
-    const nextTransientFocusPaneId = transientFocusPaneIdRef.current === focusedPaneId ? null : focusedPaneId;
-    transientFocusPaneIdRef.current = nextTransientFocusPaneId;
-    setTransientFocusPaneId(nextTransientFocusPaneId);
+    setTransientFocusLayout({
+      paneId: focusedPaneId,
+      layout: nextLayout,
+      active: true,
+    });
     focusPane(focusedPaneId);
     return true;
-  }, [closePaneMenu, focusedPaneId, focusPane, pluginRegistry, visibleLayout]);
+  }, [closePaneMenu, focusedPaneId, focusPane, pluginRegistry, setTransientFocusLayout, visibleLayout]);
+  const activateTransientFocusLayout = useCallback(() => {
+    const current = transientFocusLayoutStateRef.current;
+    if (!current) return;
+    closePaneMenu();
+    setTransientFocusLayout({ ...current, active: true });
+    focusPane(current.paneId);
+  }, [closePaneMenu, focusPane, setTransientFocusLayout]);
+  const deactivateTransientFocusLayout = useCallback(() => {
+    const current = transientFocusLayoutStateRef.current;
+    if (!current || !current.active) return;
+    closePaneMenu();
+    setTransientFocusLayout({ ...current, active: false });
+  }, [closePaneMenu, setTransientFocusLayout]);
+  const exitTransientFocusLayout = useCallback(() => {
+    closePaneMenu();
+    setTransientFocusLayout(null);
+  }, [closePaneMenu, setTransientFocusLayout]);
+
+  useEffect(() => {
+    setTransientLayout(
+      transientFocusLayoutState
+        ? {
+          id: "pane-focus",
+          label: "^F Focus",
+          active: transientFocusActive,
+          onActivate: activateTransientFocusLayout,
+          onDeactivate: deactivateTransientFocusLayout,
+          onExit: exitTransientFocusLayout,
+        }
+        : null,
+    );
+    return () => setTransientLayout(null);
+  }, [
+    activateTransientFocusLayout,
+    deactivateTransientFocusLayout,
+    exitTransientFocusLayout,
+    setTransientLayout,
+    transientFocusActive,
+    transientFocusLayoutState,
+  ]);
 
   useShellPaneManagementShortcuts({
     cancelActiveDrag,
@@ -446,6 +510,7 @@ export function Shell({
         startNativeFloatingDrag={startNativeFloatingDrag}
         startNativeFloatResize={startNativeFloatResize}
         transientFocusActive={transientFocusActive}
+        transientFocusPaneId={transientFocusPaneId}
         visibleFloatingPanes={visibleFloatingPanes}
         width={width}
         windowModeDockResizePathKey={windowModeDockResizePathKey}

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -1,5 +1,5 @@
 import { AsciiText, Box, Text, compactContextMenuItems, useContextMenu, useUiHost } from "../../../ui";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRendererHost, useUiCapabilities } from "../../../ui";
 import { useViewport } from "../../../react/input";
 import { useDialogState } from "../../../ui/dialog";
@@ -8,6 +8,7 @@ import type { DesktopDockPreviewState, DesktopWindowBridge } from "../../../type
 import {
   getDockDividerLayouts,
   getDockLeafLayouts,
+  isPaneInLayout,
   type DockGeometryOptions,
   type LayoutBounds,
   type ResolvedPane,
@@ -58,6 +59,7 @@ import {
   useShellVisibleLayout,
 } from "./layout-state";
 import { useShellPaneActions } from "./pane/actions";
+import { resolvePaneFullscreenLayout } from "./fullscreen";
 
 export { resolveAppHeaderHeightCells } from "./chrome";
 export { buildNativeWindowState } from "./native/window-state";
@@ -103,6 +105,9 @@ export function Shell({
     setHoveredPaneId((current) => (current === paneId ? current : paneId));
   }, []);
   const [menuState, setMenuState] = useState<ActionMenuState | null>(null);
+  const [fullscreenPaneId, setFullscreenPaneId] = useState<string | null>(null);
+  const fullscreenPaneIdRef = useRef<string | null>(null);
+  fullscreenPaneIdRef.current = fullscreenPaneId;
   const [hoveredMenuItemId, setHoveredMenuItemId] = useState<string | null>(null);
   const closePaneMenu = useCallback(() => {
     setMenuState(null);
@@ -149,7 +154,7 @@ export function Shell({
   }, [dispatch]);
 
   const {
-    activeLayout,
+    activeLayout: windowModeLayout,
     nativeWindowModePanelRect,
     selectWindowModePane,
     startWindowMode,
@@ -171,6 +176,20 @@ export function Shell({
     visibleLayout,
     width,
   });
+  const fullscreenLayout = useMemo(
+    () => (!windowMode && fullscreenPaneId
+      ? resolvePaneFullscreenLayout(visibleLayout, fullscreenPaneId)
+      : null),
+    [fullscreenPaneId, visibleLayout, windowMode],
+  );
+  const activeLayout = fullscreenLayout ?? windowModeLayout;
+
+  useEffect(() => {
+    if (!fullscreenPaneId) return;
+    if (windowMode || !isPaneInLayout(visibleLayout, fullscreenPaneId)) {
+      setFullscreenPaneId(null);
+    }
+  }, [fullscreenPaneId, visibleLayout, windowMode]);
 
   const {
     dockedPanes,
@@ -211,6 +230,19 @@ export function Shell({
     visibleLayout,
     width,
   });
+  const toggleFocusedPaneFullscreen = useCallback(() => {
+    if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) {
+      pluginRegistry.notify({ body: "Focus a pane to make it fullscreen", type: "info" });
+      return false;
+    }
+
+    closePaneMenu();
+    const nextFullscreenPaneId = fullscreenPaneIdRef.current === focusedPaneId ? null : focusedPaneId;
+    fullscreenPaneIdRef.current = nextFullscreenPaneId;
+    setFullscreenPaneId(nextFullscreenPaneId);
+    focusPane(focusedPaneId);
+    return true;
+  }, [closePaneMenu, focusedPaneId, focusPane, pluginRegistry, visibleLayout]);
 
   useShellPaneManagementShortcuts({
     cancelActiveDrag,
@@ -226,6 +258,7 @@ export function Shell({
     overlayOpen,
     popOutFocusedPane,
     startWindowMode,
+    toggleFocusedPaneFullscreen,
     toggleFocusedPaneFloating,
   });
 
@@ -392,6 +425,7 @@ export function Shell({
         dockLeafLayouts={dockLeafLayouts}
         dragFloatingRect={dragFloatingRect}
         focusedPaneId={focusedPaneId}
+        fullscreenPaneId={fullscreenLayout ? fullscreenPaneId : null}
         getPaneTitle={getPaneTitle}
         handleFloatingClose={handleFloatingClose}
         handleFloatingCloseMouseDown={handleFloatingCloseMouseDown}

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -105,9 +105,9 @@ export function Shell({
     setHoveredPaneId((current) => (current === paneId ? current : paneId));
   }, []);
   const [menuState, setMenuState] = useState<ActionMenuState | null>(null);
-  const [fullscreenPaneId, setFullscreenPaneId] = useState<string | null>(null);
-  const fullscreenPaneIdRef = useRef<string | null>(null);
-  fullscreenPaneIdRef.current = fullscreenPaneId;
+  const [transientFocusPaneId, setTransientFocusPaneId] = useState<string | null>(null);
+  const transientFocusPaneIdRef = useRef<string | null>(null);
+  transientFocusPaneIdRef.current = transientFocusPaneId;
   const [hoveredMenuItemId, setHoveredMenuItemId] = useState<string | null>(null);
   const closePaneMenu = useCallback(() => {
     setMenuState(null);
@@ -176,20 +176,21 @@ export function Shell({
     visibleLayout,
     width,
   });
-  const fullscreenLayout = useMemo(
-    () => (!windowMode && fullscreenPaneId
-      ? resolvePaneFullscreenLayout(visibleLayout, fullscreenPaneId)
+  const transientFocusLayout = useMemo(
+    () => (!windowMode && transientFocusPaneId
+      ? resolvePaneFullscreenLayout(visibleLayout, transientFocusPaneId)
       : null),
-    [fullscreenPaneId, visibleLayout, windowMode],
+    [transientFocusPaneId, visibleLayout, windowMode],
   );
-  const activeLayout = fullscreenLayout ?? windowModeLayout;
+  const transientFocusActive = !!transientFocusLayout;
+  const activeLayout = transientFocusLayout ?? windowModeLayout;
 
   useEffect(() => {
-    if (!fullscreenPaneId) return;
-    if (windowMode || !isPaneInLayout(visibleLayout, fullscreenPaneId)) {
-      setFullscreenPaneId(null);
+    if (!transientFocusPaneId) return;
+    if (windowMode || !isPaneInLayout(visibleLayout, transientFocusPaneId)) {
+      setTransientFocusPaneId(null);
     }
-  }, [fullscreenPaneId, visibleLayout, windowMode]);
+  }, [transientFocusPaneId, visibleLayout, windowMode]);
 
   const {
     dockedPanes,
@@ -237,9 +238,9 @@ export function Shell({
     }
 
     closePaneMenu();
-    const nextFullscreenPaneId = fullscreenPaneIdRef.current === focusedPaneId ? null : focusedPaneId;
-    fullscreenPaneIdRef.current = nextFullscreenPaneId;
-    setFullscreenPaneId(nextFullscreenPaneId);
+    const nextTransientFocusPaneId = transientFocusPaneIdRef.current === focusedPaneId ? null : focusedPaneId;
+    transientFocusPaneIdRef.current = nextTransientFocusPaneId;
+    setTransientFocusPaneId(nextTransientFocusPaneId);
     focusPane(focusedPaneId);
     return true;
   }, [closePaneMenu, focusedPaneId, focusPane, pluginRegistry, visibleLayout]);
@@ -383,6 +384,7 @@ export function Shell({
     setHoveredMenuItemId,
     setMenuState,
     snapGuides,
+    transientFocusActive,
     updateWindowModePreviewLayout,
     visibleFloatingPanes,
     visibleLayout,
@@ -425,7 +427,6 @@ export function Shell({
         dockLeafLayouts={dockLeafLayouts}
         dragFloatingRect={dragFloatingRect}
         focusedPaneId={focusedPaneId}
-        fullscreenPaneId={fullscreenLayout ? fullscreenPaneId : null}
         getPaneTitle={getPaneTitle}
         handleFloatingClose={handleFloatingClose}
         handleFloatingCloseMouseDown={handleFloatingCloseMouseDown}
@@ -444,6 +445,7 @@ export function Shell({
         startNativeDockedDrag={startNativeDockedDrag}
         startNativeFloatingDrag={startNativeFloatingDrag}
         startNativeFloatResize={startNativeFloatResize}
+        transientFocusActive={transientFocusActive}
         visibleFloatingPanes={visibleFloatingPanes}
         width={width}
         windowModeDockResizePathKey={windowModeDockResizePathKey}

--- a/src/components/layout/shell/native/pointer-runtime.ts
+++ b/src/components/layout/shell/native/pointer-runtime.ts
@@ -20,6 +20,7 @@ interface UseShellNativePointerRuntimeOptions {
   selectWindowModePane: (paneId: string) => void;
   setHoveredMenuItemId: Dispatch<SetStateAction<string | null>>;
   setMenuState: Dispatch<SetStateAction<ActionMenuState | null>>;
+  transientFocusActive: boolean;
   windowMode: WindowEditState | null;
 }
 
@@ -35,6 +36,7 @@ export function useShellNativePointerRuntime({
   selectWindowModePane,
   setHoveredMenuItemId,
   setMenuState,
+  transientFocusActive,
   windowMode,
 }: UseShellNativePointerRuntimeOptions) {
   const {
@@ -69,6 +71,7 @@ export function useShellNativePointerRuntime({
   const startNativeFloatingDrag = useCallback((paneId: string, rect: FloatingRect, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
     if (windowMode) return;
+    if (transientFocusActive) return;
     if (event.button === 2) return;
 
     const pointer = getShellPointer(event);
@@ -83,11 +86,12 @@ export function useShellNativePointerRuntime({
     };
     updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, updateDragFloatingRect, windowMode]);
+  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, updateDragFloatingRect, windowMode]);
 
   const startNativeDockedDrag = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
     if (windowMode) return;
+    if (transientFocusActive) return;
     if (event.button === 2) return;
 
     const pointer = getShellPointer(event);
@@ -101,10 +105,11 @@ export function useShellNativePointerRuntime({
       origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
     };
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, windowMode]);
+  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, windowMode]);
 
   const startNativeFloatResize = useCallback((paneId: string, rect: FloatingRect, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
+    if (transientFocusActive) return;
 
     const pointer = getShellPointer(event);
     if (windowMode) {
@@ -122,10 +127,11 @@ export function useShellNativePointerRuntime({
     updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
     event.stopPropagation();
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, selectWindowModePane, updateDragFloatingRect, windowMode]);
+  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, selectWindowModePane, transientFocusActive, updateDragFloatingRect, windowMode]);
 
   const startNativeDividerDrag = useCallback((divider: DockDividerLayout, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
+    if (transientFocusActive) return;
 
     const pointer = getShellPointer(event);
     if (menuState) {
@@ -148,7 +154,7 @@ export function useShellNativePointerRuntime({
     });
     event.stopPropagation();
     event.preventDefault();
-  }, [dragRef, getShellPointer, menuState, nativePaneChrome, setHoveredMenuItemId, setMenuState, updateDividerPreview]);
+  }, [dragRef, getShellPointer, menuState, nativePaneChrome, setHoveredMenuItemId, setMenuState, transientFocusActive, updateDividerPreview]);
 
   const handlePaneAction = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
     if (windowMode) return;

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -49,6 +49,7 @@ interface ShellPaneLayersProps {
   startNativeFloatingDrag: (paneId: string, rect: FloatingRect, event: any) => void;
   startNativeFloatResize: (paneId: string, rect: FloatingRect, event: any) => void;
   transientFocusActive: boolean;
+  transientFocusPaneId: string | null;
   visibleFloatingPanes: VisibleFloatingPane[];
   width: number;
   windowModeDockResizePathKey: string | null;
@@ -81,6 +82,7 @@ export function ShellPaneLayers({
   startNativeFloatingDrag,
   startNativeFloatResize,
   transientFocusActive,
+  transientFocusPaneId,
   visibleFloatingPanes,
   width,
   windowModeDockResizePathKey,
@@ -89,8 +91,12 @@ export function ShellPaneLayers({
   return (
     <>
       {dockLeafLayouts.map((leaf) => {
+        if (transientFocusActive && leaf.instanceId !== transientFocusPaneId) return null;
         const pane = paneMap.get(leaf.instanceId);
         if (!pane) return null;
+        const rect = transientFocusActive
+          ? { x: 0, y: 0, width, height: contentHeight }
+          : leaf.rect;
         const focused = focusedPaneId === leaf.instanceId && (!overlayOpen || menuPaneId === leaf.instanceId);
         const windowModeSelected = windowModePaneId === leaf.instanceId;
         const showActions = focused || hoveredPaneId === leaf.instanceId || menuPaneId === leaf.instanceId;
@@ -98,17 +104,17 @@ export function ShellPaneLayers({
           <Box
             key={`dock:${leaf.instanceId}`}
             position="absolute"
-            left={leaf.rect.x}
-            top={leaf.rect.y}
-            width={leaf.rect.width}
-            height={leaf.rect.height}
+            left={rect.x}
+            top={rect.y}
+            width={rect.width}
+            height={rect.height}
           >
             <PaneFooterProvider>
               {(footer) => {
                 const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
                 const bodyFrame = resolvePaneBodyFrame({
-                  width: leaf.rect.width,
-                  height: leaf.rect.height,
+                  width: rect.width,
+                  height: rect.height,
                   nativePaneChrome,
                   reserveFooter,
                 });
@@ -117,18 +123,18 @@ export function ShellPaneLayers({
                     paneId={leaf.instanceId}
                     title={getPaneTitle(pane)}
                     focused={focused}
-                    width={leaf.rect.width}
-                    height={leaf.rect.height}
+                    width={rect.width}
+                    height={rect.height}
                     showActions={showActions}
                     windowModeSelected={windowModeSelected}
                     footer={footer}
                     onMouseDown={nativePaneChrome ? (event) => handleNativePaneMouseDown(leaf.instanceId, event) : undefined}
                     onMouseMove={() => setHoveredPaneIfChanged(leaf.instanceId)}
-                    onHeaderMouseDown={nativePaneChrome && !transientFocusActive ? (event) => startNativeDockedDrag(leaf.instanceId, leaf.rect, event) : undefined}
+                    onHeaderMouseDown={nativePaneChrome && !transientFocusActive ? (event) => startNativeDockedDrag(leaf.instanceId, rect, event) : undefined}
                     onHeaderMouseDrag={nativePaneChrome && !transientFocusActive ? handleNativeDrag : undefined}
                     onHeaderMouseDragEnd={nativePaneChrome && !transientFocusActive ? handleNativeDrag : undefined}
-                    onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(leaf.instanceId, leaf.rect, event) : undefined}
-                    onActionMouseDown={(event) => handlePaneAction(leaf.instanceId, leaf.rect, event)}
+                    onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(leaf.instanceId, rect, event) : undefined}
+                    onActionMouseDown={(event) => handlePaneAction(leaf.instanceId, rect, event)}
                   >
                     <PaneContent
                       component={pane.def.component}
@@ -147,7 +153,10 @@ export function ShellPaneLayers({
       })}
 
       {visibleFloatingPanes.map(({ pane, rect }) => {
-        const preview = dragFloatingRect?.paneId === pane.instance.instanceId
+        if (transientFocusActive && pane.instance.instanceId !== transientFocusPaneId) return null;
+        const preview = transientFocusActive
+          ? { x: 0, y: 0, width, height: contentHeight }
+          : dragFloatingRect?.paneId === pane.instance.instanceId
           ? constrainFloatingRectToBounds(dragFloatingRect.rect, width, contentHeight)
           : rect;
         const focused = focusedPaneId === pane.instance.instanceId && (!overlayOpen || menuPaneId === pane.instance.instanceId);
@@ -205,6 +214,7 @@ export function ShellPaneLayers({
       })}
 
       {dockDividerLayouts.map((divider) => {
+        if (transientFocusActive) return null;
         const dividerPathKey = pathKey(divider.path);
         const previewActive = dividerPreview?.pathKey === dividerPathKey;
         const active = previewActive || windowModeDockResizePathKey === dividerPathKey;

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -30,7 +30,6 @@ interface ShellPaneLayersProps {
   dockLeafLayouts: DockLeafLayout[];
   dragFloatingRect: { paneId: string; rect: FloatingRect } | null;
   focusedPaneId: string | null;
-  fullscreenPaneId: string | null;
   getPaneTitle: (pane: ResolvedPane) => string;
   handleFloatingClose: (paneId: string) => void;
   handleFloatingCloseMouseDown: (paneId: string, event: any) => void;
@@ -49,6 +48,7 @@ interface ShellPaneLayersProps {
   startNativeDockedDrag: (paneId: string, rect: LayoutBounds, event: any) => void;
   startNativeFloatingDrag: (paneId: string, rect: FloatingRect, event: any) => void;
   startNativeFloatResize: (paneId: string, rect: FloatingRect, event: any) => void;
+  transientFocusActive: boolean;
   visibleFloatingPanes: VisibleFloatingPane[];
   width: number;
   windowModeDockResizePathKey: string | null;
@@ -62,7 +62,6 @@ export function ShellPaneLayers({
   dockLeafLayouts,
   dragFloatingRect,
   focusedPaneId,
-  fullscreenPaneId,
   getPaneTitle,
   handleFloatingClose,
   handleFloatingCloseMouseDown,
@@ -81,6 +80,7 @@ export function ShellPaneLayers({
   startNativeDockedDrag,
   startNativeFloatingDrag,
   startNativeFloatResize,
+  transientFocusActive,
   visibleFloatingPanes,
   width,
   windowModeDockResizePathKey,
@@ -92,7 +92,6 @@ export function ShellPaneLayers({
         const pane = paneMap.get(leaf.instanceId);
         if (!pane) return null;
         const focused = focusedPaneId === leaf.instanceId && (!overlayOpen || menuPaneId === leaf.instanceId);
-        const fullscreen = fullscreenPaneId === leaf.instanceId;
         const windowModeSelected = windowModePaneId === leaf.instanceId;
         const showActions = focused || hoveredPaneId === leaf.instanceId || menuPaneId === leaf.instanceId;
         return (
@@ -125,9 +124,9 @@ export function ShellPaneLayers({
                     footer={footer}
                     onMouseDown={nativePaneChrome ? (event) => handleNativePaneMouseDown(leaf.instanceId, event) : undefined}
                     onMouseMove={() => setHoveredPaneIfChanged(leaf.instanceId)}
-                    onHeaderMouseDown={nativePaneChrome && !fullscreen ? (event) => startNativeDockedDrag(leaf.instanceId, leaf.rect, event) : undefined}
-                    onHeaderMouseDrag={nativePaneChrome && !fullscreen ? handleNativeDrag : undefined}
-                    onHeaderMouseDragEnd={nativePaneChrome && !fullscreen ? handleNativeDrag : undefined}
+                    onHeaderMouseDown={nativePaneChrome && !transientFocusActive ? (event) => startNativeDockedDrag(leaf.instanceId, leaf.rect, event) : undefined}
+                    onHeaderMouseDrag={nativePaneChrome && !transientFocusActive ? handleNativeDrag : undefined}
+                    onHeaderMouseDragEnd={nativePaneChrome && !transientFocusActive ? handleNativeDrag : undefined}
                     onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(leaf.instanceId, leaf.rect, event) : undefined}
                     onActionMouseDown={(event) => handlePaneAction(leaf.instanceId, leaf.rect, event)}
                   >

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -30,6 +30,7 @@ interface ShellPaneLayersProps {
   dockLeafLayouts: DockLeafLayout[];
   dragFloatingRect: { paneId: string; rect: FloatingRect } | null;
   focusedPaneId: string | null;
+  fullscreenPaneId: string | null;
   getPaneTitle: (pane: ResolvedPane) => string;
   handleFloatingClose: (paneId: string) => void;
   handleFloatingCloseMouseDown: (paneId: string, event: any) => void;
@@ -61,6 +62,7 @@ export function ShellPaneLayers({
   dockLeafLayouts,
   dragFloatingRect,
   focusedPaneId,
+  fullscreenPaneId,
   getPaneTitle,
   handleFloatingClose,
   handleFloatingCloseMouseDown,
@@ -90,6 +92,7 @@ export function ShellPaneLayers({
         const pane = paneMap.get(leaf.instanceId);
         if (!pane) return null;
         const focused = focusedPaneId === leaf.instanceId && (!overlayOpen || menuPaneId === leaf.instanceId);
+        const fullscreen = fullscreenPaneId === leaf.instanceId;
         const windowModeSelected = windowModePaneId === leaf.instanceId;
         const showActions = focused || hoveredPaneId === leaf.instanceId || menuPaneId === leaf.instanceId;
         return (
@@ -122,9 +125,9 @@ export function ShellPaneLayers({
                     footer={footer}
                     onMouseDown={nativePaneChrome ? (event) => handleNativePaneMouseDown(leaf.instanceId, event) : undefined}
                     onMouseMove={() => setHoveredPaneIfChanged(leaf.instanceId)}
-                    onHeaderMouseDown={nativePaneChrome ? (event) => startNativeDockedDrag(leaf.instanceId, leaf.rect, event) : undefined}
-                    onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
-                    onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
+                    onHeaderMouseDown={nativePaneChrome && !fullscreen ? (event) => startNativeDockedDrag(leaf.instanceId, leaf.rect, event) : undefined}
+                    onHeaderMouseDrag={nativePaneChrome && !fullscreen ? handleNativeDrag : undefined}
+                    onHeaderMouseDragEnd={nativePaneChrome && !fullscreen ? handleNativeDrag : undefined}
                     onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(leaf.instanceId, leaf.rect, event) : undefined}
                     onActionMouseDown={(event) => handlePaneAction(leaf.instanceId, leaf.rect, event)}
                   >

--- a/src/components/layout/shell/pane/management-shortcuts.ts
+++ b/src/components/layout/shell/pane/management-shortcuts.ts
@@ -25,6 +25,7 @@ interface ShellPaneManagementShortcutOptions {
   overlayOpen: boolean;
   popOutFocusedPane(): boolean;
   startWindowMode(paneId?: string, mode?: WindowEditMode): void;
+  toggleFocusedPaneFullscreen(): boolean;
   toggleFocusedPaneFloating(): boolean;
 }
 
@@ -42,6 +43,7 @@ export function useShellPaneManagementShortcuts({
   overlayOpen,
   popOutFocusedPane,
   startWindowMode,
+  toggleFocusedPaneFullscreen,
   toggleFocusedPaneFloating,
 }: ShellPaneManagementShortcutOptions): void {
   const doubleEscapeCloseRef = useRef(createDoubleEscapeCloseState());
@@ -53,6 +55,17 @@ export function useShellPaneManagementShortcuts({
   }, [overlayOpen]);
 
   useShortcut((event) => {
+    const shortcut = resolvePaneManagementShortcut(event);
+    if (shortcut === "toggle-fullscreen" && !hasActiveDrag() && !overlayOpen) {
+      if (!inputCaptured || inputCaptureAllowsPaneManagementShortcut(shortcut, event)) {
+        if (toggleFocusedPaneFullscreen()) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+      }
+    }
+
     const isEscape = event.name === "escape" || event.name === "esc";
     if (isEscape) {
       const doubleEscapeState = doubleEscapeCloseRef.current;
@@ -90,6 +103,9 @@ export function useShellPaneManagementShortcuts({
         break;
       case "settings":
         handled = openFocusedPaneSettings();
+        break;
+      case "toggle-fullscreen":
+        handled = toggleFocusedPaneFullscreen();
         break;
       case "toggle-floating":
         handled = toggleFocusedPaneFloating();

--- a/src/components/layout/shell/pane/management-shortcuts.ts
+++ b/src/components/layout/shell/pane/management-shortcuts.ts
@@ -56,8 +56,11 @@ export function useShellPaneManagementShortcuts({
 
   useShortcut((event) => {
     const shortcut = resolvePaneManagementShortcut(event);
-    if (shortcut === "toggle-fullscreen" && !hasActiveDrag() && !overlayOpen) {
+    if (shortcut === "toggle-fullscreen" && !overlayOpen) {
       if (!inputCaptured || inputCaptureAllowsPaneManagementShortcut(shortcut, event)) {
+        if (hasActiveDrag()) {
+          cancelActiveDrag();
+        }
         if (toggleFocusedPaneFullscreen()) {
           event.preventDefault();
           event.stopPropagation();

--- a/src/components/layout/shell/shortcuts.ts
+++ b/src/components/layout/shell/shortcuts.ts
@@ -53,6 +53,7 @@ export function inputCaptureAllowsPaneManagementShortcut(
   shortcut: PaneManagementShortcut,
   event: Pick<KeyEventLike, "meta" | "super" | "targetEditable">,
 ): boolean {
+  if (shortcut === "toggle-fullscreen") return event.meta || event.super === true;
   if (shortcut !== "close" && shortcut !== "close-all-floating") return false;
   return event.meta || event.super || event.targetEditable !== true;
 }

--- a/src/components/layout/shell/shortcuts.ts
+++ b/src/components/layout/shell/shortcuts.ts
@@ -2,6 +2,7 @@ import type { KeyEventLike } from "../../../react/input";
 
 export const PANE_MANAGEMENT_ACCELERATORS = {
   settings: "CmdOrCtrl+,",
+  fullscreen: "CmdOrCtrl+Shift+F",
   toggleFloating: "CmdOrCtrl+Shift+D",
   popOut: "CmdOrCtrl+Shift+O",
   copyScreenshot: "CmdOrCtrl+Shift+C",
@@ -15,6 +16,7 @@ export const PANE_MANAGEMENT_ACCELERATORS = {
 
 export type PaneManagementShortcut =
   | "settings"
+  | "toggle-fullscreen"
   | "toggle-floating"
   | "pop-out"
   | "copy-screenshot"
@@ -38,6 +40,7 @@ export function resolvePaneManagementShortcut(
   if (!shifted || event.alt) return null;
   if (name === "c") return "copy-screenshot";
   if (name === "d") return "toggle-floating";
+  if (name === "f") return "toggle-fullscreen";
   if (name === "o") return "pop-out";
   if (name === "l") return "layout-actions";
   if (name === "g") return "gridlock-all";

--- a/src/components/layout/shell/terminal-pointer-runtime.ts
+++ b/src/components/layout/shell/terminal-pointer-runtime.ts
@@ -41,6 +41,7 @@ interface UseShellTerminalPointerRuntimeOptions {
   selectWindowModePane: (paneId: string) => void;
   setHoveredMenuItemId: Dispatch<SetStateAction<string | null>>;
   setMenuState: Dispatch<SetStateAction<ActionMenuState | null>>;
+  transientFocusActive: boolean;
   visibleFloatingPanes: VisibleFloatingPane[];
   width: number;
   windowMode: WindowEditState | null;
@@ -79,6 +80,7 @@ export function useShellTerminalPointerRuntime({
   selectWindowModePane,
   setHoveredMenuItemId,
   setMenuState,
+  transientFocusActive,
   visibleFloatingPanes,
   width,
   windowMode,
@@ -132,25 +134,27 @@ export function useShellTerminalPointerRuntime({
         return;
       }
 
-      for (const divider of dockDividerLayouts) {
-        if (!pointInRect(divider.rect, event.x, shellY)) continue;
-        dragRef.current = {
-          type: "divider",
-          path: divider.path,
-          axis: divider.axis,
-          startX: preciseX,
-          startY: preciseShellY,
-          startRatio: divider.ratio,
-          bounds: divider.bounds,
-        };
-        updateDividerPreview({
-          pathKey: divider.path.join("."),
-          rect: divider.rect,
-          ratio: divider.ratio,
-        });
-        event.stopPropagation();
-        event.preventDefault();
-        return;
+      if (!transientFocusActive) {
+        for (const divider of dockDividerLayouts) {
+          if (!pointInRect(divider.rect, event.x, shellY)) continue;
+          dragRef.current = {
+            type: "divider",
+            path: divider.path,
+            axis: divider.axis,
+            startX: preciseX,
+            startY: preciseShellY,
+            startRatio: divider.ratio,
+            bounds: divider.bounds,
+          };
+          updateDividerPreview({
+            pathKey: divider.path.join("."),
+            rect: divider.rect,
+            ratio: divider.ratio,
+          });
+          event.stopPropagation();
+          event.preventDefault();
+          return;
+        }
       }
 
       for (const leaf of dockLeafLayouts) {
@@ -279,6 +283,11 @@ export function useShellTerminalPointerRuntime({
           event.preventDefault();
           return;
         }
+        if (relativeY === 0 && transientFocusActive) {
+          event.stopPropagation();
+          event.preventDefault();
+          return;
+        }
         if (relativeY === 0) {
           dragRef.current = {
             type: "pane-drag",
@@ -317,6 +326,7 @@ export function useShellTerminalPointerRuntime({
     selectWindowModePane,
     setHoveredMenuItemId,
     setMenuState,
+    transientFocusActive,
     updateDividerPreview,
     updateDragFloatingRect,
     visibleFloatingPanes,

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -5,6 +5,8 @@ import { cloneLayout, createDefaultConfig, type LayoutConfig } from "../../types
 import type { AppNotificationRequest } from "../../types/plugin";
 import { StatusBar } from "./status-bar";
 import { setSharedRegistryForTests } from "../../plugins/registry";
+import { useEffect, useState } from "react";
+import { TransientLayoutProvider, useTransientLayout } from "./transient-layout";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -17,6 +19,37 @@ afterEach(() => {
 });
 
 describe("StatusBar", () => {
+  function SeedTransientLayout({
+    onActivate,
+    onDeactivate,
+    onExit,
+  }: {
+    onActivate?: () => void;
+    onDeactivate?: () => void;
+    onExit?: () => void;
+  }) {
+    const { setTransientLayout } = useTransientLayout();
+    const [active, setActive] = useState(true);
+    useEffect(() => {
+      setTransientLayout({
+        id: "pane-focus",
+        label: "^F Focus",
+        active,
+        onActivate: () => {
+          onActivate?.();
+          setActive(true);
+        },
+        onDeactivate: () => {
+          onDeactivate?.();
+          setActive(false);
+        },
+        onExit,
+      });
+      return () => setTransientLayout(null);
+    }, [active, onActivate, onDeactivate, onExit, setTransientLayout]);
+    return null;
+  }
+
   test("opens the command bar from the shortcut hint", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     config.layouts = [{ name: "Home", layout: cloneLayout(config.layout) }];
@@ -43,6 +76,78 @@ describe("StatusBar", () => {
     await testSetup.renderOnce();
 
     expect(actions).toContainEqual({ type: "SET_COMMAND_BAR", open: true, query: "" });
+  });
+
+  test("shows a transient focus layout tab without replacing saved layouts", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-transient-layout-test");
+    config.layouts = [
+      { name: "Default", layout: cloneLayout(config.layout) },
+      { name: "Monitor", layout: cloneLayout(config.layout) },
+    ];
+    const state = {
+      ...createInitialState(config),
+      statusBarVisible: true,
+    };
+    const actions: Array<{ type: string; index?: number }> = [];
+    let activateCount = 0;
+    let deactivateCount = 0;
+    let exitCount = 0;
+    const handleActivate = () => { activateCount += 1; };
+    const handleDeactivate = () => { deactivateCount += 1; };
+    const handleExit = () => { exitCount += 1; };
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action as { type: string; index?: number }) }}>
+        <TransientLayoutProvider>
+          <SeedTransientLayout
+            onActivate={handleActivate}
+            onDeactivate={handleDeactivate}
+            onExit={handleExit}
+          />
+          <StatusBar />
+        </TransientLayoutProvider>
+      </AppContext>,
+      { width: 120, height: 1 },
+    );
+
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("^1 Default");
+    expect(frame).toContain("^2 Monitor");
+    expect(frame).toContain("^F Focus");
+
+    const monitorX = frame.split("\n")[0]?.indexOf("^2 Monitor") ?? -1;
+    expect(monitorX).toBeGreaterThanOrEqual(0);
+
+    await testSetup.mockMouse.click(monitorX + 1, 0);
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+
+    expect(deactivateCount).toBe(1);
+    expect(exitCount).toBe(0);
+    expect(actions).toContainEqual({ type: "SWITCH_LAYOUT", index: 1 });
+
+    const afterSwitchFrame = testSetup.captureCharFrame();
+    expect(afterSwitchFrame).toContain("^F Focus");
+
+    const focusX = afterSwitchFrame.split("\n")[0]?.indexOf("^F Focus") ?? -1;
+    expect(focusX).toBeGreaterThanOrEqual(0);
+
+    await testSetup.mockMouse.click(focusX + 1, 0);
+    await testSetup.renderOnce();
+
+    expect(activateCount).toBe(1);
+
+    const activeFocusFrame = testSetup.captureCharFrame();
+    const activeFocusX = activeFocusFrame.split("\n")[0]?.indexOf("^F Focus") ?? -1;
+    expect(activeFocusX).toBeGreaterThanOrEqual(0);
+
+    await testSetup.mockMouse.click(activeFocusX + 1, 0);
+    await testSetup.renderOnce();
+
+    expect(exitCount).toBe(1);
   });
 
   test("shows a gridlock tip after a corner snap and runs gridlock on click", async () => {

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -16,6 +16,7 @@ import { notifyGridlockComplete } from "../../plugins/gridlock-notification";
 import { PluginSlot } from "../../react/plugins/plugin-slot";
 import type { ContextMenuItem } from "../../types/context-menu";
 import { Tabs } from "../ui/tabs";
+import { useTransientLayout } from "./transient-layout";
 
 const GRIDLOCK_TIP_DURATION_MS = 60_000;
 
@@ -31,6 +32,7 @@ type LayoutTabItem = {
 
 type StatusBarViewProps = {
   activeLayoutIdx: number;
+  activeLayoutValue: string;
   dismissGridlockTip: (event?: StatusBarEvent) => void;
   handleGridlockTip: (event?: StatusBarEvent) => void;
   handleLayoutSelect: (value: string) => void;
@@ -62,18 +64,40 @@ export function StatusBar() {
   const statusBarVisible = useAppSelector(selectStatusBarVisible);
   const gridlockTipVisible = useAppSelector(selectGridlockTipVisible);
   const gridlockTipSequence = useAppSelector(selectGridlockTipSequence);
+  const { transientLayout } = useTransientLayout();
   const [hoveredControl, setHoveredControl] = useState<string | null>(null);
 
-  const hasMultipleLayouts = layouts.length > 1;
+  const hasMultipleLayouts = layouts.length > 1 || !!transientLayout;
   const showGridlockTip = gridlockTipVisible && !!registry;
-  const layoutTabs = layouts.map((layout, index) => ({
+  const savedLayoutTabs = layouts.map((layout, index) => ({
     label: `^${index + 1} ${truncate(layout.name, 14)}`,
     value: String(index),
   }));
+  const layoutTabs = transientLayout
+    ? [
+      ...savedLayoutTabs,
+      {
+        label: transientLayout.label,
+        value: transientLayout.id,
+      },
+    ]
+    : savedLayoutTabs;
   const layoutTabsWidth = layoutTabs.reduce((sum, tab) => sum + tab.label.length + 2, 0);
+  const activeLayoutValue = transientLayout?.active ? transientLayout.id : String(activeLayoutIdx);
   const handleLayoutSelect = (value: string) => {
+    if (value === transientLayout?.id) {
+      if (transientLayout.active) {
+        transientLayout.onExit?.();
+      } else {
+        transientLayout.onActivate?.();
+      }
+      return;
+    }
     const index = Number(value);
     if (!Number.isInteger(index) || index < 0 || index >= layouts.length) return;
+    if (transientLayout?.active) {
+      transientLayout.onDeactivate?.();
+    }
     dispatch({ type: "SWITCH_LAYOUT", index });
   };
 
@@ -184,11 +208,12 @@ export function StatusBar() {
     );
   }, [activeLayoutIdx, layoutContextMenuItems, layouts, showContextMenu]);
   const handleLayoutTabContextMenu = useCallback((value: string, event: any) => {
+    if (value === transientLayout?.id) return;
     const index = Number(value);
     if (!Number.isInteger(index) || index < 0 || index >= layouts.length) return;
     if (event?.type !== "contextmenu" && event?.button === 2 && nativeContextMenu === true) return;
     void openLayoutContextMenu(index, event);
-  }, [layouts.length, nativeContextMenu, openLayoutContextMenu]);
+  }, [layouts.length, nativeContextMenu, openLayoutContextMenu, transientLayout?.id]);
   const layoutTabItems = layoutTabs.map((tab) => ({
     ...tab,
     onContextMenu: handleLayoutTabContextMenu,
@@ -198,6 +223,7 @@ export function StatusBar() {
 
   const viewProps: StatusBarViewProps = {
     activeLayoutIdx,
+    activeLayoutValue,
     dismissGridlockTip,
     handleGridlockTip,
     handleLayoutSelect,
@@ -272,7 +298,7 @@ function TerminalStatusBar({
 }
 
 function StatusBarLayoutControl({
-  activeLayoutIdx,
+  activeLayoutValue,
   handleLayoutSelect,
   hasMultipleLayouts,
   hoveredControl,
@@ -283,7 +309,7 @@ function StatusBarLayoutControl({
   setHoveredControl,
 }: Pick<
   StatusBarViewProps,
-  | "activeLayoutIdx"
+  | "activeLayoutValue"
   | "handleLayoutSelect"
   | "hasMultipleLayouts"
   | "hoveredControl"
@@ -303,7 +329,7 @@ function StatusBarLayoutControl({
         <Box width={layoutTabsWidth} height={1}>
           <Tabs
             tabs={layoutTabItems}
-            activeValue={String(activeLayoutIdx)}
+            activeValue={activeLayoutValue}
             onSelect={handleLayoutSelect}
             compact
             variant="pill"

--- a/src/components/layout/transient-layout.tsx
+++ b/src/components/layout/transient-layout.tsx
@@ -1,0 +1,57 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+export interface TransientLayoutState {
+  id: "pane-focus";
+  label: string;
+  active: boolean;
+  onActivate?: () => void;
+  onDeactivate?: () => void;
+  onExit?: () => void;
+}
+
+interface TransientLayoutContextValue {
+  transientLayout: TransientLayoutState | null;
+  setTransientLayout: (layout: TransientLayoutState | null) => void;
+}
+
+const noop = () => {};
+
+const TransientLayoutContext = createContext<TransientLayoutContextValue>({
+  transientLayout: null,
+  setTransientLayout: noop,
+});
+
+function sameTransientLayout(
+  left: TransientLayoutState | null,
+  right: TransientLayoutState | null,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.id === right.id
+    && left.label === right.label
+    && left.active === right.active
+    && left.onActivate === right.onActivate
+    && left.onDeactivate === right.onDeactivate
+    && left.onExit === right.onExit;
+}
+
+export function TransientLayoutProvider({ children }: { children: ReactNode }) {
+  const [transientLayout, setTransientLayoutState] = useState<TransientLayoutState | null>(null);
+  const setTransientLayout = useCallback((layout: TransientLayoutState | null) => {
+    setTransientLayoutState((current) => (sameTransientLayout(current, layout) ? current : layout));
+  }, []);
+  const value = useMemo(() => ({
+    transientLayout,
+    setTransientLayout,
+  }), [setTransientLayout, transientLayout]);
+
+  return (
+    <TransientLayoutContext.Provider value={value}>
+      {children}
+    </TransientLayoutContext.Provider>
+  );
+}
+
+export function useTransientLayout(): TransientLayoutContextValue {
+  return useContext(TransientLayoutContext);
+}

--- a/src/plugins/builtin/news/wire/read-state.ts
+++ b/src/plugins/builtin/news/wire/read-state.ts
@@ -1,55 +1,32 @@
 import { useCallback, useMemo } from "react";
 import { usePluginState } from "../../../runtime";
+import {
+  DEFAULT_MAX_READ_IDS,
+  markReadId,
+  normalizeReadIds,
+  sameStringArray,
+} from "../../shared/read-state";
 
 export interface NewsReadState {
   articleIds: string[];
 }
 
 const NEWS_READ_STATE_SCHEMA_VERSION = 1;
-export const MAX_READ_ARTICLE_IDS = 2_000;
+export const MAX_READ_ARTICLE_IDS = DEFAULT_MAX_READ_IDS;
 
 const READ_STATE_KEY = "read-articles";
 const EMPTY_READ_STATE: NewsReadState = { articleIds: [] };
 
-function normalizeArticleId(articleId: string): string {
-  return articleId.trim();
-}
-
-function sameStringArray(left: string[], right: string[]): boolean {
-  if (left.length !== right.length) return false;
-  return left.every((value, index) => value === right[index]);
-}
-
 export function normalizeNewsReadState(state: NewsReadState): NewsReadState {
-  const seen = new Set<string>();
-  const articleIds: string[] = [];
-
-  for (const rawId of state.articleIds) {
-    if (typeof rawId !== "string") continue;
-    const articleId = normalizeArticleId(rawId);
-    if (!articleId || seen.has(articleId)) continue;
-    seen.add(articleId);
-    articleIds.push(articleId);
-    if (articleIds.length >= MAX_READ_ARTICLE_IDS) break;
-  }
-
-  return { articleIds };
+  return { articleIds: normalizeReadIds(state.articleIds, MAX_READ_ARTICLE_IDS) };
 }
 
 export function markNewsArticleRead(
   state: NewsReadState,
   articleId: string,
 ): NewsReadState {
-  const normalizedId = normalizeArticleId(articleId);
   const current = normalizeNewsReadState(state).articleIds;
-  if (!normalizedId) {
-    return sameStringArray(current, state.articleIds) ? state : { articleIds: current };
-  }
-
-  const articleIds = [
-    normalizedId,
-    ...current.filter((currentId) => currentId !== normalizedId),
-  ].slice(0, MAX_READ_ARTICLE_IDS);
+  const articleIds = markReadId(current, articleId, MAX_READ_ARTICLE_IDS);
 
   return sameStringArray(articleIds, state.articleIds) ? state : { articleIds };
 }

--- a/src/plugins/builtin/shared/read-state.ts
+++ b/src/plugins/builtin/shared/read-state.ts
@@ -1,0 +1,43 @@
+export const DEFAULT_MAX_READ_IDS = 2_000;
+
+function normalizeReadId(readId: unknown): string {
+  return typeof readId === "string" ? readId.trim() : "";
+}
+
+export function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+export function normalizeReadIds(
+  readIds: readonly unknown[] | undefined,
+  maxIds = DEFAULT_MAX_READ_IDS,
+): string[] {
+  const seen = new Set<string>();
+  const normalizedIds: string[] = [];
+
+  for (const rawId of readIds ?? []) {
+    const readId = normalizeReadId(rawId);
+    if (!readId || seen.has(readId)) continue;
+    seen.add(readId);
+    normalizedIds.push(readId);
+    if (normalizedIds.length >= maxIds) break;
+  }
+
+  return normalizedIds;
+}
+
+export function markReadId(
+  readIds: readonly unknown[] | undefined,
+  readId: string,
+  maxIds = DEFAULT_MAX_READ_IDS,
+): string[] {
+  const normalizedId = normalizeReadId(readId);
+  const current = normalizeReadIds(readIds, maxIds);
+  if (!normalizedId) return current;
+
+  return [
+    normalizedId,
+    ...current.filter((currentId) => currentId !== normalizedId),
+  ].slice(0, maxIds);
+}

--- a/src/plugins/builtin/substack/article-detail.test.tsx
+++ b/src/plugins/builtin/substack/article-detail.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { resolveArticleImageSize } from "./article-detail";
+
+describe("Substack article image sizing", () => {
+  test("uses extra detail pane room without shrinking compact panes", () => {
+    expect(resolveArticleImageSize(40)).toEqual({ width: 40, height: 12 });
+    expect(resolveArticleImageSize(86)).toEqual({ width: 86, height: 15 });
+    expect(resolveArticleImageSize(220)).toEqual({ width: 152, height: 26 });
+  });
+});

--- a/src/plugins/builtin/substack/article-detail.tsx
+++ b/src/plugins/builtin/substack/article-detail.tsx
@@ -38,6 +38,25 @@ function wrappedTextProps(width: number) {
   } as const;
 }
 
+const ARTICLE_IMAGE_MAX_WIDTH = 152;
+const ARTICLE_IMAGE_MAX_HEIGHT = 26;
+const ARTICLE_IMAGE_MIN_HEIGHT = 6;
+const ARTICLE_IMAGE_LEGACY_HEIGHT_CAP = 14;
+
+export function resolveArticleImageSize(lineWidth: number) {
+  const safeLineWidth = Math.max(1, Math.floor(lineWidth));
+  const width = Math.min(safeLineWidth, ARTICLE_IMAGE_MAX_WIDTH);
+  const legacyHeight = Math.min(ARTICLE_IMAGE_LEGACY_HEIGHT_CAP, Math.floor(width * 0.32));
+  const expandedHeight = Math.floor(width * 0.18);
+  return {
+    width,
+    height: Math.max(ARTICLE_IMAGE_MIN_HEIGHT, Math.min(
+      ARTICLE_IMAGE_MAX_HEIGHT,
+      Math.max(legacyHeight, expandedHeight),
+    )),
+  };
+}
+
 function normalizedTwitterUsername(username: string | null | undefined): string | null {
   const normalized = username?.trim().replace(/^@/, "") ?? "";
   return /^[A-Za-z0-9_]{1,15}$/.test(normalized) ? normalized : null;
@@ -337,8 +356,7 @@ export const ArticleDetail = memo(function ArticleDetail({
   const blocks = resolved?.contentBlocks ?? [];
   const fallbackImageUrls = resolved?.imageUrls.length ? resolved.imageUrls : article.imageUrls;
   const lineWidth = Math.max(1, width - 2);
-  const imageWidth = Math.min(lineWidth, 86);
-  const imageHeight = Math.max(6, Math.min(14, Math.floor(imageWidth * 0.32)));
+  const { width: imageWidth, height: imageHeight } = resolveArticleImageSize(lineWidth);
 
   return (
     <ScrollBox ref={scrollRef} scrollY focusable={false} flexGrow={1} paddingX={1}>

--- a/src/plugins/builtin/substack/article-detail.tsx
+++ b/src/plugins/builtin/substack/article-detail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type RefObject } from "react";
+import { memo, useCallback, useMemo, type RefObject } from "react";
 import { Box, ScrollBox, Text, TextAttributes, useRendererHost, type ScrollBoxRenderable } from "../../../ui";
 import { Spinner } from "../../../components";
 import { RemoteImage } from "../../../components/ui";
@@ -251,7 +251,7 @@ function ArticleBlockView({
   }
 }
 
-function ArticleRichContent({
+const ArticleRichContent = memo(function ArticleRichContent({
   blocks,
   fallbackText,
   fallbackImageUrls,
@@ -269,14 +269,20 @@ function ArticleRichContent({
   imageHeight: number;
 }) {
   const rendererHost = useRendererHost();
-  const resolvedBlocks = blocks.length > 0
-    ? blocks
-    : [
-      ...(fallbackText ? [{ type: "paragraph" as const, text: fallbackText }] : []),
-      ...fallbackImageUrls.map((url): SubstackContentBlock => ({ type: "image", url, alt: articleTitle })),
-    ];
-  const tickerText = resolvedBlocks.map(articleBlockText).filter(Boolean).join("\n");
-  const { catalog, openTicker } = useInlineTickers([tickerText], { liveQuotes: false });
+  const resolvedBlocks = useMemo(() => (
+    blocks.length > 0
+      ? blocks
+      : [
+        ...(fallbackText ? [{ type: "paragraph" as const, text: fallbackText }] : []),
+        ...fallbackImageUrls.map((url): SubstackContentBlock => ({ type: "image", url, alt: articleTitle })),
+      ]
+  ), [articleTitle, blocks, fallbackImageUrls, fallbackText]);
+  const tickerText = useMemo(
+    () => resolvedBlocks.map(articleBlockText).filter(Boolean).join("\n"),
+    [resolvedBlocks],
+  );
+  const tickerTexts = useMemo(() => [tickerText], [tickerText]);
+  const { catalog, openTicker } = useInlineTickers(tickerTexts, { liveQuotes: false });
   const openLink = useCallback((url: string) => {
     void rendererHost.openExternal(url);
   }, [rendererHost]);
@@ -307,9 +313,9 @@ function ArticleRichContent({
       ))}
     </Box>
   );
-}
+});
 
-export function ArticleDetail({
+export const ArticleDetail = memo(function ArticleDetail({
   article,
   detail,
   width,
@@ -356,4 +362,4 @@ export function ArticleDetail({
       </Box>
     </ScrollBox>
   );
-}
+});

--- a/src/plugins/builtin/substack/article-stack.tsx
+++ b/src/plugins/builtin/substack/article-stack.tsx
@@ -24,6 +24,7 @@ export function SubstackArticleStack({
   detailOpen,
   selectedArticle,
   selectedArticleId,
+  readArticleIds,
   detailContent,
   activePublication,
   activeFeedState,
@@ -45,6 +46,7 @@ export function SubstackArticleStack({
   detailOpen: boolean;
   selectedArticle: SubstackArticleSummary | null;
   selectedArticleId: string | null;
+  readArticleIds: ReadonlySet<string>;
   detailContent: ReactNode;
   activePublication: SubstackPublication | null;
   activeFeedState: ActiveFeedState;
@@ -78,7 +80,9 @@ export function SubstackArticleStack({
         return {
           text: article.title,
           color: selectedColor ?? colors.text,
-          attributes: TextAttributes.BOLD,
+          attributes: readArticleIds.has(article.id)
+            ? TextAttributes.NONE
+            : TextAttributes.BOLD,
         };
       case "read":
         return {
@@ -86,7 +90,7 @@ export function SubstackArticleStack({
           color: selectedColor ?? colors.textDim,
         };
     }
-  }, []);
+  }, [readArticleIds]);
 
   const bodyAfter = activePublication && sortedRows.length > 0 && (activeFeedState.loading || activeFeedState.loadingMore) ? (
     <Box height={1} paddingX={1}>

--- a/src/plugins/builtin/substack/feed-tabs.tsx
+++ b/src/plugins/builtin/substack/feed-tabs.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import { Box } from "../../../ui";
 import { Tabs } from "../../../components";
 import { tabIdForPublication } from "./table";
@@ -7,7 +8,7 @@ import {
 } from "./types";
 import { tabLabel } from "./pane-state";
 
-export function SubstackFeedTabs({
+export const SubstackFeedTabs = memo(function SubstackFeedTabs({
   subscriptions,
   activeTab,
   focused,
@@ -20,16 +21,18 @@ export function SubstackFeedTabs({
   detailOpen: boolean;
   onSelect: (tabId: string) => void;
 }) {
+  const tabs = useMemo(() => [
+    { label: "Feed", value: SUBSTACK_FEED_TAB_ID },
+    ...subscriptions.map((publication) => ({
+      label: tabLabel(publication.name),
+      value: tabIdForPublication(publication),
+    })),
+  ], [subscriptions]);
+
   return (
     <Box height={1}>
       <Tabs
-        tabs={[
-          { label: "Feed", value: SUBSTACK_FEED_TAB_ID },
-          ...subscriptions.map((publication) => ({
-            label: tabLabel(publication.name),
-            value: tabIdForPublication(publication),
-          })),
-        ]}
+        tabs={tabs}
         activeValue={activeTab}
         onSelect={onSelect}
         compact
@@ -38,4 +41,4 @@ export function SubstackFeedTabs({
       />
     </Box>
   );
-}
+});

--- a/src/plugins/builtin/substack/pane.tsx
+++ b/src/plugins/builtin/substack/pane.tsx
@@ -58,6 +58,7 @@ import {
   type LoadState,
   type PublicationFeedState,
 } from "./pane-state";
+import { useSubstackReadState } from "./read-state";
 
 const PUBLICATION_LOAD_MORE_THRESHOLD_ROWS = 8;
 
@@ -74,6 +75,7 @@ export function SubstackPane({ focused, width, height }: PaneProps) {
     columnId: "published",
     direction: "desc",
   });
+  const { readArticleIds, markArticleRead } = useSubstackReadState();
   const homeFetchGenRef = useRef(0);
   const publicationFetchGenRef = useRef<Record<string, number>>({});
   const detailFetchGenRef = useRef(0);
@@ -206,12 +208,12 @@ export function SubstackPane({ focused, width, height }: PaneProps) {
     loadPublication(activePublication, false);
   }, [activePublication, activePublicationTabId, loadPublication, publicationFeeds]);
 
-  const activeFeedState = activeFeedStateFromSources({
+  const activeFeedState = useMemo(() => activeFeedStateFromSources({
     activePublication,
     activePublicationTabId,
     publicationFeeds,
     home,
-  });
+  }), [activePublication, activePublicationTabId, home, publicationFeeds]);
 
   const loadMoreActivePublicationRows = useCallback(() => {
     if (!activePublication || !activePublicationTabId || detailOpen) return;
@@ -335,8 +337,9 @@ export function SubstackPane({ focused, width, height }: PaneProps) {
 
   const openSelectedArticle = useCallback(() => {
     if (!selectedArticle?.url) return;
+    markArticleRead(selectedArticle.id);
     void rendererHost.openExternal(selectedArticle.url);
-  }, [rendererHost, selectedArticle]);
+  }, [markArticleRead, rendererHost, selectedArticle]);
 
   const handleLogin = useCallback((nextAuth: SubstackAuthState) => {
     setAuth(nextAuth);
@@ -477,7 +480,9 @@ export function SubstackPane({ focused, width, height }: PaneProps) {
         selectedArticle={selectedArticle}
         detailContent={detailContent}
         selectedArticleId={selectedArticleId}
+        readArticleIds={readArticleIds}
         onActivate={(article) => {
+          markArticleRead(article.id);
           setSelectedArticleId(article.id, { immediate: true });
           setDetailOpen(true);
         }}

--- a/src/plugins/builtin/substack/read-state.ts
+++ b/src/plugins/builtin/substack/read-state.ts
@@ -1,0 +1,55 @@
+import { useCallback, useMemo } from "react";
+import { usePluginState } from "../../runtime";
+import {
+  DEFAULT_MAX_READ_IDS,
+  markReadId,
+  normalizeReadIds,
+  sameStringArray,
+} from "../shared/read-state";
+
+export interface SubstackReadState {
+  articleIds: string[];
+}
+
+const SUBSTACK_READ_STATE_SCHEMA_VERSION = 1;
+const READ_STATE_KEY = "read-articles";
+const EMPTY_READ_STATE: SubstackReadState = { articleIds: [] };
+
+export const MAX_READ_SUBSTACK_ARTICLE_IDS = DEFAULT_MAX_READ_IDS;
+
+export function normalizeSubstackReadState(state: SubstackReadState): SubstackReadState {
+  return {
+    articleIds: normalizeReadIds(state.articleIds, MAX_READ_SUBSTACK_ARTICLE_IDS),
+  };
+}
+
+export function markSubstackArticleRead(
+  state: SubstackReadState,
+  articleId: string,
+): SubstackReadState {
+  const current = normalizeSubstackReadState(state).articleIds;
+  const articleIds = markReadId(current, articleId, MAX_READ_SUBSTACK_ARTICLE_IDS);
+
+  return sameStringArray(articleIds, state.articleIds) ? state : { articleIds };
+}
+
+export function useSubstackReadState() {
+  const [readState, setReadState] = usePluginState<SubstackReadState>(
+    READ_STATE_KEY,
+    EMPTY_READ_STATE,
+    { schemaVersion: SUBSTACK_READ_STATE_SCHEMA_VERSION },
+  );
+  const normalizedReadState = useMemo(
+    () => normalizeSubstackReadState(readState),
+    [readState],
+  );
+  const readArticleIds = useMemo(
+    () => new Set(normalizedReadState.articleIds),
+    [normalizedReadState],
+  );
+  const markArticleRead = useCallback((articleId: string) => {
+    setReadState((current) => markSubstackArticleRead(current, articleId));
+  }, [setReadState]);
+
+  return { readArticleIds, markArticleRead };
+}


### PR DESCRIPTION
## Summary
- throttle floating pane resize previews and reduce Substack re-render churn during resize
- persist Substack read state and unbold opened Substack items like news
- let Substack article images scale larger in wide detail panes while keeping compact pane bounds
- add Cmd/Ctrl+Shift+F to toggle pane focus as a transient layout tab without persisting saved layouts
- keep the transient focus tab available after switching saved layouts, and maximize panes without remounting them so detail/table state is preserved
- allow Cmd+Shift+F through captured desktop text input

## Validation
- bun test src/plugins/builtin/substack/article-detail.test.tsx src/plugins/builtin/substack/model.test.ts src/plugins/builtin/news/wire/read-state.test.ts
- bun test src/components/layout/status-bar.test.tsx src/components/layout/shell/index.test.tsx
- bun run build
- git diff --check
- tmux smoke: launched this repo with bun run dev in gloom-f311-focus-state-test, captured the app, and killed the session
- desktop dev watcher: stopped and left stopped while making changes