### PR TITLE
Fix standalone OpenTUI native packaging

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { gzipSync } from "zlib";
 import { syncVersion } from "./sync-version";
+import { OPEN_TUI_NATIVE_SMOKE_COMMAND } from "../src/cli/native-smoke";
 
 const rootDir = join(import.meta.dir, "..");
 
@@ -12,13 +13,14 @@ interface BuildTarget {
   arch: "arm64" | "x64";
   bunOs: "darwin" | "linux" | "windows";
   extension: "" | ".exe";
+  nativePackageName: string;
 }
 
 const targets: BuildTarget[] = [
-  { os: "darwin", arch: "arm64", bunOs: "darwin", extension: "" },
-  { os: "linux", arch: "x64", bunOs: "linux", extension: "" },
-  { os: "linux", arch: "arm64", bunOs: "linux", extension: "" },
-  { os: "windows", arch: "x64", bunOs: "windows", extension: ".exe" },
+  { os: "darwin", arch: "arm64", bunOs: "darwin", extension: "", nativePackageName: "@opentui/core-darwin-arm64" },
+  { os: "linux", arch: "x64", bunOs: "linux", extension: "", nativePackageName: "@opentui/core-linux-x64" },
+  { os: "linux", arch: "arm64", bunOs: "linux", extension: "", nativePackageName: "@opentui/core-linux-arm64" },
+  { os: "windows", arch: "x64", bunOs: "windows", extension: ".exe", nativePackageName: "@opentui/core-win32-x64" },
 ];
 
 const args = process.argv.slice(2);
@@ -87,10 +89,23 @@ async function smokeTestBinary(outfile: string, os: string, arch: string) {
 
   console.log("Smoke testing packaged binary...");
   await runProcess(
+    [outfile, OPEN_TUI_NATIVE_SMOKE_COMMAND],
+    `Packaged binary failed to load OpenTUI native package: ${outfile}`,
+    { stdout: "ignore" },
+  );
+  await runProcess(
     [outfile, "help"],
     `Packaged binary failed to launch: ${outfile}`,
     { stdout: "ignore" },
   );
+}
+
+function buildCompileEntrySource(nativePackageName: string): string {
+  return [
+    `import ${JSON.stringify(nativePackageName)};`,
+    `import "../src/cli/entry.ts";`,
+    "",
+  ].join("\n");
 }
 
 function compressGzip(path: string): string {
@@ -101,16 +116,24 @@ function compressGzip(path: string): string {
 }
 
 async function build(targetConfig: BuildTarget) {
-  const { os, arch, bunOs, extension } = targetConfig;
+  const { os, arch, bunOs, extension, nativePackageName } = targetConfig;
   mkdirSync(join(rootDir, "dist"), { recursive: true });
   const outfile = join(rootDir, `dist/gloomberb-${os}-${arch}${extension}`);
+  const compileEntry = join(rootDir, "dist", `.gloomberb-compile-entry-${os}-${arch}.ts`);
   const target = `bun-${bunOs}-${arch}`;
   console.log(`Building ${target}...`);
-  await runProcess(
-    ["bun", "build", "--compile", `--target=${target}`, "src/cli/entry.ts", `--outfile=${outfile}`],
+  writeFileSync(compileEntry, buildCompileEntrySource(nativePackageName));
+  const buildExitCode = await runProcess(
+    ["bun", "build", "--compile", `--target=${target}`, compileEntry, `--outfile=${outfile}`],
     `Failed to build ${target}`,
     { env: { ...process.env, GLOOMBERB_API_URL: "https://api.gloom.sh" } },
+    true,
   );
+  rmSync(compileEntry, { force: true });
+  if (buildExitCode !== 0) {
+    console.error(`Failed to build ${target}`);
+    process.exit(1);
+  }
 
   if (os === "darwin") {
     await signDarwinBinary(outfile);

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -2,6 +2,7 @@ import { dispatchCli } from "./index";
 import { fail, inferCliErrorOptions, printCliError } from "./errors";
 import { loadExternalPlugins } from "../plugins/loader";
 import type { CliLaunchRequest } from "../types/plugin";
+import { OPEN_TUI_NATIVE_SMOKE_COMMAND, smokeOpenTuiNative } from "./native-smoke";
 
 async function launchOpenTuiApp(options: {
   externalPlugins: Awaited<ReturnType<typeof loadExternalPlugins>>;
@@ -18,8 +19,14 @@ async function launchOpenTuiApp(options: {
 }
 
 export async function runCliEntrypoint(rawArgs = process.argv.slice(2)): Promise<void> {
-  const externalPlugins = await loadExternalPlugins();
   const command = rawArgs[0];
+
+  if (command === OPEN_TUI_NATIVE_SMOKE_COMMAND) {
+    await smokeOpenTuiNative();
+    return;
+  }
+
+  const externalPlugins = await loadExternalPlugins();
 
   if (!command) {
     await launchOpenTuiApp({ externalPlugins });

--- a/src/cli/native-smoke.ts
+++ b/src/cli/native-smoke.ts
@@ -1,0 +1,5 @@
+export const OPEN_TUI_NATIVE_SMOKE_COMMAND = "__gloomberb-smoke-opentui-native";
+
+export async function smokeOpenTuiNative(): Promise<void> {
+  await import("../renderers/opentui/native-smoke");
+}

--- a/src/renderers/opentui/native-smoke.ts
+++ b/src/renderers/opentui/native-smoke.ts
@@ -1,0 +1,1 @@
+import "@opentui/core";


### PR DESCRIPTION
## Summary
- include the target OpenTUI native package in the standalone compile entry
- add a hidden packaged-binary native smoke command and run it during host-target builds
- keep the existing `help` smoke test, but make release builds also exercise the OpenTUI native import path

## Root Cause
The release smoke test only ran `help`, which does not import the OpenTUI renderer. The UI launch path loaded `@opentui/core`, whose platform native package is selected through a runtime dynamic import. Bun did not bundle that bare native package into the standalone binary, so published binaries could launch `help` but fail on UI startup with `Cannot find module '@opentui/core-<platform>'`.

## Validation
- reproduced the current standalone binary failure on the no-argument UI path with `Cannot find module '@opentui/core-darwin-arm64'`, matching the reported Linux failure class
- `bun run scripts/build.ts`
- rebuilt archive: native smoke exits 0, `help` exits 0, no-arg UI stayed running after 5s with no stderr
- `bun test` (1365 pass)
- branch workflow: Verify Windows https://github.com/vincelwt/gloomberb/actions/runs/27796106940

Fixes #459
