### PR TITLE
Improve ticker graph history and hover

### DIFF
--- a/src/app/runtime/ticker-refresh.ts
+++ b/src/app/runtime/ticker-refresh.ts
@@ -164,7 +164,10 @@ export function useTickerRefreshRuntime({
           dispatch({ type: "SET_REFRESHING", symbol, refreshing: true });
         }
         try {
-          const entries = await marketData.loadSnapshotsBatch(instrumentEntries.map((entry) => entry.instrument));
+          const entries = await marketData.loadSnapshotsBatch(
+            instrumentEntries.map((entry) => entry.instrument),
+            { forceRefresh: true },
+          );
           entries.forEach((entry, index) => {
             const ticker = instrumentEntries[index]?.ticker;
             const data = entry.data ?? entry.lastGoodData;

--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { pathToFileURL } from "url";
 import type { AppConfig } from "../types/config";
-import type { TickerFinancials } from "../types/financials";
+import type { OptionsChain, TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
 import type { PaneRuntimeState } from "../core/state/app/state";
 import {
@@ -20,6 +20,7 @@ export interface DesktopPaneShotPayload {
   heightPx: number;
   tickers: TickerRecord[];
   financials: Array<[string, TickerFinancials]>;
+  optionsChains: Array<[string, OptionsChain]>;
   paneState: Record<string, PaneRuntimeState>;
 }
 

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from "path";
 import { mkdir } from "fs/promises";
 import type { PaneRuntimeState } from "../../core/state/app/state";
-import type { TickerFinancials } from "../../types/financials";
+import type { OptionsChain, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { slugifyName } from "../../utils/slugify";
 import { renderDesktopPaneScreenshot, type DesktopPaneShotPayload } from "../desktop-pane-shot";
@@ -18,6 +18,7 @@ import {
 
 const DESKTOP_CELL_WIDTH_PX = 8;
 const DESKTOP_CELL_HEIGHT_PX = 18;
+const OPTIONS_PANE_ID = "options";
 
 export function defaultScreenshotPath(resolved: ResolvedPaneFunction, rawArg: string): string {
   const suffix = slugifyName([resolved.token, rawArg].filter(Boolean).join("-"), "pane");
@@ -70,11 +71,21 @@ async function buildDesktopShotPayload(
 
   const tickers: TickerRecord[] = [];
   const financials: Array<[string, TickerFinancials]> = [];
+  const optionsChains: Array<[string, OptionsChain]> = [];
+  const includeOptionsChains = resolved.pane.id === OPTIONS_PANE_ID || resolved.template?.paneId === OPTIONS_PANE_ID;
   for (const symbol of collectShotSymbols(resolved, rawArg)) {
     const entry = await fetchTickerFinancials(context, symbol);
     const data = await withShotPriceHistory(context, symbol, entry.tickerFile, entry.financials);
     tickers.push(entry.tickerFile ?? createFallbackTicker(symbol, data, context));
     financials.push([symbol, data]);
+    if (includeOptionsChains && context.dataProvider.getOptionsChain) {
+      const exchange = entry.tickerFile?.metadata.exchange
+        ?? data.quote?.listingExchangeName
+        ?? data.quote?.exchangeName
+        ?? "";
+      const chain = await context.dataProvider.getOptionsChain(symbol, exchange);
+      optionsChains.push([symbol, chain]);
+    }
   }
 
   return {
@@ -86,6 +97,7 @@ async function buildDesktopShotPayload(
     heightPx,
     tickers,
     financials,
+    optionsChains,
     paneState,
   };
 }

--- a/src/components/chart/bar-chart-renderer.test.ts
+++ b/src/components/chart/bar-chart-renderer.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { buildBarChartScene, renderBarChart, renderNativeBarChart } from "./bar-chart-renderer";
+import {
+  buildBarChartScene,
+  renderBarChart,
+  renderBarChartAxis,
+  renderBarChartYAxis,
+  renderNativeBarChart,
+  resolveNativeBarPixelBounds,
+  resolveBarChartHover,
+} from "./bar-chart-renderer";
 
 const series = [
   {
@@ -27,27 +35,124 @@ describe("bar chart renderer", () => {
     const scene = buildBarChartScene(series, {
       width: 24,
       height: 8,
-      colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666" },
+      colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666", negativeColor: "#ff5555" },
     });
 
     expect(scene).not.toBeNull();
     expect(scene!.categories).toEqual(["2024", "2025"]);
     expect(scene!.bars).toHaveLength(4);
     expect(scene!.zeroRow).toBeGreaterThanOrEqual(0);
+    expect(scene!.bars.find((bar) => bar.value < 0)?.color).toBe("#ff5555");
   });
 
   test("renders text fallback and native bitmap output", () => {
     const scene = buildBarChartScene(series, {
       width: 24,
       height: 8,
-      colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666" },
+      colors: {
+        bgColor: "#000000",
+        gridColor: "#333333",
+        axisColor: "#666666",
+        negativeColor: "#ff5555",
+        hoverColor: "#ffffff",
+      },
     })!;
 
     expect(renderBarChart(scene).join("\n")).toContain("█");
 
     const bitmap = renderNativeBarChart(scene, 96, 48);
+    const negativePixel = Array.from({ length: bitmap.pixels.length / 4 }).some((_, pixelIndex) => {
+      const index = pixelIndex * 4;
+      return bitmap.pixels[index]! > 200 && bitmap.pixels[index + 1]! < 100 && bitmap.pixels[index + 2]! < 100;
+    });
     expect(bitmap.width).toBe(96);
     expect(bitmap.height).toBe(48);
     expect(bitmap.pixels.some((value) => value > 0)).toBe(true);
+    expect(negativePixel).toBe(true);
+
+    const hover = resolveBarChartHover(scene, scene.bars[0]!.x);
+    expect(renderBarChart(scene, hover).join("\n")).toContain("▓");
+    const hoverBitmap = renderNativeBarChart(scene, 96, 48, hover);
+    const hoverPixel = Array.from({ length: hoverBitmap.pixels.length / 4 }).some((_, pixelIndex) => {
+      const index = pixelIndex * 4;
+      return hoverBitmap.pixels[index]! > 240 && hoverBitmap.pixels[index + 1]! > 240 && hoverBitmap.pixels[index + 2]! > 240;
+    });
+    expect(hoverBitmap.pixels).not.toEqual(bitmap.pixels);
+    expect(hoverPixel).toBe(true);
+  });
+
+  test("renders y-axis labels and resolves hover targets", () => {
+    const scene = buildBarChartScene(series, {
+      width: 24,
+      height: 8,
+      colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666" },
+    })!;
+
+    const yAxis = renderBarChartYAxis(scene, 8, (value) => String(Math.round(value)));
+    const labelCount = yAxis.filter((line) => line.trim().length > 0).length;
+    expect(labelCount).toBeGreaterThanOrEqual(5);
+    expect(yAxis.join("\n")).toContain("22");
+    expect(yAxis.join("\n")).toContain("0");
+
+    const hover = resolveBarChartHover(scene, scene.bars[1]!.x);
+    expect(hover).toMatchObject({
+      seriesId: "NVDA",
+      seriesLabel: "NVDA",
+      category: "2024",
+      value: 20,
+      x: scene.bars[1]!.x,
+      width: scene.bars[1]!.width,
+      row: scene.bars[1]!.row,
+    });
+  });
+
+  test("renders dense single-series bars with consistent separators and readable x-axis labels", () => {
+    const denseSeries = [{
+      id: "value",
+      label: "Value",
+      color: "#00ff66",
+      points: Array.from({ length: 14 }, (_unused, index) => ({
+        category: `${2015 + index} Q1`,
+        value: index + 1,
+      })),
+    }];
+    const scene = buildBarChartScene(denseSeries, {
+      width: 47,
+      height: 8,
+      colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666", negativeColor: "#ff5555" },
+    })!;
+
+    const lastBar = scene.bars.at(-1)!;
+    expect(lastBar.x + lastBar.width).toBe(scene.width);
+    expect(renderBarChart(scene)[scene.zeroRow]).not.toContain("─");
+
+    const bitmapWidth = 470;
+    const pixelBounds = scene.bars.map((bar) => resolveNativeBarPixelBounds(scene, bar, bitmapWidth));
+    const pixelWidths = pixelBounds.map((bounds) => bounds.rightExclusive - bounds.left);
+    expect(Math.max(...pixelWidths) - Math.min(...pixelWidths)).toBeLessThanOrEqual(1);
+    expect(pixelBounds[0]!.left).toBe(0);
+    expect(pixelBounds.at(-1)!.rightExclusive).toBe(bitmapWidth);
+    const pixelGaps: number[] = [];
+    for (let index = 1; index < pixelBounds.length; index++) {
+      pixelGaps.push(pixelBounds[index]!.left - pixelBounds[index - 1]!.rightExclusive);
+    }
+    expect(new Set(pixelGaps)).toEqual(new Set([1]));
+
+    const bitmap = renderNativeBarChart(scene, bitmapWidth, 80);
+    const zeroY = Math.round((scene.zeroRow / Math.max(scene.height - 1, 1)) * (bitmap.height - 1));
+    let separatorColumns = 0;
+    for (let x = 0; x < bitmap.width; x++) {
+      const index = (zeroY * bitmap.width + x) * 4;
+      if (bitmap.pixels[index + 1]! <= 120) separatorColumns++;
+    }
+    expect(separatorColumns).toBe(scene.categories.length - 1);
+
+    const axis = renderBarChartAxis(scene, 1);
+    expect(axis).toHaveLength(1);
+    expect(axis.every((line) => line.length === scene.width)).toBe(true);
+    expect(axis.join("\n")).toContain("2015");
+    expect(axis.join("\n")).not.toContain("Q1");
+    expect(axis.join("\n")).not.toContain("20 20");
+    expect(axis[0]!.endsWith("  ")).toBe(true);
   });
 });

--- a/src/components/chart/bar-chart-renderer.ts
+++ b/src/components/chart/bar-chart-renderer.ts
@@ -1,5 +1,6 @@
 import type { NativeChartBitmap } from "./native/chart-rasterizer";
 import { fillRect, parseHex } from "./native/raster/primitives";
+import { formatCompact } from "../../utils/format";
 
 interface BarChartPoint {
   category: string;
@@ -17,6 +18,8 @@ export interface BarChartColors {
   bgColor: string;
   gridColor: string;
   axisColor: string;
+  negativeColor?: string;
+  hoverColor?: string;
 }
 
 export interface BarChartSceneOptions {
@@ -25,8 +28,9 @@ export interface BarChartSceneOptions {
   colors: BarChartColors;
 }
 
-interface BarChartBar {
+export interface BarChartBar {
   seriesId: string;
+  seriesLabel: string;
   category: string;
   value: number;
   color: string;
@@ -47,7 +51,34 @@ export interface BarChartScene {
   colors: BarChartColors;
 }
 
+export interface BarChartHover {
+  seriesId: string;
+  seriesLabel: string;
+  category: string;
+  value: number;
+  color: string;
+  x: number;
+  width: number;
+  row: number;
+}
+
+export interface NativeBarChartPixelBounds {
+  left: number;
+  rightExclusive: number;
+}
+
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+function categorySlotBounds(width: number, categoryCount: number, index: number): { left: number; width: number } {
+  const left = Math.floor((index * width) / categoryCount);
+  const right = index === categoryCount - 1
+    ? width
+    : Math.floor(((index + 1) * width) / categoryCount);
+  return {
+    left,
+    width: Math.max(1, right - left),
+  };
+}
 
 function collectCategories(series: BarChartSeries[]): string[] {
   const categories: string[] = [];
@@ -64,19 +95,30 @@ function collectCategories(series: BarChartSeries[]): string[] {
 
 function normalizeRange(values: number[]): { min: number; max: number } {
   if (values.length === 0) return { min: 0, max: 1 };
-  const rawMin = Math.min(0, ...values);
-  const rawMax = Math.max(0, ...values);
-  if (rawMin === rawMax) {
-    const delta = Math.max(Math.abs(rawMin) * 0.1, 1);
-    return { min: rawMin - delta, max: rawMax + delta };
+  const dataMin = Math.min(...values);
+  const dataMax = Math.max(...values);
+  if (dataMin === dataMax) {
+    if (dataMin === 0) return { min: -1, max: 1 };
+    const delta = Math.max(Math.abs(dataMin) * 0.1, 1);
+    return dataMin > 0
+      ? { min: 0, max: dataMax + delta }
+      : { min: dataMin - delta, max: 0 };
   }
-  const padding = (rawMax - rawMin) * 0.08;
-  return { min: rawMin - padding, max: rawMax + padding };
+  const padding = (dataMax - dataMin) * 0.08;
+  if (dataMin >= 0) return { min: 0, max: dataMax + padding };
+  if (dataMax <= 0) return { min: dataMin - padding, max: 0 };
+  return { min: dataMin - padding, max: dataMax + padding };
 }
 
 function valueToRow(value: number, min: number, max: number, height: number): number {
   const t = (value - min) / (max - min || 1);
   return clamp(Math.round((1 - t) * (height - 1)), 0, height - 1);
+}
+
+function rowToValue(row: number, scene: Pick<BarChartScene, "height" | "min" | "max">): number {
+  if (scene.height <= 1) return scene.max;
+  const t = 1 - row / Math.max(scene.height - 1, 1);
+  return scene.min + t * (scene.max - scene.min);
 }
 
 export function buildBarChartScene(series: BarChartSeries[], options: BarChartSceneOptions): BarChartScene | null {
@@ -91,23 +133,32 @@ export function buildBarChartScene(series: BarChartSeries[], options: BarChartSc
 
   const { min, max } = normalizeRange(values);
   const zeroRow = valueToRow(0, min, max, height);
-  const groupWidth = Math.max(1, Math.floor(width / categories.length));
   const seriesCount = Math.max(series.length, 1);
-  const barWidth = Math.max(1, Math.floor(Math.max(groupWidth - 1, 1) / seriesCount));
+  const categorySlots = categories.map((_, index) => categorySlotBounds(width, categories.length, index));
+  const minSlotWidth = Math.max(1, Math.min(...categorySlots.map((slot) => slot.width)));
+  const groupedInnerWidth = Math.max(seriesCount, minSlotWidth - (minSlotWidth > seriesCount * 2 ? 1 : 0));
+  const groupedBarWidth = Math.max(1, Math.floor(groupedInnerWidth / seriesCount));
   const bars: BarChartBar[] = [];
 
   categories.forEach((category, categoryIndex) => {
-    const groupLeft = categoryIndex * groupWidth;
+    const group = categorySlots[categoryIndex]!;
+    const barWidth = seriesCount === 1 ? group.width : groupedBarWidth;
+    const barGroupWidth = barWidth * seriesCount;
+    const groupOffset = Math.max(0, Math.floor((group.width - barGroupWidth) / 2));
     series.forEach((item, seriesIndex) => {
       const value = item.points.find((point) => point.category === category)?.value;
       if (typeof value !== "number" || !Number.isFinite(value)) return;
+      const color = value < 0 && options.colors.negativeColor
+        ? options.colors.negativeColor
+        : item.color;
       bars.push({
         seriesId: item.id,
+        seriesLabel: item.label,
         category,
         value,
-        color: item.color,
-        x: clamp(groupLeft + seriesIndex * barWidth, 0, width - 1),
-        width: Math.min(barWidth, Math.max(width - groupLeft, 1)),
+        color,
+        x: clamp(group.left + groupOffset + seriesIndex * barWidth, 0, width - 1),
+        width: Math.min(barWidth, Math.max(width - (group.left + groupOffset + seriesIndex * barWidth), 1)),
         row: valueToRow(value, min, max, height),
       });
     });
@@ -126,18 +177,81 @@ export function buildBarChartScene(series: BarChartSeries[], options: BarChartSc
   };
 }
 
-export function renderBarChart(scene: BarChartScene): string[] {
+function labelAtRow(labels: Array<{ row: number; value: number }>, row: number): number | null {
+  const match = labels.find((label) => label.row === row);
+  return match ? match.value : null;
+}
+
+export function barChartYAxisTicks(scene: BarChartScene): Array<{ row: number; value: number }> {
+  const ticksByRow = new Map<number, number>();
+  const addTick = (row: number, value: number) => {
+    ticksByRow.set(clamp(row, 0, scene.height - 1), value);
+  };
+
+  addTick(0, scene.max);
+  for (let i = 1; i <= 3; i++) {
+    const row = Math.round((scene.height - 1) * (i / 4));
+    addTick(row, rowToValue(row, scene));
+  }
+  addTick(scene.zeroRow, 0);
+  addTick(scene.height - 1, scene.min);
+
+  return [...ticksByRow.entries()]
+    .map(([row, value]) => ({ row, value }))
+    .sort((left, right) => left.row - right.row);
+}
+
+export function renderBarChartYAxis(
+  scene: BarChartScene,
+  width: number,
+  formatValue: (value: number) => string = formatCompact,
+): string[] {
+  const axisWidth = Math.max(0, Math.floor(width));
+  if (axisWidth === 0) return Array.from({ length: scene.height }, () => "");
+
+  const ticks = barChartYAxisTicks(scene);
+  return Array.from({ length: scene.height }, (_unused, row) => {
+    const value = labelAtRow(ticks, row);
+    const label = value === null ? "" : formatValue(value);
+    return `${label.slice(0, Math.max(axisWidth - 1, 0)).padStart(Math.max(axisWidth - 1, 0))} `;
+  });
+}
+
+export function resolveBarChartHover(scene: BarChartScene, cellX: number): BarChartHover | null {
+  if (!Number.isFinite(cellX) || scene.bars.length === 0) return null;
+  const x = clamp(Math.floor(cellX), 0, scene.width - 1);
+  const direct = scene.bars.find((bar) => x >= bar.x && x < bar.x + bar.width);
+  const bar = direct ?? scene.bars.reduce((closest, current) => {
+    const closestCenter = closest.x + closest.width / 2;
+    const currentCenter = current.x + current.width / 2;
+    return Math.abs(currentCenter - x) < Math.abs(closestCenter - x) ? current : closest;
+  }, scene.bars[0]!);
+
+  return {
+    seriesId: bar.seriesId,
+    seriesLabel: bar.seriesLabel,
+    category: bar.category,
+    value: bar.value,
+    color: bar.color,
+    x: bar.x,
+    width: bar.width,
+    row: bar.row,
+  };
+}
+
+export function renderBarChart(scene: BarChartScene, hover: BarChartHover | null = null): string[] {
   const rows = Array.from({ length: scene.height }, () => Array(scene.width).fill(" "));
   for (let x = 0; x < scene.width; x++) {
     rows[scene.zeroRow]![x] = "─";
   }
 
   for (const bar of scene.bars) {
+    const fill = hover && hover.seriesId === bar.seriesId && hover.category === bar.category ? "▓" : "█";
     const top = Math.min(bar.row, scene.zeroRow);
     const bottom = Math.max(bar.row, scene.zeroRow);
     for (let y = top; y <= bottom; y++) {
       for (let x = bar.x; x < Math.min(bar.x + bar.width, scene.width); x++) {
-        rows[y]![x] = "█";
+        rows[y]![x] = fill;
       }
     }
   }
@@ -145,26 +259,101 @@ export function renderBarChart(scene: BarChartScene): string[] {
   return rows.map((row) => row.join(""));
 }
 
-export function renderBarChartAxis(scene: BarChartScene): string {
-  const axis = Array(scene.width).fill(" ");
-  const groupWidth = Math.max(1, Math.floor(scene.width / scene.categories.length));
-  scene.categories.forEach((category, index) => {
-    const label = category.slice(0, Math.max(1, groupWidth - 1));
-    const start = index * groupWidth;
-    for (let i = 0; i < label.length && start + i < scene.width; i++) {
-      axis[start + i] = label[i]!;
-    }
-  });
-  return axis.join("");
+function centeredLabelStart(center: number, label: string, width: number, rightInset = 0): number {
+  return clamp(Math.round(center - label.length / 2), 0, Math.max(0, width - label.length - rightInset));
 }
 
-export function renderNativeBarChart(scene: BarChartScene, pixelWidth: number, pixelHeight: number): NativeChartBitmap {
+function compactCategoryLabel(category: string, previous: string | undefined, categoryCount: number): string {
+  const quarterMatch = category.match(/^(\d{4}) Q([1-4])$/);
+  if (!quarterMatch) return category;
+  const year = quarterMatch[1]!;
+  const previousYear = previous?.match(/^(\d{4}) Q[1-4]$/)?.[1];
+  if (categoryCount > 10) return previousYear === year ? "" : year;
+  return category;
+}
+
+function canPlaceLabel(row: string[], start: number, label: string, minGap: number): boolean {
+  const left = Math.max(0, start - minGap);
+  const right = Math.min(row.length - 1, start + label.length + minGap - 1);
+  for (let index = left; index <= right; index++) {
+    if (row[index] !== " ") return false;
+  }
+  return true;
+}
+
+export function renderBarChartAxis(scene: BarChartScene, rowCount = 1): string[] {
+  const rows = Array.from({ length: Math.max(1, Math.floor(rowCount)) }, () => Array(scene.width).fill(" "));
+  const minGap = scene.categories.length > 10 ? 3 : 1;
+  const rightInset = scene.categories.length > 10 ? 2 : 0;
+  scene.categories.forEach((category, index) => {
+    const label = compactCategoryLabel(category, scene.categories[index - 1], scene.categories.length);
+    if (!label) return;
+    const group = categorySlotBounds(scene.width, scene.categories.length, index);
+    const start = centeredLabelStart(group.left + group.width / 2, label, scene.width, rightInset);
+    const row = rows.find((candidate) => canPlaceLabel(candidate, start, label, minGap));
+    if (!row) return;
+    for (let i = 0; i < label.length && start + i < scene.width; i++) {
+      row[start + i] = label[i]!;
+    }
+  });
+  return rows.map((row) => row.join(""));
+}
+
+export function resolveNativeBarPixelBounds(
+  scene: BarChartScene,
+  bar: BarChartBar,
+  pixelWidth: number,
+): NativeBarChartPixelBounds {
+  const width = Math.max(1, Math.floor(pixelWidth));
+
+  if (scene.series.length === 1) {
+    const categoryIndex = scene.categories.indexOf(bar.category);
+    if (categoryIndex >= 0) {
+      const separatorWidth = scene.categories.length > 1 && width >= scene.categories.length * 3 ? 1 : 0;
+      const usableWidth = Math.max(
+        scene.categories.length,
+        width - separatorWidth * (scene.categories.length - 1),
+      );
+      const left = Math.floor((categoryIndex * usableWidth) / scene.categories.length)
+        + categoryIndex * separatorWidth;
+      const rightExclusive = categoryIndex === scene.categories.length - 1
+        ? width
+        : Math.floor(((categoryIndex + 1) * usableWidth) / scene.categories.length)
+          + categoryIndex * separatorWidth;
+      return {
+        left,
+        rightExclusive: Math.max(left + 1, rightExclusive),
+      };
+    }
+  }
+
+  const horizontalInset = 1;
+  const left = clamp(
+    Math.floor((bar.x / scene.width) * width + horizontalInset),
+    0,
+    width - 1,
+  );
+  const rightExclusive = clamp(
+    Math.ceil(((bar.x + bar.width) / scene.width) * width - horizontalInset),
+    left + 1,
+    width,
+  );
+  return { left, rightExclusive };
+}
+
+export function renderNativeBarChart(
+  scene: BarChartScene,
+  pixelWidth: number,
+  pixelHeight: number,
+  hover: BarChartHover | null = null,
+): NativeChartBitmap {
   const width = Math.max(1, Math.floor(pixelWidth));
   const height = Math.max(1, Math.floor(pixelHeight));
   const data = new Uint8Array(width * height * 4);
   const bg = parseHex(scene.colors.bgColor, 1);
   const grid = parseHex(scene.colors.gridColor, 0.45);
   const axis = parseHex(scene.colors.axisColor, 0.75);
+  const hoverColor = parseHex(scene.colors.hoverColor ?? scene.colors.axisColor, 1);
 
   fillRect(data, width, height, 0, 0, width - 1, height - 1, bg, 1);
 
@@ -177,13 +366,23 @@ export function renderNativeBarChart(scene: BarChartScene, pixelWidth: number, p
   fillRect(data, width, height, 0, zeroY, width - 1, zeroY + 1.1, axis, 0.8);
 
   for (const bar of scene.bars) {
+    const isHovered = !!hover
+      && hover.seriesId === bar.seriesId
+      && hover.category === bar.category;
     const color = parseHex(bar.color, 0.96);
-    const left = (bar.x / scene.width) * width + 1;
-    const right = ((bar.x + bar.width) / scene.width) * width - 1;
+    const bounds = resolveNativeBarPixelBounds(scene, bar, width);
+    const left = bounds.left;
+    const right = bounds.rightExclusive - 1;
     const valueY = clamp((bar.row / Math.max(scene.height - 1, 1)) * (height - 1), 0, height - 1);
     const top = Math.min(valueY, zeroY);
     const bottom = Math.max(valueY, zeroY);
-    fillRect(data, width, height, left, top, Math.max(left, right), Math.max(top + 1, bottom), color, 1);
+    fillRect(data, width, height, left, top, right, Math.max(top + 1, bottom), color, 1);
+    if (isHovered) {
+      fillRect(data, width, height, left, top, right, top + 1.3, hoverColor, 1);
+      fillRect(data, width, height, left, bottom - 1.3, right, bottom, hoverColor, 1);
+      fillRect(data, width, height, left, top, left + 1.3, bottom, hoverColor, 1);
+      fillRect(data, width, height, right - 1.3, top, right, bottom, hoverColor, 1);
+    }
   }
 
   return { width, height, pixels: data };

--- a/src/components/chart/core/pointer.ts
+++ b/src/components/chart/core/pointer.ts
@@ -11,11 +11,16 @@ interface RenderableSizeLike {
 interface PlotRenderableLike extends RenderableSizeLike {
   x?: number;
   y?: number;
+  absoluteX?: number;
+  absoluteY?: number;
+  absoluteBounds?: { x: number; y: number; width: number; height: number };
 }
 
 export interface ChartMouseEvent {
   x: number;
   y: number;
+  preciseX?: number;
+  preciseY?: number;
   pixelX?: number;
   pixelY?: number;
   stopPropagation?: () => void;
@@ -95,14 +100,33 @@ function getRendererCellMetrics(renderer: RendererMetricsHost) {
 }
 
 function getRenderableSize(renderable: RenderableSizeLike | null): { width: number; height: number } | null {
-  if (!renderable || typeof renderable.width !== "number" || typeof renderable.height !== "number") return null;
-  return { width: renderable.width, height: renderable.height };
+  if (!renderable) return null;
+  if (typeof renderable.width === "number" && typeof renderable.height === "number") {
+    return { width: renderable.width, height: renderable.height };
+  }
+  const absoluteBounds = (renderable as PlotRenderableLike).absoluteBounds;
+  if (absoluteBounds && typeof absoluteBounds.width === "number" && typeof absoluteBounds.height === "number") {
+    return { width: absoluteBounds.width, height: absoluteBounds.height };
+  }
+  return null;
 }
 
 function getPlotBounds(renderable: PlotRenderableLike | null): { x: number; y: number; width: number; height: number } | null {
-  if (!renderable || typeof renderable.x !== "number" || typeof renderable.y !== "number") return null;
+  if (!renderable) return null;
   const size = getRenderableSize(renderable);
-  return size ? { x: renderable.x, y: renderable.y, width: size.width, height: size.height } : null;
+  if (!size) return null;
+  const x = typeof renderable.absoluteX === "number"
+    ? renderable.absoluteX
+    : typeof renderable.absoluteBounds?.x === "number"
+      ? renderable.absoluteBounds.x
+      : renderable.x;
+  const y = typeof renderable.absoluteY === "number"
+    ? renderable.absoluteY
+    : typeof renderable.absoluteBounds?.y === "number"
+      ? renderable.absoluteBounds.y
+      : renderable.y;
+  if (typeof x !== "number" || typeof y !== "number") return null;
+  return { x, y, width: size.width, height: size.height };
 }
 
 export function getRenderablePixelSize(
@@ -216,8 +240,10 @@ export function getLocalPlotPointer(
   const bounds = getPlotBounds(renderable);
   if (!bounds) return null;
 
-  const localCellX = event.x - bounds.x;
-  const localCellY = event.y - bounds.y;
+  const rawCellX = typeof event.preciseX === "number" ? event.preciseX : event.x;
+  const rawCellY = typeof event.preciseY === "number" ? event.preciseY : event.y;
+  const localCellX = rawCellX - bounds.x;
+  const localCellY = rawCellY - bounds.y;
   if (localCellX < 0 || localCellX >= bounds.width || localCellY < 0 || localCellY >= bounds.height) {
     return null;
   }

--- a/src/components/chart/static/bar-chart-surface.test.tsx
+++ b/src/components/chart/static/bar-chart-surface.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { Text } from "../../../ui";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { StaticBarChartSurface } from "./bar-chart-surface";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+describe("StaticBarChartSurface", () => {
+  test("shows hover feedback without shifting chart rows", async () => {
+    testSetup = await testRender(
+      <StaticBarChartSurface
+        width={64}
+        height={12}
+        title="Operating Cash Flow (quarterly)"
+        formatValue={(value) => `${Math.round(value / 1000)}k`}
+        series={[{
+          id: "value",
+          label: "Value",
+          color: "#00ff66",
+          points: [
+            { category: "2025 Q1", value: -271000 },
+            { category: "2025 Q2", value: -138000 },
+            { category: "2025 Q3", value: 653000 },
+          ],
+        }]}
+      />,
+      { width: 66, height: 14 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const initialFrame = testSetup.captureCharFrame();
+    const initialLines = initialFrame.split("\n");
+    const initialAxisRow = initialLines.findIndex((line) => line.includes("2025 Q1") && line.includes("2025 Q2"));
+
+    await act(async () => {
+      await testSetup!.mockMouse.moveTo(14, 4);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const hoverFrame = testSetup.captureCharFrame();
+    const hoverLines = hoverFrame.split("\n");
+    const hoverAxisRow = hoverLines.findIndex((line) => line.includes("2025 Q1") && line.includes("2025 Q2"));
+
+    expect(hoverFrame).toContain("2025 Q1: -271k");
+    expect(hoverFrame).toContain("▓");
+    expect(hoverLines).toHaveLength(initialLines.length);
+    expect(hoverAxisRow).toBe(initialAxisRow);
+  });
+
+  test("shows a hover readout when a custom header is rendered", async () => {
+    testSetup = await testRender(
+      <StaticBarChartSurface
+        width={64}
+        height={12}
+        header={<Text>Revenue  Gross Profit</Text>}
+        formatValue={(value) => `${Math.round(value / 1000)}k`}
+        series={[{
+          id: "value",
+          label: "Value",
+          color: "#00ff66",
+          points: [
+            { category: "2025 Q1", value: -271000 },
+            { category: "2025 Q2", value: -138000 },
+            { category: "2025 Q3", value: 653000 },
+          ],
+        }]}
+      />,
+      { width: 66, height: 14 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+      await testSetup!.mockMouse.moveTo(14, 4);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Revenue  Gross Profit");
+    expect(frame).toContain("2025 Q1: -271k");
+  });
+});

--- a/src/components/chart/static/bar-chart-surface.tsx
+++ b/src/components/chart/static/bar-chart-surface.tsx
@@ -1,14 +1,19 @@
-import { useMemo } from "react";
-import { Box, ChartSurface, Span, Text } from "../../../ui";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import { Box, ChartSurface, Span, Text, useNativeRenderer, type BoxRenderable } from "../../../ui";
 import { colors } from "../../../theme/colors";
+import { consumeChartMouseEvent, getLocalPlotPointer, type ChartMouseEvent } from "../core/pointer";
 import type { NativeChartBitmap } from "../native/chart-rasterizer";
+import { truncateWithEllipsis } from "../../../utils/text-wrap";
 import { useStaticChartBitmapSize } from "./chart/bitmap";
 import {
   buildBarChartScene,
   renderBarChart,
   renderBarChartAxis,
+  renderBarChartYAxis,
   renderNativeBarChart,
+  resolveBarChartHover,
   type BarChartColors,
+  type BarChartHover,
   type BarChartSeries,
 } from "../bar-chart-renderer";
 
@@ -17,42 +22,116 @@ export interface StaticBarChartSurfaceProps {
   width: number;
   height: number;
   colors?: BarChartColors;
+  title?: string;
+  header?: ReactNode;
+  formatValue?: (value: number) => string;
+  onHoverChange?: (hover: BarChartHover | null) => void;
+  onMouseDown?: (event: ChartMouseEvent) => void;
 }
 
 export function StaticBarChartSurface({
   series,
   width,
   height,
-  colors: chartColors = {
-    bgColor: colors.bg,
-    gridColor: colors.border,
-    axisColor: colors.textDim,
-  },
+  title,
+  header,
+  formatValue,
+  onHoverChange,
+  onMouseDown,
+  colors: chartColors,
 }: StaticBarChartSurfaceProps) {
+  const renderer = useNativeRenderer();
+  const plotRef = useRef<BoxRenderable | null>(null);
+  const [hover, setHover] = useState<BarChartHover | null>(null);
   const totalWidth = Math.max(1, Math.floor(width));
   const totalHeight = Math.max(4, Math.floor(height));
+  const headerRows = title || header ? 1 : 0;
   const legendRows = series.length > 1 ? 1 : 0;
   const axisRows = 1;
-  const plotHeight = Math.max(2, totalHeight - legendRows - axisRows);
+  const yAxisWidth = totalWidth >= 24 ? 8 : 0;
+  const plotRightPadding = totalWidth >= 32 ? 1 : 0;
+  const plotWidth = Math.max(1, totalWidth - yAxisWidth - plotRightPadding);
+  const plotHeight = Math.max(2, totalHeight - headerRows - legendRows - axisRows);
+  const resolvedChartColors = useMemo<BarChartColors>(() => ({
+    bgColor: chartColors?.bgColor ?? colors.bg,
+    gridColor: chartColors?.gridColor ?? colors.border,
+    axisColor: chartColors?.axisColor ?? colors.textDim,
+    negativeColor: chartColors?.negativeColor ?? colors.negative,
+    hoverColor: chartColors?.hoverColor ?? colors.textBright,
+  }), [chartColors]);
   const scene = useMemo(() => buildBarChartScene(series, {
-    width: totalWidth,
+    width: plotWidth,
     height: plotHeight,
-    colors: chartColors,
-  }), [chartColors, plotHeight, series, totalWidth]);
+    colors: resolvedChartColors,
+  }), [plotHeight, plotWidth, resolvedChartColors, series]);
 
-  const bitmapSize = useStaticChartBitmapSize(totalWidth, plotHeight);
+  const bitmapSize = useStaticChartBitmapSize(plotWidth, plotHeight);
 
   const bitmap = useMemo<NativeChartBitmap | null>(() => {
     if (!scene || !bitmapSize) return null;
-    return renderNativeBarChart(scene, bitmapSize.pixelWidth, bitmapSize.pixelHeight);
-  }, [bitmapSize, scene]);
+    return renderNativeBarChart(scene, bitmapSize.pixelWidth, bitmapSize.pixelHeight, hover);
+  }, [bitmapSize, hover, scene]);
 
-  const textLines = useMemo(() => scene ? renderBarChart(scene) : [], [scene]);
-  const axis = useMemo(() => scene ? renderBarChartAxis(scene) : "", [scene]);
+  const textLines = useMemo(() => scene ? renderBarChart(scene, hover) : [], [hover, scene]);
+  const axis = useMemo(() => scene ? renderBarChartAxis(scene, axisRows) : [], [axisRows, scene]);
+  const yAxis = useMemo(() => scene ? renderBarChartYAxis(scene, yAxisWidth, formatValue) : [], [formatValue, scene, yAxisWidth]);
+  const hoverLabel = useMemo(() => {
+    if (!hover) return null;
+    const value = formatValue ? formatValue(hover.value) : String(hover.value);
+    return series.length > 1 ? `${hover.category} ${hover.seriesLabel}: ${value}` : `${hover.category}: ${value}`;
+  }, [formatValue, hover, series.length]);
+  const readout = useMemo(() => {
+    if (!hoverLabel) return title ?? "";
+    return title ? `${title}  ${hoverLabel}` : hoverLabel;
+  }, [hoverLabel, title]);
+  const hoverLabelLayout = useMemo(() => {
+    if (!hover || !hoverLabel) return null;
+    const text = truncateWithEllipsis(hoverLabel, plotWidth);
+    const labelWidth = Math.min(plotWidth, Math.max(1, text.length));
+    const labelLeft = Math.max(0, Math.min(
+      plotWidth - labelWidth,
+      hover.x + Math.floor(hover.width / 2) - Math.floor(labelWidth / 2),
+    ));
+    const labelTop = hover.value >= 0
+      ? Math.max(0, hover.row - 1)
+      : Math.min(plotHeight - 1, hover.row + 1);
+    return { labelLeft, labelTop, labelWidth, text };
+  }, [hover, hoverLabel, plotHeight, plotWidth]);
+
+  const handleMouseMove = useCallback((event: ChartMouseEvent) => {
+    if (!scene) return;
+    const pointer = getLocalPlotPointer(event, plotRef.current, renderer);
+    if (!pointer) {
+      setHover(null);
+      onHoverChange?.(null);
+      return;
+    }
+    const nextHover = resolveBarChartHover(scene, pointer.cellX);
+    setHover(nextHover);
+    onHoverChange?.(nextHover);
+    consumeChartMouseEvent(event);
+  }, [onHoverChange, renderer, scene]);
+
+  const handleMouseOut = useCallback(() => {
+    setHover(null);
+    onHoverChange?.(null);
+  }, [onHoverChange]);
+
+  const handleMouseDown = useCallback((event: ChartMouseEvent) => {
+    onMouseDown?.(event);
+    if (!scene) return;
+    const pointer = getLocalPlotPointer(event, plotRef.current, renderer);
+    if (!pointer) return;
+    const nextHover = resolveBarChartHover(scene, pointer.cellX);
+    setHover(nextHover);
+    onHoverChange?.(nextHover);
+    consumeChartMouseEvent(event);
+  }, [onHoverChange, onMouseDown, renderer, scene]);
 
   if (!scene) {
     return (
-      <Box width={totalWidth} height={totalHeight}>
+      <Box flexDirection="column" width={totalWidth} height={totalHeight} onMouseDown={onMouseDown}>
+        {header ?? (title ? <Text fg={colors.textBright} bold>{truncateWithEllipsis(title, totalWidth)}</Text> : null)}
         <Text fg={colors.textDim}>No chart data</Text>
       </Box>
     );
@@ -60,6 +139,13 @@ export function StaticBarChartSurface({
 
   return (
     <Box flexDirection="column" width={totalWidth} height={totalHeight}>
+      {headerRows ? (
+        header ?? (
+          <Text fg={hover ? hover.value < 0 ? colors.negative : colors.textBright : colors.textDim} bold={!!title}>
+            {truncateWithEllipsis(readout, totalWidth)}
+          </Text>
+        )
+      ) : null}
       {legendRows ? (
         <Text>
           {series.map((item, index) => (
@@ -69,17 +155,54 @@ export function StaticBarChartSurface({
           ))}
         </Text>
       ) : null}
-      <ChartSurface
-        width={totalWidth}
-        height={plotHeight}
-        flexDirection="column"
-        bitmaps={bitmap ? [bitmap] : null}
-      >
-        {textLines.map((line, index) => (
-          <Text key={index} fg={colors.text}>{line}</Text>
-        ))}
-      </ChartSurface>
-      <Text fg={colors.textDim}>{axis}</Text>
+      <Box flexDirection="row" width={totalWidth} height={plotHeight}>
+        {yAxisWidth ? (
+          <Box flexDirection="column" width={yAxisWidth} height={plotHeight}>
+            {yAxis.map((line, index) => (
+              <Text key={index} fg={colors.textDim}>{line}</Text>
+            ))}
+          </Box>
+        ) : null}
+        <Box position="relative" width={plotWidth} height={plotHeight}>
+          <ChartSurface
+            ref={plotRef}
+            width={plotWidth}
+            height={plotHeight}
+            flexDirection="column"
+            bitmaps={bitmap ? [bitmap] : null}
+            onMouseMove={handleMouseMove}
+            onMouseDown={handleMouseDown}
+            onMouseOut={handleMouseOut}
+            cursor="pointer"
+            data-gloom-interactive="true"
+            data-gloom-role="bar-chart-surface"
+          >
+            {textLines.map((line, index) => (
+              <Text key={index} fg={colors.text}>{line}</Text>
+            ))}
+          </ChartSurface>
+          {hoverLabelLayout ? (
+            <Box
+              position="absolute"
+              left={hoverLabelLayout.labelLeft}
+              top={hoverLabelLayout.labelTop}
+              width={hoverLabelLayout.labelWidth}
+              height={1}
+              zIndex={1}
+              backgroundColor={colors.panel}
+            >
+              <Text fg={hover && hover.value < 0 ? colors.negative : colors.textBright} bold>
+                {hoverLabelLayout.text}
+              </Text>
+            </Box>
+          ) : null}
+        </Box>
+      </Box>
+      {axis.map((line, index) => (
+        <Text key={index} fg={colors.textDim}>
+          {yAxisWidth ? `${" ".repeat(yAxisWidth)}${line}` : line}
+        </Text>
+      ))}
     </Box>
   );
 }

--- a/src/components/chart/stock-chart/index.test.ts
+++ b/src/components/chart/stock-chart/index.test.ts
@@ -76,6 +76,31 @@ describe("stock chart pointer helpers", () => {
     });
   });
 
+  test("uses absolute renderable coordinates for desktop mouse hit testing", () => {
+    const pointer = getLocalPlotPointer({
+      x: 49,
+      y: 10,
+      preciseX: 49.5,
+      preciseY: 10.25,
+      modifiers: { shift: false, alt: false, ctrl: false },
+    }, {
+      x: 0,
+      y: 0,
+      absoluteX: 10,
+      absoluteY: 5,
+      width: 40,
+      height: 12,
+    }, renderer);
+
+    expect(pointer).toMatchObject({
+      hasPixelPrecision: false,
+      pixelX: null,
+      pixelY: null,
+    });
+    expect(pointer!.cellX).toBeCloseTo(39.5, 2);
+    expect(pointer!.cellY).toBeCloseTo(5.25, 2);
+  });
+
   test("can derive local pixels from cell coordinates for non-pixel fallbacks", () => {
     const pixels = projectCellCursorToLocalPixels(14, 5, renderable, renderer);
 

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -48,6 +48,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   isSelected,
   onSelect,
   onActivate,
+  onTableMouseDown,
   onRowMouseDown,
   onRowContextMenu,
   rowContextMenuSurface = false,
@@ -60,6 +61,9 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   emptyStateHint,
   virtualize = true,
   overscan = 3,
+  columnGap = 1,
+  horizontalPadding = 1,
+  fillAvailableWidth = true,
   showHorizontalScrollbar = true,
   scrollToIndex,
   scrollToIndexAlign = "nearest",
@@ -105,17 +109,21 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
     ],
   );
   const { endIndex, startIndex, viewportHeight, visibleItems } = tableWindow;
-  const tableWidth = useMemo(() => getTableWidth(columns), [columns]);
+  const tableWidth = useMemo(
+    () => getTableWidth(columns, columnGap, horizontalPadding),
+    [columnGap, columns, horizontalPadding],
+  );
   const {
     contentWidth: measuredContentWidth,
     viewportWidth: measuredViewportWidth,
     measureContentWidth,
   } = useMeasuredTableContentWidth(tableWidth, headerScrollRef, scrollRef);
   const horizontalScrollbarVisible = showHorizontalScrollbar
-    && hasMeaningfulTableHorizontalOverflow(tableWidth, measuredViewportWidth);
+    && hasMeaningfulTableHorizontalOverflow(tableWidth, measuredViewportWidth, columnGap);
+  const contentWidth = fillAvailableWidth ? measuredContentWidth : tableWidth;
   const displayColumns = useMemo(
-    () => expandTableColumns(columns, measuredContentWidth),
-    [columns, measuredContentWidth],
+    () => expandTableColumns(columns, contentWidth, columnGap, horizontalPadding),
+    [columnGap, columns, contentWidth, horizontalPadding],
   );
   const handleRowMouseDown =
     useDoubleClickActivation<DataTableRowPointerTarget<T>>({
@@ -264,8 +272,8 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
         <Box
           flexDirection="row"
           height={1}
-          {...tableContentWidthProps(measuredContentWidth)}
-          paddingX={1}
+          {...tableContentWidthProps(contentWidth)}
+          paddingX={horizontalPadding}
           backgroundColor={colors.panel}
         >
           {displayColumns.map((column) => {
@@ -283,10 +291,11 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
             return (
               <Box
                 key={column.id}
-                width={column.width + 1}
+                width={column.width + columnGap}
                 backgroundColor={column.headerBackgroundColor ?? colors.panel}
                 onMouseDown={(event: any) => {
                   focusPane();
+                  onTableMouseDown?.(event);
                   event.preventDefault();
                   onHeaderClick(column.id);
                 }}
@@ -315,6 +324,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
         focusable={false}
         onMouseDown={() => {
           focusPane();
+          onTableMouseDown?.({});
         }}
         onSizeChange={measureContentWidth}
       >
@@ -339,11 +349,12 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                       key={getItemKey(item, index)}
                       flexDirection="row"
                       height={1}
-                      {...tableContentWidthProps(measuredContentWidth)}
-                      paddingX={1}
+                      {...tableContentWidthProps(contentWidth)}
+                      paddingX={horizontalPadding}
                       backgroundColor={sectionHeader.backgroundColor ?? colors.bg}
                       onMouseDown={(event: any) => {
                         focusPane();
+                        onTableMouseDown?.(event);
                         event.preventDefault();
                       }}
                     >
@@ -376,8 +387,8 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                     key={getItemKey(item, index)}
                     flexDirection="row"
                     height={1}
-                    {...tableContentWidthProps(measuredContentWidth)}
-                    paddingX={1}
+                    {...tableContentWidthProps(contentWidth)}
+                    paddingX={horizontalPadding}
                     backgroundColor={rowBg}
                     data-gloom-context-menu-surface={rowContextMenuSurface ? "true" : undefined}
                     onMouseMove={() => {
@@ -385,6 +396,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                     }}
                     onMouseDown={(event: any) => {
                       focusPane();
+                      onTableMouseDown?.(event);
                       if (onRowMouseDown?.(item, index, event) === true) {
                         return;
                       }
@@ -404,10 +416,11 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                       return (
                         <Box
                           key={column.id}
-                          width={column.width + 1}
+                          width={column.width + columnGap}
                           backgroundColor={cell.backgroundColor ?? rowBg}
                           onMouseDown={(event: any) => {
                             focusPane();
+                            onTableMouseDown?.(event);
                             if (cell.onMouseDown) {
                               cell.onMouseDown(event);
                               return;

--- a/src/components/ui/data-table/types.ts
+++ b/src/components/ui/data-table/types.ts
@@ -50,6 +50,7 @@ export interface DataTableProps<
   isSelected: (item: T, index: number) => boolean;
   onSelect: (item: T, index: number) => void;
   onActivate?: (item: T, index: number) => void;
+  onTableMouseDown?: (event: any) => void;
   onRowMouseDown?: (item: T, index: number, event: any) => boolean | void;
   onRowContextMenu?: (item: T, index: number, event: any) => void;
   rowContextMenuSurface?: boolean;
@@ -74,6 +75,9 @@ export interface DataTableProps<
   emptyStateHint?: string;
   virtualize?: boolean;
   overscan?: number;
+  columnGap?: number;
+  horizontalPadding?: number;
+  fillAvailableWidth?: boolean;
   showHorizontalScrollbar?: boolean;
   scrollToIndex?: number | null;
   scrollToIndexAlign?: DataTableScrollAlign;

--- a/src/components/ui/table-layout.test.ts
+++ b/src/components/ui/table-layout.test.ts
@@ -18,6 +18,22 @@ describe("table layout", () => {
     expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth - 2)).toBe(true);
   });
 
+  test("supports tables without inter-column gaps", () => {
+    const tableWidth = getTableWidth([
+      { width: 12 },
+      { width: 8 },
+    ], 0);
+    const noPaddingWidth = getTableWidth([
+      { width: 12 },
+      { width: 8 },
+    ], 0, 0);
+
+    expect(tableWidth).toBe(22);
+    expect(noPaddingWidth).toBe(20);
+    expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth, 0)).toBe(false);
+    expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth - 1, 0)).toBe(true);
+  });
+
   test("keeps non-flex web table columns fixed", () => {
     const template = buildTableGridTemplateColumns([
       { width: 4, align: "right" },
@@ -38,5 +54,14 @@ describe("table layout", () => {
     ]);
 
     expect(template).toBe("minmax(calc(8 * var(--cell-w)), 12fr) minmax(calc(8 * var(--cell-w)), 8fr)");
+  });
+
+  test("keeps fixed web table columns when fill width is disabled", () => {
+    const template = buildTableGridTemplateColumns([
+      { width: 12 },
+      { width: 8, align: "right" },
+    ], false);
+
+    expect(template).toBe("minmax(calc(8 * var(--cell-w)), calc(12 * var(--cell-w))) minmax(calc(8 * var(--cell-w)), calc(8 * var(--cell-w)))");
   });
 });

--- a/src/components/ui/table-layout.ts
+++ b/src/components/ui/table-layout.ts
@@ -10,19 +10,29 @@ export interface TableWidthColumn {
 const TRAILING_COLUMN_GUTTER_WIDTH = 1;
 const WEB_CELL_UNIT = "var(--cell-w)";
 
-export function getTableWidth(columns: readonly TableWidthColumn[]): number {
-  return columns.reduce((sum, column) => sum + column.width + 1, 2);
+export function getTableWidth(
+  columns: readonly TableWidthColumn[],
+  columnGap = 1,
+  horizontalPadding = 1,
+): number {
+  return columns.reduce((sum, column) => sum + column.width + columnGap, horizontalPadding * 2);
 }
 
-export function hasMeaningfulTableHorizontalOverflow(tableWidth: number, viewportWidth: number): boolean {
-  return viewportWidth > 0 && tableWidth - viewportWidth > TRAILING_COLUMN_GUTTER_WIDTH;
+export function hasMeaningfulTableHorizontalOverflow(
+  tableWidth: number,
+  viewportWidth: number,
+  columnGap = TRAILING_COLUMN_GUTTER_WIDTH,
+): boolean {
+  return viewportWidth > 0 && tableWidth - viewportWidth > columnGap;
 }
 
 export function expandTableColumns<C extends TableWidthColumn>(
   columns: readonly C[],
   targetWidth: number,
+  columnGap = 1,
+  horizontalPadding = 1,
 ): C[] {
-  const currentWidth = getTableWidth(columns);
+  const currentWidth = getTableWidth(columns, columnGap, horizontalPadding);
   const extraWidth = Math.floor(targetWidth) - currentWidth;
   if (extraWidth <= 0) return [...columns];
 
@@ -62,12 +72,18 @@ function cellWidthCss(width: number): string {
   return `calc(${width} * ${WEB_CELL_UNIT})`;
 }
 
-export function buildTableGridTemplateColumns(columns: readonly TableWidthColumn[]): string {
+export function buildTableGridTemplateColumns(
+  columns: readonly TableWidthColumn[],
+  fillAvailableWidth = true,
+): string {
   const hasFlexColumn = columns.some((column) => (column.flexGrow ?? 0) > 0);
   return columns
     .map((column) => {
       const width = normalizedColumnWidth(column);
       const minWidth = cellWidthCss(columnMinCh(column));
+      if (!fillAvailableWidth) {
+        return `minmax(${minWidth}, ${cellWidthCss(width)})`;
+      }
       if (!hasFlexColumn || (column.flexGrow ?? 0) > 0) {
         return `minmax(${minWidth}, ${columnFlexWeight(column)}fr)`;
       }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -31,6 +31,7 @@ export interface TabsProps {
   focused?: boolean;
   keyboardNavigation?: boolean;
   scrollable?: boolean;
+  scrollId?: string;
 }
 
 const WHEEL_DELTA_PER_CELL = 8;
@@ -47,6 +48,7 @@ export function Tabs({
   focused = false,
   keyboardNavigation = true,
   scrollable = true,
+  scrollId,
 }: TabsProps) {
   const ui = useUiHost();
   const NativeTabs = ui.Tabs;
@@ -57,11 +59,11 @@ export function Tabs({
     navigationValueRef.current = activeValue;
   }
   const palette = {
-    activeFg: variant === "bare" ? colors.textBright : colors.text,
+    activeFg: focused || variant === "bare" ? colors.textBright : colors.text,
     inactiveFg: colors.textDim,
     disabledFg: colors.textMuted,
     hoverFg: colors.text,
-    activeUnderline: colors.borderFocused,
+    activeUnderline: focused ? colors.textBright : colors.borderFocused,
     inactiveUnderline: colors.bg,
     hoverUnderline: colors.border,
     hoverBg: hoverBg(),
@@ -118,6 +120,7 @@ export function Tabs({
         closeMode={closeMode}
         addLabel={addLabel}
         onAdd={onAdd}
+        focused={focused}
         palette={palette}
       />
     );
@@ -133,7 +136,9 @@ export function Tabs({
       closeMode={closeMode}
       addLabel={addLabel}
       onAdd={onAdd}
+      focused={focused}
       scrollable={scrollable}
+      scrollId={scrollId}
       palette={palette}
     />
   );
@@ -157,7 +162,9 @@ function OpenTuiTabs({
   closeMode = "always",
   addLabel = "+",
   onAdd,
+  focused = false,
   scrollable = true,
+  scrollId,
   palette,
 }: TabsProps & {
   palette: {
@@ -187,7 +194,7 @@ function OpenTuiTabs({
   useEffect(() => {
     const scrollBox = scrollRef.current;
     const activeIndex = tabs.findIndex((tab) => tab.value === activeValue);
-    const viewportWidth = scrollBox?.viewport?.width ?? 0;
+    const viewportWidth = scrollBox?.viewport?.width || scrollBox?.width || 0;
     if (!scrollBox || activeIndex < 0 || viewportWidth <= 0) return;
 
     const activeLeft = tabWidths.slice(0, activeIndex).reduce((sum, width) => sum + width, 0);
@@ -195,14 +202,15 @@ function OpenTuiTabs({
     const currentLeft = scrollBox.scrollLeft ?? 0;
     const currentRight = currentLeft + viewportWidth;
     const maxScrollLeft = Math.max(0, totalWidth - viewportWidth);
+    const scrollToLeft = (left: number) => {
+      scrollBox.scrollLeft = left;
+      scrollBox.scrollTo({ x: left, y: scrollBox.scrollTop });
+    };
 
     if (activeLeft < currentLeft) {
-      scrollBox.scrollTo({ x: activeLeft, y: scrollBox.scrollTop });
+      scrollToLeft(activeLeft);
     } else if (activeRight > currentRight) {
-      scrollBox.scrollTo({
-        x: Math.min(activeRight - viewportWidth, maxScrollLeft),
-        y: scrollBox.scrollTop,
-      });
+      scrollToLeft(Math.min(activeRight - viewportWidth, maxScrollLeft));
     }
   }, [activeValue, tabWidths, tabs, totalWidth]);
 
@@ -214,7 +222,7 @@ function OpenTuiTabs({
     const direction = event?.scroll?.direction;
     if (!direction) return;
     const scrollBox = scrollRef.current;
-    const viewportWidth = scrollBox?.viewport?.width ?? 0;
+    const viewportWidth = scrollBox?.viewport?.width || scrollBox?.width || 0;
     if (!scrollBox || viewportWidth <= 0 || totalWidth <= viewportWidth) return;
 
     event.preventDefault?.();
@@ -228,6 +236,7 @@ function OpenTuiTabs({
       0,
       Math.min(maxScrollLeft, (scrollBox.scrollLeft ?? 0) + directionSign * deltaCells),
     );
+    scrollBox.scrollLeft = nextLeft;
     scrollBox.scrollTo({ x: nextLeft, y: scrollBox.scrollTop });
   };
 
@@ -236,10 +245,16 @@ function OpenTuiTabs({
       {tabs.map((tab, index) => {
         const active = tab.value === activeValue;
         const hovered = hoveredValue === tab.value && !tab.disabled;
+        const focusedActive = focused && active;
         const tabWidth = tabWidths[index] ?? tab.label.length + 2;
         const showClose = !!tab.onClose && (closeMode === "always" || active);
         const attributes = (active ? TextAttributes.BOLD : 0)
-          | (variant === "underline" && !compact && (active || hovered) ? TextAttributes.UNDERLINE : 0);
+          | (
+            (variant === "underline" && !compact && (active || hovered))
+              || (variant === "bare" && focusedActive)
+              ? TextAttributes.UNDERLINE
+              : 0
+          );
         const startHover = tab.disabled
           ? undefined
           : () => {
@@ -323,6 +338,7 @@ function OpenTuiTabs({
 
   return (
     <ScrollBox
+      id={scrollId}
       ref={scrollRef}
       width="100%"
       height={1}

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, useEffect, useRef, useState } from "react";
 import { TestDialogProvider, testRender } from "../../renderers/opentui/test-utils";
+import { TextAttributes } from "../../ui";
 import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core";
 import { ChoiceDialog } from "./choice-dialog";
 import { DataTable, type DataTableColumn } from "./data-table";
@@ -128,12 +129,18 @@ function DataTableHorizontalScrollHarness({
   containerWidth = 32,
   containerHeight = 5,
   rowCount = 1,
+  columnGap,
+  horizontalPadding,
+  fillAvailableWidth,
   showHorizontalScrollbar,
 }: {
   columns?: DataTableColumn[];
   containerWidth?: number;
   containerHeight?: number;
   rowCount?: number;
+  columnGap?: number;
+  horizontalPadding?: number;
+  fillAvailableWidth?: boolean;
   showHorizontalScrollbar?: boolean;
 }) {
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
@@ -162,7 +169,41 @@ function DataTableHorizontalScrollHarness({
       getItemKey={(row) => row.id}
       renderCell={(row) => ({ text: row.name })}
       emptyStateTitle="No rows."
+      columnGap={columnGap}
+      horizontalPadding={horizontalPadding}
+      fillAvailableWidth={fillAvailableWidth}
       showHorizontalScrollbar={showHorizontalScrollbar}
+    />
+  );
+}
+
+function DataTableColumnGapHarness() {
+  const headerScrollRef = useRef<ScrollBoxRenderable>(null);
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const items = [{ id: "row-0", left: "AA", right: "BB" }];
+
+  return (
+    <DataTableView
+      rootWidth={8}
+      rootHeight={4}
+      selection={{ kind: "none" }}
+      columns={[
+        { id: "left", label: "L", width: 2, align: "left" },
+        { id: "right", label: "R", width: 2, align: "left" },
+      ]}
+      items={items}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      headerScrollRef={headerScrollRef}
+      scrollRef={scrollRef}
+      getItemKey={(row) => row.id}
+      renderCell={(row, column) => ({ text: column.id === "left" ? row.left : row.right })}
+      emptyStateTitle="No rows."
+      columnGap={0}
+      horizontalPadding={0}
+      fillAvailableWidth={false}
+      showHorizontalScrollbar={false}
     />
   );
 }
@@ -358,6 +399,31 @@ describe("shared UI kit", () => {
     });
 
     expect(lastSelected).toBe("chart");
+  });
+
+  test("marks the active bare tab when it has keyboard focus", async () => {
+    testSetup = await testRender(
+      <Tabs
+        tabs={[
+          { label: "One", value: "one" },
+          { label: "Two", value: "two" },
+        ]}
+        activeValue="one"
+        onSelect={() => {}}
+        variant="bare"
+        compact
+        focused
+      />,
+      { width: 24, height: 2 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    const activeSpan = testSetup.captureSpans().lines[0]?.spans.find((span) => span.text.includes("One"));
+    expect(activeSpan).toBeDefined();
+    expect((activeSpan!.attributes & TextAttributes.UNDERLINE)).toBe(TextAttributes.UNDERLINE);
   });
 
   test("selects tabs by clicking their text labels", async () => {
@@ -735,6 +801,27 @@ describe("shared UI kit", () => {
     });
 
     expect(tableScrollBoxForTest?.horizontalScrollBar.visible).toBe(false);
+  });
+
+  test("renders data table columns without spacer cells when column gap is zero", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-test"));
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="portfolio-list:main">
+          <DataTableColumnGapHarness />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 8, height: 4 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("AABB");
+    expect(frame).not.toContain("AA BB");
   });
 
   test("hides data table horizontal scrolling when content fits", async () => {

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
 import { act } from "react";
+import type { ScrollBoxRenderable } from "@opentui/core";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
 import { AppContext, PaneInstanceProvider, createInitialState } from "../../../state/app/context";
@@ -7,6 +8,7 @@ import { createTestDataProvider } from "../../../test-support/data-provider";
 import { cloneLayout, createDefaultConfig } from "../../../types/config";
 import type { OptionContract, OptionsChain, TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
+import { formatExpDate } from "../../../utils/options";
 import { OptionsView } from "./view";
 
 const TEST_PANE_ID = "ticker-detail:options-test";
@@ -49,10 +51,14 @@ function makeContract(strike: number, side: "C" | "P", atmStrike = 101): OptionC
   };
 }
 
-function makeChain(strikes = [100, 101], atmStrike = 101): OptionsChain {
+function makeChain(
+  strikes = [100, 101],
+  atmStrike = 101,
+  expirationDates = [1_782_345_600],
+): OptionsChain {
   return {
     underlyingSymbol: "AAPL",
-    expirationDates: [1_782_345_600],
+    expirationDates,
     calls: strikes.map((strike) => makeContract(strike, "C", atmStrike)),
     puts: strikes.map((strike) => makeContract(strike, "P", atmStrike)),
   };
@@ -74,7 +80,17 @@ function makeFinancials(price: number): TickerFinancials {
   };
 }
 
-function OptionsHarness({ ticker, quotePrice }: { ticker: TickerRecord; quotePrice?: number }) {
+function OptionsHarness({
+  ticker,
+  quotePrice,
+  width = 122,
+  onCapture = () => {},
+}: {
+  ticker: TickerRecord;
+  quotePrice?: number;
+  width?: number;
+  onCapture?: (capturing: boolean) => void;
+}) {
   const config = createDefaultConfig("/tmp/gloomberb-options-test");
   config.layout = {
     dockRoot: { kind: "pane", instanceId: TEST_PANE_ID },
@@ -98,7 +114,7 @@ function OptionsHarness({ ticker, quotePrice }: { ticker: TickerRecord; quotePri
   return (
     <AppContext value={{ state, dispatch: () => {} }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
-        <OptionsView width={122} height={14} focused onCapture={() => {}} />
+        <OptionsView width={width} height={14} focused onCapture={onCapture} />
       </PaneInstanceProvider>
     </AppContext>
   );
@@ -182,4 +198,125 @@ test("defaults the table around the nearest strike to the current quote", async 
   const frame = testSetup!.captureCharFrame();
   expect(frame).toContain("120");
   expect(frame).not.toContain(" 50 ");
+});
+
+test("lets the expiration tab row use the full available width", async () => {
+  const expirationDates = Array.from({ length: 9 }, (_, index) => (
+    Math.floor(Date.UTC(2026, index, 20) / 1000)
+  ));
+  const provider = createTestDataProvider({
+    getOptionsChain: async () => makeChain([100, 101], 101, expirationDates),
+  });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+
+  await act(async () => {
+    testSetup = await testRender(
+      <OptionsHarness ticker={makeTicker("AAPL")} width={122} />,
+      {
+        width: 124,
+        height: 16,
+      },
+    );
+  });
+
+  await renderSettled();
+
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain(formatExpDate(expirationDates.at(-1)!));
+});
+
+test("keeps expiration tabs independently scrollable from a narrow strike table", async () => {
+  const expirationDates = Array.from({ length: 12 }, (_, index) => (
+    Math.floor(Date.UTC(2026, index, 20) / 1000)
+  ));
+  const requestedExpirations: Array<number | undefined> = [];
+  const provider = createTestDataProvider({
+    getOptionsChain: async (_ticker, _exchange, expirationDate) => {
+      requestedExpirations.push(expirationDate);
+      return makeChain([100, 101], 101, expirationDates);
+    },
+  });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+  const captures: boolean[] = [];
+
+  await act(async () => {
+    testSetup = await testRender(
+      <OptionsHarness ticker={makeTicker("AAPL")} width={54} onCapture={(capturing) => captures.push(capturing)} />,
+      {
+        width: 56,
+        height: 16,
+      },
+    );
+  });
+
+  await renderSettled();
+  const bodyScroll = testSetup!.renderer.root.findDescendantById("options-table-body-scroll") as ScrollBoxRenderable | undefined;
+  const expirationTabsScroll = testSetup!.renderer.root.findDescendantById("options-expiration-tabs-scroll") as ScrollBoxRenderable | undefined;
+  expect(bodyScroll?.horizontalScrollBar.visible).toBe(true);
+  expect(expirationTabsScroll?.horizontalScrollBar.visible).toBe(false);
+  expect(testSetup!.captureCharFrame()).not.toContain(formatExpDate(expirationDates.at(-1)!));
+
+  await act(async () => {
+    testSetup!.mockInput.pressEnter();
+    await testSetup!.renderOnce();
+  });
+  await renderSettled();
+  expect(captures).toContain(true);
+  expect(captures.at(-1)).toBe(true);
+
+  for (let index = 1; index < expirationDates.length; index += 1) {
+    await act(async () => {
+      testSetup!.mockInput.pressKey("l");
+      await testSetup!.renderOnce();
+    });
+    await renderSettled();
+  }
+
+  expect(bodyScroll?.horizontalScrollBar.visible).toBe(true);
+  expect(bodyScroll?.scrollLeft ?? 0).toBe(0);
+  expect(expirationTabsScroll?.scrollLeft ?? 0).toBeGreaterThan(0);
+  expect(requestedExpirations).toContain(expirationDates.at(-1));
+  expect(testSetup!.captureCharFrame()).toContain(formatExpDate(expirationDates.at(-1)!));
+});
+
+test("clicking the option table focuses expiration tabs for arrow navigation", async () => {
+  const expirationDates = Array.from({ length: 3 }, (_, index) => (
+    Math.floor(Date.UTC(2026, index, 20) / 1000)
+  ));
+  const requestedExpirations: Array<number | undefined> = [];
+  const provider = createTestDataProvider({
+    getOptionsChain: async (_ticker, _exchange, expirationDate) => {
+      requestedExpirations.push(expirationDate);
+      return makeChain([100, 101], 101, expirationDates);
+    },
+  });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+  const captures: boolean[] = [];
+
+  await act(async () => {
+    testSetup = await testRender(
+      <OptionsHarness ticker={makeTicker("AAPL")} width={80} onCapture={(capturing) => captures.push(capturing)} />,
+      {
+        width: 82,
+        height: 16,
+      },
+    );
+  });
+
+  await renderSettled();
+
+  await act(async () => {
+    await testSetup!.mockMouse.click(8, 4);
+    await testSetup!.renderOnce();
+  });
+  await renderSettled();
+  expect(captures.at(-1)).toBe(true);
+
+  await act(async () => {
+    testSetup!.mockInput.pressArrow("right");
+    await testSetup!.renderOnce();
+  });
+  await renderSettled();
+
+  expect(requestedExpirations).toContain(expirationDates[1]);
 });

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -6,6 +6,7 @@ import { isPlainKey } from "../../../utils/keyboard";
 import { formatExpDate, resolveOptionsTarget } from "../../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../../market-data/hooks";
 import { DataTableView, Spinner, Tabs, usePaneFooter, type DataTableKeyEvent } from "../../../components";
+import { useShortcut } from "../../../react/input";
 import {
   OPTION_COLUMNS,
   buildStrikeList,
@@ -26,6 +27,7 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
   const [scrollToIndexAlign, setScrollToIndexAlign] = useState<"nearest" | "center">("nearest");
   const [interactive, setInteractive] = useState(false);
   const userSelectedStrikeRef = useRef(false);
+  const onCaptureRef = useRef(onCapture);
   const target = resolveOptionsTarget(ticker);
   const isOpt = target?.isOptionTicker ?? false;
   const parsed = target?.parsedOption ?? null;
@@ -53,6 +55,7 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
   );
   const expirationChain = useResolvedEntryValue(expirationChainEntry);
   const chain = expirationChain ?? initialChain;
+  const expirationCount = chain?.expirationDates.length ?? 0;
   const loading = (initialChainEntry?.phase === "loading" || initialChainEntry?.phase === "refreshing") && !chain
     || (expirationChainEntry?.phase === "loading" || expirationChainEntry?.phase === "refreshing");
   const error = initialChainEntry?.phase === "error"
@@ -61,24 +64,34 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
       ? expirationChainEntry.error?.message ?? "Failed to load options"
       : null;
 
-  const enterInteractive = () => {
+  useEffect(() => {
+    onCaptureRef.current = onCapture;
+  }, [onCapture]);
+
+  const enterInteractive = useCallback(() => {
     if (!interactive) {
       setInteractive(true);
-      onCapture(true);
+      onCaptureRef.current(true);
     }
-  };
+  }, [interactive]);
 
-  const exitInteractive = () => {
+  const exitInteractive = useCallback(() => {
     if (interactive) {
       setInteractive(false);
-      onCapture(false);
+      onCaptureRef.current(false);
     }
-  };
+  }, [interactive]);
+
+  const selectAdjacentExpiration = useCallback((offset: -1 | 1) => {
+    if (expirationCount === 0) return;
+    setExpIdx((index) => Math.max(0, Math.min(index + offset, expirationCount - 1)));
+  }, [expirationCount]);
 
   useEffect(() => {
     userSelectedStrikeRef.current = false;
     setScrollToIndexAlign("nearest");
-    exitInteractive();
+    setInteractive(false);
+    onCaptureRef.current(false);
     setExpIdx(0);
     setStrikeIdx(0);
   }, [effectiveTicker]);
@@ -154,6 +167,37 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
     setAutoScrollVersion((version) => version + 1);
   }, [expIdx, financials?.quote?.price, parsed?.strike, strikes]);
 
+  useShortcut((event) => {
+    if (event.defaultPrevented || event.propagationStopped || event.targetEditable) return;
+    if (event.ctrl || event.meta || event.alt || event.shift) return;
+
+    const isEnter = event.name === "enter" || event.name === "return";
+    const isEscape = event.name === "escape" || event.name === "esc";
+    if (isEnter && !interactive) {
+      event.preventDefault();
+      event.stopPropagation();
+      enterInteractive();
+      return;
+    }
+    if (isEscape && interactive) {
+      event.preventDefault();
+      event.stopPropagation();
+      exitInteractive();
+      return;
+    }
+    if (interactive && isPlainKey(event, "h", "left")) {
+      event.preventDefault();
+      event.stopPropagation();
+      selectAdjacentExpiration(-1);
+      return;
+    }
+    if (interactive && isPlainKey(event, "l", "right")) {
+      event.preventDefault();
+      event.stopPropagation();
+      selectAdjacentExpiration(1);
+    }
+  }, { enabled: focused, phase: "before" });
+
   const handleTableKeyDown = useCallback((event: DataTableKeyEvent) => {
     const isEnter = event.name === "enter" || event.name === "return";
 
@@ -167,6 +211,18 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
       event.preventDefault?.();
       event.stopPropagation?.();
       exitInteractive();
+      return true;
+    }
+    if (interactive && isPlainKey(event, "h", "left")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      selectAdjacentExpiration(-1);
+      return true;
+    }
+    if (interactive && isPlainKey(event, "l", "right")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      selectAdjacentExpiration(1);
       return true;
     }
 
@@ -190,30 +246,27 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
     }
 
     return false;
-  }, [enterInteractive, exitInteractive, interactive, strikes.length]);
+  }, [enterInteractive, exitInteractive, interactive, selectAdjacentExpiration, strikes.length]);
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view options.</Text>;
   if (loading && !chain) return <Spinner label="Loading options chain..." />;
   if (error) return <Text fg={colors.textDim}>{error}</Text>;
   if (!chain || chain.expirationDates.length === 0) return <Text fg={colors.textDim}>No options available for {effectiveTicker}.</Text>;
 
-  const innerWidth = Math.max(width - 4, 60);
   const posShares = isOpt && parsed
     ? ticker.metadata.positions.reduce((sum, p) => sum + p.shares, 0)
     : 0;
-  const maxExpVisible = Math.max(Math.floor((innerWidth - 14) / 13), 3);
-  const expStart = Math.max(0, Math.min(expIdx - Math.floor(maxExpVisible / 2), chain.expirationDates.length - maxExpVisible));
-  const visibleExps = chain.expirationDates.slice(expStart, expStart + maxExpVisible);
+  const expirationTabsWidth = Math.max(width - 7 - (loading ? 2 : 0), 8);
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1} onMouseDown={() => { if (!interactive) enterInteractive(); }}>
       <Box flexDirection="row" height={1} gap={1}>
         <Text fg={colors.textDim}>Exp:</Text>
-        <Box flexGrow={1} height={1}>
+        <Box width={expirationTabsWidth} height={1} overflow="hidden">
           <Tabs
-            tabs={visibleExps.map((ts, i) => ({
+            tabs={chain.expirationDates.map((ts, i) => ({
               label: formatExpDate(ts),
-              value: String(expStart + i),
+              value: String(i),
             }))}
             activeValue={String(expIdx)}
             onSelect={(value) => {
@@ -223,6 +276,8 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
             compact
             variant="bare"
             focused={focused && interactive}
+            keyboardNavigation={false}
+            scrollId="options-expiration-tabs-scroll"
           />
         </Box>
         {loading && <Spinner />}
@@ -255,14 +310,20 @@ export function OptionsView({ width, focused, onCapture = () => {} }: OptionsVie
           setStrikeIdx(index);
         }}
         onRootKeyDown={handleTableKeyDown}
+        headerScrollId="options-table-header-scroll"
+        bodyScrollId="options-table-body-scroll"
         columns={optionColumns}
         items={rows}
         sortColumnId={null}
         sortDirection="asc"
         onHeaderClick={() => {}}
+        onTableMouseDown={enterInteractive}
         getItemKey={(row) => String(row.strike)}
         renderCell={renderOptionCell}
         emptyStateTitle="No strikes available."
+        columnGap={0}
+        horizontalPadding={0}
+        fillAvailableWidth={false}
         scrollToIndex={strikeIdx}
         scrollToIndexAlign={scrollToIndexAlign}
         scrollToIndexVersion={autoScrollVersion}

--- a/src/plugins/builtin/ticker-detail/data-panes.test.ts
+++ b/src/plugins/builtin/ticker-detail/data-panes.test.ts
@@ -49,6 +49,22 @@ describe("ticker data panes", () => {
     ]);
   });
 
+  test("collapses duplicate quarterly statement dates into one displayed period", () => {
+    const rows = buildFundamentalGraphRows([
+      { date: "2025-03-29", eps: 0.44 },
+      { date: "2025-03-31", eps: 0.44 },
+      { date: "2025-06-28", eps: 0.54 },
+      { date: "2025-06-30", eps: 0.54 },
+      { date: "2025-09-27", eps: 0.75 },
+    ] satisfies FinancialStatement[], "eps", "AMD", "quarterly");
+
+    expect(rows.map((row) => [row.date, row.category, row.value])).toEqual([
+      ["2025-03-31", "2025 Q1", 0.44],
+      ["2025-06-30", "2025 Q2", 0.54],
+      ["2025-09-27", "2025 Q3", 0.75],
+    ]);
+  });
+
   test("builds valuation graph rows from available multiples", () => {
     const rows = buildValuationGraphRows({
       quote: { symbol: "AMD", price: 100, currency: "USD", change: 0, changePercent: 0, lastUpdated: 1, marketCap: 1_000 },

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { PaneProps, PaneTemplateDef } from "../../../../types/plugin";
+import type { PaneProps, PaneTemplateDef, TickerResearchTabProps } from "../../../../types/plugin";
 import { formatTickerListInput } from "../../../../tickers/list";
 import { usePaneInstance, usePaneTicker } from "../../../../state/app/context";
 import { usePluginPaneState } from "../../../runtime";
@@ -26,7 +26,7 @@ export function FundamentalGraphPane({ focused, width, height }: PaneProps) {
   const { symbol, exchange } = useBoundTicker();
   const symbols = useMemo(() => symbolsFromPaneSettings(pane?.settings, symbol), [pane?.settings, symbol]);
   const configuredKind = graphKindFromSettings(pane?.settings, "fundamental");
-  const [period, setPeriod] = usePluginPaneState<FundamentalPeriod>("period", "annual");
+  const [period, setPeriod] = usePluginPaneState<FundamentalPeriod>("period", "quarterly");
   const [chartKind, setChartKind] = usePluginPaneState<GraphKind>("chartKind", configuredKind);
   const [metric, setMetric] = usePluginPaneState<GraphMetricKey>("metric", defaultMetric(configuredKind));
   const resolvedMetric = isMetricForKind(chartKind, metric) ? metric : defaultMetric(chartKind);
@@ -54,9 +54,9 @@ export function FundamentalGraphPane({ focused, width, height }: PaneProps) {
   );
 }
 
-export function FundamentalGraphsResearchTab({ focused, width, height }: { focused: boolean; width: number; height: number }) {
+export function FundamentalGraphsResearchTab({ focused, width, height, onCapture }: TickerResearchTabProps) {
   const { symbol, financials } = usePaneTicker();
-  const [period, setPeriod] = usePluginPaneState<FundamentalPeriod>("detailPeriod", "annual");
+  const [period, setPeriod] = usePluginPaneState<FundamentalPeriod>("detailPeriod", "quarterly");
   const [chartKind, setChartKind] = usePluginPaneState<GraphKind>("detailChartKind", "fundamental");
   const [metric, setMetric] = usePluginPaneState<GraphMetricKey>("detailMetric", "totalRevenue");
   const resolvedMetric = isMetricForKind(chartKind, metric) ? metric : defaultMetric(chartKind);
@@ -79,6 +79,7 @@ export function FundamentalGraphsResearchTab({ focused, width, height }: { focus
       setMetric={setMetric}
       chartKind={chartKind}
       setChartKind={setChartKind}
+      onCapture={onCapture}
     />
   );
 }

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/content.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/content.tsx
@@ -1,23 +1,25 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, TextAttributes } from "../../../../../ui";
 import {
   DataTableView,
+  Tabs,
   usePaneFooter,
   type DataTableCell,
   type DataTableKeyEvent,
 } from "../../../../../components";
+import { useShortcut } from "../../../../../react/input";
+import type { BarChartHover } from "../../../../../components/chart/bar-chart-renderer";
 import { StaticBarChartSurface } from "../../../../../components/chart/static/bar-chart-surface";
 import { colors, priceColor } from "../../../../../theme/colors";
 import { usePluginPaneState } from "../../../../runtime";
 import { loadingErrorFooterInfo, refreshFooterHint, useClampSelectedIndex } from "../../../shared/table-pane";
 import {
+  allMetricDefs,
   buildFundamentalColumns,
   buildGraphBarSeries,
-  defaultMetric,
   formatMaybePercent,
-  isMetricForKind,
   metricDef,
-  nextMetric,
+  metricKind,
 } from "./model";
 import type {
   FundamentalColumn,
@@ -41,6 +43,7 @@ export function FundamentalGraphContent({
   setMetric,
   chartKind,
   setChartKind,
+  onCapture,
 }: {
   focused: boolean;
   width: number;
@@ -55,39 +58,106 @@ export function FundamentalGraphContent({
   setMetric: (updater: (current: GraphMetricKey) => GraphMetricKey) => void;
   chartKind: GraphKind;
   setChartKind: (updater: (current: GraphKind) => GraphKind) => void;
+  onCapture?: (capturing: boolean) => void;
 }) {
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
+  const [hoveredBar, setHoveredBar] = useState<BarChartHover | null>(null);
+  const [metricTabsFocused, setMetricTabsFocused] = useState(false);
   const definition = metricDef(chartKind, metric);
+  const metricOptions = useMemo(() => allMetricDefs(), []);
+  const metricTabs = useMemo(() => metricOptions.map(({ definition }) => ({
+    label: definition.label,
+    value: definition.key,
+  })), [metricOptions]);
   const multiSymbol = new Set(rows.map((row) => row.symbol)).size > 1;
   const columns = useMemo(() => buildFundamentalColumns(width, multiSymbol), [multiSymbol, width]);
-  const boundedSelectedIdx = rows.length > 0 ? Math.min(selectedIdx, rows.length - 1) : -1;
-  const chartHeight = height >= 14 ? Math.min(12, Math.max(7, Math.floor(height * 0.52))) : Math.max(4, Math.floor(height / 2));
-  const tableHeight = Math.max(4, height - chartHeight);
+  const tableRows = useMemo(() => [...rows].sort((left, right) => (
+    right.date.localeCompare(left.date) || left.symbol.localeCompare(right.symbol)
+  )), [rows]);
+  const boundedSelectedIdx = tableRows.length > 0 ? Math.min(selectedIdx, tableRows.length - 1) : -1;
+  const minTableHeight = tableRows.length > 0 ? 4 : 3;
+  const desiredChartHeight = height >= 14 ? Math.min(16, Math.max(9, Math.floor(height * 0.58))) : Math.max(4, Math.floor(height / 2));
+  const chartHeight = Math.max(1, Math.min(desiredChartHeight, Math.max(1, height - minTableHeight)));
+  const tableHeight = Math.max(0, height - chartHeight);
   const chartSeries = useMemo(() => buildGraphBarSeries(rows), [rows]);
-  const cycleMetric = useCallback(() => setMetric((current) => nextMetric(chartKind, current)), [chartKind, setMetric]);
-  const togglePeriod = useCallback(() => setPeriod((current) => current === "annual" ? "quarterly" : "annual"), [setPeriod]);
-  const toggleGraphKind = useCallback(() => {
-    const nextKind = chartKind === "fundamental" ? "valuation" : "fundamental";
+  const selectMetric = useCallback((value: string) => {
+    const nextMetric = value as GraphMetricKey;
+    const nextKind = metricKind(nextMetric);
+    if (!nextKind) return;
+    setHoveredBar(null);
     setChartKind(() => nextKind);
-    setMetric((current) => isMetricForKind(nextKind, current) ? current : defaultMetric(nextKind));
-  }, [chartKind, setChartKind, setMetric]);
+    setMetric(() => nextMetric);
+  }, [setChartKind, setMetric]);
+  const focusMetricTabs = useCallback(() => {
+    if (metricTabsFocused) return;
+    setMetricTabsFocused(true);
+    onCapture?.(true);
+  }, [metricTabsFocused, onCapture]);
+  const releaseMetricTabs = useCallback(() => {
+    if (!metricTabsFocused) return;
+    setMetricTabsFocused(false);
+    onCapture?.(false);
+  }, [metricTabsFocused, onCapture]);
+  const selectMetricFromTabs = useCallback((value: string) => {
+    focusMetricTabs();
+    selectMetric(value);
+  }, [focusMetricTabs, selectMetric]);
+  const togglePeriod = useCallback(() => setPeriod((current) => current === "annual" ? "quarterly" : "annual"), [setPeriod]);
+  const hoveredValue = useMemo(() => {
+    if (!hoveredBar) return null;
+    const label = chartSeries.length > 1 ? `${hoveredBar.category} ${hoveredBar.seriesLabel}` : hoveredBar.category;
+    return `${label} ${definition.format(hoveredBar.value)}`;
+  }, [chartSeries.length, definition, hoveredBar]);
 
-  useClampSelectedIndex(rows.length, selectedIdx, setSelectedIdx);
+  useClampSelectedIndex(tableRows.length, selectedIdx, setSelectedIdx);
+
+  useEffect(() => {
+    if (!focused && metricTabsFocused) {
+      setMetricTabsFocused(false);
+      onCapture?.(false);
+    }
+  }, [focused, metricTabsFocused, onCapture]);
+
+  useEffect(() => () => {
+    onCapture?.(false);
+  }, [onCapture]);
+
+  useShortcut((event) => {
+    if (event.defaultPrevented || event.propagationStopped || event.targetEditable) return;
+    if (event.ctrl || event.meta || event.alt || event.shift) return;
+
+    const isEnter = event.name === "enter" || event.name === "return";
+    const isEscape = event.name === "escape" || event.name === "esc";
+    if (isEnter) {
+      event.preventDefault();
+      event.stopPropagation();
+      focusMetricTabs();
+      return;
+    }
+    if (isEscape && metricTabsFocused) {
+      event.preventDefault();
+      event.stopPropagation();
+      releaseMetricTabs();
+    }
+  }, { enabled: focused, phase: "before" });
 
   const handleKeyDown = useCallback((event: DataTableKeyEvent) => {
+    const isEnter = event.name === "enter" || event.name === "return";
+    if (isEnter) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusMetricTabs();
+      return true;
+    }
+    if ((event.name === "escape" || event.name === "esc") && metricTabsFocused) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      releaseMetricTabs();
+      return true;
+    }
     if (event.name === "r") {
       event.preventDefault?.();
       reload();
-      return true;
-    }
-    if (event.name === "m") {
-      event.preventDefault?.();
-      cycleMetric();
-      return true;
-    }
-    if (event.name === "g") {
-      event.preventDefault?.();
-      toggleGraphKind();
       return true;
     }
     if (event.name === "p") {
@@ -96,7 +166,7 @@ export function FundamentalGraphContent({
       return true;
     }
     return false;
-  }, [cycleMetric, reload, toggleGraphKind, togglePeriod]);
+  }, [focusMetricTabs, metricTabsFocused, releaseMetricTabs, reload, togglePeriod]);
 
   const renderCell = useCallback((
     row: FundamentalGraphRow,
@@ -111,7 +181,11 @@ export function FundamentalGraphContent({
       case "date":
         return { text: row.date, color: selectedColor ?? colors.textDim };
       case "value":
-        return { text: definition.format(row.value), color: selectedColor ?? colors.textBright, attributes: TextAttributes.BOLD };
+        return {
+          text: definition.format(row.value),
+          color: row.value < 0 ? colors.negative : selectedColor ?? colors.textBright,
+          attributes: TextAttributes.BOLD,
+        };
       case "growth":
         return { text: formatMaybePercent(row.growth), color: selectedColor ?? priceColor(row.growth ?? 0) };
     }
@@ -119,41 +193,68 @@ export function FundamentalGraphContent({
 
   usePaneFooter("fundamental-graph", () => ({
     info: [
-      { id: "metric", parts: [{ text: definition.label, tone: "muted" as const }] },
-      { id: "kind", parts: [{ text: chartKind === "valuation" ? "valuation" : "fundamental", tone: "muted" as const }] },
-      { id: "period", parts: [{ text: period, tone: "muted" as const }] },
+      { id: "period", parts: [{ text: "period", tone: "label" as const }, { text: period, tone: "value" as const }] },
+      ...(hoveredValue ? [{ id: "hover", parts: [{ text: hoveredValue, tone: "value" as const }] }] : []),
       ...loadingErrorFooterInfo(loading, error),
     ],
     hints: [
-      { id: "metric", key: "m", label: "etric", onPress: cycleMetric },
-      { id: "kind", key: "g", label: "raph", onPress: toggleGraphKind },
       { id: "period", key: "p", label: "eriod", onPress: togglePeriod },
       refreshFooterHint(reload),
     ],
-  }), [chartKind, cycleMetric, definition.label, error, loading, period, reload, toggleGraphKind, togglePeriod]);
+  }), [error, hoveredValue, loading, period, reload, togglePeriod]);
+
+  const metricHeader = (
+    <Tabs
+      tabs={metricTabs}
+      activeValue={metric}
+      onSelect={selectMetricFromTabs}
+      compact
+      focused={focused && metricTabsFocused}
+      keyboardNavigation={metricTabsFocused}
+      scrollable
+      variant="underline"
+    />
+  );
 
   return (
-    <Box flexDirection="column" width={width} height={height} overflow="hidden">
-      <StaticBarChartSurface width={width} height={chartHeight} series={chartSeries} />
-      <DataTableView<FundamentalGraphRow, FundamentalColumn>
-        focused={focused}
-        selection={{
-          kind: "index",
-          selectedIndex: boundedSelectedIdx,
-          onChange: (index) => setSelectedIdx(index),
-        }}
-        onRootKeyDown={handleKeyDown}
-        rootWidth={width}
-        rootHeight={tableHeight}
-        columns={columns}
-        items={rows}
-        sortColumnId={null}
-        sortDirection="asc"
-        onHeaderClick={() => {}}
-        getItemKey={(row) => row.key}
-        renderCell={renderCell}
-        emptyStateTitle={loading ? "Loading fundamentals..." : "No graph data"}
+    <Box
+      flexDirection="column"
+      width={width}
+      height={height}
+      overflow="hidden"
+      onMouseDown={focusMetricTabs}
+    >
+      <StaticBarChartSurface
+        width={width}
+        height={chartHeight}
+        series={chartSeries}
+        header={metricHeader}
+        formatValue={definition.format}
+        onHoverChange={setHoveredBar}
+        onMouseDown={focusMetricTabs}
       />
+      {tableHeight > 0 ? (
+        <DataTableView<FundamentalGraphRow, FundamentalColumn>
+          focused={focused}
+          selection={{
+            kind: "index",
+            selectedIndex: boundedSelectedIdx,
+            onChange: (index) => setSelectedIdx(index),
+          }}
+          onRootKeyDown={handleKeyDown}
+          rootWidth={width}
+          rootHeight={tableHeight}
+          columns={columns}
+          items={tableRows}
+          sortColumnId="date"
+          sortDirection="desc"
+          onHeaderClick={() => {}}
+          onTableMouseDown={focusMetricTabs}
+          getItemKey={(row) => row.key}
+          renderCell={renderCell}
+          emptyStateTitle={loading ? "Loading fundamentals..." : "No graph data"}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/model.ts
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/model.ts
@@ -71,9 +71,19 @@ export function buildFundamentalGraphRows(
   symbol = "",
   period: FundamentalPeriod = "annual",
 ): FundamentalGraphRow[] {
-  const sorted = [...statements]
+  const sortedStatements = [...statements]
     .filter((statement) => typeof statement[metric] === "number")
     .sort((left, right) => left.date.localeCompare(right.date));
+  const byCategory = new Map<string, FinancialStatement>();
+  for (const statement of sortedStatements) {
+    const category = periodCategory(statement.date, period);
+    const key = `${symbol}\u0000${category}`;
+    const previous = byCategory.get(key);
+    if (!previous || statement.date.localeCompare(previous.date) >= 0) {
+      byCategory.set(key, statement);
+    }
+  }
+  const sorted = [...byCategory.values()].sort((left, right) => left.date.localeCompare(right.date));
   const maxAbs = Math.max(1, ...sorted.map((statement) => Math.abs(statement[metric] as number)));
   return sorted.map((statement, index) => {
     const value = statement[metric] as number;
@@ -159,8 +169,21 @@ export function buildValuationGraphRows(
   });
 }
 
-function metricDefs(kind: GraphKind): ReadonlyArray<MetricDefinition> {
+export function metricDefs(kind: GraphKind): ReadonlyArray<MetricDefinition> {
   return kind === "valuation" ? VALUATION_METRICS : FUNDAMENTAL_METRICS;
+}
+
+export function allMetricDefs(): ReadonlyArray<{ kind: GraphKind; definition: MetricDefinition }> {
+  return [
+    ...FUNDAMENTAL_METRICS.map((definition) => ({ kind: "fundamental" as const, definition })),
+    ...VALUATION_METRICS.map((definition) => ({ kind: "valuation" as const, definition })),
+  ];
+}
+
+export function metricKind(metric: GraphMetricKey): GraphKind | null {
+  if (FUNDAMENTAL_METRICS.some((definition) => definition.key === metric)) return "fundamental";
+  if (VALUATION_METRICS.some((definition) => definition.key === metric)) return "valuation";
+  return null;
 }
 
 export function defaultMetric(kind: GraphKind): GraphMetricKey {

--- a/src/plugins/builtin/ticker-detail/index.test.tsx
+++ b/src/plugins/builtin/ticker-detail/index.test.tsx
@@ -305,6 +305,25 @@ async function clickFrameText(text: string) {
   await flushFrame();
 }
 
+async function emitKeypress(event: { name?: string; sequence?: string }) {
+  await act(async () => {
+    (testSetup!.renderer as any).keyInput.emit("keypress", {
+      ctrl: false,
+      meta: false,
+      option: false,
+      shift: false,
+      eventType: "press",
+      repeated: false,
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      ...event,
+    });
+    await Promise.resolve();
+    await testSetup!.renderOnce();
+  });
+  await flushFrame();
+}
+
 function spanLineText(line: { spans: Array<{ text: string }> }): string {
   return line.spans.map((span) => span.text).join("");
 }
@@ -529,6 +548,130 @@ describe("TickerResearchPane", () => {
 
     await settleTickerTabCommit();
     expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("financials");
+  });
+
+  test("shows metric tabs for fundamental graph charts and defaults them to quarterly data", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setOptionsProvider(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={makeFinancials({
+          annualStatements: [{ date: "2024-12-31", totalRevenue: 1_000 }],
+          quarterlyStatements: [
+            { date: "2025-03-31", totalRevenue: 200 },
+            { date: "2025-06-30", totalRevenue: 250 },
+          ],
+        })}
+        activeTabId="fundamental-graphs"
+        height={28}
+      />,
+      { width: 90, height: 28 },
+    );
+
+    await flushFrame();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Revenue");
+    expect(frame).toContain("Gross Profit");
+    expect(frame).not.toContain("Revenue (quarterly)");
+    expect(frame).not.toContain("[g]roup");
+    expect(frame).toContain("2025-03-31");
+    expect(frame).toContain("2025-06-30");
+    expect(frame.indexOf("2025-06-30")).toBeLessThan(frame.indexOf("2025-03-31"));
+  });
+
+  test("captures arrows for graph metric tabs between enter and escape", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setOptionsProvider(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={makeFinancials({
+          annualStatements: [{ date: "2024-12-31", totalRevenue: 1_000, grossProfit: 400 }],
+          quarterlyStatements: [
+            { date: "2025-03-31", totalRevenue: 200, grossProfit: 80 },
+            { date: "2025-06-30", totalRevenue: 250, grossProfit: 120 },
+          ],
+        })}
+        activeTabId="fundamental-graphs"
+        height={28}
+      />,
+      { width: 90, height: 28 },
+    );
+
+    await flushFrame();
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("fundamental-graphs");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("right");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.pluginState?.["ticker-detail"]?.detailMetric).toBe("grossProfit");
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("fundamental-graphs");
+
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    expect(detailHarnessState?.inputCaptured).toBe(false);
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("right");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    await settleTickerTabCommit();
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("chart");
+  });
+
+  test("clicking graph content focuses metric tabs for arrow navigation", async () => {
+    setSharedRegistryForTests(makeRegistry());
+    setOptionsProvider(createProvider(false));
+
+    testSetup = await testRender(
+      <DetailHarness
+        config={createDetailConfig("AAPL")}
+        ticker={makeTicker("AAPL")}
+        financials={makeFinancials({
+          annualStatements: [{ date: "2024-12-31", totalRevenue: 1_000, grossProfit: 400 }],
+          quarterlyStatements: [
+            { date: "2025-03-31", totalRevenue: 200, grossProfit: 80 },
+            { date: "2025-06-30", totalRevenue: 250, grossProfit: 120 },
+          ],
+        })}
+        activeTabId="fundamental-graphs"
+        height={28}
+      />,
+      { width: 90, height: 28 },
+    );
+
+    await flushFrame();
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(24, 6);
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+    expect(detailHarnessState?.inputCaptured).toBe(true);
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("right");
+      await testSetup!.renderOnce();
+    });
+    await flushFrame();
+
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.pluginState?.["ticker-detail"]?.detailMetric).toBe("grossProfit");
+    expect(detailHarnessState?.paneState[TEST_PANE_ID]?.activeTabId).toBe("fundamental-graphs");
   });
 
   test("shows Trade when an IBKR gateway profile exists", async () => {

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -20,7 +20,7 @@ import { resolvePaneBodyFrame } from "../../../components/layout/pane/sizing";
 import { getPaneDisplayTitle } from "../../../components/layout/pane/title";
 import type { AppConfig } from "../../../types/config";
 import type { CachedFinancialsTarget, DataProvider, QuoteSubscriptionTarget } from "../../../types/data-provider";
-import type { TickerFinancials } from "../../../types/financials";
+import type { OptionsChain, TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import type { AppState, PaneRuntimeState } from "../../../core/state/app/state";
 import type { PaneDef } from "../../../types/plugin";
@@ -32,6 +32,7 @@ interface CliPaneShotPayload {
   heightCells: number;
   tickers: TickerRecord[];
   financials: Array<[string, TickerFinancials]>;
+  optionsChains: Array<[string, OptionsChain]>;
   paneState: Record<string, PaneRuntimeState>;
 }
 
@@ -56,6 +57,7 @@ const TRACKED_RESPONSE_METHODS = new Set<PropertyKey>([
 
 let pendingShotWork = 0;
 let didInstallShotFetchTracker = false;
+let shotDataProvider: DataProvider | null = null;
 
 const rendererHost: RendererHost = {
   requestExit() {},
@@ -152,6 +154,7 @@ function waitForShotReadiness(): () => void {
 
 function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
   const financials = new Map(payload.financials.map(([symbol, data]) => [normalizeSymbol(symbol), data]));
+  const optionsChains = new Map((payload.optionsChains ?? []).map(([symbol, data]) => [normalizeSymbol(symbol), data]));
 
   const getFinancials = (symbol: string) => {
     const data = financials.get(normalizeSymbol(symbol));
@@ -187,6 +190,13 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
     getExchangeRate() {
       return resolveShotWork(1);
     },
+    getOptionsChain(ticker) {
+      return trackShotWork(Promise.resolve().then(() => {
+        const chain = optionsChains.get(normalizeSymbol(ticker));
+        if (!chain) throw new Error(`No screenshot options data available for ${ticker}.`);
+        return chain;
+      }));
+    },
     search(query) {
       const normalized = normalizeSymbol(query);
       return resolveShotWork(payload.tickers
@@ -217,6 +227,7 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
 
 function installShotMarketData(payload: CliPaneShotPayload): void {
   const provider = createShotDataProvider(payload);
+  shotDataProvider = provider;
   const coordinator = new MarketDataCoordinator(provider);
   coordinator.primeCachedFinancials(payload.tickers.flatMap((ticker) => {
     const financials = payload.financials.find(([symbol]) => normalizeSymbol(symbol) === normalizeSymbol(ticker.metadata.ticker))?.[1];
@@ -236,7 +247,7 @@ function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
     return (payload.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? null;
   }
   return {
-    getMarketData: () => null,
+    getMarketData: () => shotDataProvider,
     getCapability: () => null,
     getBrokerAdapter: () => null,
     connectBrokerInstance: async () => {},

--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -59,6 +59,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   isSelected,
   onSelect,
   onActivate,
+  onTableMouseDown,
   onRowMouseDown,
   onRowContextMenu,
   rowContextMenuSurface = false,
@@ -71,6 +72,9 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   emptyStateHint,
   virtualize = true,
   overscan = 3,
+  columnGap = 1,
+  horizontalPadding = 1,
+  fillAvailableWidth = true,
   showHorizontalScrollbar = true,
   scrollToIndex,
   scrollToIndexAlign = "nearest",
@@ -85,10 +89,13 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const bodyVertical = useScrollbarState(true);
   const [viewportWidth, setViewportWidth] = useState(0);
   const [scrollbarActive, markScrollbarActive] = useScrollbarActivity();
-  const tableWidth = useMemo(() => getTableWidth(columns), [columns]);
+  const tableWidth = useMemo(
+    () => getTableWidth(columns, columnGap, horizontalPadding),
+    [columnGap, columns, horizontalPadding],
+  );
   const gridTemplateColumns = useMemo(
-    () => buildTableGridTemplateColumns(columns),
-    [columns],
+    () => buildTableGridTemplateColumns(columns, fillAvailableWidth),
+    [columns, fillAvailableWidth],
   );
   const selectRow = useCallback((item: T, index: number) => {
     onSelect(item, index);
@@ -136,8 +143,9 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     : WEB_CELL_HEIGHT + items.length * WEB_CELL_HEIGHT;
   const bodyAfterHeight = bodyAfter ? WEB_CELL_HEIGHT * 6 : 0;
   const horizontalScrollEnabled = showHorizontalScrollbar
-    && hasMeaningfulTableHorizontalOverflow(tableWidth, viewportWidth);
+    && hasMeaningfulTableHorizontalOverflow(tableWidth, viewportWidth, columnGap);
   const scrollContentWidth = horizontalScrollEnabled
+    || !fillAvailableWidth
     ? Math.max(1, tableWidth * WEB_CELL_WIDTH)
     : "100%";
   const measureViewportWidth = useCallback(() => {
@@ -247,6 +255,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
         style={bodyScrollerStyle}
         onMouseDown={() => {
           focusPane();
+          onTableMouseDown?.({});
         }}
         onMouseLeave={() => {
           if (hoveredIdx !== null) setHoveredIdx(null);
@@ -270,7 +279,10 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
         >
           <WebDataTableHeader
             columns={columns}
+            columnGap={columnGap}
+            horizontalPadding={horizontalPadding}
             focusPane={focusPane}
+            onTableMouseDown={onTableMouseDown}
             gridTemplateColumns={gridTemplateColumns}
             onHeaderClick={onHeaderClick}
             sortColumnId={sortColumnId}
@@ -314,7 +326,10 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                     item={item}
                     itemKey={itemKey}
                     columns={columns}
+                    columnGap={columnGap}
+                    horizontalPadding={horizontalPadding}
                     focusPane={focusPane}
+                    onTableMouseDown={onTableMouseDown}
                     gridTemplateColumns={gridTemplateColumns}
                     onActivateRow={onActivate ? activateRow : undefined}
                     onRowContextMenu={onRowContextMenu}

--- a/src/renderers/electrobun/view/data-table/row.tsx
+++ b/src/renderers/electrobun/view/data-table/row.tsx
@@ -44,16 +44,30 @@ function contentJustifyForAlign(align: string | undefined): CSSProperties["justi
   return "flex-start";
 }
 
+function columnGapCss(columnGap: number): CSSProperties["columnGap"] {
+  return columnGap === 0 ? 0 : `calc(${columnGap} * var(--cell-w))`;
+}
+
+function inlinePaddingPx(horizontalPadding: number): number {
+  return TABLE_INLINE_PADDING_PX * horizontalPadding;
+}
+
 export function WebDataTableHeader<C extends DataTableColumn>({
   columns,
+  columnGap,
+  horizontalPadding,
   focusPane,
+  onTableMouseDown,
   gridTemplateColumns,
   onHeaderClick,
   sortColumnId,
   sortDirection,
 }: {
   columns: C[];
+  columnGap: number;
+  horizontalPadding: number;
   focusPane: () => void;
+  onTableMouseDown?: (event: any) => void;
   gridTemplateColumns: string;
   onHeaderClick: (columnId: string) => void;
   sortColumnId: string | null;
@@ -69,13 +83,13 @@ export function WebDataTableHeader<C extends DataTableColumn>({
         zIndex: 2,
         display: "grid",
         gridTemplateColumns,
-        columnGap: "var(--cell-w)",
+        columnGap: columnGapCss(columnGap),
         alignItems: "center",
         width: "100%",
         minWidth: 0,
         height: WEB_CELL_HEIGHT,
-        paddingLeft: TABLE_INLINE_PADDING_PX,
-        paddingRight: TABLE_INLINE_PADDING_PX,
+        paddingLeft: inlinePaddingPx(horizontalPadding),
+        paddingRight: inlinePaddingPx(horizontalPadding),
         boxSizing: "border-box",
         backgroundColor: CSS_PANEL,
       }}
@@ -99,6 +113,7 @@ export function WebDataTableHeader<C extends DataTableColumn>({
             }}
             onMouseDown={(event) => {
               focusPane();
+              onTableMouseDown?.(event);
               event.preventDefault();
               onHeaderClick(column.id);
             }}
@@ -128,7 +143,10 @@ function WebDataTableRowInner<
   C extends DataTableColumn,
 >({
   columns,
+  columnGap,
+  horizontalPadding,
   focusPane,
+  onTableMouseDown,
   onActivateRow,
   onRowContextMenu,
   onRowMouseDown,
@@ -148,7 +166,10 @@ function WebDataTableRowInner<
   setHoveredIdx,
 }: {
   columns: C[];
+  columnGap: number;
+  horizontalPadding: number;
   focusPane: () => void;
+  onTableMouseDown?: (event: any) => void;
   onActivateRow?: (item: T, index: number) => void;
   onRowContextMenu?: DataTableProps<T, C>["onRowContextMenu"];
   onRowMouseDown?: DataTableProps<T, C>["onRowMouseDown"];
@@ -177,13 +198,13 @@ function WebDataTableRowInner<
     transform: `translateY(${rowStart}px)`,
     display: "grid",
     gridTemplateColumns,
-    columnGap: "var(--cell-w)",
+    columnGap: columnGapCss(columnGap),
     alignItems: "center",
     width: "100%",
     minWidth: 0,
     height: rowSize,
-    paddingLeft: TABLE_INLINE_PADDING_PX,
-    paddingRight: TABLE_INLINE_PADDING_PX,
+    paddingLeft: inlinePaddingPx(horizontalPadding),
+    paddingRight: inlinePaddingPx(horizontalPadding),
     boxSizing: "border-box",
     lineHeight: "var(--cell-h)",
   };
@@ -199,6 +220,7 @@ function WebDataTableRowInner<
         }}
         onMouseDown={(event) => {
           focusPane();
+          onTableMouseDown?.(event);
           event.preventDefault();
         }}
       >
@@ -243,6 +265,7 @@ function WebDataTableRowInner<
       }}
       onMouseDown={(event) => {
         focusPane();
+        onTableMouseDown?.(event);
         if (onRowMouseDown?.(item, index, eventWithCellCoordinates(event)) === true) {
           return;
         }
@@ -274,6 +297,7 @@ function WebDataTableRowInner<
             }}
             onMouseDown={(event) => {
               focusPane();
+              onTableMouseDown?.(event);
               if (cell.onMouseDown) {
                 cell.onMouseDown(eventWithCellCoordinates(event));
                 return;

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -21,6 +21,7 @@ export function WebTabs({
   closeMode = "always",
   addLabel = "+",
   onAdd,
+  focused = false,
   palette,
 }: HostTabsProps) {
   const activeTabRef = useRef<HTMLButtonElement | null>(null);
@@ -112,16 +113,20 @@ export function WebTabs({
           paddingBlock: 0,
           paddingBottom: showUnderline ? 2 : 0,
           margin: 0,
-          border: 0,
+          border: "1px solid transparent",
           borderRadius: variant === "underline" ? 5 : 6,
           background: resolveTabBackground(active, hovered),
+          boxSizing: "border-box",
           font: "inherit",
           fontSize: tabFontSize,
           fontWeight: active ? 700 : 500,
           lineHeight: 1,
           textAlign: "center",
           whiteSpace: "nowrap",
-          transition: "background-color 110ms ease, color 110ms ease, box-shadow 110ms ease",
+          borderColor: active && focused && variant !== "pill"
+            ? `color-mix(in srgb, ${palette.activeUnderline} 35%, transparent)`
+            : "transparent",
+          transition: "background-color 110ms ease, border-color 110ms ease, color 110ms ease",
           cursor: disabled ? "default" : "pointer",
         } satisfies CssVars;
 

--- a/src/sources/provider-router/batches.ts
+++ b/src/sources/provider-router/batches.ts
@@ -11,7 +11,12 @@ import { normalizeTickerFinancialsPriceHistory } from "../../utils/price-history
 import { isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
 import { resolveTickerFinancialsQuoteState } from "../../market-data/quotes/resolution";
 import { selectCachedResource } from "./cache";
-import { quoteWithFreshnessExchange, type CachedFinancialsSelection } from "./financials";
+import {
+  hasDeepStatementHistory,
+  hasDetailedStatementRows,
+  quoteWithFreshnessExchange,
+  type CachedFinancialsSelection,
+} from "./financials";
 import type { ProviderRouterCoreDeps } from "./route-types";
 
 export interface ProviderRouterBatchDeps extends ProviderRouterCoreDeps {
@@ -30,6 +35,10 @@ export interface ProviderRouterBatchDeps extends ProviderRouterCoreDeps {
 
 export class ProviderRouterBatchRoutes {
   constructor(private readonly deps: ProviderRouterBatchDeps) {}
+
+  private needsSingleFinancialsRoute(value: TickerFinancials): boolean {
+    return !(hasDetailedStatementRows(value) && hasDeepStatementHistory(value));
+  }
 
   async getQuotesBatch(
     targets: QuoteSubscriptionTarget[],
@@ -105,6 +114,7 @@ export class ProviderRouterBatchRoutes {
   ): Promise<TickerFinancialsBatchResult[]> {
     const forceRefresh = options.forceRefresh === true;
     const results = new Array<TickerFinancialsBatchResult | null>(targets.length).fill(null);
+    const batchFallbacks = new Array<TickerFinancials | null>(targets.length).fill(null);
     const misses: Array<{ index: number; target: CachedFinancialsTarget }> = [];
 
     targets.forEach((target, index) => {
@@ -139,6 +149,8 @@ export class ProviderRouterBatchRoutes {
           const entityKey = this.deps.getEntityKey(entry.target.symbol, entry.target.instrument ?? undefined);
           const variantKey = this.deps.getTickerVariantCandidates(entry.target.exchange)[0] ?? "";
           this.deps.cacheResource("financials", entityKey, variantKey, sourceKey, value, this.deps.resolveProviderPolicy("financials", batchProvider));
+          batchFallbacks[entry.index] = value;
+          if (this.needsSingleFinancialsRoute(value)) continue;
           results[entry.index] = { target: entry.target, financials: value };
         }
       }
@@ -153,7 +165,9 @@ export class ProviderRouterBatchRoutes {
         });
         results[index] = { target, financials };
       } catch (error) {
-        results[index] = { target, financials: null, error };
+        results[index] = batchFallbacks[index]
+          ? { target, financials: batchFallbacks[index] }
+          : { target, financials: null, error };
       }
     }));
 

--- a/src/sources/provider-router/financial-routes.ts
+++ b/src/sources/provider-router/financial-routes.ts
@@ -19,6 +19,7 @@ import { withBrokerTimeout } from "./brokers";
 import {
   deriveMarketCapFromShares,
   hasMeaningfulProfile,
+  hasShallowStatementHistory,
   mergeCachedFinancialRecords,
   mergeFinancials,
   quoteWithFreshnessExchange,
@@ -85,6 +86,10 @@ export class ProviderRouterFinancialRoutes {
     if (cached.value && !forceRefresh) {
       if (isOptionTicker && !cached.value.quote) {
         return quoteOnlyFinancials(cached.value);
+      }
+      if (!cached.stale && hasMeaningfulProfile(cached.value) && hasShallowStatementHistory(cached.value)) {
+        const providerResult = await this.deps.primaryRoutes.fetchProviderFinancials(ticker, exchange, context);
+        return mergeFinancials(cached.value, providerResult?.value ?? null) ?? cached.value;
       }
       if (!cached.stale && hasMeaningfulProfile(cached.value)) {
         return cached.value;

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -1,6 +1,7 @@
 import type { CachedResourceRecord } from "../../data/resource-store";
 import type { AnalystResearchData, CorporateActionsData, FinancialStatement, Quote, TickerFinancials } from "../../types/financials";
 import { hasLikelyQuoteUnitMismatch } from "../../utils/currency-units";
+import { mergeFinancialStatementRows } from "../../utils/financial-statements";
 import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../../utils/price-history";
 import { isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
 import {
@@ -122,33 +123,20 @@ export function hasDetailedStatementRows(data: TickerFinancials | null | undefin
   return rows.some((row) => DETAILED_STATEMENT_KEYS.some((key) => typeof row[key] === "number"));
 }
 
-function mergeStatementRows(
-  primaryRows: FinancialStatement[],
-  fallbackRows: FinancialStatement[],
-): FinancialStatement[] {
-  if (primaryRows.length === 0) return fallbackRows;
-  if (fallbackRows.length === 0) return primaryRows;
+export function hasDeepStatementHistory(data: TickerFinancials | null | undefined): boolean {
+  if (!data) return false;
+  return data.annualStatements.length >= 5 || data.quarterlyStatements.length >= 8;
+}
 
-  const fallbackByDate = new Map(fallbackRows.map((row) => [row.date, row]));
-  const primaryDates = new Set(primaryRows.map((row) => row.date));
-  const mergedRows = primaryRows.map((row) => ({
-    ...fallbackByDate.get(row.date),
-    ...row,
-    date: row.date,
-  }));
-
-  for (const row of fallbackRows) {
-    if (!primaryDates.has(row.date)) mergedRows.push(row);
-  }
-
-  return mergedRows.sort((left, right) => left.date.localeCompare(right.date));
+export function hasShallowStatementHistory(data: TickerFinancials | null | undefined): boolean {
+  return hasStatementRows(data) && !hasDeepStatementHistory(data);
 }
 
 export function mergeMissingStatementArrays(primary: TickerFinancials, fallback: TickerFinancials): TickerFinancials {
   return {
     ...primary,
-    annualStatements: mergeStatementRows(primary.annualStatements, fallback.annualStatements),
-    quarterlyStatements: mergeStatementRows(primary.quarterlyStatements, fallback.quarterlyStatements),
+    annualStatements: mergeFinancialStatementRows(primary.annualStatements, fallback.annualStatements),
+    quarterlyStatements: mergeFinancialStatementRows(primary.quarterlyStatements, fallback.quarterlyStatements),
   };
 }
 
@@ -216,8 +204,8 @@ export function mergeFinancials(primary: TickerFinancials | null, fallback: Tick
     profile: mergeDefinedObject(primary.profile, fallback.profile),
     fundamentals: mergeDefinedObject(primary.fundamentals, fallback.fundamentals),
     priceHistory: normalizePriceHistory(dominant.priceHistory.length > 0 ? dominant.priceHistory : secondary.priceHistory),
-    annualStatements: mergeStatementRows(primary.annualStatements, fallback.annualStatements),
-    quarterlyStatements: mergeStatementRows(primary.quarterlyStatements, fallback.quarterlyStatements),
+    annualStatements: mergeFinancialStatementRows(primary.annualStatements, fallback.annualStatements),
+    quarterlyStatements: mergeFinancialStatementRows(primary.quarterlyStatements, fallback.quarterlyStatements),
   });
 }
 

--- a/src/sources/provider-router/index.test.ts
+++ b/src/sources/provider-router/index.test.ts
@@ -1069,6 +1069,195 @@ describe("AssetDataRouter", () => {
     expect(yahooCalls).toBe(1);
   });
 
+  test("supplements shallow preferred provider statement history", async () => {
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getTickerFinancials() {
+        return makeFinancials({
+          profile: { sector: "Technology" },
+          quote: makeQuote({ symbol: "LINK", price: 25 }),
+          quarterlyStatements: [
+            { date: "2025-03-31", operatingCashFlow: -271_000 },
+            { date: "2025-06-30", operatingCashFlow: -138_000 },
+            { date: "2025-09-30", operatingCashFlow: 653_000 },
+            { date: "2025-12-31", operatingCashFlow: -356_000 },
+            { date: "2026-03-31", operatingCashFlow: -543_000 },
+          ],
+        });
+      },
+    };
+    let yahooCalls = 0;
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getTickerFinancials() {
+        yahooCalls += 1;
+        return makeFinancials({
+          quarterlyStatements: [
+            { date: "2024-03-31", operatingCashFlow: -601_000 },
+            { date: "2024-06-30", operatingCashFlow: -488_000 },
+            { date: "2024-09-30", operatingCashFlow: -204_000 },
+            { date: "2024-12-31", operatingCashFlow: 122_000 },
+          ],
+        });
+      },
+    };
+
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
+    const merged = await router.getTickerFinancials("LINK", "NASDAQ");
+
+    expect(yahooCalls).toBe(1);
+    expect(merged.profile?.sector).toBe("Technology");
+    expect(merged.quote?.price).toBe(25);
+    expect(merged.quarterlyStatements.map((row) => row.date)).toEqual([
+      "2024-03-31",
+      "2024-06-30",
+      "2024-09-30",
+      "2024-12-31",
+      "2025-03-31",
+      "2025-06-30",
+      "2025-09-30",
+      "2025-12-31",
+      "2026-03-31",
+    ]);
+  });
+
+  test("enriches shallow batch provider statement history through the single financial route", async () => {
+    const shallowCloudRows = [
+      { date: "2025-03-31", eps: 0.44 },
+      { date: "2025-06-30", eps: 0.54 },
+      { date: "2025-09-30", eps: 0.75 },
+      { date: "2025-12-31", eps: 0.92 },
+      { date: "2026-03-31", eps: 0.84 },
+    ];
+    let cloudBatchCalls = 0;
+    let cloudSingleCalls = 0;
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getTickerFinancials() {
+        cloudSingleCalls += 1;
+        return makeFinancials({
+          profile: { sector: "Technology" },
+          quote: makeQuote({ symbol: "AMD", price: 125 }),
+          quarterlyStatements: shallowCloudRows,
+        });
+      },
+      async getTickerFinancialsBatch(targets) {
+        cloudBatchCalls += 1;
+        return targets.map((target) => ({
+          target,
+          financials: makeFinancials({
+            profile: { sector: "Technology" },
+            quote: makeQuote({ symbol: target.symbol, price: 125 }),
+            quarterlyStatements: shallowCloudRows,
+          }),
+        }));
+      },
+    };
+    let yahooCalls = 0;
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getTickerFinancials() {
+        yahooCalls += 1;
+        return makeFinancials({
+          quarterlyStatements: [
+            { date: "2024-03-31", eps: 0.07 },
+            { date: "2024-06-30", eps: 0.16 },
+            { date: "2024-09-30", eps: 0.47 },
+            { date: "2024-12-31", eps: 0.29 },
+          ],
+        });
+      },
+    };
+
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
+    const results = await router.getTickerFinancialsBatch([{ symbol: "AMD", exchange: "NASDAQ" }], { forceRefresh: true });
+    const financials = results[0]?.financials;
+
+    expect(cloudBatchCalls).toBe(1);
+    expect(cloudSingleCalls).toBe(1);
+    expect(yahooCalls).toBe(1);
+    expect(financials?.profile?.sector).toBe("Technology");
+    expect(financials?.quote?.symbol).toBe("AMD");
+    expect(financials?.quarterlyStatements.map((row) => row.date)).toEqual([
+      "2024-03-31",
+      "2024-06-30",
+      "2024-09-30",
+      "2024-12-31",
+      "2025-03-31",
+      "2025-06-30",
+      "2025-09-30",
+      "2025-12-31",
+      "2026-03-31",
+    ]);
+  });
+
+  test("refreshes shallow cached provider statement history", async () => {
+    const dbPath = createTempDbPath("cached-shallow-statement-history");
+    const persistence = new AppPersistence(dbPath);
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getTickerFinancials() {
+        return makeFinancials({
+          profile: { sector: "Technology" },
+          quote: makeQuote({ symbol: "LINK", price: 25 }),
+          quarterlyStatements: [
+            { date: "2025-03-31", operatingCashFlow: -271_000 },
+            { date: "2025-06-30", operatingCashFlow: -138_000 },
+            { date: "2025-09-30", operatingCashFlow: 653_000 },
+            { date: "2025-12-31", operatingCashFlow: -356_000 },
+            { date: "2026-03-31", operatingCashFlow: -543_000 },
+          ],
+        });
+      },
+    };
+    let yahooCalls = 0;
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getTickerFinancials() {
+        yahooCalls += 1;
+        return makeFinancials({
+          quarterlyStatements: [
+            { date: "2024-03-31", operatingCashFlow: -601_000 },
+            { date: "2024-06-30", operatingCashFlow: -488_000 },
+            { date: "2024-09-30", operatingCashFlow: -204_000 },
+            { date: "2024-12-31", operatingCashFlow: 122_000 },
+          ],
+        });
+      },
+    };
+
+    try {
+      const seedRouter = new AssetDataRouter(null, [cloudProvider], persistence.resources);
+      await seedRouter.getTickerFinancials("LINK", "NASDAQ");
+
+      const cachedRouter = new AssetDataRouter(yahooProvider, [cloudProvider], persistence.resources);
+      const merged = await cachedRouter.getTickerFinancials("LINK", "NASDAQ");
+
+      expect(yahooCalls).toBe(1);
+      expect(merged.quarterlyStatements).toHaveLength(9);
+    } finally {
+      persistence.close();
+    }
+  });
+
   test("fills missing preferred statement fields from richer fallback rows", async () => {
     const cloudProvider: DataProvider = {
       ...fallbackProvider,

--- a/src/sources/provider-router/primary.ts
+++ b/src/sources/provider-router/primary.ts
@@ -6,6 +6,7 @@ import { resolveTickerFinancialsQuoteState } from "../../market-data/quotes/reso
 import { shouldLogProviderError } from "../provider-errors";
 import {
   hasDetailedStatementRows,
+  hasDeepStatementHistory,
   hasStatementRows,
   mergeMissingStatementArrays,
 } from "./financials";
@@ -80,7 +81,7 @@ export class ProviderRouterPrimaryRoutes {
         );
         if (!primaryResult) {
           primaryResult = { sourceKey, value };
-          if (hasDetailedStatementRows(value)) return primaryResult;
+          if (hasDetailedStatementRows(value) && hasDeepStatementHistory(value)) return primaryResult;
           continue;
         }
         if (hasStatementRows(value)) {
@@ -88,7 +89,7 @@ export class ProviderRouterPrimaryRoutes {
             sourceKey: primaryResult.sourceKey,
             value: mergeMissingStatementArrays(primaryResult.value, value),
           };
-          if (hasDetailedStatementRows(primaryResult.value)) return primaryResult;
+          if (hasDetailedStatementRows(primaryResult.value) && hasDeepStatementHistory(primaryResult.value)) return primaryResult;
         }
       } catch (error) {
         if (shouldLogProviderError(error)) {

--- a/src/sources/sec-edgar.test.ts
+++ b/src/sources/sec-edgar.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   SecEdgarClient,
   extractFilingContent,
+  parseCompanyFactsFinancialStatements,
   parseFilingDocuments,
   parseRecentFilings,
   parseTickerLookup,
@@ -114,6 +115,88 @@ describe("parseFilingDocuments", () => {
         description: "Results of Operations and Financial Condition",
         document: "aapl-ex991.htm",
         isPrimary: false,
+      },
+    ]);
+  });
+});
+
+describe("parseCompanyFactsFinancialStatements", () => {
+  test("maps SEC company facts into deeper annual and quarterly statement rows", () => {
+    const fact = (tag: string, unit: string, rows: unknown[]) => ({
+      [tag]: {
+        units: {
+          [unit]: rows,
+        },
+      },
+    });
+    const duration = (end: string, val: number, overrides: Record<string, unknown> = {}) => ({
+      start: `${end.slice(0, 4)}-01-01`,
+      end,
+      val,
+      filed: end,
+      form: "10-K",
+      fp: "FY",
+      ...overrides,
+    });
+    const instant = (end: string, val: number, overrides: Record<string, unknown> = {}) => ({
+      end,
+      val,
+      filed: end,
+      form: "10-K",
+      fp: "FY",
+      ...overrides,
+    });
+
+    const statements = parseCompanyFactsFinancialStatements({
+      facts: {
+        "us-gaap": {
+          ...fact("RevenueFromContractWithCustomerExcludingAssessedTax", "USD", [
+            duration("2020-12-31", 100),
+            duration("2021-03-31", 30, { form: "10-Q", fp: "Q1", frame: "CY2021Q1" }),
+            duration("2021-06-30", 40, { form: "10-Q", fp: "Q2", frame: "CY2021Q2" }),
+          ]),
+          ...fact("NetCashProvidedByUsedInOperatingActivities", "USD", [
+            duration("2020-12-31", 25),
+            duration("2021-03-31", 8, { form: "10-Q", fp: "Q1", frame: "CY2021Q1" }),
+          ]),
+          ...fact("PaymentsToAcquirePropertyPlantAndEquipment", "USD", [
+            duration("2020-12-31", 5),
+            duration("2021-03-31", 3, { form: "10-Q", fp: "Q1", frame: "CY2021Q1" }),
+          ]),
+          ...fact("Assets", "USD", [
+            instant("2020-12-31", 500),
+            instant("2021-03-31", 520, { form: "10-Q", fp: "Q1", frame: "CY2021Q1I" }),
+          ]),
+          ...fact("EarningsPerShareDiluted", "USD/shares", [
+            duration("2020-12-31", 1.25),
+            duration("2021-03-31", 0.35, { form: "10-Q", fp: "Q1", frame: "CY2021Q1" }),
+          ]),
+        },
+      },
+    });
+
+    expect(statements.annualStatements).toEqual([{
+      date: "2020-12-31",
+      totalRevenue: 100,
+      operatingCashFlow: 25,
+      capitalExpenditure: -5,
+      freeCashFlow: 20,
+      totalAssets: 500,
+      eps: 1.25,
+    }]);
+    expect(statements.quarterlyStatements).toEqual([
+      {
+        date: "2021-03-31",
+        totalRevenue: 30,
+        operatingCashFlow: 8,
+        capitalExpenditure: -3,
+        freeCashFlow: 5,
+        totalAssets: 520,
+        eps: 0.35,
+      },
+      {
+        date: "2021-06-30",
+        totalRevenue: 40,
       },
     ]);
   });

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -1,4 +1,5 @@
 import type { SecFilingDocument, SecFilingItem } from "../types/data-provider";
+import type { FinancialStatement } from "../types/financials";
 import { truncateWithEllipsis } from "../utils/text-wrap";
 import {
   PDF_FALLBACK_MESSAGE,
@@ -10,6 +11,7 @@ export { extractFilingContent } from "./sec-edgar/content";
 
 const LOOKUP_URL = "https://www.sec.gov/files/company_tickers_exchange.json";
 const SUBMISSIONS_URL = "https://data.sec.gov/submissions";
+const COMPANY_FACTS_URL = "https://data.sec.gov/api/xbrl/companyfacts";
 const FETCH_TIMEOUT_MS = 15_000;
 
 function sanitizeIdentityPart(value: string, fallback: string): string {
@@ -51,6 +53,69 @@ type LookupEntry = {
   exchange?: string;
   name?: string;
 };
+
+type CompanyFactsEntry = {
+  start?: string;
+  end?: string;
+  val?: number;
+  fy?: number | null;
+  fp?: string | null;
+  form?: string;
+  filed?: string;
+  frame?: string;
+};
+
+type CompanyFactsStatementField = {
+  field: keyof FinancialStatement;
+  tags: string[];
+  units: string[];
+  periodType: "duration" | "instant";
+  transform?: (value: number) => number;
+};
+
+export type SecCompanyFactsStatements = {
+  annualStatements: FinancialStatement[];
+  quarterlyStatements: FinancialStatement[];
+};
+
+const COMPANY_FACTS_STATEMENT_FIELDS: CompanyFactsStatementField[] = [
+  {
+    field: "totalRevenue",
+    tags: ["RevenueFromContractWithCustomerExcludingAssessedTax", "Revenues", "SalesRevenueNet"],
+    units: ["USD"],
+    periodType: "duration",
+  },
+  { field: "grossProfit", tags: ["GrossProfit"], units: ["USD"], periodType: "duration" },
+  { field: "operatingIncome", tags: ["OperatingIncomeLoss"], units: ["USD"], periodType: "duration" },
+  { field: "netIncome", tags: ["NetIncomeLoss", "ProfitLoss"], units: ["USD"], periodType: "duration" },
+  {
+    field: "operatingCashFlow",
+    tags: [
+      "NetCashProvidedByUsedInOperatingActivities",
+      "NetCashProvidedByUsedInOperatingActivitiesContinuingOperations",
+    ],
+    units: ["USD"],
+    periodType: "duration",
+  },
+  {
+    field: "capitalExpenditure",
+    tags: ["PaymentsToAcquirePropertyPlantAndEquipment"],
+    units: ["USD"],
+    periodType: "duration",
+    transform: (value) => -Math.abs(value),
+  },
+  { field: "totalAssets", tags: ["Assets"], units: ["USD"], periodType: "instant" },
+  {
+    field: "totalEquity",
+    tags: [
+      "StockholdersEquity",
+      "StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest",
+    ],
+    units: ["USD"],
+    periodType: "instant",
+  },
+  { field: "eps", tags: ["EarningsPerShareDiluted"], units: ["USD/shares"], periodType: "duration" },
+];
 
 function normalize(value?: string): string {
   return (value ?? "").trim().toUpperCase();
@@ -297,6 +362,160 @@ export function parseFilingDocuments(indexHtml: string, filing: SecFilingItem): 
   return documents;
 }
 
+function companyFactsRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function companyFactsEntries(payload: unknown, tag: string, units: string[]): CompanyFactsEntry[] {
+  const facts = companyFactsRecord(companyFactsRecord(companyFactsRecord(payload)?.facts)?.["us-gaap"]);
+  const fact = companyFactsRecord(facts?.[tag]);
+  const unitRecord = companyFactsRecord(fact?.units);
+  if (!unitRecord) return [];
+
+  for (const unit of units) {
+    const entries = unitRecord[unit];
+    if (!Array.isArray(entries)) continue;
+    return entries
+      .map((entry) => companyFactsRecord(entry))
+      .filter((entry): entry is Record<string, unknown> => !!entry)
+      .map((entry) => ({
+        start: typeof entry.start === "string" ? entry.start : undefined,
+        end: typeof entry.end === "string" ? entry.end : undefined,
+        val: typeof entry.val === "number" ? entry.val : undefined,
+        fy: typeof entry.fy === "number" ? entry.fy : null,
+        fp: typeof entry.fp === "string" ? entry.fp : null,
+        form: typeof entry.form === "string" ? entry.form : undefined,
+        filed: typeof entry.filed === "string" ? entry.filed : undefined,
+        frame: typeof entry.frame === "string" ? entry.frame : undefined,
+      }))
+      .filter((entry) => (
+        typeof entry.val === "number"
+        && Number.isFinite(entry.val)
+        && typeof entry.end === "string"
+        && /^\d{4}-\d{2}-\d{2}$/.test(entry.end)
+      ));
+  }
+
+  return [];
+}
+
+function secFormRank(form: string | undefined): number {
+  const normalized = normalize(form);
+  if (normalized === "10-K/A") return 4;
+  if (normalized === "10-K") return 3;
+  if (normalized === "10-Q/A") return 2;
+  if (normalized === "10-Q") return 1;
+  return 0;
+}
+
+function companyFactsFiledRank(value: string | undefined): number {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return 0;
+  return Date.parse(`${value}T00:00:00Z`) || 0;
+}
+
+function compareCompanyFactsEntries(left: CompanyFactsEntry, right: CompanyFactsEntry | undefined): number {
+  if (!right) return 1;
+  const filedDiff = companyFactsFiledRank(left.filed) - companyFactsFiledRank(right.filed);
+  if (filedDiff !== 0) return filedDiff;
+  const formDiff = secFormRank(left.form) - secFormRank(right.form);
+  if (formDiff !== 0) return formDiff;
+  return String(left.frame ?? "").localeCompare(String(right.frame ?? ""));
+}
+
+function isAnnualCompanyFact(entry: CompanyFactsEntry): boolean {
+  const form = normalize(entry.form);
+  return (form === "10-K" || form === "10-K/A") && normalize(entry.fp ?? undefined) === "FY";
+}
+
+function isQuarterlyCompanyFact(entry: CompanyFactsEntry, periodType: "duration" | "instant"): boolean {
+  if (periodType === "instant") {
+    return /^CY\d{4}Q[1-4]I$/.test(entry.frame ?? "")
+      || (
+        (normalize(entry.form) === "10-Q" || normalize(entry.form) === "10-Q/A")
+        && /^Q[1-3]$/.test(normalize(entry.fp ?? undefined))
+      );
+  }
+  return /^CY\d{4}Q[1-4]$/.test(entry.frame ?? "");
+}
+
+function setCompanyFactValue(
+  rows: Map<string, FinancialStatement>,
+  selectedFacts: Map<string, CompanyFactsEntry>,
+  date: string,
+  field: keyof FinancialStatement,
+  value: number,
+  entry: CompanyFactsEntry,
+): void {
+  const selectionKey = `${date}:${String(field)}`;
+  if (compareCompanyFactsEntries(entry, selectedFacts.get(selectionKey)) < 0) return;
+  const row = rows.get(date) ?? { date };
+  (row as Record<string, unknown>)[field] = value;
+  rows.set(date, row);
+  selectedFacts.set(selectionKey, entry);
+}
+
+function fillCompanyFactsStatementRows(
+  rows: Map<string, FinancialStatement>,
+  selectedFacts: Map<string, CompanyFactsEntry>,
+  entries: CompanyFactsEntry[],
+  field: CompanyFactsStatementField,
+  period: "annual" | "quarterly",
+): void {
+  for (const entry of entries) {
+    if (!entry.end || typeof entry.val !== "number") continue;
+    const matchesPeriod = period === "annual"
+      ? isAnnualCompanyFact(entry)
+      : isQuarterlyCompanyFact(entry, field.periodType);
+    if (!matchesPeriod) continue;
+    setCompanyFactValue(
+      rows,
+      selectedFacts,
+      entry.end,
+      field.field,
+      field.transform ? field.transform(entry.val) : entry.val,
+      entry,
+    );
+  }
+}
+
+function finalizeCompanyFactsStatements(rows: Map<string, FinancialStatement>): FinancialStatement[] {
+  const statements = Array.from(rows.values()).sort((left, right) => left.date.localeCompare(right.date));
+  for (const statement of statements) {
+    if (
+      typeof statement.freeCashFlow !== "number"
+      && typeof statement.operatingCashFlow === "number"
+      && typeof statement.capitalExpenditure === "number"
+    ) {
+      statement.freeCashFlow = statement.operatingCashFlow + statement.capitalExpenditure;
+    }
+  }
+  return statements;
+}
+
+export function parseCompanyFactsFinancialStatements(payload: unknown): SecCompanyFactsStatements {
+  const annualRows = new Map<string, FinancialStatement>();
+  const quarterlyRows = new Map<string, FinancialStatement>();
+  const annualSelectedFacts = new Map<string, CompanyFactsEntry>();
+  const quarterlySelectedFacts = new Map<string, CompanyFactsEntry>();
+
+  for (const field of COMPANY_FACTS_STATEMENT_FIELDS) {
+    for (const tag of field.tags) {
+      const entries = companyFactsEntries(payload, tag, field.units);
+      if (entries.length === 0) continue;
+      fillCompanyFactsStatementRows(annualRows, annualSelectedFacts, entries, field, "annual");
+      fillCompanyFactsStatementRows(quarterlyRows, quarterlySelectedFacts, entries, field, "quarterly");
+      break;
+    }
+  }
+
+  return {
+    annualStatements: finalizeCompanyFactsStatements(annualRows),
+    quarterlyStatements: finalizeCompanyFactsStatements(quarterlyRows),
+  };
+}
+
 export class SecEdgarClient {
   private lookupPromise: Promise<Map<string, LookupEntry>> | null = null;
 
@@ -405,6 +624,18 @@ export class SecEdgarClient {
 
     const payload = await this.fetchJson<unknown>(`${SUBMISSIONS_URL}/CIK${entry.cik}.json`);
     return parseRecentFilings(payload, count);
+  }
+
+  async getFinancialStatements(ticker: string): Promise<SecCompanyFactsStatements | null> {
+    const normalizedTicker = normalize(ticker);
+    if (!normalizedTicker) return null;
+
+    const lookup = await this.loadLookup();
+    const entry = lookup.get(normalizedTicker);
+    if (!entry) return null;
+
+    const payload = await this.fetchJson<unknown>(`${COMPANY_FACTS_URL}/CIK${entry.cik}.json`);
+    return parseCompanyFactsFinancialStatements(payload);
   }
 
   async getFilingDocuments(filing: SecFilingItem): Promise<SecFilingDocument[]> {

--- a/src/sources/yahoo-finance.test.ts
+++ b/src/sources/yahoo-finance.test.ts
@@ -17,6 +17,7 @@ describe("YahooFinanceClient exchange aliases", () => {
     provider.fetchAssetProfile = async () => undefined;
     provider.fetchQuoteSupplement = async () => ({});
     provider.fetchExtendedHoursData = async () => ({});
+    provider.secClient.getFinancialStatements = async () => null;
     provider.fetchTimeseries = async () => [
       point("annualAccountsReceivable", 7_450_000_000),
       point("annualInventory", 4_880_000_000),
@@ -50,6 +51,56 @@ describe("YahooFinanceClient exchange aliases", () => {
       cashFlowFromContinuingFinancingActivities: -328_000_000,
       endCashPosition: 5_540_000_000,
     });
+  });
+
+  test("supplements US Yahoo financials with deeper SEC statement history", async () => {
+    const provider = new YahooFinanceClient() as any;
+    const point = (type: string, date: string, value: number) => ({
+      meta: { type: [type] },
+      [type]: [{ asOfDate: date, reportedValue: { raw: value } }],
+    });
+
+    provider.fetchChart = async () => ({
+      meta: { currency: "USD", regularMarketPrice: 100, shortName: "AMD" },
+      history: [{ date: new Date("2025-12-31T00:00:00Z"), close: 100 }],
+    });
+    provider.fetchAssetProfile = async () => undefined;
+    provider.fetchQuoteSupplement = async () => ({});
+    provider.fetchExtendedHoursData = async () => ({});
+    provider.fetchTimeseries = async () => [
+      point("annualTotalRevenue", "2025-12-31", 200),
+      point("quarterlyTotalRevenue", "2025-12-31", 60),
+    ];
+    provider.secClient.getFinancialStatements = async (ticker: string) => {
+      expect(ticker).toBe("AMD");
+      return {
+        annualStatements: [
+          { date: "2023-12-31", totalRevenue: 100 },
+          { date: "2024-12-31", totalRevenue: 150 },
+          { date: "2025-12-31", totalRevenue: 190, netIncome: 40 },
+        ],
+        quarterlyStatements: [
+          { date: "2025-03-31", totalRevenue: 45 },
+          { date: "2025-06-30", totalRevenue: 50 },
+          { date: "2025-09-30", totalRevenue: 55 },
+          { date: "2025-12-31", totalRevenue: 58, netIncome: 12 },
+        ],
+      };
+    };
+
+    const financials = await provider.getTickerFinancials("AMD", "NASDAQ");
+
+    expect(financials.annualStatements.map((row: any) => [row.date, row.totalRevenue, row.netIncome])).toEqual([
+      ["2023-12-31", 100, undefined],
+      ["2024-12-31", 150, undefined],
+      ["2025-12-31", 200, 40],
+    ]);
+    expect(financials.quarterlyStatements.map((row: any) => [row.date, row.totalRevenue, row.netIncome])).toEqual([
+      ["2025-03-31", 45, undefined],
+      ["2025-06-30", 50, undefined],
+      ["2025-09-30", 55, undefined],
+      ["2025-12-31", 60, 12],
+    ]);
   });
 
   test("tries the Taipei Exchange suffix for TPEX tickers", () => {

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -8,6 +8,7 @@ import {
 import type { InstrumentSearchResult } from "../types/instrument";
 import { parseOptionSymbol } from "../utils/options";
 import { SecEdgarClient } from "./sec-edgar";
+import { mergeFinancialStatementRows } from "../utils/financial-statements";
 import { YahooHttpClient } from "./yahoo-finance/http";
 import {
   normalizeSubUnitCurrency,
@@ -42,6 +43,21 @@ import {
   loadYahooTickerFinancials,
 } from "./yahoo-finance/snapshots";
 
+const SEC_STATEMENT_SUPPLEMENT_EXCHANGES = new Set([
+  "",
+  "AMEX",
+  "ARCA",
+  "BATS",
+  "BYX",
+  "IEX",
+  "NASDAQ",
+  "NMS",
+  "NYSE",
+  "NYSEARCA",
+  "OTC",
+  "PINK",
+]);
+
 export class YahooFinanceClient implements DataProvider {
   readonly id = "yahoo";
   readonly name = "Yahoo Finance";
@@ -49,6 +65,38 @@ export class YahooFinanceClient implements DataProvider {
   private readonly secClient = new SecEdgarClient();
 
   constructor(private readonly http = new YahooHttpClient()) {}
+
+  private shouldSupplementSecStatements(ticker: string, exchange: string, financials: TickerFinancials): boolean {
+    if (!/^[A-Z0-9.-]+$/i.test(ticker.trim())) return false;
+    if (ticker.includes(".")) return false;
+    const normalizedExchange = exchange.trim().toUpperCase();
+    return SEC_STATEMENT_SUPPLEMENT_EXCHANGES.has(normalizedExchange)
+      && (financials.quote?.currency ?? "USD").toUpperCase() === "USD";
+  }
+
+  private async supplementSecStatements(
+    ticker: string,
+    exchange: string,
+    financials: TickerFinancials,
+  ): Promise<TickerFinancials> {
+    if (!this.shouldSupplementSecStatements(ticker, exchange, financials)) return financials;
+    try {
+      const secStatements = await this.secClient.getFinancialStatements(ticker);
+      if (
+        !secStatements
+        || (secStatements.annualStatements.length === 0 && secStatements.quarterlyStatements.length === 0)
+      ) {
+        return financials;
+      }
+      return {
+        ...financials,
+        annualStatements: mergeFinancialStatementRows(financials.annualStatements, secStatements.annualStatements),
+        quarterlyStatements: mergeFinancialStatementRows(financials.quarterlyStatements, secStatements.quarterlyStatements),
+      };
+    } catch {
+      return financials;
+    }
+  }
 
   private async fetchChart(symbol: string, range: string, interval = "1d", includePrePost = false) {
     return fetchYahooChart(this.http, symbol, range, interval, includePrePost);
@@ -90,7 +138,7 @@ export class YahooFinanceClient implements DataProvider {
           fetchTimeseries: (targetSymbol, types, period1) => this.fetchTimeseries(targetSymbol, types, period1),
           providerId: this.id,
         });
-        return result;
+        return await this.supplementSecStatements(ticker, exchange, result);
       } catch (err) {
         lastError = err;
       }

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -259,6 +259,7 @@ export interface HostTabsProps {
   closeMode?: "active" | "always";
   addLabel?: string;
   onAdd?: () => void;
+  focused?: boolean;
   palette: HostTabsPalette;
 }
 

--- a/src/utils/financial-statements.ts
+++ b/src/utils/financial-statements.ts
@@ -1,0 +1,23 @@
+import type { FinancialStatement } from "../types/financials";
+
+export function mergeFinancialStatementRows(
+  primaryRows: FinancialStatement[],
+  fallbackRows: FinancialStatement[],
+): FinancialStatement[] {
+  if (primaryRows.length === 0) return fallbackRows;
+  if (fallbackRows.length === 0) return primaryRows;
+
+  const fallbackByDate = new Map(fallbackRows.map((row) => [row.date, row]));
+  const primaryDates = new Set(primaryRows.map((row) => row.date));
+  const mergedRows = primaryRows.map((row) => ({
+    ...fallbackByDate.get(row.date),
+    ...row,
+    date: row.date,
+  }));
+
+  for (const row of fallbackRows) {
+    if (!primaryDates.has(row.date)) mergedRows.push(row);
+  }
+
+  return mergedRows.sort((left, right) => left.date.localeCompare(right.date));
+}


### PR DESCRIPTION
## Summary
- expand ticker graph history by enriching shallow batch/cached financial snapshots through the single-symbol Yahoo/SEC route
- improve fundamental bar charts with clearer axes, hover feedback, negative-value coloring, metric tabs, and newest-first tables
- align options/table overflow behavior across terminal and desktop renderers

## Root Cause
The graph could stop at shallow batch/cloud financial data even when deeper AMD statements were available through the single-symbol route. Bar hover state could also remain stale or be mapped from the wrong coordinate space, which made a prior period label appear while inspecting later bars.

## Validation
- bun test src/components/ui/ui.test.tsx src/plugins/builtin/ticker-detail/data-panes.test.ts src/components/chart/stock-chart/index.test.ts src/components/chart/static/bar-chart-surface.test.tsx src/sources/provider-router/index.test.ts
- bun run build
- bun run desktop:view:build
- git diff --check
- direct AMD EPS check: 77 quarterly statements, 60 EPS bars from 2009 Q2 through 2026 Q1
- tmux TUI smoke: AMD EPS rendered with 2026-03-31 row at 0.84 and session cleaned up