### PR TITLE
Fix desktop wordmark and window activation

### DIFF
--- a/src/renderers/electrobun/bun/window/focus.test.ts
+++ b/src/renderers/electrobun/bun/window/focus.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { detachedRpcKey, focusWindowForRpcKey, MAIN_WINDOW_RPC_KEY, type FocusableElectrobunWindow } from "./focus";
+
+describe("Electrobun window focus routing", () => {
+  test("uses activate for the main window", () => {
+    const calls: string[] = [];
+    const mainWindow: FocusableElectrobunWindow = {
+      activate: () => calls.push("activate"),
+      focus: () => calls.push("focus"),
+    };
+
+    expect(focusWindowForRpcKey(MAIN_WINDOW_RPC_KEY, mainWindow, new Map())).toBe(true);
+    expect(calls).toEqual(["activate"]);
+  });
+
+  test("uses activate for detached windows", () => {
+    const calls: string[] = [];
+    const detachedWindows = new Map<string, FocusableElectrobunWindow>([
+      ["pane:1", { activate: () => calls.push("detached") }],
+    ]);
+
+    expect(focusWindowForRpcKey(detachedRpcKey("pane:1"), null, detachedWindows)).toBe(true);
+    expect(calls).toEqual(["detached"]);
+  });
+
+  test("falls back to focus for legacy window objects", () => {
+    const calls: string[] = [];
+    const mainWindow: FocusableElectrobunWindow = {
+      focus: () => calls.push("focus"),
+    };
+
+    expect(focusWindowForRpcKey(MAIN_WINDOW_RPC_KEY, mainWindow, new Map())).toBe(true);
+    expect(calls).toEqual(["focus"]);
+  });
+});

--- a/src/renderers/electrobun/bun/window/focus.ts
+++ b/src/renderers/electrobun/bun/window/focus.ts
@@ -3,6 +3,7 @@ export const MAIN_WINDOW_RPC_KEY = "main";
 const DETACHED_WINDOW_RPC_PREFIX = "detached:";
 
 export interface FocusableElectrobunWindow {
+  activate?: () => void;
   focus?: () => void;
 }
 
