### PR TITLE
Fix OpenTUI React user timing leak

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
   "patchedDependencies": {
     "@opentui/core@0.3.2": "patches/@opentui%2Fcore@0.3.2.patch",
     "electrobun@1.18.1": "patches/electrobun@1.18.1.patch",
+    "react-reconciler@0.33.0": "patches/react-reconciler@0.33.0.patch",
   },
   "packages": {
     "@babylonjs/core": ["@babylonjs/core@7.54.3", "", {}, "sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw=="],

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "patchedDependencies": {
     "@opentui/core@0.3.2": "patches/@opentui%2Fcore@0.3.2.patch",
-    "electrobun@1.18.1": "patches/electrobun@1.18.1.patch"
+    "electrobun@1.18.1": "patches/electrobun@1.18.1.patch",
+    "react-reconciler@0.33.0": "patches/react-reconciler@0.33.0.patch"
   }
 }

--- a/patches/react-reconciler@0.33.0.patch
+++ b/patches/react-reconciler@0.33.0.patch
@@ -1,0 +1,10 @@
+diff --git a/cjs/react-reconciler.development.js b/cjs/react-reconciler.development.js
+--- a/cjs/react-reconciler.development.js
++++ b/cjs/react-reconciler.development.js
+@@ -17213,5 +17213,6 @@
+       hasOwnProperty = Object.prototype.hasOwnProperty,
+       supportsUserTiming =
++        "undefined" !== typeof window &&
+         "undefined" !== typeof console &&
+         "function" === typeof console.timeStamp &&
+         "undefined" !== typeof performance &&

--- a/src/components/chart/native/kitty/index.test.ts
+++ b/src/components/chart/native/kitty/index.test.ts
@@ -143,6 +143,53 @@ describe("resolveNativeSurfaceVisibleRect", () => {
 
     expect(resolveNativeSurfaceVisibleRect(child, 100, 30)).toBeNull();
   });
+
+  test("stops at repeated ancestors in cyclic native renderable trees", () => {
+    const root: NativeSurfaceRenderableNode = {
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 30,
+      parent: null,
+    };
+    const child: NativeSurfaceRenderableNode = {
+      x: 2,
+      y: 3,
+      width: 20,
+      height: 8,
+      parent: root,
+    };
+    root.parent = child;
+
+    expect(resolveNativeSurfaceVisibleRect(child, 100, 30)).toEqual({
+      x: 2,
+      y: 3,
+      width: 20,
+      height: 8,
+    });
+  });
+
+  test("fails closed when native renderable ancestors exceed a sane depth", () => {
+    let node: NativeSurfaceRenderableNode = {
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 30,
+      parent: null,
+    };
+
+    for (let index = 0; index < 300; index += 1) {
+      node = {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 30,
+        parent: node,
+      };
+    }
+
+    expect(resolveNativeSurfaceVisibleRect(node, 100, 30)).toBeNull();
+  });
 });
 
 describe("renderNativeChartBase", () => {

--- a/src/components/chart/native/surface/visibility.ts
+++ b/src/components/chart/native/surface/visibility.ts
@@ -9,6 +9,8 @@ export interface NativeSurfaceRenderableNode {
   parent: NativeSurfaceRenderableNode | null;
 }
 
+const MAX_RENDERABLE_ANCESTOR_DEPTH = 256;
+
 export function getRenderableCellRect(
   renderable: Pick<NativeSurfaceRenderableNode, "x" | "y" | "width" | "height">,
 ): CellRect {
@@ -34,8 +36,13 @@ export function resolveNativeSurfaceVisibleRect(
     height: terminalHeight,
   };
   let current: NativeSurfaceRenderableNode | null = renderable;
+  const seen = new Set<NativeSurfaceRenderableNode>();
+  let depth = 0;
 
-  while (current) {
+  while (current && !seen.has(current)) {
+    if (depth >= MAX_RENDERABLE_ANCESTOR_DEPTH) return null;
+    seen.add(current);
+    depth += 1;
     if (current.visible === false) return null;
 
     const nextVisible = intersectCellRects(visible, getRenderableCellRect(current));

--- a/src/components/layout/shell/cursor-occlusion.ts
+++ b/src/components/layout/shell/cursor-occlusion.ts
@@ -23,6 +23,8 @@ interface ResolveShellCursorOcclusionRectsOptions {
   width: number;
 }
 
+const MAX_RENDERABLE_ANCESTOR_DEPTH = 256;
+
 export function resolveShellCursorOcclusionRects({
   contentHeight,
   dragFloatingRect,
@@ -102,7 +104,13 @@ function readRenderableBounds(renderable: unknown): LayoutBounds | null {
 
 function readRenderablePaneId(renderable: unknown): string | null {
   let current = renderable;
-  while (current && typeof current === "object") {
+  const seen = new Set<object>();
+  let depth = 0;
+
+  while (current && typeof current === "object" && !seen.has(current)) {
+    if (depth >= MAX_RENDERABLE_ANCESTOR_DEPTH) return null;
+    seen.add(current);
+    depth += 1;
     const record = current as Record<string, unknown>;
     const paneId = record["data-gloom-pane-id"];
     if (typeof paneId === "string") return paneId;


### PR DESCRIPTION
## Summary
- patch react-reconciler dev User Timing detection so Bun/OpenTUI terminal renders do not enable browser performance measures
- keep app startup/imports normal; no app-level guard or hover-state workaround
- bound native renderable ancestor walks to avoid cyclic parent chains in native surface and cursor occlusion code

## Root cause
After the OpenTUI/React dependency update, react-reconciler@0.33.0 enabled dev User Timing under Bun because Bun exposes console.timeStamp and performance.measure even outside a browser. The terminal renderer then filled Bun performance entries during normal OpenTUI rendering, which drove memory and CPU growth.

## Validation
- bun install --frozen-lockfile
- bun test src/components/chart/native/kitty/index.test.ts
- bun test src/components/layout/shell/index.test.tsx
- direct OpenTUI render with performance.measure monkey-patched: measureCount 0
- forced native tmux run with current ~/.gloomberb data: 527 MB -> 562 MB RSS over 1:57, CPU idle
- clean bun run dev tmux run with focus/layout/command interactions: 554 MB -> 586 MB RSS over 2:05, responsive
- bun src/index.tsx help
- bun bin/gloomberb help
- bun run build