### PR TITLE
Fix non-kitty native bitmap churn

### DIFF
--- a/src/components/chart/native/bitmap-support.test.ts
+++ b/src/components/chart/native/bitmap-support.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import type { NativeRendererHost } from "../../../ui";
+import { shouldRenderNativeBitmap } from "./bitmap-support";
+
+function rendererWithCapabilities(capabilities: unknown): NativeRendererHost {
+  return {
+    terminalWidth: 80,
+    terminalHeight: 24,
+    resolution: null,
+    capabilities,
+    on() {},
+    off() {},
+    requestRender() {},
+    registerLifecyclePass() {},
+    unregisterLifecyclePass() {},
+  };
+}
+
+describe("shouldRenderNativeBitmap", () => {
+  test("skips native bitmaps only when kitty graphics are known unsupported", () => {
+    expect(shouldRenderNativeBitmap(rendererWithCapabilities({ kitty_graphics: false }), true)).toBe(false);
+    expect(shouldRenderNativeBitmap(rendererWithCapabilities({ kitty_graphics: true }), true)).toBe(true);
+    expect(shouldRenderNativeBitmap(rendererWithCapabilities(null), true)).toBe(true);
+    expect(shouldRenderNativeBitmap(rendererWithCapabilities({}), true)).toBe(true);
+    expect(shouldRenderNativeBitmap(rendererWithCapabilities({ kitty_graphics: true }), false)).toBe(false);
+  });
+});

--- a/src/components/chart/native/bitmap-support.ts
+++ b/src/components/chart/native/bitmap-support.ts
@@ -1,0 +1,55 @@
+import type { NativeRendererHost, PixelResolution } from "../../../ui";
+import { computeBitmapSize } from "./chart-rasterizer";
+
+interface NativeBitmapRendererCapabilities {
+  kitty_graphics?: boolean;
+}
+
+export interface NativeBitmapSize {
+  pixelWidth: number;
+  pixelHeight: number;
+}
+
+function hasKnownUnsupportedKittyGraphics(renderer: NativeRendererHost): boolean {
+  const capabilities = renderer.capabilities as NativeBitmapRendererCapabilities | null | undefined;
+  return capabilities?.kitty_graphics === false;
+}
+
+export function shouldRenderNativeBitmap(renderer: NativeRendererHost, nativeCharts: boolean): boolean {
+  return nativeCharts && !hasKnownUnsupportedKittyGraphics(renderer);
+}
+
+export function resolveNativeBitmapSize({
+  width,
+  height,
+  resolution,
+  terminalWidth,
+  terminalHeight,
+  cellWidthPx,
+  cellHeightPx,
+  pixelRatio,
+}: {
+  width: number;
+  height: number;
+  resolution: PixelResolution | null;
+  terminalWidth: number;
+  terminalHeight: number;
+  cellWidthPx: number;
+  cellHeightPx: number;
+  pixelRatio: number;
+}): NativeBitmapSize {
+  if (resolution && terminalWidth > 0 && terminalHeight > 0) {
+    return computeBitmapSize(
+      { x: 0, y: 0, width, height },
+      resolution,
+      terminalWidth,
+      terminalHeight,
+    );
+  }
+
+  const scale = Math.max(1, pixelRatio);
+  return {
+    pixelWidth: Math.max(1, Math.round(width * cellWidthPx * scale)),
+    pixelHeight: Math.max(1, Math.round(height * cellHeightPx * scale)),
+  };
+}

--- a/src/components/chart/static/chart/bitmap.ts
+++ b/src/components/chart/static/chart/bitmap.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useNativeRenderer, useUiCapabilities } from "../../../../ui";
-import { computeBitmapSize } from "../../native/chart-rasterizer";
+import { resolveNativeBitmapSize, shouldRenderNativeBitmap } from "../../native/bitmap-support";
 
 export interface StaticChartBitmapSize {
   pixelWidth: number;
@@ -16,20 +16,25 @@ export function useStaticChartBitmapSize(width: number, height: number): StaticC
     pixelRatio = 1,
   } = useUiCapabilities();
   const nativeRenderer = useNativeRenderer();
