### PR TITLE
Add portfolio margin leverage

### DIFF
--- a/src/plugins/builtin/analytics/index.test.tsx
+++ b/src/plugins/builtin/analytics/index.test.tsx
@@ -300,6 +300,7 @@ describe("PortfolioAnalyticsPane", () => {
               excessLiquidity: 12000,
               buyingPower: 30000,
               netLiquidation: 125000,
+              grossPositionValue: 113636,
               dailyPnl: 900,
               unrealizedPnl: 777,
               realizedPnl: -25,
@@ -319,6 +320,8 @@ describe("PortfolioAnalyticsPane", () => {
 
     const frame = testSetup!.captureCharFrame();
     expect(frame).toContain("Net Liq       125k");
+    expect(frame).toContain("Val           113.6k");
+    expect(frame).toContain("Margin Lev    1.1x");
     expect(frame).toContain("Cash          -50k");
     expect(frame).toContain("Day           +900");
     expect(frame).toContain("P&L           +777");

--- a/src/plugins/builtin/analytics/pane-model.ts
+++ b/src/plugins/builtin/analytics/pane-model.ts
@@ -54,6 +54,15 @@ function formatAccountFreshness(account: ResolvedPortfolioAccountState["account"
   return account.updatedAt ? formatRelativeAge(account.updatedAt) : null;
 }
 
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function formatMarginLeverage(netLiquidation: number | undefined, totalMarketValue: number): string | null {
+  if (!finiteNumber(netLiquidation) || !finiteNumber(totalMarketValue) || totalMarketValue <= 0) return null;
+  return `${(netLiquidation / totalMarketValue).toFixed(1)}x`;
+}
+
 export function buildPortfolioChartTargets(portfolioTickers: TickerRecord[]): PortfolioChartTarget[] {
   return portfolioTickers.flatMap((ticker) => {
     const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
@@ -124,6 +133,7 @@ export function buildAnalyticsSummaryRows({
   const account = accountState?.account;
   const accountMetrics = resolvePortfolioAccountMetrics(portfolioStats, account);
   const accountFreshness = formatAccountFreshness(account);
+  const totalMarketValue = resolvePortfolioMarketValue(portfolioStats, account);
 
   if (account?.netLiquidation != null) {
     rows.push({
@@ -137,9 +147,19 @@ export function buildAnalyticsSummaryRows({
   rows.push({
     id: "total-value",
     label: "Val",
-    value: formatCompact(resolvePortfolioMarketValue(portfolioStats, account)),
+    value: formatCompact(totalMarketValue),
     color: colors.text,
   });
+
+  const marginLeverage = formatMarginLeverage(account?.netLiquidation, totalMarketValue);
+  if (marginLeverage) {
+    rows.push({
+      id: "margin-leverage",
+      label: "Margin Lev",
+      value: marginLeverage,
+      color: colors.text,
+    });
+  }
 
   if (account?.totalCashValue != null) {
     rows.push({


### PR DESCRIPTION
## Summary

- Add a Margin Lev summary row to the portfolio analytics pane
- Calculate leverage from net liquidation divided by the portfolio market value already shown as Val
- Cover the broker account render path with the existing analytics pane test

## Validation

- bun test src/plugins/builtin/analytics/index.test.tsx
- bun test
- tmux terminal smoke test