### PR TITLE
Fix chart layout shortcuts

### DIFF
--- a/src/app/global-shortcuts.test.tsx
+++ b/src/app/global-shortcuts.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { createTestRenderer } from "@opentui/core/testing";
 import { act } from "react";
 import { createOpenTuiTestRoot as createRoot, TestDialogProvider } from "../renderers/opentui/test-utils";
-import { createDefaultConfig } from "../types/config";
+import { cloneLayout, createDefaultConfig } from "../types/config";
 import { createInitialState, type AppAction, type AppState } from "../state/app/context";
 import type { PluginRegistry } from "../plugins/registry";
 import { useAppGlobalShortcuts } from "./global-shortcuts";
@@ -160,6 +160,25 @@ describe("useAppGlobalShortcuts", () => {
       query: "",
       launch: { kind: "ticker-search", query: "" },
     }]);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.propagationStopped).toBe(true);
+  });
+
+  test("switches saved layouts with Ctrl-number and consumes the shortcut", async () => {
+    const actions: AppAction[] = [];
+    const config = createDefaultConfig("/tmp/gloomberb-global-shortcuts-layouts");
+    config.layouts = [
+      { name: "One", layout: cloneLayout(config.layout) },
+      { name: "Two", layout: cloneLayout(config.layout) },
+      { name: "Three", layout: cloneLayout(config.layout) },
+    ];
+    config.activeLayoutIndex = 0;
+    const state = createInitialState(config);
+    await renderHarness(state, createRegistry(), (action) => actions.push(action));
+
+    const event = await emitKeypress({ name: "2", ctrl: true });
+
+    expect(actions).toEqual([{ type: "SWITCH_LAYOUT", index: 1 }]);
     expect(event.defaultPrevented).toBe(true);
     expect(event.propagationStopped).toBe(true);
   });

--- a/src/app/global-shortcuts.ts
+++ b/src/app/global-shortcuts.ts
@@ -76,6 +76,8 @@ export function useAppGlobalShortcuts({
       if (idx < layouts.length && idx !== state.config.activeLayoutIndex) {
         dispatch({ type: "SWITCH_LAYOUT", index: idx });
       }
+      event.preventDefault();
+      event.stopPropagation();
       return;
     }
 

--- a/src/components/chart/core/keyboard.ts
+++ b/src/components/chart/core/keyboard.ts
@@ -1,4 +1,13 @@
-export function resolveChartKeyboardKey(event: { name?: string; sequence?: string }): string {
+export function resolveChartKeyboardKey(event: {
+  name?: string;
+  sequence?: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  alt?: boolean;
+  super?: boolean;
+}): string {
+  if (event.ctrl || event.meta || event.alt || event.super) return "";
+
   const name = event.name ?? "";
   const sequence = event.sequence ?? "";
   const candidates = [name, sequence];

--- a/src/components/chart/stock-chart/index.test.ts
+++ b/src/components/chart/stock-chart/index.test.ts
@@ -159,6 +159,13 @@ describe("stock chart keyboard helpers", () => {
     expect(resolveChartKeyboardKey({ name: "minus" })).toBe("zoom-out");
     expect(resolveChartKeyboardKey({ name: "A" })).toBe("a");
   });
+
+  test("ignores shortcut-modified keys so app shortcuts can handle them", () => {
+    expect(resolveChartKeyboardKey({ name: "1", ctrl: true })).toBe("");
+    expect(resolveChartKeyboardKey({ name: "2", meta: true })).toBe("");
+    expect(resolveChartKeyboardKey({ name: "3", super: true })).toBe("");
+    expect(resolveChartKeyboardKey({ name: "4", alt: true })).toBe("");
+  });
 });
 
 describe("stock chart viewport helpers", () => {


### PR DESCRIPTION
## Summary
- Stop Ctrl+number saved-layout shortcuts from propagating after the app handles them.
- Keep chart range shortcuts limited to unmodified number keys so focused charts do not capture layout switching.
- Add focused tests for the global shortcut and chart keyboard normalization paths.

## Validation
- `bun test src/app/global-shortcuts.test.tsx`
- `bun test src/components/chart/stock-chart/index.test.ts`
- `bun test src/plugins/builtin/comparison-chart/index.test.tsx`
- `git diff --check`
- tmux smoke using a chart-focused layout and a Ctrl+2 modifyOtherKeys sequence