### PR TITLE
Fix prediction market pane layout

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -60,7 +60,16 @@ interface AppInnerProps {
 function ThemedAppRoot({ children }: { children: ReactNode }) {
   const themeColors = useThemeColors();
   return (
-    <Box flexDirection="column" flexGrow={1} backgroundColor={themeColors.bg}>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexShrink={1}
+      flexBasis={0}
+      minWidth={0}
+      minHeight={0}
+      overflow="hidden"
+      backgroundColor={themeColors.bg}
+    >
       {children}
     </Box>
   );

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -10,7 +10,7 @@ import { useThemeColors } from "../../theme/theme-context";
 import { hasPaneFooterContent, PaneFooterBar, PaneFooterProvider } from "./pane/footer";
 import { PaneBodyFrame, getPaneWindowAttributes } from "./pane/frame";
 import { PaneContent } from "./pane/content";
-import { resolvePaneBodyFrame } from "./pane/sizing";
+import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./pane/sizing";
 import { getPaneDisplayTitle } from "./pane/title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX, getTitlebarLeadingInset } from "./titlebar-overlay";
 import { WindowControls, WINDOWS_CONTROL_GROUP_WIDTH_PX } from "./window-controls";
@@ -130,6 +130,8 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     <PaneFooterProvider>
       {(footer) => {
         const showFooter = hasPaneFooterContent(footer);
+        const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
+        const renderFooter = reserveFooter || showFooter;
         const headerHeightRows = titleBarOverlay ? TITLEBAR_OVERLAY_HEIGHT_PX / cellHeightPx : 1;
         const background = floatingPaneBg(focused);
         const titleBackground = floatingPaneTitleBg(focused);
@@ -137,7 +139,8 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
           width,
           height,
           nativePaneChrome,
-          reserveFooter: showFooter,
+          footerVisible: renderFooter,
+          reserveFooter,
           headerRows: headerHeightRows,
         });
         const bodyWidth = bodyFrame.width ?? 1;
@@ -208,7 +211,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
                 height={bodyHeight}
               />
             </PaneBodyFrame>
-            {showFooter && <PaneFooterBar footer={footer} focused={focused} width={width} />}
+            {renderFooter && <PaneFooterBar footer={footer} focused={focused} width={width} />}
           </Box>
         );
       }}

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -80,7 +80,8 @@ export function FloatingPaneWrapper({
   const bg = floatingPaneBg(focused);
   const showFooter = hasPaneFooterContent(footer);
   const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
-  const bodyFrame = resolvePaneBodyFrame({ height, nativePaneChrome, reserveFooter });
+  const renderFooter = reserveFooter || showFooter;
+  const bodyFrame = resolvePaneBodyFrame({ height, nativePaneChrome, footerVisible: renderFooter, reserveFooter });
 
   return (
     <Box
@@ -124,7 +125,7 @@ export function FloatingPaneWrapper({
         {children}
       </PaneBodyFrame>
 
-      {reserveFooter && (
+      {renderFooter && (
         <PaneFooterBar
           footer={footer}
           focused={focused}

--- a/src/components/layout/pane/content.tsx
+++ b/src/components/layout/pane/content.tsx
@@ -3,6 +3,7 @@ import { PaneInstanceProvider } from "../../../state/app/context";
 import { PaneKeyboardScrollController } from "../../../state/pane-scroll-registry";
 import { useThemeColors } from "../../../theme/theme-context";
 import type { PaneDef } from "../../../types/plugin";
+import { Box } from "../../../ui";
 
 interface PaneContentProps {
   component: PaneDef["component"];
@@ -31,14 +32,25 @@ export const PaneContent = memo(function PaneContent({
   return (
     <PaneInstanceProvider paneId={paneId}>
       <PaneKeyboardScrollController paneId={paneId} focused={focused} />
-      <Component
-        paneId={paneId}
-        paneType={paneType}
-        focused={focused}
-        width={width}
-        height={height}
-        close={onClose ? close : undefined}
-      />
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis={0}
+        minWidth={0}
+        minHeight={0}
+        overflow="hidden"
+        data-gloom-role="pane-content"
+      >
+        <Component
+          paneId={paneId}
+          paneType={paneType}
+          focused={focused}
+          width={width}
+          height={height}
+          close={onClose ? close : undefined}
+        />
+      </Box>
     </PaneInstanceProvider>
   );
 });

--- a/src/components/layout/pane/footer/registration.tsx
+++ b/src/components/layout/pane/footer/registration.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -16,6 +17,9 @@ import {
   type PaneFooterRegistration,
   type PaneHint,
 } from "./model";
+
+const usePaneFooterRegistrationEffect =
+  typeof document === "undefined" ? useEffect : useLayoutEffect;
 
 interface PaneFooterContextValue {
   register(registrationId: string, registration: PaneFooterRegistration | null): void;
@@ -85,14 +89,14 @@ export function usePaneFooter(
   const context = useContext(PaneFooterContext);
   const previousRegistrationRef = useRef<PaneFooterRegistration | null>(null);
 
-  useEffect(() => {
+  usePaneFooterRegistrationEffect(() => {
     return () => {
       previousRegistrationRef.current = null;
       context?.unregister(registrationId);
     };
   }, [context, registrationId]);
 
-  useEffect(() => {
+  usePaneFooterRegistrationEffect(() => {
     if (!context) return;
     const nextRegistration = factory() ?? null;
     if (samePaneFooterRegistration(previousRegistrationRef.current, nextRegistration)) return;

--- a/src/components/layout/pane/frame.tsx
+++ b/src/components/layout/pane/frame.tsx
@@ -48,7 +48,7 @@ export function PaneBodyFrame({
   children: ReactNode;
 }) {
   return (
-    <Box {...layoutProps} overflow="hidden" backgroundColor={backgroundColor}>
+    <Box {...layoutProps} overflow="hidden" backgroundColor={backgroundColor} data-gloom-role="pane-body">
       {children}
     </Box>
   );

--- a/src/components/layout/pane/index.tsx
+++ b/src/components/layout/pane/index.tsx
@@ -49,9 +49,11 @@ export function PaneWrapper({
   const bg = paneBg(focused);
   const showFooter = hasPaneFooterContent(footer);
   const reserveFooter = !!title && shouldReservePaneFooter(nativePaneChrome, showFooter);
+  const renderFooter = !!title && (reserveFooter || showFooter);
   const bodyFrame = resolvePaneBodyFrame({
     height: typeof height === "number" ? height : undefined,
     nativePaneChrome,
+    footerVisible: renderFooter,
     reserveFooter,
     headerRows: title ? 1 : 0,
   });
@@ -93,7 +95,7 @@ export function PaneWrapper({
       <PaneBodyFrame layoutProps={bodyFrame.layoutProps} backgroundColor={bg}>
         {children}
       </PaneBodyFrame>
-      {title && reserveFooter && (
+      {renderFooter && (
         <PaneFooterBar
           footer={footer}
           focused={focused}

--- a/src/components/layout/pane/sizing.test.ts
+++ b/src/components/layout/pane/sizing.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./sizing";
+
+describe("pane sizing", () => {
+  test("lets native pane chrome lay out footer bars in normal flex flow", () => {
+    expect(shouldReservePaneFooter(true, true)).toBe(false);
+
+    const bodyFrame = resolvePaneBodyFrame({
+      width: 80,
+      height: 30,
+      nativePaneChrome: true,
+      footerVisible: true,
+      reserveFooter: false,
+    });
+
+    expect(bodyFrame.height).toBe(28);
+    expect(bodyFrame.layoutProps).toEqual({
+      flexGrow: 1,
+      flexShrink: 1,
+      flexBasis: 0,
+      minWidth: 0,
+      minHeight: 0,
+    });
+  });
+
+  test("keeps terminal pane footer rows reserved for border rendering", () => {
+    expect(shouldReservePaneFooter(false, false)).toBe(true);
+
+    const bodyFrame = resolvePaneBodyFrame({
+      width: 80,
+      height: 30,
+      nativePaneChrome: false,
+      reserveFooter: true,
+    });
+
+    expect(bodyFrame.height).toBe(28);
+    expect(bodyFrame.layoutProps).toEqual({
+      height: 28,
+      flexGrow: 0,
+      flexBasis: undefined,
+    });
+  });
+});

--- a/src/components/layout/pane/sizing.ts
+++ b/src/components/layout/pane/sizing.ts
@@ -4,28 +4,35 @@ const PANE_FOOTER_ROWS = 1;
 
 const NATIVE_PANE_BODY_LAYOUT_PROPS = {
   flexGrow: 1,
+  flexShrink: 1,
   flexBasis: 0,
+  minWidth: 0,
   minHeight: 0,
 } as const;
 
-export function shouldReservePaneFooter(nativePaneChrome: boolean | undefined, showFooter: boolean): boolean {
-  return !nativePaneChrome || showFooter;
+export function shouldReservePaneFooter(nativePaneChrome: boolean | undefined, _showFooter: boolean): boolean {
+  return !nativePaneChrome;
 }
 
 function resolvePaneBodyHeight({
   height,
   nativePaneChrome,
+  footerVisible,
   reserveFooter = true,
   headerRows = PANE_HEADER_ROWS,
 }: {
   height: number;
   nativePaneChrome?: boolean;
+  footerVisible?: boolean;
   reserveFooter?: boolean;
   headerRows?: number;
 }): number {
   const finiteHeight = Number.isFinite(height) ? height : 1;
   const normalizedHeight = nativePaneChrome ? finiteHeight : Math.max(1, Math.floor(finiteHeight));
-  return Math.max(1, normalizedHeight - headerRows - (reserveFooter ? PANE_FOOTER_ROWS : 0));
+  const footerRows = nativePaneChrome
+    ? footerVisible ? PANE_FOOTER_ROWS : 0
+    : reserveFooter ? PANE_FOOTER_ROWS : 0;
+  return Math.max(1, normalizedHeight - headerRows - footerRows);
 }
 
 function getPaneBodyLayoutProps(nativePaneChrome: boolean | undefined, bodyHeight: number | undefined) {
@@ -41,17 +48,19 @@ export function resolvePaneBodyFrame({
   width,
   height,
   nativePaneChrome,
+  footerVisible,
   reserveFooter = true,
   headerRows = PANE_HEADER_ROWS,
 }: {
   width?: number;
   height?: number;
   nativePaneChrome?: boolean;
+  footerVisible?: boolean;
   reserveFooter?: boolean;
   headerRows?: number;
 }) {
   const bodyHeight = typeof height === "number"
-    ? resolvePaneBodyHeight({ height, nativePaneChrome, reserveFooter, headerRows })
+    ? resolvePaneBodyHeight({ height, nativePaneChrome, footerVisible, reserveFooter, headerRows })
     : undefined;
   return {
     width: typeof width === "number" ? resolvePaneBodyWidth(width, nativePaneChrome) : undefined,

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -518,6 +518,10 @@ export function Shell({
       ref={shellRef}
       flexDirection="row"
       flexGrow={1}
+      flexShrink={1}
+      flexBasis={0}
+      minWidth={0}
+      minHeight={0}
       height={nativePaneChrome ? undefined : contentHeight}
       position={nativePaneChrome ? "relative" : undefined}
       overflow="hidden"

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -111,11 +111,14 @@ export function ShellPaneLayers({
           >
             <PaneFooterProvider>
               {(footer) => {
-                const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
+                const showFooter = hasPaneFooterContent(footer);
+                const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
+                const renderFooter = reserveFooter || showFooter;
                 const bodyFrame = resolvePaneBodyFrame({
                   width: rect.width,
                   height: rect.height,
                   nativePaneChrome,
+                  footerVisible: renderFooter,
                   reserveFooter,
                 });
                 return (
@@ -165,11 +168,14 @@ export function ShellPaneLayers({
         return (
           <PaneFooterProvider key={`float:${pane.instance.instanceId}`}>
             {(footer) => {
-              const reserveFooter = shouldReservePaneFooter(nativePaneChrome, hasPaneFooterContent(footer));
+              const showFooter = hasPaneFooterContent(footer);
+              const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
+              const renderFooter = reserveFooter || showFooter;
               const bodyFrame = resolvePaneBodyFrame({
                 width: preview.width,
                 height: preview.height,
                 nativePaneChrome,
+                footerVisible: renderFooter,
                 reserveFooter,
               });
               return (

--- a/src/components/table-view-shared.tsx
+++ b/src/components/table-view-shared.tsx
@@ -6,7 +6,7 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import { Box, type ScrollBoxRenderable } from "../ui";
+import { Box, useUiCapabilities, type ScrollBoxRenderable } from "../ui";
 import { isPlainKeyboardEvent } from "../utils/keyboard";
 
 function listenToScrollBarChange(
@@ -56,15 +56,23 @@ export function TableViewFrame({
   after,
   children,
 }: TableViewFrameProps) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const nativeFlexibleFrame = nativePaneChrome === true;
+
   return (
     <Box
       flexDirection="column"
-      flexGrow={height == null ? 1 : undefined}
-      flexShrink={height == null ? undefined : 0}
+      flexGrow={nativeFlexibleFrame || height == null ? 1 : undefined}
+      flexShrink={nativeFlexibleFrame ? 1 : height == null ? undefined : 0}
+      flexBasis={nativeFlexibleFrame ? 0 : undefined}
       width={width}
-      height={height}
+      height={nativeFlexibleFrame ? undefined : height}
+      minWidth={nativeFlexibleFrame ? 0 : undefined}
+      minHeight={nativeFlexibleFrame ? 0 : undefined}
+      maxHeight={nativeFlexibleFrame ? "100%" : undefined}
       backgroundColor={backgroundColor}
       overflow="hidden"
+      data-gloom-role="table-view-frame"
     >
       {before}
       {children}

--- a/src/components/ui/page-stack-view.tsx
+++ b/src/components/ui/page-stack-view.tsx
@@ -69,7 +69,7 @@ export function PageStackView({
 
   if (!detailOpen) {
     return (
-      <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      <Box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} minWidth={0} minHeight={0} overflow="hidden">
         {rootContent}
       </Box>
     );
@@ -79,6 +79,10 @@ export function PageStackView({
     <Box
       flexDirection="column"
       flexGrow={1}
+      flexShrink={1}
+      flexBasis={0}
+      minWidth={0}
+      minHeight={0}
       overflow="hidden"
       onMouseDown={handleMouseDown}
     >
@@ -111,7 +115,7 @@ export function PageStackView({
         )}
         {backHint ? <Text fg={colors.textMuted}>{backHint}</Text> : null}
       </Box>
-      <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      <Box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} minWidth={0} minHeight={0} overflow="hidden">
         {detailContent}
       </Box>
     </Box>

--- a/src/plugins/prediction-markets/chart.tsx
+++ b/src/plugins/prediction-markets/chart.tsx
@@ -72,12 +72,14 @@ export function PredictionMarketChart({
   history,
   width,
   height,
+  loading = false,
   range,
   onRangeSelect,
 }: {
   history: PredictionHistoryPoint[];
   width: number;
   height: number;
+  loading?: boolean;
   range: PredictionHistoryRange;
   onRangeSelect: (range: PredictionHistoryRange) => void;
 }) {
@@ -93,10 +95,14 @@ export function PredictionMarketChart({
           />
         </Box>
         <Box flexGrow={1} justifyContent="center">
-          <EmptyState
-            title="No chart history."
-            hint="This venue did not return price history for the selected market."
-          />
+          {loading ? (
+            <Text fg={colors.textDim}>Loading chart...</Text>
+          ) : (
+            <EmptyState
+              title="No chart history."
+              hint="This venue did not return price history for the selected market."
+            />
+          )}
         </Box>
       </Box>
     );

--- a/src/plugins/prediction-markets/detail.test.tsx
+++ b/src/plugins/prediction-markets/detail.test.tsx
@@ -48,4 +48,54 @@ describe("prediction markets detail views", () => {
     expect(frame).not.toContain("Kalshi");
     expect(frame).not.toContain("targets");
   });
+
+  test("keeps grouped outcomes in place while selected detail is loading", async () => {
+    testSetup = await testRender(<GroupedDetailHarness loading />, {
+      width: 64,
+      height: 24,
+    });
+    await flushFrames(testSetup);
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Outcomes");
+    expect(frame).toContain("Above 4.25%");
+    expect(frame).toContain("Loading chart...");
+    expect(frame).not.toContain("No chart history.");
+    expect(frame).not.toContain("Loading market detail...");
+  });
+
+  test("renders book levels in the shared data table", async () => {
+    testSetup = await testRender(<GroupedDetailHarness detailTab="book" />, {
+      width: 64,
+      height: 24,
+    });
+    await flushFrames(testSetup);
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("OUT");
+    expect(frame).toContain("SIDE");
+    expect(frame).toContain("PRICE");
+    expect(frame).toContain("SIZE");
+    expect(frame).toContain("YES");
+    expect(frame).toContain("BID");
+    expect(frame).toContain("47c");
+  });
+
+  test("renders recent trades in the shared data table", async () => {
+    testSetup = await testRender(<GroupedDetailHarness detailTab="trades" />, {
+      width: 64,
+      height: 24,
+    });
+    await flushFrames(testSetup);
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("TIME");
+    expect(frame).toContain("SIDE");
+    expect(frame).toContain("OUT");
+    expect(frame).toContain("PRICE");
+    expect(frame).toContain("SIZE");
+    expect(frame).toContain("BUY");
+    expect(frame).toContain("YES");
+    expect(frame).toContain("48c");
+  });
 });

--- a/src/plugins/prediction-markets/detail/book.tsx
+++ b/src/plugins/prediction-markets/detail/book.tsx
@@ -1,7 +1,7 @@
-import { Box, Text } from "../../../ui";
-import { TextAttributes } from "../../../ui";
+import { useEffect, useMemo, useState } from "react";
+import { DataTableView, type DataTableColumn } from "../../../components";
 import { colors } from "../../../theme/colors";
-import { formatNumber, padTo } from "../../../utils/format";
+import { formatNumber } from "../../../utils/format";
 import { formatPredictionProbability } from "../metrics";
 import type {
   PredictionBookLevel,
@@ -9,111 +9,156 @@ import type {
   PredictionOrderPreviewIntent,
 } from "../types";
 
-function BookTable({
-  title,
+type BookColumnId = "outcome" | "side" | "price" | "size";
+type BookColumn = DataTableColumn & { id: BookColumnId };
+
+interface BookRow {
+  id: string;
+  outcome: "yes" | "no";
+  side: "buy" | "sell";
+  level: PredictionBookLevel;
+  intent: PredictionOrderPreviewIntent;
+}
+
+const BOOK_COLUMNS: BookColumn[] = [
+  { id: "outcome", label: "OUT", width: 5 },
+  { id: "side", label: "SIDE", width: 6 },
+  { id: "price", label: "PRICE", width: 8, align: "right" },
+  { id: "size", label: "SIZE", width: 10, align: "right" },
+];
+
+function bookRowsForLevels({
   levels,
-  onSelect,
+  marketKey,
+  outcome,
+  side,
 }: {
-  title: string;
   levels: PredictionBookLevel[];
-  onSelect: (level: PredictionBookLevel) => void;
-}) {
-  return (
-    <Box flexDirection="column" flexGrow={1}>
-      <Box height={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          {title}
-        </Text>
-      </Box>
-      <Box height={1}>
-        <Text fg={colors.textDim}>
-          {padTo("PRICE", 8)} {padTo("SIZE", 10)}
-        </Text>
-      </Box>
-      {levels.slice(0, 10).map((level) => (
-        <Box
-          key={`${title}:${level.price}:${level.size}`}
-          height={1}
-          onMouseDown={(event) => {
-            event.preventDefault();
-            onSelect(level);
-          }}
-        >
-          <Text fg={colors.text}>
-            {`${padTo(formatPredictionProbability(level.price), 8)} ${padTo(formatNumber(level.size, 0), 10, "right")}`}
-          </Text>
-        </Box>
-      ))}
-      {levels.length === 0 && <Text fg={colors.textDim}>No levels.</Text>}
-    </Box>
-  );
+  marketKey: string;
+  outcome: "yes" | "no";
+  side: "buy" | "sell";
+}): BookRow[] {
+  return levels.slice(0, 10).map((level, index) => ({
+    id: `${outcome}:${side}:${index}:${level.price}:${level.size}`,
+    outcome,
+    side,
+    level,
+    intent: {
+      marketKey,
+      outcome,
+      side,
+      price: level.price,
+      size: level.size,
+    },
+  }));
+}
+
+function buildBookRows(detail: PredictionMarketDetail): BookRow[] {
+  const marketKey = detail.summary.key;
+  return [
+    ...bookRowsForLevels({
+      levels: detail.book.yesBids,
+      marketKey,
+      outcome: "yes",
+      side: "buy",
+    }),
+    ...bookRowsForLevels({
+      levels: detail.book.yesAsks,
+      marketKey,
+      outcome: "yes",
+      side: "sell",
+    }),
+    ...bookRowsForLevels({
+      levels: detail.book.noBids,
+      marketKey,
+      outcome: "no",
+      side: "buy",
+    }),
+    ...bookRowsForLevels({
+      levels: detail.book.noAsks,
+      marketKey,
+      outcome: "no",
+      side: "sell",
+    }),
+  ];
 }
 
 export function PredictionMarketBookView({
   detail,
+  focused,
   onPreviewOrder,
+  width,
 }: {
   detail: PredictionMarketDetail;
+  focused: boolean;
   onPreviewOrder: (intent: PredictionOrderPreviewIntent) => void;
+  width: number;
 }) {
+  const rows = useMemo(() => buildBookRows(detail), [detail]);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(() =>
+    rows.length > 0 ? 0 : null,
+  );
+
+  useEffect(() => {
+    setSelectedIndex((current) => {
+      if (rows.length === 0) return null;
+      if (current == null || current >= rows.length) return 0;
+      return current;
+    });
+  }, [rows.length]);
+
   return (
-    <Box flexDirection="column" gap={1}>
-      <Box flexDirection="row" gap={2}>
-        <BookTable
-          title="YES Bids"
-          levels={detail.book.yesBids}
-          onSelect={(level) =>
-            onPreviewOrder({
-              marketKey: detail.summary.key,
-              outcome: "yes",
-              side: "buy",
-              price: level.price,
-              size: level.size,
-            })
-          }
-        />
-        <BookTable
-          title="YES Asks"
-          levels={detail.book.yesAsks}
-          onSelect={(level) =>
-            onPreviewOrder({
-              marketKey: detail.summary.key,
-              outcome: "yes",
-              side: "sell",
-              price: level.price,
-              size: level.size,
-            })
-          }
-        />
-      </Box>
-      <Box flexDirection="row" gap={2}>
-        <BookTable
-          title="NO Bids"
-          levels={detail.book.noBids}
-          onSelect={(level) =>
-            onPreviewOrder({
-              marketKey: detail.summary.key,
-              outcome: "no",
-              side: "buy",
-              price: level.price,
-              size: level.size,
-            })
-          }
-        />
-        <BookTable
-          title="NO Asks"
-          levels={detail.book.noAsks}
-          onSelect={(level) =>
-            onPreviewOrder({
-              marketKey: detail.summary.key,
-              outcome: "no",
-              side: "sell",
-              price: level.price,
-              size: level.size,
-            })
-          }
-        />
-      </Box>
-    </Box>
+    <DataTableView<BookRow, BookColumn>
+      focused={focused}
+      keyboardNavigation={focused}
+      rootWidth={width}
+      rootBackgroundColor={colors.panel}
+      selection={{
+        kind: "index",
+        selectedIndex,
+        onChange: (index) => setSelectedIndex(index),
+      }}
+      columns={BOOK_COLUMNS}
+      items={rows}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      getItemKey={(row) => row.id}
+      onActivate={(row) => onPreviewOrder(row.intent)}
+      onRowMouseDown={(row, index, event) => {
+        event.preventDefault();
+        setSelectedIndex(index);
+        onPreviewOrder(row.intent);
+        return true;
+      }}
+      renderCell={(row, column, _index, rowState) => {
+        const color = (fallback: string) =>
+          rowState.selected ? undefined : fallback;
+        switch (column.id) {
+          case "outcome":
+            return {
+              text: row.outcome.toUpperCase(),
+              color: color(colors.textBright),
+            };
+          case "side":
+            return {
+              text: row.side === "buy" ? "BID" : "ASK",
+              color: color(row.side === "buy" ? colors.positive : colors.negative),
+            };
+          case "price":
+            return {
+              text: formatPredictionProbability(row.level.price),
+              color: color(colors.text),
+            };
+          case "size":
+            return {
+              text: formatNumber(row.level.size, 0),
+              color: color(colors.textDim),
+            };
+        }
+      }}
+      emptyStateTitle="No book levels."
+      emptyStateHint="This venue did not return current order book depth."
+    />
   );
 }

--- a/src/plugins/prediction-markets/detail/overview.tsx
+++ b/src/plugins/prediction-markets/detail/overview.tsx
@@ -17,6 +17,7 @@ export function PredictionMarketOverviewView({
   detailWidth,
   height,
   historyRange,
+  loading,
   onHistoryRangeChange,
   onSelectMarket,
   selectedRow,
@@ -26,6 +27,7 @@ export function PredictionMarketOverviewView({
   detailWidth: number;
   height: number;
   historyRange: PredictionHistoryRange;
+  loading: boolean;
   onHistoryRangeChange: (range: PredictionHistoryRange) => void;
   onSelectMarket: (marketKey: string) => void;
   selectedRow: PredictionListRow | null;
@@ -47,6 +49,7 @@ export function PredictionMarketOverviewView({
         history={detail?.history ?? []}
         width={detailWidth}
         height={Math.max(Math.floor(height * 0.36), 10)}
+        loading={loading}
         range={historyRange}
         onRangeSelect={onHistoryRangeChange}
       />

--- a/src/plugins/prediction-markets/detail/pane.tsx
+++ b/src/plugins/prediction-markets/detail/pane.tsx
@@ -1,7 +1,7 @@
 import { Box, ScrollBox, Text } from "../../../ui";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import type { RefObject } from "react";
-import { Spinner, Tabs } from "../../../components";
+import { Tabs } from "../../../components";
 import { EmptyState } from "../../../components/ui/status";
 import { colors } from "../../../theme/colors";
 import { padTo } from "../../../utils/format";
@@ -37,8 +37,11 @@ interface MetricCell {
 function MetricLabelRow({ metrics }: { metrics: MetricCell[] }) {
   return (
     <Box flexDirection="row" height={1}>
-      {metrics.map((metric) => (
-        <Box key={metric.label} width={metric.width + 1}>
+      {metrics.map((metric, index) => (
+        <Box
+          key={metric.label}
+          width={metric.width + (index === metrics.length - 1 ? 0 : 1)}
+        >
           <Text fg={colors.textDim}>{padTo(metric.label, metric.width)}</Text>
         </Box>
       ))}
@@ -49,8 +52,11 @@ function MetricLabelRow({ metrics }: { metrics: MetricCell[] }) {
 function MetricValueRow({ metrics }: { metrics: MetricCell[] }) {
   return (
     <Box flexDirection="row" height={1}>
-      {metrics.map((metric) => (
-        <Box key={metric.label} width={metric.width + 1}>
+      {metrics.map((metric, index) => (
+        <Box
+          key={metric.label}
+          width={metric.width + (index === metrics.length - 1 ? 0 : 1)}
+        >
           <Text
             fg={metric.color ?? colors.textBright}
             attributes={TextAttributes.BOLD}
@@ -108,8 +114,6 @@ export function PredictionMarketDetailPane({
   }
 
   const summaryMetrics = detail?.summary ?? selectedSummary;
-  const detailTitle =
-    selectedRow?.kind === "group" ? selectedRow.title : summaryMetrics.title;
   const detailSubtitleParts: string[] = [];
   if (selectedRow?.kind === "group") {
     if (summaryMetrics.category) detailSubtitleParts.push(summaryMetrics.category);
@@ -126,18 +130,18 @@ export function PredictionMarketDetailPane({
   );
   if (endsLabel !== "—") detailSubtitleParts.push(endsLabel);
   const detailSubtitle = detailSubtitleParts.join(" · ");
-  const primaryMetrics: MetricCell[] = [
+  const metrics: MetricCell[] = [
     {
       label: "YES",
       value: formatPredictionProbability(summaryMetrics.yesPrice),
       color: getPredictionProbabilityColor(summaryMetrics.yesPrice),
-      width: 12,
+      width: 6,
     },
     {
       label: "NO",
       value: formatPredictionProbability(summaryMetrics.noPrice),
       color: getPredictionProbabilityColor(summaryMetrics.noPrice),
-      width: 12,
+      width: 6,
     },
     {
       label: "24H VOL",
@@ -145,7 +149,7 @@ export function PredictionMarketDetailPane({
         summaryMetrics.volume24h,
         summaryMetrics.volume24hUnit ?? "usd",
       ),
-      width: 16,
+      width: 8,
     },
     {
       label: "TOTAL VOL",
@@ -153,28 +157,26 @@ export function PredictionMarketDetailPane({
         summaryMetrics.totalVolume,
         summaryMetrics.totalVolumeUnit ?? "usd",
       ),
-      width: 16,
+      width: 9,
     },
-  ];
-  const secondaryMetrics: MetricCell[] = [
     {
       label: "OI",
       value: formatPredictionMetric(
         summaryMetrics.openInterest,
         summaryMetrics.openInterestUnit ?? "usd",
       ),
-      width: 16,
+      width: 7,
     },
     {
       label: "SPREAD",
       value: formatPredictionSpread(summaryMetrics.spread),
-      width: 16,
+      width: 7,
     },
     {
       label: "LAST",
       value: formatPredictionProbability(summaryMetrics.lastTradePrice),
       color: colors.textBright,
-      width: 16,
+      width: 7,
     },
   ];
   const relatedSiblings =
@@ -186,33 +188,25 @@ export function PredictionMarketDetailPane({
             0,
             Math.max(Math.min(Math.floor((detailWidth - 10) / 18), 3), 0),
           ) ?? []);
-  const headerHeight = detailSubtitle.length > 0 ? 3 : 2;
+  const headerHeight = detailSubtitle.length > 0 ? 2 : 0;
   const detailLoading = detailLoadCount > 0 && !detail;
-  const titleColor = focused ? colors.textBright : colors.text;
   const detailTextWidth = Math.max(detailWidth, 12);
 
   return (
     <>
-      <Box flexDirection="column" height={headerHeight} paddingBottom={1}>
-        <Box flexDirection="row" height={1}>
-          <Text fg={titleColor} attributes={TextAttributes.BOLD}>
-            {truncatePredictionText(detailTitle, detailTextWidth)}
-          </Text>
-        </Box>
-        {detailSubtitle.length > 0 && (
+      {headerHeight > 0 && (
+        <Box flexDirection="column" height={headerHeight} paddingBottom={1}>
           <Box flexDirection="row" height={1}>
             <Text fg={colors.textDim}>
               {truncatePredictionText(detailSubtitle, detailTextWidth)}
             </Text>
           </Box>
-        )}
-      </Box>
+        </Box>
+      )}
 
-      <Box flexDirection="column" height={4} paddingBottom={1}>
-        <MetricLabelRow metrics={primaryMetrics} />
-        <MetricValueRow metrics={primaryMetrics} />
-        <MetricLabelRow metrics={secondaryMetrics} />
-        <MetricValueRow metrics={secondaryMetrics} />
+      <Box flexDirection="column" height={3} paddingBottom={1}>
+        <MetricLabelRow metrics={metrics} />
+        <MetricValueRow metrics={metrics} />
       </Box>
 
       {relatedSiblings.length > 0 && (
@@ -260,43 +254,56 @@ export function PredictionMarketDetailPane({
         </Box>
       )}
 
-      <ScrollBox ref={scrollRef} flexGrow={1} scrollY>
-        {detailLoading && (
-          <Box height={1} paddingBottom={1}>
-            <Spinner label="Loading market detail..." />
-          </Box>
-        )}
-        {detailTab === "overview" && (
-          <PredictionMarketOverviewView
-            detail={detail}
-            detailWidth={detailWidth}
-            height={height}
-            historyRange={historyRange}
-            onHistoryRangeChange={onHistoryRangeChange}
-            onSelectMarket={onSelectMarket}
-            selectedRow={selectedRow}
-            summary={summaryMetrics}
-          />
-        )}
+      {detailTab === "overview" || detailTab === "rules" ? (
+        <ScrollBox ref={scrollRef} flexGrow={1} scrollY>
+          {detailTab === "overview" && (
+            <PredictionMarketOverviewView
+              detail={detail}
+              detailWidth={detailWidth}
+              height={height}
+              historyRange={historyRange}
+              loading={detailLoading}
+              onHistoryRangeChange={onHistoryRangeChange}
+              onSelectMarket={onSelectMarket}
+              selectedRow={selectedRow}
+              summary={summaryMetrics}
+            />
+          )}
 
-        {detailTab === "book" && detail && (
+          {detailTab === "rules" && (
+            <PredictionMarketRulesView
+              detailWidth={detailTextWidth}
+              rules={detail?.rules ?? []}
+            />
+          )}
+        </ScrollBox>
+      ) : null}
+
+      {detailTab === "book" && (
+        detail ? (
           <PredictionMarketBookView
             detail={detail}
+            focused={focused}
             onPreviewOrder={onPreviewOrder}
+            width={detailWidth}
           />
-        )}
+        ) : (
+          <Box flexGrow={1} justifyContent="center">
+            <EmptyState
+              title={detailLoading ? "Loading order book." : "No order book."}
+              hint="This venue did not return current order book depth."
+            />
+          </Box>
+        )
+      )}
 
-        {detailTab === "trades" && (
-          <PredictionMarketTradesView trades={detail?.trades ?? []} />
-        )}
-
-        {detailTab === "rules" && (
-          <PredictionMarketRulesView
-            detailWidth={detailTextWidth}
-            rules={detail?.rules ?? []}
-          />
-        )}
-      </ScrollBox>
+      {detailTab === "trades" && (
+        <PredictionMarketTradesView
+          focused={focused}
+          trades={detail?.trades ?? []}
+          width={detailWidth}
+        />
+      )}
     </>
   );
 }

--- a/src/plugins/prediction-markets/detail/shared.tsx
+++ b/src/plugins/prediction-markets/detail/shared.tsx
@@ -1,6 +1,11 @@
 import { Box } from "../../../ui";
 import { colors } from "../../../theme/colors";
 import { ExternalLinkText } from "../../../components/ui/external-link";
+import type {
+  PredictionListRow,
+  PredictionMarketDetail,
+  PredictionMarketSummary,
+} from "../types";
 
 export function truncatePredictionText(
   value: string,
@@ -9,6 +14,20 @@ export function truncatePredictionText(
   if (value.length <= maxLength) return value;
   if (maxLength <= 3) return value.slice(0, maxLength);
   return `${value.slice(0, maxLength - 3)}...`;
+}
+
+export function resolvePredictionDetailTitle({
+  detail,
+  selectedRow,
+  selectedSummary,
+}: {
+  detail: PredictionMarketDetail | null;
+  selectedRow: PredictionListRow | null;
+  selectedSummary: PredictionMarketSummary | null;
+}): string | undefined {
+  if (!selectedSummary) return undefined;
+  const summary = detail?.summary ?? selectedSummary;
+  return selectedRow?.kind === "group" ? selectedRow.title : summary.title;
 }
 
 export function SummaryLink({

--- a/src/plugins/prediction-markets/detail/trades.tsx
+++ b/src/plugins/prediction-markets/detail/trades.tsx
@@ -1,31 +1,76 @@
-import { Box, Text } from "../../../ui";
+import { DataTableView, type DataTableColumn } from "../../../components";
 import { colors } from "../../../theme/colors";
-import { formatNumber, padTo } from "../../../utils/format";
+import { formatNumber } from "../../../utils/format";
 import { formatPredictionProbability } from "../metrics";
 import type { PredictionTrade } from "../types";
 
+type TradeColumnId = "time" | "side" | "outcome" | "price" | "size";
+type TradeColumn = DataTableColumn & { id: TradeColumnId };
+
+const TRADE_COLUMNS: TradeColumn[] = [
+  { id: "time", label: "TIME", width: 16 },
+  { id: "side", label: "SIDE", width: 6 },
+  { id: "outcome", label: "OUT", width: 4 },
+  { id: "price", label: "PRICE", width: 8, align: "right" },
+  { id: "size", label: "SIZE", width: 10, align: "right" },
+];
+
 export function PredictionMarketTradesView({
+  focused,
   trades,
+  width,
 }: {
+  focused: boolean;
   trades: PredictionTrade[];
+  width: number;
 }) {
   return (
-    <Box flexDirection="column">
-      <Box height={1}>
-        <Text
-          fg={colors.textDim}
-        >{`${padTo("TIME", 16)} ${padTo("SIDE", 6)} ${padTo("OUT", 4)} ${padTo("PRICE", 8)} ${padTo("SIZE", 10)}`}</Text>
-      </Box>
-      {trades.slice(0, 30).map((trade) => (
-        <Box key={trade.id} height={1}>
-          <Text fg={trade.side === "buy" ? colors.positive : colors.negative}>
-            {`${padTo(new Date(trade.timestamp).toLocaleTimeString("en-US", { hour12: false }), 16)} ${padTo(trade.side.toUpperCase(), 6)} ${padTo(trade.outcome.toUpperCase(), 4)} ${padTo(formatPredictionProbability(trade.price), 8)} ${padTo(formatNumber(trade.size, 0), 10, "right")}`}
-          </Text>
-        </Box>
-      ))}
-      {trades.length === 0 && (
-        <Text fg={colors.textDim}>No recent trades.</Text>
-      )}
-    </Box>
+    <DataTableView<PredictionTrade, TradeColumn>
+      focused={focused}
+      keyboardNavigation={false}
+      rootWidth={width}
+      rootBackgroundColor={colors.panel}
+      selection={{ kind: "none" }}
+      columns={TRADE_COLUMNS}
+      items={trades.slice(0, 30)}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      getItemKey={(trade) => trade.id}
+      renderCell={(trade, column) => {
+        const tradeColor = trade.side === "buy" ? colors.positive : colors.negative;
+        switch (column.id) {
+          case "time":
+            return {
+              text: new Date(trade.timestamp).toLocaleTimeString("en-US", {
+                hour12: false,
+              }),
+              color: colors.textDim,
+            };
+          case "side":
+            return {
+              text: trade.side.toUpperCase(),
+              color: tradeColor,
+            };
+          case "outcome":
+            return {
+              text: trade.outcome.toUpperCase(),
+              color: colors.text,
+            };
+          case "price":
+            return {
+              text: formatPredictionProbability(trade.price),
+              color: tradeColor,
+            };
+          case "size":
+            return {
+              text: formatNumber(trade.size, 0),
+              color: colors.textDim,
+            };
+        }
+      }}
+      emptyStateTitle="No recent trades."
+      emptyStateHint="This venue did not return recent prints."
+    />
   );
 }

--- a/src/plugins/prediction-markets/pane.test.tsx
+++ b/src/plugins/prediction-markets/pane.test.tsx
@@ -130,6 +130,32 @@ describe("prediction markets pane interactions", () => {
     expect(frame).not.toContain("Was there a typo in the url or port?");
   });
 
+  test("shows loading instead of an empty state while empty catalogs are pending", async () => {
+    attachPredictionMarketsPersistence(new MemoryPersistence());
+
+    const releaseFetches: Array<() => void> = [];
+    globalThis.fetch = (async (input: Request | string | URL) => {
+      await new Promise<void>((resolve) => {
+        releaseFetches.push(resolve);
+      });
+      const url = String(input);
+      if (url.includes("/trade-api/v2/events?")) {
+        return new Response(JSON.stringify({ events: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    testSetup = await testRender(<Harness />, { width: 120, height: 34 });
+    await flushFrames(testSetup);
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Loading markets...");
+    expect(frame).not.toContain("No markets matched.");
+
+    for (const release of releaseFetches) release();
+    await flushFrames(testSetup);
+  });
+
   test("selects a market on single click and opens detail on double click", async () => {
     installPredictionMarketMocks();
 
@@ -172,6 +198,23 @@ describe("prediction markets pane interactions", () => {
 
     frame = testSetup.captureCharFrame();
     expect(frame).toContain("Kalshi primary rule");
+    expect(frame).toContain("\u2190 Back Will the Fed cut rates?");
+    expect(frame.match(/Will the Fed cut rates\?/g) ?? []).toHaveLength(1);
+    expect(frame).not.toContain("[/]search");
+    expect(frame).not.toContain("[w]atch");
+    expect(frame).not.toContain("[1-4]browse");
+
+    const metricsHeader = frame
+      .split("\n")
+      .find((line) =>
+        line.includes("YES") &&
+        line.includes("NO") &&
+        line.includes("24H VOL"),
+      );
+    expect(metricsHeader).toContain("TOTAL VOL");
+    expect(metricsHeader).toContain("OI");
+    expect(metricsHeader).toContain("SPREAD");
+    expect(metricsHeader).toContain("LAST");
   });
 
   test("focuses the pane when a market row is clicked", async () => {

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -2,6 +2,7 @@ import { Box, Input, Text } from "../../ui";
 import { useCallback, useMemo, useRef } from "react";
 import {
   DataTableStackView,
+  Spinner,
   Tabs,
   usePaneFooter,
   type DataTableKeyEvent,
@@ -13,6 +14,7 @@ import { colors } from "../../theme/colors";
 import { PREDICTION_CATEGORY_OPTIONS } from "./categories";
 import { usePredictionMarketsController } from "./controller";
 import { PredictionMarketDetailPane } from "./detail/pane";
+import { resolvePredictionDetailTitle } from "./detail/shared";
 import { getPredictionColumnValue } from "./metrics";
 import { BROWSE_TABS, VENUE_TABS } from "./navigation";
 import { isPlainArrowUp, stopSearchFocusNavigation } from "../../utils/search-focus-navigation";
@@ -73,33 +75,45 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
     controller.catalogStatus?.tone === "danger"
       ? colors.negative
       : colors.borderFocused;
-  usePaneFooter("prediction-markets", () => ({
-    info: [
-      ...(controller.searchQuery.trim() ? [{ id: "search", parts: [{ text: `search: ${controller.searchQuery.trim()}`, tone: "value" as const }] }] : []),
-      ...(controller.searchLoading ? [{ id: "search-loading", parts: [{ text: "searching", tone: "muted" as const }] }] : []),
-      ...(controller.catalogStatus ? [{
-        id: "catalog",
-        parts: [{ text: controller.catalogStatus.message, tone: controller.catalogStatus.tone === "danger" ? "warning" as const : "muted" as const, color: catalogStatusColor }],
-      }] : []),
-    ],
-    hints: [
-      { id: "search", key: "/", label: "search", onPress: controller.actions.focusSearch },
-      { id: "watch", key: "w", label: "atch", onPress: controller.selectedRow ? () => controller.actions.toggleWatchlist(controller.selectedRow!) : undefined, disabled: !controller.selectedRow },
-      {
-        id: "browse",
-        key: "1-4",
-        label: "browse",
-        onPress: () => {
-          const index = BROWSE_TABS.findIndex((tab) => tab.value === controller.browseTab);
-          controller.actions.selectBrowseTab(BROWSE_TABS[(index + 1) % BROWSE_TABS.length]!.value as PredictionBrowseTab);
+  const rowsLoading =
+    controller.visibleRows.length === 0 &&
+    (controller.catalogLoadCount > 0 || controller.searchLoading);
+  const detailTitle = resolvePredictionDetailTitle({
+    detail: controller.detail,
+    selectedRow: controller.selectedRow,
+    selectedSummary: controller.selectedSummary,
+  });
+  usePaneFooter("prediction-markets", () => {
+    if (controller.detailOpen) return null;
+    return {
+      info: [
+        ...(controller.searchQuery.trim() ? [{ id: "search", parts: [{ text: `search: ${controller.searchQuery.trim()}`, tone: "value" as const }] }] : []),
+        ...(controller.searchLoading ? [{ id: "search-loading", parts: [{ text: "searching", tone: "muted" as const }] }] : []),
+        ...(controller.catalogStatus ? [{
+          id: "catalog",
+          parts: [{ text: controller.catalogStatus.message, tone: controller.catalogStatus.tone === "danger" ? "warning" as const : "muted" as const, color: catalogStatusColor }],
+        }] : []),
+      ],
+      hints: [
+        { id: "search", key: "/", label: "search", onPress: controller.actions.focusSearch },
+        { id: "watch", key: "w", label: "atch", onPress: controller.selectedRow ? () => controller.actions.toggleWatchlist(controller.selectedRow!) : undefined, disabled: !controller.selectedRow },
+        {
+          id: "browse",
+          key: "1-4",
+          label: "browse",
+          onPress: () => {
+            const index = BROWSE_TABS.findIndex((tab) => tab.value === controller.browseTab);
+            controller.actions.selectBrowseTab(BROWSE_TABS[(index + 1) % BROWSE_TABS.length]!.value as PredictionBrowseTab);
+          },
         },
-      },
-    ],
-  }), [
+      ],
+    };
+  }, [
     catalogStatusColor,
     controller.browseTab,
     controller.catalogStatus?.message,
     controller.catalogStatus?.tone,
+    controller.detailOpen,
     controller.searchLoading,
     controller.searchQuery,
     controller.selectedRow,
@@ -275,6 +289,7 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       detailOpen={controller.detailOpen && !!controller.selectedSummary}
       onBack={controller.actions.closeDetail}
       detailContent={detailContent}
+      detailTitle={detailTitle}
       rootBefore={browseControls}
       rootWidth={width}
       rootHeight={height}
@@ -301,6 +316,19 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
       getItemKey={(row) => row.key}
       virtualize
       renderCell={renderCell}
+      emptyContent={
+        rowsLoading ? (
+          <Box width="100%" paddingX={1} paddingY={1}>
+            <Spinner
+              label={
+                controller.searchQuery.trim().length > 0
+                  ? "Searching markets..."
+                  : "Loading markets..."
+              }
+            />
+          </Box>
+        ) : undefined
+      }
       emptyStateTitle="No markets matched."
       emptyStateHint="Change the venue, browse tab, or search query."
     />

--- a/src/plugins/prediction-markets/test-helpers.tsx
+++ b/src/plugins/prediction-markets/test-helpers.tsx
@@ -24,6 +24,7 @@ import {
   attachPredictionMarketsPersistence,
 } from "./services/fetch";
 import { normalizeKalshiMarket } from "./services/kalshi/adapter";
+import type { PredictionDetailTab } from "./types";
 
 export const TEST_PANE_ID = "prediction-markets:main";
 const originalFetch = globalThis.fetch;
@@ -408,7 +409,13 @@ export function ChartHarness({
   );
 }
 
-export function GroupedDetailHarness() {
+export function GroupedDetailHarness({
+  detailTab = "overview",
+  loading = false,
+}: {
+  detailTab?: PredictionDetailTab;
+  loading?: boolean;
+} = {}) {
   const [state, dispatch] = useReducer(
     appReducer,
     (() => {
@@ -475,29 +482,40 @@ export function GroupedDetailHarness() {
     <AppContext value={{ state, dispatch }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
         <PredictionMarketDetailPane
-          detail={{
-            summary,
-            siblings: selectedRow!.markets.map((market) => ({
-              key: market.key,
-              marketId: market.marketId,
-              label: market.marketLabel,
-              yesPrice: market.yesPrice,
-              volume24h: market.volume24h,
-            })),
-            rules: [],
-            history: [],
-            book: {
-              yesBids: [],
-              yesAsks: [],
-              noBids: [],
-              noAsks: [],
-              lastTradePrice: null,
-            },
-            trades: [],
-          }}
+          detail={
+            loading
+              ? null
+              : {
+                  summary,
+                  siblings: selectedRow!.markets.map((market) => ({
+                    key: market.key,
+                    marketId: market.marketId,
+                    label: market.marketLabel,
+                    yesPrice: market.yesPrice,
+                    volume24h: market.volume24h,
+                  })),
+                  rules: [],
+                  history: [],
+                  book: {
+                    yesBids: [{ price: 0.47, size: 120 }],
+                    yesAsks: [{ price: 0.49, size: 95 }],
+                    noBids: [{ price: 0.51, size: 80 }],
+                    noAsks: [{ price: 0.53, size: 105 }],
+                    lastTradePrice: null,
+                  },
+                  trades: [{
+                    id: "trade-1",
+                    timestamp: Date.parse("2026-04-01T12:34:56Z"),
+                    side: "buy",
+                    outcome: "yes",
+                    price: 0.48,
+                    size: 50,
+                  }],
+                }
+          }
           detailError={null}
-          detailLoadCount={0}
-          detailTab="overview"
+          detailLoadCount={loading ? 1 : 0}
+          detailTab={detailTab}
           detailWidth={58}
           focused
           height={24}

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -353,14 +353,14 @@ export function WebPageStackView({
 
   if (!detailOpen) {
     return (
-      <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      <Box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} minWidth={0} minHeight={0} overflow="hidden">
         {rootContent}
       </Box>
     );
   }
 
   return (
-    <Box flexDirection="column" flexGrow={1} overflow="hidden">
+    <Box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} minWidth={0} minHeight={0} overflow="hidden">
       <Box
         flexDirection="row"
         alignItems="flex-start"
@@ -419,7 +419,7 @@ export function WebPageStackView({
           </Text>
         ) : null}
       </Box>
-      <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      <Box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} minWidth={0} minHeight={0} overflow="hidden">
         {detailContent}
       </Box>
     </Box>

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -170,6 +170,17 @@ body.gloom-dragging {
 [data-gloom-role="status-bar"] span {
   line-height: var(--cell-h);
 }
+[data-gloom-role="pane-body"] {
+  overflow: hidden;
+}
+[data-gloom-role="pane-content"] {
+  overflow: hidden;
+}
+[data-gloom-role="pane-content"] > * {
+  min-width: 0;
+  min-height: 0;
+  max-height: 100%;
+}
 [data-gloom-role="pane-footer"] {
   flex: 0 0 var(--cell-h);
   height: var(--cell-h);


### PR DESCRIPTION
## Summary
- Fix prediction market loading, detail header, metrics layout, target-table spinner shift, and detail footer behavior.
- Move prediction market book and trades onto the shared DataTable component.
- Fix desktop pane/footer layout so scrollable DataTables shrink inside pane content instead of extending under status bars.

## Root Cause
Desktop pane content and shared table stack wrappers could keep fixed numeric heights inside flex containers. Pane footers were in normal flow, but some descendants did not shrink to the available body height, so DataTable rows could render under the footer/status bar.

## Validation
- `bun test src/components/data-table src/components/feed-data-table src/components/layout/pane/content.test.tsx src/components/layout/pane/sizing.test.ts src/plugins/prediction-markets src/components/layout/shell/index.test.tsx src/components/layout/pane/footer/index.test.tsx src/components/layout/status-bar.test.tsx`
- `bun run desktop:view:build`
- `git diff --check HEAD~1..HEAD`