### PR TITLE
Fix OpenTUI native hover memory growth

### DIFF
--- a/patches/@opentui%2Fcore@0.3.2.patch
+++ b/patches/@opentui%2Fcore@0.3.2.patch
@@ -1,5 +1,5 @@
 diff --git a/index-218h9p3f.js b/index-218h9p3f.js
-index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346939bb068 100644
+index b9445d2cca9477dfe06026da451b6d19268fcbdd..da790c31da185325405227329dad2ac12f5329e7 100644
 --- a/index-218h9p3f.js
 +++ b/index-218h9p3f.js
 @@ -6487,17 +6487,27 @@ class MouseParser {
@@ -210,7 +210,101 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
    }
    throw new Error(`opentui is not supported on the current platform: ${process.platform}-${process.arch}`);
  }
-@@ -22288,6 +22323,8 @@ class MouseEvent {
+@@ -17996,5 +18031,7 @@ function isGapType(value) {
+ class BoxRenderable extends Renderable {
+   _backgroundColor;
++  _hoverBackgroundColor;
++  _isHovered = false;
+   _border;
+   _borderStyle;
+   _borderColor;
+@@ -18023,6 +18060,7 @@ class BoxRenderable extends Renderable {
+       this._focusable = true;
+     }
+     this._backgroundColor = parseColor(options.backgroundColor || this._defaultOptions.backgroundColor);
++    this._hoverBackgroundColor = options.hoverBackgroundColor === undefined ? undefined : parseColor(options.hoverBackgroundColor);
+     this._border = options.border ?? this._defaultOptions.border;
+     if (!options.border && (options.borderStyle || options.borderColor || options.focusedBorderColor || options.customBorderChars)) {
+       this._border = true;
+@@ -18064,11 +18102,26 @@ class BoxRenderable extends Renderable {
+   }
+   set backgroundColor(value) {
+     const newColor = parseColor(value ?? this._defaultOptions.backgroundColor);
+-    if (this._backgroundColor !== newColor) {
++    if (!this._backgroundColor.equals(newColor)) {
+       this._backgroundColor = newColor;
+       this.requestRender();
+     }
+   }
++  get hoverBackgroundColor() {
++    return this._hoverBackgroundColor;
++  }
++  set hoverBackgroundColor(value) {
++    const newColor = value === undefined || value === null ? undefined : parseColor(value);
++    const changed = newColor === undefined
++      ? this._hoverBackgroundColor !== undefined
++      : !this._hoverBackgroundColor?.equals(newColor);
++    if (changed) {
++      this._hoverBackgroundColor = newColor;
++      if (this._isHovered) {
++        this.requestRender();
++      }
++    }
++  }
+   get border() {
+     return this._border;
+   }
+@@ -18152,9 +18205,39 @@ class BoxRenderable extends Renderable {
+       this.requestRender();
+     }
+   }
++  onMouseEvent(event) {
++    if (!this._hoverBackgroundColor) {
++      if (this._isHovered) {
++        this._isHovered = false;
++        this.requestRender();
++      }
++      return;
++    }
++    if (event.type === "over" && !this._isHovered) {
++      this._isHovered = true;
++      this.requestRender();
++    } else if (event.type === "out" && this._isHovered) {
++      this._isHovered = false;
++      this.requestRender();
++    }
++  }
++  getActiveHoverBackgroundColor() {
++    if (this._isHovered && this._hoverBackgroundColor) {
++      return this._hoverBackgroundColor;
++    }
++    let parent = this.parent;
++    while (parent) {
++      if (parent instanceof BoxRenderable && parent._isHovered && parent._hoverBackgroundColor) {
++        return parent._hoverBackgroundColor;
++      }
++      parent = parent.parent;
++    }
++    return undefined;
++  }
+   renderSelf(buffer) {
+     const hasBorder = this.borderSides.top || this.borderSides.right || this.borderSides.bottom || this.borderSides.left;
+-    const hasVisibleFill = this.shouldFill && this._backgroundColor.a > 0;
++    const backgroundColor = this.getActiveHoverBackgroundColor() ?? this._backgroundColor;
++    const hasVisibleFill = this.shouldFill && backgroundColor.a > 0;
+     if (!hasBorder && !hasVisibleFill) {
+       return;
+     }
+@@ -18171,7 +18254,7 @@ class BoxRenderable extends Renderable {
+       customBorderChars: this._customBorderChars,
+       border: this._border,
+       borderColor: currentBorderColor,
+-      backgroundColor: this._backgroundColor,
++      backgroundColor,
+       shouldFill: this.shouldFill,
+       title: this._title,
+       titleAlignment: this._titleAlignment,
+@@ -22288,6 +22371,8 @@ class MouseEvent {
    button;
    x;
    y;
@@ -219,7 +313,7 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
    source;
    modifiers;
    scroll;
-@@ -22307,6 +22344,8 @@ class MouseEvent {
+@@ -22307,6 +22392,8 @@ class MouseEvent {
      this.button = attributes.button;
      this.x = attributes.x;
      this.y = attributes.y;
@@ -228,16 +322,18 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
      this.modifiers = attributes.modifiers;
      this.scroll = attributes.scroll;
      this.source = attributes.source;
-@@ -22457,6 +22496,8 @@ class CliRenderer extends EventEmitter9 {
+@@ -22457,6 +22544,10 @@ class CliRenderer extends EventEmitter9 {
    resizeDebounceDelay = 100;
    enableMouseMovement = false;
    _useMouse = true;
 +  _mouseProtocolSignature = "disabled";
 +  _pixelMouseEnabled = false;
++  _pendingMouseMoveEvent = null;
++  _pendingMouseMoveTimer = null;
    autoFocus = true;
    _screenMode = "alternate-screen";
    _footerHeight = DEFAULT_FOOTER_HEIGHT;
-@@ -22491,7 +22532,7 @@ class CliRenderer extends EventEmitter9 {
+@@ -22491,7 +22582,7 @@ class CliRenderer extends EventEmitter9 {
      this.handleResize(width, height);
    }).bind(this);
    _capabilities = null;
@@ -246,7 +342,7 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
    _hasPointer = false;
    _lastPointerModifiers = {
      shift: false,
-@@ -22738,7 +22779,13 @@ Captured external output:
+@@ -22738,7 +22829,13 @@ Captured external output:
          privateCapabilityRepliesActive: false,
          pixelResolutionQueryActive: false,
          explicitWidthCprActive: false,
@@ -261,7 +357,7 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
        },
        clock: this.clock
      });
-@@ -24021,12 +24068,14 @@ Captured external output:
+@@ -24021,12 +24118,14 @@ Captured external output:
    enableMouse() {
      this._useMouse = true;
      this.lib.enableMouse(this.rendererPtr, this.enableMouseMovement);
@@ -276,7 +372,7 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
    }
    enableKittyKeyboard(flags = 3) {
      this.lib.enableKittyKeyboard(this.rendererPtr, flags);
-@@ -24036,6 +24085,52 @@ Captured external output:
+@@ -24036,6 +24135,52 @@ Captured external output:
      this.lib.disableKittyKeyboard(this.rendererPtr);
      this.updateStdinParserProtocolContext({ kittyKeyboardEnabled: false }, true);
    }
@@ -329,7 +425,7 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
    set useThread(useThread) {
      this._useThread = useThread;
      this.lib.setUseThread(this.rendererPtr, useThread);
-@@ -24141,6 +24236,7 @@ Captured external output:
+@@ -24141,6 +24286,7 @@ Captured external output:
      }
      this.lib.processCapabilityResponse(this.rendererPtr, sequence);
      this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr);
@@ -337,7 +433,7 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
      if (this._capabilities?.terminal?.from_xtversion) {
        this.resolveXtVersionWaiters();
      }
-@@ -24170,6 +24266,7 @@ Captured external output:
+@@ -24170,6 +24316,7 @@ Captured external output:
      if (sequence === "\x1B[I") {
        if (this.shouldRestoreModesOnNextFocus) {
          this.lib.restoreTerminalModes(this.rendererPtr);
@@ -345,7 +441,16 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
          this.shouldRestoreModesOnNextFocus = false;
        }
        if (this._terminalFocusState !== true) {
-@@ -24264,6 +24361,7 @@ Captured external output:
+@@ -24218,7 +24365,7 @@ Captured external output:
+         this._keyHandler.processParsedKey(event.key);
+         return;
+       case "mouse":
+-        if (this._useMouse && this.processSingleMouseEvent(event.event)) {
++        if (this._useMouse && this.processMouseEvent(event.event)) {
+           return;
+         }
+         this.dispatchSequenceHandlers(event.raw);
+@@ -24264,6 +24411,7 @@ Captured external output:
          }
          this.waitingForPixelResolution = false;
          this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: false }, true);
@@ -353,7 +458,54 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
          return true;
        }
        return false;
-@@ -24298,9 +24396,15 @@ Captured external output:
+@@ -24292,15 +24440,62 @@ Captured external output:
+     }
+     return event;
+   }
++  cloneMouseEventAttributes(mouseEvent) {
++    return {
++      ...mouseEvent,
++      modifiers: { ...mouseEvent.modifiers }
++    };
++  }
++  processMouseEvent(mouseEvent) {
++    if (mouseEvent.type !== "move") {
++      this.flushPendingMouseMove();
++      return this.processSingleMouseEvent(mouseEvent);
++    }
++    if (this._pendingMouseMoveTimer === null) {
++      const handled = this.processSingleMouseEvent(mouseEvent);
++      this.schedulePendingMouseMove();
++      return handled;
++    }
++    this._pendingMouseMoveEvent = this.cloneMouseEventAttributes(mouseEvent);
++    return true;
++  }
++  schedulePendingMouseMove() {
++    if (this._pendingMouseMoveTimer !== null || this._isDestroyed) {
++      return;
++    }
++    const delay = Math.max(100, Math.floor(this.targetFrameTime));
++    this._pendingMouseMoveTimer = this.clock.setTimeout(() => {
++      this._pendingMouseMoveTimer = null;
++      this.flushPendingMouseMove();
++    }, delay);
++  }
++  flushPendingMouseMove() {
++    if (this._pendingMouseMoveTimer !== null) {
++      this.clock.clearTimeout(this._pendingMouseMoveTimer);
++      this._pendingMouseMoveTimer = null;
++    }
++    const pending = this._pendingMouseMoveEvent;
++    this._pendingMouseMoveEvent = null;
++    if (!pending || this._isDestroyed) {
++      return false;
++    }
++    return this.processSingleMouseEvent(pending);
++  }
+   processSingleMouseEvent(mouseEvent) {
+     if (this._splitHeight > 0) {
+       if (mouseEvent.y < this.renderOffset) {
          return false;
        }
        mouseEvent.y -= this.renderOffset;
@@ -369,31 +521,43 @@ index b9445d2cca9477dfe06026da451b6d19268fcbdd..3efd05fa41eb713ac6e539764b15c346
      this._hasPointer = true;
      this._lastPointerModifiers = mouseEvent.modifiers;
      if (this._console.visible) {
-@@ -24441,6 +24545,8 @@ Captured external output:
-       button: 0,
-       x: this._latestPointer.x,
-       y: this._latestPointer.y,
+@@ -24437,6 +24632,8 @@ Captured external output:
+       return;
+     }
+     const baseEvent = {
 +      pixelX: this._latestPointer.pixelX,
 +      pixelY: this._latestPointer.pixelY,
-       modifiers: this._lastPointerModifiers
-     };
-     if (lastOver && !lastOver.isDestroyed) {
-@@ -24531,6 +24637,7 @@ Captured external output:
+       type: "move",
+       button: 0,
+       x: this._latestPointer.x,
+@@ -24527,6 +24724,7 @@ Captured external output:
+     const pendingSplitFooterTransition = this.pendingSplitFooterTransition;
+     const previousGeometry = calculateRenderGeometry(this._screenMode, this._terminalWidth, this._terminalHeight, this._footerHeight);
+     const prevWidth = this._terminalWidth;
++    this.syncPixelMouseMode();
+     const previousTerminalHeight = this._terminalHeight;
      const visiblePreviousSplitHeight = pendingSplitFooterTransition?.sourceHeight ?? previousGeometry.effectiveFooterHeight;
      this._terminalWidth = width;
-     this._terminalHeight = height;
-+    this.syncPixelMouseMode();
-     this.queryPixelResolution();
-     this.setCapturedRenderable(undefined);
-     this.stdinParser?.resetMouseState();
-@@ -24848,6 +24955,7 @@ Captured external output:
+@@ -24832,6 +25030,11 @@ Captured external output:
+       this.clock.clearTimeout(this.resizeTimeoutId);
+       this.resizeTimeoutId = null;
+     }
++    if (this._pendingMouseMoveTimer !== null) {
++      this.clock.clearTimeout(this._pendingMouseMoveTimer);
++      this._pendingMouseMoveTimer = null;
++    }
++    this._pendingMouseMoveEvent = null;
+     if (this.capabilityTimeoutId !== null) {
+       this.clock.clearTimeout(this.capabilityTimeoutId);
+       this.capabilityTimeoutId = null;
+@@ -24847,6 +25050,7 @@ Captured external output:
+       this.renderTimeout = null;
+     }
      this.themeModeState.cancelRefresh();
++    this.disablePixelMouseMode();
      this._isRunning = false;
      this.waitingForPixelResolution = false;
-+    this.disablePixelMouseMode();
      this.updateStdinParserProtocolContext({
-       privateCapabilityRepliesActive: false,
-       pixelResolutionQueryActive: false,
 diff --git a/lib/parse.mouse.d.ts b/lib/parse.mouse.d.ts
 index c29f953fde0b78f09d2ec7a830e5a72452c1fe7e..04613b921bd9b4a9a7a1a4fbd0234d4012df67a1 100644
 --- a/lib/parse.mouse.d.ts
@@ -450,6 +614,44 @@ index 6b733d534d8e9b77c5c2773f93c7a22063c18d84..a5c318d591e9f3775e276e555c15052c
  }
  export interface StdinParserOptions {
      timeoutMs?: number;
+diff --git a/renderables/Box.d.ts b/renderables/Box.d.ts
+index 7ecb70d38ca41d1afdc078780985827e8f10e3a7..0845141e20ebd71a163dba67880d494a05b27d9a 100644
+--- a/renderables/Box.d.ts
++++ b/renderables/Box.d.ts
+@@ -5,6 +5,7 @@ import { type ColorInput, RGBA } from "../lib/RGBA.js";
+ import type { RenderContext } from "../types.js";
+ export interface BoxOptions<TRenderable extends Renderable = BoxRenderable> extends RenderableOptions<TRenderable> {
+     backgroundColor?: string | RGBA;
++    hoverBackgroundColor?: string | RGBA;
+     borderStyle?: BorderStyle;
+     border?: boolean | BorderSides[];
+     borderColor?: string | RGBA;
+@@ -22,6 +23,8 @@ export interface BoxOptions<TRenderable extends Renderable = BoxRenderable> exte
+ }
+ export declare class BoxRenderable extends Renderable {
+     protected _backgroundColor: RGBA;
++    protected _hoverBackgroundColor?: RGBA;
++    protected _isHovered: boolean;
+     protected _border: boolean | BorderSides[];
+     protected _borderStyle: BorderStyle;
+     protected _borderColor: RGBA;
+@@ -50,6 +53,8 @@ export declare class BoxRenderable extends Renderable {
+     set customBorderChars(value: BorderCharacters | undefined);
+     get backgroundColor(): RGBA;
+     set backgroundColor(value: RGBA | string | undefined);
++    get hoverBackgroundColor(): RGBA | undefined;
++    set hoverBackgroundColor(value: RGBA | string | undefined);
+     get border(): boolean | BorderSides[];
+     set border(value: boolean | BorderSides[]);
+     get borderStyle(): BorderStyle;
+@@ -66,6 +71,7 @@ export declare class BoxRenderable extends Renderable {
+     set bottomTitle(value: string | undefined);
+     get bottomTitleAlignment(): "left" | "center" | "right";
+     set bottomTitleAlignment(value: "left" | "center" | "right");
++    protected getActiveHoverBackgroundColor(): RGBA | undefined;
+     protected renderSelf(buffer: OptimizedBuffer): void;
+     protected getScissorRect(): {
+         x: number;
 diff --git a/renderer.d.ts b/renderer.d.ts
 index 96189246f423809fc52d2ad182d57ed2e80ac098..7dd0baf1697041cf8ad556b115cd13ad2e18bc65 100644
 --- a/renderer.d.ts

--- a/src/components/command-bar/list/view.tsx
+++ b/src/components/command-bar/list/view.tsx
@@ -165,7 +165,7 @@ const CommandBarListItemRow = memo(function CommandBarListItemRow({
         : isHovered
           ? paletteHoverBg
           : (nativePaneChrome ? panelBg : paletteBg)}
-      onMouseMove={() => onHoverIndex(globalIdx)}
+      onMouseOver={() => onHoverIndex(globalIdx)}
       onMouseOut={() => onHoverIndex(null)}
       {...(!nativePaneChrome ? { onMouseScroll: onListScroll } : {})}
       onMouseDown={(event: any) => onRowMouseDown(event, item, globalIdx)}

--- a/src/components/command-bar/theme-picker.tsx
+++ b/src/components/command-bar/theme-picker.tsx
@@ -219,7 +219,7 @@ export const ThemePicker = memo(forwardRef<ThemePickerHandle, ThemePickerProps>(
               : hovered
                 ? paletteHoverBg
                 : (nativePaneChrome ? panelBg : paletteBg)}
-            onMouseMove={() => setHoveredIndex(index)}
+            onMouseOver={() => setHoveredIndex(index)}
             onMouseOut={() => setHoveredIndex(null)}
             onMouseDown={(event: any) => {
               event.stopPropagation?.();

--- a/src/components/data-table/view.tsx
+++ b/src/components/data-table/view.tsx
@@ -73,8 +73,6 @@ export interface DataTableViewProps<
     | "scrollRef"
     | "syncHeaderScroll"
     | "onBodyScrollActivity"
-    | "hoveredIdx"
-    | "setHoveredIdx"
     | "isSelected"
     | "onSelect"
     | "onActivate"
@@ -97,8 +95,6 @@ export interface DataTableViewProps<
   scrollRef?: RefObject<ScrollBoxRenderable | null>;
   syncHeaderScroll?: () => void;
   onBodyScrollActivity?: () => void;
-  hoveredIdx?: number | null;
-  setHoveredIdx?: (index: number | null) => void;
   keyboardNavigation?: boolean;
   onRootKeyDown?: (
     event: DataTableKeyEvent,
@@ -125,8 +121,6 @@ export function DataTableView<
   scrollRef,
   syncHeaderScroll,
   onBodyScrollActivity,
-  hoveredIdx,
-  setHoveredIdx,
   keyboardNavigation = true,
   onRootKeyDown,
   resetScrollKey,
@@ -137,15 +131,11 @@ export function DataTableView<
   const {
     effectiveHeaderScrollRef,
     effectiveScrollRef,
-    effectiveHoveredIdx,
-    effectiveSetHoveredIdx,
     effectiveSyncHeaderScroll,
   } = useTableViewState({
     headerScrollRef,
     scrollRef,
     syncHeaderScroll,
-    hoveredIdx,
-    setHoveredIdx,
   });
   const [cursorIndex, setCursorIndex] = useState<number | null>(null);
   const pendingCommitRef = useRef(false);
@@ -532,8 +522,6 @@ export function DataTableView<
         scrollRef={effectiveScrollRef}
         syncHeaderScroll={effectiveSyncHeaderScroll}
         onBodyScrollActivity={handleBodyScrollActivity}
-        hoveredIdx={effectiveHoveredIdx}
-        setHoveredIdx={effectiveSetHoveredIdx}
         scrollToIndex={effectiveScrollToIndex}
         scrollToIndexVersion={scrollToIndexVersion + selectionScrollVersion}
         isSelected={isItemSelected}

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -18,7 +18,7 @@ interface FloatingPaneWrapperProps {
   windowModeSelected?: boolean;
   showActions?: boolean;
   onMouseDown?: (event: any) => void;
-  onMouseMove?: (event: any) => void;
+  onHeaderMouseMove?: (event: any) => void;
   onHeaderMouseDown?: (event: any) => void;
   onHeaderMouseDrag?: (event: any) => void;
   onHeaderMouseDragEnd?: (event: any) => void;
@@ -63,7 +63,7 @@ export function FloatingPaneWrapper({
   windowModeSelected = false,
   showActions = false,
   onMouseDown,
-  onMouseMove,
+  onHeaderMouseMove,
   onHeaderMouseDown,
   onHeaderMouseDrag,
   onHeaderMouseDragEnd,
@@ -104,7 +104,6 @@ export function FloatingPaneWrapper({
         showBorderColor: true,
       })}
       onMouseDown={onMouseDown}
-      onMouseMove={onMouseMove}
     >
       <PaneHeader
         title={title}
@@ -113,6 +112,7 @@ export function FloatingPaneWrapper({
         windowModeSelected={windowModeSelected}
         floating
         showActions={showActions}
+        onHeaderMouseMove={onHeaderMouseMove}
         onHeaderMouseDown={onHeaderMouseDown}
         onHeaderMouseDrag={onHeaderMouseDrag}
         onHeaderMouseDragEnd={onHeaderMouseDragEnd}

--- a/src/components/layout/pane/header.tsx
+++ b/src/components/layout/pane/header.tsx
@@ -14,6 +14,7 @@ interface PaneHeaderProps {
   windowModeSelected?: boolean;
   floating?: boolean;
   showActions?: boolean;
+  onHeaderMouseMove?: (event: any) => void;
   onHeaderMouseDown?: (event: any) => void;
   onHeaderMouseDrag?: (event: any) => void;
   onHeaderMouseDragEnd?: (event: any) => void;
@@ -111,6 +112,7 @@ export function PaneHeader({
   windowModeSelected = false,
   floating = false,
   showActions = false,
+  onHeaderMouseMove,
   onHeaderMouseDown,
   onHeaderMouseDrag,
   onHeaderMouseDragEnd,
@@ -143,6 +145,7 @@ export function PaneHeader({
         data-focused={focused ? "true" : "false"}
         data-window-mode-selected={windowModeSelected ? "true" : "false"}
         onMouseDown={onHeaderMouseDown}
+        onMouseMove={onHeaderMouseMove}
         onMouseDrag={onHeaderMouseDrag}
         onMouseDragEnd={onHeaderMouseDragEnd}
         onContextMenu={onHeaderContextMenu}
@@ -226,6 +229,7 @@ export function PaneHeader({
         backgroundColor={backgroundColor}
         flexDirection="row"
         onMouseDown={handleTerminalHeaderMouseDown}
+        onMouseMove={onHeaderMouseMove}
         onMouseDrag={onHeaderMouseDrag}
         onMouseDragEnd={onHeaderMouseDragEnd}
       >
@@ -263,6 +267,7 @@ export function PaneHeader({
       backgroundColor={backgroundColor}
       flexDirection="row"
       onMouseDown={handleTerminalHeaderMouseDown}
+      onMouseMove={onHeaderMouseMove}
       onMouseDrag={onHeaderMouseDrag}
       onMouseDragEnd={onHeaderMouseDragEnd}
     >

--- a/src/components/layout/pane/index.tsx
+++ b/src/components/layout/pane/index.tsx
@@ -16,7 +16,7 @@ interface PaneWrapperProps {
   flexGrow?: number;
   showActions?: boolean;
   onMouseDown?: (event: any) => void;
-  onMouseMove?: (event: any) => void;
+  onHeaderMouseMove?: (event: any) => void;
   onHeaderMouseDown?: (event: any) => void;
   onHeaderMouseDrag?: (event: any) => void;
   onHeaderMouseDragEnd?: (event: any) => void;
@@ -36,7 +36,7 @@ export function PaneWrapper({
   flexGrow,
   showActions = false,
   onMouseDown,
-  onMouseMove,
+  onHeaderMouseMove,
   onHeaderMouseDown,
   onHeaderMouseDrag,
   onHeaderMouseDragEnd,
@@ -76,7 +76,6 @@ export function PaneWrapper({
         showBorderColor: true,
       })}
       onMouseDown={onMouseDown}
-      onMouseMove={onMouseMove}
     >
       {title && (
         <PaneHeader
@@ -85,6 +84,7 @@ export function PaneWrapper({
           focused={focused}
           windowModeSelected={windowModeSelected}
           showActions={showActions}
+          onHeaderMouseMove={onHeaderMouseMove}
           onHeaderMouseDown={onHeaderMouseDown}
           onHeaderMouseDrag={onHeaderMouseDrag}
           onHeaderMouseDragEnd={onHeaderMouseDragEnd}

--- a/src/components/layout/shell/action-menu-overlay.tsx
+++ b/src/components/layout/shell/action-menu-overlay.tsx
@@ -52,7 +52,7 @@ export function ShellActionMenuOverlay({
             height={1}
             width={innerWidth}
             backgroundColor={hovered ? colors.selected : colors.panel}
-            onMouseMove={() => onHoverItem(item.id)}
+            onMouseOver={() => onHoverItem(item.id)}
             onMouseDown={(mouseEvent: any) => {
               mouseEvent.stopPropagation();
               mouseEvent.preventDefault();

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -525,7 +525,14 @@ export function Shell({
       height={nativePaneChrome ? undefined : contentHeight}
       position={nativePaneChrome ? "relative" : undefined}
       overflow="hidden"
-      {...(!nativePaneChrome ? { onMouse: handleMouse } : {})}
+      {...(!nativePaneChrome
+        ? {
+          onMouseDown: handleMouse,
+          onMouseDrag: handleMouse,
+          onMouseDragEnd: handleMouse,
+          onMouseUp: handleMouse,
+        }
+        : {})}
     >
       <Box
         position="absolute"

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -132,7 +132,7 @@ export function ShellPaneLayers({
                     windowModeSelected={windowModeSelected}
                     footer={footer}
                     onMouseDown={nativePaneChrome ? (event) => handleNativePaneMouseDown(leaf.instanceId, event) : undefined}
-                    onMouseMove={() => setHoveredPaneIfChanged(leaf.instanceId)}
+                    onHeaderMouseMove={() => setHoveredPaneIfChanged(leaf.instanceId)}
                     onHeaderMouseDown={nativePaneChrome && !transientFocusActive ? (event) => startNativeDockedDrag(leaf.instanceId, rect, event) : undefined}
                     onHeaderMouseDrag={nativePaneChrome && !transientFocusActive ? handleNativeDrag : undefined}
                     onHeaderMouseDragEnd={nativePaneChrome && !transientFocusActive ? handleNativeDrag : undefined}
@@ -192,7 +192,7 @@ export function ShellPaneLayers({
                   showActions={showActions}
                   footer={footer}
                   onMouseDown={nativePaneChrome ? (event) => handleNativePaneMouseDown(pane.instance.instanceId, event) : undefined}
-                  onMouseMove={() => setHoveredPaneIfChanged(pane.instance.instanceId)}
+                  onHeaderMouseMove={() => setHoveredPaneIfChanged(pane.instance.instanceId)}
                   onHeaderMouseDown={nativePaneChrome ? (event) => startNativeFloatingDrag(pane.instance.instanceId, preview, event) : undefined}
                   onHeaderMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
                   onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -364,7 +364,7 @@ function CommandBarHint({
     <Text
       fg={hovered ? colors.text : colors.textDim}
       {...(!nativePaneChrome ? { bg: hovered ? hoverBg() : undefined } : {})}
-      onMouseMove={() => setHoveredControl((current) => (current === "command-bar" ? current : "command-bar"))}
+      onMouseOver={() => setHoveredControl((current) => (current === "command-bar" ? current : "command-bar"))}
       onMouseDown={openCommandBar}
       {...(nativePaneChrome ? { "data-gloom-interactive": "true" } : {})}
     >
@@ -385,7 +385,7 @@ function NativeGridlockTip({
       <Text
         fg={hoveredControl === "gridlock-tip" ? colors.textBright : colors.borderFocused}
         attributes={TextAttributes.BOLD}
-        onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip" ? current : "gridlock-tip"))}
+        onMouseOver={() => setHoveredControl((current) => (current === "gridlock-tip" ? current : "gridlock-tip"))}
         onMouseDown={handleGridlockTip}
         data-gloom-interactive="true"
       >
@@ -393,7 +393,7 @@ function NativeGridlockTip({
       </Text>
       <Text
         fg={hoveredControl === "gridlock-tip-dismiss" ? colors.text : colors.textDim}
-        onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip-dismiss" ? current : "gridlock-tip-dismiss"))}
+        onMouseOver={() => setHoveredControl((current) => (current === "gridlock-tip-dismiss" ? current : "gridlock-tip-dismiss"))}
         onMouseDown={dismissGridlockTip}
         data-gloom-interactive="true"
       >
@@ -415,14 +415,14 @@ function TerminalGridlockTip({
       <Box width={1} />
       <Box
         backgroundColor={hoveredControl === "gridlock-tip" ? hoverBg() : colors.header}
-        onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip" ? current : "gridlock-tip"))}
+        onMouseOver={() => setHoveredControl((current) => (current === "gridlock-tip" ? current : "gridlock-tip"))}
         onMouseDown={handleGridlockTip}
       >
         <Text fg={colors.headerText}> Gridlock All </Text>
       </Box>
       <Text
         fg={hoveredControl === "gridlock-tip-dismiss" ? colors.text : colors.textDim}
-        onMouseMove={() => setHoveredControl((current) => (current === "gridlock-tip-dismiss" ? current : "gridlock-tip-dismiss"))}
+        onMouseOver={() => setHoveredControl((current) => (current === "gridlock-tip-dismiss" ? current : "gridlock-tip-dismiss"))}
         onMouseDown={dismissGridlockTip}
       >
         {" x"}

--- a/src/components/pane-settings-dialog/desktop.tsx
+++ b/src/components/pane-settings-dialog/desktop.tsx
@@ -183,7 +183,7 @@ function DesktopSettingsRow({
       flexDirection="column"
       minHeight={field.description ? undefined : 2}
       backgroundColor={hovered || selected ? desktopHoverSurface() : "transparent"}
-      onMouseMove={onHover}
+      onMouseOver={onHover}
       onMouseDown={field.type === "select" ? undefined : (event: any) => {
         event.stopPropagation?.();
         event.preventDefault?.();

--- a/src/components/price-performance.tsx
+++ b/src/components/price-performance.tsx
@@ -157,7 +157,7 @@ export function PriceReturnTable({
             height={1}
             width={width}
             backgroundColor={row.selected ? blendHex(colors.panel, colors.borderFocused, 0.18) : colors.panel}
-            onMouseMove={() => onSelectSymbol(row.symbol)}
+            onMouseOver={() => onSelectSymbol(row.symbol)}
             onMouseDown={(event: any) => {
               onFocusInteraction?.(event);
               onSelectSymbol(row.symbol);

--- a/src/components/table-view-shared.tsx
+++ b/src/components/table-view-shared.tsx
@@ -2,7 +2,6 @@ import {
   useCallback,
   useEffect,
   useRef,
-  useState,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -114,23 +113,16 @@ export function useTableViewState({
   headerScrollRef,
   scrollRef,
   syncHeaderScroll,
-  hoveredIdx,
-  setHoveredIdx,
 }: {
   headerScrollRef?: RefObject<ScrollBoxRenderable | null>;
   scrollRef?: RefObject<ScrollBoxRenderable | null>;
   syncHeaderScroll?: () => void;
-  hoveredIdx?: number | null;
-  setHoveredIdx?: (index: number | null) => void;
 }) {
   const internalHeaderScrollRef = useRef<ScrollBoxRenderable>(null);
   const internalScrollRef = useRef<ScrollBoxRenderable>(null);
-  const [internalHoveredIdx, setInternalHoveredIdx] = useState<number | null>(null);
 
   const effectiveHeaderScrollRef = headerScrollRef ?? internalHeaderScrollRef;
   const effectiveScrollRef = scrollRef ?? internalScrollRef;
-  const effectiveHoveredIdx = hoveredIdx !== undefined ? hoveredIdx : internalHoveredIdx;
-  const effectiveSetHoveredIdx = setHoveredIdx ?? setInternalHoveredIdx;
 
   const defaultSyncHeaderScroll = useCallback(() => {
     const body = effectiveScrollRef.current;
@@ -144,8 +136,6 @@ export function useTableViewState({
   return {
     effectiveHeaderScrollRef,
     effectiveScrollRef,
-    effectiveHoveredIdx,
-    effectiveSetHoveredIdx,
     effectiveSyncHeaderScroll: syncHeaderScroll ?? defaultSyncHeaderScroll,
   };
 }

--- a/src/components/ticker/list-table-view.tsx
+++ b/src/components/ticker/list-table-view.tsx
@@ -56,8 +56,6 @@ export interface TickerListTableViewProps {
   scrollRef?: RefObject<ScrollBoxRenderable | null>;
   syncHeaderScroll?: () => void;
   onBodyScrollActivity?: () => void;
-  hoveredIdx?: number | null;
-  setHoveredIdx?: (index: number | null) => void;
   keyboardNavigation?: boolean;
   onRootKeyDown?: (event: DataTableKeyEvent) => boolean | void;
   onVisibleRangeChange?: (range: TickerListVisibleRange) => void;
@@ -119,8 +117,6 @@ export function TickerListTableView({
   scrollRef,
   syncHeaderScroll,
   onBodyScrollActivity,
-  hoveredIdx,
-  setHoveredIdx,
   keyboardNavigation = true,
   onRootKeyDown,
   onVisibleRangeChange,
@@ -187,7 +183,7 @@ export function TickerListTableView({
     ticker: TickerRecord,
     column: ColumnConfig,
     _index: number,
-    rowState: { selected: boolean; hovered: boolean },
+    rowState: { selected: boolean },
   ) => {
     const financials = financialsMap.get(ticker.metadata.ticker);
     if (column.id === PRICE_SPARKLINE_COLUMN_ID) {
@@ -279,8 +275,6 @@ export function TickerListTableView({
       scrollRef={effectiveScrollRef}
       syncHeaderScroll={syncHeaderScroll}
       onBodyScrollActivity={handleBodyScrollActivity}
-      hoveredIdx={hoveredIdx}
-      setHoveredIdx={setHoveredIdx}
       keyboardNavigation={keyboardNavigation}
       onRootKeyDown={onRootKeyDown}
       resetScrollKey={resetScrollKey}

--- a/src/components/ticker/list-table.test.tsx
+++ b/src/components/ticker/list-table.test.tsx
@@ -32,8 +32,6 @@ const manyTickers: TickerRecord[] = Array.from({ length: 1000 }, (_, index) => (
   },
 }));
 
-function noop(_index: number | null): void {}
-
 function resolveCell(_column: ColumnConfig, ticker: TickerRecord, _financials: TickerFinancials | undefined): TickerTableCell {
   resolveCellCallCount += 1;
   return { text: ticker.metadata.ticker };
@@ -69,8 +67,6 @@ function LargeTickerListTableHarness() {
         columns={columns}
         tickers={manyTickers}
         cursorSymbol={cursorSymbol}
-        hoveredIdx={null}
-        setHoveredIdx={noop}
         setCursorSymbol={setCursorSymbol}
         resolveCell={resolveCell}
         financialsMap={financialsMap}

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -40,8 +40,6 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   scrollRef,
   syncHeaderScroll,
   onBodyScrollActivity,
-  hoveredIdx,
-  setHoveredIdx,
   headerScrollId,
   bodyScrollId,
   getItemKey,
@@ -369,8 +367,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                 }
 
                 const selected = isSelected(item, index);
-                const hovered = hoveredIdx === index && !selected;
-                const rowState = { selected, hovered };
+                const rowState = { selected };
                 const rowBackgroundColor = getRowBackgroundColor?.(
                   item,
                   index,
@@ -378,9 +375,8 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                 );
                 const rowBg = selected
                   ? colors.selected
-                  : hovered
-                    ? hoverBg()
-                    : rowBackgroundColor ?? colors.bg;
+                  : rowBackgroundColor ?? colors.bg;
+                const rowHoverBg = selected ? undefined : hoverBg();
 
                 return (
                   <Box
@@ -390,10 +386,8 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                     {...tableContentWidthProps(contentWidth)}
                     paddingX={horizontalPadding}
                     backgroundColor={rowBg}
+                    hoverBackgroundColor={rowHoverBg}
                     data-gloom-context-menu-surface={rowContextMenuSurface ? "true" : undefined}
-                    onMouseMove={() => {
-                      if (hoveredIdx !== index) setHoveredIdx(index);
-                    }}
                     onMouseDown={(event: any) => {
                       focusPane();
                       onTableMouseDown?.(event);

--- a/src/components/ui/data-table/types.ts
+++ b/src/components/ui/data-table/types.ts
@@ -29,6 +29,10 @@ export interface DataTableSectionHeader {
 
 export type DataTableScrollAlign = "nearest" | "center";
 
+export interface DataTableRowState {
+  selected: boolean;
+}
+
 export interface DataTableProps<
   T,
   C extends DataTableColumn = DataTableColumn,
@@ -42,8 +46,6 @@ export interface DataTableProps<
   scrollRef: RefObject<ScrollBoxRenderable | null>;
   syncHeaderScroll: () => void;
   onBodyScrollActivity: () => void;
-  hoveredIdx: number | null;
-  setHoveredIdx: (index: number | null) => void;
   headerScrollId?: string;
   bodyScrollId?: string;
   getItemKey: (item: T, index: number) => string;
@@ -58,7 +60,7 @@ export interface DataTableProps<
     item: T,
     column: C,
     index: number,
-    rowState: { selected: boolean; hovered: boolean },
+    rowState: DataTableRowState,
   ) => DataTableCell;
   renderSectionHeader?: (
     item: T,
@@ -67,7 +69,7 @@ export interface DataTableProps<
   getRowBackgroundColor?: (
     item: T,
     index: number,
-    rowState: { selected: boolean; hovered: boolean },
+    rowState: DataTableRowState,
   ) => string | undefined;
   emptyContent?: ReactNode;
   bodyAfter?: ReactNode;

--- a/src/components/ui/list-view.tsx
+++ b/src/components/ui/list-view.tsx
@@ -166,7 +166,7 @@ export function ListView({
         key={item.id}
         height={1}
         backgroundColor={rowBg}
-        onMouseMove={() => {
+        onMouseOver={() => {
           if (!disabled) {
             setHoveredIndex((current) => (current === index ? current : index));
             if (selectOnHover) onSelect?.(index);

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -287,7 +287,6 @@ function OpenTuiTabs({
             flexDirection="row"
             backgroundColor={active && variant === "pill" ? palette.activeBg : hovered ? palette.hoverBg : undefined}
             onMouseOver={startHover}
-            onMouseMove={startHover}
             onMouseOut={endHover}
             onMouseDown={selectTab}
             onDoubleClick={tab.disabled || !tab.onDoubleClick ? undefined : () => tab.onDoubleClick?.(tab.value)}
@@ -319,7 +318,7 @@ function OpenTuiTabs({
           width={addWidth}
           height={1}
           backgroundColor={hoveredValue === "__add__" ? palette.hoverBg : undefined}
-          onMouseMove={() => setHoveredValue((current) => (current === "__add__" ? current : "__add__"))}
+          onMouseOver={() => setHoveredValue((current) => (current === "__add__" ? current : "__add__"))}
           onMouseOut={() => setHoveredValue((current) => (current === "__add__" ? null : current))}
           onMouseDown={(event: TabPointerEvent) => {
             event.preventDefault();

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -51,7 +51,6 @@ function DataTableActivationHarness() {
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
 
   return (
     <DataTable
@@ -64,8 +63,6 @@ function DataTableActivationHarness() {
       scrollRef={scrollRef}
       syncHeaderScroll={() => {}}
       onBodyScrollActivity={() => {}}
-      hoveredIdx={hoveredIdx}
-      setHoveredIdx={setHoveredIdx}
       getItemKey={(row) => row.id}
       isSelected={(row) => selectedId === row.id}
       onSelect={(row) => {
@@ -89,7 +86,6 @@ function DataTableSectionHarness() {
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const rows: SectionTableRow[] = [
     { kind: "header", id: "macro", label: "Macro Releases" },
     { kind: "row", id: "cpi", name: "CPI" },
@@ -106,8 +102,6 @@ function DataTableSectionHarness() {
       scrollRef={scrollRef}
       syncHeaderScroll={() => {}}
       onBodyScrollActivity={() => {}}
-      hoveredIdx={hoveredIdx}
-      setHoveredIdx={setHoveredIdx}
       getItemKey={(row) => row.id}
       isSelected={(row) => row.kind === "row" && row.id === selectedId}
       onSelect={(row) => {
@@ -211,7 +205,6 @@ function DataTableColumnGapHarness() {
 function DataTableVirtualizationHarness() {
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
-  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const rows = Array.from({ length: 100 }, (_, index) => ({
     id: `row-${index}`,
     name: `Row ${index}`,
@@ -237,8 +230,6 @@ function DataTableVirtualizationHarness() {
       scrollRef={scrollRef}
       syncHeaderScroll={() => {}}
       onBodyScrollActivity={() => {}}
-      hoveredIdx={hoveredIdx}
-      setHoveredIdx={setHoveredIdx}
       getItemKey={(row) => row.id}
       isSelected={() => false}
       onSelect={() => {}}

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -85,7 +85,7 @@ export function PickerRow({
   return (
     <Box
       flexDirection="column"
-      onMouseMove={onFocus}
+      onMouseOver={onFocus}
       onMouseDown={(event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
         event?.stopPropagation?.();
         event?.preventDefault?.();
@@ -135,7 +135,7 @@ export function CheckboxRow({
     <Box
       flexDirection="column"
       backgroundColor={hovered ? hoverBg() : undefined}
-      onMouseMove={() => {
+      onMouseOver={() => {
         setHovered(true);
         onFocus();
       }}

--- a/src/plugins/builtin/alerts/pane.tsx
+++ b/src/plugins/builtin/alerts/pane.tsx
@@ -214,7 +214,7 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     alert: AlertRule,
     column: AlertColumn,
     _index: number,
-    rowState: { selected: boolean; hovered: boolean },
+    rowState: { selected: boolean },
   ): DataTableCell => {
     const selectedColor = rowState.selected ? colors.selectedText : undefined;
     const actionMouseDown = (handler: () => void) => (

--- a/src/plugins/builtin/buildout/cells.tsx
+++ b/src/plugins/builtin/buildout/cells.tsx
@@ -26,7 +26,7 @@ interface BuildoutCellContext {
 export function renderBuildoutCell(
   row: BuildoutRow,
   column: BuildoutColumn,
-  rowState: { selected: boolean; hovered: boolean },
+  rowState: { selected: boolean },
   context: BuildoutCellContext,
 ): DataTableCell {
   const selectedColor = rowState.selected ? colors.selectedText : undefined;

--- a/src/plugins/builtin/buildout/pane/index.tsx
+++ b/src/plugins/builtin/buildout/pane/index.tsx
@@ -314,7 +314,7 @@ export function BuildoutPane({ focused, width, height }: PaneProps) {
     row: BuildoutRow,
     column: BuildoutColumn,
     _index: number,
-    rowState: { selected: boolean; hovered: boolean },
+    rowState: { selected: boolean },
   ) => renderBuildoutCell(row, column, rowState, {
     favoriteBusyKey,
     toggleFavorite,

--- a/src/plugins/builtin/chat/message/desktop.tsx
+++ b/src/plugins/builtin/chat/message/desktop.tsx
@@ -97,7 +97,7 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
           <Text
             fg={state.authorColor}
             attributes={state.authorAttributes}
-            onMouseMove={() => onUserHover(msg.user)}
+            onMouseOver={() => onUserHover(msg.user)}
             onMouseOut={onUserHoverEnd}
             style={{ cursor: "default" }}
           >

--- a/src/plugins/builtin/chat/message/inline-tokens.tsx
+++ b/src/plugins/builtin/chat/message/inline-tokens.tsx
@@ -58,7 +58,7 @@ export function ResponsiveTickerBadgeText({
         height={1}
         flexDirection="row"
         backgroundColor={blendHex(colors.panel, colors.positive, 0.24)}
-        onMouseMove={() => {
+        onMouseOver={() => {
           if (user) onUserHover?.(user);
         }}
         onMouseOut={() => {

--- a/src/plugins/builtin/chat/message/terminal.tsx
+++ b/src/plugins/builtin/chat/message/terminal.tsx
@@ -44,7 +44,7 @@ export function TerminalChatMessage({
   const messageRowProps = {
     width: contentWidth,
     backgroundColor: state.bgColor,
-    onMouseMove: setHovered,
+    onMouseOver: setHovered,
     onMouseOut: clearHovered,
   };
 
@@ -80,7 +80,7 @@ export function TerminalChatMessage({
           <Text
             fg={state.authorColor}
             attributes={state.authorAttributes}
-            onMouseMove={() => onUserHover(msg.user)}
+            onMouseOver={() => onUserHover(msg.user)}
             onMouseOut={onUserHoverEnd}
           >
             {msg.user.username ?? "anon"}

--- a/src/plugins/builtin/chat/sidebar.tsx
+++ b/src/plugins/builtin/chat/sidebar.tsx
@@ -239,7 +239,7 @@ export function ChannelSidebar({
               flexDirection="row"
               backgroundColor={bg}
               onMouseDown={selectChannel}
-              onMouseMove={() => setHoveredChannelId((current) => (current === channel.id ? current : channel.id))}
+              onMouseOver={() => setHoveredChannelId((current) => (current === channel.id ? current : channel.id))}
               onMouseOut={() => setHoveredChannelId((current) => (current === channel.id ? null : current))}
               style={{ cursor: "pointer" }}
             >

--- a/src/plugins/builtin/chat/status-widget.tsx
+++ b/src/plugins/builtin/chat/status-widget.tsx
@@ -98,7 +98,7 @@ export function ChatStatusWidget({ controller = chatController }: ChatStatusWidg
         <Box
           flexDirection="row"
           backgroundColor={hovered ? hoverBg() : undefined}
-          onMouseMove={() => setHovered((current) => (current ? current : true))}
+          onMouseOver={() => setHovered((current) => (current ? current : true))}
           onMouseOut={() => setHovered((current) => (current ? false : current))}
           onMouseDown={openChat}
         >

--- a/src/plugins/builtin/cloud/auth-actions.tsx
+++ b/src/plugins/builtin/cloud/auth-actions.tsx
@@ -22,7 +22,7 @@ export function InlineAuthActions({ showSignup = true }: { showSignup?: boolean 
     <Box flexDirection="row">
       <Box
         backgroundColor={hoveredAction === "login" ? hoverBg() : undefined}
-        onMouseMove={() => setHoveredAction((current) => (current === "login" ? current : "login"))}
+        onMouseOver={() => setHoveredAction((current) => (current === "login" ? current : "login"))}
         onMouseOut={() => setHoveredAction((current) => (current === "login" ? null : current))}
         onMouseDown={(event: any) => openAuthCommand(openCommandBar, "Log In", event)}
       >
@@ -33,7 +33,7 @@ export function InlineAuthActions({ showSignup = true }: { showSignup?: boolean 
           <Text fg={colors.textDim}>/</Text>
           <Box
             backgroundColor={hoveredAction === "signup" ? hoverBg() : undefined}
-            onMouseMove={() => setHoveredAction((current) => (current === "signup" ? current : "signup"))}
+            onMouseOver={() => setHoveredAction((current) => (current === "signup" ? current : "signup"))}
             onMouseOut={() => setHoveredAction((current) => (current === "signup" ? null : current))}
             onMouseDown={(event: any) => openAuthCommand(openCommandBar, "Sign Up", event)}
           >

--- a/src/plugins/builtin/correlation/matrix/symbol-cell.tsx
+++ b/src/plugins/builtin/correlation/matrix/symbol-cell.tsx
@@ -41,7 +41,7 @@ export function SymbolLabelCell({
       overflow="hidden"
       backgroundColor={hovered ? hoverBg() : undefined}
       style={{ cursor: "pointer" }}
-      onMouseMove={() => onHover(symbol)}
+      onMouseOver={() => onHover(symbol)}
       onMouseOut={() => onLeave(symbol)}
       onMouseDown={(event: any) => handleSymbolMouseDown(event, openSymbol)}
     >

--- a/src/plugins/builtin/debug/index.tsx
+++ b/src/plugins/builtin/debug/index.tsx
@@ -64,7 +64,6 @@ function DebugPane({ focused, width, height }: PaneProps) {
   const [filterSource, setFilterSource] = useState<string | null>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [selectedIdx, setSelectedIdx] = useState(-1);
-  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [showDetail, setShowDetail] = useState(false);
   const sourcesRef = useRef<string[]>(debugLog.getSources());
 
@@ -261,8 +260,8 @@ function DebugPane({ focused, width, height }: PaneProps) {
         {visibleEntries.map((entry, i) => {
           const globalIdx = viewStart + i;
           const isSelected = globalIdx === selectedIdx;
-          const isHovered = globalIdx === hoveredIdx && !isSelected;
-          const bgColor = isSelected ? colors.selected : isHovered ? hoverBg() : undefined;
+          const bgColor = isSelected ? colors.selected : undefined;
+          const rowHoverBg = isSelected ? undefined : hoverBg();
           const ts = formatTimestamp(entry.timestamp);
           const lvl = LEVEL_LABELS[entry.level];
           const sourceTag = entry.source;
@@ -278,7 +277,7 @@ function DebugPane({ focused, width, height }: PaneProps) {
               width={contentWidth}
               flexDirection="row"
               backgroundColor={bgColor}
-              onMouseMove={() => setHoveredIdx((current) => (current === globalIdx ? current : globalIdx))}
+              hoverBackgroundColor={rowHoverBg}
               onMouseDown={() => { setSelectedIdx(globalIdx); setAutoScroll(false); }}
             >
               <Text fg={colors.textMuted}> {ts} </Text>

--- a/src/plugins/builtin/help/components.tsx
+++ b/src/plugins/builtin/help/components.tsx
@@ -63,7 +63,7 @@ export function ActionButton({
   return (
     <Box
       backgroundColor={hovered ? hoverBg() : colors.panel}
-      onMouseMove={() => onHover(id)}
+      onMouseOver={() => onHover(id)}
       onMouseOut={() => onHover(null)}
       onMouseDown={(event: any) => {
         event.stopPropagation?.();

--- a/src/plugins/builtin/holders/treemap.tsx
+++ b/src/plugins/builtin/holders/treemap.tsx
@@ -165,7 +165,7 @@ function DesktopTile({ tile, chartWidth, chartHeight, selected, hovered, currenc
         onSelect();
       }}
       onDoubleClick={onActivate}
-      onMouseMove={() => onHover(true)}
+      onMouseOver={() => onHover(true)}
       onMouseOut={() => onHover(false)}
     >
       {canShowLabel && (

--- a/src/plugins/builtin/options/table.ts
+++ b/src/plugins/builtin/options/table.ts
@@ -130,9 +130,9 @@ function optionMoneynessBackground(
   row: OptionTableRow,
   contract: OptionContract | undefined,
   columnId: OptionColumnId,
-  rowState: { selected: boolean; hovered: boolean },
+  rowState: { selected: boolean },
 ): string | undefined {
-  if (rowState.selected || rowState.hovered) return undefined;
+  if (rowState.selected) return undefined;
   const inTheMoney = inferColumnMoneyness(row, contract, columnId);
   const sideColor = columnId.startsWith("call") ? colors.positive : colors.negative;
   return inTheMoney
@@ -180,13 +180,13 @@ export function renderOptionCell(
   row: OptionTableRow,
   column: OptionColumn,
   _index: number,
-  rowState: { selected: boolean; hovered: boolean },
+  rowState: { selected: boolean },
 ): DataTableCell {
   const selectedColor = rowState.selected ? colors.selectedText : undefined;
-  const rowSurface = rowState.selected ? colors.selected : rowState.hovered ? hoverBg() : colors.bg;
+  const rowSurface = rowState.selected ? colors.selected : colors.bg;
 
   if (column.id === "strike") {
-    const backgroundColor = rowState.selected || rowState.hovered
+    const backgroundColor = rowState.selected
       ? undefined
       : blendHex(colors.bg, row.isPositionStrike ? colors.borderFocused : colors.header, row.isPositionStrike ? 0.18 : 0.1);
     const surface = backgroundColor ?? rowSurface;

--- a/src/plugins/ibkr/trade/ticket-panel.tsx
+++ b/src/plugins/ibkr/trade/ticket-panel.tsx
@@ -72,7 +72,7 @@ function TradeFieldPill({
       backgroundColor={backgroundColor}
       paddingX={1}
       marginRight={1}
-      onMouseMove={() => {
+      onMouseOver={() => {
         if (!disabled) setHoveredField((current) => (current === id ? current : id));
       }}
       onMouseDown={disabled ? undefined : () => {

--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -53,8 +53,6 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   scrollRef,
   syncHeaderScroll: _syncHeaderScroll,
   onBodyScrollActivity,
-  hoveredIdx,
-  setHoveredIdx,
   getItemKey,
   isSelected,
   onSelect,
@@ -257,9 +255,6 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
           focusPane();
           onTableMouseDown?.({});
         }}
-        onMouseLeave={() => {
-          if (hoveredIdx !== null) setHoveredIdx(null);
-        }}
         onScroll={() => {
           markScrollbarActive();
           scheduleBodyScrollActivity();
@@ -315,7 +310,6 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                 const item = items[row.index];
                 if (!item) return null;
                 const selected = isSelected(item, row.index);
-                const hovered = hoveredIdx === row.index && !selected;
                 const itemKey = getItemKey(item, row.index);
                 return (
                   <WebDataTableRow<T, C>
@@ -335,13 +329,11 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                     onRowContextMenu={onRowContextMenu}
                     onRowMouseDown={onRowMouseDown}
                     onSelectRow={selectRow}
-                    hovered={hovered}
                     getRowBackgroundColor={getRowBackgroundColor}
                     renderCell={renderCell}
                     renderSectionHeader={renderSectionHeader}
                     rowContextMenuSurface={rowContextMenuSurface}
                     selected={selected}
-                    setHoveredIdx={setHoveredIdx}
                   />
                 );
               }),

--- a/src/renderers/electrobun/view/data-table/row.tsx
+++ b/src/renderers/electrobun/view/data-table/row.tsx
@@ -12,7 +12,6 @@ import type {
 import { WEB_CELL_HEIGHT } from "../input-host";
 import {
   CSS_BG,
-  CSS_HOVER_BG,
   CSS_PANEL,
   CSS_SELECTED,
   CSS_SELECTED_TEXT,
@@ -151,7 +150,6 @@ function WebDataTableRowInner<
   onRowContextMenu,
   onRowMouseDown,
   onSelectRow,
-  hovered,
   index,
   item,
   itemKey,
@@ -163,7 +161,6 @@ function WebDataTableRowInner<
   rowStart,
   rowContextMenuSurface,
   selected,
-  setHoveredIdx,
 }: {
   columns: C[];
   columnGap: number;
@@ -174,7 +171,6 @@ function WebDataTableRowInner<
   onRowContextMenu?: DataTableProps<T, C>["onRowContextMenu"];
   onRowMouseDown?: DataTableProps<T, C>["onRowMouseDown"];
   onSelectRow: (item: T, index: number) => void;
-  hovered: boolean;
   index: number;
   item: T;
   itemKey: string;
@@ -186,7 +182,6 @@ function WebDataTableRowInner<
   rowStart: number;
   rowContextMenuSurface: boolean;
   selected: boolean;
-  setHoveredIdx: (index: number | null) => void;
 }) {
   useThemeColors();
   const sectionHeader: DataTableSectionHeader | null =
@@ -242,13 +237,11 @@ function WebDataTableRowInner<
     );
   }
 
-  const rowState = { selected, hovered };
+  const rowState = { selected };
   const rowBackgroundColor = getRowBackgroundColor?.(item, index, rowState);
   const rowBg = selected
     ? CSS_SELECTED
-    : hovered
-      ? CSS_HOVER_BG
-      : rowBackgroundColor ?? CSS_BG;
+    : rowBackgroundColor ?? CSS_BG;
 
   return (
     <div
@@ -259,9 +252,6 @@ function WebDataTableRowInner<
       style={{
         ...baseRowStyle,
         backgroundColor: rowBg,
-      }}
-      onMouseMove={() => {
-        if (!hovered) setHoveredIdx(index);
       }}
       onMouseDown={(event) => {
         focusPane();

--- a/src/renderers/electrobun/view/host/box.tsx
+++ b/src/renderers/electrobun/view/host/box.tsx
@@ -33,6 +33,9 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
     const pendingDragRef = useRef<CellMouseEvent | null>(null);
     const propsRef = useRef(props);
     propsRef.current = props;
+    const hoverBackgroundColor = typeof props.hoverBackgroundColor === "string"
+      ? props.hoverBackgroundColor
+      : undefined;
 
     useImperativeHandle(ref, () => cellBoundsForElement(() => elementRef.current, () => propsRef.current) as unknown as HTMLDivElement, []);
 
@@ -140,6 +143,7 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
     return (
       <div
         {...cleanDomProps(props)}
+        data-gloom-hover-bg={hoverBackgroundColor ? "true" : undefined}
         data-gloom-interactive={hasDirectMouseHandler(props) ? "true" : undefined}
         ref={elementRef}
         onMouseDown={handleMouseDown}
@@ -149,9 +153,10 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
         onWheel={typeof props.onMouseScroll === "function" ? handleWheel : undefined}
         style={{
           ...commonStyle(props),
+          "--gloom-box-hover-bg": hoverBackgroundColor,
           ...(props.style as CSSProperties | undefined),
           ...(props.visible === false ? { display: "none" } : undefined),
-        }}
+        } as CSSProperties}
       >
         {children as ReactNode}
       </div>

--- a/src/renderers/electrobun/view/host/style.ts
+++ b/src/renderers/electrobun/view/host/style.ts
@@ -104,6 +104,7 @@ export function cleanDomProps(props: Record<string, unknown>): Record<string, un
     "cursorColor", "selectionBg", "selectionFg", "showCursor", "keyBindings", "wrapText", "wrapMode",
     "initialValue", "value", "onInput", "onChange", "onSubmit", "onCursorChange", "onMouse",
     "scrollX", "scrollY", "focusable", "bitmap", "bitmaps", "crosshair", "text", "font",
+    "hoverBackgroundColor",
   ]) {
     delete next[key];
   }

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -20,6 +20,13 @@ body {
 input, textarea, button { font: inherit; }
 input, textarea { cursor: text; user-select: text; }
 button, [data-gloom-interactive="true"] { cursor: pointer; }
+[data-gloom-hover-bg="true"]:hover {
+  background-color: var(--gloom-box-hover-bg) !important;
+}
+[data-gloom-role="data-table-row"]:not([data-selected="true"]):hover,
+[data-gloom-role="data-table-row"]:not([data-selected="true"]):hover > [data-gloom-role="data-table-cell"] {
+  background-color: var(--gloom-hover-bg) !important;
+}
 [data-gloom-role="pane-window"] {
   background-clip: padding-box;
   isolation: isolate;


### PR DESCRIPTION
## Summary
- Add native OpenTUI Box hover background support so high-volume row hover paint no longer requires React row-hover state commits.
- Remove shared DataTable hover state plumbing and use native hover paint for table/debug rows.
- Convert simple hover-enter handlers from continuous mouse move events to mouse-over events while leaving true pointer tracking paths unchanged.

Fixes #452.

## Validation
- bun install --frozen-lockfile
- bun test src/components/ui/ui.test.tsx src/components/ticker/list-table.test.tsx src/components/data-table/stack-view.test.tsx src/plugins/builtin/options/table.test.ts src/plugins/builtin/debug/index.test.tsx
- bun test src/components/command-bar/helpers.test.ts src/plugins/builtin/chat/message/render-state.test.ts src/plugins/builtin/correlation/matrix/model.test.ts
- bun test src/components/layout/status-bar.test.tsx src/plugins/builtin/chat/sidebar.test.tsx src/plugins/builtin/chat/chat.test.tsx src/plugins/builtin/options/view.test.tsx
- bun test src/plugins/builtin/correlation/index.test.tsx src/plugins/builtin/holders/index.test.ts src/plugins/builtin/account-management/model.test.ts
- bun test src/components/command-bar/surface/index.test.tsx src/components/command-bar/surface/pane.test.tsx src/components/command-bar/surface/portfolio.test.tsx src/components/command-bar/view-model.test.ts src/components/command-bar/workflow/ops.test.ts src/components/command-bar/routes/root/shortcuts.test.ts src/components/command-bar/layout-items/current-layout.test.ts
- Real app tmux stress: app RSS 639.7MB start, 644.5MB after 16 mouse batches, 646.8MB after 20s idle

## Notes
- Full tsc still reports existing project-wide type noise; no new touched-file hover API errors were surfaced by the filtered check.