@@ -31,6 +32,10 @@ export function focusWindowForRpcKey(
   detachedWindows: ReadonlyMap<string, FocusableElectrobunWindow>,
 ): boolean {
   const window = resolveWindowForRpcKey(rpcKey, mainWindow, detachedWindows);
+  if (window?.activate) {
+    window.activate();
+    return true;
+  }
   if (!window?.focus) return false;
   window.focus();
   return true;

--- a/src/renderers/electrobun/view/host/ascii-text.ts
+++ b/src/renderers/electrobun/view/host/ascii-text.ts
@@ -1,0 +1,50 @@
+import { renderAsciiText, type AsciiFontName } from "../../../../ui/ascii-font";
+
+const WEB_GLOOMBERB_WORDMARK = [
+  "  ____ _                       _               _     ",
+  " / ___| | ___   ___  _ __ ___ | |__   ___ _ __| |__  ",
+  "| |  _| |/ _ \\ / _ \\| '_ ` _ \\| '_ \\ / _ \\ '__| '_ \\ ",
+  "| |_| | | (_) | (_) | | | | | | |_) |  __/ |  | |_) |",
+  " \\____|_|\\___/ \\___/|_| |_| |_|_.__/ \\___|_|  |_.__/ ",
+];
+
+type WebWordmarkVariant = "legacy" | "compat" | null;
+
+function currentDesktopPlatform(): string {
+  const navigatorLike = (globalThis as {
+    navigator?: {
+      platform?: string;
+      userAgent?: string;
+      userAgentData?: { platform?: string };
+    };
+  }).navigator;
+  return [
+    navigatorLike?.userAgentData?.platform,
+    navigatorLike?.platform,
+    navigatorLike?.userAgent,
+  ].filter(Boolean).join(" ");
+}
+
+function isMacDesktopPlatform(desktopPlatform?: string): boolean {
+  const raw = desktopPlatform?.trim() || currentDesktopPlatform();
+  return /(darwin|mac|iphone|ipad|ipod)/i.test(raw);
+}
+
+export function webAsciiTextWordmarkVariant(
+  text: string,
+  font: AsciiFontName = "tiny",
+  desktopPlatform?: string,
+): WebWordmarkVariant {
+  if (font !== "wordmark" || text.trim().toLowerCase() !== "gloomberb") return null;
+  return isMacDesktopPlatform(desktopPlatform) ? "legacy" : "compat";
+}
+
+export function webAsciiTextLines(
+  text: string,
+  font: AsciiFontName = "tiny",
+  desktopPlatform?: string,
+): string[] {
+  return webAsciiTextWordmarkVariant(text, font, desktopPlatform) === "compat"
+    ? WEB_GLOOMBERB_WORDMARK
+    : renderAsciiText(text, font);
+}

--- a/src/renderers/electrobun/view/host/text.test.ts
+++ b/src/renderers/electrobun/view/host/text.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { renderAsciiText } from "../../../../ui/ascii-font";
+import { webAsciiTextLines, webAsciiTextWordmarkVariant } from "./ascii-text";
+
+describe("desktop web ASCII text", () => {
+  test("keeps the legacy Gloomberb wordmark on macOS", () => {
+    expect(webAsciiTextWordmarkVariant("Gloomberb", "wordmark", "darwin")).toBe("legacy");
+    expect(webAsciiTextWordmarkVariant("Gloomberb", "wordmark", "MacIntel")).toBe("legacy");
+    expect(webAsciiTextLines("Gloomberb", "wordmark", "darwin")).toEqual(
+      renderAsciiText("Gloomberb", "wordmark"),
+    );
+  });
+
+  test("uses the web-safe Gloomberb wordmark off macOS", () => {
+    const lines = webAsciiTextLines("Gloomberb", "wordmark", "win32");
+
+    expect(webAsciiTextWordmarkVariant("Gloomberb", "wordmark", "win32")).toBe("compat");
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toContain("____");
+    expect(lines).not.toEqual(renderAsciiText("Gloomberb", "wordmark"));
+  });
+});

--- a/src/renderers/electrobun/view/host/text.tsx
+++ b/src/renderers/electrobun/view/host/text.tsx
@@ -7,20 +7,16 @@ import {
   type StyledTextChunk,
   type TextProps,
 } from "../../../../ui/host";
-import { renderAsciiText } from "../../../../ui/ascii-font";
 import { WEB_CELL_WIDTH } from "../input-host";
+import { webAsciiTextLines, webAsciiTextWordmarkVariant } from "./ascii-text";
 import { hasDirectMouseHandler, mouseHandlers } from "./mouse";
 import { cleanDomProps, commonStyle, textStyle } from "./style";
 
-const WEB_GLOOMBERB_WORDMARK = [
-  "  ____ _                       _               _     ",
-  " / ___| | ___   ___  _ __ ___ | |__   ___ _ __| |__  ",
-  "| |  _| |/ _ \\ / _ \\| '_ ` _ \\| '_ \\ / _ \\ '__| '_ \\ ",
-  "| |_| | | (_) | (_) | | | | | | |_) |  __/ |  | |_) |",
-  " \\____|_|\\___/ \\___/|_| |_| |_|_.__/ \\___|_|  |_.__/ ",
-];
-
 const WEB_WORDMARK_CHAR_WIDTH_PX = Math.max(10, WEB_CELL_WIDTH);
+
+interface WebAsciiTextProps extends AsciiTextProps {
+  desktopPlatform?: string;
+}
 
 function isStyledTextContent(value: unknown): value is { chunks: StyledTextChunk[] } {
   return value instanceof StyledText
@@ -100,16 +96,17 @@ export function WebAsciiText({
   bg,
   backgroundColor,
   selectable = false,
+  desktopPlatform,
   ...props
-}: AsciiTextProps) {
-  const isWordmark = font === "wordmark";
-  const lines = isWordmark && text.trim().toLowerCase() === "gloomberb"
-    ? WEB_GLOOMBERB_WORDMARK
-    : renderAsciiText(text, font);
+}: WebAsciiTextProps) {
+  const wordmarkVariant = webAsciiTextWordmarkVariant(text, font, desktopPlatform);
+  const isCompatWordmark = wordmarkVariant === "compat";
+  const isLegacyWordmark = wordmarkVariant === "legacy";
+  const lines = webAsciiTextLines(text, font, desktopPlatform);
   const resolvedColor = color ?? fg;
   const resolvedBackground = bg ?? backgroundColor;
-  const lineHeightPx = isWordmark ? 16 : 12;
-  const wordmarkWidthPx = isWordmark
+  const lineHeightPx = isCompatWordmark ? 16 : 12;
+  const wordmarkWidthPx = isCompatWordmark
     ? Math.max(...lines.map((line) => line.length)) * WEB_WORDMARK_CHAR_WIDTH_PX
     : undefined;
   return (
@@ -118,15 +115,16 @@ export function WebAsciiText({
       data-gloom-role={(props["data-gloom-role"] as string | undefined) ?? "ascii-text"}
       style={{
         ...commonStyle({ ...props, fg: resolvedColor, bg: resolvedBackground }),
-        display: "block",
+        display: isLegacyWordmark ? "flex" : "block",
+        flexDirection: isLegacyWordmark ? "column" : undefined,
         flexShrink: 0,
         ...(wordmarkWidthPx != null && props.width == null
           ? { width: `${wordmarkWidthPx}px`, minWidth: `${wordmarkWidthPx}px` }
           : {}),
         color: resolvedColor,
         backgroundColor: resolvedBackground,
-        fontFamily: isWordmark ? "\"Cascadia Mono\", Consolas, \"Courier New\", monospace" : undefined,
-        fontSize: isWordmark ? "16px" : undefined,
+        fontFamily: isCompatWordmark ? "\"Cascadia Mono\", Consolas, \"Courier New\", monospace" : undefined,
+        fontSize: isCompatWordmark ? "16px" : undefined,
         fontVariantLigatures: "none",
         lineHeight: `${lineHeightPx}px`,
         whiteSpace: "pre",
@@ -135,7 +133,13 @@ export function WebAsciiText({
         ...(props.style as CSSProperties | undefined),
       }}
     >
-      {lines.join("\n")}
+      {isLegacyWordmark
+        ? lines.map((line, index) => (
+          <span key={index} style={{ display: "block", height: "12px", lineHeight: "12px" }}>
+            {line}
+          </span>
+        ))
+        : lines.join("\n")}
     </div>
   );
 }

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -137,7 +137,7 @@ export function createWebUiHost(desktopPlatform?: string): UiHost {
         *
       </span>
     ),
-    AsciiText: WebAsciiText,
+    AsciiText: (props) => <WebAsciiText {...props} desktopPlatform={desktopPlatform} />,
   };
 }
 


### PR DESCRIPTION
## Summary
- Restore the legacy compact Gloomberb ASCII wordmark on macOS desktop windows while keeping the web-safe wordmark off macOS.
- Pass the detected desktop platform into the web ASCII renderer.
- Use BrowserWindow.activate() for Electrobun focus routing to avoid deprecated focus() warnings.

## Validation
- bun test src/renderers/electrobun/bun/window/focus.test.ts src/renderers/electrobun/view/host/text.test.ts
- bun run desktop:view:build