### PR TITLE
Restore focus after closing floating pane

### DIFF
--- a/src/app/pane-runtime/index.tsx
+++ b/src/app/pane-runtime/index.tsx
@@ -73,17 +73,20 @@ export function useAppPaneRuntime({
     return resolvePaneTargetInLayout(layout, paneId);
   }, [state.config.layout]);
 
-  const persistLayout = useCallback((layout: LayoutConfig, options?: { pushHistory?: boolean }) => {
+  const persistLayout = useCallback((layout: LayoutConfig, options?: { pushHistory?: boolean; focusedPaneId?: string | null }) => {
     const currentState = stateRef.current;
     const normalizedLayout = normalizePaneLayout(layout);
     if (options?.pushHistory !== false) {
       dispatch({ type: "PUSH_LAYOUT_HISTORY" });
     }
-    dispatch({ type: "UPDATE_LAYOUT", layout: normalizedLayout });
+    const hasFocusTarget = !!options && Object.prototype.hasOwnProperty.call(options, "focusedPaneId");
+    dispatch(hasFocusTarget
+      ? { type: "UPDATE_LAYOUT", layout: normalizedLayout, focusedPaneId: options.focusedPaneId ?? null }
+      : { type: "UPDATE_LAYOUT", layout: normalizedLayout });
     scheduleConfigSave(syncConfigActiveLayoutState(
       { ...currentState.config, layout: normalizedLayout },
       currentState.paneState,
-      currentState.focusedPaneId,
+      hasFocusTarget ? (options.focusedPaneId ?? null) : currentState.focusedPaneId,
       currentState.activePanel,
     ));
   }, [dispatch, stateRef]);

--- a/src/app/pane-runtime/pane-settings-runtime.tsx
+++ b/src/app/pane-runtime/pane-settings-runtime.tsx
@@ -15,7 +15,7 @@ interface UseAppPaneSettingsRuntimeOptions {
   dataProvider: DataProvider;
   dialog: DialogApi;
   dispatch: Dispatch<AppAction>;
-  persistLayout: (layout: LayoutConfig, options?: { pushHistory?: boolean }) => void;
+  persistLayout: (layout: LayoutConfig, options?: { pushHistory?: boolean; focusedPaneId?: string | null }) => void;
   pluginRegistry: PluginRegistry;
   resolvePaneTarget: (paneId: string, layout?: LayoutConfig) => string | null;
   stateRef: { current: AppState };

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -1271,6 +1271,7 @@ describe("Shell", () => {
         layouts: [{ name: "Default", layout: cloneLayout(mixedLayout) }],
       }),
       focusedPaneId: "ticker-detail:main",
+      previousFocusedPaneId: "portfolio-list:main",
     };
     const actions: Array<any> = [];
 
@@ -1294,6 +1295,7 @@ describe("Shell", () => {
     expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId)).toEqual(["portfolio-list:main"]);
     expect(updateLayout?.layout.floating).toEqual([]);
     expect(updateLayout?.layout.dockRoot).toEqual({ kind: "pane", instanceId: "portfolio-list:main" });
+    expect(updateLayout?.focusedPaneId).toBe("portfolio-list:main");
   });
 
   test("closes the focused floating pane with Cmd+W", async () => {

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -95,6 +95,7 @@ export function Shell({
   const config = useAppSelector((state) => state.config);
   const paneState = useAppSelector((state) => state.paneState);
   const focusedPaneId = useAppSelector(selectFocusedPaneId);
+  const previousFocusedPaneId = useAppSelector((state) => state.previousFocusedPaneId);
   const activePanel = useAppSelector((state) => state.activePanel);
   const commandBarOpen = useAppSelector(selectCommandBarOpen);
   const inputCaptured = useAppSelector((state) => state.inputCaptured);
@@ -154,15 +155,18 @@ export function Shell({
   ), [nativePaneChrome]);
   const bounds = useMemo<LayoutBounds>(() => ({ x: 0, y: 0, width, height: contentHeight }), [contentHeight, width]);
 
-  const persistLayout = useCallback((nextLayout: LayoutConfig, options?: { pushHistory?: boolean }) => {
+  const persistLayout = useCallback((nextLayout: LayoutConfig, options?: { pushHistory?: boolean; focusedPaneId?: string | null }) => {
     if (options?.pushHistory !== false) {
       dispatch({ type: "PUSH_LAYOUT_HISTORY" });
     }
-    dispatch({ type: "UPDATE_LAYOUT", layout: nextLayout });
+    const hasFocusTarget = !!options && Object.prototype.hasOwnProperty.call(options, "focusedPaneId");
+    dispatch(hasFocusTarget
+      ? { type: "UPDATE_LAYOUT", layout: nextLayout, focusedPaneId: options.focusedPaneId ?? null }
+      : { type: "UPDATE_LAYOUT", layout: nextLayout });
     scheduleConfigSave(syncConfigActiveLayoutState(
       { ...config, layout: nextLayout },
       paneState,
-      focusedPaneId,
+      hasFocusTarget ? (options.focusedPaneId ?? null) : focusedPaneId,
       activePanel,
     ));
   }, [activePanel, config, dispatch, focusedPaneId, paneState]);
@@ -261,6 +265,7 @@ export function Shell({
     nativePaneChrome,
     paneMap,
     persistLayout,
+    previousFocusedPaneId,
     pluginRegistry,
     rendererHost,
     visibleLayout,

--- a/src/components/layout/shell/pane/actions.ts
+++ b/src/components/layout/shell/pane/actions.ts
@@ -14,6 +14,15 @@ import type { LayoutConfig } from "../../../../types/config";
 import type { RendererHost } from "../../../../ui";
 import { capturePaneScreenshotPngBase64 } from "../../../../utils/dom-screenshot";
 
+function removedFocusRestoreOptions(
+  layout: LayoutConfig,
+  currentFocusedPaneId: string | null,
+  paneId: string | null,
+): { focusedPaneId: string } | undefined {
+  if (currentFocusedPaneId && isPaneInLayout(layout, currentFocusedPaneId)) return undefined;
+  return paneId && isPaneInLayout(layout, paneId) ? { focusedPaneId: paneId } : undefined;
+}
+
 interface UseShellPaneActionsOptions {
   closePaneMenu: () => void;
   contentHeight: number;
@@ -22,7 +31,8 @@ interface UseShellPaneActionsOptions {
   focusPane: (paneId: string) => void;
   nativePaneChrome: boolean;
   paneMap: Map<string, ResolvedPane>;
-  persistLayout: (nextLayout: LayoutConfig, options?: { pushHistory?: boolean }) => void;
+  persistLayout: (nextLayout: LayoutConfig, options?: { pushHistory?: boolean; focusedPaneId?: string | null }) => void;
+  previousFocusedPaneId: string | null;
   pluginRegistry: PluginRegistry;
   rendererHost: RendererHost;
   visibleLayout: LayoutConfig;
@@ -38,6 +48,7 @@ export function useShellPaneActions({
   nativePaneChrome,
   paneMap,
   persistLayout,
+  previousFocusedPaneId,
   pluginRegistry,
   rendererHost,
   visibleLayout,
@@ -70,15 +81,17 @@ export function useShellPaneActions({
 
   const closeFocusedPane = useCallback(() => {
     if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) return false;
-    persistLayout(removePane(visibleLayout, focusedPaneId));
+    const nextLayout = removePane(visibleLayout, focusedPaneId);
+    persistLayout(nextLayout, removedFocusRestoreOptions(nextLayout, focusedPaneId, previousFocusedPaneId));
     return true;
-  }, [focusedPaneId, persistLayout, visibleLayout]);
+  }, [focusedPaneId, persistLayout, previousFocusedPaneId, visibleLayout]);
 
   const closeAllFloatingPanes = useCallback(() => {
     if (visibleLayout.floating.length === 0) return false;
-    persistLayout(removeFloatingPanes(visibleLayout));
+    const nextLayout = removeFloatingPanes(visibleLayout);
+    persistLayout(nextLayout, removedFocusRestoreOptions(nextLayout, focusedPaneId, previousFocusedPaneId));
     return true;
-  }, [persistLayout, visibleLayout]);
+  }, [focusedPaneId, persistLayout, previousFocusedPaneId, visibleLayout]);
 
   const copyFocusedPaneScreenshot = useCallback(() => {
     if (!focusedPaneId || !nativePaneChrome || !rendererHost.copyPngImage) return false;
@@ -118,8 +131,9 @@ export function useShellPaneActions({
   }, [contentHeight, persistLayout, visibleLayout, width]);
 
   const handleFloatingClose = useCallback((paneId: string) => {
-    persistLayout(removePane(visibleLayout, paneId));
-  }, [persistLayout, visibleLayout]);
+    const nextLayout = removePane(visibleLayout, paneId);
+    persistLayout(nextLayout, removedFocusRestoreOptions(nextLayout, focusedPaneId, previousFocusedPaneId));
+  }, [focusedPaneId, persistLayout, previousFocusedPaneId, visibleLayout]);
 
   return {
     closeAllFloatingPanes,

--- a/src/core/state/app/layout-reducer.ts
+++ b/src/core/state/app/layout-reducer.ts
@@ -64,7 +64,13 @@ export function reduceLayoutAction(state: AppState, action: AppAction): AppState
     }
 
     case "UPDATE_LAYOUT":
-      return withFocusedPane(state, { ...state.config, layout: action.layout });
+      return withFocusedPane(
+        state,
+        { ...state.config, layout: action.layout },
+        Object.prototype.hasOwnProperty.call(action, "focusedPaneId")
+          ? { focusedPaneId: action.focusedPaneId ?? null }
+          : {},
+      );
 
     case "SWITCH_LAYOUT": {
       if (action.index < 0 || action.index >= state.config.layouts.length) return state;

--- a/src/core/state/app/layout.ts
+++ b/src/core/state/app/layout.ts
@@ -351,6 +351,9 @@ export function focusPaneState(state: AppState, paneId: string): AppState {
     ...state,
     config: syncConfigActiveLayoutState(config, state.paneState, paneId, state.activePanel),
     focusedPaneId: paneId,
+    previousFocusedPaneId: state.focusedPaneId && state.focusedPaneId !== paneId
+      ? state.focusedPaneId
+      : state.previousFocusedPaneId,
     recentTickers,
   };
 }
@@ -386,6 +389,9 @@ export function withFocusedPane(
     paneState: nextPaneState,
     brokerAccounts: reconcileBrokerAccounts(syncedConfig, state.brokerAccounts),
     focusedPaneId,
+    previousFocusedPaneId: state.focusedPaneId && state.focusedPaneId !== focusedPaneId
+      ? state.focusedPaneId
+      : state.previousFocusedPaneId,
     activePanel,
   };
 }

--- a/src/core/state/app/state.ts
+++ b/src/core/state/app/state.ts
@@ -319,6 +319,7 @@ export function createInitialState(config: AppConfig, sessionSnapshot: AppSessio
     brokerAccounts: {},
     activePanel,
     focusedPaneId,
+    previousFocusedPaneId: null,
     paneState,
     recentTickers: config.recentTickers,
     commandBarOpen: false,

--- a/src/core/state/app/types.ts
+++ b/src/core/state/app/types.ts
@@ -48,6 +48,7 @@ export interface AppState {
   brokerAccounts: Record<string, BrokerAccount[]>;
   activePanel: "left" | "right";
   focusedPaneId: string | null;
+  previousFocusedPaneId: string | null;
   paneState: Record<string, PaneRuntimeState>;
   recentTickers: string[];
   commandBarOpen: boolean;
@@ -104,7 +105,7 @@ export type AppAction =
   | { type: "PUSH_LAYOUT_HISTORY" }
   | { type: "UNDO_LAYOUT" }
   | { type: "REDO_LAYOUT" }
-  | { type: "UPDATE_LAYOUT"; layout: LayoutConfig }
+  | { type: "UPDATE_LAYOUT"; layout: LayoutConfig; focusedPaneId?: string | null }
   | { type: "SWITCH_LAYOUT"; index: number }
   | { type: "NEW_LAYOUT"; name: string }
   | { type: "DELETE_LAYOUT"; index: number }

--- a/src/state/app/context/index.test.tsx
+++ b/src/state/app/context/index.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { cloneLayout, createBlankLayout, createDefaultConfig } from "../../../types/config";
 import { appReducer, createInitialState } from "./index";
+import { removePane } from "../../../plugins/pane-manager";
 
 describe("appReducer command bar state", () => {
   test("opens the command bar with an explicit query", () => {
@@ -172,6 +173,25 @@ describe("appReducer command bar state", () => {
     const secondUndone = appReducer(backToSecond, { type: "UNDO_LAYOUT" });
     expect(secondUndone.config.activeLayoutIndex).toBe(newLayoutIndex);
     expect(secondUndone.config.layout).toEqual(createBlankLayout());
+  });
+
+  test("restores an explicit focus target after a layout removes the focused pane", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test-focus-restore");
+    const nextLayout = removePane(config.layout, "ticker-detail:main");
+    const state = {
+      ...createInitialState(config),
+      focusedPaneId: "ticker-detail:main",
+      previousFocusedPaneId: "portfolio-list:main",
+    };
+
+    const next = appReducer(state, {
+      type: "UPDATE_LAYOUT",
+      layout: nextLayout,
+      focusedPaneId: "portfolio-list:main",
+    });
+
+    expect(next.focusedPaneId).toBe("portfolio-list:main");
+    expect(next.config.layouts[next.config.activeLayoutIndex]?.focusedPaneId).toBe("portfolio-list:main");
   });
 
   test("tracks manual update-check feedback", () => {


### PR DESCRIPTION
## Summary

Restore focus to the previously focused pane when a focused floating pane is closed, instead of falling back to layout order.

## Root cause

When the focused pane was removed from the layout, the reducer resolved the next focus target from top floating pane or first pane order. That made focus jump to an unrelated pane after closing a floating details pane.

## Changes

- Track the previously focused pane in app state.
- Allow layout updates to carry an explicit focus target.
- Restore focus only when the current focused pane was removed and the previous pane is still visible.
- Add reducer and shell regression coverage for the focus restore path.

## Validation

- `bun test src/state/app/context/index.test.tsx src/components/layout/shell/index.test.tsx`

Closes #351