### PR TITLE
Open chat through pane templates

### DIFF
--- a/src/plugins/builtin/chat/channels.ts
+++ b/src/plugins/builtin/chat/channels.ts
@@ -1,6 +1,6 @@
 import type { CommandResultDef, GloomPluginContext } from "../../../types/plugin";
 import type { ChatChannel, ChatChannelState } from "../../../api-client";
-import type { AppConfig, PaneInstanceConfig } from "../../../types/config";
+import type { AppConfig } from "../../../types/config";
 import { chatController } from "./controller";
 import { formatChannelLabel } from "./channel-labels";
 
@@ -23,14 +23,6 @@ export function normalizeShortcutChannelId(channelId: string | null | undefined)
 
 export function getLastVisitedChatChannelId(config: { pluginConfig: Record<string, Record<string, unknown>> }) {
   return normalizeChannelId(config.pluginConfig["gloomberb-cloud"]?.[LAST_VISITED_CHAT_CHANNEL_KEY] as string | undefined);
-}
-
-export function findChatPaneInstanceForChannel(config: AppConfig, channelId: string): PaneInstanceConfig | undefined {
-  const normalizedChannelId = normalizeChannelId(channelId);
-  return config.layout.instances.find((instance) => (
-    instance.paneId === "chat"
-    && normalizeChannelId(typeof instance.settings?.channelId === "string" ? instance.settings.channelId : null) === normalizedChannelId
-  ));
 }
 
 export function getPreferredChatOpenChannelId(
@@ -80,17 +72,12 @@ export function hasOnlyDmUsernameArgs(value: string): boolean {
   return parts.length > 0 && parts.every((part) => CHAT_USERNAME_ARG.test(part));
 }
 
-function openChatChannelFromCommand(ctx: Pick<GloomPluginContext, "createPaneFromTemplate" | "focusPane" | "getConfig">, channelId: string): void {
-  const existingInstance = findChatPaneInstanceForChannel(ctx.getConfig(), channelId);
-  if (existingInstance) {
-    ctx.focusPane(existingInstance.instanceId);
-    return;
-  }
+function openChatChannelFromCommand(ctx: Pick<GloomPluginContext, "createPaneFromTemplate">, channelId: string): void {
   ctx.createPaneFromTemplate("new-chat-pane", { arg: channelId });
 }
 
-export function openDefaultChatFromCommand(
-  ctx: Pick<GloomPluginContext, "createPaneFromTemplate" | "focusPane" | "getConfig">,
+function openDefaultChatPane(
+  ctx: Pick<GloomPluginContext, "createPaneFromTemplate" | "getConfig">,
 ): void {
   const config = ctx.getConfig();
   openChatChannelFromCommand(ctx, getPreferredChatOpenChannelId(config, chatController.getSnapshot()));
@@ -98,7 +85,7 @@ export function openDefaultChatFromCommand(
 
 export async function openDmTargetFromCommand(ctx: GloomPluginContext, usernames: string[]): Promise<void> {
   if (usernames.length === 0) {
-    openDefaultChatFromCommand(ctx);
+    openDefaultChatPane(ctx);
     return;
   }
   const channel = usernames.length === 1

--- a/src/plugins/builtin/chat/chat.test.tsx
+++ b/src/plugins/builtin/chat/chat.test.tsx
@@ -1178,16 +1178,12 @@ describe("ChatContent", () => {
       user: { id: "u1", username: "vince", emailVerified: true },
     });
     const openedTemplates: Array<{ templateId: string; options?: { arg?: string } }> = [];
-    const focusedPanes: string[] = [];
     const state = createInitialState(createDefaultConfig("/tmp/gloomberb-chat"));
     state.config.disabledPlugins = [];
 
     const runtime = createTestPluginRuntime({
       createPaneFromTemplate(templateId: string, options?: { arg?: string }) {
         openedTemplates.push({ templateId, options });
-      },
-      focusPane(paneId: string) {
-        focusedPanes.push(paneId);
       },
     });
 
@@ -1230,9 +1226,7 @@ describe("ChatContent", () => {
       await setup().renderOnce();
     });
 
-    expect(openedTemplates).toEqual([]);
-    expect(focusedPanes).toHaveLength(1);
-    expect(focusedPanes[0]?.startsWith("chat:")).toBe(true);
+    expect(openedTemplates).toEqual([{ templateId: "new-chat-pane", options: { arg: "everyone" } }]);
   });
 
   test("opens an unread direct-message channel from the status widget", async () => {

--- a/src/plugins/builtin/chat/status-widget.tsx
+++ b/src/plugins/builtin/chat/status-widget.tsx
@@ -5,7 +5,6 @@ import { Box, Span, Text, TextAttributes, useUiCapabilities } from "../../../ui"
 import { usePluginAppActions } from "../../runtime";
 import { InlineAuthActions } from "../cloud/auth-actions";
 import {
-  findChatPaneInstanceForChannel,
   getPreferredChatOpenChannelId,
 } from "./channels";
 import { chatController, type ChatController } from "./controller";
@@ -53,7 +52,7 @@ function CloudStatusIcon() {
 }
 
 export function ChatStatusWidget({ controller = chatController }: ChatStatusWidgetProps) {
-  const { createPaneFromTemplate, focusPane } = usePluginAppActions();
+  const { createPaneFromTemplate } = usePluginAppActions();
   const config = useAppSelector((state) => state.config);
   const cloudPluginDisabled = config.disabledPlugins.includes("gloomberb-cloud");
   const initialSnapshot = controller.getSnapshot();
@@ -67,11 +66,6 @@ export function ChatStatusWidget({ controller = chatController }: ChatStatusWidg
     event?.preventDefault?.();
     event?.stopPropagation?.();
     const channelId = getPreferredChatOpenChannelId(config, snapshot);
-    const existingInstance = findChatPaneInstanceForChannel(config, channelId);
-    if (existingInstance) {
-      focusPane(existingInstance.instanceId);
-      return;
-    }
     createPaneFromTemplate("new-chat-pane", { arg: channelId });
   };
 

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -14,10 +14,9 @@ import { registerTwitterFeedFeature } from "../cloud-tweets";
 import {
   buildDmCommandResults,
   formatChatPaneTitle,
-  getLastVisitedChatChannelId,
+  getPreferredChatOpenChannelId,
   hasOnlyDmUsernameArgs,
   normalizeShortcutChannelId,
-  openDefaultChatFromCommand,
   openDmTargetFromCommand,
   parseDmUsernames,
 } from "../chat/channels";
@@ -50,7 +49,9 @@ export function createGloomberbCloudPlugin({
         createInstance: async (context, options) => {
           const channelId = options?.arg
             ? await chatController.resolveRequiredChannelId(normalizeShortcutChannelId(options.arg))
-            : await chatController.resolvePreferredChannelId(getLastVisitedChatChannelId(context.config));
+            : await chatController.resolvePreferredChannelId(
+              getPreferredChatOpenChannelId(context.config, chatController.getSnapshot()),
+            );
           const channel = chatController.getChannels().find((entry) => entry.id === channelId);
           return {
             placement: "floating",
@@ -143,16 +144,6 @@ export function createGloomberbCloudPlugin({
       });
 
       registerTwitterFeedFeature(ctx);
-
-      ctx.registerCommand({
-        id: "open-chat",
-        label: "Chat",
-        description: "Open chat",
-        keywords: ["chat", "message", "messages"],
-        category: "navigation",
-        shortcut: "CHAT",
-        execute: () => openDefaultChatFromCommand(ctx),
-      });
 
       ctx.registerCommand({
         id: "direct-message",


### PR DESCRIPTION
## Summary
- route CHAT through the chat pane template instead of a plugin command that focuses existing instances
- open chat status and DM targets by creating chat panes with channel args
- preserve preferred/unread channel selection for bare CHAT

## Tests
- bun test src/plugins/builtin/chat/channels.test.ts src/plugins/builtin/chat/chat.test.tsx src/components/command-bar/surface/index.test.tsx
- git diff --check
- tmux smoke: CHAT opens a floating #everyone pane from the Monitor layout with orphan chat:main