### PR TITLE
Fix IBKR Flex account snapshots

### DIFF
--- a/src/brokers/account-cache.ts
+++ b/src/brokers/account-cache.ts
@@ -124,7 +124,7 @@ export function loadPersistedBrokerAccountMap(
 
   for (const instance of brokerInstances) {
     const broker = brokers.get(instance.brokerType);
-    if (!broker?.listAccounts) continue;
+    if (!broker?.listAccounts && !broker?.importPortfolioSnapshot) continue;
     const accounts = loadPersistedBrokerAccounts(resources, instance, broker);
     if (!accounts || accounts.length === 0) continue;
     accountMap[instance.id] = accounts;

--- a/src/brokers/sync-broker-instance.test.ts
+++ b/src/brokers/sync-broker-instance.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { createDefaultConfig, type BrokerInstanceConfig } from "../types/config";
 import type { BrokerAdapter } from "../types/broker";
 import type { TickerRecord } from "../types/ticker";
+import { AppPersistence } from "../data/app-persistence";
+import { loadPersistedBrokerAccounts, persistBrokerAccounts } from "./account-cache";
 import {
   restoreBrokerPortfoliosFromTickerPositions,
   syncBrokerInstance,
@@ -162,6 +164,111 @@ describe("syncBrokerInstance", () => {
         brokerAccountId: "ACC-1",
       }),
     ]);
+  });
+
+  test("imports account and position data from one broker portfolio snapshot", async () => {
+    const instance = createBrokerInstance();
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-sync-broker-snapshot"),
+      portfolios: [],
+      brokerInstances: [instance],
+    };
+    const tickerRepository = createTickerRepository();
+    const persistence = new AppPersistence(":memory:");
+    let listAccountsCalled = false;
+    let importPositionsCalled = false;
+    const broker: BrokerAdapter = {
+      ...createDemoBroker(),
+      listAccounts: async () => {
+        listAccountsCalled = true;
+        return [];
+      },
+      importPositions: async () => {
+        importPositionsCalled = true;
+        return [];
+      },
+      importPortfolioSnapshot: async () => ({
+        accounts: [{
+          accountId: "ACC-1",
+          name: "Snapshot Account",
+          currency: "USD",
+          netLiquidation: 125_000,
+          grossPositionValue: 175_000,
+          totalCashValue: -50_000,
+        }],
+        positions: [{
+          ticker: "AAPL",
+          exchange: "NASDAQ",
+          shares: 12,
+          avgCost: 180,
+          currency: "USD",
+          accountId: "ACC-1",
+          name: "Apple Inc.",
+          assetCategory: "STK",
+        }],
+      }),
+    };
+
+    try {
+      const result = await syncBrokerInstance({
+        config,
+        instanceId: "demo-broker",
+        brokers: new Map([["demo", broker]]),
+        tickerRepository: tickerRepository as any,
+        resources: persistence.resources,
+      });
+
+      expect(listAccountsCalled).toBe(false);
+      expect(importPositionsCalled).toBe(false);
+      expect(result.brokerAccounts[0]?.netLiquidation).toBe(125_000);
+      expect(result.positions).toHaveLength(1);
+      expect(loadPersistedBrokerAccounts(persistence.resources, instance, broker)).toEqual(result.brokerAccounts);
+    } finally {
+      persistence.close();
+    }
+  });
+
+  test("preserves the last account snapshot when a broker portfolio snapshot fails", async () => {
+    const instance = createBrokerInstance();
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-sync-broker-snapshot-failure"),
+      portfolios: [],
+      brokerInstances: [instance],
+    };
+    const tickerRepository = createTickerRepository();
+    const persistence = new AppPersistence(":memory:");
+    const broker: BrokerAdapter = {
+      ...createDemoBroker(),
+      importPortfolioSnapshot: async () => {
+        throw new Error("account snapshot unavailable");
+      },
+    };
+
+    try {
+      persistBrokerAccounts(persistence.resources, instance, broker, [{
+        accountId: "ACC-1",
+        name: "Stale Account",
+        currency: "USD",
+        netLiquidation: 99_000,
+      }]);
+
+      await expect(syncBrokerInstance({
+        config,
+        instanceId: "demo-broker",
+        brokers: new Map([["demo", broker]]),
+        tickerRepository: tickerRepository as any,
+        resources: persistence.resources,
+      })).rejects.toThrow("account snapshot unavailable");
+
+      expect(loadPersistedBrokerAccounts(persistence.resources, instance, broker)).toEqual([{
+        accountId: "ACC-1",
+        name: "Stale Account",
+        currency: "USD",
+        netLiquidation: 99_000,
+      }]);
+    } finally {
+      persistence.close();
+    }
   });
 
   test("preserves broker portfolios across sequential profile syncs", async () => {

--- a/src/brokers/sync-broker-instance.ts
+++ b/src/brokers/sync-broker-instance.ts
@@ -131,17 +131,30 @@ export async function syncBrokerInstance({
   const tickers = await loadTickerMap(tickerRepository, existingTickers);
 
   let brokerAccounts: BrokerAccount[] = [];
-  if (broker.listAccounts) {
-    try {
-      brokerAccounts = await broker.listAccounts(instance);
-      if (resources) {
-        try {
-          persistBrokerAccounts(resources, instance, broker, brokerAccounts);
-        } catch {}
-      }
-    } catch {
-      brokerAccounts = [];
+  let positions: BrokerPosition[];
+  if (broker.importPortfolioSnapshot) {
+    const snapshot = await broker.importPortfolioSnapshot(instance);
+    brokerAccounts = snapshot.accounts;
+    positions = snapshot.positions;
+    if (resources) {
+      try {
+        persistBrokerAccounts(resources, instance, broker, brokerAccounts);
+      } catch {}
     }
+  } else {
+    if (broker.listAccounts) {
+      try {
+        brokerAccounts = await broker.listAccounts(instance);
+        if (resources) {
+          try {
+            persistBrokerAccounts(resources, instance, broker, brokerAccounts);
+          } catch {}
+        }
+      } catch (error) {
+        throw error;
+      }
+    }
+    positions = await broker.importPositions(instance);
   }
 
   const accountMetadata = new Map(
@@ -154,7 +167,6 @@ export async function syncBrokerInstance({
     ]),
   );
 
-  const positions = await broker.importPositions(instance);
   const syncedAt = Date.now();
 
   let nextConfig = config;

--- a/src/plugins/builtin/analytics/index.test.tsx
+++ b/src/plugins/builtin/analytics/index.test.tsx
@@ -293,6 +293,7 @@ describe("PortfolioAnalyticsPane", () => {
               currency: "USD",
               source: "flex",
               updatedAt: new Date(2026, 2, 27).getTime(),
+              asOfDate: "2026-03-26",
               totalCashValue: -50000,
               settledCash: -45000,
               availableFunds: 15000,
@@ -326,8 +327,8 @@ describe("PortfolioAnalyticsPane", () => {
     expect(frame).toContain("Avail         15k");
     expect(frame).toContain("Excess        12k");
     expect(frame).toContain("BP            30k");
-    expect(frame).toContain("Synced        just now");
-    expect(frame).toContain("Source        Flex Mar 27");
+    expect(frame).toContain("As Of         Mar 26");
+    expect(frame).toContain("Source        Flex Mar 26");
   });
 
   test("falls back from a Gateway portfolio to a configured Flex profile for IBKR history", async () => {

--- a/src/plugins/builtin/analytics/pane-model.ts
+++ b/src/plugins/builtin/analytics/pane-model.ts
@@ -7,7 +7,7 @@ import { formatCompact, formatNumber, formatPercentRaw } from "../../../utils/fo
 import { formatRelativeAge } from "../../../utils/relative-time";
 import { instrumentFromTicker, type ChartRequest } from "../../../market-data/request-types";
 import { buildChartKey } from "../../../market-data/selectors";
-import { resolvePortfolioAccountMetrics } from "../portfolio-list/account-metrics";
+import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "../portfolio-list/account-metrics";
 import type { ColumnContext, PortfolioSummaryTotals } from "../portfolio-list/metrics";
 import type { ResolvedPortfolioAccountState } from "../portfolio-list/summary";
 import { performancePointValue } from "./broker-performance";
@@ -37,6 +37,22 @@ export type ChartEntryLookup = Map<string, {
   data?: PricePoint[] | null;
   lastGoodData?: PricePoint[] | null;
 } | undefined>;
+
+function formatIsoDateMonthDay(value: string): string {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return value;
+  const [, year, month, day] = match;
+  return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatAccountFreshness(account: ResolvedPortfolioAccountState["account"] | undefined): string | null {
+  if (!account) return null;
+  if (account.asOfDate) return formatIsoDateMonthDay(account.asOfDate);
+  return account.updatedAt ? formatRelativeAge(account.updatedAt) : null;
+}
 
 export function buildPortfolioChartTargets(portfolioTickers: TickerRecord[]): PortfolioChartTarget[] {
   return portfolioTickers.flatMap((ticker) => {
@@ -96,7 +112,6 @@ export function buildBenchmarkReturnSeries(
 
 export function buildAnalyticsSummaryRows({
   accountState,
-  activePortfolio,
   brokerPerformance,
   portfolioStats,
 }: {
@@ -108,7 +123,7 @@ export function buildAnalyticsSummaryRows({
   const rows: AnalyticsMetricRow[] = [];
   const account = accountState?.account;
   const accountMetrics = resolvePortfolioAccountMetrics(portfolioStats, account);
-  const syncedAt = activePortfolio?.lastSyncedAt ?? account?.updatedAt;
+  const accountFreshness = formatAccountFreshness(account);
 
   if (account?.netLiquidation != null) {
     rows.push({
@@ -122,7 +137,7 @@ export function buildAnalyticsSummaryRows({
   rows.push({
     id: "total-value",
     label: "Val",
-    value: formatCompact(portfolioStats.totalMktValue),
+    value: formatCompact(resolvePortfolioMarketValue(portfolioStats, account)),
     color: colors.text,
   });
 
@@ -202,11 +217,11 @@ export function buildAnalyticsSummaryRows({
     });
   }
   if (accountState) {
-    if (syncedAt) {
+    if (accountFreshness) {
       rows.push({
-        id: "last-sync",
-        label: "Synced",
-        value: formatRelativeAge(syncedAt),
+        id: "account-freshness",
+        label: "As Of",
+        value: accountFreshness,
         color: colors.textDim,
       });
     }

--- a/src/plugins/builtin/portfolio-list/account-metrics.test.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { BrokerAccount } from "../../../types/trading";
 import type { PortfolioSummaryTotals } from "./metrics";
-import { resolvePortfolioAccountMetrics } from "./account-metrics";
+import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "./account-metrics";
 
 function createTotals(overrides: Partial<PortfolioSummaryTotals> = {}): PortfolioSummaryTotals {
   return {
@@ -46,5 +46,30 @@ describe("resolvePortfolioAccountMetrics", () => {
       unrealizedPnlPct: 25,
       realizedPnl: undefined,
     });
+  });
+});
+
+describe("resolvePortfolioMarketValue", () => {
+  test("uses explicit broker gross position value when available", () => {
+    const account: BrokerAccount = {
+      accountId: "DU12345",
+      name: "DU12345",
+      grossPositionValue: 12_345,
+      netLiquidation: 20_000,
+      totalCashValue: 7_000,
+    };
+
+    expect(resolvePortfolioMarketValue(createTotals({ totalMktValue: 10_000 }), account)).toBe(12_345);
+  });
+
+  test("does not derive market value from account cash and net liquidation", () => {
+    const account: BrokerAccount = {
+      accountId: "DU12345",
+      name: "DU12345",
+      netLiquidation: 20_000,
+      totalCashValue: 7_000,
+    };
+
+    expect(resolvePortfolioMarketValue(createTotals({ totalMktValue: 10_000 }), account)).toBe(10_000);
   });
 });

--- a/src/plugins/builtin/portfolio-list/account-metrics.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.ts
@@ -17,6 +17,20 @@ function percentChange(value: number, previousValue: number): number {
   return previousValue !== 0 ? (value / previousValue) * 100 : 0;
 }
 
+export function resolveBrokerPortfolioMarketValue(account?: BrokerAccount | null): number | null {
+  if (finiteNumber(account?.grossPositionValue)) {
+    return account.grossPositionValue;
+  }
+  return null;
+}
+
+export function resolvePortfolioMarketValue(
+  totals: PortfolioSummaryTotals,
+  account?: BrokerAccount | null,
+): number {
+  return resolveBrokerPortfolioMarketValue(account) ?? totals.totalMktValue;
+}
+
 export function resolvePortfolioAccountMetrics(
   totals: PortfolioSummaryTotals,
   account?: BrokerAccount | null,

--- a/src/plugins/builtin/portfolio-list/index.test.ts
+++ b/src/plugins/builtin/portfolio-list/index.test.ts
@@ -40,6 +40,7 @@ describe("buildPortfolioSummarySegments", () => {
     accountId: "DU12345",
     name: "DU12345",
     netLiquidation: 125000,
+    grossPositionValue: 175000,
     totalCashValue: -50000,
     settledCash: -45000,
     availableFunds: 12000,
@@ -55,6 +56,16 @@ describe("buildPortfolioSummarySegments", () => {
     });
 
     expect(segments.map((segment) => segment.id)).toEqual(["netliq", "val"]);
+  });
+
+  test("uses broker gross position value for broker portfolio value", () => {
+    const segments = buildPortfolioSummarySegments({
+      totals,
+      accountState: { account, sourceLabel: "Live" },
+      widthBudget: 80,
+    });
+
+    expect(segments.find((segment) => segment.id === "val")?.parts[1]?.text).toBe("175k");
   });
 
   test("drops low-priority broker segments before required ones", () => {
@@ -83,6 +94,18 @@ describe("buildPortfolioSummarySegments", () => {
     });
 
     expect(segments.map((segment) => segment.id)).toContain("source");
+  });
+
+  test("shows account status when a broker portfolio has positions but no account snapshot", () => {
+    const segments = buildPortfolioSummarySegments({
+      totals,
+      accountState: null,
+      accountStatusText: "Acct missing",
+      widthBudget: 80,
+    });
+
+    expect(segments.map((segment) => segment.id)).toContain("account-status");
+    expect(segments.find((segment) => segment.id === "account-status")?.parts[0]?.text).toBe("Acct missing");
   });
 
   test("treats c as the cash drawer shortcut only when the drawer is available", () => {

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -294,6 +294,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
 
   const summaryFooterInfo = useMemo(() => buildPortfolioFooterSegments({
     accountState: accountState ? { account: accountState.account, sourceLabel: accountState.sourceLabel } : null,
+    accountStatusText: isPortfolioTab && currentPortfolio?.brokerInstanceId && !accountState ? "Acct missing" : undefined,
     activeCollectionId,
     baseCurrency: config.baseCurrency,
     exchangeRates: effectiveExchangeRates,
@@ -306,6 +307,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   }), [
     accountState,
     activeCollectionId,
+    currentPortfolio?.brokerInstanceId,
     effectiveExchangeRates,
     financialsMap,
     isPortfolioTab,

--- a/src/plugins/builtin/portfolio-list/summary/index.test.ts
+++ b/src/plugins/builtin/portfolio-list/summary/index.test.ts
@@ -112,6 +112,7 @@ describe("resolvePortfolioAccountState", () => {
           currency: "USD",
           source: "flex",
           updatedAt: new Date("2026-05-15T05:02:17.000Z").getTime(),
+          asOfDate: "2026-05-14",
           netLiquidation: 123456,
         }],
       },
@@ -121,6 +122,63 @@ describe("resolvePortfolioAccountState", () => {
     });
 
     expect(accountState?.account.netLiquidation).toBe(123456);
-    expect(accountState?.sourceLabel).toBe("Flex May 15");
+    expect(accountState?.sourceLabel).toBe("Flex May 14");
   });
+
+  test("uses the account as-of date when choosing the freshest cached Flex account", () => {
+    const accountState = resolvePortfolioAccountState({
+      id: "broker:ibkr-old:U12345",
+      name: "U12345",
+      currency: "USD",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-old",
+      brokerAccountId: "U12345",
+    }, {
+      config: {
+        brokerInstances: [
+          {
+            id: "ibkr-old",
+            label: "IBKR Old",
+            brokerType: "ibkr",
+            enabled: true,
+            config: {},
+          },
+          {
+            id: "ibkr-new",
+            label: "IBKR New",
+            brokerType: "ibkr",
+            enabled: true,
+            config: {},
+          },
+        ],
+      } as any,
+      brokerAccounts: {
+        "ibkr-old": [{
+          accountId: "U12345",
+          name: "U12345",
+          currency: "USD",
+          source: "flex",
+          updatedAt: new Date("2026-06-16T10:00:00.000Z").getTime(),
+          asOfDate: "2026-06-15",
+          netLiquidation: 100000,
+        }],
+        "ibkr-new": [{
+          accountId: "U12345",
+          name: "U12345",
+          currency: "USD",
+          source: "flex",
+          updatedAt: new Date("2026-06-15T10:00:00.000Z").getTime(),
+          asOfDate: "2026-06-16",
+          netLiquidation: 200000,
+        }],
+      },
+    }, {
+      status: null,
+      accounts: [],
+    });
+
+    expect(accountState?.account.netLiquidation).toBe(200000);
+    expect(accountState?.sourceLabel).toBe("Flex Jun 16");
+  });
+
 });

--- a/src/plugins/builtin/portfolio-list/summary/index.tsx
+++ b/src/plugins/builtin/portfolio-list/summary/index.tsx
@@ -9,7 +9,7 @@ import type { Portfolio, TickerRecord } from "../../../../types/ticker";
 import type { BrokerAccount, BrokerCashBalance } from "../../../../types/trading";
 import { formatCompact, formatPercentRaw } from "../../../../utils/format";
 import { getBrokerInstance } from "../../../../utils/broker-instances";
-import { resolvePortfolioAccountMetrics } from "../account-metrics";
+import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "../account-metrics";
 import { calculatePortfolioSummaryTotals, type PortfolioSummaryTotals } from "./totals";
 import { getMostRecentQuoteUpdate } from "../../../../market-data/quotes/time";
 
@@ -54,6 +54,22 @@ function formatSignedCompact(value: number): string {
   return `${value >= 0 ? "+" : ""}${formatCompact(value)}`;
 }
 
+function formatMonthDay(date: Date): string {
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function parseIsoDateAsLocalDate(value: string): Date | null {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+  const [, year, month, day] = match;
+  return new Date(Number(year), Number(month) - 1, Number(day));
+}
+
+function getAccountFreshnessTime(account: BrokerAccount): number {
+  const asOfDate = account.asOfDate ? parseIsoDateAsLocalDate(account.asOfDate) : null;
+  return asOfDate?.getTime() ?? account.updatedAt ?? 0;
+}
+
 function fitSummarySegments(candidates: PortfolioSummarySegment[], widthBudget: number): PortfolioSummarySegment[] {
   const fitted: PortfolioSummarySegment[] = [];
   let used = 0;
@@ -71,9 +87,12 @@ function formatSourceBadge(account: BrokerAccount, liveGateway: boolean): { labe
     return { label: "Live", kind: "live" };
   }
   if (account.source === "flex") {
+    const asOfDate = account.asOfDate ? parseIsoDateAsLocalDate(account.asOfDate) : null;
     return {
-      label: account.updatedAt
-        ? `Flex ${new Date(account.updatedAt).toLocaleDateString("en-US", { month: "short", day: "numeric" })}`
+      label: asOfDate
+        ? `Flex ${formatMonthDay(asOfDate)}`
+        : account.updatedAt
+          ? `Flex ${formatMonthDay(new Date(account.updatedAt))}`
         : "Flex",
       kind: "flex",
     };
@@ -120,7 +139,7 @@ function findPortfolioAccount(
 }
 
 function sortAccountsByFreshness(accounts: BrokerAccount[]): BrokerAccount[] {
-  return [...accounts].sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+  return [...accounts].sort((left, right) => getAccountFreshnessTime(right) - getAccountFreshnessTime(left));
 }
 
 export function resolvePortfolioAccountState(
@@ -165,16 +184,19 @@ export function resolvePortfolioAccountState(
 export function buildPortfolioSummarySegments({
   totals,
   accountState,
+  accountStatusText,
   widthBudget,
   refreshText,
 }: {
   totals: PortfolioSummaryTotals;
   accountState: PortfolioSummaryAccountState | null;
+  accountStatusText?: string;
   widthBudget: number;
   refreshText?: string;
 }): PortfolioSummarySegment[] {
   const candidates: PortfolioSummarySegment[] = [];
   const accountMetrics = resolvePortfolioAccountMetrics(totals, accountState?.account);
+  const totalMarketValue = resolvePortfolioMarketValue(totals, accountState?.account);
 
   if (accountState?.account.netLiquidation != null) {
     candidates.push(createSummarySegment("netliq", [
@@ -185,7 +207,7 @@ export function buildPortfolioSummarySegments({
 
   candidates.push(createSummarySegment("val", [
     { text: "Val", tone: "label" },
-    { text: formatCompact(totals.totalMktValue), tone: "value", bold: true },
+    { text: formatCompact(totalMarketValue), tone: "value", bold: true },
   ]));
 
   if (accountState?.account.totalCashValue != null) {
@@ -247,6 +269,12 @@ export function buildPortfolioSummarySegments({
     return fitSummarySegments([...candidates, ...brokerSegments], widthBudget);
   }
 
+  if (accountStatusText) {
+    candidates.push(createSummarySegment("account-status", [
+      { text: accountStatusText, tone: "muted" },
+    ]));
+  }
+
   if (refreshText) {
     candidates.push(createSummarySegment("refresh", [
       { text: refreshText, tone: "muted" },
@@ -258,6 +286,7 @@ export function buildPortfolioSummarySegments({
 
 export function buildPortfolioFooterSegments({
   accountState,
+  accountStatusText,
   activeCollectionId,
   baseCurrency,
   exchangeRates,
@@ -269,6 +298,7 @@ export function buildPortfolioFooterSegments({
   width,
 }: {
   accountState: PortfolioSummaryAccountState | null;
+  accountStatusText?: string;
   activeCollectionId: string | null;
   baseCurrency: string;
   exchangeRates: Map<string, number>;
@@ -319,6 +349,7 @@ export function buildPortfolioFooterSegments({
   return buildPortfolioSummarySegments({
     totals,
     accountState,
+    accountStatusText,
     widthBudget: Math.max(16, width - 14),
     refreshText,
   }).map((segment) => ({

--- a/src/plugins/ibkr/broker-adapter.ts
+++ b/src/plugins/ibkr/broker-adapter.ts
@@ -40,6 +40,25 @@ export const ibkrBroker: BrokerAdapter = {
     return importFlexPositions(normalized.flex);
   },
 
+  async importPortfolioSnapshot(instance) {
+    const normalized = normalizeIbkrConfig(instance.config);
+    if (normalized.connectionMode === "gateway") {
+      const service = ibkrGatewayManager.getService(instance.id);
+      await refreshGatewayData(instance);
+      const [accounts, positions] = await Promise.all([
+        service.getAccounts(normalized.gateway),
+        service.getPositions(normalized.gateway),
+      ]);
+      return { accounts, positions };
+    }
+
+    const xml = await loadFlexStatement(normalized.flex);
+    return {
+      accounts: parseFlexAccounts(xml),
+      positions: parseFlexPositions(xml),
+    };
+  },
+
   async connect(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode !== "gateway") return;

--- a/src/plugins/ibkr/config.test.ts
+++ b/src/plugins/ibkr/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { buildIbkrConfigFromValues, normalizeIbkrConfig } from "./config";
+import {
+  buildIbkrConfigFromValues,
+  IBKR_STATEMENT_URL,
+  LEGACY_IBKR_STATEMENT_URL,
+  normalizeIbkrConfig,
+} from "./config";
 
 describe("ibkr config helpers", () => {
   test("builds nested manual gateway config from flat wizard values", () => {
@@ -45,6 +50,30 @@ describe("ibkr config helpers", () => {
     expect(config.gatewaySetupMode).toBe("auto");
     expect(config.flex.token).toBe("abc");
     expect(config.flex.queryId).toBe("123");
-    expect(config.flex.endpoint).toContain("FlexStatementService.SendRequest");
+    expect(config.flex.endpoint).toBe(IBKR_STATEMENT_URL);
+  });
+
+  test("migrates the legacy default Flex endpoint to the current IBKR endpoint", () => {
+    const config = normalizeIbkrConfig({
+      flex: {
+        token: "abc",
+        queryId: "123",
+        endpoint: LEGACY_IBKR_STATEMENT_URL,
+      },
+    });
+
+    expect(config.flex.endpoint).toBe(IBKR_STATEMENT_URL);
+  });
+
+  test("preserves custom non-default Flex endpoints", () => {
+    const config = normalizeIbkrConfig({
+      flex: {
+        token: "abc",
+        queryId: "123",
+        endpoint: "https://example.com/custom/SendRequest",
+      },
+    });
+
+    expect(config.flex.endpoint).toBe("https://example.com/custom/SendRequest");
   });
 });

--- a/src/plugins/ibkr/config.ts
+++ b/src/plugins/ibkr/config.ts
@@ -1,7 +1,8 @@
 import type { BrokerConfigField } from "../../types/broker";
 import type { IbkrGatewayConfig, ResolvedIbkrGatewayConnection } from "./gateway/service";
 
-export const IBKR_STATEMENT_URL = "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.SendRequest";
+export const LEGACY_IBKR_STATEMENT_URL = "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.SendRequest";
+export const IBKR_STATEMENT_URL = "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/SendRequest";
 
 type IbkrConnectionMode = "flex" | "gateway";
 type IbkrGatewaySetupMode = "auto" | "manual";
@@ -119,6 +120,12 @@ function coerceString(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
 }
 
+function normalizeFlexEndpoint(value: unknown): string {
+  const endpoint = coerceString(value, DEFAULT_FLEX_CONFIG.endpoint).trim();
+  if (!endpoint || endpoint === LEGACY_IBKR_STATEMENT_URL) return IBKR_STATEMENT_URL;
+  return endpoint;
+}
+
 function getMode(value: unknown): IbkrConnectionMode {
   return value === "gateway" ? "gateway" : "flex";
 }
@@ -166,7 +173,7 @@ export function normalizeIbkrConfig(raw?: Record<string, unknown>): IbkrConfig {
     flex: {
       token: coerceString(nestedFlex.token ?? input.token),
       queryId: coerceString(nestedFlex.queryId ?? input.queryId),
-      endpoint: coerceString(nestedFlex.endpoint ?? input.endpoint, DEFAULT_FLEX_CONFIG.endpoint),
+      endpoint: normalizeFlexEndpoint(nestedFlex.endpoint ?? input.endpoint),
     },
     gateway: {
       host,

--- a/src/plugins/ibkr/flex/index.test.ts
+++ b/src/plugins/ibkr/flex/index.test.ts
@@ -59,6 +59,10 @@ describe("parseFlexAccounts", () => {
               <FxPosition accountId="DU12345" assetCategory="CASH" functionalCurrency="USD" fxCurrency="USD" quantity="-303029.144938754" value="-303029.144938754" />
               <FxPosition accountId="DU12345" assetCategory="CASH" functionalCurrency="USD" fxCurrency="EUR" quantity="-351957.025" value="-405102.535775" />
             </FxPositions>
+            <OpenPositions>
+              <OpenPosition accountId="DU12345" symbol="AAPL" assetCategory="STK" position="100" currency="USD" positionValue="100000" fxRateToBase="1" />
+              <OpenPosition accountId="DU12345" symbol="ASML" assetCategory="STK" position="10" currency="EUR" positionValue="50000" fxRateToBase="1.2" />
+            </OpenPositions>
           </FlexStatement>
         </FlexStatements>
       </FlexQueryResponse>
@@ -71,7 +75,9 @@ describe("parseFlexAccounts", () => {
       name: "Main",
       currency: "USD",
       source: "flex",
+      asOfDate: "2026-03-27",
       netLiquidation: 764713.626876249,
+      grossPositionValue: 160000,
       totalCashValue: -1050953.720462251,
       settledCash: -917604.448220862,
       cashBalances: [
@@ -110,7 +116,9 @@ describe("parseFlexAccounts", () => {
         currency: "USD",
         source: "flex",
         updatedAt: new Date(2026, 2, 27).getTime(),
+        asOfDate: "2026-03-27",
         netLiquidation: 12345.67,
+        grossPositionValue: undefined,
         totalCashValue: undefined,
         settledCash: undefined,
         cashBalances: undefined,
@@ -190,9 +198,9 @@ describe("parseFlexPortfolioPerformance", () => {
 
 describe("requestFlexStatement", () => {
   test("uses the configured HTTP transport for statement requests", async () => {
-    const requests: string[] = [];
-    setHttpFetchTransport(async (url) => {
-      requests.push(url);
+    const requests: Array<{ url: string; init: RequestInit | undefined }> = [];
+    setHttpFetchTransport(async (url, init) => {
+      requests.push({ url, init });
       return new Response(
         "<FlexStatementResponse><ReferenceCode>987654</ReferenceCode></FlexStatementResponse>",
         { status: 200 },
@@ -202,16 +210,17 @@ describe("requestFlexStatement", () => {
     await expect(requestFlexStatement({
       token: "secret-flex-token",
       queryId: "12345",
-      endpoint: "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.SendRequest",
+      endpoint: "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/SendRequest",
     })).resolves.toBe("987654");
 
     expect(requests).toHaveLength(1);
-    expect(requests[0]).toContain("q=12345");
+    expect(requests[0]?.url).toContain("q=12345");
+    expect((requests[0]?.init?.headers as Record<string, string> | undefined)?.["User-Agent"]).toBeTruthy();
   });
 
   test("adds request context to vague IBKR Flex errors without exposing the token", async () => {
     globalThis.fetch = (async () => new Response(
-      "<FlexStatementResponse><ErrorMessage>Load failed</ErrorMessage></FlexStatementResponse>",
+      "<FlexStatementResponse><ErrorCode>1001</ErrorCode><ErrorMessage>Load failed</ErrorMessage></FlexStatementResponse>",
       { status: 200 },
     )) as unknown as typeof fetch;
 
@@ -220,14 +229,14 @@ describe("requestFlexStatement", () => {
       await requestFlexStatement({
         token: "secret-flex-token",
         queryId: "12345",
-        endpoint: "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.SendRequest",
+        endpoint: "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/SendRequest",
       });
     } catch (error) {
       message = error instanceof Error ? error.message : String(error);
     }
 
-    expect(message).toContain("IBKR Flex request failed while requesting the statement: Load failed.");
-    expect(message).toContain("Endpoint FlexStatementService.SendRequest");
+    expect(message).toContain("IBKR Flex request failed while requesting the statement: IBKR error 1001: Load failed.");
+    expect(message).toContain("Endpoint SendRequest");
     expect(message).toContain("query ID 12345");
     expect(message).toContain("token configured");
     expect(message).toContain("Flex Web Service is enabled");

--- a/src/plugins/ibkr/flex/index.ts
+++ b/src/plugins/ibkr/flex/index.ts
@@ -63,6 +63,34 @@ function parseFlexDate(raw: string | undefined): string | null {
   return new Date(parsed).toISOString().slice(0, 10);
 }
 
+function parseFlexGrossPositionValue(
+  body: string,
+  statementAccountId: string,
+  baseCurrency: string | undefined,
+): number | undefined {
+  let total = 0;
+  let hasValue = false;
+
+  for (const entry of body.matchAll(/<OpenPosition\b([^>]*)\/?>/g)) {
+    const attributes = parseAttributes(entry[1] ?? "");
+    const accountId = attributes.accountId || statementAccountId;
+    if (!accountId || (statementAccountId && accountId !== statementAccountId)) continue;
+
+    const marketValue = parseNumber(attributes.positionValue);
+    if (marketValue == null) continue;
+
+    const positionCurrency = attributes.currency || baseCurrency;
+    const fxRateToBase = parseNumber(attributes.fxRateToBase)
+      ?? (baseCurrency && positionCurrency === baseCurrency ? 1 : undefined);
+    if (fxRateToBase == null) continue;
+
+    total += Math.abs(marketValue * fxRateToBase);
+    hasValue = true;
+  }
+
+  return hasValue ? total : undefined;
+}
+
 function buildContractRef(attributes: Record<string, string>, symbol: string, assetCategory: string): BrokerContractRef | undefined {
   const conIdRaw = attributes.conid || attributes.conId;
   const strikeRaw = attributes.strike;
@@ -211,7 +239,9 @@ export function parseFlexAccounts(xml: string): BrokerAccount[] {
       currency: accountCurrency,
       source: "flex",
       updatedAt: parseFlexTimestamp(statementAttrs.whenGenerated, statementAttrs.toDate || statementAttrs.fromDate),
+      asOfDate: parseFlexDate(statementAttrs.toDate || statementAttrs.fromDate) ?? undefined,
       netLiquidation: parseNumber(changeInNavAttrs?.endingValue),
+      grossPositionValue: parseFlexGrossPositionValue(body, accountId, accountCurrency),
       totalCashValue: parseNumber(baseCashAttrs?.endingCash),
       settledCash: parseNumber(baseCashAttrs?.endingSettledCash),
       cashBalances: cashBalances.length > 0 ? cashBalances : undefined,

--- a/src/plugins/ibkr/flex/statement-client.ts
+++ b/src/plugins/ibkr/flex/statement-client.ts
@@ -2,7 +2,8 @@ import { httpFetch } from "../../../utils/http-transport";
 import type { FlexQueryConfig } from "../config";
 import { IBKR_STATEMENT_URL } from "../config";
 
-const IBKR_STATEMENT_GET_URL = "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.GetStatement";
+const IBKR_STATEMENT_GET_URL = "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/GetStatement";
+const FLEX_USER_AGENT = "Gloomberb/1.0 Flex";
 const FLEX_STATEMENT_CACHE_MS = 15 * 60_000;
 const FLEX_STATEMENT_INITIAL_WAIT_MS = 3_000;
 const FLEX_STATEMENT_POLL_DELAY_MS = 5_000;
@@ -29,10 +30,54 @@ function decodeXmlText(value: string): string {
     .replace(/&apos;/g, "'");
 }
 
+function extractXmlTag(text: string, tagName: string): string | null {
+  const match = text.match(new RegExp(`<${tagName}>\\s*([^<]*?)\\s*<\\/${tagName}>`, "i"));
+  return match?.[1] ? decodeXmlText(match[1].trim()) : null;
+}
+
 function extractFlexErrorMessage(text: string): string | null {
-  const errorMatch = text.match(/<ErrorMessage>([^<]+)<\/ErrorMessage>/);
-  if (errorMatch?.[1]) return decodeXmlText(errorMatch[1].trim());
-  return null;
+  const message = extractXmlTag(text, "ErrorMessage");
+  const code = extractXmlTag(text, "ErrorCode");
+  if (message && code) return `IBKR error ${code}: ${message}`;
+  return message;
+}
+
+function buildFlexUrl(endpoint: string, params: Record<string, string>): string {
+  const url = new URL(endpoint);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+function resolveFlexGetEndpoint(sendEndpoint: string | undefined): string {
+  if (!sendEndpoint || sendEndpoint === IBKR_STATEMENT_URL) return IBKR_STATEMENT_GET_URL;
+
+  try {
+    const url = new URL(sendEndpoint);
+    url.search = "";
+    if (url.pathname.endsWith("/SendRequest")) {
+      url.pathname = url.pathname.replace(/\/SendRequest$/, "/GetStatement");
+      return url.toString();
+    }
+    if (url.pathname.endsWith("FlexStatementService.SendRequest")) {
+      url.pathname = url.pathname.replace(/FlexStatementService\.SendRequest$/, "FlexStatementService.GetStatement");
+      return url.toString();
+    }
+  } catch {
+    return IBKR_STATEMENT_GET_URL;
+  }
+
+  return IBKR_STATEMENT_GET_URL;
+}
+
+function flexRequestInit(): RequestInit {
+  return {
+    headers: {
+      "User-Agent": FLEX_USER_AGENT,
+    },
+    signal: AbortSignal.timeout(30_000),
+  };
 }
 
 function endpointName(endpoint: string | undefined): string {
@@ -69,11 +114,15 @@ function flexError(providerMessage: string, context: FlexErrorContext): Error {
 
 export async function requestFlexStatement(config: FlexQueryConfig): Promise<string> {
   const endpoint = config.endpoint || IBKR_STATEMENT_URL;
-  const url = `${endpoint}?t=${config.token}&q=${config.queryId}&v=3`;
+  const url = buildFlexUrl(endpoint, {
+    t: config.token,
+    q: config.queryId,
+    v: "3",
+  });
   let resp: Response;
   let text: string;
   try {
-    resp = await httpFetch(url, { signal: AbortSignal.timeout(30_000) });
+    resp = await httpFetch(url, flexRequestInit());
     text = await resp.text();
   } catch (error) {
     throw flexError(error instanceof Error ? error.message : "Network request failed", {
@@ -84,8 +133,8 @@ export async function requestFlexStatement(config: FlexQueryConfig): Promise<str
     });
   }
 
-  const codeMatch = text.match(/<ReferenceCode>(\d+)<\/ReferenceCode>/);
-  if (!codeMatch) {
+  const referenceCode = extractXmlTag(text, "ReferenceCode");
+  if (!referenceCode) {
     throw flexError(extractFlexErrorMessage(text) || "No reference code returned", {
       phase: "request",
       endpoint,
@@ -95,7 +144,7 @@ export async function requestFlexStatement(config: FlexQueryConfig): Promise<str
     });
   }
 
-  return codeMatch[1]!;
+  return referenceCode;
 }
 
 async function getFlexStatement(
@@ -105,17 +154,22 @@ async function getFlexStatement(
 ): Promise<string> {
   await new Promise((resolve) => setTimeout(resolve, FLEX_STATEMENT_INITIAL_WAIT_MS));
 
-  const url = `${IBKR_STATEMENT_GET_URL}?t=${token}&q=${referenceCode}&v=3`;
+  const endpoint = resolveFlexGetEndpoint(context.endpoint);
+  const url = buildFlexUrl(endpoint, {
+    t: token,
+    q: referenceCode,
+    v: "3",
+  });
   for (let attempt = 0; attempt < FLEX_STATEMENT_MAX_DOWNLOAD_ATTEMPTS; attempt += 1) {
     let resp: Response;
     let text: string;
     try {
-      resp = await httpFetch(url, { signal: AbortSignal.timeout(30_000) });
+      resp = await httpFetch(url, flexRequestInit());
       text = await resp.text();
     } catch (error) {
       throw flexError(error instanceof Error ? error.message : "Network request failed", {
         phase: "download",
-        endpoint: context.endpoint,
+        endpoint,
         queryId: context.queryId,
         token,
         referenceCode,
@@ -135,7 +189,7 @@ async function getFlexStatement(
     if (providerMessage) {
       throw flexError(providerMessage, {
         phase: "download",
-        endpoint: context.endpoint,
+        endpoint,
         queryId: context.queryId,
         token,
         referenceCode,
@@ -146,7 +200,7 @@ async function getFlexStatement(
 
   throw flexError("statement generation timed out", {
     phase: "download",
-    endpoint: context.endpoint,
+    endpoint,
     queryId: context.queryId,
     token,
     referenceCode,

--- a/src/plugins/ibkr/gateway/account-loaders.ts
+++ b/src/plugins/ibkr/gateway/account-loaders.ts
@@ -96,7 +96,7 @@ export async function loadIbkrAccounts({
     const result = await firstValueFrom(
       api.getAccountSummary(
         "All",
-        "NetLiquidation,TotalCashValue,SettledCash,AvailableFunds,BuyingPower,ExcessLiquidity,InitMarginReq,MaintMarginReq,$LEDGER:ALL",
+        "NetLiquidation,GrossPositionValue,TotalCashValue,SettledCash,AvailableFunds,BuyingPower,ExcessLiquidity,InitMarginReq,MaintMarginReq,$LEDGER:ALL",
       )
         .pipe(take(1), timeout(10_000)),
     );

--- a/src/plugins/ibkr/gateway/account-summary.ts
+++ b/src/plugins/ibkr/gateway/account-summary.ts
@@ -148,6 +148,7 @@ export function summarizeBrokerAccount(
     source: "gateway",
     updatedAt,
     netLiquidation: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "NetLiquidation", currency, allowAggregateCashBalances),
+    grossPositionValue: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "GrossPositionValue", currency, allowAggregateCashBalances),
     totalCashValue: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "TotalCashValue", currency, allowAggregateCashBalances),
     settledCash: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "SettledCash", currency, allowAggregateCashBalances),
     availableFunds: getAccountSummaryNumberWithAggregateFallback(tags, aggregateTags, "AvailableFunds", currency, allowAggregateCashBalances),

--- a/src/plugins/ibkr/gateway/service/index.test.ts
+++ b/src/plugins/ibkr/gateway/service/index.test.ts
@@ -35,6 +35,7 @@ describe("summarizeBrokerAccount", () => {
   test("maps gateway account summary fields and ledger balances", () => {
     const tags = makeTags({
       NetLiquidation: { USD: "764713.62" },
+      GrossPositionValue: { USD: "1815667.34" },
       TotalCashValue: { USD: "-1050953.72" },
       SettledCash: { USD: "-917604.44" },
       AvailableFunds: { USD: "112345.67" },
@@ -52,6 +53,7 @@ describe("summarizeBrokerAccount", () => {
       source: "gateway",
       updatedAt: 1_717_000_000_000,
       netLiquidation: 764713.62,
+      grossPositionValue: 1815667.34,
       totalCashValue: -1050953.72,
       settledCash: -917604.44,
       availableFunds: 112345.67,
@@ -72,6 +74,7 @@ describe("summarizeBrokerAccount", () => {
   test("falls back to the aggregate cash summary for single-account gateways", () => {
     const accountTags = makeTags({
       NetLiquidation: { USD: "129360.15" },
+      GrossPositionValue: { USD: "1066.36" },
       TotalCashValue: { USD: "128293.79" },
       AvailableFunds: { USD: "129031.52" },
       BuyingPower: { USD: "860210.13" },
@@ -99,6 +102,7 @@ describe("summarizeBrokerAccount", () => {
       source: "gateway",
       updatedAt: 1_717_000_000_000,
       netLiquidation: 129360.15,
+      grossPositionValue: 1066.36,
       totalCashValue: 128293.79,
       settledCash: undefined,
       availableFunds: 129031.52,
@@ -119,6 +123,7 @@ describe("summarizeBrokerAccount", () => {
   test("falls back to aggregate summary metrics when a single-account gateway only returns the All row", () => {
     const aggregateTags = makeTags({
       NetLiquidation: { USD: "129360.15" },
+      GrossPositionValue: { USD: "1066.36" },
       TotalCashValue: { USD: "128293.79" },
       AvailableFunds: { USD: "129031.52" },
       BuyingPower: { USD: "860210.13" },
@@ -144,6 +149,7 @@ describe("summarizeBrokerAccount", () => {
       source: "gateway",
       updatedAt: 1_717_000_000_000,
       netLiquidation: 129360.15,
+      grossPositionValue: 1066.36,
       totalCashValue: 128293.79,
       settledCash: undefined,
       availableFunds: 129031.52,
@@ -164,6 +170,7 @@ describe("summarizeBrokerAccount", () => {
   test("maps account-level P&L into gateway account snapshots", () => {
     const tags = makeTags({
       NetLiquidation: { USD: "100000" },
+      GrossPositionValue: { USD: "75000" },
     });
 
     expect(summarizeBrokerAccount("DU12345", tags, 1_717_000_000_000, undefined, false, {
@@ -186,6 +193,7 @@ describe("summarizeBrokerAccount", () => {
       source: "gateway",
       updatedAt: 123,
       netLiquidation: undefined,
+      grossPositionValue: undefined,
       totalCashValue: undefined,
       settledCash: undefined,
       availableFunds: undefined,

--- a/src/types/broker.ts
+++ b/src/types/broker.ts
@@ -85,6 +85,7 @@ export interface BrokerAdapter {
   readonly cachePolicy?: CachePolicyMap;
   validate(instance: BrokerInstanceConfig): Promise<boolean>;
   importPositions(instance: BrokerInstanceConfig): Promise<BrokerPosition[]>;
+  importPortfolioSnapshot?(instance: BrokerInstanceConfig): Promise<{ accounts: BrokerAccount[]; positions: BrokerPosition[] }>;
   configSchema: BrokerConfigField[];
   connect?(instance: BrokerInstanceConfig): Promise<void>;
   disconnect?(instance: BrokerInstanceConfig): Promise<void>;

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -16,7 +16,9 @@ export interface BrokerAccount {
   currency?: string;
   source?: "gateway" | "flex";
   updatedAt?: number;
+  asOfDate?: string;
   netLiquidation?: number;
+  grossPositionValue?: number;
   totalCashValue?: number;
   settledCash?: number;
   buyingPower?: number;


### PR DESCRIPTION
## Summary
- move IBKR Flex requests to the current Flex Web Service endpoints with a required User-Agent and clearer provider errors
- import account and position data from one broker snapshot so Net Liq, Val, Cash, and cash balances come from the same Flex XML
- preserve the last account snapshot on sync failure and show Flex account freshness from the statement as-of date
- use broker-provided gross position value for portfolio Val and expose missing account snapshots in the portfolio footer

## Root Cause
The app was still using the legacy IBKR Flex servlet endpoint and treated the report fetch/generation timestamp as account freshness. A newly fetched Flex report can still contain prior-day account values, so the UI could imply current cash/net-liq while the statement was actually as of the prior report date.

## Validation
- bun test src/plugins/builtin/portfolio-list/index.test.ts src/plugins/builtin/portfolio-list/summary/index.test.ts src/plugins/builtin/analytics/index.test.tsx src/plugins/ibkr/flex/index.test.ts src/plugins/ibkr/config.test.ts src/brokers/sync-broker-instance.test.ts src/plugins/builtin/portfolio-list/account-metrics.test.ts src/plugins/ibkr/gateway/service/index.test.ts
- git diff --check
- staged diff secret scan only matched dummy test fixture token text
