### PR TITLE
Add Kelly position sizer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Use tmux to test terminal TUI changes (see the `tui-testing` skill). Always kill
 Pane footers/status bars should only show status that can change, such as loading, error, live/delayed, stale, or auth state. Do not use them for fixed pane labels, row counts, or generic keyboard hints.
 Information density matters: never repeat the same information in a pane title/header and again in the body. If a stack/detail title already names the item, start the body with metadata or content.
 For Electrobun/desktop-web-only work, do not load the OpenTUI or tui-testing skills unless the change also touches terminal OpenTUI behavior or explicitly needs tmux coverage.
+For desktop/Electrobun/web UI, do not draw GUI primitives with terminal cell characters. Use real DOM/CSS/canvas/SVG primitives for lines, markers, shapes, overlays, and interaction affordances; reserve cell-character drawing for the OpenTUI terminal renderer only.
 Add mouse/cursor interactivity for everything interactive.
 Never fix chart issues by disabling / turning off the kitty renderer; preserve kitty support and fix the root cause.
 When adding new pane/plugin, read PLUGINS.md check how others are made first to keep UI consistent. Always prefer shared UI components and plugin APIs before rolling your own.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Open command mode with `Ctrl+P`, then type a command. Press `` ` `` to open tick
 | `TOP` | Ranked market stories |
 | `MOST` | Market movers |
 | `PF` | Portfolios and watchlists |
+| `KELLY AAPL` | Position sizing |
 | `HELP` | Full in-app shortcut list |
 
 ## What It Does

--- a/src/components/chart/price-axis-labels.tsx
+++ b/src/components/chart/price-axis-labels.tsx
@@ -12,6 +12,7 @@ interface PriceAxisLabelsProps {
   cursorPixelY?: number | null;
   cursorLabel: string | null;
   cursorColor: string;
+  axisColor?: string;
 }
 
 interface CursorPriceAxisOverlay {
@@ -61,6 +62,7 @@ export function PriceAxisLabels({
   cursorPixelY = null,
   cursorLabel,
   cursorColor,
+  axisColor = colors.textDim,
 }: PriceAxisLabelsProps) {
   const { cellHeightPx = 18, fractionalViewport = false } = useUiCapabilities();
   const overlay = useMemo(() => buildCursorPriceAxisOverlay({
@@ -100,7 +102,7 @@ export function PriceAxisLabels({
         const label = isCursorRow ? cursorLabel : (axisLabels.get(row) ?? null);
         return (
           <Box key={row} height={1}>
-            {renderAxisLabel(label, isCursorRow ? cursorColor : colors.textDim)}
+            {renderAxisLabel(label, isCursorRow ? cursorColor : axisColor)}
           </Box>
         );
       })}

--- a/src/components/chart/static/chart/axis-overlays.tsx
+++ b/src/components/chart/static/chart/axis-overlays.tsx
@@ -1,0 +1,243 @@
+import { Box, Text, useUiCapabilities, useUiHost } from "../../../../ui";
+
+export interface StaticChartXMarker {
+  id: string;
+  xRatio: number;
+  label?: string;
+  color?: string;
+  lineChar?: string;
+}
+
+export function clampRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function markerColumn(xRatio: number, width: number): number {
+  return Math.round(clampRatio(xRatio) * Math.max(0, width - 1));
+}
+
+function alignAxisLabel(label: string, width: number, index: number, count: number): string {
+  const clipped = label.length > width ? label.slice(0, width) : label;
+  const padding = Math.max(0, width - clipped.length);
+  if (index === 0) return clipped.padEnd(width);
+  if (index === count - 1) return clipped.padStart(width);
+  const left = Math.floor(padding / 2);
+  return `${" ".repeat(left)}${clipped}${" ".repeat(padding - left)}`;
+}
+
+export function StaticXAxisLabels({
+  labels,
+  width,
+  color,
+  cursorColumn,
+  cursorPixelX,
+  cursorLabel,
+  cursorColor,
+  cursorBackgroundColor,
+}: {
+  labels: string[];
+  width: number;
+  color?: string;
+  cursorColumn?: number | null;
+  cursorPixelX?: number | null;
+  cursorLabel?: string | null;
+  cursorColor?: string;
+  cursorBackgroundColor?: string;
+}) {
+  const { cellWidthPx = 8, fractionalViewport = false } = useUiCapabilities();
+  const visibleLabels = labels.filter(Boolean);
+  if (visibleLabels.length === 0 || width <= 0) return null;
+  const baseWidth = Math.floor(width / visibleLabels.length);
+  let remainder = width - baseWidth * visibleLabels.length;
+  const clippedCursorLabel = cursorLabel ? cursorLabel.slice(0, width) : null;
+  const cursorLabelWidth = clippedCursorLabel?.length ?? 0;
+  const usePixelOverlay = fractionalViewport
+    && clippedCursorLabel !== null
+    && cursorPixelX !== null
+    && cursorPixelX !== undefined
+    && Number.isFinite(cursorPixelX)
+    && cursorLabelWidth > 0;
+  const pixelWidth = Math.max(width * cellWidthPx, 1);
+  const halfCursorLabelWidthPx = Math.min((cursorLabelWidth * cellWidthPx) / 2, (pixelWidth - 1) / 2);
+  const cursorLeftPercent = usePixelOverlay
+    ? (
+      Math.max(
+        halfCursorLabelWidthPx,
+        Math.min(cursorPixelX!, Math.max(pixelWidth - halfCursorLabelWidthPx, halfCursorLabelWidthPx)),
+      ) / Math.max(pixelWidth - 1, 1)
+    ) * 100
+    : null;
+  const cursorLeft = cursorColumn !== null
+    && cursorColumn !== undefined
+    && Number.isFinite(cursorColumn)
+    && cursorLabelWidth > 0
+    ? Math.max(0, Math.min(Math.max(0, width - cursorLabelWidth), Math.round(cursorColumn) - Math.floor(cursorLabelWidth / 2)))
+    : null;
+
+  return (
+    <Box
+      width={width}
+      height={1}
+      flexDirection="row"
+      position="relative"
+      overflow="hidden"
+    >
+      <Box width={width} height={1} flexDirection="row">
+        {visibleLabels.map((label, index) => {
+          const cellWidth = baseWidth + (remainder > 0 ? 1 : 0);
+          remainder -= remainder > 0 ? 1 : 0;
+          return (
+            <Box key={`${label}:${index}`} width={cellWidth} overflow="hidden">
+              <Text fg={color}>{alignAxisLabel(label, cellWidth, index, visibleLabels.length)}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+      {clippedCursorLabel && (cursorLeftPercent !== null || cursorLeft !== null) ? (
+        <Text
+          fg={cursorColor}
+          bg={cursorBackgroundColor}
+          selectable={false}
+          style={cursorLeftPercent !== null
+            ? {
+              position: "absolute",
+              left: `${cursorLeftPercent}%`,
+              top: 0,
+              transform: "translateX(-50%)",
+              whiteSpace: "pre",
+              pointerEvents: "none",
+              zIndex: 3,
+            }
+            : {
+              position: "absolute",
+              left: cursorLeft ?? 0,
+              top: 0,
+              whiteSpace: "pre",
+              pointerEvents: "none",
+              zIndex: 3,
+            }}
+        >
+          {clippedCursorLabel}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+export function StaticXMarkerOverlay({
+  markers,
+  width,
+  height,
+  fallbackColor,
+}: {
+  markers: StaticChartXMarker[];
+  width: number;
+  height: number;
+  fallbackColor?: string;
+}) {
+  const uiHost = useUiHost();
+  const visibleMarkers = markers.filter((marker) => Number.isFinite(marker.xRatio));
+  if (visibleMarkers.length === 0 || width <= 0 || height <= 0) return null;
+
+  if (uiHost.kind === "desktop-web") {
+    return (
+      <Box position="absolute" left={0} top={0} width={width} height={height}>
+        {visibleMarkers.map((marker) => (
+          <Box
+            key={marker.id}
+            position="absolute"
+            left={`${clampRatio(marker.xRatio) * 100}%`}
+            top={0}
+            bottom={0}
+            width={0}
+            zIndex={2}
+            style={{
+              width: 1,
+              transform: "translateX(-0.5px)",
+              backgroundColor: marker.color ?? fallbackColor ?? "currentColor",
+              opacity: 0.85,
+              pointerEvents: "none",
+            }}
+          />
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <Box position="absolute" left={0} top={0} width={width} height={height}>
+      {visibleMarkers.map((marker) => {
+        const left = markerColumn(marker.xRatio, width);
+        return (
+          <Box
+            key={marker.id}
+            position="absolute"
+            left={left}
+            top={0}
+            width={1}
+            height={height}
+            flexDirection="column"
+            zIndex={2}
+          >
+            {Array.from({ length: height }, (_, row) => (
+              <Text key={row} fg={marker.color}>
+                {marker.lineChar ?? "│"}
+              </Text>
+            ))}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function StaticXMarkerLabels({
+  markers,
+  width,
+  fallbackColor,
+}: {
+  markers: StaticChartXMarker[];
+  width: number;
+  fallbackColor?: string;
+}) {
+  const visibleMarkers = markers
+    .filter((marker) => marker.label && Number.isFinite(marker.xRatio))
+    .sort((left, right) => markerColumn(left.xRatio, width) - markerColumn(right.xRatio, width));
+  if (visibleMarkers.length === 0 || width <= 0) return null;
+
+  let nextAvailableLeft = 0;
+  const placements = visibleMarkers.map((marker) => {
+    const label = marker.label ?? "";
+    const labelWidth = Math.min(label.length, width);
+    const centeredLeft = markerColumn(marker.xRatio, width) - Math.floor(labelWidth / 2);
+    let left = Math.max(0, Math.min(Math.max(0, width - labelWidth), centeredLeft));
+    left = Math.max(left, nextAvailableLeft);
+    if (left + labelWidth > width) {
+      left = Math.max(nextAvailableLeft, width - labelWidth);
+    }
+    nextAvailableLeft = Math.min(width, left + labelWidth + 1);
+    return { marker, label, labelWidth, left };
+  }).filter((placement) => placement.labelWidth > 0 && placement.left < width);
+
+  return (
+    <Box position="relative" width={width} height={1}>
+      {placements.map(({ marker, label, labelWidth, left }) => {
+        return (
+          <Box
+            key={marker.id}
+            position="absolute"
+            left={left}
+            top={0}
+            width={labelWidth}
+            height={1}
+            overflow="hidden"
+            zIndex={2}
+          >
+            <Text fg={marker.color ?? fallbackColor}>{label.slice(0, labelWidth)}</Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/components/chart/static/chart/surface.test.tsx
+++ b/src/components/chart/static/chart/surface.test.tsx
@@ -48,4 +48,96 @@ describe("StaticChartSurface", () => {
     expect(frame).toContain("4.90%");
     expect(frame).toContain("3.50%");
   });
+
+  test("renders custom x-axis scale labels", async () => {
+    testSetup = await testRender(
+      <StaticChartSurface
+        points={points}
+        width={48}
+        height={10}
+        mode="line"
+        colors={resolveChartPalette(colors, "positive")}
+        xAxisLabels={["0%", "50%", "100%"]}
+        xAxisColor={colors.textDim}
+      />,
+      { width: 50, height: 12 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("0%");
+    expect(frame).toContain("50%");
+    expect(frame).toContain("100%");
+  });
+
+  test("renders x-axis decision markers", async () => {
+    testSetup = await testRender(
+      <StaticChartSurface
+        points={points}
+        width={56}
+        height={10}
+        mode="line"
+        colors={resolveChartPalette(colors, "positive")}
+        xAxisLabels={["0%", "50%", "100%"]}
+        xMarkers={[
+          { id: "current", xRatio: 0.1, label: "current", lineChar: "┊" },
+          { id: "target", xRatio: 0.5, label: "target", lineChar: "┃" },
+          { id: "full", xRatio: 0.8, label: "full", lineChar: "│" },
+        ]}
+        xAxisColor={colors.textDim}
+      />,
+      { width: 58, height: 12 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("current");
+    expect(frame).toContain("target");
+    expect(frame).toContain("full");
+    expect(frame).toContain("┃");
+  });
+
+  test("renders a cursor crosshair after mouse movement", async () => {
+    testSetup = await testRender(
+      <StaticChartSurface
+        points={points}
+        width={48}
+        height={10}
+        mode="line"
+        colors={resolveChartPalette(colors, "positive")}
+        xAxisLabels={["0%", "50%", "100%"]}
+        formatXAxisCursorValue={(ratio) => `X${Math.round(ratio * 100)}`}
+        formatYAxisValue={(value) => `Y${value.toFixed(2)}`}
+        xMarkers={[
+          { id: "current", xRatio: 0.1, label: "current", lineChar: "┊" },
+          { id: "target", xRatio: 0.5, label: "target", lineChar: "┃" },
+        ]}
+      />,
+      { width: 50, height: 12 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    const initialFrame = testSetup.captureCharFrame();
+
+    await act(async () => {
+      await testSetup!.mockMouse.moveTo(20, 4);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(testSetup.captureCharFrame()).not.toBe(initialFrame);
+    expect(testSetup.captureCharFrame()).toContain("X49");
+    expect(testSetup.captureCharFrame()).toContain("Y3.97");
+  });
 });

--- a/src/components/chart/static/chart/surface.tsx
+++ b/src/components/chart/static/chart/surface.tsx
@@ -1,16 +1,26 @@
-import { useMemo } from "react";
-import { Box, ChartSurface, Text } from "../../../../ui";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Box, ChartSurface, Text, type BoxRenderable, type ChartSurfaceProps, useUiCapabilities } from "../../../../ui";
+import { colors as themeColors } from "../../../../theme/colors";
 import { useThemeColors } from "../../../../theme/theme-context";
+import { PriceAxisLabels } from "../../price-axis-labels";
 import type { ProjectedChartPoint } from "../../core/data";
 import {
   buildChartScene,
   computeGridLines,
-  formatAxisCell,
   renderChart,
   type RenderChartOptions,
 } from "../../core/renderer";
 import { renderNativeChartBase, type NativeChartBitmap } from "../../native/chart-rasterizer";
 import { useStaticChartBitmapSize } from "./bitmap";
+import {
+  StaticXAxisLabels,
+  StaticXMarkerLabels,
+  StaticXMarkerOverlay,
+  clampRatio,
+  type StaticChartXMarker,
+} from "./axis-overlays";
+
+export type { StaticChartXMarker } from "./axis-overlays";
 
 export interface StaticChartSurfaceProps extends Omit<
   RenderChartOptions,
@@ -23,9 +33,50 @@ export interface StaticChartSurfaceProps extends Omit<
   volumeHeight?: number;
   showTimeAxis?: boolean;
   timeAxisColor?: string;
+  xAxisLabels?: string[];
+  xAxisColor?: string;
+  formatXAxisCursorValue?: (xRatio: number) => string;
+  xMarkers?: StaticChartXMarker[];
   yAxisLabel?: string;
   yAxisColor?: string;
   formatYAxisValue?: (value: number) => string;
+}
+
+interface ChartMouseEventLike {
+  x: number;
+  y: number;
+  preciseX?: number;
+  preciseY?: number;
+  preventDefault?: () => void;
+}
+
+function localPlotPointer(
+  event: ChartMouseEventLike,
+  renderable: BoxRenderable | null,
+): { x: number; y: number } | null {
+  if (!renderable) return null;
+  const originX = typeof renderable.absoluteX === "number"
+    ? renderable.absoluteX
+    : typeof renderable.x === "number"
+      ? renderable.x
+      : 0;
+  const originY = typeof renderable.absoluteY === "number"
+    ? renderable.absoluteY
+    : typeof renderable.y === "number"
+      ? renderable.y
+      : 0;
+  const rawX = typeof event.preciseX === "number" ? event.preciseX : event.x;
+  const rawY = typeof event.preciseY === "number" ? event.preciseY : event.y;
+  const x = rawX - originX;
+  const y = rawY - originY;
+  const width = typeof renderable.width === "number" ? renderable.width : 0;
+  const height = typeof renderable.height === "number" ? renderable.height : 0;
+  if (!Number.isFinite(x) || !Number.isFinite(y) || width <= 0 || height <= 0) return null;
+  if (x < 0 || y < 0 || x >= width || y >= height) return null;
+  return {
+    x: Math.max(0, Math.min(x, Math.max(width - 1, 0))),
+    y: Math.max(0, Math.min(y, Math.max(height - 1, 0))),
+  };
 }
 
 export function StaticChartSurface({
@@ -43,16 +94,24 @@ export function StaticChartSurface({
   volumeHeight = 0,
   showTimeAxis = false,
   timeAxisColor,
+  xAxisLabels,
+  xAxisColor,
+  formatXAxisCursorValue,
+  xMarkers,
   yAxisLabel,
   yAxisColor,
   formatYAxisValue,
 }: StaticChartSurfaceProps) {
   useThemeColors();
-  const timeAxisRows = showTimeAxis ? 1 : 0;
+  const { cellWidthPx = 8, cellHeightPx = 18 } = useUiCapabilities();
+  const plotRef = useRef<BoxRenderable | null>(null);
+  const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
+  const xAxisRows = showTimeAxis || (xAxisLabels?.length ?? 0) > 0 ? 1 : 0;
+  const xMarkerRows = xMarkers?.some((marker) => marker.label) ? 1 : 0;
   const labelRows = yAxisLabel ? 1 : 0;
   const totalWidth = Math.max(1, Math.floor(width));
   const totalHeight = Math.max(1, Math.floor(height));
-  const plotHeight = Math.max(1, totalHeight - timeAxisRows - labelRows);
+  const plotHeight = Math.max(1, totalHeight - xAxisRows - xMarkerRows - labelRows);
   const axisSourceOptions = useMemo<RenderChartOptions>(() => ({
     width: totalWidth,
     height: plotHeight,
@@ -104,8 +163,8 @@ export function StaticChartSurface({
     height: plotHeight,
     showVolume,
     volumeHeight,
-    cursorX: null,
-    cursorY: null,
+    cursorX: cursor?.x ?? null,
+    cursorY: cursor?.y ?? null,
     mode,
     axisMode,
     currency,
@@ -122,6 +181,7 @@ export function StaticChartSurface({
     mode,
     plotHeight,
     plotWidth,
+    cursor,
     showVolume,
     timeAxisDates,
     volumeHeight,
@@ -133,6 +193,14 @@ export function StaticChartSurface({
   const effectiveAxisLabelsByRow = useMemo(() => {
     return new Map(axisLabels.map((entry) => [entry.row, entry.label] as const));
   }, [axisLabels]);
+  const cursorAxisLabel = useMemo(() => {
+    if (!formatYAxisValue || textResult.crosshairPrice === null) return null;
+    return formatYAxisValue(textResult.crosshairPrice);
+  }, [formatYAxisValue, textResult.crosshairPrice]);
+  const cursorXAxisLabel = useMemo(() => {
+    if (!formatXAxisCursorValue || !cursor) return null;
+    return formatXAxisCursorValue(clampRatio(cursor.x / Math.max(plotWidth - 1, 1)));
+  }, [cursor, formatXAxisCursorValue, plotWidth]);
   const effectiveAxisWidth = axisWidth;
   const effectiveAxisGap = effectiveAxisWidth > 0 ? 1 : 0;
   const bitmap = useMemo<NativeChartBitmap | null>(() => {
@@ -141,40 +209,115 @@ export function StaticChartSurface({
     if (!scene) return null;
     return renderNativeChartBase(scene, bitmapSize.pixelWidth, bitmapSize.pixelHeight);
   }, [bitmapSize, points, renderOptions]);
+  const canvasCrosshair = useMemo<ChartSurfaceProps["crosshair"]>(() => {
+    if (!bitmap || !cursor) return null;
+    return {
+      pixelX: Math.round(clampRatio(cursor.x / Math.max(plotWidth - 1, 1)) * Math.max(bitmap.width - 1, 0)),
+      pixelY: Math.round(clampRatio(cursor.y / Math.max(plotHeight - 1, 1)) * Math.max(bitmap.height - 1, 0)),
+      color: colors.crosshairColor,
+    };
+  }, [bitmap, colors.crosshairColor, cursor, plotHeight, plotWidth]);
+  const handleCursorEvent = useCallback((event: ChartMouseEventLike) => {
+    const pointer = localPlotPointer(event, plotRef.current);
+    if (!pointer) return;
+    event.preventDefault?.();
+    setCursor((current) => (
+      current && current.x === pointer.x && current.y === pointer.y ? current : pointer
+    ));
+  }, []);
+  const clearCursor = useCallback(() => {
+    setCursor(null);
+  }, []);
 
   return (
-    <Box flexDirection="column" width={totalWidth} height={plotHeight + timeAxisRows + labelRows}>
+    <Box flexDirection="column" width={totalWidth} height={plotHeight + xAxisRows + xMarkerRows + labelRows}>
       {yAxisLabel ? (
         <Box height={1}>
           <Text fg={yAxisColor}>{yAxisLabel}</Text>
         </Box>
       ) : null}
       <Box flexDirection="row" height={plotHeight}>
-        <ChartSurface
+        <Box
+          ref={plotRef}
+          position="relative"
           width={plotWidth}
           height={plotHeight}
-          flexDirection="column"
-          bitmaps={bitmap ? [bitmap] : null}
+          onMouseMove={handleCursorEvent}
+          onMouseDown={handleCursorEvent}
+          onMouseOut={clearCursor}
+          data-gloom-role="static-chart-plot"
         >
-          {textResult.lines.map((line, index) => (
-            <Text key={index} content={line} />
-          ))}
-        </ChartSurface>
+          <ChartSurface
+            width={plotWidth}
+            height={plotHeight}
+            flexDirection="column"
+            bitmaps={bitmap ? [bitmap] : null}
+            crosshair={canvasCrosshair}
+          >
+            {textResult.lines.map((line, index) => (
+              <Text key={index} content={line} />
+            ))}
+          </ChartSurface>
+          {xMarkers ? (
+            <StaticXMarkerOverlay
+              markers={xMarkers}
+              width={plotWidth}
+              height={plotHeight}
+              fallbackColor={xAxisColor ?? timeAxisColor}
+            />
+          ) : null}
+        </Box>
         {effectiveAxisWidth > 0 ? (
           <>
             <Box width={effectiveAxisGap} />
-            <Box width={effectiveAxisWidth} height={plotHeight} flexDirection="column">
-              {Array.from({ length: plotHeight }, (_, row) => (
-                <Text key={row} fg={yAxisColor}>
-                  {formatAxisCell(effectiveAxisLabelsByRow.get(row) ?? null, effectiveAxisWidth)}
-                </Text>
-              ))}
-            </Box>
+            <PriceAxisLabels
+              axisLabels={effectiveAxisLabelsByRow}
+              axisWidth={effectiveAxisWidth}
+              axisSectionWidth={effectiveAxisWidth}
+              height={plotHeight}
+              cursorRow={textResult.cursorRow}
+              cursorPixelY={cursor ? cursor.y * cellHeightPx : null}
+              cursorLabel={cursorAxisLabel}
+              cursorColor={colors.crosshairColor}
+              axisColor={yAxisColor}
+            />
           </>
         ) : null}
       </Box>
-      {showTimeAxis ? (
-        <Text fg={timeAxisColor}>{textResult.timeLabels}</Text>
+      {showTimeAxis || (xAxisLabels?.length ?? 0) > 0 ? (
+        <Box height={1} flexDirection="row">
+          {xAxisLabels ? (
+            <StaticXAxisLabels
+              labels={xAxisLabels}
+              width={plotWidth}
+              color={xAxisColor ?? timeAxisColor}
+              cursorColumn={textResult.cursorColumn}
+              cursorPixelX={cursor ? cursor.x * cellWidthPx : null}
+              cursorLabel={cursorXAxisLabel}
+              cursorColor={colors.crosshairColor}
+              cursorBackgroundColor={colors.bgColor ?? themeColors.bg}
+            />
+          ) : (
+            <Text fg={timeAxisColor}>{textResult.timeLabels}</Text>
+          )}
+          {effectiveAxisWidth > 0 ? (
+            <>
+              <Box width={effectiveAxisGap} />
+              <Box width={effectiveAxisWidth} />
+            </>
+          ) : null}
+        </Box>
+      ) : null}
+      {xMarkers && xMarkerRows > 0 ? (
+        <Box height={1} flexDirection="row">
+          <StaticXMarkerLabels markers={xMarkers} width={plotWidth} fallbackColor={xAxisColor ?? timeAxisColor} />
+          {effectiveAxisWidth > 0 ? (
+            <>
+              <Box width={effectiveAxisGap} />
+              <Box width={effectiveAxisWidth} />
+            </>
+          ) : null}
+        </Box>
       ) : null}
     </Box>
   );

--- a/src/components/ui/fields.tsx
+++ b/src/components/ui/fields.tsx
@@ -12,6 +12,7 @@ export interface TextFieldProps {
   inputRef?: RefObject<InputRenderable | null>;
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
+  onBlur?: (value: string) => void;
   hint?: string;
   type?: "text" | "password";
   variant?: "default" | "plain";
@@ -36,6 +37,7 @@ export function TextField({
   inputRef,
   onChange,
   onSubmit,
+  onBlur,
   hint,
   type = "text",
   variant = "default",
@@ -56,6 +58,7 @@ export function TextField({
         inputRef={inputRef}
         onChange={onChange}
         onSubmit={onSubmit}
+        onBlur={onBlur}
         hint={hint}
         type={type}
         variant={variant}
@@ -118,17 +121,18 @@ export function TextField({
           selectionFg={isPassword ? backgroundColor : undefined}
           showCursor={!isPassword}
           onCursorChange={() => syncCursorOffset()}
-          onInput={(nextValue) => {
+          onInput={(nextValue: string) => {
             currentValueRef.current = nextValue;
             syncCursorOffset(nextValue);
             onChange?.(nextValue);
           }}
-          onChange={(nextValue) => {
+          onChange={(nextValue: string) => {
             currentValueRef.current = nextValue;
             syncCursorOffset(nextValue);
             onChange?.(nextValue);
           }}
           onSubmit={() => onSubmit?.(currentValueRef.current)}
+          onBlur={() => onBlur?.(currentValueRef.current)}
         />
         {isPassword && (
           <Box
@@ -178,11 +182,12 @@ function sanitizeNumberInput(value: string, allowDecimal: boolean, allowNegative
   return next;
 }
 
-export interface NumberFieldProps extends Omit<TextFieldProps, "onChange" | "onSubmit"> {
+export interface NumberFieldProps extends Omit<TextFieldProps, "onChange" | "onSubmit" | "onBlur"> {
   allowDecimal?: boolean;
   allowNegative?: boolean;
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
+  onBlur?: (value: string) => void;
 }
 
 export function NumberField({
@@ -190,6 +195,7 @@ export function NumberField({
   allowNegative = false,
   onChange,
   onSubmit,
+  onBlur,
   ...props
 }: NumberFieldProps) {
   return (
@@ -197,6 +203,7 @@ export function NumberField({
       {...props}
       onChange={(nextValue) => onChange?.(sanitizeNumberInput(nextValue, allowDecimal, allowNegative))}
       onSubmit={(nextValue) => onSubmit?.(sanitizeNumberInput(nextValue, allowDecimal, allowNegative))}
+      onBlur={(nextValue) => onBlur?.(sanitizeNumberInput(nextValue, allowDecimal, allowNegative))}
     />
   );
 }

--- a/src/plugins/builtin/kelly-sizer/constants.ts
+++ b/src/plugins/builtin/kelly-sizer/constants.ts
@@ -1,0 +1,3 @@
+export const KELLY_PANE_ID = "kelly-sizer";
+export const COMMON_ASSUMPTIONS_STATE_KEY = "commonAssumptions:v1";
+export const DEFAULT_FLOATING_SIZE = { width: 88, height: 30 };

--- a/src/plugins/builtin/kelly-sizer/fields.ts
+++ b/src/plugins/builtin/kelly-sizer/fields.ts
@@ -1,0 +1,214 @@
+import {
+  type KellyCommonAssumptions,
+  type KellySizerDraft,
+  type KellySizerModeDrafts,
+  type KellySizingMode,
+  type ScenarioKellyAssumptions,
+} from "./model";
+
+export interface InlineField {
+  id: string;
+  label: string;
+  value?: number;
+  valueText?: string;
+  percent?: boolean;
+  suffix?: string;
+  allowNegative?: boolean;
+  onValue?: (value: number) => void;
+  onClear?: () => void;
+  onPress?: () => void;
+  tone?: "neutral" | "positive" | "negative";
+}
+
+export function buildModeFields({
+  mode,
+  draft,
+  updateDraft,
+}: {
+  mode: KellySizingMode;
+  draft: KellySizerDraft;
+  updateDraft: (patch: Partial<KellySizerDraft>) => void;
+}): InlineField[] {
+  if (mode === "scenario") {
+    const scenario = draft as ScenarioKellyAssumptions;
+    const updateOutcome = (index: number, patch: Partial<ScenarioKellyAssumptions["outcomes"][number]>) => {
+      updateDraft({
+        outcomes: scenario.outcomes.map((outcome, outcomeIndex) => (
+          outcomeIndex === index ? { ...outcome, ...patch } : outcome
+        )),
+      } as Partial<KellySizerDraft>);
+    };
+    return scenario.outcomes.flatMap((outcome, index): InlineField[] => [
+      {
+        id: `${outcome.id}:p`,
+        label: `${outcome.label} p`,
+        value: outcome.probability,
+        percent: true,
+        onValue: (value) => updateOutcome(index, { probability: value }),
+      },
+      {
+        id: `${outcome.id}:ret`,
+        label: `${outcome.label} ret`,
+        value: outcome.returnPct,
+        percent: true,
+        allowNegative: true,
+        tone: outcome.returnPct >= 0 ? "positive" : "negative",
+        onValue: (value) => updateOutcome(index, { returnPct: value }),
+      },
+    ]);
+  }
+
+  if (mode === "risk-budget") {
+    const risk = draft as KellySizerModeDrafts["risk-budget"];
+    return [
+      {
+        id: "riskBudget",
+        label: "Risk budget",
+        value: risk.riskBudgetFraction,
+        percent: true,
+        onValue: (value) => updateDraft({ riskBudgetFraction: value } as Partial<KellySizerDraft>),
+      },
+      {
+        id: "downside",
+        label: "Downside",
+        value: risk.downsideReturn,
+        percent: true,
+        allowNegative: true,
+        tone: "negative",
+        onValue: (value) => updateDraft({ downsideReturn: value } as Partial<KellySizerDraft>),
+      },
+      {
+        id: "winProbability",
+        label: "Win p",
+        value: risk.winProbability,
+        percent: true,
+        onValue: (value) => updateDraft({ winProbability: value } as Partial<KellySizerDraft>),
+      },
+      {
+        id: "upside",
+        label: "Upside",
+        value: risk.upsideReturn,
+        percent: true,
+        tone: "positive",
+        onValue: (value) => updateDraft({ upsideReturn: value } as Partial<KellySizerDraft>),
+      },
+    ];
+  }
+
+  if (mode === "prediction-market") {
+    const market = draft as KellySizerModeDrafts["prediction-market"];
+    return [
+      {
+        id: "side",
+        label: "Side",
+        valueText: market.side.toUpperCase(),
+        tone: "positive",
+        onPress: () => updateDraft({ side: market.side === "yes" ? "no" : "yes" } as Partial<KellySizerDraft>),
+      },
+      {
+        id: "estimatedProbability",
+        label: "Est p",
+        value: market.estimatedProbability,
+        percent: true,
+        onValue: (value) => updateDraft({ estimatedProbability: value } as Partial<KellySizerDraft>),
+      },
+      {
+        id: "marketPrice",
+        label: "Price",
+        value: market.marketPrice,
+        percent: true,
+        onValue: (value) => updateDraft({ marketPrice: value } as Partial<KellySizerDraft>),
+      },
+    ];
+  }
+
+  if (mode === "asymmetric") {
+    const asymmetric = draft as KellySizerModeDrafts["asymmetric"];
+    return [
+      {
+        id: "winProbability",
+        label: "Win p",
+        value: asymmetric.winProbability,
+        percent: true,
+        onValue: (value) => updateDraft({ winProbability: value } as Partial<KellySizerDraft>),
+      },
+      {
+        id: "targetReturn",
+        label: "Target",
+        value: asymmetric.targetReturn,
+        percent: true,
+        tone: "positive",
+        onValue: (value) => updateDraft({ targetReturn: value } as Partial<KellySizerDraft>),
+      },
+      {
+        id: "maxLossReturn",
+        label: "Max loss",
+        value: asymmetric.maxLossReturn,
+        percent: true,
+        allowNegative: true,
+        tone: "negative",
+        onValue: (value) => updateDraft({ maxLossReturn: value } as Partial<KellySizerDraft>),
+      },
+    ];
+  }
+
+  const binary = draft as KellySizerModeDrafts["binary"];
+  return [
+    {
+      id: "winProbability",
+      label: "Win p",
+      value: binary.winProbability,
+      percent: true,
+      onValue: (value) => updateDraft({ winProbability: value } as Partial<KellySizerDraft>),
+    },
+    {
+      id: "upside",
+      label: "Upside",
+      value: binary.upsideReturn,
+      percent: true,
+      tone: "positive",
+      onValue: (value) => updateDraft({ upsideReturn: value } as Partial<KellySizerDraft>),
+    },
+    {
+      id: "downside",
+      label: "Downside",
+      value: binary.downsideReturn,
+      percent: true,
+      allowNegative: true,
+      tone: "negative",
+      onValue: (value) => updateDraft({ downsideReturn: value } as Partial<KellySizerDraft>),
+    },
+  ];
+}
+
+export function buildCommonFields({
+  common,
+  updateCommon,
+}: {
+  common: KellyCommonAssumptions;
+  updateCommon: (patch: Partial<KellyCommonAssumptions>) => void;
+}): InlineField[] {
+  return [
+    {
+      id: "common:kellyFraction",
+      label: "Kelly",
+      value: common.kellyFraction,
+      percent: true,
+      onValue: (value) => updateCommon({ kellyFraction: value }),
+    },
+    {
+      id: "common:maxLoss",
+      label: "Loss cap",
+      value: common.maxLossFraction,
+      percent: true,
+      onValue: (value) => updateCommon({ maxLossFraction: value }),
+    },
+    {
+      id: "common:maxName",
+      label: "Name cap",
+      value: common.maxNameFraction,
+      percent: true,
+      onValue: (value) => updateCommon({ maxNameFraction: value }),
+    },
+  ];
+}

--- a/src/plugins/builtin/kelly-sizer/index.test.tsx
+++ b/src/plugins/builtin/kelly-sizer/index.test.tsx
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
+import type { TickerRecord } from "../../../types/ticker";
+import { KellySizerHarness, createFinancials, createSizerConfig, createTicker } from "./test-support";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+async function renderPane(props?: Parameters<typeof KellySizerHarness>[0]) {
+  await act(async () => {
+    testSetup = await testRender(<KellySizerHarness {...props} />, { width: 100, height: 30 });
+    await Promise.resolve();
+    await testSetup.renderOnce();
+  });
+}
+
+async function flushFrame() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+}
+
+beforeEach(() => {
+  setSharedMarketDataCoordinator(null);
+});
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+  setSharedMarketDataCoordinator(null);
+});
+
+describe("KellySizerPane", () => {
+  test("renders binary sizing context, result, and curve", async () => {
+    await renderPane();
+    await flushFrame();
+
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("AAPL · Main Portfolio");
+    expect(frame).toContain("Bankroll");
+    expect(frame).toContain("100000");
+    expect(frame).toContain("Win p");
+    expect(frame).toContain("Full Kelly");
+    expect(frame).toContain("Clipped");
+    expect(frame).toContain("Target val");
+    expect(frame).toContain("Current %");
+    expect(frame).toContain("Kelly Curve");
+    expect(frame).toContain("4.0% -> 8.0%");
+    expect(frame).toContain("growth");
+    expect(frame).toContain("loss cap");
+    expect(frame).toContain("cap max loss, max name");
+    expect(frame).toContain("full");
+    expect(frame).toContain("159%");
+    expect(frame).toContain("636%");
+    expect(frame).not.toContain("Mode");
+    expect(frame).not.toContain("Sensitivity");
+  });
+
+  test("prefills shared caps from plugin config", async () => {
+    const config = {
+      ...createSizerConfig(),
+      pluginConfig: {
+        "kelly-sizer": {
+          "commonAssumptions:v1": {
+            kellyFraction: 0.5,
+            maxLossFraction: 0.02,
+            maxNameFraction: 0.1,
+          },
+        },
+      },
+    };
+
+    await renderPane({ config, paneState: { mode: "scenario" } });
+    await flushFrame();
+
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("Scenario");
+    expect(frame).toMatch(/Kelly\s+50\.0\s+%/);
+    expect(frame).toMatch(/Loss cap\s+2\.00\s+%/);
+    expect(frame).toMatch(/Name cap\s+10\.0\s+%/);
+  });
+
+  test("keeps shared caps scoped to pane state after seeding", async () => {
+    const config = {
+      ...createSizerConfig(),
+      pluginConfig: {
+        "kelly-sizer": {
+          "commonAssumptions:v1": {
+            kellyFraction: 0.5,
+            maxLossFraction: 0.02,
+            maxNameFraction: 0.1,
+          },
+        },
+      },
+    };
+
+    await renderPane({
+      config,
+      paneState: {
+        mode: "scenario",
+        "commonAssumptions:v1": {
+          kellyFraction: 0.3,
+          maxLossFraction: 0.015,
+          maxNameFraction: 0.07,
+        },
+      },
+    });
+    await flushFrame();
+
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("Scenario");
+    expect(frame).toMatch(/Kelly\s+30\.0\s+%/);
+    expect(frame).toMatch(/Loss cap\s+1\.50\s+%/);
+    expect(frame).toMatch(/Name cap\s+7\.00\s+%/);
+    expect(frame).not.toMatch(/Kelly\s+50\.0\s+%/);
+  });
+
+  test("converts foreign quote current value to base currency", async () => {
+    const ticker = createTicker({
+      symbol: "SIVE",
+      currency: "SEK",
+      positions: [{
+        portfolio: "main",
+        shares: 100,
+        avgCost: 50,
+        currency: "SEK",
+        broker: "ibkr",
+        brokerInstanceId: "ibkr-flex",
+        brokerAccountId: "DU12345",
+        marketValue: 10_000,
+        unrealizedPnl: 5_000,
+      }],
+    });
+    const financials = createFinancials({ symbol: "SIVE", price: 100, currency: "SEK" });
+
+    await renderPane({
+      config: createSizerConfig("SIVE"),
+      ticker,
+      financials,
+      exchangeRates: new Map([["USD", 1], ["SEK", 0.1]]),
+    });
+    await flushFrame();
+
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("SIVE · Main Portfolio");
+    expect(frame).toMatch(/Current\s+1000\s+USD/);
+    expect(frame).not.toMatch(/Current\s+10000\s+USD/);
+  });
+
+  test("toggles sensitivity with s", async () => {
+    await renderPane();
+    await flushFrame();
+
+    await act(async () => {
+      (testSetup!.renderer.keyInput as any).emit("keypress", {
+        name: "s",
+        sequence: "s",
+        ctrl: false,
+        meta: false,
+        shift: false,
+      });
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("Sensitivity");
+    expect(frame).toContain("Win p");
+    expect(frame).toContain("Upside");
+    expect(frame).not.toContain("Kelly Curve");
+  });
+
+  test("focuses ticker search with t", async () => {
+    await renderPane();
+    await flushFrame();
+
+    await act(async () => {
+      (testSetup!.renderer.keyInput as any).emit("keypress", {
+        name: "t",
+        sequence: "t",
+        ctrl: false,
+        meta: false,
+        shift: false,
+      });
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("/ AAPL");
+  });
+});

--- a/src/plugins/builtin/kelly-sizer/index.tsx
+++ b/src/plugins/builtin/kelly-sizer/index.tsx
@@ -1,0 +1,47 @@
+import type { GloomPlugin, PaneTemplateContext, PaneTemplateCreateOptions } from "../../../types/plugin";
+import { DEFAULT_FLOATING_SIZE, KELLY_PANE_ID } from "./constants";
+import { KellySizerPane } from "./pane";
+
+function resolveTemplateSymbol(context: PaneTemplateContext, options?: PaneTemplateCreateOptions): string | null {
+  return options?.symbol
+    ?? options?.ticker?.metadata.ticker
+    ?? options?.arg?.trim().toUpperCase()
+    ?? context.activeTicker
+    ?? null;
+}
+
+export const kellySizerPlugin: GloomPlugin = {
+  id: KELLY_PANE_ID,
+  name: "Position Sizer",
+  version: "1.0.0",
+  description: "Size positions from Kelly, risk budget, and asymmetric payoff assumptions.",
+  toggleable: true,
+  panes: [
+    {
+      id: KELLY_PANE_ID,
+      name: "Position Sizer",
+      icon: "K",
+      component: KellySizerPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: DEFAULT_FLOATING_SIZE,
+    },
+  ],
+  paneTemplates: [
+    {
+      id: "kelly-sizer-pane",
+      paneId: KELLY_PANE_ID,
+      label: "Position Sizer",
+      description: "Open Kelly-based position sizing for a ticker.",
+      keywords: ["kelly", "position", "sizing", "risk", "bet", "portfolio"],
+      shortcut: { prefix: "KELLY", argPlaceholder: "ticker", argKind: "ticker", argOptional: true },
+      canCreate: (context, options) => !!resolveTemplateSymbol(context, options),
+      createInstance: (context, options) => {
+        const symbol = resolveTemplateSymbol(context, options);
+        return symbol ? { params: { symbol }, placement: "floating" } : null;
+      },
+    },
+  ],
+};
+
+export default kellySizerPlugin;

--- a/src/plugins/builtin/kelly-sizer/model.test.ts
+++ b/src/plugins/builtin/kelly-sizer/model.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildBinaryOutcomes,
+  buildKellyCurvePoints,
+  buildSensitivityGrid,
+  calculateKellySizing,
+  solveKellyFraction,
+  type BinaryKellyAssumptions,
+  type PredictionMarketKellyAssumptions,
+  type ScenarioKellyAssumptions,
+} from "./model";
+
+function expectClose(actual: number, expected: number, precision = 4) {
+  expect(actual).toBeGreaterThan(expected - precision);
+  expect(actual).toBeLessThan(expected + precision);
+}
+
+describe("kelly sizing model", () => {
+  test("solves classic even-money Kelly sizing", () => {
+    const result = solveKellyFraction(buildBinaryOutcomes(0.6, 1, -1));
+    expectClose(result.fraction, 0.2);
+    expectClose(result.expectedReturn, 0.2);
+  });
+
+  test("clips fractional binary Kelly by max name and max loss caps", () => {
+    const draft: BinaryKellyAssumptions = {
+      winProbability: 0.57,
+      upsideReturn: 0.24,
+      downsideReturn: -0.09,
+      kellyFraction: 0.25,
+      maxNameFraction: 0.08,
+      maxLossFraction: 0.01,
+    };
+
+    const result = calculateKellySizing({
+      mode: "binary",
+      draft,
+      bankroll: 100_000,
+      currentValue: 4_000,
+      price: 200,
+    });
+
+    expect(result.fullKellyFraction).toBeGreaterThan(4);
+    expectClose(result.clippedFraction, 0.08);
+    expect(result.clipReasons).toContain("max name");
+    expectClose(result.targetValue, 8_000, 0.01);
+    expectClose(result.addTrimValue, 4_000, 0.01);
+    expectClose(result.estimatedUnits ?? 0, 20, 0.01);
+    expectClose(result.riskFraction, 0.0072, 0.0001);
+  });
+
+  test("returns zero size when there is no positive edge", () => {
+    const draft: BinaryKellyAssumptions = {
+      winProbability: 0.45,
+      upsideReturn: 0.1,
+      downsideReturn: -0.1,
+      kellyFraction: 0.25,
+      maxNameFraction: 0.2,
+      maxLossFraction: 0.05,
+    };
+
+    const result = calculateKellySizing({
+      mode: "binary",
+      draft,
+      bankroll: 10_000,
+    });
+
+    expect(result.clippedFraction).toBe(0);
+    expect(result.warnings).toContain("No positive Kelly edge.");
+  });
+
+  test("solves scenario trees numerically", () => {
+    const draft: ScenarioKellyAssumptions = {
+      outcomes: [
+        { id: "loss", label: "Loss", probability: 0.4, returnPct: -1 },
+        { id: "win", label: "Win", probability: 0.6, returnPct: 1 },
+      ],
+      kellyFraction: 1,
+      maxNameFraction: 1,
+      maxLossFraction: 1,
+    };
+
+    const result = calculateKellySizing({
+      mode: "scenario",
+      draft,
+      bankroll: 1_000,
+    });
+
+    expectClose(result.fullKellyFraction, 0.2);
+    expectClose(result.clippedFraction, 0.2);
+  });
+
+  test("uses risk budget size before Kelly when in risk budget mode", () => {
+    const result = calculateKellySizing({
+      mode: "risk-budget",
+      draft: {
+        riskBudgetFraction: 0.01,
+        downsideReturn: -0.1,
+        winProbability: 0.6,
+        upsideReturn: 0.2,
+        kellyFraction: 0.25,
+        maxNameFraction: 1,
+        maxLossFraction: 1,
+      },
+      bankroll: 50_000,
+    });
+
+    expectClose(result.unclippedFraction, 0.1);
+    expectClose(result.clippedFraction, 0.1);
+    expectClose(result.riskValue, 500);
+  });
+
+  test("sizes prediction market yes contracts from probability and price", () => {
+    const draft: PredictionMarketKellyAssumptions = {
+      estimatedProbability: 0.57,
+      marketPrice: 0.48,
+      side: "yes",
+      kellyFraction: 1,
+      maxNameFraction: 1,
+      maxLossFraction: 1,
+    };
+
+    const result = calculateKellySizing({
+      mode: "prediction-market",
+      draft,
+      bankroll: 1_000,
+    });
+
+    expectClose(result.fullKellyFraction, 0.173076, 0.0001);
+    expectClose(result.clippedFraction, 0.173076, 0.0001);
+  });
+
+  test("builds sensitivity grid and Kelly curve data", () => {
+    const draft: BinaryKellyAssumptions = {
+      winProbability: 0.57,
+      upsideReturn: 0.24,
+      downsideReturn: -0.09,
+      kellyFraction: 0.25,
+      maxNameFraction: 0.08,
+      maxLossFraction: 0.01,
+    };
+
+    const grid = buildSensitivityGrid("binary", draft);
+    expect(grid.rows).toHaveLength(3);
+    expect(grid.columns).toHaveLength(3);
+    expect(grid.cells[1]?.[1]?.text).toBe("8.00%");
+
+    const points = buildKellyCurvePoints("binary", draft);
+    expect(points.length).toBeGreaterThan(10);
+    expect(points[0]?.close).toBe(0);
+  });
+});

--- a/src/plugins/builtin/kelly-sizer/model.ts
+++ b/src/plugins/builtin/kelly-sizer/model.ts
@@ -1,0 +1,580 @@
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import {
+  DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  DEFAULT_KELLY_DRAFTS,
+  type AsymmetricKellyAssumptions,
+  type BinaryKellyAssumptions,
+  type KellyCommonAssumptions,
+  type KellyOutcome,
+  type KellySizerDraft,
+  type KellySizerModeDrafts,
+  type KellySizingMode,
+  type KellySizingResult,
+  type KellySolveResult,
+  type PredictionMarketKellyAssumptions,
+  type RiskBudgetKellyAssumptions,
+  type ScenarioKellyAssumptions,
+  type SensitivityGrid,
+  type SensitivityGridCell,
+} from "./types";
+export {
+  DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  DEFAULT_KELLY_DRAFTS,
+  KELLY_MODES,
+} from "./types";
+export type {
+  AsymmetricKellyAssumptions,
+  BinaryKellyAssumptions,
+  KellyCommonAssumptions,
+  KellyOutcome,
+  KellySizerDraft,
+  KellySizerModeDrafts,
+  KellySizingMode,
+  KellySizingResult,
+  KellySolveResult,
+  PredictionMarketKellyAssumptions,
+  RiskBudgetKellyAssumptions,
+  ScenarioKellyAssumptions,
+  ScenarioKellyOutcome,
+  SensitivityGrid,
+  SensitivityGridCell,
+} from "./types";
+
+const MAX_NUMERIC_KELLY_FRACTION = 10;
+const SOLVER_ITERATIONS = 80;
+
+function finite(value: number): boolean {
+  return Number.isFinite(value);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function sanitizeFraction(value: number, fallback: number, min = 0, max = 1): number {
+  return finite(value) ? clamp(value, min, max) : fallback;
+}
+
+function normalizeProbability(value: number): number {
+  return sanitizeFraction(value, 0, 0, 1);
+}
+
+function normalizeOutcomes(outcomes: KellyOutcome[]): KellyOutcome[] {
+  const valid = outcomes.filter((outcome) => (
+    finite(outcome.probability)
+    && outcome.probability > 0
+    && finite(outcome.returnPct)
+    && outcome.returnPct >= -1
+  ));
+  const totalProbability = valid.reduce((sum, outcome) => sum + outcome.probability, 0);
+  if (totalProbability <= 0) return [];
+  return valid.map((outcome) => ({
+    probability: outcome.probability / totalProbability,
+    returnPct: outcome.returnPct,
+  }));
+}
+
+function expectedReturn(outcomes: KellyOutcome[]): number {
+  return outcomes.reduce((sum, outcome) => sum + outcome.probability * outcome.returnPct, 0);
+}
+
+export function computeExpectedLogGrowth(fraction: number, outcomes: KellyOutcome[]): number {
+  if (!finite(fraction) || fraction < 0) return Number.NEGATIVE_INFINITY;
+  let growth = 0;
+  for (const outcome of outcomes) {
+    const terminalValue = 1 + fraction * outcome.returnPct;
+    if (terminalValue <= 0) return Number.NEGATIVE_INFINITY;
+    growth += outcome.probability * Math.log(terminalValue);
+  }
+  return growth;
+}
+
+export function calculateExpectedLogGrowthAtFraction(
+  mode: KellySizingMode,
+  draft: KellySizerDraft,
+  fraction: number,
+): number {
+  if (!finite(fraction) || fraction < 0) return 0;
+  const { outcomes } = getModeOutcomes(mode, draft);
+  const normalizedOutcomes = normalizeOutcomes(outcomes);
+  if (normalizedOutcomes.length === 0) return 0;
+  const growth = computeExpectedLogGrowth(fraction, normalizedOutcomes);
+  return finite(growth) ? growth : 0;
+}
+
+function derivativeAt(fraction: number, outcomes: KellyOutcome[]): number {
+  let derivative = 0;
+  for (const outcome of outcomes) {
+    derivative += outcome.probability * outcome.returnPct / (1 + fraction * outcome.returnPct);
+  }
+  return derivative;
+}
+
+export function solveKellyFraction(rawOutcomes: KellyOutcome[]): KellySolveResult {
+  const outcomes = normalizeOutcomes(rawOutcomes);
+  if (outcomes.length === 0) {
+    return {
+      fraction: 0,
+      expectedReturn: 0,
+      expectedLogGrowth: 0,
+      warning: "No valid payoff outcomes.",
+    };
+  }
+
+  const edge = expectedReturn(outcomes);
+  if (edge <= 0) {
+    return {
+      fraction: 0,
+      expectedReturn: edge,
+      expectedLogGrowth: 0,
+    };
+  }
+
+  const negativeReturns = outcomes.map((outcome) => outcome.returnPct).filter((value) => value < 0);
+  if (negativeReturns.length === 0) {
+    return {
+      fraction: MAX_NUMERIC_KELLY_FRACTION,
+      expectedReturn: edge,
+      expectedLogGrowth: computeExpectedLogGrowth(MAX_NUMERIC_KELLY_FRACTION, outcomes),
+      warning: "No downside outcome; Kelly is unbounded.",
+    };
+  }
+
+  const worstReturn = Math.min(...negativeReturns);
+  let low = 0;
+  let high = Math.min(MAX_NUMERIC_KELLY_FRACTION, (-1 / worstReturn) * 0.999999);
+  if (!finite(high) || high <= 0) {
+    return {
+      fraction: 0,
+      expectedReturn: edge,
+      expectedLogGrowth: 0,
+      warning: "Invalid downside domain.",
+    };
+  }
+
+  if (derivativeAt(low, outcomes) <= 0) {
+    return {
+      fraction: 0,
+      expectedReturn: edge,
+      expectedLogGrowth: 0,
+    };
+  }
+
+  const highDerivative = derivativeAt(high, outcomes);
+  if (highDerivative > 0) {
+    return {
+      fraction: high,
+      expectedReturn: edge,
+      expectedLogGrowth: computeExpectedLogGrowth(high, outcomes),
+      warning: "Optimum is beyond the pane's solver cap.",
+    };
+  }
+
+  for (let i = 0; i < SOLVER_ITERATIONS; i++) {
+    const mid = (low + high) / 2;
+    if (derivativeAt(mid, outcomes) > 0) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+
+  const fraction = (low + high) / 2;
+  return {
+    fraction,
+    expectedReturn: edge,
+    expectedLogGrowth: computeExpectedLogGrowth(fraction, outcomes),
+  };
+}
+
+export function buildBinaryOutcomes(
+  winProbability: number,
+  upsideReturn: number,
+  downsideReturn: number,
+): KellyOutcome[] {
+  const probability = normalizeProbability(winProbability);
+  return [
+    { probability, returnPct: Math.max(0, upsideReturn) },
+    { probability: 1 - probability, returnPct: Math.min(0, downsideReturn) },
+  ];
+}
+
+function getModeOutcomes(
+  mode: KellySizingMode,
+  draft: KellySizerDraft,
+): { outcomes: KellyOutcome[]; recommendationLabel: string; warnings: string[] } {
+  if (mode === "binary") {
+    const binary = draft as BinaryKellyAssumptions;
+    return {
+      outcomes: buildBinaryOutcomes(binary.winProbability, binary.upsideReturn, binary.downsideReturn),
+      recommendationLabel: "Binary thesis",
+      warnings: [],
+    };
+  }
+
+  if (mode === "scenario") {
+    const scenario = draft as ScenarioKellyAssumptions;
+    return {
+      outcomes: scenario.outcomes.map((outcome) => ({
+        probability: outcome.probability,
+        returnPct: outcome.returnPct,
+      })),
+      recommendationLabel: "Scenario tree",
+      warnings: [],
+    };
+  }
+
+  if (mode === "risk-budget") {
+    const risk = draft as RiskBudgetKellyAssumptions;
+    return {
+      outcomes: buildBinaryOutcomes(risk.winProbability, risk.upsideReturn, risk.downsideReturn),
+      recommendationLabel: "Risk budget",
+      warnings: [],
+    };
+  }
+
+  if (mode === "prediction-market") {
+    const market = draft as PredictionMarketKellyAssumptions;
+    const price = sanitizeFraction(market.side === "yes" ? market.marketPrice : 1 - market.marketPrice, 0, 0.0001, 0.9999);
+    const winProbability = market.side === "yes"
+      ? normalizeProbability(market.estimatedProbability)
+      : 1 - normalizeProbability(market.estimatedProbability);
+    return {
+      outcomes: buildBinaryOutcomes(winProbability, (1 - price) / price, -1),
+      recommendationLabel: `${market.side.toUpperCase()} contract`,
+      warnings: [],
+    };
+  }
+
+  const asymmetric = draft as AsymmetricKellyAssumptions;
+  return {
+    outcomes: buildBinaryOutcomes(
+      asymmetric.winProbability,
+      asymmetric.targetReturn,
+      asymmetric.maxLossReturn,
+    ),
+    recommendationLabel: "Asymmetric payoff",
+    warnings: [],
+  };
+}
+
+function getCommonAssumptions(draft: KellySizerDraft): KellyCommonAssumptions {
+  return normalizeKellyCommonAssumptions(draft);
+}
+
+export function normalizeKellyCommonAssumptions(
+  value: Partial<KellyCommonAssumptions> | null | undefined,
+  fallback: KellyCommonAssumptions = DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+): KellyCommonAssumptions {
+  return {
+    kellyFraction: sanitizeFraction(value?.kellyFraction ?? fallback.kellyFraction, fallback.kellyFraction, 0, 1),
+    maxNameFraction: sanitizeFraction(value?.maxNameFraction ?? fallback.maxNameFraction, fallback.maxNameFraction, 0, 1),
+    maxLossFraction: sanitizeFraction(value?.maxLossFraction ?? fallback.maxLossFraction, fallback.maxLossFraction, 0, 1),
+  };
+}
+
+export function applyKellyCommonAssumptions<T extends KellySizerDraft>(
+  draft: T,
+  common: KellyCommonAssumptions,
+): T {
+  return {
+    ...draft,
+    ...normalizeKellyCommonAssumptions(common),
+  };
+}
+
+function getDownsideLossFraction(mode: KellySizingMode, draft: KellySizerDraft, outcomes: KellyOutcome[]): number {
+  if (mode === "risk-budget") {
+    return Math.abs(Math.min(0, (draft as RiskBudgetKellyAssumptions).downsideReturn));
+  }
+  const worstReturn = Math.min(...outcomes.map((outcome) => outcome.returnPct), 0);
+  return Math.abs(worstReturn);
+}
+
+export function calculateKellySizing({
+  mode,
+  draft,
+  bankroll,
+  currentValue = 0,
+  price = null,
+}: {
+  mode: KellySizingMode;
+  draft: KellySizerDraft;
+  bankroll: number;
+  currentValue?: number;
+  price?: number | null;
+}): KellySizingResult {
+  const warnings: string[] = [];
+  if (!finite(bankroll) || bankroll <= 0) {
+    return {
+      mode,
+      bankroll: 0,
+      currentValue: 0,
+      currentFraction: 0,
+      price: null,
+      fullKellyFraction: 0,
+      fractionalKellyFraction: 0,
+      unclippedFraction: 0,
+      clippedFraction: 0,
+      targetValue: 0,
+      addTrimValue: 0,
+      estimatedUnits: null,
+      downsideLossFraction: 0,
+      riskValue: 0,
+      riskFraction: 0,
+      expectedReturn: 0,
+      expectedLogGrowth: 0,
+      warnings: ["No positive bankroll available."],
+      clipReasons: [],
+      recommendationLabel: "Unavailable",
+    };
+  }
+
+  const { outcomes, recommendationLabel, warnings: outcomeWarnings } = getModeOutcomes(mode, draft);
+  warnings.push(...outcomeWarnings);
+  const normalizedOutcomes = normalizeOutcomes(outcomes);
+  const solve = solveKellyFraction(normalizedOutcomes);
+  if (solve.warning) warnings.push(solve.warning);
+
+  const common = getCommonAssumptions(draft);
+  const downsideLossFraction = getDownsideLossFraction(mode, draft, normalizedOutcomes);
+  const fullKellyFraction = Math.max(0, solve.fraction);
+  const fractionalKellyFraction = fullKellyFraction * common.kellyFraction;
+  const riskBudgetFraction = mode === "risk-budget"
+    ? (draft as RiskBudgetKellyAssumptions).riskBudgetFraction
+    : null;
+  const riskBudgetSize = riskBudgetFraction != null && downsideLossFraction > 0
+    ? Math.max(0, riskBudgetFraction) / downsideLossFraction
+    : null;
+  const unclippedFraction = riskBudgetSize ?? fractionalKellyFraction;
+  let clippedFraction = Math.max(0, unclippedFraction);
+  const clipReasons: string[] = [];
+
+  if (common.maxLossFraction > 0 && downsideLossFraction > 0) {
+    const lossCapFraction = common.maxLossFraction / downsideLossFraction;
+    if (clippedFraction > lossCapFraction) {
+      clippedFraction = lossCapFraction;
+      clipReasons.push("max loss");
+    }
+  }
+
+  if (common.maxNameFraction > 0 && clippedFraction > common.maxNameFraction) {
+    clippedFraction = common.maxNameFraction;
+    clipReasons.push("max name");
+  }
+
+  const safeCurrentValue = finite(currentValue) ? Math.max(0, currentValue) : 0;
+  const safePrice = price != null && finite(price) && price > 0 ? price : null;
+  const targetValue = clippedFraction * bankroll;
+  const addTrimValue = targetValue - safeCurrentValue;
+  const estimatedUnits = safePrice ? addTrimValue / safePrice : null;
+  const riskFraction = clippedFraction * downsideLossFraction;
+  const riskValue = riskFraction * bankroll;
+
+  if (fullKellyFraction === 0 && solve.expectedReturn <= 0) warnings.push("No positive Kelly edge.");
+  if (downsideLossFraction <= 0) warnings.push("No downside assumption; risk caps cannot bind.");
+
+  return {
+    mode,
+    bankroll,
+    currentValue: safeCurrentValue,
+    currentFraction: safeCurrentValue / bankroll,
+    price: safePrice,
+    fullKellyFraction,
+    fractionalKellyFraction,
+    unclippedFraction,
+    clippedFraction,
+    targetValue,
+    addTrimValue,
+    estimatedUnits,
+    downsideLossFraction,
+    riskValue,
+    riskFraction,
+    expectedReturn: solve.expectedReturn,
+    expectedLogGrowth: solve.expectedLogGrowth,
+    warnings,
+    clipReasons,
+    recommendationLabel,
+  };
+}
+
+function formatPercentCell(value: number | null): string {
+  if (value == null || !finite(value)) return "—";
+  return `${(value * 100).toFixed(Math.abs(value) >= 0.1 ? 1 : 2)}%`;
+}
+
+function resultForSensitivity(mode: KellySizingMode, draft: KellySizerDraft): SensitivityGridCell {
+  const result = calculateKellySizing({
+    mode,
+    draft,
+    bankroll: 100,
+    currentValue: 0,
+    price: 1,
+  });
+  return {
+    fraction: result.clippedFraction,
+    text: formatPercentCell(result.clippedFraction),
+  };
+}
+
+function applyCommon<T extends KellyCommonAssumptions>(base: T, patch: Partial<T>): T {
+  return { ...base, ...patch };
+}
+
+function probabilityLabels(center: number): number[] {
+  return [-0.05, 0, 0.05].map((offset) => clamp(center + offset, 0.01, 0.99));
+}
+
+export function buildSensitivityGrid(mode: KellySizingMode, draft: KellySizerDraft): SensitivityGrid {
+  if (mode === "prediction-market") {
+    const market = draft as PredictionMarketKellyAssumptions;
+    const rows = probabilityLabels(market.estimatedProbability);
+    const columns = [-0.05, 0, 0.05].map((offset) => clamp(market.marketPrice + offset, 0.01, 0.99));
+    return {
+      rowLabel: "Est p",
+      columnLabel: "Price",
+      rows: rows.map(formatPercentCell),
+      columns: columns.map(formatPercentCell),
+      cells: rows.map((estimatedProbability) => columns.map((marketPrice) => (
+        resultForSensitivity(mode, applyCommon(market, { estimatedProbability, marketPrice }))
+      ))),
+    };
+  }
+
+  if (mode === "scenario") {
+    const scenario = draft as ScenarioKellyAssumptions;
+    const bear = scenario.outcomes[0] ?? DEFAULT_KELLY_DRAFTS.scenario.outcomes[0]!;
+    const base = scenario.outcomes[1] ?? DEFAULT_KELLY_DRAFTS.scenario.outcomes[1]!;
+    const bull = scenario.outcomes[2] ?? DEFAULT_KELLY_DRAFTS.scenario.outcomes[2]!;
+    const bearProbabilities = probabilityLabels(bear.probability);
+    const bullReturns = [-0.06, 0, 0.06].map((offset) => bull.returnPct + offset);
+    return {
+      rowLabel: "Bear p",
+      columnLabel: "Bull ret",
+      rows: bearProbabilities.map(formatPercentCell),
+      columns: bullReturns.map(formatPercentCell),
+      cells: bearProbabilities.map((bearProbability) => bullReturns.map((bullReturn) => {
+        const bullProbability = bull.probability;
+        const baseProbability = Math.max(0.01, 1 - bearProbability - bullProbability);
+        return resultForSensitivity(mode, {
+          ...scenario,
+          outcomes: [
+            { ...bear, probability: bearProbability },
+            { ...base, probability: baseProbability },
+            { ...bull, returnPct: bullReturn },
+          ],
+        });
+      })),
+    };
+  }
+
+  const twoOutcome = mode === "risk-budget"
+    ? draft as RiskBudgetKellyAssumptions
+    : mode === "asymmetric"
+      ? draft as AsymmetricKellyAssumptions
+      : draft as BinaryKellyAssumptions;
+  const winProbability = "winProbability" in twoOutcome ? twoOutcome.winProbability : 0.5;
+  const upside = "upsideReturn" in twoOutcome
+    ? twoOutcome.upsideReturn
+    : (twoOutcome as AsymmetricKellyAssumptions).targetReturn;
+  const rows = probabilityLabels(winProbability);
+  const columns = [-0.06, 0, 0.06].map((offset) => Math.max(0.01, upside + offset));
+
+  return {
+    rowLabel: "Win p",
+    columnLabel: "Upside",
+    rows: rows.map(formatPercentCell),
+    columns: columns.map(formatPercentCell),
+    cells: rows.map((probability) => columns.map((upsideReturn) => {
+      if (mode === "risk-budget") {
+        return resultForSensitivity(mode, applyCommon(draft as RiskBudgetKellyAssumptions, {
+          winProbability: probability,
+          upsideReturn,
+        }));
+      }
+      if (mode === "asymmetric") {
+        return resultForSensitivity(mode, applyCommon(draft as AsymmetricKellyAssumptions, {
+          winProbability: probability,
+          targetReturn: upsideReturn,
+        }));
+      }
+      return resultForSensitivity(mode, applyCommon(draft as BinaryKellyAssumptions, {
+        winProbability: probability,
+        upsideReturn,
+      }));
+    })),
+  };
+}
+
+export function buildKellyCurvePoints(
+  mode: KellySizingMode,
+  draft: KellySizerDraft,
+  maxFractionOverride?: number,
+): ProjectedChartPoint[] {
+  const { outcomes } = getModeOutcomes(mode, draft);
+  const normalizedOutcomes = normalizeOutcomes(outcomes);
+  if (normalizedOutcomes.length === 0) return [];
+  const maxFraction = maxFractionOverride ?? getKellyCurveMaxFraction(mode, draft);
+  if (maxFraction <= 0) return [];
+
+  return Array.from({ length: 32 }, (_, index) => {
+    const fraction = (maxFraction * index) / 31;
+    const growth = computeExpectedLogGrowth(fraction, normalizedOutcomes);
+    const safeGrowth = finite(growth) ? growth : 0;
+    return {
+      date: new Date(Date.UTC(2026, 0, 1 + index)),
+      open: safeGrowth,
+      high: safeGrowth,
+      low: safeGrowth,
+      close: safeGrowth,
+      volume: 0,
+    };
+  });
+}
+
+export function getKellyCurveMaxFraction(
+  mode: KellySizingMode,
+  draft: KellySizerDraft,
+  focusFractions: number[] = [],
+): number {
+  const { outcomes } = getModeOutcomes(mode, draft);
+  const normalizedOutcomes = normalizeOutcomes(outcomes);
+  if (normalizedOutcomes.length === 0) return 0;
+
+  const result = calculateKellySizing({
+    mode,
+    draft,
+    bankroll: 100,
+    currentValue: 0,
+    price: 1,
+  });
+  const worstReturn = Math.min(...normalizedOutcomes.map((outcome) => outcome.returnPct), 0);
+  const domainLimit = worstReturn < 0 ? (-1 / worstReturn) * 0.95 : MAX_NUMERIC_KELLY_FRACTION;
+  const focusMax = Math.max(0, ...focusFractions.filter((value) => finite(value) && value >= 0));
+  const maxFraction = clamp(
+    Math.max(result.fullKellyFraction * 1.4, result.clippedFraction * 2, focusMax * 1.15, 0.2),
+    0.05,
+    Math.min(MAX_NUMERIC_KELLY_FRACTION, domainLimit),
+  );
+  return maxFraction;
+}
+
+export function cloneKellyDrafts(drafts: Partial<KellySizerModeDrafts> = DEFAULT_KELLY_DRAFTS): KellySizerModeDrafts {
+  const binary = { ...DEFAULT_KELLY_DRAFTS.binary, ...drafts.binary };
+  const scenario = {
+    ...DEFAULT_KELLY_DRAFTS.scenario,
+    ...drafts.scenario,
+    outcomes: (drafts.scenario?.outcomes ?? DEFAULT_KELLY_DRAFTS.scenario.outcomes).map((outcome) => ({ ...outcome })),
+  };
+  const riskBudget = { ...DEFAULT_KELLY_DRAFTS["risk-budget"], ...drafts["risk-budget"] };
+  const predictionMarket = { ...DEFAULT_KELLY_DRAFTS["prediction-market"], ...drafts["prediction-market"] };
+  const asymmetric = { ...DEFAULT_KELLY_DRAFTS.asymmetric, ...drafts.asymmetric };
+
+  return {
+    binary,
+    scenario,
+    "risk-budget": riskBudget,
+    "prediction-market": predictionMarket,
+    asymmetric,
+  };
+}

--- a/src/plugins/builtin/kelly-sizer/pane.tsx
+++ b/src/plugins/builtin/kelly-sizer/pane.tsx
@@ -1,0 +1,558 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, TextAttributes, type InputRenderable } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { colors } from "../../../theme/colors";
+import {
+  InputSearchBar,
+  Tabs,
+  usePaneFooter,
+} from "../../../components";
+import type { PaneProps } from "../../../types/plugin";
+import { useFxRatesMap, useTickerFinancials, useTickerFinancialsMap } from "../../../market-data/hooks";
+import { formatCurrency } from "../../../utils/format";
+import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
+import {
+  useAppDispatch,
+  getFocusedCollectionId,
+  getFocusedTickerSymbol,
+  useAppSelector,
+  usePaneInstance,
+  usePaneStateValue,
+} from "../../../state/app/context";
+import { selectCommandBarOpen } from "../../../state/selectors-ui";
+import { usePortfolioAccountState } from "../portfolio-list/header";
+import { getSharedRegistry } from "../../registry";
+import { resolveTickerOpenTarget } from "../../../tickers/open-target";
+import { calculatePortfolioSummaryTotals } from "../portfolio-list/metrics";
+import {
+  buildTrackedCurrencies,
+  getCollectionTickersFromConfig,
+} from "../portfolio-list/pane/data";
+import {
+  DEFAULT_KELLY_DRAFTS,
+  KELLY_MODES,
+  applyKellyCommonAssumptions,
+  buildKellyCurvePoints,
+  buildSensitivityGrid,
+  calculateExpectedLogGrowthAtFraction,
+  calculateKellySizing,
+  cloneKellyDrafts,
+  getKellyCurveMaxFraction,
+  type KellySizerDraft,
+  type KellySizerModeDrafts,
+  type KellySizingMode,
+} from "./model";
+import { KELLY_PANE_ID } from "./constants";
+import {
+  InlineFieldView,
+  buildKellyCurveXAxisLabels,
+  isPlainShortcut,
+  truncateText,
+} from "./view";
+import {
+  buildCommonFields,
+  buildModeFields,
+  type InlineField,
+} from "./fields";
+import type { StaticChartXMarker } from "../../../components/chart/static/chart/surface";
+import {
+  KellyCurveSection,
+  KellyResultMetrics,
+  KellySensitivitySection,
+} from "./sections";
+import { getPortfolioPositionValue, resolveActivePortfolioId } from "./portfolio";
+import { useKellyCommonAssumptions } from "./state";
+
+export function KellySizerPane({ focused, width, height }: PaneProps) {
+  const paneInstance = usePaneInstance();
+  const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config);
+  const activeCollectionId = useAppSelector((state) => getFocusedCollectionId(state));
+  const focusedSymbol = useAppSelector((state) => getFocusedTickerSymbol(state));
+  const [symbolOverride, setSymbolOverride] = usePaneStateValue<string | null>("symbol", null);
+  const requestedSymbol = symbolOverride || paneInstance?.params?.symbol || focusedSymbol;
+  const ticker = useAppSelector((state) => (requestedSymbol ? state.tickers.get(requestedSymbol) ?? null : null));
+  const cachedFinancials = useAppSelector((state) => (requestedSymbol ? state.financials.get(requestedSymbol) ?? null : null));
+  const liveFinancials = useTickerFinancials(requestedSymbol ?? null, ticker);
+  const financials = liveFinancials ?? cachedFinancials;
+  const tickersBySymbol = useAppSelector((state) => state.tickers);
+  const cachedPortfolioFinancials = useAppSelector((state) => state.financials);
+  const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
+  const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
+  const commandBarOpen = useAppSelector(selectCommandBarOpen);
+
+  const [mode, setMode] = usePaneStateValue<KellySizingMode>("mode", "binary");
+  const [drafts, setDrafts] = usePaneStateValue<KellySizerModeDrafts>("drafts", cloneKellyDrafts());
+  const [showSensitivity, setShowSensitivity] = usePaneStateValue<boolean>("showSensitivity", false);
+  const [selectedPortfolioId, setSelectedPortfolioId] = usePaneStateValue<string | null>("portfolioId", null);
+  const [bankrollOverride, setBankrollOverride] = usePaneStateValue<number | null>("bankrollOverride", null);
+  const [currentValueOverride, setCurrentValueOverride] = usePaneStateValue<number | null>("currentValueOverride", null);
+  const [selectedFieldIndex, setSelectedFieldIndex] = useState(0);
+  const [activeInputId, setActiveInputId] = useState<string | null>(null);
+  const tickerInputRef = useRef<InputRenderable | null>(null);
+  const [tickerSearchActive, setTickerSearchActive] = useState(false);
+  const [tickerSearchQuery, setTickerSearchQuery] = useState(requestedSymbol ?? "");
+  const [tickerSearchFocusToken, setTickerSearchFocusToken] = useState(0);
+  const [tickerSearchStatus, setTickerSearchStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!tickerSearchActive) {
+      setTickerSearchQuery(requestedSymbol ?? "");
+    }
+  }, [requestedSymbol, tickerSearchActive]);
+
+  const activateInput = useCallback((inputId: string | null, fieldIndex?: number) => {
+    if (typeof fieldIndex === "number") setSelectedFieldIndex(fieldIndex);
+    setActiveInputId(inputId);
+  }, []);
+
+  const focusTickerSearch = useCallback(() => {
+    setTickerSearchActive(true);
+    setTickerSearchFocusToken((value) => value + 1);
+    activateInput(null);
+  }, [activateInput]);
+
+  const resolveTickerQuery = useCallback(async (query: string) => {
+    const normalizedQuery = query.trim().toUpperCase();
+    setTickerSearchQuery(normalizedQuery);
+    if (!normalizedQuery || normalizedQuery === requestedSymbol) {
+      setTickerSearchStatus(null);
+      return;
+    }
+
+    const registry = getSharedRegistry();
+    if (!registry) {
+      setTickerSearchStatus("lookup unavailable");
+      return;
+    }
+
+    setTickerSearchStatus("checking...");
+    const target = await resolveTickerOpenTarget({
+      query: normalizedQuery,
+      tickers: tickersBySymbol,
+      dataProvider: registry.marketData,
+      tickerRepository: registry.tickerRepository,
+    });
+
+    if (!target) {
+      setTickerSearchStatus("not found");
+      return;
+    }
+
+    dispatch({ type: "UPDATE_TICKER", ticker: target.ticker });
+    if (target.created) {
+      registry.events.emit("ticker:added", { symbol: target.symbol, ticker: target.ticker });
+    }
+    setSymbolOverride(target.symbol);
+    setBankrollOverride(null);
+    setCurrentValueOverride(null);
+    setTickerSearchQuery(target.symbol);
+    setTickerSearchStatus(null);
+  }, [
+    dispatch,
+    requestedSymbol,
+    setBankrollOverride,
+    setCurrentValueOverride,
+    setSymbolOverride,
+    tickersBySymbol,
+  ]);
+
+  const activePortfolioId = resolveActivePortfolioId({
+    requestedPortfolioId: selectedPortfolioId ?? paneInstance?.params?.portfolioId ?? null,
+    activeCollectionId,
+    symbol: requestedSymbol ?? null,
+    ticker,
+    config,
+  });
+  const activePortfolio = useMemo(
+    () => config.portfolios.find((portfolio) => portfolio.id === activePortfolioId) ?? null,
+    [activePortfolioId, config.portfolios],
+  );
+  const portfolioTickers = useMemo(
+    () => activePortfolioId ? getCollectionTickersFromConfig(config, tickersBySymbol, activePortfolioId) : [],
+    [activePortfolioId, config, tickersBySymbol],
+  );
+  const livePortfolioFinancials = useTickerFinancialsMap(portfolioTickers);
+  const portfolioFinancials = useMemo(() => {
+    const merged = new Map(cachedPortfolioFinancials);
+    for (const [symbol, value] of livePortfolioFinancials) merged.set(symbol, value);
+    if (requestedSymbol && financials) merged.set(requestedSymbol, financials);
+    return merged;
+  }, [cachedPortfolioFinancials, financials, livePortfolioFinancials, requestedSymbol]);
+  const accountState = usePortfolioAccountState(activePortfolio, { brokerAccounts, config });
+  const trackedCurrencies = useMemo(
+    () => buildTrackedCurrencies(portfolioTickers, portfolioFinancials, accountState, config.baseCurrency),
+    [accountState, config.baseCurrency, portfolioFinancials, portfolioTickers],
+  );
+  const fetchedExchangeRates = useFxRatesMap(trackedCurrencies);
+  const exchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, cachedExchangeRates);
+  const portfolioSummary = useMemo(
+    () => calculatePortfolioSummaryTotals(
+      portfolioTickers,
+      portfolioFinancials,
+      config.baseCurrency,
+      exchangeRates,
+      true,
+      activePortfolioId,
+    ),
+    [activePortfolioId, config.baseCurrency, exchangeRates, portfolioFinancials, portfolioTickers],
+  );
+  const sourceBankroll = accountState?.account.netLiquidation
+    ?? portfolioSummary.totalMktValue
+    ?? 0;
+  const sourceCurrentValue = getPortfolioPositionValue({
+    ticker,
+    financials,
+    portfolioId: activePortfolioId,
+    baseCurrency: config.baseCurrency,
+    exchangeRates,
+  });
+  const bankroll = bankrollOverride ?? sourceBankroll;
+  const currentValue = currentValueOverride ?? sourceCurrentValue;
+  const price = financials?.quote?.price ?? null;
+  const rawActiveDraft = drafts[mode] ?? DEFAULT_KELLY_DRAFTS[mode];
+  const { commonAssumptions, updateCommon } = useKellyCommonAssumptions(rawActiveDraft);
+  const activeDraft = useMemo(
+    () => applyKellyCommonAssumptions(rawActiveDraft, commonAssumptions),
+    [commonAssumptions, rawActiveDraft],
+  );
+
+  const updateDraft = useCallback((patch: Partial<KellySizerDraft>) => {
+    setDrafts((current) => ({
+      ...cloneKellyDrafts(current),
+      [mode]: {
+        ...(current[mode] ?? DEFAULT_KELLY_DRAFTS[mode]),
+        ...patch,
+      } as KellySizerDraft,
+    }));
+  }, [mode, setDrafts]);
+
+  const fields = useMemo(
+    () => buildModeFields({ mode, draft: activeDraft, updateDraft }),
+    [activeDraft, mode, updateDraft],
+  );
+  const commonFields = useMemo(
+    () => buildCommonFields({ common: commonAssumptions, updateCommon }),
+    [commonAssumptions, updateCommon],
+  );
+  const contextFields = useMemo<InlineField[]>(() => [
+    {
+      id: "context:bankroll",
+      label: "Bankroll",
+      value: bankroll,
+      suffix: config.baseCurrency,
+      onValue: (value) => setBankrollOverride(Math.max(0, value)),
+      onClear: () => setBankrollOverride(null),
+    },
+    {
+      id: "context:current",
+      label: "Current",
+      value: currentValue,
+      suffix: config.baseCurrency,
+      onValue: (value) => setCurrentValueOverride(Math.max(0, value)),
+      onClear: () => setCurrentValueOverride(null),
+    },
+  ], [bankroll, config.baseCurrency, currentValue, setBankrollOverride, setCurrentValueOverride]);
+  const editableFields = useMemo(() => [...commonFields, ...fields], [commonFields, fields]);
+  const safeSelectedFieldIndex = Math.min(selectedFieldIndex, Math.max(0, editableFields.length - 1));
+  const result = useMemo(
+    () => calculateKellySizing({
+      mode,
+      draft: activeDraft,
+      bankroll,
+      currentValue,
+      price,
+    }),
+    [activeDraft, bankroll, currentValue, mode, price],
+  );
+  const sensitivity = useMemo(() => buildSensitivityGrid(mode, activeDraft), [activeDraft, mode]);
+  const curveMaxFraction = useMemo(
+    () => getKellyCurveMaxFraction(mode, activeDraft, [
+      result.currentFraction,
+      result.clippedFraction,
+      result.fullKellyFraction,
+    ]),
+    [activeDraft, mode, result.clippedFraction, result.currentFraction, result.fullKellyFraction],
+  );
+  const curvePoints = useMemo(
+    () => buildKellyCurvePoints(mode, activeDraft, curveMaxFraction),
+    [activeDraft, curveMaxFraction, mode],
+  );
+  const curveXAxisLabels = useMemo(() => buildKellyCurveXAxisLabels(curveMaxFraction), [curveMaxFraction]);
+  const currentGrowth = useMemo(
+    () => calculateExpectedLogGrowthAtFraction(mode, activeDraft, result.currentFraction),
+    [activeDraft, mode, result.currentFraction],
+  );
+  const targetGrowth = useMemo(
+    () => calculateExpectedLogGrowthAtFraction(mode, activeDraft, result.clippedFraction),
+    [activeDraft, mode, result.clippedFraction],
+  );
+  const curveMarkers = useMemo<StaticChartXMarker[]>(() => {
+    if (!Number.isFinite(curveMaxFraction) || curveMaxFraction <= 0) return [];
+    const targetLabel = result.clipReasons[0]?.replace(/^max /, "") ?? "target";
+    const markers: StaticChartXMarker[] = [
+      {
+        id: "current",
+        xRatio: result.currentFraction / curveMaxFraction,
+        label: "current",
+        color: colors.textDim,
+        lineChar: "┊",
+      },
+      {
+        id: "target",
+        xRatio: result.clippedFraction / curveMaxFraction,
+        label: targetLabel === "target" ? "target" : `${targetLabel} cap`,
+        color: colors.positive,
+        lineChar: "┃",
+      },
+      {
+        id: "full",
+        xRatio: result.fullKellyFraction / curveMaxFraction,
+        label: "full",
+        color: colors.textMuted,
+        lineChar: "│",
+      },
+    ];
+    return markers.filter((marker) => Number.isFinite(marker.xRatio) && marker.xRatio >= 0);
+  }, [
+    curveMaxFraction,
+    result.clipReasons,
+    result.clippedFraction,
+    result.currentFraction,
+    result.fullKellyFraction,
+  ]);
+  const summaryLine = requestedSymbol
+    ? `${requestedSymbol}${activePortfolio ? ` · ${activePortfolio.name}` : ""}`
+    : "No ticker selected";
+
+  const toggleSensitivity = useCallback(() => {
+    setShowSensitivity((current) => !current);
+  }, [setShowSensitivity]);
+
+  useShortcut((event) => {
+    if (!focused) return;
+    if (commandBarOpen || event.defaultPrevented || event.propagationStopped) return;
+    if (event.ctrl || event.meta || event.super || event.alt || event.targetEditable) return;
+
+    if (isPlainShortcut(event, "s")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      toggleSensitivity();
+      return;
+    }
+    if (isPlainShortcut(event, "t")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusTickerSearch();
+      return;
+    }
+    if (isPlainShortcut(event, "e")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      activateInput(editableFields[safeSelectedFieldIndex]?.id ?? null);
+    }
+  }, { enabled: focused });
+
+  usePaneFooter(KELLY_PANE_ID, () => ({
+    info: result.warnings.length > 0
+      ? [{ id: "warning", parts: [{ text: result.warnings[0]!, tone: "warning" as const }] }]
+      : result.clipReasons.length > 0
+        ? [{ id: "clip", parts: [{ text: `clip ${result.clipReasons.join(", ")}`, tone: "muted" as const }] }]
+        : [],
+    hints: [
+      { id: "ticker", key: "t", label: "icker", onPress: focusTickerSearch },
+      { id: "sensitivity", key: "s", label: showSensitivity ? "ensitivity off" : "ensitivity", onPress: toggleSensitivity },
+    ],
+  }), [focusTickerSearch, result.clipReasons, result.warnings, showSensitivity, toggleSensitivity]);
+
+  const portfolioTabs = useMemo(
+    () => config.portfolios.map((portfolio) => ({ label: portfolio.name, value: portfolio.id })),
+    [config.portfolios],
+  );
+  const fieldColumns = width >= 92 ? 3 : 2;
+  const commonColumns = width >= 78 ? 3 : 2;
+  const commonRows = Math.max(1, Math.ceil(commonFields.length / commonColumns));
+  const fieldsRows = Math.max(1, Math.ceil(fields.length / fieldColumns));
+  const commonFieldWidth = Math.max(22, Math.floor((width - 2) / commonColumns));
+  const fieldWidth = Math.max(22, Math.floor((width - 2) / fieldColumns));
+  const contextFieldWidth = Math.max(28, Math.floor((width - 2) / 2));
+  const metricsRows = 6;
+  const curveDecisionRows = 1;
+  const chartHeight = showSensitivity ? 0 : Math.max(7, Math.min(10, height - commonRows - fieldsRows - metricsRows - curveDecisionRows - 8));
+  const showChart = !showSensitivity && chartHeight >= 6 && curvePoints.length > 0;
+  const leftMetricsWidth = Math.max(36, Math.floor((width - 2) * 0.52));
+  const rightMetricsWidth = Math.max(28, width - 2 - leftMetricsWidth);
+
+  if (!requestedSymbol || !ticker) {
+    return (
+      <Box flexDirection="column" width={width} height={height} paddingX={1} paddingY={1}>
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Position Sizer</Text>
+        <Box height={1} />
+        <Text fg={colors.textMuted}>Select a ticker or open with KELLY &lt;ticker&gt;.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      width={width}
+      height={height}
+    >
+      <Box height={1} paddingX={1} flexDirection="row">
+        <Box flexGrow={1} overflow="hidden">
+          {tickerSearchActive ? (
+            <InputSearchBar
+              value={tickerSearchQuery}
+              focused={focused}
+              active={tickerSearchActive}
+              width={Math.min(36, Math.max(12, width - 18))}
+              focusToken={tickerSearchFocusToken}
+              inputRef={tickerInputRef}
+              placeholder="ticker"
+              debounceMs={500}
+              normalizeValue={(value) => value.trim().toUpperCase()}
+              onFocus={() => setTickerSearchActive(true)}
+              onBlur={() => setTickerSearchActive(false)}
+              onQueryChange={(query) => {
+                void resolveTickerQuery(query);
+              }}
+            />
+          ) : (
+            <Box height={1} flexDirection="row" onMouseDown={focusTickerSearch}>
+              <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+                {truncateText(summaryLine, Math.max(8, width - 2))}
+              </Text>
+              {tickerSearchStatus ? (
+                <Text fg={colors.textMuted}>
+                  {truncateText(`  ${tickerSearchStatus}`, Math.max(0, width - summaryLine.length - 18))}
+                </Text>
+              ) : null}
+            </Box>
+          )}
+        </Box>
+        {price != null && (
+          <Text fg={colors.textDim}>
+            {formatCurrency(price, financials?.quote?.currency ?? ticker.metadata.currency ?? config.baseCurrency)}
+          </Text>
+        )}
+      </Box>
+
+      {portfolioTabs.length > 1 && (
+        <Box height={1} flexDirection="row">
+          <Box flexShrink={1} overflow="hidden">
+            <Tabs
+              tabs={portfolioTabs}
+              activeValue={activePortfolioId}
+              onSelect={(portfolioId) => {
+                setSelectedPortfolioId(portfolioId);
+                setBankrollOverride(null);
+                setCurrentValueOverride(null);
+              }}
+              compact
+              focused={focused && !activeInputId}
+              keyboardNavigation={false}
+            />
+          </Box>
+        </Box>
+      )}
+
+      <Box height={1} flexDirection="row" paddingX={1}>
+        {contextFields.map((field) => (
+          <InlineFieldView
+            key={field.id}
+            field={field}
+            active={activeInputId === field.id}
+            focused={focused}
+            width={contextFieldWidth}
+            onFocus={() => activateInput(field.id)}
+          />
+        ))}
+        {bankrollOverride != null || currentValueOverride != null ? (
+          <Text fg={colors.textMuted}> override</Text>
+        ) : null}
+      </Box>
+
+      <Box height={1} paddingX={1}>
+        <Tabs
+          tabs={KELLY_MODES.map((entry) => ({ label: entry.label, value: entry.id }))}
+          activeValue={mode}
+          onSelect={(nextMode) => {
+            setMode(nextMode as KellySizingMode);
+            setSelectedFieldIndex(0);
+            activateInput(null);
+          }}
+          compact
+          focused={focused && !activeInputId}
+        />
+      </Box>
+
+      <Box flexDirection="column" paddingX={1} height={commonRows}>
+        {Array.from({ length: commonRows }, (_, rowIndex) => (
+          <Box key={rowIndex} height={1} flexDirection="row">
+            {commonFields.slice(rowIndex * commonColumns, rowIndex * commonColumns + commonColumns).map((field, offset) => {
+              const index = rowIndex * commonColumns + offset;
+              return (
+                <InlineFieldView
+                  key={field.id}
+                  field={field}
+                  active={activeInputId === field.id}
+                  focused={focused}
+                  width={commonFieldWidth}
+                  onFocus={() => activateInput(field.id, index)}
+                />
+              );
+            })}
+          </Box>
+        ))}
+      </Box>
+
+      <Box flexDirection="column" paddingX={1} height={fieldsRows}>
+        {Array.from({ length: fieldsRows }, (_, rowIndex) => (
+          <Box key={rowIndex} height={1} flexDirection="row">
+            {fields.slice(rowIndex * fieldColumns, rowIndex * fieldColumns + fieldColumns).map((field, offset) => {
+              const index = rowIndex * fieldColumns + offset;
+              return (
+                <InlineFieldView
+                  key={field.id}
+                  field={field}
+                  active={activeInputId === field.id}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={() => activateInput(field.id, commonFields.length + index)}
+                />
+              );
+            })}
+          </Box>
+        ))}
+      </Box>
+
+      <KellyResultMetrics
+        result={result}
+        activeDraft={activeDraft}
+        baseCurrency={config.baseCurrency}
+        leftWidth={leftMetricsWidth}
+        rightWidth={rightMetricsWidth}
+      />
+
+      {showChart && (
+        <KellyCurveSection
+          width={width}
+          height={chartHeight}
+          points={curvePoints}
+          xAxisLabels={curveXAxisLabels}
+          curveMaxFraction={curveMaxFraction}
+          markers={curveMarkers}
+          result={result}
+          currentGrowth={currentGrowth}
+          targetGrowth={targetGrowth}
+          baseCurrency={config.baseCurrency}
+        />
+      )}
+
+      {showSensitivity && (
+        <KellySensitivitySection width={width} sensitivity={sensitivity} />
+      )}
+    </Box>
+  );
+}

--- a/src/plugins/builtin/kelly-sizer/portfolio.ts
+++ b/src/plugins/builtin/kelly-sizer/portfolio.ts
@@ -1,0 +1,71 @@
+import type { AppConfig } from "../../../types/config";
+import type { TickerFinancials } from "../../../types/financials";
+import type { TickerRecord } from "../../../types/ticker";
+import { getActiveQuoteDisplay } from "../../../market-data/market/status";
+import { convertCurrency } from "../../../utils/format";
+import { getCollectionTypeFromConfig } from "../portfolio-list/pane/data";
+import { getPortfolioPositionMetrics, resolveBrokerFallbackMarketValue } from "../portfolio-list/position-metrics";
+
+export function getPortfolioPositionValue({
+  ticker,
+  financials,
+  portfolioId,
+  baseCurrency,
+  exchangeRates,
+}: {
+  ticker: TickerRecord | null;
+  financials: TickerFinancials | null;
+  portfolioId: string | null;
+  baseCurrency: string;
+  exchangeRates: Map<string, number>;
+}): number {
+  if (!ticker) return 0;
+  const scopedTicker: TickerRecord = portfolioId
+    ? {
+        ...ticker,
+        metadata: {
+          ...ticker.metadata,
+          positions: ticker.metadata.positions.filter((position) => position.portfolio === portfolioId),
+        },
+      }
+    : ticker;
+  const quote = financials?.quote;
+  const activeQuote = getActiveQuoteDisplay(quote);
+  const quoteCurrency = quote?.currency || ticker.metadata.currency || baseCurrency;
+  const metrics = getPortfolioPositionMetrics(scopedTicker, undefined, quoteCurrency);
+
+  if (activeQuote && metrics.totalPriceUnits !== 0) {
+    return convertCurrency(Math.abs(metrics.totalPriceUnits) * activeQuote.price, quoteCurrency, baseCurrency, exchangeRates);
+  }
+
+  const brokerFallback = resolveBrokerFallbackMarketValue(metrics);
+  const positionCurrency = metrics.positionCurrency || quoteCurrency;
+  return convertCurrency(Math.abs(brokerFallback ?? metrics.totalCost), positionCurrency, baseCurrency, exchangeRates);
+}
+
+export function resolveActivePortfolioId({
+  requestedPortfolioId,
+  activeCollectionId,
+  symbol,
+  ticker,
+  config,
+}: {
+  requestedPortfolioId?: string | null;
+  activeCollectionId: string | null;
+  symbol: string | null;
+  ticker: TickerRecord | null;
+  config: AppConfig;
+}): string | null {
+  if (requestedPortfolioId && config.portfolios.some((portfolio) => portfolio.id === requestedPortfolioId)) {
+    return requestedPortfolioId;
+  }
+  if (activeCollectionId && getCollectionTypeFromConfig(config, activeCollectionId) === "portfolio") {
+    return activeCollectionId;
+  }
+  if (ticker) {
+    const positionPortfolio = ticker.metadata.positions.find((position) => position.portfolio)?.portfolio;
+    if (positionPortfolio) return positionPortfolio;
+    if (ticker.metadata.portfolios[0]) return ticker.metadata.portfolios[0];
+  }
+  return symbol ? config.portfolios[0]?.id ?? null : null;
+}

--- a/src/plugins/builtin/kelly-sizer/sections.tsx
+++ b/src/plugins/builtin/kelly-sizer/sections.tsx
@@ -1,0 +1,142 @@
+import { Box, Text, TextAttributes } from "../../../ui";
+import { StaticChartSurface } from "../../../components";
+import { resolveChartPalette } from "../../../components/chart/core/renderer";
+import type { StaticChartXMarker } from "../../../components/chart/static/chart/surface";
+import { colors, priceColor } from "../../../theme/colors";
+import { formatCompact, formatCurrency, formatNumber } from "../../../utils/format";
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import type { KellySizerDraft, KellySizingResult, SensitivityGrid } from "./model";
+import {
+  KellyCurveDecisionView,
+  MetricLine,
+  SensitivityGridView,
+  formatPct,
+  formatSignedPct,
+} from "./view";
+
+export function KellyResultMetrics({
+  result,
+  activeDraft,
+  baseCurrency,
+  leftWidth,
+  rightWidth,
+}: {
+  result: KellySizingResult;
+  activeDraft: KellySizerDraft;
+  baseCurrency: string;
+  leftWidth: number;
+  rightWidth: number;
+}) {
+  return (
+    <Box flexDirection="row" paddingX={1}>
+      <Box flexDirection="column" width={leftWidth}>
+        <MetricLine width={leftWidth} label="Full Kelly" value={formatPct(result.fullKellyFraction, 1)} />
+        <MetricLine width={leftWidth} label="Fractional" value={formatPct(result.fractionalKellyFraction, 1)} detail={formatPct(activeDraft.kellyFraction, 0)} />
+        <MetricLine
+          width={leftWidth}
+          label="Clipped"
+          value={formatPct(result.clippedFraction, 2)}
+          detail={result.clipReasons.length > 0 ? result.clipReasons.join(", ") : undefined}
+          color={result.clipReasons.length > 0 ? colors.positive : colors.text}
+        />
+        <MetricLine width={leftWidth} label="Target val" value={formatCurrency(result.targetValue, baseCurrency)} />
+        <MetricLine
+          width={leftWidth}
+          label="Add / trim"
+          value={formatCurrency(result.addTrimValue, baseCurrency)}
+          color={priceColor(result.addTrimValue)}
+        />
+        <MetricLine
+          width={leftWidth}
+          label="Units"
+          value={result.estimatedUnits == null ? "—" : formatNumber(result.estimatedUnits, 1)}
+        />
+      </Box>
+      <Box flexDirection="column" width={rightWidth}>
+        <MetricLine width={rightWidth} label="Risk" value={formatCurrency(result.riskValue, baseCurrency)} detail={formatPct(result.riskFraction, 2)} color={colors.negative} />
+        <MetricLine width={rightWidth} label="Worst loss" value={formatPct(result.downsideLossFraction, 1)} />
+        <MetricLine width={rightWidth} label="Current %" value={formatPct(result.currentFraction, 1)} />
+        <MetricLine width={rightWidth} label="Exp return" value={formatSignedPct(result.expectedReturn)} color={priceColor(result.expectedReturn)} />
+        <MetricLine width={rightWidth} label="Log growth" value={formatCompact(result.expectedLogGrowth)} />
+      </Box>
+    </Box>
+  );
+}
+
+export function KellyCurveSection({
+  width,
+  height,
+  points,
+  xAxisLabels,
+  curveMaxFraction,
+  markers,
+  result,
+  currentGrowth,
+  targetGrowth,
+  baseCurrency,
+}: {
+  width: number;
+  height: number;
+  points: ProjectedChartPoint[];
+  xAxisLabels: string[];
+  curveMaxFraction: number;
+  markers: StaticChartXMarker[];
+  result: KellySizingResult;
+  currentGrowth: number;
+  targetGrowth: number;
+  baseCurrency: string;
+}) {
+  return (
+    <>
+      <Box height={1} paddingX={1}>
+        <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>Kelly Curve</Text>
+      </Box>
+      <Box paddingX={1} height={height}>
+        <StaticChartSurface
+          points={points}
+          width={Math.max(10, width - 2)}
+          height={height}
+          mode="line"
+          axisMode="percent"
+          colors={resolveChartPalette(colors, "positive")}
+          yAxisLabel="Expected log growth"
+          yAxisColor={colors.textDim}
+          formatYAxisValue={(value) => formatSignedPct(value)}
+          xAxisLabels={xAxisLabels}
+          xAxisColor={colors.textDim}
+          formatXAxisCursorValue={(ratio) => formatPct(curveMaxFraction * ratio, 1)}
+          xMarkers={markers}
+        />
+      </Box>
+      <KellyCurveDecisionView
+        width={Math.max(10, width - 2)}
+        currentFraction={result.currentFraction}
+        targetFraction={result.clippedFraction}
+        fullKellyFraction={result.fullKellyFraction}
+        currentGrowth={currentGrowth}
+        targetGrowth={targetGrowth}
+        addTrimValue={result.addTrimValue}
+        currency={baseCurrency}
+        clipReasons={result.clipReasons}
+      />
+    </>
+  );
+}
+
+export function KellySensitivitySection({
+  width,
+  sensitivity,
+}: {
+  width: number;
+  sensitivity: SensitivityGrid;
+}) {
+  return (
+    <>
+      <Box height={1} paddingX={1} flexDirection="row">
+        <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>Sensitivity</Text>
+        <Text fg={colors.textDim}>{`  ${sensitivity.columnLabel}`}</Text>
+      </Box>
+      <SensitivityGridView width={Math.max(10, width - 2)} grid={sensitivity} />
+    </>
+  );
+}

--- a/src/plugins/builtin/kelly-sizer/state.ts
+++ b/src/plugins/builtin/kelly-sizer/state.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePaneStateValue } from "../../../state/app/context";
+import { usePluginConfigState } from "../../runtime";
+import { COMMON_ASSUMPTIONS_STATE_KEY } from "./constants";
+import {
+  DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  normalizeKellyCommonAssumptions,
+  type KellyCommonAssumptions,
+  type KellySizerDraft,
+} from "./model";
+
+export function useKellyCommonAssumptions(rawActiveDraft: KellySizerDraft): {
+  commonAssumptions: KellyCommonAssumptions;
+  updateCommon: (patch: Partial<KellyCommonAssumptions>) => void;
+} {
+  const commonFallback = useMemo(
+    () => normalizeKellyCommonAssumptions(rawActiveDraft, DEFAULT_KELLY_COMMON_ASSUMPTIONS),
+    [rawActiveDraft],
+  );
+  const [storedCommonAssumptions, setStoredCommonAssumptions] = usePluginConfigState<KellyCommonAssumptions>(
+    COMMON_ASSUMPTIONS_STATE_KEY,
+    commonFallback,
+  );
+  const [paneCommonAssumptions, setPaneCommonAssumptions] = usePaneStateValue<KellyCommonAssumptions | null>(
+    COMMON_ASSUMPTIONS_STATE_KEY,
+    null,
+  );
+  const seededCommonAssumptions = useMemo(
+    () => normalizeKellyCommonAssumptions(storedCommonAssumptions, commonFallback),
+    [commonFallback, storedCommonAssumptions],
+  );
+  const [localCommonAssumptions, setLocalCommonAssumptions] = useState<KellyCommonAssumptions | null>(null);
+
+  useEffect(() => {
+    if (paneCommonAssumptions === null) {
+      setPaneCommonAssumptions(seededCommonAssumptions);
+    }
+  }, [paneCommonAssumptions, seededCommonAssumptions, setPaneCommonAssumptions]);
+
+  useEffect(() => {
+    if (localCommonAssumptions !== null) return;
+    setLocalCommonAssumptions(normalizeKellyCommonAssumptions(
+      paneCommonAssumptions ?? seededCommonAssumptions,
+      seededCommonAssumptions,
+    ));
+  }, [localCommonAssumptions, paneCommonAssumptions, seededCommonAssumptions]);
+
+  const commonAssumptions = useMemo(
+    () => normalizeKellyCommonAssumptions(
+      localCommonAssumptions ?? paneCommonAssumptions ?? seededCommonAssumptions,
+      seededCommonAssumptions,
+    ),
+    [localCommonAssumptions, paneCommonAssumptions, seededCommonAssumptions],
+  );
+
+  const updateCommon = useCallback((patch: Partial<KellyCommonAssumptions>) => {
+    const next = normalizeKellyCommonAssumptions({
+      ...commonAssumptions,
+      ...patch,
+    }, commonAssumptions);
+    setLocalCommonAssumptions(next);
+    setPaneCommonAssumptions(next);
+    setStoredCommonAssumptions(next);
+  }, [commonAssumptions, setPaneCommonAssumptions, setStoredCommonAssumptions]);
+
+  return { commonAssumptions, updateCommon };
+}

--- a/src/plugins/builtin/kelly-sizer/test-support.tsx
+++ b/src/plugins/builtin/kelly-sizer/test-support.tsx
@@ -1,0 +1,174 @@
+import { useReducer, type ReactElement } from "react";
+import {
+  AppContext,
+  appReducer,
+  createInitialState,
+  PaneInstanceProvider,
+} from "../../../state/app/context";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { cloneLayout, createDefaultConfig, type AppConfig } from "../../../types/config";
+import type { TickerFinancials } from "../../../types/financials";
+import type { TickerRecord } from "../../../types/ticker";
+import type { BrokerAccount } from "../../../types/trading";
+import { PluginRenderProvider } from "../../runtime";
+import { kellySizerPlugin } from "./index";
+
+export const TEST_PANE_ID = "kelly-sizer:test";
+
+const KellySizerPane = kellySizerPlugin.panes![0]!.component as (props: {
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+}) => ReactElement;
+
+export function createSizerConfig(symbol = "AAPL"): AppConfig {
+  const baseConfig = createDefaultConfig("/tmp/gloomberb-kelly-sizer");
+  const layout: AppConfig["layout"] = {
+    dockRoot: { kind: "pane", instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "kelly-sizer",
+      binding: { kind: "none" },
+      params: { symbol },
+    }],
+    floating: [],
+    detached: [],
+  };
+
+  return {
+    ...baseConfig,
+    brokerInstances: [{
+      id: "ibkr-flex",
+      brokerType: "ibkr",
+      label: "IBKR Flex",
+      config: {},
+    }],
+    portfolios: [{
+      id: "main",
+      name: "Main Portfolio",
+      currency: "USD",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-flex",
+      brokerAccountId: "DU12345",
+    }],
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  };
+}
+
+export function createTicker({
+  symbol = "AAPL",
+  currency = "USD",
+  positions,
+}: {
+  symbol?: string;
+  currency?: string;
+  positions?: TickerRecord["metadata"]["positions"];
+} = {}): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency,
+      name: symbol === "AAPL" ? "Apple" : symbol,
+      sector: "Technology",
+      portfolios: ["main"],
+      watchlists: [],
+      positions: positions ?? [{
+        portfolio: "main",
+        shares: 20,
+        avgCost: 180,
+        currency,
+        broker: "ibkr",
+        brokerInstanceId: "ibkr-flex",
+        brokerAccountId: "DU12345",
+        marketValue: 4_000,
+        unrealizedPnl: 400,
+      }],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+export function createFinancials({
+  symbol = "AAPL",
+  price = 200,
+  currency = "USD",
+}: {
+  symbol?: string;
+  price?: number;
+  currency?: string;
+} = {}): TickerFinancials {
+  return {
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: [],
+    quote: {
+      symbol,
+      price,
+      currency,
+      change: price * 0.01,
+      changePercent: 1,
+      previousClose: price * 0.99,
+      lastUpdated: Date.now(),
+    },
+  };
+}
+
+function createBrokerAccount(): BrokerAccount {
+  return {
+    accountId: "DU12345",
+    name: "DU12345",
+    currency: "USD",
+    source: "flex",
+    updatedAt: Date.now(),
+    totalCashValue: 20_000,
+    netLiquidation: 100_000,
+    dailyPnl: 0,
+    unrealizedPnl: 400,
+    cashBalances: [],
+  };
+}
+
+export function KellySizerHarness({
+  config = createSizerConfig(),
+  ticker = createTicker(),
+  financials = createFinancials({ symbol: ticker.metadata.ticker, currency: ticker.metadata.currency }),
+  exchangeRates,
+  paneState,
+}: {
+  config?: AppConfig;
+  ticker?: TickerRecord;
+  financials?: TickerFinancials;
+  exchangeRates?: Map<string, number>;
+  paneState?: Record<string, unknown>;
+}) {
+  const initialState = createInitialState(config);
+  initialState.focusedPaneId = TEST_PANE_ID;
+  if (paneState) initialState.paneState[TEST_PANE_ID] = paneState;
+  initialState.tickers = new Map([[ticker.metadata.ticker, ticker]]);
+  initialState.financials = new Map([[ticker.metadata.ticker, financials]]);
+  if (exchangeRates) initialState.exchangeRates = exchangeRates;
+  initialState.brokerAccounts = { "ibkr-flex": [createBrokerAccount()] };
+
+  const [state, dispatch] = useReducer(appReducer, initialState);
+
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <PluginRenderProvider pluginId={kellySizerPlugin.id} runtime={createTestPluginRuntime()}>
+          <KellySizerPane
+            paneId={TEST_PANE_ID}
+            paneType="kelly-sizer"
+            focused
+            width={100}
+            height={30}
+          />
+        </PluginRenderProvider>
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}

--- a/src/plugins/builtin/kelly-sizer/types.ts
+++ b/src/plugins/builtin/kelly-sizer/types.ts
@@ -1,0 +1,156 @@
+export type KellySizingMode =
+  | "binary"
+  | "scenario"
+  | "risk-budget"
+  | "prediction-market"
+  | "asymmetric";
+
+export interface KellyCommonAssumptions {
+  kellyFraction: number;
+  maxNameFraction: number;
+  maxLossFraction: number;
+}
+
+export interface BinaryKellyAssumptions extends KellyCommonAssumptions {
+  winProbability: number;
+  upsideReturn: number;
+  downsideReturn: number;
+}
+
+export interface ScenarioKellyOutcome {
+  id: string;
+  label: string;
+  probability: number;
+  returnPct: number;
+}
+
+export interface ScenarioKellyAssumptions extends KellyCommonAssumptions {
+  outcomes: ScenarioKellyOutcome[];
+}
+
+export interface RiskBudgetKellyAssumptions extends KellyCommonAssumptions {
+  riskBudgetFraction: number;
+  downsideReturn: number;
+  winProbability: number;
+  upsideReturn: number;
+}
+
+export interface PredictionMarketKellyAssumptions extends KellyCommonAssumptions {
+  estimatedProbability: number;
+  marketPrice: number;
+  side: "yes" | "no";
+}
+
+export interface AsymmetricKellyAssumptions extends KellyCommonAssumptions {
+  winProbability: number;
+  targetReturn: number;
+  maxLossReturn: number;
+}
+
+export interface KellySizerModeDrafts {
+  binary: BinaryKellyAssumptions;
+  scenario: ScenarioKellyAssumptions;
+  "risk-budget": RiskBudgetKellyAssumptions;
+  "prediction-market": PredictionMarketKellyAssumptions;
+  asymmetric: AsymmetricKellyAssumptions;
+}
+
+export type KellySizerDraft = KellySizerModeDrafts[KellySizingMode];
+
+export interface KellyOutcome {
+  probability: number;
+  returnPct: number;
+}
+
+export interface KellySolveResult {
+  fraction: number;
+  expectedReturn: number;
+  expectedLogGrowth: number;
+  warning?: string;
+}
+
+export interface KellySizingResult {
+  mode: KellySizingMode;
+  bankroll: number;
+  currentValue: number;
+  currentFraction: number;
+  price: number | null;
+  fullKellyFraction: number;
+  fractionalKellyFraction: number;
+  unclippedFraction: number;
+  clippedFraction: number;
+  targetValue: number;
+  addTrimValue: number;
+  estimatedUnits: number | null;
+  downsideLossFraction: number;
+  riskValue: number;
+  riskFraction: number;
+  expectedReturn: number;
+  expectedLogGrowth: number;
+  warnings: string[];
+  clipReasons: string[];
+  recommendationLabel: string;
+}
+
+export interface SensitivityGridCell {
+  fraction: number | null;
+  text: string;
+}
+
+export interface SensitivityGrid {
+  rowLabel: string;
+  columnLabel: string;
+  rows: string[];
+  columns: string[];
+  cells: SensitivityGridCell[][];
+}
+
+export const KELLY_MODES: Array<{ id: KellySizingMode; label: string }> = [
+  { id: "binary", label: "Binary" },
+  { id: "scenario", label: "Scenario" },
+  { id: "risk-budget", label: "Risk" },
+  { id: "prediction-market", label: "Market" },
+  { id: "asymmetric", label: "Asym" },
+];
+
+export const DEFAULT_KELLY_COMMON_ASSUMPTIONS: KellyCommonAssumptions = {
+  kellyFraction: 0.25,
+  maxNameFraction: 0.08,
+  maxLossFraction: 0.01,
+};
+
+export const DEFAULT_KELLY_DRAFTS: KellySizerModeDrafts = {
+  binary: {
+    winProbability: 0.57,
+    upsideReturn: 0.24,
+    downsideReturn: -0.09,
+    ...DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  },
+  scenario: {
+    outcomes: [
+      { id: "bear", label: "Bear", probability: 0.25, returnPct: -0.12 },
+      { id: "base", label: "Base", probability: 0.45, returnPct: 0.08 },
+      { id: "bull", label: "Bull", probability: 0.30, returnPct: 0.28 },
+    ],
+    ...DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  },
+  "risk-budget": {
+    riskBudgetFraction: 0.01,
+    downsideReturn: -0.09,
+    winProbability: 0.57,
+    upsideReturn: 0.24,
+    ...DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  },
+  "prediction-market": {
+    estimatedProbability: 0.57,
+    marketPrice: 0.48,
+    side: "yes",
+    ...DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  },
+  asymmetric: {
+    winProbability: 0.42,
+    targetReturn: 1.5,
+    maxLossReturn: -1,
+    ...DEFAULT_KELLY_COMMON_ASSUMPTIONS,
+  },
+};

--- a/src/plugins/builtin/kelly-sizer/view.test.tsx
+++ b/src/plugins/builtin/kelly-sizer/view.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useState, type Dispatch, type SetStateAction } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { InlineFieldView } from "./view";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let setFieldActive: Dispatch<SetStateAction<boolean>> | null = null;
+
+afterEach(async () => {
+  setFieldActive = null;
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+function InlineFieldHarness({ commits }: { commits: number[] }) {
+  const [active, setActive] = useState(false);
+  const [value, setValue] = useState(0.01);
+  setFieldActive = setActive;
+
+  return (
+    <InlineFieldView
+      field={{
+        id: "loss-cap",
+        label: "Loss cap",
+        value,
+        percent: true,
+        onValue: (nextValue) => {
+          commits.push(nextValue);
+          setValue(nextValue);
+        },
+      }}
+      active={active}
+      focused
+      width={30}
+      onFocus={() => setActive(true)}
+    />
+  );
+}
+
+describe("InlineFieldView", () => {
+  test("replaces the formatted value and commits when focus leaves the active field", async () => {
+    const commits: number[] = [];
+    testSetup = await testRender(<InlineFieldHarness commits={commits} />, { width: 36, height: 4 });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      setFieldActive?.(true);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("2");
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      setFieldActive?.(false);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(commits.at(-1)).toBeCloseTo(0.02);
+    expect(testSetup.captureCharFrame()).toContain("2.00");
+  });
+});

--- a/src/plugins/builtin/kelly-sizer/view.tsx
+++ b/src/plugins/builtin/kelly-sizer/view.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Box, Text, TextAttributes, type InputRenderable } from "../../../ui";
+import type { KeyEventLike } from "../../../react/input";
+import { colors } from "../../../theme/colors";
+import { NumberField } from "../../../components/ui";
+import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { isPlainKey } from "../../../utils/keyboard";
+import type { SensitivityGrid } from "./model";
+import type { InlineField } from "./fields";
+export type { InlineField } from "./fields";
+
+export function truncateText(value: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (value.length <= maxWidth) return value;
+  if (maxWidth <= 1) return value.slice(0, maxWidth);
+  return `${value.slice(0, maxWidth - 1)}…`;
+}
+
+export function formatPct(value: number, decimals = 1): string {
+  return `${formatNumber(value * 100, decimals)}%`;
+}
+
+export function formatSignedPct(value: number): string {
+  return formatPercentRaw(value * 100);
+}
+
+export function isPlainShortcut(event: KeyEventLike, ...names: string[]): boolean {
+  if (isPlainKey(event, ...names)) return true;
+  const key = event.key?.toLowerCase();
+  return !event.ctrl && !event.meta && !event.super && !event.alt && names.includes(key);
+}
+
+function parsePromptNumber(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatInputNumber(value: number, percent = false): string {
+  const scaled = percent ? value * 100 : value;
+  const decimals = percent
+    ? Math.abs(scaled) >= 10 ? 1 : 2
+    : Math.abs(scaled) >= 100 ? 0 : 2;
+  return formatNumber(scaled, decimals).replace(/,/g, "");
+}
+
+export function InlineFieldView({
+  field,
+  active,
+  width,
+  focused,
+  onFocus,
+}: {
+  field: InlineField;
+  active: boolean;
+  width: number;
+  focused: boolean;
+  onFocus: () => void;
+}) {
+  const labelWidth = Math.min(12, Math.max(7, Math.floor(width * 0.38)));
+  const suffixWidth = field.suffix ? field.suffix.length + 1 : field.percent ? 2 : 0;
+  const valueWidth = Math.max(5, width - labelWidth - suffixWidth - 2);
+  const inputNodeRef = useRef<InputRenderable | null>(null);
+  const displayValue = field.valueText ?? formatInputNumber(field.value ?? 0, field.percent);
+  const fieldRef = useRef(field);
+  const displayValueRef = useRef(displayValue);
+  const [text, setText] = useState(displayValue);
+  const latestTextRef = useRef(displayValue);
+  const committedTextRef = useRef(displayValue);
+  const wasActiveRef = useRef(active);
+  const dirtyRef = useRef(false);
+  fieldRef.current = field;
+  displayValueRef.current = displayValue;
+  const focusInput = useCallback(() => {
+    const input = inputNodeRef.current;
+    try {
+      input?.focus?.();
+      input?.setCursorOffset?.(0);
+    } catch {
+      // Renderer teardown can race queued focus attempts.
+    }
+  }, []);
+  const fg = active
+    ? colors.selectedText
+    : field.tone === "positive"
+      ? colors.positive
+      : field.tone === "negative"
+        ? colors.negative
+        : colors.text;
+
+  const commitText = useCallback((nextText: string): string | null => {
+    const currentField = fieldRef.current;
+    if (nextText.trim() === "") {
+      currentField.onClear?.();
+      return null;
+    }
+    const parsed = parsePromptNumber(nextText);
+    if (parsed == null) return null;
+    const nextValue = currentField.percent ? parsed / 100 : parsed;
+    currentField.onValue?.(nextValue);
+    return formatInputNumber(nextValue, currentField.percent);
+  }, []);
+
+  const commitEditText = useCallback((nextText: string, fallbackText = displayValue) => {
+    latestTextRef.current = nextText;
+    const committedText = commitText(nextText);
+    committedTextRef.current = committedText ?? fallbackText;
+    setText(committedTextRef.current);
+    dirtyRef.current = false;
+  }, [commitText, displayValue]);
+
+  const getLiveInputText = useCallback(() => {
+    const input = inputNodeRef.current;
+    if (!input) return latestTextRef.current;
+    try {
+      return input.editBuffer.getText();
+    } catch {
+      return latestTextRef.current;
+    }
+  }, []);
+
+  const commitLiveInputText = useCallback(() => {
+    const liveText = getLiveInputText();
+    const nextText = typeof liveText === "string" ? liveText : latestTextRef.current;
+    if (!dirtyRef.current && (nextText.trim() === "" || nextText === committedTextRef.current)) return;
+    latestTextRef.current = nextText;
+    const committedText = commitText(nextText);
+    committedTextRef.current = committedText ?? displayValueRef.current;
+    dirtyRef.current = false;
+  }, [commitText, getLiveInputText]);
+
+  useLayoutEffect(() => {
+    const wasActive = wasActiveRef.current;
+    wasActiveRef.current = active;
+    if (!wasActive && active) {
+      dirtyRef.current = false;
+      latestTextRef.current = "";
+      committedTextRef.current = displayValue;
+      setText("");
+      return;
+    }
+    if (wasActive && !active) {
+      const nextText = dirtyRef.current ? latestTextRef.current : text;
+      if (dirtyRef.current) {
+        commitEditText(nextText);
+      } else {
+        committedTextRef.current = displayValue;
+        setText(displayValue);
+      }
+      return;
+    }
+    if (!active) {
+      latestTextRef.current = displayValue;
+      committedTextRef.current = displayValue;
+      setText(displayValue);
+    }
+  }, [active, commitEditText, displayValue, text]);
+
+  useEffect(() => {
+    if (!active) return;
+    let animationFrame: number | null = null;
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+    focusInput();
+    queueMicrotask(focusInput);
+    animationFrame = globalThis.requestAnimationFrame?.(focusInput) ?? null;
+    timeouts.push(setTimeout(focusInput, 0), setTimeout(focusInput, 32));
+    return () => {
+      if (animationFrame !== null) globalThis.cancelAnimationFrame?.(animationFrame);
+      for (const timeout of timeouts) clearTimeout(timeout);
+    };
+  }, [active, focusInput]);
+
+  useLayoutEffect(() => {
+    if (!active) return;
+    return () => {
+      commitLiveInputText();
+    };
+  }, [active, commitLiveInputText]);
+
+  const handleSubmit = (nextText: string) => {
+    commitEditText(nextText, nextText);
+  };
+
+  const handleBlur = (nextText: string) => {
+    if (!dirtyRef.current && (nextText.trim() === "" || nextText === committedTextRef.current)) return;
+    commitEditText(nextText, nextText);
+  };
+
+  if (field.onPress && !field.onValue) {
+    return (
+      <Box
+        width={width}
+        height={1}
+        flexDirection="row"
+        backgroundColor={active ? colors.selected : colors.panel}
+        data-gloom-field-id={field.id}
+        onMouseDown={() => {
+          onFocus();
+          field.onPress?.();
+        }}
+      >
+        <Text fg={active ? colors.selectedText : colors.textDim}>
+          {truncateText(field.label, labelWidth).padEnd(labelWidth)}
+        </Text>
+        <Text fg={fg} attributes={active ? TextAttributes.BOLD : 0}>
+          {truncateText(field.valueText ?? "", Math.max(1, width - labelWidth))}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      width={width}
+      height={1}
+      flexDirection="row"
+      backgroundColor={active ? colors.selected : colors.panel}
+      data-gloom-field-id={field.id}
+      onMouseDown={() => {
+        onFocus();
+        focusInput();
+      }}
+    >
+      <Text fg={active ? colors.selectedText : colors.textDim}>
+        {truncateText(field.label, labelWidth).padEnd(labelWidth)}
+      </Text>
+      {active ? (
+        <NumberField
+          inputRef={inputNodeRef}
+          focused={active}
+          value={text}
+          placeholder={displayValue}
+          allowNegative={field.allowNegative}
+          allowDecimal
+          width={valueWidth}
+          variant="plain"
+          backgroundColor={colors.selected}
+          textColor={fg}
+          placeholderColor={colors.textMuted}
+          onMouseDown={onFocus}
+          onChange={(nextText) => {
+            dirtyRef.current = true;
+            latestTextRef.current = nextText;
+            setText(nextText);
+          }}
+          onSubmit={handleSubmit}
+          onBlur={handleBlur}
+        />
+      ) : (
+        <Box width={valueWidth} height={1} onMouseDown={() => {
+          onFocus();
+          focusInput();
+        }}>
+          <Text fg={fg}>{truncateText(displayValue, valueWidth)}</Text>
+        </Box>
+      )}
+      {suffixWidth > 0 && (
+        <Text fg={active ? colors.selectedText : colors.textDim}>
+          {field.suffix ?? (field.percent ? "%" : "")}
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+export function MetricLine({
+  label,
+  value,
+  detail,
+  color,
+  width,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  color?: string;
+  width: number;
+}) {
+  const labelWidth = Math.min(12, Math.max(8, Math.floor(width * 0.32)));
+  const valueWidth = Math.min(Math.max(8, width - labelWidth), Math.max(8, Math.floor(width * 0.42)));
+  const detailWidth = Math.max(0, width - labelWidth - valueWidth);
+  return (
+    <Box height={1} width={width} flexDirection="row" overflow="hidden">
+      <Box width={labelWidth} flexShrink={0}>
+        <Text fg={colors.textDim}>{label}</Text>
+      </Box>
+      <Box width={valueWidth} flexShrink={0}>
+        <Text fg={color ?? colors.text} attributes={TextAttributes.BOLD}>
+          {truncateText(value, valueWidth)}
+        </Text>
+      </Box>
+      {detail && detailWidth > 0 && (
+        <Text fg={colors.textDim}>{truncateText(detail, detailWidth)}</Text>
+      )}
+    </Box>
+  );
+}
+
+export function SensitivityGridView({
+  width,
+  grid,
+}: {
+  width: number;
+  grid: SensitivityGrid;
+}) {
+  const labelWidth = 9;
+  const cellWidth = Math.max(8, Math.floor((width - labelWidth) / Math.max(1, grid.columns.length)));
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box height={1} flexDirection="row">
+        <Box width={labelWidth}>
+          <Text fg={colors.textDim}>{truncateText(grid.rowLabel, labelWidth)}</Text>
+        </Box>
+        {grid.columns.map((column) => (
+          <Box key={column} width={cellWidth}>
+            <Text fg={colors.textDim}>{truncateText(column, cellWidth - 1).padStart(cellWidth - 1)}</Text>
+          </Box>
+        ))}
+      </Box>
+      {grid.rows.map((row, rowIndex) => (
+        <Box key={row} height={1} flexDirection="row">
+          <Box width={labelWidth}>
+            <Text fg={colors.textDim}>{truncateText(row, labelWidth)}</Text>
+          </Box>
+          {grid.cells[rowIndex]?.map((cell, cellIndex) => (
+            <Box key={`${row}:${cellIndex}`} width={cellWidth}>
+              <Text fg={colors.text}>{truncateText(cell.text, cellWidth - 1).padStart(cellWidth - 1)}</Text>
+            </Box>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export function buildKellyCurveXAxisLabels(maxFraction: number): string[] {
+  if (!Number.isFinite(maxFraction) || maxFraction <= 0) return [];
+  return [0, 0.25, 0.5, 0.75, 1].map((ratio) => formatPct(maxFraction * ratio, 0));
+}
+
+export function KellyCurveDecisionView({
+  width,
+  currentFraction,
+  targetFraction,
+  fullKellyFraction,
+  currentGrowth,
+  targetGrowth,
+  addTrimValue,
+  currency,
+  clipReasons,
+}: {
+  width: number;
+  currentFraction: number;
+  targetFraction: number;
+  fullKellyFraction: number;
+  currentGrowth: number;
+  targetGrowth: number;
+  addTrimValue: number;
+  currency: string;
+  clipReasons: string[];
+}) {
+  const moveLabel = addTrimValue >= 0 ? "add" : "trim";
+  const capLabel = clipReasons.length > 0 ? `cap ${clipReasons.join(", ")}` : "cap none";
+  const text = [
+    `${formatPct(currentFraction, 1)} -> ${formatPct(targetFraction, 1)}`,
+    `${moveLabel} ${formatCurrency(Math.abs(addTrimValue), currency)}`,
+    `growth ${formatSignedPct(currentGrowth)} -> ${formatSignedPct(targetGrowth)}`,
+    `full ${formatPct(fullKellyFraction, 0)}`,
+    capLabel,
+  ].join("  ");
+  return (
+    <Box height={1} paddingX={1}>
+      <Text fg={colors.textDim}>{truncateText(text, Math.max(1, width - 2))}</Text>
+    </Box>
+  );
+}

--- a/src/plugins/catalog-ui.ts
+++ b/src/plugins/catalog-ui.ts
@@ -12,6 +12,7 @@ import { layoutManagerPlugin } from "./builtin/layout-manager";
 import { predictionMarketsPlugin } from "./prediction-markets";
 import { analyticsPlugin } from "./builtin/analytics";
 import { alertsPlugin } from "./builtin/alerts";
+import { kellySizerPlugin } from "./builtin/kelly-sizer";
 import {
   brokerPlugin,
   macroPlugin,
@@ -36,6 +37,7 @@ export const uiBuiltinPlugins: GloomPlugin[] = [
   marketOverviewPlugin,
   macroPlugin,
   analyticsPlugin,
+  kellySizerPlugin,
   alertsPlugin,
 ];
 

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -84,6 +84,7 @@ export function WebTextField({
   inputRef,
   onChange,
   onSubmit,
+  onBlur,
   hint,
   type = "text",
   variant = "default",
@@ -155,7 +156,12 @@ export function WebTextField({
           }}
           onInput={onChange}
           onChange={onChange}
-          onSubmit={() => onSubmit?.(value ?? resolvedInputRef.current?.editBuffer.getText() ?? "")}
+          onSubmit={(nextValue?: string) => onSubmit?.(
+            typeof nextValue === "string" ? nextValue : resolvedInputRef.current?.editBuffer.getText() ?? value ?? "",
+          )}
+          onBlur={(nextValue?: string) => onBlur?.(
+            typeof nextValue === "string" ? nextValue : resolvedInputRef.current?.editBuffer.getText() ?? value ?? "",
+          )}
         />
       </Box>
       {hint && (
@@ -370,7 +376,7 @@ export function WebPageStackView({
           flexDirection="row"
           alignItems="center"
           backgroundColor={panelFill()}
-          onMouseDown={(event) => {
+          onMouseDown={(event: { preventDefault?: () => void; stopPropagation?: () => void }) => {
             event.preventDefault?.();
             event.stopPropagation?.();
             onBack();

--- a/src/renderers/electrobun/view/host/input.tsx
+++ b/src/renderers/electrobun/view/host/input.tsx
@@ -2,12 +2,14 @@
 /** @jsxImportSource react */
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
   useState,
   type CSSProperties,
   type KeyboardEvent,
+  type RefObject,
 } from "react";
 import type { InputRenderable, TextareaRenderable } from "../../../../ui/host";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "../input-host";
@@ -77,6 +79,65 @@ function useEditableValue(props: Record<string, unknown>) {
   };
 
   return { value, valueRef, setValue };
+}
+
+function useLatestRef<T>(value: T): RefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
+function useSyncedEditableElement<T extends HTMLInputElement | HTMLTextAreaElement>({
+  elementRef,
+  propsRef,
+  valueRef,
+  handleValueChange,
+  active,
+}: {
+  elementRef: RefObject<T | null>;
+  propsRef: RefObject<Record<string, unknown>>;
+  valueRef: RefObject<string>;
+  handleValueChange: (nextValue: string) => void;
+  active: boolean;
+}): () => string {
+  const syncElementValue = useCallback(() => {
+    const nextValue = elementRef.current?.value;
+    if (typeof nextValue !== "string") return valueRef.current;
+    if (nextValue !== valueRef.current) {
+      handleValueChange(nextValue);
+    }
+    return nextValue;
+  }, [elementRef, handleValueChange, valueRef]);
+
+  useEffect(() => {
+    if (!active) return;
+    let animationFrame: number | null = null;
+    const syncDomValue = () => {
+      syncElementValue();
+      animationFrame = globalThis.requestAnimationFrame?.(syncDomValue) ?? null;
+    };
+    animationFrame = globalThis.requestAnimationFrame?.(syncDomValue) ?? null;
+    return () => {
+      if (animationFrame !== null) globalThis.cancelAnimationFrame?.(animationFrame);
+    };
+  }, [active, syncElementValue]);
+
+  useEffect(() => {
+    if (!active) return;
+    const commitBeforeOutsideMouseDown = (event: globalThis.MouseEvent) => {
+      const element = elementRef.current;
+      const target = event.target;
+      if (!element || (target instanceof Node && element.contains(target))) return;
+      const nextValue = syncElementValue();
+      callTextHandler(propsRef.current.onBlur, nextValue);
+    };
+    document.addEventListener("mousedown", commitBeforeOutsideMouseDown, true);
+    return () => {
+      document.removeEventListener("mousedown", commitBeforeOutsideMouseDown, true);
+    };
+  }, [active, elementRef, propsRef, syncElementValue]);
+
+  return syncElementValue;
 }
 
 type WebVisualCursor = TextareaRenderable["visualCursor"];
@@ -149,8 +210,10 @@ function textareaMetrics(
 
 export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(function WebInput(props, ref) {
   const elementRef = useRef<HTMLInputElement | null>(null);
+  const propsRef = useLatestRef(props);
   const { value, valueRef, setValue } = useEditableValue(props);
   const [cursorOffset, setCursorOffset] = useState(value.length);
+  const [domFocused, setDomFocused] = useState(false);
   const applyCursorOffset = (offset: number) => {
     setCursorOffset(offset);
     queueMicrotask(() => applyDomCursorOffset(elementRef.current, offset));
@@ -165,7 +228,7 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
 
   useImperativeHandle(ref, () => ({
     editBuffer: {
-      getText: () => valueRef.current,
+      getText: () => elementRef.current?.value ?? valueRef.current,
       setText: (nextText: string) => setValue(nextText),
     },
     get cursorOffset() {
@@ -175,18 +238,25 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
     focus: () => elementRef.current?.focus(),
   }), [applyCursorOffset, cursorOffset, setValue, valueRef]);
 
-  const handleValueChange = (nextValue: string) => {
+  const handleValueChange = useCallback((nextValue: string) => {
     setValue(nextValue);
     setCursorOffset(elementRef.current?.selectionStart ?? nextValue.length);
-    callTextHandler(props.onInput, nextValue);
-    callTextHandler(props.onChange, nextValue);
-    callTextHandler(props.onCursorChange, nextValue);
-  };
+    callTextHandler(propsRef.current.onInput, nextValue);
+    callTextHandler(propsRef.current.onChange, nextValue);
+    callTextHandler(propsRef.current.onCursorChange, nextValue);
+  }, [propsRef, setValue]);
+  const syncElementValue = useSyncedEditableElement({
+    elementRef,
+    propsRef,
+    valueRef,
+    handleValueChange,
+    active: props.focused === true || domFocused,
+  });
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter" && typeof props.onSubmit === "function") {
+    if (event.key === "Enter" && typeof propsRef.current.onSubmit === "function") {
       event.preventDefault();
-      (props.onSubmit as (value: string) => void)(valueRef.current);
+      (propsRef.current.onSubmit as (value: string) => void)(syncElementValue());
     }
   };
 
@@ -200,7 +270,16 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
       autoComplete="off"
       spellCheck={false}
       placeholder={getStringProp(props, "placeholder")}
+      onInput={(event) => handleValueChange(event.currentTarget.value)}
       onChange={(event) => handleValueChange(event.currentTarget.value)}
+      onFocus={() => {
+        setDomFocused(true);
+        callTextHandler(propsRef.current.onFocus, elementRef.current?.value ?? valueRef.current);
+      }}
+      onBlur={() => {
+        setDomFocused(false);
+        callTextHandler(propsRef.current.onBlur, syncElementValue());
+      }}
       onKeyDown={handleKeyDown}
       onContextMenu={(event) => {
         if (!NATIVE_CONTEXT_MENU_SUPPORTED) return;
@@ -211,7 +290,7 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
       }}
       onSelect={() => {
         setCursorOffset(elementRef.current?.selectionStart ?? valueRef.current.length);
-        callTextHandler(props.onCursorChange, valueRef.current);
+        callTextHandler(propsRef.current.onCursorChange, valueRef.current);
       }}
       style={textInputStyle(props, false)}
     />
@@ -220,8 +299,10 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
 
 export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown>>(function WebTextarea(props, ref) {
   const elementRef = useRef<HTMLTextAreaElement | null>(null);
+  const propsRef = useLatestRef(props);
   const { value, valueRef, setValue } = useEditableValue(props);
   const [cursorOffset, setCursorOffset] = useState(value.length);
+  const [domFocused, setDomFocused] = useState(false);
   const applyCursorOffset = (offset: number) => {
     setCursorOffset(offset);
     queueMicrotask(() => applyDomCursorOffset(elementRef.current, offset));
@@ -236,7 +317,7 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
 
   useImperativeHandle(ref, () => ({
     editBuffer: {
-      getText: () => valueRef.current,
+      getText: () => elementRef.current?.value ?? valueRef.current,
       setText: (nextText: string) => setValue(nextText),
     },
     get cursorOffset() {
@@ -271,18 +352,25 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
     clearLineHighlights: () => {},
   }), [applyCursorOffset, cursorOffset, props, setValue, valueRef]);
 
-  const handleValueChange = (nextValue: string) => {
+  const handleValueChange = useCallback((nextValue: string) => {
     setValue(nextValue);
     setCursorOffset(elementRef.current?.selectionStart ?? nextValue.length);
-    callTextHandler(props.onInput, nextValue);
-    callTextHandler(props.onChange, nextValue);
-    callTextHandler(props.onCursorChange, nextValue);
-  };
+    callTextHandler(propsRef.current.onInput, nextValue);
+    callTextHandler(propsRef.current.onChange, nextValue);
+    callTextHandler(propsRef.current.onCursorChange, nextValue);
+  }, [propsRef, setValue]);
+  const syncElementValue = useSyncedEditableElement({
+    elementRef,
+    propsRef,
+    valueRef,
+    handleValueChange,
+    active: props.focused === true || domFocused,
+  });
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Enter" && !event.shiftKey && typeof props.onSubmit === "function") {
+    if (event.key === "Enter" && !event.shiftKey && typeof propsRef.current.onSubmit === "function") {
       event.preventDefault();
-      (props.onSubmit as (value: string) => void)(valueRef.current);
+      (propsRef.current.onSubmit as (value: string) => void)(syncElementValue());
     }
   };
 
@@ -296,7 +384,16 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
       autoComplete="off"
       spellCheck={false}
       placeholder={getStringProp(props, "placeholder")}
+      onInput={(event) => handleValueChange(event.currentTarget.value)}
       onChange={(event) => handleValueChange(event.currentTarget.value)}
+      onFocus={() => {
+        setDomFocused(true);
+        callTextHandler(propsRef.current.onFocus, elementRef.current?.value ?? valueRef.current);
+      }}
+      onBlur={() => {
+        setDomFocused(false);
+        callTextHandler(propsRef.current.onBlur, syncElementValue());
+      }}
       onKeyDown={handleKeyDown}
       onContextMenu={(event) => {
         if (!NATIVE_CONTEXT_MENU_SUPPORTED) return;
@@ -307,7 +404,7 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
       }}
       onSelect={() => {
         setCursorOffset(elementRef.current?.selectionStart ?? valueRef.current.length);
-        callTextHandler(props.onCursorChange, valueRef.current);
+        callTextHandler(propsRef.current.onCursorChange, valueRef.current);
       }}
       style={textInputStyle(props, true)}
     />


### PR DESCRIPTION
## Summary
- add a Kelly-based Position Sizer pane with binary, scenario, risk budget, prediction market, and asymmetric payoff modes
- add shared desktop input blur/value syncing so inline fields commit correctly across the app
- add static chart x-axis markers and cursor value labels for the Kelly curve

## Cleanup
- split the Position Sizer implementation into pane, state, field, section, portfolio, and model/type modules
- extract static chart x-axis overlays out of the surface component
- prune low-value modal-regression tests while keeping focused coverage for sizing math, pane state, currency conversion, field blur, and chart cursor labels

## Validation
- bun test src/plugins/builtin/kelly-sizer/model.test.ts src/plugins/builtin/kelly-sizer/view.test.tsx src/plugins/builtin/kelly-sizer/index.test.tsx src/components/chart/static/chart/surface.test.tsx
- bun run desktop:view:build
- git diff --check
- touched-file TypeScript diagnostics filter
- desktop Computer Use check in an isolated temporary profile for Loss cap/Name cap blur persistence and chart crosshair x/y labels