### PR TITLE
Make new saved layouts blank

### DIFF
--- a/src/core/state/app/layout-reducer.ts
+++ b/src/core/state/app/layout-reducer.ts
@@ -1,4 +1,4 @@
-import { cloneLayout, DEFAULT_LAYOUT, type SavedLayout } from "../../../types/config";
+import { cloneLayout, createBlankLayout, type SavedLayout } from "../../../types/config";
 import {
   clonePaneStateMap,
   cloneSavedLayout,
@@ -96,7 +96,7 @@ export function reduceLayoutAction(state: AppState, action: AppAction): AppState
       );
       const newLayout: SavedLayout = {
         name: action.name,
-        layout: cloneLayout(DEFAULT_LAYOUT),
+        layout: createBlankLayout(),
         paneState: {},
       };
       const layouts = [...currentConfig.layouts, newLayout];

--- a/src/state/app/context/index.test.tsx
+++ b/src/state/app/context/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { cloneLayout, createDefaultConfig } from "../../../types/config";
+import { cloneLayout, createBlankLayout, createDefaultConfig } from "../../../types/config";
 import { appReducer, createInitialState } from "./index";
 
 describe("appReducer command bar state", () => {
@@ -150,11 +150,10 @@ describe("appReducer command bar state", () => {
 
     const noUndoOnFreshLayout = appReducer(state, { type: "UNDO_LAYOUT" });
     expect(noUndoOnFreshLayout.config.activeLayoutIndex).toBe(newLayoutIndex);
-    expect(noUndoOnFreshLayout.config.layout.dockRoot && noUndoOnFreshLayout.config.layout.dockRoot.kind === "split"
-      ? noUndoOnFreshLayout.config.layout.dockRoot.ratio
-      : null).toBe(defaultRatio);
+    expect(noUndoOnFreshLayout.config.layout).toEqual(createBlankLayout());
+    expect(noUndoOnFreshLayout.focusedPaneId).toBeNull();
 
-    const secondLayout = cloneLayout(noUndoOnFreshLayout.config.layout);
+    const secondLayout = cloneLayout(initial.config.layout);
     if (!secondLayout.dockRoot || secondLayout.dockRoot.kind !== "split") {
       throw new Error("expected split dock root");
     }
@@ -172,9 +171,7 @@ describe("appReducer command bar state", () => {
     const backToSecond = appReducer(firstUndone, { type: "SWITCH_LAYOUT", index: newLayoutIndex });
     const secondUndone = appReducer(backToSecond, { type: "UNDO_LAYOUT" });
     expect(secondUndone.config.activeLayoutIndex).toBe(newLayoutIndex);
-    expect(secondUndone.config.layout.dockRoot && secondUndone.config.layout.dockRoot.kind === "split"
-      ? secondUndone.config.layout.dockRoot.ratio
-      : null).toBe(defaultRatio);
+    expect(secondUndone.config.layout).toEqual(createBlankLayout());
   });
 
   test("tracks manual update-check feedback", () => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -309,6 +309,12 @@ const DEFAULT_MONITOR_LAYOUT: LayoutConfig = {
 };
 
 export const DEFAULT_LAYOUT = DEFAULT_HOME_LAYOUT;
+const BLANK_LAYOUT: LayoutConfig = {
+  dockRoot: null,
+  instances: [],
+  floating: [],
+  detached: [],
+};
 
 let nextPaneInstanceSeq = 0;
 
@@ -592,6 +598,10 @@ export function cloneLayout(layout: LayoutConfig): LayoutConfig {
     floating: layout.floating.map((entry) => ({ ...entry })),
     detached: detached.map((entry) => ({ ...entry })),
   };
+}
+
+export function createBlankLayout(): LayoutConfig {
+  return cloneLayout(BLANK_LAYOUT);
 }
 
 export function findPaneInstance(layout: LayoutConfig, instanceId: string): PaneInstanceConfig | undefined {


### PR DESCRIPTION
## Summary
- add a shared blank layout helper for empty saved layouts
- create new user-saved layouts without default panes
- keep seeded default layouts unchanged and update reducer coverage

## Validation
- bun test src/state/app/context/index.test.tsx
- bun test src/data/config/store/index.test.ts src/types/config.test.ts
- bun test