+  const rendererCapabilities = nativeRenderer.capabilities;
   const rendererResolution = nativeRenderer.resolution;
   const rendererTerminalWidth = nativeRenderer.terminalWidth;
   const rendererTerminalHeight = nativeRenderer.terminalHeight;
 
   return useMemo(() => {
-    if (nativeCharts && rendererResolution && rendererTerminalWidth > 0 && rendererTerminalHeight > 0) {
-      return computeBitmapSize(
-        { x: 0, y: 0, width, height },
-        rendererResolution,
-        rendererTerminalWidth,
-        rendererTerminalHeight,
-      );
+    if (shouldRenderNativeBitmap(nativeRenderer, nativeCharts === true)) {
+      return resolveNativeBitmapSize({
+        width,
+        height,
+        resolution: rendererResolution,
+        terminalWidth: rendererTerminalWidth,
+        terminalHeight: rendererTerminalHeight,
+        cellWidthPx,
+        cellHeightPx,
+        pixelRatio,
+      });
     }
-    if (!canvasCharts && !nativeCharts) return null;
+    if (!canvasCharts) return null;
     const scale = Math.max(1, pixelRatio);
     return {
       pixelWidth: Math.max(1, Math.round(width * cellWidthPx * scale)),
@@ -41,7 +46,9 @@ export function useStaticChartBitmapSize(width: number, height: number): StaticC
     cellWidthPx,
     height,
     nativeCharts,
+    nativeRenderer,
     pixelRatio,
+    rendererCapabilities,
     rendererResolution,
     rendererTerminalHeight,
     rendererTerminalWidth,

--- a/src/components/price-sparkline/view.tsx
+++ b/src/components/price-sparkline/view.tsx
@@ -10,7 +10,7 @@ import {
 import { colors } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
 import type { PricePoint } from "../../types/financials";
-import { computeBitmapSize } from "../chart/native/chart-rasterizer";
+import { resolveNativeBitmapSize, shouldRenderNativeBitmap } from "../chart/native/bitmap-support";
 import { renderSparklineBitmap } from "./bitmap";
 import {
   buildSamples,
@@ -90,22 +90,21 @@ function TerminalPriceSparkline({
   const { nativeCharts, cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1 } = useUiCapabilities();
   const nativeRenderer = useNativeRenderer();
   const rendererResolution = nativeRenderer.resolution;
+  const rendererCapabilities = nativeRenderer.capabilities;
   const rendererTerminalWidth = nativeRenderer.terminalWidth;
   const rendererTerminalHeight = nativeRenderer.terminalHeight;
   const bitmap = useMemo(() => {
-    if (!nativeCharts || values.length < 2) return null;
-    const scale = Math.max(1, pixelRatio);
-    const bitmapSize = rendererResolution && rendererTerminalWidth > 0 && rendererTerminalHeight > 0
-      ? computeBitmapSize(
-        { x: 0, y: 0, width, height },
-        rendererResolution,
-        rendererTerminalWidth,
-        rendererTerminalHeight,
-      )
-      : {
-          pixelWidth: Math.max(1, Math.round(width * cellWidthPx * scale)),
-          pixelHeight: Math.max(1, Math.round(height * cellHeightPx * scale)),
-        };
+    if (values.length < 2 || !shouldRenderNativeBitmap(nativeRenderer, nativeCharts === true)) return null;
+    const bitmapSize = resolveNativeBitmapSize({
+      width,
+      height,
+      resolution: rendererResolution,
+      terminalWidth: rendererTerminalWidth,
+      terminalHeight: rendererTerminalHeight,
+      cellWidthPx,
+      cellHeightPx,
+      pixelRatio,
+    });
     return renderSparklineBitmap(values, bitmapSize.pixelWidth, bitmapSize.pixelHeight, color, { area, compact: height <= 1 });
   }, [
     area,
@@ -114,7 +113,9 @@ function TerminalPriceSparkline({
     color,
     height,
     nativeCharts,
+    nativeRenderer,
     pixelRatio,
+    rendererCapabilities,
     rendererResolution,
     rendererTerminalHeight,
     rendererTerminalWidth,

--- a/src/components/speedometer-gauge/terminal.tsx
+++ b/src/components/speedometer-gauge/terminal.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Box, ChartSurface, Span, Text, TextAttributes, useNativeRenderer, useUiCapabilities } from "../../ui";
-import { computeBitmapSize, type NativeChartBitmap } from "../chart/native/chart-rasterizer";
+import type { NativeChartBitmap } from "../chart/native/chart-rasterizer";
+import { resolveNativeBitmapSize, shouldRenderNativeBitmap } from "../chart/native/bitmap-support";
 import { drawCircle, drawLine, parseHex } from "../chart/native/raster/primitives";
 import { colors } from "../../theme/colors";
 import {
@@ -203,29 +204,29 @@ export function TerminalSpeedometerGauge({
   const labelRow = useMemo(() => renderLabelRow(gaugeWidth, min, max, segments), [gaugeWidth, max, min, segments]);
   const tickRow = useMemo(() => renderTickRow(gaugeWidth, min, max), [gaugeWidth, max, min]);
   const arcRows = useMemo(() => renderArcRows(value, min, max, gaugeWidth, segments), [gaugeWidth, max, min, segments, value]);
+  const rendererCapabilities = nativeRenderer.capabilities;
   const rendererResolution = nativeRenderer.resolution;
   const rendererTerminalWidth = nativeRenderer.terminalWidth;
   const rendererTerminalHeight = nativeRenderer.terminalHeight;
   const bitmap = useMemo<NativeChartBitmap | null>(() => {
-    if (!nativeCharts) return null;
-    const bitmapSize = rendererResolution && rendererTerminalWidth > 0 && rendererTerminalHeight > 0
-      ? computeBitmapSize(
-        { x: 0, y: 0, width: gaugeWidth, height: arcRows.length },
-        rendererResolution,
-        rendererTerminalWidth,
-        rendererTerminalHeight,
-      )
-      : null;
-    const scale = Math.max(1, pixelRatio);
-    const pixelWidth = bitmapSize?.pixelWidth ?? Math.max(1, Math.round(gaugeWidth * cellWidthPx * scale));
-    const pixelHeight = bitmapSize?.pixelHeight ?? Math.max(1, Math.round(arcRows.length * cellHeightPx * scale));
+    if (!shouldRenderNativeBitmap(nativeRenderer, nativeCharts === true)) return null;
+    const bitmapSize = resolveNativeBitmapSize({
+      width: gaugeWidth,
+      height: arcRows.length,
+      resolution: rendererResolution,
+      terminalWidth: rendererTerminalWidth,
+      terminalHeight: rendererTerminalHeight,
+      cellWidthPx,
+      cellHeightPx,
+      pixelRatio,
+    });
     return renderGaugeBitmap(
       value,
       min,
       max,
       segments,
-      pixelWidth,
-      pixelHeight,
+      bitmapSize.pixelWidth,
+      bitmapSize.pixelHeight,
     );
   }, [
     arcRows.length,
@@ -235,7 +236,9 @@ export function TerminalSpeedometerGauge({
     max,
     min,
     nativeCharts,
+    nativeRenderer,
     pixelRatio,
+    rendererCapabilities,
     rendererResolution,
     rendererTerminalHeight,
     rendererTerminalWidth,


### PR DESCRIPTION
## Summary
- skip terminal native bitmap rasterization when OpenTUI already reports kitty graphics as unsupported
- share the bitmap size/gating logic across static charts, the terminal speedometer, and price sparklines
- add a focused regression test for the non-kitty/native bitmap gate

## Root Cause
Fear & Greed mounts the terminal speedometer and several static chart surfaces. In tmux, OpenTUI reports `kitty_graphics: false`, but the chart components still rasterized native bitmap payloads every render even though those bitmaps could never be displayed. That wasted raster work drove the watcher to ~100% CPU and multi-GB RSS after the pane stayed open.

## Validation
- `bun test src/components/chart/native/bitmap-support.test.ts src/components/chart/static/chart/surface.test.tsx src/components/chart/static/bar-chart-surface.test.tsx src/plugins/builtin/analytics/index.test.tsx src/plugins/builtin/correlation/index.test.tsx src/plugins/builtin/kelly-sizer/index.test.tsx src/plugins/builtin/ticker-detail/quote-monitor/index.test.tsx`
- `bun test src/components/chart/native/kitty/index.test.ts`
- tmux `bun run dev` Fear & Greed repro in a non-kitty terminal: after 1m36s open, watcher stayed ~1.2% CPU and ~599 MB RSS; `Ctrl+W` closed the pane normally

Fixes #452
