### PR TITLE
Fix gridlock blank panes

### DIFF
--- a/src/app/runtime/desktop-menu.ts
+++ b/src/app/runtime/desktop-menu.ts
@@ -54,7 +54,11 @@ export function useDesktopApplicationMenuRuntime({
           break;
         case "layout-gridlock": {
           const { width, height } = pluginRegistry.getTermSizeFn();
-          pluginRegistry.updateLayoutFn(gridlockAllPanes(stateRef.current.config.layout, { x: 0, y: 0, width, height }));
+          pluginRegistry.updateLayoutFn(gridlockAllPanes(
+            stateRef.current.config.layout,
+            { x: 0, y: 0, width, height },
+            pluginRegistry.panes,
+          ));
           notifyGridlockComplete(pluginRegistry.notify.bind(pluginRegistry), () => {
             dispatch({ type: "UNDO_LAYOUT" });
           });

--- a/src/components/command-bar/layout-items/current-layout.ts
+++ b/src/components/command-bar/layout-items/current-layout.ts
@@ -87,7 +87,11 @@ export function buildCurrentLayoutItems({
       kind: "action",
       action: () => {
         const { width, height } = pluginRegistry.getTermSizeFn();
-        persistLayoutChange(gridlockAllPanes(currentLayout, { x: 0, y: 0, width, height }));
+        persistLayoutChange(gridlockAllPanes(
+          currentLayout,
+          { x: 0, y: 0, width, height },
+          pluginRegistry.panes,
+        ));
         notifyGridlockRevert();
         closeAll({ revertThemePreview: false });
       },

--- a/src/components/layout/shell/layout-state.test.ts
+++ b/src/components/layout/shell/layout-state.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { getDockedPaneIds } from "../../../plugins/pane-manager";
+import { createPaneInstance, type LayoutConfig } from "../../../types/config";
+import { resolveShellVisibleLayout } from "./visible-layout";
+
+describe("shell visible layout", () => {
+  test("removes unregistered pane types before resolving dock geometry", () => {
+    const layout: LayoutConfig = {
+      dockRoot: {
+        kind: "split",
+        axis: "horizontal",
+        ratio: 0.5,
+        first: { kind: "pane", instanceId: "missing:main" },
+        second: { kind: "pane", instanceId: "chat:main" },
+      },
+      instances: [
+        createPaneInstance("missing-plugin", { instanceId: "missing:main" }),
+        createPaneInstance("chat", { instanceId: "chat:main" }),
+      ],
+      floating: [],
+      detached: [],
+    };
+
+    const visibleLayout = resolveShellVisibleLayout(
+      layout,
+      new Set(),
+      new Map([["chat", true]]),
+    );
+
+    expect(visibleLayout.instances.map((instance) => instance.instanceId)).toEqual(["chat:main"]);
+    expect(getDockedPaneIds(visibleLayout)).toEqual(["chat:main"]);
+  });
+});

--- a/src/components/layout/shell/layout-state.ts
+++ b/src/components/layout/shell/layout-state.ts
@@ -6,8 +6,9 @@ import {
   type ResolvedPane,
 } from "../../../plugins/pane-manager";
 import type { PluginRegistry } from "../../../plugins/registry";
-import { removePaneInstances, type LayoutConfig } from "../../../types/config";
+import type { LayoutConfig } from "../../../types/config";
 import { constrainFloatingRectToBounds } from "./drag";
+import { resolveShellVisibleLayout } from "./visible-layout";
 
 interface ShellVisibleLayoutOptions {
   disabledPlugins: readonly string[];
@@ -34,15 +35,9 @@ export function useShellVisibleLayout({
     return paneIds;
   }, [disabledPlugins, pluginRegistry]);
 
-  const hiddenInstanceIds = useMemo(() => (
-    layout.instances
-      .filter((instance) => disabledPaneIds.has(instance.paneId))
-      .map((instance) => instance.instanceId)
-  ), [disabledPaneIds, layout.instances]);
-
   const visibleLayout = useMemo(
-    () => (hiddenInstanceIds.length > 0 ? removePaneInstances(layout, hiddenInstanceIds) : layout),
-    [hiddenInstanceIds, layout],
+    () => resolveShellVisibleLayout(layout, disabledPaneIds, pluginRegistry.panes),
+    [disabledPaneIds, layout, pluginRegistry.panes],
   );
 
   return { disabledPaneIds, visibleLayout };

--- a/src/components/layout/shell/visible-layout.ts
+++ b/src/components/layout/shell/visible-layout.ts
@@ -1,0 +1,17 @@
+import {
+  removeUnavailablePaneTypes,
+  type PaneTypeAvailability,
+} from "../../../plugins/pane-manager";
+import type { LayoutConfig } from "../../../types/config";
+
+export function resolveShellVisibleLayout(
+  layout: LayoutConfig,
+  disabledPaneIds: ReadonlySet<string>,
+  registeredPaneIds: PaneTypeAvailability,
+): LayoutConfig {
+  return removeUnavailablePaneTypes(
+    layout,
+    registeredPaneIds,
+    { disabledPaneIds },
+  );
+}

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { AppContext, createInitialState } from "../../state/app/context";
-import { cloneLayout, createDefaultConfig, type LayoutConfig } from "../../types/config";
+import { cloneLayout, createDefaultConfig, TICKER_RESEARCH_PANE_ID, type LayoutConfig } from "../../types/config";
 import type { AppNotificationRequest } from "../../types/plugin";
 import { StatusBar } from "./status-bar";
 import { setSharedRegistryForTests } from "../../plugins/registry";
@@ -174,6 +174,10 @@ describe("StatusBar", () => {
     const notifications: AppNotificationRequest[] = [];
 
     setSharedRegistryForTests({
+      panes: new Map([
+        ["portfolio-list", {}],
+        [TICKER_RESEARCH_PANE_ID, {}],
+      ]),
       getLayoutFn: () => state.config.layout,
       getTermSizeFn: () => ({ width: 120, height: 40 }),
       updateLayoutFn: (layout: LayoutConfig) => { updatedLayout = layout; },
@@ -233,6 +237,7 @@ describe("StatusBar", () => {
     globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
 
     setSharedRegistryForTests({
+      panes: new Map(),
       getLayoutFn: () => state.config.layout,
       getTermSizeFn: () => ({ width: 120, height: 40 }),
       updateLayoutFn: () => {},

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -114,7 +114,11 @@ export function StatusBar() {
     event?.stopPropagation?.();
     if (!registry) return;
     const { width, height } = registry.getTermSizeFn();
-    registry.updateLayoutFn(gridlockAllPanes(registry.getLayoutFn(), { x: 0, y: 0, width, height }));
+    registry.updateLayoutFn(gridlockAllPanes(
+      registry.getLayoutFn(),
+      { x: 0, y: 0, width, height },
+      registry.panes,
+    ));
     notifyGridlockComplete(registry.notify.bind(registry), () => {
       dispatch({ type: "UNDO_LAYOUT" });
     });

--- a/src/plugins/builtin/layout-manager/index.tsx
+++ b/src/plugins/builtin/layout-manager/index.tsx
@@ -105,7 +105,11 @@ export const layoutManagerPlugin: GloomPlugin = {
       execute: async () => {
         if (!getStateRef) return;
         const { layout, termWidth, termHeight } = getStateRef();
-        persistLayout(ctx, gridlockAllPanes(layout, { x: 0, y: 0, width: termWidth, height: termHeight }));
+        persistLayout(ctx, gridlockAllPanes(
+          layout,
+          { x: 0, y: 0, width: termWidth, height: termHeight },
+          ctx.getPaneDef,
+        ));
         notifyGridlockComplete(ctx.notify, () => {
           dispatchRef?.({ type: "UNDO_LAYOUT" });
         });

--- a/src/plugins/pane-manager.test.ts
+++ b/src/plugins/pane-manager.test.ts
@@ -109,6 +109,39 @@ describe("pane-manager split-tree drops", () => {
     expect(getDockedPaneIds(next)).toHaveLength(layout.instances.length);
   });
 
+  test("gridlock drops pane types that cannot render before tiling", () => {
+    const layout: LayoutConfig = {
+      dockRoot: {
+        kind: "split" as const,
+        axis: "horizontal" as const,
+        ratio: 0.5,
+        first: {
+          kind: "split" as const,
+          axis: "vertical" as const,
+          ratio: 0.5,
+          first: { kind: "pane" as const, instanceId: "missing:main" },
+          second: { kind: "pane" as const, instanceId: "chat:main" },
+        },
+        second: { kind: "pane" as const, instanceId: "sectors:main" },
+      },
+      instances: [
+        createPaneInstance("missing-plugin", { instanceId: "missing:main" }),
+        createPaneInstance("chat", { instanceId: "chat:main" }),
+        createPaneInstance("sectors", { instanceId: "sectors:main" }),
+      ],
+      floating: [],
+      detached: [],
+    };
+
+    const next = gridlockAllPanes(layout, BOUNDS, new Set(["chat", "sectors"]));
+
+    expect(next.instances.map((instance) => instance.instanceId)).toEqual(["chat:main", "sectors:main"]);
+    expect(getDockedPaneIds(next)).toEqual(["chat:main", "sectors:main"]);
+    expect(getLeafRect(next, "missing:main", BOUNDS)).toBeNull();
+    expect(getLeafRect(next, "chat:main", BOUNDS)).toEqual({ x: 0, y: 0, width: 60, height: 40 });
+    expect(getLeafRect(next, "sectors:main", BOUNDS)).toEqual({ x: 60, y: 0, width: 60, height: 40 });
+  });
+
   test("gridlock infers a matching tiled layout from arranged windows", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     let layout: LayoutConfig = {

--- a/src/plugins/pane-manager.ts
+++ b/src/plugins/pane-manager.ts
@@ -49,7 +49,12 @@ export {
   swapPanes,
 } from "./pane-manager/docking";
 
-export { removeFloatingPanes, removePane } from "./pane-manager/layout-state";
+export {
+  removeFloatingPanes,
+  removePane,
+  removeUnavailablePaneTypes,
+  type PaneTypeAvailability,
+} from "./pane-manager/layout-state";
 export { gridlockAllPanes } from "./pane-manager/gridlock";
 export type {
   DropTarget,

--- a/src/plugins/pane-manager/gridlock.ts
+++ b/src/plugins/pane-manager/gridlock.ts
@@ -8,15 +8,23 @@ import {
   getDockLeafLayouts,
   type LayoutBounds,
 } from "./dock-tree";
-import { finalizeLayout } from "./layout-state";
+import {
+  finalizeLayout,
+  removeUnavailablePaneTypes,
+  type PaneTypeAvailability,
+} from "./layout-state";
 
 export function gridlockAllPanes(
   layout: LayoutConfig,
   bounds: LayoutBounds = { x: 0, y: 0, width: 120, height: 40 },
+  paneTypes?: PaneTypeAvailability,
 ): LayoutConfig {
-  const dockedRects: GridlockRect[] = getDockLeafLayouts(layout, bounds)
+  const visibleLayout = paneTypes
+    ? removeUnavailablePaneTypes(layout, paneTypes)
+    : layout;
+  const dockedRects: GridlockRect[] = getDockLeafLayouts(visibleLayout, bounds)
     .map((leaf) => ({ instanceId: leaf.instanceId, ...leaf.rect }));
-  const floatingRects: GridlockRect[] = layout.floating.map((entry) => ({
+  const floatingRects: GridlockRect[] = visibleLayout.floating.map((entry) => ({
     instanceId: entry.instanceId,
     x: entry.x,
     y: entry.y,
@@ -24,10 +32,10 @@ export function gridlockAllPanes(
     height: entry.height,
   }));
   const allRects = [...dockedRects, ...floatingRects];
-  if (allRects.length === 0) return layout;
+  if (allRects.length === 0) return visibleLayout;
 
   return finalizeLayout({
-    ...layout,
+    ...visibleLayout,
     dockRoot: inferDockTreeFromRects(allRects, boundsForRects(allRects)),
     floating: [],
   });

--- a/src/plugins/pane-manager/layout-state.ts
+++ b/src/plugins/pane-manager/layout-state.ts
@@ -169,3 +169,28 @@ export function removeFloatingPanes(layout: LayoutConfig): LayoutConfig {
     layout.floating.map((entry) => entry.instanceId),
   ));
 }
+
+export type PaneTypeAvailability = { has(paneId: string): boolean } | ((paneId: string) => unknown);
+
+function paneTypeIsAvailable(availability: PaneTypeAvailability, paneId: string): boolean {
+  return typeof availability === "function"
+    ? !!availability(paneId)
+    : availability.has(paneId);
+}
+
+export function removeUnavailablePaneTypes(
+  layout: LayoutConfig,
+  availability: PaneTypeAvailability,
+  options: { disabledPaneIds?: ReadonlySet<string> } = {},
+): LayoutConfig {
+  const unavailableInstanceIds = layout.instances
+    .filter((instance) => (
+      options.disabledPaneIds?.has(instance.paneId)
+      || !paneTypeIsAvailable(availability, instance.paneId)
+    ))
+    .map((instance) => instance.instanceId);
+
+  return unavailableInstanceIds.length > 0
+    ? removePaneInstances(layout, unavailableInstanceIds)
+    : layout;
+}


### PR DESCRIPTION
## Summary
- Filter unregistered pane types out of gridlock before inferring dock geometry.
- Reuse the same pane-type availability filter for shell visible layout and gridlock entry points.
- Add regression coverage for stale pane definitions reserving blank dock space.

## Root Cause
Saved layouts could contain pane instances whose pane type was no longer registered. Those instances did not render, but they still participated in dock geometry, leaving visible blank regions after gridlock.

## Validation
- `bun test src/plugins/pane-manager.test.ts src/components/layout/shell/layout-state.test.ts src/components/layout/shell/index.test.tsx src/components/layout/status-bar.test.tsx`
- tmux smoke test with a temporary Monitor layout copy verified stale `kelly-sizer` panes no longer reserve blank regions.