### PR TITLE
Add semantic remote control API

### DIFF
--- a/scripts/electrobun-dev.ts
+++ b/scripts/electrobun-dev.ts
@@ -2,7 +2,13 @@ import { existsSync } from "fs";
 import { join } from "path";
 
 const rootDir = join(import.meta.dir, "..");
-const electrobunBin = join(rootDir, "node_modules", "electrobun", "bin", process.platform === "win32" ? "electrobun.exe" : "electrobun");
+const electrobunBinCandidates = process.platform === "win32"
+  ? [join(rootDir, "node_modules", "electrobun", "bin", "electrobun.exe")]
+  : [
+    join(rootDir, "node_modules", "electrobun", "bin", "electrobun"),
+    join(rootDir, "node_modules", "electrobun", "bin", "electrobun.cjs"),
+  ];
+const electrobunBin = electrobunBinCandidates.find((path) => existsSync(path));
 
 async function run(command: string[], options: { allowFailure?: boolean; stdout?: "inherit" | "ignore"; stderr?: "inherit" | "ignore" } = {}) {
   const proc = Bun.spawn(command, {
@@ -22,8 +28,8 @@ async function ensureMacExecutableSignature(path: string) {
   await run(["codesign", "--force", "--sign", "-", path]);
 }
 
-if (!existsSync(electrobunBin)) {
-  throw new Error(`Electrobun CLI not found at ${electrobunBin}. Run bun install first.`);
+if (!electrobunBin) {
+  throw new Error(`Electrobun CLI not found. Checked: ${electrobunBinCandidates.join(", ")}. Run bun install first.`);
 }
 
 await ensureMacExecutableSignature(electrobunBin);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -39,6 +39,8 @@ import { bindPluginRegistryRuntimeAccess } from "./app/runtime/plugin-bindings";
 import { useAppStartupRuntime } from "./app/runtime/startup";
 import { useTickerRefreshRuntime } from "./app/runtime/ticker-refresh";
 import { useAppUpdateRuntime } from "./app/runtime/update";
+import { RemoteControlHost, type RemoteControlAdapter } from "./remote/app-host";
+import { RemoteUiRegistryProvider } from "./remote/semantic-tree";
 import {
   resolveAppSessionSnapshot,
   resolveCliLaunchConfig,
@@ -55,6 +57,7 @@ interface AppInnerProps {
   sessionSnapshot?: AppSessionSnapshot | null;
   desktopWindowBridge?: DesktopWindowBridge;
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
+  remoteControlAdapter?: RemoteControlAdapter;
 }
 
 function ThemedAppRoot({ children }: { children: ReactNode }) {
@@ -83,9 +86,11 @@ function AppInner({
   sessionSnapshot = null,
   desktopWindowBridge,
   desktopApplicationMenuBridge,
+  remoteControlAdapter,
 }: AppInnerProps) {
   const dispatch = useAppDispatch();
   const stateRef = useAppStateRef();
+  const getRemoteState = useCallback(() => stateRef.current, [stateRef]);
   const config = useAppSelector((state) => state.config);
   const tickers = useAppSelector((state) => state.tickers);
   const paneState = useAppSelector((state) => state.paneState);
@@ -288,6 +293,13 @@ function AppInner({
   if (desktopWindowBridge?.kind === "detached" && desktopWindowBridge.paneId) {
     return (
       <ContextMenuProvider pluginRegistry={pluginRegistry}>
+        <RemoteControlHost
+          adapter={remoteControlAdapter}
+          dispatch={dispatch}
+          getState={getRemoteState}
+          pluginRegistry={pluginRegistry}
+          desktopWindowBridge={desktopWindowBridge}
+        />
         <ThemedAppRoot>
           <DetachedPaneShell
             pluginRegistry={pluginRegistry}
@@ -301,6 +313,13 @@ function AppInner({
 
   return (
     <ContextMenuProvider pluginRegistry={pluginRegistry}>
+      <RemoteControlHost
+        adapter={remoteControlAdapter}
+        dispatch={dispatch}
+        getState={getRemoteState}
+        pluginRegistry={pluginRegistry}
+        desktopWindowBridge={desktopWindowBridge}
+      />
       <ThemedAppRoot>
         <Header />
         <TransientLayoutProvider>
@@ -336,6 +355,7 @@ interface AppProps {
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
   desktopSnapshot?: DesktopSharedStateSnapshot | null;
   desktopThemePreview?: DesktopThemePreviewState | null;
+  remoteControlAdapter?: RemoteControlAdapter;
 }
 
 export function App({
@@ -346,6 +366,7 @@ export function App({
   desktopApplicationMenuBridge,
   desktopSnapshot = null,
   desktopThemePreview = null,
+  remoteControlAdapter,
 }: AppProps) {
   const renderer = useNativeRenderer();
   const effectiveInitialConfig = useMemo(() => {
@@ -413,23 +434,26 @@ export function App({
   }
 
   return (
-    <AppProvider
-      config={config}
-      sessionStore={desktopWindowBridge?.kind === "detached" ? undefined : services.persistence.sessions}
-      sessionSnapshot={sessionSnapshot}
-      desktopBridge={desktopWindowBridge}
-      desktopSnapshot={desktopSnapshot}
-      initialThemePreview={desktopThemePreview}
-    >
-      <AppInner
-        pluginRegistry={services.pluginRegistry}
-        tickerRepository={services.tickerRepository}
-        dataProvider={services.dataProvider}
-        marketData={services.marketData}
+    <RemoteUiRegistryProvider>
+      <AppProvider
+        config={config}
+        sessionStore={desktopWindowBridge?.kind === "detached" ? undefined : services.persistence.sessions}
         sessionSnapshot={sessionSnapshot}
-        desktopWindowBridge={desktopWindowBridge}
-        desktopApplicationMenuBridge={desktopApplicationMenuBridge}
-      />
-    </AppProvider>
+        desktopBridge={desktopWindowBridge}
+        desktopSnapshot={desktopSnapshot}
+        initialThemePreview={desktopThemePreview}
+      >
+        <AppInner
+          pluginRegistry={services.pluginRegistry}
+          tickerRepository={services.tickerRepository}
+          dataProvider={services.dataProvider}
+          marketData={services.marketData}
+          sessionSnapshot={sessionSnapshot}
+          desktopWindowBridge={desktopWindowBridge}
+          desktopApplicationMenuBridge={desktopApplicationMenuBridge}
+          remoteControlAdapter={remoteControlAdapter}
+        />
+      </AppProvider>
+    </RemoteUiRegistryProvider>
   );
 }

--- a/src/cli/commands/remote.ts
+++ b/src/cli/commands/remote.ts
@@ -1,0 +1,206 @@
+import { getDataDir } from "../../data/config/store";
+import type { CliCommandContext, CliCommandDef } from "../../types/plugin";
+import { sendRemoteControlRequest } from "../../remote/client";
+import type { RemoteAppKind, RemoteControlRequest, RemoteControlResponse } from "../../remote/types";
+
+interface RemoteArgs {
+  args: string[];
+  appKind?: RemoteAppKind;
+  expectRev?: string;
+  intervalMs: number;
+}
+
+export const remoteCliCommand: CliCommandDef = {
+  name: "remote",
+  description: "Control a running app through the semantic remote API",
+  help: {
+    usage: [
+      "remote schema [--app tui|desktop]",
+      "remote help [--app tui|desktop]",
+      "remote get <resource> [--app tui|desktop]",
+      "remote call <operation> [json] [--dry-run] [--app tui|desktop]",
+      "remote patch <resource> <json-patch> [--expect-rev rev] [--dry-run] [--app tui|desktop]",
+      "remote batch <json> [--dry-run] [--app tui|desktop]",
+      "remote watch <resource> [--interval ms] [--limit n] [--app tui|desktop]",
+    ],
+  },
+  execute: async (rawArgs, ctx) => {
+    const parsed = parseRemoteArgs(rawArgs);
+    const action = parsed.args[0];
+    if (!action) {
+      ctx.fail("Usage: gloomberb remote <schema|help|get|call|patch|batch|watch>");
+      return;
+    }
+
+    const dataDir = await getDataDir();
+    if (!dataDir) {
+      ctx.fail("No data directory configured.", "Run gloomberb once before using remote control.");
+      return;
+    }
+
+    if (action === "watch") {
+      const resource = parsed.args[1];
+      if (!resource) {
+        ctx.fail("Usage: gloomberb remote watch <resource>");
+        return;
+      }
+      const limit = ctx.cliOptions.limit ?? Number.POSITIVE_INFINITY;
+      for (let index = 0; index < limit; index += 1) {
+        const response = await sendRemoteControlRequest({ type: "get", resource }, {
+          dataDir,
+          appKind: parsed.appKind,
+        });
+        printRemoteResponse(response, ctx);
+        if (index < limit - 1) await new Promise((resolve) => setTimeout(resolve, parsed.intervalMs));
+      }
+      return;
+    }
+
+    const request = buildRemoteRequest(action, parsed, ctx.cliOptions.dryRun);
+    const response = await sendRemoteControlRequest(request, {
+      dataDir,
+      appKind: parsed.appKind,
+    });
+    printRemoteResponse(response, ctx);
+  },
+};
+
+function parseRemoteArgs(rawArgs: string[]): RemoteArgs {
+  const args: string[] = [];
+  let appKind: RemoteAppKind | undefined;
+  let expectRev: string | undefined;
+  let intervalMs = 1_000;
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index]!;
+    if (arg === "--app") {
+      index += 1;
+      appKind = parseAppKind(rawArgs[index]);
+      continue;
+    }
+    if (arg.startsWith("--app=")) {
+      appKind = parseAppKind(arg.slice("--app=".length));
+      continue;
+    }
+    if (arg === "--expect-rev") {
+      index += 1;
+      expectRev = rawArgs[index];
+      if (!expectRev) throw new Error("Missing value for --expect-rev.");
+      continue;
+    }
+    if (arg.startsWith("--expect-rev=")) {
+      expectRev = arg.slice("--expect-rev=".length);
+      continue;
+    }
+    if (arg === "--interval") {
+      index += 1;
+      intervalMs = parseInterval(rawArgs[index]);
+      continue;
+    }
+    if (arg.startsWith("--interval=")) {
+      intervalMs = parseInterval(arg.slice("--interval=".length));
+      continue;
+    }
+    args.push(arg);
+  }
+
+  return { args, appKind, expectRev, intervalMs };
+}
+
+function buildRemoteRequest(action: string, parsed: RemoteArgs, dryRun: boolean): RemoteControlRequest {
+  switch (action) {
+    case "schema":
+      return { type: "schema" };
+    case "help":
+      return { type: "help" };
+    case "get": {
+      const resource = parsed.args[1];
+      if (!resource) throw new Error("Usage: gloomberb remote get <resource>");
+      return { type: "get", resource };
+    }
+    case "call": {
+      const operation = parsed.args[1];
+      if (!operation) throw new Error("Usage: gloomberb remote call <operation> [json]");
+      return {
+        type: "call",
+        operation,
+        input: parseJsonValue(parsed.args[2], {}),
+        dryRun,
+      };
+    }
+    case "patch": {
+      const resource = parsed.args[1];
+      const patchRaw = parsed.args[2];
+      if (!resource || !patchRaw) throw new Error("Usage: gloomberb remote patch <resource> <json-patch>");
+      const patch = parseJsonValue(patchRaw, []);
+      if (!Array.isArray(patch)) throw new Error("Remote patch payload must be a JSON array.");
+      return {
+        type: "patch",
+        resource,
+        patch,
+        expectRev: parsed.expectRev,
+        dryRun,
+      };
+    }
+    case "batch": {
+      const payload = parseJsonValue(parsed.args[1], null);
+      if (!payload) throw new Error("Usage: gloomberb remote batch <json>");
+      if (Array.isArray(payload)) return { type: "batch", requests: payload as RemoteControlRequest[], dryRun };
+      return withCliDryRun(payload as RemoteControlRequest, dryRun);
+    }
+    default:
+      throw new Error(`Unknown remote action "${action}".`);
+  }
+}
+
+function withCliDryRun(request: RemoteControlRequest, dryRun: boolean): RemoteControlRequest {
+  if (!dryRun) return request;
+  if (request.type === "batch") return { ...request, dryRun: true };
+  if (request.type === "call" || request.type === "patch") return { ...request, dryRun: true };
+  return request;
+}
+
+function parseAppKind(value: string | undefined): RemoteAppKind {
+  if (value === "tui" || value === "desktop") return value;
+  throw new Error("--app must be either tui or desktop.");
+}
+
+function parseInterval(value: string | undefined): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 100) {
+    throw new Error("--interval must be an integer >= 100.");
+  }
+  return parsed;
+}
+
+function parseJsonValue<T>(raw: string | undefined, fallback: T): unknown {
+  if (raw == null) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Invalid JSON payload: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function printRemoteResponse(
+  response: RemoteControlResponse,
+  ctx: CliCommandContext,
+): void {
+  if (!response.ok) {
+    const details = response.error.details == null
+      ? undefined
+      : typeof response.error.details === "string"
+        ? response.error.details
+        : JSON.stringify(response.error.details, null, 2);
+    ctx.fail(response.error.message, details);
+    return;
+  }
+  const data = response.state ? { data: response.data, state: response.state } : response.data;
+  ctx.printResult({
+    data,
+    metadata: response.rev ? { rev: response.rev } : undefined,
+    warnings: response.warnings,
+  }, {
+    text: (data) => JSON.stringify(data, null, 2),
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import { ticker, buildTickerReport } from "./commands/ticker";
 import { apiCliCommand } from "./commands/api";
 import { marketDataCliCommands } from "./commands/market";
 import { overviewCliCommands } from "./commands/overview";
+import { remoteCliCommand } from "./commands/remote";
 import { createSystemCliCommands } from "./commands/system";
 import {
   aiCliCommand,
@@ -188,6 +189,7 @@ function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
     apiCliCommand,
     ...marketDataCliCommands,
     ...overviewCliCommands,
+    remoteCliCommand,
     ...createSystemCliCommands(() => commands),
     brokerCliCommand,
     ibkrCliCommand,

--- a/src/components/chart/static/bar-chart-surface.test.tsx
+++ b/src/components/chart/static/bar-chart-surface.test.tsx
@@ -47,6 +47,8 @@ describe("StaticBarChartSurface", () => {
 
     await act(async () => {
       await testSetup!.mockMouse.moveTo(14, 4);
+    });
+    await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
     });
@@ -86,6 +88,8 @@ describe("StaticBarChartSurface", () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
       await testSetup!.mockMouse.moveTo(14, 4);
+    });
+    await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
     });

--- a/src/components/chart/static/chart/surface.test.tsx
+++ b/src/components/chart/static/chart/surface.test.tsx
@@ -1,19 +1,23 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act } from "react";
+import { act, useEffect } from "react";
 import { testRender } from "../../../../renderers/opentui/test-utils";
 import { colors } from "../../../../theme/colors";
+import { RemoteUiRegistryProvider, useRemoteUiRegistry, type RemoteUiRegistry } from "../../../../remote/semantic-tree";
 import { resolveChartPalette } from "../../core/renderer";
 import { StaticChartSurface } from "./surface";
 import type { ProjectedChartPoint } from "../../core/data";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let remoteRegistry: RemoteUiRegistry | null = null;
 
 afterEach(async () => {
-  if (!testSetup) return;
-  await act(async () => {
-    testSetup!.renderer.destroy();
-  });
+  const setup = testSetup;
   testSetup = undefined;
+  remoteRegistry = null;
+  if (!setup) return;
+  await act(async () => {
+    setup.renderer.destroy();
+  });
 });
 
 const points: ProjectedChartPoint[] = [
@@ -21,6 +25,14 @@ const points: ProjectedChartPoint[] = [
   { date: new Date("2026-01-02"), open: 4.1, high: 4.1, low: 4.1, close: 4.1, volume: 0 },
   { date: new Date("2026-01-03"), open: 4.9, high: 4.9, low: 4.9, close: 4.9, volume: 0 },
 ];
+
+function RemoteRegistryProbe() {
+  const registry = useRemoteUiRegistry();
+  useEffect(() => {
+    remoteRegistry = registry;
+  }, [registry]);
+  return null;
+}
 
 describe("StaticChartSurface", () => {
   test("renders unit and custom y-axis labels", async () => {
@@ -132,6 +144,49 @@ describe("StaticChartSurface", () => {
 
     await act(async () => {
       await testSetup!.mockMouse.moveTo(20, 4);
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(testSetup.captureCharFrame()).not.toBe(initialFrame);
+    expect(testSetup.captureCharFrame()).toContain("X49");
+    expect(testSetup.captureCharFrame()).toContain("Y3.97");
+  });
+
+  test("exposes semantic remote cursor control", async () => {
+    testSetup = await testRender(
+      <RemoteUiRegistryProvider>
+        <RemoteRegistryProbe />
+        <StaticChartSurface
+          points={points}
+          width={48}
+          height={10}
+          mode="line"
+          colors={resolveChartPalette(colors, "positive")}
+          xAxisLabels={["0%", "50%", "100%"]}
+          formatXAxisCursorValue={(ratio) => `X${Math.round(ratio * 100)}`}
+          formatYAxisValue={(value) => `Y${value.toFixed(2)}`}
+        />
+      </RemoteUiRegistryProvider>,
+      { width: 50, height: 12 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    const initialFrame = testSetup.captureCharFrame();
+    const chartNode = remoteRegistry?.snapshot().find((node) => (
+      node.role === "chart" && node.metadata?.kind === "static-chart"
+    ));
+    expect(chartNode?.actions).toContain("moveCursor");
+
+    await act(async () => {
+      await remoteRegistry!.invoke(chartNode!.id, "moveCursor", { x: 20, y: 4 });
+    });
+    await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
     });

--- a/src/components/chart/static/chart/surface.tsx
+++ b/src/components/chart/static/chart/surface.tsx
@@ -253,6 +253,10 @@ export function StaticChartSurface({
             flexDirection="column"
             bitmaps={bitmap ? [bitmap] : null}
             crosshair={canvasCrosshair}
+            onMouseMove={handleCursorEvent}
+            onMouseDown={handleCursorEvent}
+            onMouseOut={clearCursor}
+            data-gloom-remote-kind="static-chart"
           >
             {textResult.lines.map((line, index) => (
               <Text key={index} content={line} />

--- a/src/components/command-bar/list/view.tsx
+++ b/src/components/command-bar/list/view.tsx
@@ -10,6 +10,7 @@ import {
 import { Spinner } from "../../ui";
 import type { CommandBarListRow, ListScreenState, ResultItem } from "./model";
 import { getRowPresentation, truncateText } from "../view-model";
+import { useRemoteUiNode } from "../../../remote/semantic-tree";
 
 export type CommandBarListScrollEvent = {
   stopPropagation: () => void;
@@ -70,6 +71,8 @@ export const CommandBarListHeader = memo(function CommandBarListHeader({
             onChange={onQueryChange}
             placeholder={kind === "root" ? "Search commands" : title === "Security Description" ? "Search tickers" : "Filter"}
             focused
+            data-gloom-remote-scope="command-bar"
+            data-gloom-remote-surface="command-bar"
             width={nativePaneChrome ? "100%" : queryDisplayWidth}
             backgroundColor={nativePaneChrome ? "transparent" : paletteBg}
             focusedBackgroundColor={nativePaneChrome ? "transparent" : paletteBg}
@@ -114,6 +117,9 @@ interface CommandBarListItemRowProps {
   globalIdx: number;
   isSelected: boolean;
   isHovered: boolean;
+  listKind: ListScreenState["kind"];
+  listTitle: string;
+  listQuery: string;
   contentPadding: number;
   labelWidth: number;
   trailingWidth: number;
@@ -135,6 +141,9 @@ const CommandBarListItemRow = memo(function CommandBarListItemRow({
   globalIdx,
   isSelected,
   isHovered,
+  listKind,
+  listTitle,
+  listQuery,
   contentPadding,
   labelWidth,
   trailingWidth,
@@ -153,6 +162,41 @@ const CommandBarListItemRow = memo(function CommandBarListItemRow({
   const presentation = getRowPresentation(item, isSelected, trailingWidth > 0);
   const label = truncateText(presentation.label, labelWidth);
   const trailing = truncateText(presentation.trailing, trailingWidth);
+  const activate = () => onRowMouseDown({
+    preventDefault() {},
+    stopPropagation() {},
+  }, item, globalIdx);
+  useRemoteUiNode({
+    role: "command-bar-result",
+    label: item.label,
+    disabled: item.disabled === true,
+    actions: {
+      activate,
+      press: activate,
+      secondary: item.secondaryAction ? () => item.secondaryAction?.() : undefined,
+    },
+    metadata: {
+      index: globalIdx,
+      selected: isSelected,
+      hovered: isHovered,
+      listKind,
+      listTitle,
+      listQuery,
+      item: {
+        id: item.id,
+        label: item.label,
+        detail: item.detail,
+        category: item.category,
+        kind: item.kind,
+        right: item.right,
+        shortcutQuery: item.shortcutQuery,
+        searchText: item.searchText,
+        checked: item.checked,
+        current: item.current,
+        disabled: item.disabled === true,
+      },
+    },
+  });
 
   return (
     <Box
@@ -283,6 +327,9 @@ export const CommandBarListBody = memo(function CommandBarListBody({
             globalIdx={row.globalIdx}
             isSelected={isSelected}
             isHovered={isHovered}
+            listKind={visibleListState.kind}
+            listTitle={visibleListState.title}
+            listQuery={visibleListState.query}
             contentPadding={contentPadding}
             labelWidth={labelWidth}
             trailingWidth={trailingWidth}

--- a/src/components/command-bar/multi-select-picker.tsx
+++ b/src/components/command-bar/multi-select-picker.tsx
@@ -197,6 +197,13 @@ export function CommandBarMultiSelectBody({
         onSelect={onSelect}
         onToggle={onToggle}
         bgColor={nativePaneChrome ? panelBg : paletteBg}
+        remoteLabel={route.title}
+        remoteScope="command-bar"
+        remoteMetadata={{
+          surface: "multi-select-picker",
+          routeKind: route.kind,
+          pickerId: route.pickerId,
+        }}
       />
       <Box flexDirection="row" gap={1}>
         <Button label="Done" variant="primary" onPress={onCommit} />

--- a/src/components/command-bar/routing/navigation-state.ts
+++ b/src/components/command-bar/routing/navigation-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from "react";
+import { useCallback, useEffect, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from "react";
 import type { AppAction } from "../../../state/app/context";
 import type { Command } from "../commands/registry";
 import { resolveCommandBarMode } from "../view-model";
@@ -62,6 +62,15 @@ export function useCommandBarNavigationState({
   const currentRoute = routeStack[routeStack.length - 1] ?? null;
   const currentRouteRef = useRef<CommandBarRoute | null>(currentRoute);
   currentRouteRef.current = currentRoute;
+
+  useEffect(() => {
+    if (currentRouteRef.current) return;
+    if (initialQuery === rootQueryRef.current) return;
+    rootQueryRef.current = initialQuery;
+    setRootQueryValue(initialQuery);
+    setRootSelectedIdx(0);
+    setRootHoveredIdx(null);
+  }, [initialQuery]);
 
   const closeAll = useCallback((options?: CloseCommandBarOptions) => {
     if (options?.revertThemePreview !== false) {

--- a/src/components/command-bar/surface/index.test.tsx
+++ b/src/components/command-bar/surface/index.test.tsx
@@ -129,6 +129,20 @@ describe("CommandBar", () => {
     expect(testSetup.captureCharFrame()).not.toContain("Commands");
   });
 
+  test("shows theme picker rows and commits a filtered light theme", async () => {
+    testSetup = await testRender(<CommandBarHarness query="TH light" live />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("GitHub Light");
+
+    await clickFrameText("GitHub Light");
+    await waitForFrameToContain("theme:github-light");
+    expect(testSetup.captureCharFrame()).not.toContain("GitHub Light");
+  });
+
   test("runs plugin command shortcuts from the root query", async () => {
     const calls: string[] = [];
 

--- a/src/components/command-bar/theme-picker.tsx
+++ b/src/components/command-bar/theme-picker.tsx
@@ -4,13 +4,14 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { Box, ScrollBox, Text } from "../../ui";
-import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
+import { Box, Text } from "../../ui";
+import { TextAttributes } from "../../ui";
+import { ListView, type ListViewItem } from "../ui";
+import type { ListRowState } from "../ui/list-view";
 import { getThemeIds, themes as themeRegistry } from "../../theme/themes";
 import { truncateText } from "./view-model";
 
@@ -75,7 +76,6 @@ export const ThemePicker = memo(forwardRef<ThemePickerHandle, ThemePickerProps>(
   onPreview,
   onCommit,
 }: ThemePickerProps, ref) {
-  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingPreviewIdRef = useRef<string | null>(null);
   const committedThemeIdRef = useRef(committedThemeId);
@@ -92,9 +92,20 @@ export const ThemePicker = memo(forwardRef<ThemePickerHandle, ThemePickerProps>(
   const [selectedIndex, setSelectedIndex] = useState(() => (
     Math.max(0, themes.findIndex((theme) => theme.id === committedThemeId))
   ));
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const themesRef = useRef(themes);
   const selectedIndexRef = useRef(selectedIndex);
+  const items = useMemo<ListViewItem[]>(() => themes.map((theme) => {
+    const current = theme.id === committedThemeId;
+    return {
+      id: theme.id,
+      label: theme.name,
+      detail: current ? "current" : "",
+      category: "Themes",
+      kind: "theme",
+      right: current ? "current" : "",
+      current,
+    };
+  }), [committedThemeId, themes]);
 
   themesRef.current = themes;
   selectedIndexRef.current = selectedIndex;
@@ -131,7 +142,6 @@ export const ThemePicker = memo(forwardRef<ThemePickerHandle, ThemePickerProps>(
     if (nextIndex === selectedIndexRef.current) return false;
     selectedIndexRef.current = nextIndex;
     setSelectedIndex(nextIndex);
-    setHoveredIndex(null);
     requestPreview(options[nextIndex]!.id);
     return true;
   }, [requestPreview]);
@@ -155,23 +165,9 @@ export const ThemePicker = memo(forwardRef<ThemePickerHandle, ThemePickerProps>(
     const nextIndex = preferredIndex >= 0 ? preferredIndex : 0;
     selectedIndexRef.current = nextIndex;
     setSelectedIndex(nextIndex);
-    setHoveredIndex(null);
   }, [committedThemeId, themes]);
 
   useEffect(() => cancelPreview, [cancelPreview]);
-
-  useLayoutEffect(() => {
-    const scrollBox = scrollRef.current;
-    if (!scrollBox) return;
-    if (scrollBox.verticalScrollBar) scrollBox.verticalScrollBar.visible = false;
-    if (themes.length === 0) return;
-    const viewportHeight = Math.max(1, scrollBox.viewport?.height ?? height);
-    if (selectedIndex < scrollBox.scrollTop) {
-      scrollBox.scrollTo(selectedIndex);
-    } else if (selectedIndex >= scrollBox.scrollTop + viewportHeight) {
-      scrollBox.scrollTo(selectedIndex - viewportHeight + 1);
-    }
-  }, [height, selectedIndex, themes.length]);
 
   const handleScroll = useCallback((event: ThemePickerScrollEvent) => {
     event.stopPropagation();
@@ -185,70 +181,86 @@ export const ThemePicker = memo(forwardRef<ThemePickerHandle, ThemePickerProps>(
     }
   }, [move]);
 
-  if (themes.length === 0) {
+  const handleSelect = useCallback((index: number) => {
+    const selected = themesRef.current[index];
+    if (!selected) return;
+    selectedIndexRef.current = index;
+    setSelectedIndex(index);
+    requestPreview(selected.id);
+  }, [requestPreview]);
+
+  const handleActivate = useCallback((item: ListViewItem, index: number) => {
+    const selected = themesRef.current[index] ?? themesRef.current.find((theme) => theme.id === item.id);
+    if (!selected) return;
+    selectedIndexRef.current = index;
+    setSelectedIndex(index);
+    cancelPreview();
+    onCommitRef.current(selected.id);
+  }, [cancelPreview]);
+
+  const renderRow = useCallback((item: ListViewItem, state: ListRowState) => {
+    const label = truncateText(item.label, labelWidth);
+    const trailing = item.current ? "current" : "";
     return (
-      <Box height={height} paddingX={contentPadding}>
-        <Text fg={paletteSubtleText}>{truncateText("No themes match", queryDisplayWidth)}</Text>
+      <Box
+        flexDirection="row"
+        height={1}
+        paddingX={contentPadding}
+        width="100%"
+        data-command-bar-row-selected={nativePaneChrome && state.selected ? "true" : undefined}
+        style={nativePaneChrome ? { borderRadius: 6 } : undefined}
+      >
+        <Box width={labelWidth}>
+          <Text
+            fg={state.selected ? paletteSelectedText : paletteText}
+            attributes={item.current ? TextAttributes.BOLD : undefined}
+          >
+            {label}
+          </Text>
+        </Box>
+        <Box width={trailingWidth}>
+          <Text fg={state.selected ? paletteSelectedText : paletteSubtleText}>
+            {truncateText(trailing, trailingWidth)}
+          </Text>
+        </Box>
       </Box>
     );
-  }
+  }, [
+    contentPadding,
+    labelWidth,
+    nativePaneChrome,
+    paletteSelectedText,
+    paletteSubtleText,
+    paletteText,
+    trailingWidth,
+  ]);
 
   return (
-    <ScrollBox
-      ref={scrollRef}
-      flexDirection="column"
+    <ListView
+      items={items}
+      selectedIndex={selectedIndex}
       height={height}
-      scrollY
-      focusable={false}
-      {...(!nativePaneChrome ? { onMouseScroll: handleScroll } : {})}
-    >
-      {themes.map((theme, index) => {
-        const selected = index === selectedIndex;
-        const hovered = index === hoveredIndex && !selected;
-        const current = theme.id === committedThemeId;
-        const label = truncateText(theme.name, labelWidth);
-        const trailing = current ? "current" : "";
-        return (
-          <Box
-            key={theme.id}
-            flexDirection="row"
-            height={1}
-            paddingX={contentPadding}
-            backgroundColor={selected
-              ? paletteSelectedBg
-              : hovered
-                ? paletteHoverBg
-                : (nativePaneChrome ? panelBg : paletteBg)}
-            onMouseOver={() => setHoveredIndex(index)}
-            onMouseOut={() => setHoveredIndex(null)}
-            onMouseDown={(event: any) => {
-              event.stopPropagation?.();
-              event.preventDefault?.();
-              selectedIndexRef.current = index;
-              setSelectedIndex(index);
-              cancelPreview();
-              onCommitRef.current(theme.id);
-            }}
-            {...(!nativePaneChrome ? { onMouseScroll: handleScroll } : {})}
-            data-command-bar-row-selected={nativePaneChrome && selected ? "true" : undefined}
-            style={nativePaneChrome ? { borderRadius: 6 } : undefined}
-          >
-            <Box width={labelWidth}>
-              <Text
-                fg={selected ? paletteSelectedText : paletteText}
-                attributes={current ? TextAttributes.BOLD : undefined}
-              >
-                {label}
-              </Text>
-            </Box>
-            <Box width={trailingWidth}>
-              <Text fg={selected ? paletteSelectedText : paletteSubtleText}>
-                {truncateText(trailing, trailingWidth)}
-              </Text>
-            </Box>
-          </Box>
-        );
-      })}
-    </ScrollBox>
+      scrollable
+      rowGap={0}
+      rowHeight={1}
+      surface="plain"
+      bgColor={nativePaneChrome ? panelBg : paletteBg}
+      selectedBgColor={paletteSelectedBg}
+      hoverBgColor={paletteHoverBg}
+      emptyMessage={truncateText("No themes match", queryDisplayWidth)}
+      showSelectedDescription={false}
+      onSelect={handleSelect}
+      onActivate={handleActivate}
+      onMouseScroll={!nativePaneChrome ? handleScroll : undefined}
+      renderRow={renderRow}
+      remoteLabel="Theme picker"
+      remoteScope="command-bar"
+      remoteItemKind="theme"
+      remoteItemCategory="Themes"
+      remoteMetadata={{
+        surface: "theme-picker",
+        filter: normalizedFilter,
+      }}
+    />
   );
 }));

--- a/src/components/command-bar/workflow/field-row.tsx
+++ b/src/components/command-bar/workflow/field-row.tsx
@@ -15,6 +15,7 @@ import {
   isWorkflowTextField,
   summarizeWorkflowFieldValue,
 } from "../helpers";
+import { useRemoteUiNode } from "../../../remote/semantic-tree";
 import type {
   CommandBarFieldValue,
   CommandBarWorkflowField,
@@ -84,6 +85,34 @@ export function CommandBarWorkflowFieldRow({
       onMoveFieldFocus(1);
     }
   };
+  const focusOrOpenField = () => {
+    onActiveTextareaSync(route);
+    onFieldFocus(field.id);
+    if (!isWorkflowTextField(field) && !useNativeSelect) {
+      onFieldPickerOpen(route, field);
+    }
+  };
+
+  useRemoteUiNode({
+    role: "command-bar-field",
+    label: field.label,
+    disabled: route.pending,
+    actions: {
+      focus: focusOrOpenField,
+      open: !isWorkflowTextField(field) && !useNativeSelect ? focusOrOpenField : undefined,
+      submit: () => void onSubmit(route),
+    },
+    metadata: {
+      scope: "command-bar",
+      surface: "workflow",
+      routeTitle: route.title,
+      fieldId: field.id,
+      fieldType: field.type,
+      active,
+      value: summarizeWorkflowFieldValue(field, value),
+      description: fieldDescription,
+    },
+  });
 
   return (
     <Box
@@ -93,11 +122,7 @@ export function CommandBarWorkflowFieldRow({
       backgroundColor={fieldBg}
       onMouseDown={(event: any) => {
         event.stopPropagation?.();
-        onActiveTextareaSync(route);
-        onFieldFocus(field.id);
-        if (!isWorkflowTextField(field) && !useNativeSelect) {
-          onFieldPickerOpen(route, field);
-        }
+        focusOrOpenField();
       }}
       style={nativePaneChrome ? {
         marginBottom: isLastField ? 8 : 10,

--- a/src/components/layout/pane/footer/index.tsx
+++ b/src/components/layout/pane/footer/index.tsx
@@ -2,6 +2,7 @@ import { Box, Span, Text, TextAttributes, useUiCapabilities } from "../../../../
 import { useRef } from "react";
 import { colors, blendHex } from "../../../../theme/colors";
 import { getShortcutHintWidth, ShortcutHint } from "../../../ui/shortcut-hint";
+import { useRemoteUiNode } from "../../../../remote/semantic-tree";
 import {
   EMPTY_FOOTER,
   hasPaneFooterContent,
@@ -50,6 +51,15 @@ function stopMouseEvent(event?: { stopPropagation?: () => void; preventDefault?:
 
 function SegmentView({ segment }: { segment: PaneFooterSegment }) {
   const interactive = !!segment.onPress && !segment.disabled;
+  useRemoteUiNode(interactive ? {
+    role: "pane-footer-segment",
+    label: segment.parts.map((part) => part.text).join(" "),
+    disabled: segment.disabled,
+    actions: {
+      press: () => segment.onPress?.(),
+    },
+    metadata: { id: segment.id },
+  } : null);
   const attributes = segment.parts.some((part) => part.bold) || interactive ? TextAttributes.BOLD : 0;
   const triggerMouseDownRef = useRef(false);
   const startSegmentPress = (event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
@@ -93,6 +103,19 @@ function totalHintsWidth(hints: PaneHint[]): number {
 }
 
 function HintView({ hint, prefixSpace }: { hint: PaneHint; prefixSpace: boolean }) {
+  useRemoteUiNode({
+    role: "pane-hint",
+    label: `${hint.key}${hint.label}`,
+    disabled: hint.disabled,
+    actions: {
+      press: hint.onPress ? () => hint.onPress?.() : undefined,
+    },
+    metadata: {
+      id: hint.id,
+      key: hint.key,
+      label: hint.label,
+    },
+  });
   return (
     <ShortcutHint
       hotkey={hint.key}

--- a/src/components/toggle-list.tsx
+++ b/src/components/toggle-list.tsx
@@ -26,6 +26,9 @@ export interface ToggleListProps {
   rowGap?: number;
   rowHeight?: number;
   surface?: "framed" | "plain";
+  remoteLabel?: string;
+  remoteScope?: string;
+  remoteMetadata?: Record<string, unknown>;
 }
 
 function DesktopToggleRow({
@@ -124,6 +127,9 @@ export function ToggleList({
   rowGap,
   rowHeight,
   surface,
+  remoteLabel,
+  remoteScope,
+  remoteMetadata,
 }: ToggleListProps) {
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const listItems: ListViewItem[] = items.map((item) => ({
@@ -145,6 +151,10 @@ export function ToggleList({
       rowGap={rowGap ?? (isDesktopWeb ? 0 : undefined)}
       rowHeight={rowHeight}
       surface={surface}
+      remoteLabel={remoteLabel}
+      remoteScope={remoteScope}
+      remoteMetadata={remoteMetadata}
+      remoteItemKind="toggle"
       onSelect={onSelect}
       onActivate={(item) => {
         onToggle?.(item.id);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useUiHost } from "../../ui";
 import { TextAttributes } from "../../ui";
 import { type ComponentType } from "react";
 import { colors } from "../../theme/colors";
+import { useRemoteUiNode } from "../../remote/semantic-tree";
 
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 
@@ -45,6 +46,17 @@ export function Button({
   shortcut,
   width,
 }: ButtonProps) {
+  useRemoteUiNode({
+    role: "button",
+    label,
+    disabled,
+    actions: {
+      press: () => {
+        if (!disabled) onPress?.();
+      },
+    },
+    metadata: { variant, active, shortcut },
+  });
   const HostButton = useUiHost().Button as ComponentType<ButtonProps> | undefined;
   if (HostButton) {
     return (

--- a/src/components/ui/data-table/index.tsx
+++ b/src/components/ui/data-table/index.tsx
@@ -5,6 +5,8 @@ import type {
   DataTableColumn,
   DataTableProps,
 } from "./types";
+import { useRemoteUiNode } from "../../../remote/semantic-tree";
+import { resolveRemoteItemIndex } from "../../../remote/semantic-helpers";
 
 export type {
   DataTableCell,
@@ -16,6 +18,46 @@ export type {
 export function DataTable<T, C extends DataTableColumn = DataTableColumn>(
   props: DataTableProps<T, C>,
 ) {
+  useRemoteUiNode({
+    role: "table",
+    label: "Data table",
+    actions: {
+      selectRow: (input) => {
+        const index = resolveTableIndex(input, props);
+        const item = index >= 0 ? props.items[index] : undefined;
+        if (item) props.onSelect(item, index);
+      },
+      activateRow: (input) => {
+        const index = resolveTableIndex(input, props);
+        const item = index >= 0 ? props.items[index] : undefined;
+        if (item) {
+          props.onSelect(item, index);
+          props.onActivate?.(item, index);
+        }
+      },
+      sort: (input) => {
+        const columnId = typeof input === "string"
+          ? input
+          : input && typeof input === "object" && typeof (input as { columnId?: unknown }).columnId === "string"
+            ? (input as { columnId: string }).columnId
+            : null;
+        if (columnId && props.columns.some((column) => column.id === columnId)) {
+          props.onHeaderClick(columnId);
+        }
+      },
+    },
+    metadata: {
+      sortColumnId: props.sortColumnId,
+      sortDirection: props.sortDirection,
+      columns: props.columns.map((column) => ({ id: column.id, label: column.label })),
+      rows: props.items.slice(0, 200).map((item, index) => ({
+        index,
+        key: props.getItemKey(item, index),
+        selected: props.isSelected(item, index),
+      })),
+      rowCount: props.items.length,
+    },
+  });
   const HostDataTable = useUiHost().DataTable as
     | ComponentType<DataTableProps<T, C>>
     | undefined;
@@ -23,4 +65,13 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>(
     return <HostDataTable {...props} />;
   }
   return <OpenTuiDataTable {...props} />;
+}
+
+function resolveTableIndex<T, C extends DataTableColumn>(
+  input: unknown,
+  props: DataTableProps<T, C>,
+): number {
+  return resolveRemoteItemIndex(input, props.items, {
+    key: (item, index) => props.getItemKey(item, index),
+  });
 }

--- a/src/components/ui/fields.tsx
+++ b/src/components/ui/fields.tsx
@@ -2,6 +2,8 @@ import { Box, Input, Span, Text, useUiHost } from "../../ui";
 import { useEffect, useRef, useState, type ComponentType, type RefObject } from "react";
 import { type InputRenderable } from "../../ui";
 import { colors } from "../../theme/colors";
+import { useRemoteUiNode } from "../../remote/semantic-tree";
+import { remoteStringValue } from "../../remote/semantic-helpers";
 
 export interface TextFieldProps {
   label?: string;
@@ -46,6 +48,22 @@ export function TextField({
   placeholderColor = colors.textDim,
   onMouseDown,
 }: TextFieldProps) {
+  useRemoteUiNode({
+    role: "text-field",
+    label: label ?? placeholder,
+    actions: {
+      setValue: (input) => {
+        const nextValue = remoteStringValue(input);
+        onChange?.(nextValue);
+      },
+      submit: (input) => {
+        const nextValue = remoteStringValue(input, value ?? "");
+        onSubmit?.(nextValue);
+      },
+      blur: () => onBlur?.(value ?? ""),
+    },
+    metadata: { value, placeholder, focused, type, variant },
+  });
   const HostTextField = useUiHost().TextField as ComponentType<TextFieldProps> | undefined;
   if (HostTextField) {
     return (

--- a/src/components/ui/list-view.tsx
+++ b/src/components/ui/list-view.tsx
@@ -2,12 +2,19 @@ import { Box, ScrollBox, Text, useUiHost } from "../../ui";
 import { useEffect, useRef, useState, type ComponentType, type ReactNode } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
+import { useRemoteUiNode } from "../../remote/semantic-tree";
+import { resolveRemoteItemIndex } from "../../remote/semantic-helpers";
 
 export interface ListViewItem {
   id: string;
   label: string;
   description?: string;
   detail?: string;
+  category?: string;
+  kind?: string;
+  right?: string;
+  checked?: boolean;
+  current?: boolean;
   disabled?: boolean;
 }
 
@@ -38,6 +45,13 @@ export interface ListViewProps {
   scrollable?: boolean;
   selectOnHover?: boolean;
   autoScrollToIndex?: boolean;
+  onMouseScroll?: (event: any) => void;
+  remoteRole?: string;
+  remoteLabel?: string;
+  remoteScope?: string;
+  remoteItemKind?: string;
+  remoteItemCategory?: string;
+  remoteMetadata?: Record<string, unknown>;
 }
 
 function DefaultRow({
@@ -88,7 +102,49 @@ export function ListView({
   scrollable = false,
   selectOnHover = false,
   autoScrollToIndex = true,
+  onMouseScroll,
+  remoteRole = "list",
+  remoteLabel,
+  remoteScope,
+  remoteItemKind,
+  remoteItemCategory,
+  remoteMetadata,
 }: ListViewProps) {
+  useRemoteUiNode({
+    role: remoteRole,
+    label: remoteLabel ?? emptyMessage,
+    actions: {
+      select: (input) => {
+        const index = resolveListIndex(input, items);
+        if (index >= 0 && !items[index]?.disabled) onSelect?.(index);
+      },
+      activate: (input) => {
+        const index = resolveListIndex(input, items);
+        const item = index >= 0 ? items[index] : undefined;
+        if (item && !item.disabled) {
+          onSelect?.(index);
+          onActivate?.(item, index);
+        }
+      },
+    },
+    metadata: {
+      ...remoteMetadata,
+      scope: remoteScope,
+      selectedIndex,
+      items: items.map((item, index) => ({
+        index,
+        id: item.id,
+        label: item.label,
+        detail: item.detail,
+        category: item.category ?? remoteItemCategory,
+        kind: item.kind ?? remoteItemKind,
+        right: item.right,
+        checked: item.checked,
+        current: item.current,
+        disabled: item.disabled === true,
+      })),
+    },
+  });
   const HostListView = useUiHost().ListView as ComponentType<ListViewProps> | undefined;
   if (HostListView) {
     return (
@@ -113,6 +169,13 @@ export function ListView({
         scrollable={scrollable}
         selectOnHover={selectOnHover}
         autoScrollToIndex={autoScrollToIndex}
+        onMouseScroll={onMouseScroll}
+        remoteRole={remoteRole}
+        remoteLabel={remoteLabel}
+        remoteScope={remoteScope}
+        remoteItemKind={remoteItemKind}
+        remoteItemCategory={remoteItemCategory}
+        remoteMetadata={remoteMetadata}
       />
     );
   }
@@ -130,7 +193,7 @@ export function ListView({
     const sb = scrollRef.current;
     if (!sb) return;
     const safeIndex = Math.min(activeScrollIndex, items.length - 1);
-    const viewportH = Math.max(sb.viewport.height, 1);
+    const viewportH = Math.max(sb.viewport?.height ?? 1, 1);
     if (safeIndex < sb.scrollTop) {
       sb.scrollTo(safeIndex);
     } else if (safeIndex >= sb.scrollTop + viewportH) {
@@ -142,7 +205,9 @@ export function ListView({
     if (!scrollable) return;
     const sb = scrollRef.current;
     if (!sb) return;
-    sb.verticalScrollBar.visible = items.length > sb.viewport.height;
+    if (sb.verticalScrollBar) {
+      sb.verticalScrollBar.visible = items.length > (sb.viewport?.height ?? 0);
+    }
   }, [items.length, height, flexGrow, scrollable]);
 
   if (items.length === 0) {
@@ -172,6 +237,7 @@ export function ListView({
             if (selectOnHover) onSelect?.(index);
           }
         }}
+        {...(onMouseScroll ? { onMouseScroll } : {})}
         onMouseDown={() => {
           if (disabled) return;
           onSelect?.(index);
@@ -188,7 +254,14 @@ export function ListView({
   return (
     <Box flexDirection="column" height={height} flexGrow={flexGrow}>
       {scrollable ? (
-        <ScrollBox ref={scrollRef} height={height} flexGrow={flexGrow} scrollY focusable={false}>
+        <ScrollBox
+          ref={scrollRef}
+          height={height}
+          flexGrow={flexGrow}
+          scrollY
+          focusable={false}
+          {...(onMouseScroll ? { onMouseScroll } : {})}
+        >
           {rows}
         </ScrollBox>
       ) : rows}
@@ -203,4 +276,11 @@ export function ListView({
       )}
     </Box>
   );
+}
+
+function resolveListIndex(input: unknown, items: ListViewItem[]): number {
+  return resolveRemoteItemIndex(input, items, {
+    id: (item) => item.id,
+    label: (item) => item.label,
+  });
 }

--- a/src/components/ui/message-composer.tsx
+++ b/src/components/ui/message-composer.tsx
@@ -2,6 +2,8 @@ import { Box, Text, Textarea, useUiHost } from "../../ui";
 import { type ComponentType, type RefObject } from "react";
 import { type TextareaRenderable } from "../../ui";
 import { colors } from "../../theme/colors";
+import { useRemoteUiNode } from "../../remote/semantic-tree";
+import { remoteStringValue } from "../../remote/semantic-helpers";
 
 export interface MessageComposerProps {
   inputRef?: RefObject<TextareaRenderable | null>;
@@ -54,6 +56,26 @@ export function MessageComposer({
   keyBindings,
   wrapText = false,
 }: MessageComposerProps) {
+  useRemoteUiNode({
+    role: "message-composer",
+    label: placeholder || "Message composer",
+    actions: {
+      setValue: (input) => {
+        const value = remoteStringValue(input);
+        onFocusRequest?.();
+        onInput?.(value);
+      },
+      submit: () => {
+        onFocusRequest?.();
+        onSubmit?.();
+      },
+      focus: () => {
+        onFocusRequest?.();
+        inputRef?.current?.focus?.();
+      },
+    },
+    metadata: { focused, placeholder, height },
+  });
   const HostMessageComposer = useUiHost().MessageComposer as ComponentType<MessageComposerProps> | undefined;
   if (HostMessageComposer) {
     return (

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -3,6 +3,7 @@ import { useShortcut } from "../../react/input";
 import { Box, ScrollBox, Text, useUiHost } from "../../ui";
 import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
 import { colors, hoverBg } from "../../theme/colors";
+import { useRemoteUiNode } from "../../remote/semantic-tree";
 
 type TabPointerEvent = {
   button?: number;
@@ -76,6 +77,36 @@ export function Tabs({
     navigationValueRef.current = value;
     onSelect(value);
   }, [onSelect]);
+  useRemoteUiNode({
+    role: "tabs",
+    label: "Tabs",
+    actions: {
+      select: (input) => {
+        const value = resolveTabValue(input, tabs);
+        if (!value) return;
+        const tab = tabs.find((entry) => entry.value === value);
+        if (!tab || tab.disabled) return;
+        handleSelect(value);
+      },
+      add: onAdd ? () => onAdd() : undefined,
+      close: (input) => {
+        const value = resolveTabValue(input, tabs);
+        if (!value) return;
+        const tab = tabs.find((entry) => entry.value === value);
+        if (!tab || tab.disabled) return;
+        tab.onClose?.(value);
+      },
+    },
+    metadata: {
+      activeValue,
+      tabs: tabs.map((tab) => ({
+        label: tab.label,
+        value: tab.value,
+        disabled: tab.disabled === true,
+        closeable: !!tab.onClose,
+      })),
+    },
+  });
 
   const selectAdjacentTab = useCallback((direction: -1 | 1) => {
     const enabledTabs = tabs.filter((tab) => !tab.disabled);
@@ -142,6 +173,20 @@ export function Tabs({
       palette={palette}
     />
   );
+}
+
+function resolveTabValue(input: unknown, tabs: TabItem[]): string | null {
+  if (typeof input === "string") return input;
+  if (typeof input === "number") return tabs[input]?.value ?? null;
+  if (input && typeof input === "object") {
+    const value = input as { value?: unknown; label?: unknown; index?: unknown };
+    if (typeof value.value === "string") return value.value;
+    if (typeof value.label === "string") {
+      return tabs.find((tab) => tab.label === value.label)?.value ?? null;
+    }
+    if (typeof value.index === "number") return tabs[value.index]?.value ?? null;
+  }
+  return null;
 }
 
 function tabWidth(

--- a/src/core/state/app/state.ts
+++ b/src/core/state/app/state.ts
@@ -262,6 +262,25 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       };
     }
 
+    case "REPLACE_PANE_STATE": {
+      const current = state.paneState[action.paneId] ?? {};
+      const nextState = action.state;
+      if (Object.is(current, nextState)) return state;
+      const paneState = {
+        ...state.paneState,
+        [action.paneId]: nextState,
+      };
+      const recentTickers = current.cursorSymbol !== nextState.cursorSymbol
+        ? nextRecentTickers(state.recentTickers, typeof nextState.cursorSymbol === "string" ? nextState.cursorSymbol : null)
+        : state.recentTickers;
+      return {
+        ...state,
+        config: syncConfigActiveLayoutState(state.config, paneState, state.focusedPaneId, state.activePanel),
+        paneState,
+        recentTickers,
+      };
+    }
+
     case "UPDATE_PLUGIN_PANE_STATE": {
       const current = state.paneState[action.paneId] ?? {};
       const currentPluginState = current.pluginState ?? {};

--- a/src/core/state/app/types.ts
+++ b/src/core/state/app/types.ts
@@ -122,4 +122,5 @@ export type AppAction =
       key: string;
       value: unknown;
     }
+  | { type: "REPLACE_PANE_STATE"; paneId: string; state: PaneRuntimeState }
   | { type: "UPDATE_PANE_STATE"; paneId: string; patch: Partial<PaneRuntimeState> };

--- a/src/remote/app-host.tsx
+++ b/src/remote/app-host.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useMemo } from "react";
+import type { Dispatch } from "react";
+import type { PluginRegistry } from "../plugins/registry";
+import type { AppAction, AppState } from "../state/app/context";
+import type { DesktopWindowBridge } from "../types/desktop-window";
+import { createAppRemoteController } from "./controller";
+import { useRemoteUiRegistry } from "./semantic-tree";
+import type { RemoteControlRequest, RemoteControlResponse } from "./types";
+
+export type RemoteControlHandler = (request: RemoteControlRequest) => Promise<RemoteControlResponse>;
+
+export interface RemoteControlAdapter {
+  startServer?(options: { dataDir: string; handle: RemoteControlHandler }): void | (() => void | Promise<void>);
+  registerHandler?(handler: RemoteControlHandler | null): void | (() => void);
+}
+
+interface RemoteControlHostProps {
+  adapter?: RemoteControlAdapter;
+  dispatch: Dispatch<AppAction>;
+  getState: () => AppState;
+  pluginRegistry: PluginRegistry;
+  desktopWindowBridge?: DesktopWindowBridge;
+}
+
+export function RemoteControlHost({
+  adapter,
+  dispatch,
+  getState,
+  pluginRegistry,
+  desktopWindowBridge,
+}: RemoteControlHostProps) {
+  const uiRegistry = useRemoteUiRegistry();
+  const controller = useMemo(() => createAppRemoteController({
+    dispatch,
+    getState,
+    pluginRegistry,
+    uiRegistry,
+    desktopWindowBridge,
+    afterMutation: async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          resolve(undefined);
+        };
+        if (typeof requestAnimationFrame === "function") {
+          requestAnimationFrame(finish);
+        }
+        setTimeout(finish, 50);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    },
+  }), [desktopWindowBridge, dispatch, getState, pluginRegistry, uiRegistry]);
+  const dataDir = getState().config.dataDir;
+
+  useEffect(() => {
+    if (!adapter?.startServer) return;
+    const cleanup = adapter.startServer({ dataDir, handle: controller.handle });
+    if (!cleanup) return;
+    return () => {
+      void cleanup();
+    };
+  }, [adapter, controller, dataDir]);
+
+  useEffect(() => {
+    if (!adapter?.registerHandler) return;
+    const cleanup = adapter.registerHandler(controller.handle);
+    if (!cleanup) return;
+    return () => {
+      cleanup();
+    };
+  }, [adapter, controller]);
+
+  return null;
+}

--- a/src/remote/client.ts
+++ b/src/remote/client.ts
@@ -1,0 +1,34 @@
+import type { RemoteAppKind, RemoteControlRequest, RemoteControlResponse } from "./types";
+import { readRemoteEndpoint } from "./endpoint";
+
+export interface SendRemoteControlRequestOptions {
+  dataDir: string;
+  appKind?: RemoteAppKind;
+}
+
+export async function sendRemoteControlRequest(
+  request: RemoteControlRequest,
+  options: SendRemoteControlRequestOptions,
+): Promise<RemoteControlResponse> {
+  const endpoint = await readRemoteEndpoint(options.dataDir, options.appKind);
+  const response = await fetch(`http://127.0.0.1:${endpoint.port}/rpc`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${endpoint.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+  const payload = await response.json() as RemoteControlResponse;
+  if (!response.ok && payload.ok !== false) {
+    return {
+      ok: false,
+      error: {
+        code: "remote_http_error",
+        message: `Remote control request failed with HTTP ${response.status}.`,
+        details: payload,
+      },
+    };
+  }
+  return payload;
+}

--- a/src/remote/command-bar.ts
+++ b/src/remote/command-bar.ts
@@ -1,0 +1,98 @@
+import type { AppState } from "../state/app/context";
+import type { RemoteUiNodeSnapshot } from "./types";
+
+export function commandBarResultsFromNodes(nodes: RemoteUiNodeSnapshot[]) {
+  const directResults = nodes
+    .filter((node) => node.role === "command-bar-result")
+    .map((node) => {
+      const metadata = node.metadata ?? {};
+      const item = metadata.item && typeof metadata.item === "object"
+        ? metadata.item as Record<string, unknown>
+        : {};
+      return {
+        nodeId: node.id,
+        index: metadata.index,
+        label: node.label ?? item.label,
+        detail: item.detail,
+        category: item.category,
+        kind: item.kind,
+        right: item.right,
+        selected: metadata.selected === true,
+        disabled: node.disabled === true,
+        actions: node.actions,
+        itemId: item.id,
+        actionInput: undefined,
+        metadata,
+      };
+    });
+
+  const listResults = nodes.flatMap((node) => {
+    const metadata = node.metadata ?? {};
+    if (node.role !== "list" && node.role !== "command-bar-list") return [];
+    if (metadata.scope !== "command-bar") return [];
+    const rawItems = Array.isArray(metadata.items) ? metadata.items : [];
+    const selectedIndex = typeof metadata.selectedIndex === "number" ? metadata.selectedIndex : -1;
+    return rawItems
+      .map((entry, fallbackIndex) => (
+        entry && typeof entry === "object"
+          ? entry as Record<string, unknown>
+          : { label: String(entry), index: fallbackIndex }
+      ))
+      .map((item, fallbackIndex) => {
+        const index = typeof item.index === "number" ? item.index : fallbackIndex;
+        return {
+          nodeId: node.id,
+          index,
+          label: item.label,
+          detail: item.detail,
+          category: item.category ?? metadata.category,
+          kind: item.kind ?? metadata.itemKind,
+          right: item.right,
+          selected: selectedIndex === index,
+          disabled: item.disabled === true || node.disabled === true,
+          actions: node.actions,
+          itemId: item.id,
+          actionInput: {
+            index,
+            id: item.id,
+            label: item.label,
+          },
+          metadata: {
+            ...metadata,
+            item,
+          },
+        };
+      });
+  });
+
+  return [...directResults, ...listResults].sort((left, right) => {
+    const leftIndex = typeof left.index === "number" ? left.index : Number.MAX_SAFE_INTEGER;
+    const rightIndex = typeof right.index === "number" ? right.index : Number.MAX_SAFE_INTEGER;
+    return leftIndex - rightIndex;
+  });
+}
+
+export function isCommandBarInputNode(node: RemoteUiNodeSnapshot): boolean {
+  return (
+    (node.role === "input" || node.role === "command-bar-input")
+    && node.metadata?.scope === "command-bar"
+  );
+}
+
+function commandBarInputValue(nodes: RemoteUiNodeSnapshot[], fallback: string): string {
+  const focusedInput = nodes.find((node) => isCommandBarInputNode(node) && node.metadata?.focused === true);
+  const value = focusedInput?.metadata?.value;
+  return typeof value === "string" ? value : fallback;
+}
+
+export function commandBarSnapshot(state: AppState, nodes: RemoteUiNodeSnapshot[]) {
+  const results = commandBarResultsFromNodes(nodes);
+  return {
+    open: state.commandBarOpen,
+    query: commandBarInputValue(nodes, state.commandBarQuery),
+    stateQuery: state.commandBarQuery,
+    launchRequest: state.commandBarLaunchRequest,
+    selectedIndex: results.find((result) => result.selected)?.index ?? null,
+    results,
+  };
+}

--- a/src/remote/controller-utils.ts
+++ b/src/remote/controller-utils.ts
@@ -1,0 +1,111 @@
+import { getDockedPaneIds } from "../plugins/pane-manager";
+import type { AppState } from "../state/app/context";
+import type { LayoutConfig, PaneInstanceConfig } from "../types/config";
+import { revisionFor } from "./revision";
+import type { RemoteControlResponse, RemoteIncludedState, RemoteStateInclude } from "./types";
+
+export interface PatchTarget<T> {
+  value: T;
+  apply(value: T): Promise<void> | void;
+}
+
+export function ok<T>(data: T, rev?: string, state?: RemoteIncludedState): RemoteControlResponse<T> {
+  return {
+    ok: true,
+    data,
+    ...(rev ? { rev } : {}),
+    ...(state ? { state } : {}),
+  };
+}
+
+export function fail(code: string, error: unknown): RemoteControlResponse {
+  return {
+    ok: false,
+    error: {
+      code,
+      message: error instanceof Error ? error.message : String(error),
+    },
+  };
+}
+
+export function asRecord(input: unknown): Record<string, unknown> {
+  return input && typeof input === "object" && !Array.isArray(input) ? input as Record<string, unknown> : {};
+}
+
+export function stringInput(input: Record<string, unknown>, key: string): string {
+  const value = input[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${key} is required.`);
+  }
+  return value;
+}
+
+export function optionalString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function numberInput(input: Record<string, unknown>, key: string): number {
+  const value = input[key];
+  if (!Number.isInteger(value)) {
+    throw new Error(`${key} must be an integer.`);
+  }
+  return value as number;
+}
+
+export function optionalNumber(input: Record<string, unknown>, key: string): number | undefined {
+  const value = input[key];
+  return Number.isInteger(value) ? value as number : undefined;
+}
+
+export function activeLayoutRev(state: AppState): string {
+  return revisionFor({
+    layout: state.config.layout,
+    paneState: state.paneState,
+    focusedPaneId: state.focusedPaneId,
+    activePanel: state.activePanel,
+  });
+}
+
+export function panePlacement(layout: LayoutConfig, instanceId: string): "docked" | "floating" | "detached" | "hidden" {
+  if (getDockedPaneIds(layout).includes(instanceId)) return "docked";
+  if (layout.floating.some((entry) => entry.instanceId === instanceId)) return "floating";
+  if ((layout.detached ?? []).some((entry) => entry.instanceId === instanceId)) return "detached";
+  return "hidden";
+}
+
+export function paneSnapshot(state: AppState, pane: PaneInstanceConfig) {
+  return {
+    ...pane,
+    placement: panePlacement(state.config.layout, pane.instanceId),
+    focused: state.focusedPaneId === pane.instanceId,
+    runtimeState: state.paneState[pane.instanceId] ?? {},
+  };
+}
+
+export function mutationSummary(state: AppState, extra: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    rev: activeLayoutRev(state),
+    activeLayoutIndex: state.config.activeLayoutIndex,
+    activeLayoutName: state.config.layouts[state.config.activeLayoutIndex]?.name ?? null,
+    focusedPaneId: state.focusedPaneId,
+    commandBarOpen: state.commandBarOpen,
+    commandBarQuery: state.commandBarQuery,
+    dockedPaneIds: getDockedPaneIds(state.config.layout),
+    floatingPaneIds: state.config.layout.floating.map((entry) => entry.instanceId),
+    detachedPaneIds: (state.config.layout.detached ?? []).map((entry) => entry.instanceId),
+    ...extra,
+  };
+}
+
+export function normalizeIncludes(
+  include: RemoteStateInclude[] | undefined,
+  defaults: RemoteStateInclude[] = [],
+): RemoteStateInclude[] {
+  const raw = include ?? defaults;
+  if (raw.includes("all")) {
+    return ["app", "layout", "panes", "commandBar", "ui", "schema", "help"];
+  }
+  return [...new Set(raw)];
+}

--- a/src/remote/controller.test.ts
+++ b/src/remote/controller.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, test } from "bun:test";
+import type { Dispatch } from "react";
+import { appReducer, createInitialState, type AppAction, type AppState } from "../core/state/app/state";
+import type { PluginRegistry } from "../plugins/registry";
+import { createDefaultConfig } from "../types/config";
+import { createAppRemoteController } from "./controller";
+import type { RemoteControlSchema, RemoteUiNodeSnapshot } from "./types";
+import type { RemoteUiRegistry } from "./semantic-tree";
+
+function createRegistryHarness() {
+  let state = createInitialState({
+    ...createDefaultConfig("/tmp/gloom-remote-controller"),
+    onboardingComplete: true,
+  });
+  const actions: AppAction[] = [];
+  const dispatch: Dispatch<AppAction> = (action) => {
+    actions.push(action);
+    state = appReducer(state, action);
+  };
+  const registry = {
+    panes: new Map(),
+    paneTemplates: new Map(),
+    commands: new Map(),
+    capabilities: {
+      manifests: () => [],
+      invoke: async () => ({ invoked: true }),
+    },
+    resolvePaneSettings: () => null,
+    showPane: () => {},
+    focusPane: () => {},
+    hidePane: () => {},
+    createPaneFromTemplateAsyncFn: async () => {},
+    navigateTicker: () => {},
+    pinTicker: () => {},
+    selectTicker: () => {},
+    switchTab: () => {},
+    getTermSizeFn: () => ({ width: 120, height: 40 }),
+    updateLayoutFn: (layout: AppState["config"]["layout"]) => {
+      dispatch({ type: "UPDATE_LAYOUT", layout });
+    },
+    applyPaneSettingValueFn: async () => {},
+    notify: () => {},
+  } as unknown as PluginRegistry;
+  let uiNodes: RemoteUiNodeSnapshot[] = [{ id: "ui:test", role: "button", label: "Test", actions: ["press"] }];
+  const invokedUiActions: Array<{ nodeId: string; action: string; input?: unknown }> = [];
+  const uiRegistry: RemoteUiRegistry = {
+    register: () => {},
+    unregister: () => {},
+    snapshot: () => uiNodes,
+    invoke: async (nodeId, action, input) => {
+      invokedUiActions.push({ nodeId, action, input });
+      return { nodeId, action, input };
+    },
+  };
+  const controller = createAppRemoteController({
+    dispatch,
+    getState: () => state,
+    pluginRegistry: registry,
+    uiRegistry,
+  });
+  return {
+    actions,
+    controller,
+    getState: () => state,
+    invokedUiActions,
+    setUiNodes: (nodes: RemoteUiNodeSnapshot[]) => {
+      uiNodes = nodes;
+    },
+  };
+}
+
+describe("createAppRemoteController", () => {
+  test("exposes schema, app snapshot, and semantic UI tree", async () => {
+    const { controller } = createRegistryHarness();
+
+    const schema = await controller.handle({ type: "schema" });
+    expect(schema.ok).toBe(true);
+    if (schema.ok) {
+      const data = schema.data as RemoteControlSchema;
+      expect(data.resources.some((resource) => resource.uri === "ui://tree")).toBe(true);
+      expect(data.operations.some((operation) => operation.id === "ui.invoke")).toBe(true);
+      expect(data.help).toMatchObject({
+        title: "Gloomberb remote control guide",
+      });
+    }
+
+    const help = await controller.handle({ type: "help" });
+    expect(help.ok).toBe(true);
+    if (help.ok) {
+      expect(help.data).toMatchObject({
+        batching: expect.any(Object),
+      });
+    }
+
+    const snapshot = await controller.handle({ type: "get", resource: "app://snapshot" });
+    expect(snapshot.ok).toBe(true);
+    if (snapshot.ok) {
+      const data = snapshot.data as { ui: unknown[] };
+      expect(data.ui).toEqual([{ id: "ui:test", role: "button", label: "Test", actions: ["press"] }]);
+      expect(typeof snapshot.rev).toBe("string");
+    }
+  });
+
+  test("dispatches semantic app operations", async () => {
+    const { actions, controller, getState } = createRegistryHarness();
+
+    const response = await controller.handle({
+      type: "call",
+      operation: "app.openCommandBar",
+      input: { query: "NVDA" },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(actions).toContainEqual({ type: "SET_COMMAND_BAR", open: true, query: "NVDA" });
+    expect(getState().commandBarOpen).toBe(true);
+    expect(getState().commandBarQuery).toBe("NVDA");
+    if (response.ok) {
+      expect(response.state?.commandBar).toMatchObject({
+        open: true,
+        stateQuery: "NVDA",
+      });
+    }
+  });
+
+  test("opens ticker search without requiring command-bar prefix syntax", async () => {
+    const { actions, controller, getState } = createRegistryHarness();
+
+    const response = await controller.handle({
+      type: "call",
+      operation: "app.search",
+      input: { mode: "ticker", query: "google" },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(actions).toContainEqual({
+      type: "SET_COMMAND_BAR",
+      open: true,
+      launch: { kind: "ticker-search", query: "google" },
+    });
+    expect(getState().commandBarOpen).toBe(true);
+    expect(getState().commandBarLaunchRequest).toMatchObject({
+      kind: "ticker-search",
+      query: "google",
+    });
+  });
+
+  test("exposes and activates semantic command-bar results", async () => {
+    const { controller, invokedUiActions, setUiNodes } = createRegistryHarness();
+    setUiNodes([
+      {
+        id: "ui:input",
+        role: "input",
+        actions: ["setValue"],
+        metadata: { value: "T google", focused: true },
+      },
+      {
+        id: "ui:goog",
+        role: "command-bar-result",
+        label: "GOOG",
+        actions: ["activate"],
+        metadata: {
+          index: 1,
+          selected: false,
+          item: {
+            id: "ticker:GOOG",
+            label: "GOOG",
+            detail: "Alphabet Inc.",
+            category: "Primary Listing",
+            kind: "ticker",
+            right: "Equity NASDAQ",
+          },
+        },
+      },
+    ]);
+
+    const results = await controller.handle({ type: "get", resource: "app://command-bar/results" });
+    expect(results.ok).toBe(true);
+    if (results.ok) {
+      expect(results.data).toMatchObject([
+        {
+          nodeId: "ui:goog",
+          index: 1,
+          label: "GOOG",
+          kind: "ticker",
+          right: "Equity NASDAQ",
+        },
+      ]);
+    }
+
+    const activated = await controller.handle({
+      type: "call",
+      operation: "commandBar.activateResult",
+      input: { index: 1 },
+    });
+    expect(activated.ok).toBe(true);
+    expect(invokedUiActions).toContainEqual({ nodeId: "ui:goog", action: "activate", input: undefined });
+  });
+
+  test("scopes command-bar query reads to the command-bar input", async () => {
+    const { controller, setUiNodes } = createRegistryHarness();
+    setUiNodes([
+      {
+        id: "ui:pane-input",
+        role: "input",
+        actions: ["setValue"],
+        metadata: { value: "pane search", focused: true },
+      },
+      {
+        id: "ui:command-input",
+        role: "input",
+        actions: ["setValue"],
+        metadata: { value: "theme", focused: true, scope: "command-bar" },
+      },
+    ]);
+
+    const response = await controller.handle({ type: "get", resource: "app://command-bar" });
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect((response.data as { query: string }).query).toBe("theme");
+    }
+  });
+
+  test("exposes shared list items as command-bar results", async () => {
+    const { controller, invokedUiActions, setUiNodes } = createRegistryHarness();
+    setUiNodes([
+      {
+        id: "ui:theme-list",
+        role: "list",
+        label: "Theme picker",
+        actions: ["activate", "select"],
+        metadata: {
+          scope: "command-bar",
+          selectedIndex: 1,
+          itemKind: "theme",
+          items: [
+            { index: 0, id: "github-dark", label: "GitHub Dark", kind: "theme", category: "Themes" },
+            { index: 1, id: "github-light", label: "GitHub Light", kind: "theme", category: "Themes", current: true },
+          ],
+        },
+      },
+    ]);
+
+    const results = await controller.handle({ type: "get", resource: "app://command-bar/results" });
+    expect(results.ok).toBe(true);
+    if (results.ok) {
+      expect(results.data).toMatchObject([
+        { nodeId: "ui:theme-list", index: 0, label: "GitHub Dark", kind: "theme", itemId: "github-dark" },
+        { nodeId: "ui:theme-list", index: 1, label: "GitHub Light", kind: "theme", itemId: "github-light", selected: true },
+      ]);
+    }
+
+    const activated = await controller.handle({
+      type: "call",
+      operation: "commandBar.activateResult",
+      input: { label: "GitHub Light" },
+    });
+    expect(activated.ok).toBe(true);
+    expect(invokedUiActions).toContainEqual({
+      nodeId: "ui:theme-list",
+      action: "activate",
+      input: { index: 1, id: "github-light", label: "GitHub Light" },
+    });
+  });
+
+  test("invokes semantic UI nodes by selector", async () => {
+    const { controller, invokedUiActions, setUiNodes } = createRegistryHarness();
+    setUiNodes([
+      { id: "ui:cancel", role: "button", label: "Cancel", actions: ["press"] },
+      { id: "ui:done", role: "button", label: "Done", actions: ["press"], metadata: { scope: "command-bar" } },
+    ]);
+
+    const response = await controller.handle({
+      type: "call",
+      operation: "ui.invokeMatching",
+      input: { role: "button", label: "Done", action: "press" },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(invokedUiActions).toContainEqual({ nodeId: "ui:done", action: "press", input: undefined });
+
+    const directResponse = await controller.handle({
+      type: "call",
+      operation: "ui.invoke",
+      input: { nodeId: "ui:done", action: "press" },
+    });
+    expect(directResponse.ok).toBe(true);
+    if (directResponse.ok) {
+      expect(directResponse.data).toMatchObject({
+        ok: true,
+        result: { nodeId: "ui:done", action: "press" },
+      });
+    }
+  });
+
+  test("runs sequential batches with halt-on-error and final state", async () => {
+    const { controller } = createRegistryHarness();
+
+    const response = await controller.handle({
+      type: "batch",
+      include: ["commandBar"],
+      requests: [
+        { type: "call", operation: "app.openCommandBar", input: { query: "theme" } },
+        { type: "call", operation: "missing.operation", input: {} },
+        { type: "call", operation: "app.closeCommandBar", input: {} },
+      ],
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.data).toMatchObject({
+        ok: false,
+        haltedAt: 1,
+      });
+      expect((response.data as { responses: unknown[] }).responses).toHaveLength(2);
+      expect(response.state?.commandBar).toMatchObject({
+        open: true,
+      });
+    }
+  });
+
+  test("patches pane runtime state with replace semantics", async () => {
+    const { controller, getState } = createRegistryHarness();
+    const paneId = getState().config.layout.instances[0]!.instanceId;
+    await controller.handle({
+      type: "call",
+      operation: "pane.setState",
+      input: { paneId, patch: { cursorSymbol: "NVDA", stale: true } },
+    });
+
+    const response = await controller.handle({
+      type: "patch",
+      resource: `app://pane-state/${encodeURIComponent(paneId)}`,
+      patch: [{ op: "remove", path: "/stale" }],
+    });
+
+    expect(response.ok).toBe(true);
+    expect(getState().paneState[paneId]).toMatchObject({ cursorSymbol: "NVDA" });
+    expect(getState().paneState[paneId]?.stale).toBeUndefined();
+  });
+
+  test("closes floating panes and grids visible panes through layout helpers", async () => {
+    const { controller, getState } = createRegistryHarness();
+    expect(getState().config.layout.floating.length).toBeGreaterThan(0);
+
+    const closeResponse = await controller.handle({
+      type: "call",
+      operation: "layout.closeFloating",
+      input: {},
+    });
+    expect(closeResponse.ok).toBe(true);
+    expect(getState().config.layout.floating).toEqual([]);
+
+    const paneIds = getState().config.layout.instances.slice(0, 4).map((pane) => pane.instanceId);
+    const gridResponse = await controller.handle({
+      type: "call",
+      operation: "layout.setGrid",
+      input: { paneIds, columns: 2 },
+    });
+    expect(gridResponse.ok).toBe(true);
+    expect(getState().config.layout.dockRoot).toMatchObject({
+      kind: "split",
+      axis: "vertical",
+    });
+  });
+});

--- a/src/remote/controller.ts
+++ b/src/remote/controller.ts
@@ -1,0 +1,434 @@
+import type { Dispatch } from "react";
+import {
+  dockPane,
+  floatPane,
+  getDockLeafLayouts,
+  gridlockAllPanes,
+  insertAtRootEdge,
+  removeFloatingPanes,
+} from "../plugins/pane-manager";
+import type { PluginRegistry } from "../plugins/registry";
+import type { AppAction, AppState } from "../state/app/context";
+import { setPaneSettings } from "../pane-settings";
+import type { DesktopWindowBridge } from "../types/desktop-window";
+import { applyJsonPatch } from "./json-patch";
+import { revisionFor } from "./revision";
+import type {
+  RemoteControlRequest,
+  RemoteControlResponse,
+  RemoteJsonPatchOperation,
+  RemoteStateInclude,
+} from "./types";
+import type { RemoteUiRegistry } from "./semantic-tree";
+import { commandBarResultsFromNodes, isCommandBarInputNode } from "./command-bar";
+import { REMOTE_AGENT_HELP, remoteControlSchema } from "./schema";
+import {
+  asRecord,
+  fail,
+  mutationSummary,
+  numberInput,
+  ok,
+  optionalNumber,
+  optionalString,
+  stringInput,
+} from "./controller-utils";
+import {
+  buildGridDockRoot,
+  regionToDockPosition,
+  regionToRootEdge,
+  requirePaneInstance,
+  visiblePaneIds,
+} from "./layout-helpers";
+import { createRemoteResources } from "./resources";
+
+interface AppRemoteControllerOptions {
+  dispatch: Dispatch<AppAction>;
+  getState: () => AppState;
+  pluginRegistry: PluginRegistry;
+  uiRegistry: RemoteUiRegistry | null;
+  desktopWindowBridge?: DesktopWindowBridge;
+  afterMutation?: () => Promise<void> | void;
+}
+
+const DEFAULT_MUTATION_INCLUDE: RemoteStateInclude[] = ["app", "layout", "panes", "commandBar"];
+const DEFAULT_BATCH_INCLUDE: RemoteStateInclude[] = ["app", "layout", "panes", "commandBar"];
+
+export function createAppRemoteController({
+  dispatch,
+  getState,
+  pluginRegistry,
+  uiRegistry,
+  desktopWindowBridge,
+  afterMutation = () => {},
+}: AppRemoteControllerOptions) {
+  const { buildIncludedState, getResource, patchTarget } = createRemoteResources({
+    dispatch,
+    getState,
+    pluginRegistry,
+    uiRegistry,
+  });
+
+  const getAfterMutation = async (resource: string): Promise<unknown> => {
+    await afterMutation();
+    return getResource(resource);
+  };
+
+  const getAfterMutationSummary = async (extra?: Record<string, unknown>): Promise<unknown> => {
+    await afterMutation();
+    return mutationSummary(getState(), extra);
+  };
+
+  const openCommandBar = async (input: Record<string, unknown>): Promise<unknown> => {
+    const mode = optionalString(input, "mode") ?? "command";
+    const query = optionalString(input, "query") ?? "";
+    if (getState().commandBarOpen) {
+      dispatch({ type: "SET_COMMAND_BAR", open: false });
+      await afterMutation();
+    }
+    if (mode === "ticker") {
+      dispatch({ type: "SET_COMMAND_BAR", open: true, launch: { kind: "ticker-search", query } });
+      await afterMutation();
+      return mutationSummary(getState(), { commandBar: getResource("app://command-bar") });
+    }
+    if (mode !== "command" && mode !== "default") {
+      throw new Error(`Unsupported command-bar mode "${mode}".`);
+    }
+    dispatch({ type: "SET_COMMAND_BAR", open: true, query });
+    await afterMutation();
+    return mutationSummary(getState(), { commandBar: getResource("app://command-bar") });
+  };
+
+  const setVisibleCommandBarQuery = async (query: string): Promise<void> => {
+    dispatch({ type: "SET_COMMAND_BAR_QUERY", query });
+    await afterMutation();
+    const inputNode = (uiRegistry?.snapshot() ?? [])
+      .find((node) => isCommandBarInputNode(node) && node.metadata?.focused === true && node.actions.includes("setValue"));
+    if (!inputNode) return;
+    if (inputNode.metadata?.value === query) return;
+    await uiRegistry?.invoke(inputNode.id, "setValue", { value: query });
+    await afterMutation();
+  };
+
+  const activateCommandBarResult = async (input: Record<string, unknown>): Promise<unknown> => {
+    const nodeId = optionalString(input, "nodeId");
+    const index = optionalNumber(input, "index");
+    const itemId = optionalString(input, "itemId");
+    const label = optionalString(input, "label");
+    const results = commandBarResultsFromNodes(uiRegistry?.snapshot() ?? []);
+    const result = nodeId
+      ? results.find((entry) => entry.nodeId === nodeId)
+      : itemId
+        ? results.find((entry) => entry.itemId === itemId)
+        : label
+          ? results.find((entry) => entry.label === label)
+      : typeof index === "number"
+        ? results.find((entry) => entry.index === index)
+        : results.find((entry) => entry.selected) ?? results[0];
+    if (!result) throw new Error("No matching command-bar result is visible.");
+    if (!result.actions.includes("activate")) {
+      throw new Error(`Command-bar result "${result.nodeId}" does not expose activate.`);
+    }
+    await uiRegistry?.invoke(result.nodeId, "activate", result.actionInput);
+    return getAfterMutationSummary({ activatedResult: result });
+  };
+
+  const invokeMatchingUiNode = async (input: Record<string, unknown>): Promise<unknown> => {
+    const role = optionalString(input, "role");
+    const label = optionalString(input, "label");
+    const contains = optionalString(input, "contains");
+    const index = optionalNumber(input, "index");
+    const action = optionalString(input, "action") ?? "press";
+    const metadataFilter = asRecord(input.metadata);
+    const candidates = (uiRegistry?.snapshot() ?? []).filter((node) => {
+      if (role && node.role !== role) return false;
+      if (label && node.label !== label && node.metadata?.item && typeof node.metadata.item === "object") {
+        const item = node.metadata.item as Record<string, unknown>;
+        if (item.label !== label && item.id !== label) return false;
+      } else if (label && node.label !== label) {
+        return false;
+      }
+      if (contains) {
+        const haystack = [
+          node.label,
+          node.role,
+          JSON.stringify(node.metadata ?? {}),
+        ].filter((entry): entry is string => typeof entry === "string").join(" ").toLowerCase();
+        if (!haystack.includes(contains.toLowerCase())) return false;
+      }
+      for (const [key, value] of Object.entries(metadataFilter)) {
+        if (node.metadata?.[key] !== value) return false;
+      }
+      if (!node.actions.includes(action)) return false;
+      if (node.disabled) return false;
+      return true;
+    });
+    const node = typeof index === "number" ? candidates[index] : candidates[0];
+    if (!node) throw new Error("No matching semantic UI node is visible.");
+    const result = await uiRegistry?.invoke(node.id, action, input.input);
+    return getAfterMutationSummary({ invokedNode: node, result });
+  };
+
+  const call = async (operation: string, rawInput: unknown, dryRun?: boolean): Promise<unknown> => {
+    const input = asRecord(rawInput);
+    const dryRunResult = () => ({ operation, input, dryRun: true });
+    if (dryRun) return dryRunResult();
+
+    switch (operation) {
+      case "app.openCommandBar":
+        return openCommandBar(input);
+      case "app.closeCommandBar":
+        dispatch({ type: "SET_COMMAND_BAR", open: false });
+        return getAfterMutationSummary();
+      case "app.setCommandBarQuery":
+        await setVisibleCommandBarQuery(stringInput(input, "query"));
+        return mutationSummary(getState(), { commandBar: getResource("app://command-bar") });
+      case "app.search":
+        return openCommandBar(input);
+      case "app.switchPanel":
+        dispatch({ type: "SET_ACTIVE_PANEL", panel: input.panel === "right" ? "right" : "left" });
+        return getAfterMutationSummary();
+      case "app.notify":
+        pluginRegistry.notify({ body: stringInput(input, "body"), type: input.type as never });
+        return null;
+      case "commandBar.activateResult":
+        return activateCommandBarResult(input);
+      case "pane.show":
+        pluginRegistry.showPane(stringInput(input, "paneId"));
+        return getAfterMutationSummary();
+      case "pane.focus":
+        pluginRegistry.focusPane(stringInput(input, "paneId"));
+        return getAfterMutationSummary();
+      case "pane.close": {
+        const paneId = stringInput(input, "paneId");
+        pluginRegistry.hidePane(paneId);
+        return getAfterMutationSummary({ affectedPaneIds: [paneId] });
+      }
+      case "pane.createFromTemplate":
+        await pluginRegistry.createPaneFromTemplateAsyncFn(
+          stringInput(input, "templateId"),
+          asRecord(input.options),
+        );
+        return getAfterMutationSummary();
+      case "pane.setState":
+        dispatch({
+          type: "UPDATE_PANE_STATE",
+          paneId: stringInput(input, "paneId"),
+          patch: asRecord(input.patch),
+        });
+        return getAfterMutationSummary({ affectedPaneIds: [stringInput(input, "paneId")] });
+      case "pane.setSetting": {
+        const paneId = stringInput(input, "paneId");
+        const key = stringInput(input, "key");
+        const descriptor = pluginRegistry.resolvePaneSettings(paneId);
+        const field = descriptor?.settingsDef.fields.find((entry) => entry.key === key);
+        if (field) {
+          await pluginRegistry.applyPaneSettingValueFn(descriptor!.paneId, field, input.value);
+        } else {
+          const instanceId = descriptor?.paneId ?? paneId;
+          const current = pluginRegistry.resolvePaneSettings(instanceId)?.context.settings ?? {};
+          pluginRegistry.updateLayoutFn(setPaneSettings(getState().config.layout, instanceId, {
+            ...current,
+            [key]: input.value,
+          }));
+        }
+        return getAfterMutationSummary({ affectedPaneIds: [paneId] });
+      }
+      case "ticker.navigate":
+        pluginRegistry.navigateTicker(stringInput(input, "symbol"), { sourcePaneId: optionalString(input, "sourcePaneId") });
+        return getAfterMutationSummary({ symbol: stringInput(input, "symbol") });
+      case "ticker.pin":
+        pluginRegistry.pinTicker(stringInput(input, "symbol"), {
+          floating: input.floating === true,
+          forceNewPane: input.forceNewPane === true,
+          paneType: optionalString(input, "paneType"),
+        });
+        return getAfterMutationSummary({ symbol: stringInput(input, "symbol") });
+      case "ticker.select":
+        pluginRegistry.selectTicker(stringInput(input, "symbol"), optionalString(input, "paneId"));
+        return getAfterMutationSummary({ symbol: stringInput(input, "symbol") });
+      case "ticker.switchTab":
+        pluginRegistry.switchTab(stringInput(input, "tabId"), optionalString(input, "paneId"));
+        return getAfterMutationSummary({ tabId: stringInput(input, "tabId") });
+      case "layout.switch":
+        dispatch({ type: "SWITCH_LAYOUT", index: numberInput(input, "index") });
+        return getAfterMutationSummary();
+      case "layout.new":
+        dispatch({ type: "NEW_LAYOUT", name: stringInput(input, "name") });
+        return getAfterMutationSummary();
+      case "layout.rename":
+        dispatch({ type: "RENAME_LAYOUT", index: numberInput(input, "index"), name: stringInput(input, "name") });
+        return getAfterMutationSummary();
+      case "layout.duplicate":
+        dispatch({ type: "DUPLICATE_LAYOUT", index: numberInput(input, "index") });
+        return getAfterMutationSummary();
+      case "layout.delete":
+        dispatch({ type: "DELETE_LAYOUT", index: numberInput(input, "index") });
+        return getAfterMutationSummary();
+      case "layout.undo":
+        dispatch({ type: "UNDO_LAYOUT" });
+        return getAfterMutationSummary();
+      case "layout.redo":
+        dispatch({ type: "REDO_LAYOUT" });
+        return getAfterMutationSummary();
+      case "layout.gridlock": {
+        const { width, height } = pluginRegistry.getTermSizeFn();
+        pluginRegistry.updateLayoutFn(gridlockAllPanes(
+          getState().config.layout,
+          { x: 0, y: 0, width, height },
+          pluginRegistry.panes,
+        ));
+        return getAfterMutationSummary();
+      }
+      case "layout.closeFloating": {
+        const floatingPaneIds = getState().config.layout.floating.map((entry) => entry.instanceId);
+        pluginRegistry.updateLayoutFn(removeFloatingPanes(getState().config.layout));
+        return getAfterMutationSummary({ affectedPaneIds: floatingPaneIds });
+      }
+      case "layout.placePane": {
+        const pane = requirePaneInstance(getState().config.layout, stringInput(input, "paneId"));
+        const region = stringInput(input, "region");
+        const { width, height } = pluginRegistry.getTermSizeFn();
+        const def = pluginRegistry.panes.get(pane.paneId);
+        const nextLayout = region === "floating"
+          ? floatPane(getState().config.layout, pane.instanceId, width, height, def)
+          : optionalString(input, "relativeTo")
+            ? dockPane(getState().config.layout, pane.instanceId, {
+              relativeTo: requirePaneInstance(getState().config.layout, optionalString(input, "relativeTo")!).instanceId,
+              position: regionToDockPosition(region),
+            })
+            : insertAtRootEdge(getState().config.layout, pane.instanceId, regionToRootEdge(region));
+        pluginRegistry.updateLayoutFn(nextLayout);
+        return getAfterMutationSummary({ affectedPaneIds: [pane.instanceId] });
+      }
+      case "layout.focusRegion": {
+        const region = stringInput(input, "region");
+        const { width, height } = pluginRegistry.getTermSizeFn();
+        const leaves = getDockLeafLayouts(getState().config.layout, { x: 0, y: 0, width, height });
+        if (leaves.length === 0) throw new Error("No docked panes are visible.");
+        const target = leaves
+          .map((leaf) => {
+            const centerX = leaf.rect.x + leaf.rect.width / 2;
+            const centerY = leaf.rect.y + leaf.rect.height / 2;
+            const score = region === "left" ? centerX
+              : region === "right" ? -centerX
+                : region === "top" ? centerY
+                  : region === "bottom" ? -centerY
+                    : Math.abs(centerX - width / 2) + Math.abs(centerY - height / 2);
+            return { leaf, score };
+          })
+          .sort((a, b) => a.score - b.score)[0]!.leaf;
+        dispatch({ type: "FOCUS_PANE", paneId: target.instanceId });
+        return getAfterMutationSummary({ affectedPaneIds: [target.instanceId] });
+      }
+      case "layout.setGrid": {
+        const rawPaneIds = Array.isArray(input.paneIds) ? input.paneIds : visiblePaneIds(getState().config.layout);
+        const paneIds = rawPaneIds.map((id) => requirePaneInstance(getState().config.layout, String(id)).instanceId);
+        const nextLayout = {
+          ...getState().config.layout,
+          dockRoot: buildGridDockRoot(paneIds, optionalNumber(input, "columns")),
+          floating: getState().config.layout.floating.filter((entry) => !paneIds.includes(entry.instanceId)),
+          detached: (getState().config.layout.detached ?? []).filter((entry) => !paneIds.includes(entry.instanceId)),
+        };
+        pluginRegistry.updateLayoutFn(nextLayout);
+        return getAfterMutationSummary({ affectedPaneIds: paneIds });
+      }
+      case "desktop.popOutPane":
+        await desktopWindowBridge?.popOutPane?.(stringInput(input, "paneId"));
+        return getAfterMutationSummary({ affectedPaneIds: [stringInput(input, "paneId")] });
+      case "desktop.dockPane":
+        await desktopWindowBridge?.dockDetachedPane?.(stringInput(input, "paneId"));
+        return getAfterMutationSummary({ affectedPaneIds: [stringInput(input, "paneId")] });
+      case "desktop.closeDetachedPane":
+        await desktopWindowBridge?.closeDetachedPane?.(stringInput(input, "paneId"));
+        return getAfterMutationSummary({ affectedPaneIds: [stringInput(input, "paneId")] });
+      case "desktop.focusDetachedPane":
+        await desktopWindowBridge?.focusDetachedPane?.(stringInput(input, "paneId"));
+        return getAfterMutationSummary({ affectedPaneIds: [stringInput(input, "paneId")] });
+      case "capability.invoke":
+        return await pluginRegistry.capabilities.invoke(
+          stringInput(input, "capabilityId"),
+          stringInput(input, "operationId"),
+          input.payload ?? {},
+        );
+      case "ui.invoke": {
+        const result = await uiRegistry?.invoke(
+          stringInput(input, "nodeId"),
+          optionalString(input, "action") ?? "press",
+          input.input,
+        );
+        return getAfterMutationSummary({ result });
+      }
+      case "ui.invokeMatching":
+        return invokeMatchingUiNode(input);
+      default:
+        throw new Error(`Unknown remote operation "${operation}".`);
+    }
+  };
+
+  const handle = async (request: RemoteControlRequest): Promise<RemoteControlResponse> => {
+    try {
+      switch (request.type) {
+        case "help":
+          return ok(REMOTE_AGENT_HELP, revisionFor(REMOTE_AGENT_HELP));
+        case "schema":
+          return ok(remoteControlSchema());
+        case "get": {
+          const data = getResource(request.resource);
+          return ok(data, revisionFor(data), buildIncludedState(request.include));
+        }
+        case "call": {
+          const data = await call(request.operation, request.input, request.dryRun);
+          return ok(data, undefined, buildIncludedState(request.include, request.dryRun ? [] : DEFAULT_MUTATION_INCLUDE));
+        }
+        case "patch": {
+          const target = patchTarget(request.resource);
+          const currentRev = revisionFor(target.value);
+          if (request.expectRev && request.expectRev !== currentRev) {
+            throw new Error(`Revision mismatch for ${request.resource}: expected ${request.expectRev}, got ${currentRev}.`);
+          }
+          const nextValue = applyJsonPatch(target.value, request.patch as RemoteJsonPatchOperation[]);
+          if (!request.dryRun) {
+            await target.apply(nextValue);
+            await afterMutation();
+          }
+          return ok(
+            nextValue,
+            revisionFor(nextValue),
+            buildIncludedState(request.include, request.dryRun ? [] : DEFAULT_MUTATION_INCLUDE),
+          );
+        }
+        case "batch": {
+          const responses = [];
+          const haltOnError = request.haltOnError !== false;
+          let haltedAt: number | null = null;
+          for (const entry of request.requests) {
+            const entryRequest = request.dryRun && (entry.type === "call" || entry.type === "patch")
+              ? { ...entry, dryRun: true, include: entry.include ?? [] } as RemoteControlRequest
+              : (entry.type === "call" || entry.type === "patch")
+                ? { ...entry, include: entry.include ?? [] } as RemoteControlRequest
+                : entry;
+            const response = await handle(entryRequest);
+            responses.push(response);
+            if (request.settle === "afterEach") await afterMutation();
+            if (!response.ok && haltOnError) {
+              haltedAt = responses.length - 1;
+              break;
+            }
+          }
+          if (request.settle === "afterBatch") await afterMutation();
+          return ok({
+            ok: responses.every((response) => response.ok),
+            haltedAt,
+            responses,
+          }, undefined, buildIncludedState(request.include, request.dryRun ? [] : DEFAULT_BATCH_INCLUDE));
+        }
+        default:
+          throw new Error(`Unknown remote request type: ${(request as { type?: unknown }).type}`);
+      }
+    } catch (error) {
+      return fail("remote_error", error);
+    }
+  };
+
+  return { handle };
+}

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -1,0 +1,41 @@
+import { readFile, rm, writeFile, mkdir } from "fs/promises";
+import { dirname, join } from "path";
+import type { RemoteAppKind, RemoteEndpoint } from "./types";
+
+const DEFAULT_ENDPOINT_FILE = "remote-control.json";
+
+export function remoteEndpointPath(dataDir: string, appKind?: RemoteAppKind): string {
+  return join(dataDir, appKind ? `remote-control.${appKind}.json` : DEFAULT_ENDPOINT_FILE);
+}
+
+export async function readRemoteEndpoint(dataDir: string, appKind?: RemoteAppKind): Promise<RemoteEndpoint> {
+  const raw = await readFile(remoteEndpointPath(dataDir, appKind), "utf-8");
+  return JSON.parse(raw) as RemoteEndpoint;
+}
+
+export async function writeRemoteEndpointFiles(dataDir: string, endpoint: RemoteEndpoint): Promise<void> {
+  await writeRemoteEndpoint(remoteEndpointPath(dataDir, endpoint.appKind), endpoint);
+  await writeRemoteEndpoint(remoteEndpointPath(dataDir), endpoint);
+}
+
+export async function removeRemoteEndpointFiles(dataDir: string, endpoint: RemoteEndpoint): Promise<void> {
+  await Promise.all([
+    removeRemoteEndpointIfOwned(remoteEndpointPath(dataDir, endpoint.appKind), endpoint),
+    removeRemoteEndpointIfOwned(remoteEndpointPath(dataDir), endpoint),
+  ]);
+}
+
+async function writeRemoteEndpoint(filePath: string, endpoint: RemoteEndpoint): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(endpoint, null, 2), { encoding: "utf-8", mode: 0o600 });
+}
+
+async function removeRemoteEndpointIfOwned(filePath: string, endpoint: RemoteEndpoint): Promise<void> {
+  try {
+    const existing = JSON.parse(await readFile(filePath, "utf-8")) as RemoteEndpoint;
+    if (existing.pid !== endpoint.pid || existing.token !== endpoint.token || existing.port !== endpoint.port) return;
+    await rm(filePath, { force: true });
+  } catch {
+    await rm(filePath, { force: true });
+  }
+}

--- a/src/remote/json-patch.test.ts
+++ b/src/remote/json-patch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { applyJsonPatch } from "./json-patch";
+
+describe("applyJsonPatch", () => {
+  test("adds, replaces, and removes nested values without mutating the source", () => {
+    const source: { panes: Array<{ id: string; state: Record<string, unknown> }> } = {
+      panes: [
+        { id: "one", state: { symbol: "NVDA", stale: true } },
+      ],
+    };
+
+    const patched = applyJsonPatch(source, [
+      { op: "replace", path: "/panes/0/state/symbol", value: "AAPL" },
+      { op: "remove", path: "/panes/0/state/stale" },
+      { op: "add", path: "/panes/0/state/tab", value: "chart" },
+    ]);
+
+    expect(patched).toEqual({
+      panes: [
+        { id: "one", state: { symbol: "AAPL", tab: "chart" } },
+      ],
+    });
+    expect(source.panes[0]!.state).toEqual({ symbol: "NVDA", stale: true });
+  });
+
+  test("appends to arrays with dash pointer", () => {
+    expect(applyJsonPatch({ values: ["a"] }, [
+      { op: "add", path: "/values/-", value: "b" },
+    ])).toEqual({ values: ["a", "b"] });
+  });
+});

--- a/src/remote/json-patch.ts
+++ b/src/remote/json-patch.ts
@@ -1,0 +1,89 @@
+import type { RemoteJsonPatchOperation } from "./types";
+
+function decodePointerSegment(segment: string): string {
+  return segment.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function pointerSegments(path: string): string[] {
+  if (path === "") return [];
+  if (!path.startsWith("/")) {
+    throw new Error(`JSON patch path must start with "/": ${path}`);
+  }
+  return path.slice(1).split("/").map(decodePointerSegment);
+}
+
+function cloneJson<T>(value: T): T {
+  return value == null ? value : JSON.parse(JSON.stringify(value)) as T;
+}
+
+function containerFor(root: unknown, path: string): { parent: unknown; key: string } {
+  const segments = pointerSegments(path);
+  if (segments.length === 0) {
+    throw new Error("Patch path cannot target the document root.");
+  }
+  let parent = root;
+  for (const segment of segments.slice(0, -1)) {
+    if (Array.isArray(parent)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= parent.length) {
+        throw new Error(`Invalid array index in JSON patch path: ${segment}`);
+      }
+      parent = parent[index];
+    } else if (parent && typeof parent === "object") {
+      parent = (parent as Record<string, unknown>)[segment];
+    } else {
+      throw new Error(`Cannot descend into non-object patch path: ${path}`);
+    }
+  }
+  return { parent, key: segments[segments.length - 1]! };
+}
+
+function applyOperation(root: unknown, operation: RemoteJsonPatchOperation): void {
+  const { parent, key } = containerFor(root, operation.path);
+  if (Array.isArray(parent)) {
+    const index = key === "-" ? parent.length : Number(key);
+    if (!Number.isInteger(index) || index < 0 || index > parent.length) {
+      throw new Error(`Invalid array index in JSON patch path: ${key}`);
+    }
+    if (operation.op === "remove") {
+      if (index >= parent.length) throw new Error(`Cannot remove missing array index: ${key}`);
+      parent.splice(index, 1);
+      return;
+    }
+    if (operation.op === "add") {
+      parent.splice(index, 0, operation.value);
+      return;
+    }
+    if (index >= parent.length) throw new Error(`Cannot replace missing array index: ${key}`);
+    parent[index] = operation.value;
+    return;
+  }
+
+  if (!parent || typeof parent !== "object") {
+    throw new Error(`Cannot patch non-object at path: ${operation.path}`);
+  }
+
+  const target = parent as Record<string, unknown>;
+  if (operation.op === "remove") {
+    if (!Object.prototype.hasOwnProperty.call(target, key)) {
+      throw new Error(`Cannot remove missing key: ${key}`);
+    }
+    delete target[key];
+    return;
+  }
+  if (operation.op === "replace" && !Object.prototype.hasOwnProperty.call(target, key)) {
+    throw new Error(`Cannot replace missing key: ${key}`);
+  }
+  target[key] = operation.value;
+}
+
+export function applyJsonPatch<T>(value: T, patch: RemoteJsonPatchOperation[]): T {
+  const next = cloneJson(value);
+  for (const operation of patch) {
+    if (operation.op !== "add" && operation.op !== "replace" && operation.op !== "remove") {
+      throw new Error(`Unsupported JSON patch operation: ${(operation as { op?: unknown }).op}`);
+    }
+    applyOperation(next, operation);
+  }
+  return next;
+}

--- a/src/remote/layout-helpers.ts
+++ b/src/remote/layout-helpers.ts
@@ -1,0 +1,62 @@
+import {
+  getDockedPaneIds,
+} from "../plugins/pane-manager";
+import type { DockLayoutNode, LayoutConfig, PaneInstanceConfig } from "../types/config";
+
+export function requirePaneInstance(layout: LayoutConfig, paneId: string): PaneInstanceConfig {
+  const instance = layout.instances.find((entry) => entry.instanceId === paneId)
+    ?? layout.instances.find((entry) => entry.paneId === paneId);
+  if (!instance) throw new Error(`Unknown pane "${paneId}".`);
+  return instance;
+}
+
+export function buildGridDockRoot(paneIds: string[], columns?: number): DockLayoutNode | null {
+  if (paneIds.length === 0) return null;
+  const columnCount = Math.max(1, Math.min(
+    paneIds.length,
+    Number.isInteger(columns) && columns! > 0 ? columns! : Math.ceil(Math.sqrt(paneIds.length)),
+  ));
+  const rows: DockLayoutNode[] = [];
+  for (let index = 0; index < paneIds.length; index += columnCount) {
+    rows.push(buildSplit(
+      paneIds.slice(index, index + columnCount).map((instanceId) => ({ kind: "pane", instanceId })),
+      "horizontal",
+    ));
+  }
+  return buildSplit(rows, "vertical");
+}
+
+export function visiblePaneIds(layout: LayoutConfig): string[] {
+  const ids = new Set<string>();
+  getDockedPaneIds(layout).forEach((id) => ids.add(id));
+  layout.floating.forEach((entry) => ids.add(entry.instanceId));
+  (layout.detached ?? []).forEach((entry) => ids.add(entry.instanceId));
+  return [...ids];
+}
+
+export function regionToDockPosition(region: string): "left" | "right" | "above" | "below" {
+  if (region === "left" || region === "right") return region;
+  if (region === "top") return "above";
+  if (region === "bottom") return "below";
+  throw new Error(`Unsupported dock region "${region}".`);
+}
+
+export function regionToRootEdge(region: string): "left" | "right" | "top" | "bottom" {
+  if (region === "left" || region === "right" || region === "top" || region === "bottom") return region;
+  throw new Error(`Unsupported root-edge region "${region}".`);
+}
+
+function buildSplit(nodes: DockLayoutNode[], axis: "horizontal" | "vertical"): DockLayoutNode {
+  if (nodes.length === 0) throw new Error("Cannot build an empty dock split.");
+  if (nodes.length === 1) return nodes[0]!;
+  const splitIndex = Math.ceil(nodes.length / 2);
+  const firstNodes = nodes.slice(0, splitIndex);
+  const secondNodes = nodes.slice(splitIndex);
+  return {
+    kind: "split",
+    axis,
+    ratio: firstNodes.length / nodes.length,
+    first: buildSplit(firstNodes, axis),
+    second: buildSplit(secondNodes, axis),
+  };
+}

--- a/src/remote/resources.ts
+++ b/src/remote/resources.ts
@@ -1,0 +1,186 @@
+import type { Dispatch } from "react";
+import type { PluginRegistry } from "../plugins/registry";
+import type { AppAction, AppState } from "../state/app/context";
+import type { PaneRuntimeState } from "../core/state/app/state";
+import { setPaneSettings } from "../pane-settings";
+import type { LayoutConfig } from "../types/config";
+import { commandBarResultsFromNodes, commandBarSnapshot } from "./command-bar";
+import type { RemoteUiRegistry } from "./semantic-tree";
+import { REMOTE_AGENT_HELP, remoteControlSchema } from "./schema";
+import type { RemoteIncludedState, RemoteStateInclude } from "./types";
+import {
+  activeLayoutRev,
+  normalizeIncludes,
+  paneSnapshot,
+  type PatchTarget,
+} from "./controller-utils";
+
+interface RemoteResourceContext {
+  dispatch: Dispatch<AppAction>;
+  getState: () => AppState;
+  pluginRegistry: PluginRegistry;
+  uiRegistry: RemoteUiRegistry | null;
+}
+
+export function createRemoteResources({
+  dispatch,
+  getState,
+  pluginRegistry,
+  uiRegistry,
+}: RemoteResourceContext) {
+  const getResource = (resource: string): unknown => {
+    const state = getState();
+    const uiNodes = uiRegistry?.snapshot() ?? [];
+    if (resource === "app://snapshot") {
+      return {
+        rev: activeLayoutRev(state),
+        app: {
+          activePanel: state.activePanel,
+          focusedPaneId: state.focusedPaneId,
+          previousFocusedPaneId: state.previousFocusedPaneId,
+          statusBarVisible: state.statusBarVisible,
+          commandBarOpen: state.commandBarOpen,
+          commandBarQuery: state.commandBarQuery,
+          initialized: state.initialized,
+        },
+        config: state.config,
+        panes: state.config.layout.instances.map((pane) => paneSnapshot(state, pane)),
+        commandBar: commandBarSnapshot(state, uiNodes),
+        ui: uiNodes,
+        schema: remoteControlSchema(),
+        help: REMOTE_AGENT_HELP,
+      };
+    }
+    if (resource === "app://config") return state.config;
+    if (resource === "app://layout/current") return state.config.layout;
+    if (resource === "app://layouts") return state.config.layouts;
+    if (resource === "app://panes") return state.config.layout.instances.map((pane) => paneSnapshot(state, pane));
+    if (resource === "app://pane-types") {
+      return [...pluginRegistry.panes.values()].map((pane) => ({
+        id: pane.id,
+        name: pane.name,
+        defaultPosition: pane.defaultPosition,
+        defaultMode: pane.defaultMode,
+        hasSettings: !!pane.settings,
+      }));
+    }
+    if (resource === "app://pane-templates") {
+      return [...pluginRegistry.paneTemplates.values()].map((template) => ({
+        id: template.id,
+        paneId: template.paneId,
+        label: template.label,
+        description: template.description,
+        shortcut: template.shortcut,
+      }));
+    }
+    if (resource.startsWith("app://pane-state/")) {
+      const paneId = decodeURIComponent(resource.slice("app://pane-state/".length));
+      return state.paneState[paneId] ?? {};
+    }
+    if (resource.startsWith("app://pane-settings/")) {
+      const paneId = decodeURIComponent(resource.slice("app://pane-settings/".length));
+      const descriptor = pluginRegistry.resolvePaneSettings(paneId);
+      if (!descriptor) throw new Error(`Pane "${paneId}" does not expose settings.`);
+      return {
+        paneId: descriptor.paneId,
+        settings: descriptor.context.settings,
+        fields: descriptor.settingsDef.fields,
+      };
+    }
+    if (resource === "app://commands") {
+      return [...pluginRegistry.commands.values()].map((command) => ({
+        id: command.id,
+        label: command.label,
+        description: command.description,
+        shortcut: command.shortcut,
+        hasWizard: !!command.wizard?.length,
+      }));
+    }
+    if (resource === "app://command-bar") return commandBarSnapshot(state, uiNodes);
+    if (resource === "app://command-bar/results") return commandBarResultsFromNodes(uiNodes);
+    if (resource === "app://capabilities") return pluginRegistry.capabilities.manifests();
+    if (resource === "app://remote/help") return REMOTE_AGENT_HELP;
+    if (resource === "ui://tree") return uiNodes;
+    throw new Error(`Unknown remote resource "${resource}".`);
+  };
+
+  const buildIncludedState = (include: RemoteStateInclude[] | undefined, defaults: RemoteStateInclude[] = []): RemoteIncludedState | undefined => {
+    const included = normalizeIncludes(include, defaults);
+    if (included.length === 0) return undefined;
+    const state = getState();
+    const uiNodes = uiRegistry?.snapshot() ?? [];
+    const result: RemoteIncludedState = {
+      rev: activeLayoutRev(state),
+      included,
+    };
+    if (included.includes("app")) {
+      result.app = {
+        activePanel: state.activePanel,
+        focusedPaneId: state.focusedPaneId,
+        previousFocusedPaneId: state.previousFocusedPaneId,
+        statusBarVisible: state.statusBarVisible,
+        commandBarOpen: state.commandBarOpen,
+        commandBarQuery: state.commandBarQuery,
+        initialized: state.initialized,
+        activeLayoutIndex: state.config.activeLayoutIndex,
+        activeLayoutName: state.config.layouts[state.config.activeLayoutIndex]?.name ?? null,
+      };
+    }
+    if (included.includes("layout")) result.layout = state.config.layout;
+    if (included.includes("panes")) {
+      result.panes = state.config.layout.instances.map((pane) => paneSnapshot(state, pane));
+    }
+    if (included.includes("commandBar") || included.includes("commandBar.results")) {
+      const commandBar = commandBarSnapshot(state, uiNodes);
+      result.commandBar = included.includes("commandBar")
+        ? commandBar
+        : { results: commandBar.results };
+    }
+    if (included.includes("ui")) result.ui = uiNodes;
+    if (included.includes("schema")) result.schema = remoteControlSchema();
+    if (included.includes("help")) result.help = REMOTE_AGENT_HELP;
+    return result;
+  };
+
+  const patchTarget = (resource: string): PatchTarget<unknown> => {
+    const state = getState();
+    if (resource === "app://config") {
+      return {
+        value: state.config,
+        apply: (value) => dispatch({ type: "SET_CONFIG", config: value as AppState["config"] }),
+      };
+    }
+    if (resource === "app://layout/current") {
+      return {
+        value: state.config.layout,
+        apply: (value) => pluginRegistry.updateLayoutFn(value as LayoutConfig),
+      };
+    }
+    if (resource.startsWith("app://pane-state/")) {
+      const paneId = decodeURIComponent(resource.slice("app://pane-state/".length));
+      return {
+        value: state.paneState[paneId] ?? {},
+        apply: (value) => dispatch({ type: "REPLACE_PANE_STATE", paneId, state: value as PaneRuntimeState }),
+      };
+    }
+    if (resource.startsWith("app://pane-settings/")) {
+      const paneId = decodeURIComponent(resource.slice("app://pane-settings/".length));
+      const descriptor = pluginRegistry.resolvePaneSettings(paneId);
+      if (!descriptor) throw new Error(`Pane "${paneId}" does not expose settings.`);
+      return {
+        value: descriptor.context.settings,
+        apply: (value) => {
+          const nextLayout = setPaneSettings(getState().config.layout, descriptor.paneId, value as Record<string, unknown>);
+          pluginRegistry.updateLayoutFn(nextLayout);
+        },
+      };
+    }
+    throw new Error(`Remote resource "${resource}" is not patchable.`);
+  };
+
+  return {
+    buildIncludedState,
+    getResource,
+    patchTarget,
+  };
+}

--- a/src/remote/revision.ts
+++ b/src/remote/revision.ts
@@ -1,0 +1,18 @@
+export function stableStringify(value: unknown): string {
+  if (value == null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) => (
+    `${JSON.stringify(key)}:${stableStringify(object[key])}`
+  )).join(",")}}`;
+}
+
+export function revisionFor(value: unknown): string {
+  const input = stableStringify(value);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/src/remote/schema.ts
+++ b/src/remote/schema.ts
@@ -1,0 +1,143 @@
+import type { RemoteControlSchema, RemoteOperationSchema, RemoteResourceSchema } from "./types";
+
+export const REMOTE_RESOURCES: RemoteResourceSchema[] = [
+  { uri: "app://snapshot", description: "Current app snapshot including layout, focus, panes, command bar, and plugin/capability catalogs." },
+  { uri: "app://config", description: "Current app config.", patchable: true },
+  { uri: "app://layout/current", description: "Current active layout.", patchable: true },
+  { uri: "app://layouts", description: "Saved layouts." },
+  { uri: "app://panes", description: "Current pane instances with placement and runtime state." },
+  { uri: "app://pane-types", description: "Registered pane types from core and plugins." },
+  { uri: "app://pane-templates", description: "Registered pane templates from core and plugins." },
+  { uri: "app://pane-state/{paneId}", description: "Runtime state for a pane instance.", patchable: true },
+  { uri: "app://pane-settings/{paneId}", description: "Persisted settings for a pane instance.", patchable: true },
+  { uri: "app://commands", description: "Registered command-bar commands." },
+  { uri: "app://command-bar", description: "Current command-bar state and semantic result rows." },
+  { uri: "app://command-bar/results", description: "Current semantic command-bar result rows." },
+  { uri: "app://capabilities", description: "Registered plugin capability manifests." },
+  { uri: "app://remote/help", description: "Agent-oriented remote usage guide with efficient recipes and caveats." },
+  { uri: "ui://tree", description: "Live semantic UI node tree populated by shared controls and interactive primitives." },
+];
+
+export const REMOTE_OPERATIONS: RemoteOperationSchema[] = [
+  op("app.openCommandBar", "Open the command bar with an optional query and optional mode.", "{ query?: string, mode?: 'command' | 'ticker' }", "local-write"),
+  op("app.closeCommandBar", "Close the command bar.", "{}", "local-write"),
+  op("app.setCommandBarQuery", "Set the command bar query.", "{ query: string }", "local-write"),
+  op("app.search", "Open command-bar search without requiring UI prefix syntax.", "{ mode: 'command' | 'ticker', query?: string }", "local-write"),
+  op("app.switchPanel", "Switch the active panel.", "{ panel: 'left' | 'right' }", "local-write"),
+  op("app.notify", "Show an in-app notification.", "{ body: string, type?: string }", "local-write"),
+  op("commandBar.activateResult", "Activate a visible command-bar result by zero-based index, node id, item id, or label.", "{ index?: number, nodeId?: string, itemId?: string, label?: string }", "local-write"),
+  op("pane.show", "Show or focus a pane type.", "{ paneId: string }", "local-write"),
+  op("pane.focus", "Focus a pane instance or pane type.", "{ paneId: string }", "local-write"),
+  op("pane.close", "Close a pane instance or pane type.", "{ paneId: string }", "local-write"),
+  op("pane.createFromTemplate", "Create a pane from a registered template.", "{ templateId: string, options?: object }", "local-write"),
+  op("pane.setState", "Patch pane runtime state.", "{ paneId: string, patch: object }", "local-write"),
+  op("pane.setSetting", "Set one pane setting using the pane's registered setting field when available.", "{ paneId: string, key: string, value: any }", "local-write"),
+  op("ticker.navigate", "Navigate a ticker into the best available ticker research target.", "{ symbol: string, sourcePaneId?: string }", "local-write"),
+  op("ticker.pin", "Open or focus a fixed ticker research pane.", "{ symbol: string, floating?: boolean, forceNewPane?: boolean, paneType?: string }", "local-write"),
+  op("ticker.select", "Select a ticker in a target pane.", "{ symbol: string, paneId?: string }", "local-write"),
+  op("ticker.switchTab", "Switch ticker research tab.", "{ tabId: string, paneId?: string }", "local-write"),
+  op("layout.switch", "Switch active layout by index.", "{ index: number }", "local-write"),
+  op("layout.new", "Create a new blank layout.", "{ name: string }", "local-write"),
+  op("layout.rename", "Rename a layout.", "{ index: number, name: string }", "local-write"),
+  op("layout.duplicate", "Duplicate a layout.", "{ index: number }", "local-write"),
+  op("layout.delete", "Delete a layout.", "{ index: number }", "local-write"),
+  op("layout.undo", "Undo last layout change.", "{}", "local-write"),
+  op("layout.redo", "Redo last layout change.", "{}", "local-write"),
+  op("layout.gridlock", "Gridlock all visible panes into a dense layout.", "{}", "local-write"),
+  op("layout.closeFloating", "Close all floating panes in the active layout.", "{}", "local-write"),
+  op("layout.placePane", "Move a pane to a layout region.", "{ paneId: string, region: 'left' | 'right' | 'top' | 'bottom' | 'floating', relativeTo?: string }", "local-write"),
+  op("layout.focusRegion", "Focus a pane by visual layout region.", "{ region: 'left' | 'right' | 'top' | 'bottom' | 'center' }", "local-write"),
+  op("layout.setGrid", "Dock visible or specified panes into a simple grid.", "{ paneIds?: string[], columns?: number }", "local-write"),
+  op("desktop.popOutPane", "Pop a pane into a detached desktop window.", "{ paneId: string }", "local-write"),
+  op("desktop.dockPane", "Dock a detached desktop pane.", "{ paneId: string }", "local-write"),
+  op("desktop.closeDetachedPane", "Close a detached desktop pane.", "{ paneId: string }", "local-write"),
+  op("desktop.focusDetachedPane", "Focus a detached desktop pane.", "{ paneId: string }", "local-write"),
+  op("capability.invoke", "Invoke a registered plugin capability operation.", "{ capabilityId: string, operationId: string, payload?: object }", "local-write"),
+  op("ui.invoke", "Invoke an action on a live semantic UI node.", "{ nodeId: string, action?: string, input?: any }", "local-write"),
+  op("ui.invokeMatching", "Invoke an action on the first semantic UI node matching role, label, index, or metadata.", "{ role?: string, label?: string, contains?: string, index?: number, action?: string, input?: any, metadata?: object }", "local-write"),
+];
+
+export const REMOTE_AGENT_HELP = {
+  title: "Gloomberb remote control guide",
+  quickStart: [
+    "Read app://snapshot once to orient; it includes schema, current layout, panes, command bar state, and semantic UI nodes.",
+    "Prefer app-level operations such as app.search, layout.setGrid, layout.closeFloating, and ticker.pin before falling back to ui.invoke.",
+    "Use commandBar.activateResult with label, itemId, or index after app.search; avoid raw node ids unless there is no stable semantic selector.",
+    "For list-like surfaces, prefer semantic list activation through commandBar.activateResult or ui.invokeMatching.",
+    "Use batch for multi-step flows; steps run sequentially and can return a compact final state so a separate read is not required.",
+  ],
+  resources: [
+    { uri: "app://command-bar", use: "Current command-bar query, open state, selected row, and semantic result rows." },
+    { uri: "app://command-bar/results", use: "Just the visible command-bar result/list rows." },
+    { uri: "ui://tree", use: "Low-level live semantic controls; use when no app-level operation exists." },
+    { uri: "app://panes", use: "Pane instances, placement, focus, and runtime state." },
+  ],
+  recipes: [
+    {
+      goal: "Search for a ticker and open the first result",
+      requests: [
+        { type: "call", operation: "app.search", input: { mode: "ticker", query: "google" } },
+        { type: "call", operation: "commandBar.activateResult", input: { index: 0 } },
+      ],
+      batch: {
+        type: "batch",
+        include: ["commandBar", "panes"],
+        requests: [
+          { type: "call", operation: "app.search", input: { mode: "ticker", query: "google" } },
+          { type: "call", operation: "commandBar.activateResult", input: { index: 0 } },
+        ],
+      },
+    },
+    {
+      goal: "Run a command-bar command",
+      requests: [
+        { type: "call", operation: "app.search", input: { mode: "command", query: "theme" } },
+        { type: "call", operation: "commandBar.activateResult", input: { label: "Change Theme" } },
+      ],
+    },
+    {
+      goal: "Activate a visible semantic control without knowing its node id",
+      request: { type: "call", operation: "ui.invokeMatching", input: { role: "button", label: "Done", action: "press" } },
+    },
+    {
+      goal: "Arrange current panes",
+      request: { type: "call", operation: "layout.setGrid", input: { columns: 2 }, include: ["layout", "panes"] },
+    },
+    {
+      goal: "Move a chart cursor without mouse/keyboard control",
+      request: { type: "call", operation: "ui.invokeMatching", input: { role: "chart", action: "moveCursor", input: { x: 20, y: 4 } } },
+    },
+    {
+      goal: "Pan a chart through its semantic scroll action",
+      request: { type: "call", operation: "ui.invokeMatching", input: { role: "chart", action: "scroll", input: { direction: "down", delta: 3 } } },
+    },
+  ],
+  batching: {
+    requestShape: "{ type: 'batch', requests: RemoteControlRequest[], haltOnError?: boolean, settle?: 'none' | 'afterEach' | 'afterBatch', include?: RemoteStateInclude[] }",
+    behavior: "Requests run sequentially. By default the batch stops on the first failed step and returns a compact final state.",
+  },
+  caveats: [
+    "Capability manifests are for plugin services; UI control should rely on app-level operations and shared semantic UI nodes so plugins remain remote-agnostic.",
+    "If an operation changes UI, request include: ['commandBar'] or use batch include to avoid a follow-up get.",
+    "For charts, use visible semantic chart nodes with actions such as moveCursor, press, drag, release, and scroll.",
+    "Use ui.invokeMatching only after checking app-level operations; it is intentionally generic and depends on visible semantic controls.",
+  ],
+};
+
+export function remoteControlSchema(): RemoteControlSchema {
+  return {
+    protocolVersion: 1,
+    resources: REMOTE_RESOURCES,
+    operations: REMOTE_OPERATIONS,
+    help: REMOTE_AGENT_HELP,
+  };
+}
+
+function op(
+  id: string,
+  description: string,
+  inputShape: string,
+  sideEffectLevel: RemoteOperationSchema["sideEffectLevel"],
+): RemoteOperationSchema {
+  return { id, description, inputShape, sideEffectLevel, dryRun: sideEffectLevel !== "none" };
+}

--- a/src/remote/semantic-helpers.ts
+++ b/src/remote/semantic-helpers.ts
@@ -1,0 +1,161 @@
+export function remoteEvent(input?: unknown) {
+  return {
+    input,
+    preventDefault() {},
+    stopPropagation() {},
+  };
+}
+
+export function remoteStringValue(input: unknown): string;
+export function remoteStringValue<T extends string | undefined>(input: unknown, fallback: T): string | T;
+export function remoteStringValue(input: unknown, fallback?: string): string | undefined {
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object" && typeof (input as { value?: unknown }).value === "string") {
+    return (input as { value: string }).value;
+  }
+  return arguments.length >= 2 ? fallback : "";
+}
+
+export function remoteNumberValue(input: unknown, keys: string[], fallback = 0): number {
+  if (typeof input === "number") return input;
+  if (input && typeof input === "object") {
+    const record = input as Record<string, unknown>;
+    for (const key of keys) {
+      if (typeof record[key] === "number") return record[key];
+    }
+  }
+  return fallback;
+}
+
+export function remoteOptionalNumberValue(input: unknown, keys: string[]): number | undefined {
+  if (typeof input === "number") return input;
+  if (input && typeof input === "object") {
+    const record = input as Record<string, unknown>;
+    for (const key of keys) {
+      if (typeof record[key] === "number") return record[key];
+    }
+  }
+  return undefined;
+}
+
+export function remoteChartEvent(input: unknown, renderable: unknown, width?: number, height?: number) {
+  const record = input && typeof input === "object" ? input as Record<string, unknown> : {};
+  const resolvedWidth = Math.max(1, width ?? remoteNumberProp(renderable, "width") ?? remoteNumberProp(remoteObjectProp(renderable, "absoluteBounds"), "width") ?? 1);
+  const resolvedHeight = Math.max(1, height ?? remoteNumberProp(renderable, "height") ?? remoteNumberProp(remoteObjectProp(renderable, "absoluteBounds"), "height") ?? 1);
+  const x = clampRemoteCoordinate(remoteOptionalNumberValue(input, ["x", "cellX", "column"]), resolvedWidth);
+  const y = clampRemoteCoordinate(remoteOptionalNumberValue(input, ["y", "cellY", "row"]), resolvedHeight);
+  const originX = remoteNumberProp(renderable, "absoluteX")
+    ?? remoteNumberProp(remoteObjectProp(renderable, "absoluteBounds"), "x")
+    ?? remoteNumberProp(renderable, "x")
+    ?? 0;
+  const originY = remoteNumberProp(renderable, "absoluteY")
+    ?? remoteNumberProp(remoteObjectProp(renderable, "absoluteBounds"), "y")
+    ?? remoteNumberProp(renderable, "y")
+    ?? 0;
+  return {
+    input,
+    x: originX + x,
+    y: originY + y,
+    preciseX: originX + x,
+    preciseY: originY + y,
+    pixelX: remoteOptionalNumberValue(input, ["pixelX"]),
+    pixelY: remoteOptionalNumberValue(input, ["pixelY"]),
+    button: typeof record.button === "number" ? record.button : 0,
+    modifiers: {
+      shift: record.shift === true,
+      alt: record.alt === true,
+      ctrl: record.ctrl === true,
+    },
+    scroll: remoteChartScroll(input),
+    preventDefault() {},
+    stopPropagation() {},
+  };
+}
+
+export function remotePropLabel(props: Record<string, unknown>): string | undefined {
+  for (const key of ["aria-label", "title", "label", "placeholder"]) {
+    const value = props[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+export function remotePropRole(props: Record<string, unknown>, fallback: string): string {
+  const explicit = props["data-gloom-role"];
+  return typeof explicit === "string" && explicit.trim() ? explicit.trim() : fallback;
+}
+
+export function remoteMetadataFromProps(props: Record<string, unknown>): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  const scope = props["data-gloom-remote-scope"];
+  const surface = props["data-gloom-remote-surface"];
+  const kind = props["data-gloom-remote-kind"];
+  if (typeof scope === "string" && scope.trim()) metadata.scope = scope.trim();
+  if (typeof surface === "string" && surface.trim()) metadata.surface = surface.trim();
+  if (typeof kind === "string" && kind.trim()) metadata.kind = kind.trim();
+  return metadata;
+}
+
+type RemoteItemSelector<T> = (item: T, index: number) => string | undefined;
+
+interface RemoteIndexSelectors<T> {
+  id?: RemoteItemSelector<T>;
+  key?: RemoteItemSelector<T>;
+  label?: RemoteItemSelector<T>;
+  value?: RemoteItemSelector<T>;
+}
+
+export function resolveRemoteItemIndex<T>(
+  input: unknown,
+  items: readonly T[],
+  selectors: RemoteIndexSelectors<T>,
+): number {
+  if (typeof input === "number") return input;
+  if (typeof input === "string") return findRemoteItemIndex(input, items, Object.values(selectors));
+  if (input && typeof input === "object") {
+    const record = input as Record<string, unknown>;
+    if (typeof record.index === "number") return record.index;
+    for (const key of ["id", "key", "label", "value"] as const) {
+      if (typeof record[key] !== "string") continue;
+      const selector = selectors[key];
+      if (!selector) continue;
+      return findRemoteItemIndex(record[key], items, [selector]);
+    }
+  }
+  return -1;
+}
+
+function remoteChartScroll(input: unknown) {
+  if (!input || typeof input !== "object") return undefined;
+  const record = input as Record<string, unknown>;
+  const direction = record.direction;
+  if (direction !== "up" && direction !== "down" && direction !== "left" && direction !== "right") return undefined;
+  return {
+    direction,
+    delta: typeof record.delta === "number" ? record.delta : 1,
+  };
+}
+
+function remoteObjectProp(value: unknown, key: string): unknown {
+  return value && typeof value === "object" ? (value as Record<string, unknown>)[key] : undefined;
+}
+
+function remoteNumberProp(value: unknown, key: string): number | undefined {
+  const prop = remoteObjectProp(value, key);
+  return typeof prop === "number" ? prop : undefined;
+}
+
+function clampRemoteCoordinate(value: number | undefined, extent: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return Math.max(0, (extent - 1) / 2);
+  return Math.max(0, Math.min(value, Math.max(extent - 1, 0)));
+}
+
+function findRemoteItemIndex<T>(
+  value: string,
+  items: readonly T[],
+  selectors: Array<RemoteItemSelector<T> | undefined>,
+): number {
+  const activeSelectors = selectors.filter((selector): selector is RemoteItemSelector<T> => !!selector);
+  if (activeSelectors.length === 0) return -1;
+  return items.findIndex((item, index) => activeSelectors.some((selector) => selector(item, index) === value));
+}

--- a/src/remote/semantic-tree.tsx
+++ b/src/remote/semantic-tree.tsx
@@ -1,0 +1,112 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
+import type { RemoteUiNodeSnapshot } from "./types";
+
+type RemoteUiAction = (input?: unknown) => unknown | Promise<unknown>;
+
+export interface RemoteUiNodeRegistration {
+  role: string;
+  label?: string;
+  disabled?: boolean;
+  actions?: Record<string, RemoteUiAction | undefined>;
+  metadata?: Record<string, unknown>;
+}
+
+interface RegisteredRemoteUiNode extends RemoteUiNodeRegistration {
+  id: string;
+  actions: Record<string, RemoteUiAction>;
+}
+
+export interface RemoteUiRegistry {
+  register(id: string, registration: RemoteUiNodeRegistration): void;
+  unregister(id: string): void;
+  snapshot(): RemoteUiNodeSnapshot[];
+  invoke(nodeId: string, action: string, input?: unknown): Promise<unknown>;
+}
+
+const RemoteUiRegistryContext = createContext<RemoteUiRegistry | null>(null);
+
+function createRemoteUiRegistry(): RemoteUiRegistry {
+  const nodes = new Map<string, RegisteredRemoteUiNode>();
+
+  return {
+    register(id, registration) {
+      nodes.set(id, {
+        ...registration,
+        id,
+        actions: Object.fromEntries(
+          Object.entries(registration.actions ?? {})
+            .filter((entry): entry is [string, RemoteUiAction] => typeof entry[1] === "function"),
+        ),
+      });
+    },
+    unregister(id) {
+      nodes.delete(id);
+    },
+    snapshot() {
+      return [...nodes.values()].map((node) => ({
+        id: node.id,
+        role: node.role,
+        label: node.label,
+        disabled: node.disabled,
+        actions: Object.keys(node.actions).sort(),
+        metadata: node.metadata,
+      }));
+    },
+    async invoke(nodeId, action, input) {
+      const node = nodes.get(nodeId);
+      if (!node) throw new Error(`Unknown UI node "${nodeId}".`);
+      if (node.disabled) throw new Error(`UI node "${nodeId}" is disabled.`);
+      const handler = node.actions[action];
+      if (!handler) throw new Error(`UI node "${nodeId}" does not expose action "${action}".`);
+      return await handler(input);
+    },
+  };
+}
+
+export function RemoteUiRegistryProvider({ children }: { children: ReactNode }) {
+  const registryRef = useRef<RemoteUiRegistry | null>(null);
+  if (!registryRef.current) {
+    registryRef.current = createRemoteUiRegistry();
+  }
+  return (
+    <RemoteUiRegistryContext value={registryRef.current}>
+      {children}
+    </RemoteUiRegistryContext>
+  );
+}
+
+export function useRemoteUiRegistry(): RemoteUiRegistry | null {
+  return useContext(RemoteUiRegistryContext);
+}
+
+export function useRemoteUiNode(registration: RemoteUiNodeRegistration | null | undefined): string | null {
+  const registry = useRemoteUiRegistry();
+  const generatedId = useId();
+  const nodeId = useMemo(() => `ui:${generatedId.replace(/:/g, "")}`, [generatedId]);
+
+  useEffect(() => {
+    if (!registry) return;
+    if (!registration) {
+      registry.unregister(nodeId);
+      return;
+    }
+    registry.register(nodeId, registration);
+  });
+
+  useEffect(() => {
+    return () => registry?.unregister(nodeId);
+  }, [
+    nodeId,
+    registry,
+  ]);
+
+  return registry && registration ? nodeId : null;
+}

--- a/src/remote/server.test.ts
+++ b/src/remote/server.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readRemoteEndpoint, remoteEndpointPath } from "./endpoint";
+import { sendRemoteControlRequest } from "./client";
+import { startRemoteControlServer, type RemoteControlServer } from "./server";
+
+describe("remote control server", () => {
+  const tempDirs: string[] = [];
+  const servers: RemoteControlServer[] = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => server.close().catch(() => {})));
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  test("writes an endpoint and serves authenticated RPC requests", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "gloom-remote-"));
+    tempDirs.push(dataDir);
+    const server = await startRemoteControlServer({
+      dataDir,
+      appKind: "tui",
+      handle: async (request) => ({ ok: true, data: { type: request.type } }),
+    });
+    servers.push(server);
+
+    const defaultEndpoint = await readRemoteEndpoint(dataDir);
+    const tuiEndpoint = await readRemoteEndpoint(dataDir, "tui");
+    expect(defaultEndpoint.port).toBe(server.endpoint.port);
+    expect(tuiEndpoint.token).toBe(server.endpoint.token);
+
+    const response = await sendRemoteControlRequest({ type: "schema" }, { dataDir, appKind: "tui" });
+    expect(response).toEqual({ ok: true, data: { type: "schema" } });
+  });
+
+  test("removes endpoint files on close", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "gloom-remote-"));
+    tempDirs.push(dataDir);
+    const server = await startRemoteControlServer({
+      dataDir,
+      appKind: "desktop",
+      handle: async () => ({ ok: true, data: null }),
+    });
+    await server.close();
+
+    expect(await Bun.file(remoteEndpointPath(dataDir)).exists()).toBe(false);
+    expect(await Bun.file(remoteEndpointPath(dataDir, "desktop")).exists()).toBe(false);
+  });
+});

--- a/src/remote/server.ts
+++ b/src/remote/server.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "http";
+import type { RemoteAppKind, RemoteControlRequest, RemoteControlResponse, RemoteEndpoint } from "./types";
+import { REMOTE_CONTROL_PROTOCOL_VERSION } from "./types";
+import { removeRemoteEndpointFiles, writeRemoteEndpointFiles } from "./endpoint";
+
+export interface RemoteControlServerOptions {
+  dataDir: string;
+  appKind: RemoteAppKind;
+  handle: (request: RemoteControlRequest) => Promise<RemoteControlResponse>;
+}
+
+export interface RemoteControlServer {
+  endpoint: RemoteEndpoint;
+  close(): Promise<void>;
+}
+
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
+
+export async function startRemoteControlServer(options: RemoteControlServerOptions): Promise<RemoteControlServer> {
+  const token = randomUUID();
+  const httpServer = createServer((request, response) => {
+    void handleHttpRequest(options.handle, token, request, response);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", () => {
+      httpServer.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    httpServer.close();
+    throw new Error("Remote control server did not bind to a TCP port.");
+  }
+
+  const endpoint: RemoteEndpoint = {
+    protocolVersion: REMOTE_CONTROL_PROTOCOL_VERSION,
+    appKind: options.appKind,
+    pid: process.pid,
+    port: address.port,
+    token,
+    startedAt: new Date().toISOString(),
+  };
+  await writeRemoteEndpointFiles(options.dataDir, endpoint);
+
+  return {
+    endpoint,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      }).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING") throw error;
+      });
+      await removeRemoteEndpointFiles(options.dataDir, endpoint);
+    },
+  };
+}
+
+async function handleHttpRequest(
+  handle: RemoteControlServerOptions["handle"],
+  token: string,
+  request: IncomingMessage,
+  response: ServerResponse,
+): Promise<void> {
+  try {
+    if (request.method === "GET" && request.url === "/health") {
+      sendJson(response, 200, { ok: true });
+      return;
+    }
+    if (request.method !== "POST" || request.url !== "/rpc") {
+      sendJson(response, 404, { ok: false, error: { code: "not_found", message: "Unknown remote control endpoint." } });
+      return;
+    }
+    if (request.headers.authorization !== `Bearer ${token}`) {
+      sendJson(response, 401, { ok: false, error: { code: "unauthorized", message: "Invalid remote control token." } });
+      return;
+    }
+
+    const body = await readBody(request);
+    const remoteRequest = JSON.parse(body) as RemoteControlRequest;
+    sendJson(response, 200, await handle(remoteRequest));
+  } catch (error) {
+    sendJson(response, 500, {
+      ok: false,
+      error: {
+        code: "remote_transport_error",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  let total = 0;
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of request) {
+    const bytes = chunk instanceof Uint8Array ? new Uint8Array(chunk) : new TextEncoder().encode(String(chunk));
+    total += bytes.byteLength;
+    if (total > MAX_BODY_BYTES) throw new Error("Remote control request is too large.");
+    chunks.push(bytes);
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(JSON.stringify(body));
+}

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -1,0 +1,119 @@
+export const REMOTE_CONTROL_PROTOCOL_VERSION = 1;
+
+export type RemoteAppKind = "tui" | "desktop";
+
+export interface RemoteEndpoint {
+  protocolVersion: number;
+  appKind: RemoteAppKind;
+  pid: number;
+  port: number;
+  token: string;
+  startedAt: string;
+}
+
+export interface RemoteJsonPatchOperation {
+  op: "add" | "replace" | "remove";
+  path: string;
+  value?: unknown;
+}
+
+export type RemoteStateInclude =
+  | "app"
+  | "layout"
+  | "panes"
+  | "commandBar"
+  | "commandBar.results"
+  | "ui"
+  | "schema"
+  | "help"
+  | "all";
+
+export type RemoteControlRequest =
+  | { type: "help"; topic?: string }
+  | { type: "schema" }
+  | { type: "get"; resource: string; include?: RemoteStateInclude[] }
+  | { type: "call"; operation: string; input?: unknown; dryRun?: boolean; include?: RemoteStateInclude[] }
+  | {
+    type: "patch";
+    resource: string;
+    patch: RemoteJsonPatchOperation[];
+    expectRev?: string;
+    dryRun?: boolean;
+    include?: RemoteStateInclude[];
+  }
+  | {
+    type: "batch";
+    requests: RemoteControlRequest[];
+    dryRun?: boolean;
+    haltOnError?: boolean;
+    settle?: "none" | "afterEach" | "afterBatch";
+    include?: RemoteStateInclude[];
+  };
+
+export interface RemoteIncludedState {
+  rev: string;
+  included: RemoteStateInclude[];
+  app?: unknown;
+  layout?: unknown;
+  panes?: unknown;
+  commandBar?: unknown;
+  ui?: RemoteUiNodeSnapshot[];
+  schema?: RemoteControlSchema;
+  help?: unknown;
+}
+
+export interface RemoteControlSuccess<T = unknown> {
+  ok: true;
+  data: T;
+  rev?: string;
+  state?: RemoteIncludedState;
+  warnings?: string[];
+}
+
+export interface RemoteControlFailure {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}
+
+export type RemoteControlResponse<T = unknown> =
+  | RemoteControlSuccess<T>
+  | RemoteControlFailure;
+
+export interface RemoteResourceSchema {
+  uri: string;
+  description: string;
+  patchable?: boolean;
+}
+
+export interface RemoteOperationSchema {
+  id: string;
+  description: string;
+  inputShape?: string;
+  outputShape?: string;
+  returns?: string;
+  recommendedNextReads?: string[];
+  examples?: unknown[];
+  sideEffectLevel: "none" | "local-write" | "network-write" | "external-side-effect" | "external-trade";
+  requiresConfirmation?: boolean;
+  dryRun?: boolean;
+}
+
+export interface RemoteControlSchema {
+  protocolVersion: number;
+  resources: RemoteResourceSchema[];
+  operations: RemoteOperationSchema[];
+  help: unknown;
+}
+
+export interface RemoteUiNodeSnapshot {
+  id: string;
+  role: string;
+  label?: string;
+  disabled?: boolean;
+  actions: string[];
+  metadata?: Record<string, unknown>;
+}

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -55,6 +55,8 @@ import {
   desktopWindowStyleMask,
 } from "./desktop/window-style";
 import { applyDesktopWindowControl, type DesktopWindowControlAction } from "./desktop/window-controls";
+import { startRemoteControlServer, type RemoteControlServer } from "../../../remote/server";
+import type { RemoteControlRequest, RemoteControlResponse } from "../../../remote/types";
 
 type DesktopRpc = ReturnType<typeof BrowserView.defineRPC<ElectrobunDesktopRpcSchema>>;
 
@@ -70,6 +72,7 @@ let services: AppServices | null = null;
 let mainWindow: BrowserWindow | null = null;
 let desktopWorkspace: DesktopWorkspace | null = null;
 let desktopRestartInProgress = false;
+let desktopRemoteControlServer: RemoteControlServer | null = null;
 
 const windowRpcRegistry = createDesktopRpcRegistry<DesktopRpc>();
 const contextMenuRequestRpcs = new Map<string, DesktopRpc>();
@@ -98,6 +101,10 @@ function registerCoreCapabilities(): void {
 function requireDesktopWorkspace(): DesktopWorkspace {
   if (!desktopWorkspace) throw new Error("Desktop workspace has not been initialized.");
   return desktopWorkspace;
+}
+
+function remoteFailure(code: string, message: string): RemoteControlResponse {
+  return { ok: false, error: { code, message } };
 }
 
 const {
@@ -129,6 +136,46 @@ const detachedWindowManager = new DesktopDetachedWindowManager<DesktopRpc>({
   unregisterWindowRpc,
   stateBroadcaster: desktopStateBroadcaster,
 });
+
+async function forwardRemoteControlRequest(request: RemoteControlRequest): Promise<RemoteControlResponse> {
+  const rpc = getWindowRpc(MAIN_WINDOW_RPC_KEY);
+  if (!rpc || !isWindowRpcReady(MAIN_WINDOW_RPC_KEY)) {
+    return remoteFailure("remote_unavailable", "The main desktop window is not ready for remote control requests.");
+  }
+  try {
+    const response = await rpc.request["remote.request"]({
+      request: encodeRpcValue(request) as RemoteControlRequest,
+    });
+    return decodeRpcValue<RemoteControlResponse>(response);
+  } catch (error) {
+    return remoteFailure(
+      "remote_forward_error",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+async function ensureDesktopRemoteControlServer(): Promise<void> {
+  if (desktopRemoteControlServer) return;
+  const config = requireConfig();
+  desktopRemoteControlServer = await startRemoteControlServer({
+    dataDir: config.dataDir,
+    appKind: "desktop",
+    handle: forwardRemoteControlRequest,
+  });
+  console.error("[remote] desktop control endpoint started", {
+    port: desktopRemoteControlServer.endpoint.port,
+  });
+}
+
+function stopDesktopRemoteControlServer(): void {
+  const server = desktopRemoteControlServer;
+  desktopRemoteControlServer = null;
+  if (!server) return;
+  void server.close().catch((error) => {
+    console.error("[remote] desktop control endpoint cleanup failed", summarizeError(error));
+  });
+}
 
 function openMainWindowDevTools(): void {
   mainWindow?.webview.openDevTools();
@@ -228,6 +275,7 @@ function disposeWindowScopedResources(windowKey: string): void {
 }
 
 function teardownServices(): void {
+  stopDesktopRemoteControlServer();
   capabilityBridge.disposeAll();
   services?.destroy();
   services = null;
@@ -306,7 +354,7 @@ async function initialize(
   rpc: DesktopRpc,
   payload: Record<string, unknown>,
 ) {
-  return initializeDesktopBackend({
+  const init = await initializeDesktopBackend({
     getCurrentConfig: () => currentConfig,
     getCurrentServices: () => services,
     getDesktopSnapshot,
@@ -328,6 +376,12 @@ async function initialize(
     },
     syncConfigAccessors,
   });
+  if (init.windowKind === "main") {
+    void ensureDesktopRemoteControlServer().catch((error) => {
+      console.error("[remote] desktop control endpoint failed", summarizeError(error));
+    });
+  }
+  return init;
 }
 
 async function handleBackendRequest(

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -4,6 +4,7 @@ import type { DesktopApplicationMenuCommand } from "../../../types/desktop-menu"
 import type { AppConfig } from "../../../types/config";
 import type { UpdateProgress } from "../../../updater";
 import type { CapabilityManifest } from "../../../capabilities";
+import type { RemoteControlRequest, RemoteControlResponse } from "../../../remote/types";
 
 export const ELECTROBUN_CONTEXT_MENU_ACTION = "gloom.context-menu.select";
 
@@ -59,6 +60,10 @@ export interface DesktopRestartMessage {
   source?: string;
 }
 
+export interface RemoteControlRequestMessage {
+  request: RemoteControlRequest;
+}
+
 export interface ElectrobunDesktopRpcSchema {
   bun: {
     requests: {
@@ -72,7 +77,12 @@ export interface ElectrobunDesktopRpcSchema {
     };
   };
   webview: {
-    requests: {};
+    requests: {
+      "remote.request": {
+        params: RemoteControlRequestMessage;
+        response: RemoteControlResponse;
+      };
+    };
     messages: {
       "context-menu.select": ContextMenuSelectMessage;
       "application-menu.select": ApplicationMenuSelectMessage;

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -9,10 +9,12 @@ import {
   type DesktopStateMessage,
   type DesktopThemePreviewMessage,
   type ElectrobunBackendInit,
+  type RemoteControlRequestMessage,
   type ElectrobunDesktopRpcSchema,
   type UpdateProgressMessage,
 } from "../shared/protocol";
 import { decodeRpcValue, encodeRpcValue } from "./rpc-codec";
+import type { RemoteControlRequest, RemoteControlResponse } from "../../../remote/types";
 
 type ContextMenuSelectListener = (message: ContextMenuSelectMessage) => void;
 type ApplicationMenuSelectListener = (message: ApplicationMenuSelectMessage) => void;
@@ -21,8 +23,10 @@ type DesktopDockPreviewListener = (message: DesktopDockPreviewMessage) => void;
 type DesktopThemePreviewListener = (message: DesktopThemePreviewMessage) => void;
 type UpdateProgressListener = (message: UpdateProgressMessage) => void;
 type CapabilityEventListener = (message: CapabilityEventMessage) => void;
+type RemoteControlRequestHandler = (request: RemoteControlRequest) => Promise<RemoteControlResponse>;
 
 let initSnapshot: ElectrobunBackendInit | null = null;
+let remoteControlRequestHandler: RemoteControlRequestHandler | null = null;
 const contextMenuSelectListeners = new Map<string, Set<ContextMenuSelectListener>>();
 const applicationMenuSelectListeners = new Set<ApplicationMenuSelectListener>();
 const desktopStateListeners = new Set<DesktopStateListener>();
@@ -63,7 +67,21 @@ function subscribe<T>(
 const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
   maxRequestTime: 120_000,
   handlers: {
-    requests: {},
+    requests: {
+      "remote.request": async (message: RemoteControlRequestMessage) => {
+        if (!remoteControlRequestHandler) {
+          return {
+            ok: false,
+            error: {
+              code: "remote_unavailable",
+              message: "The desktop app has not installed a remote control handler yet.",
+            },
+          };
+        }
+        const decoded = decodeRpcValue<RemoteControlRequest>(message.request);
+        return encodeRpcValue(await remoteControlRequestHandler(decoded)) as RemoteControlResponse;
+      },
+    },
     messages: {
       "context-menu.select": (message) => {
         dispatch(contextMenuSelectListeners, message.requestId, message);
@@ -138,6 +156,15 @@ export function requestElectrobunRestart(message: DesktopRestartMessage = {}): v
 
 export function getElectrobunBackendInitSnapshot(): ElectrobunBackendInit | null {
   return initSnapshot;
+}
+
+export function setElectrobunRemoteRequestHandler(handler: RemoteControlRequestHandler | null): () => void {
+  remoteControlRequestHandler = handler;
+  return () => {
+    if (remoteControlRequestHandler === handler) {
+      remoteControlRequestHandler = null;
+    }
+  };
 }
 
 export function onCapabilityEvent(

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -5,7 +5,7 @@ import { App } from "../../../app";
 import { UiHostProvider } from "../../../ui/host";
 import { debugLog } from "../../../utils/debug-log";
 import { measurePerfAsync } from "../../../utils/perf-marks";
-import { backendRequest, initElectrobunBackend } from "./backend-rpc";
+import { backendRequest, initElectrobunBackend, setElectrobunRemoteRequestHandler } from "./backend-rpc";
 import { installElectrobunAiHost } from "./ai-host";
 import { installElectrobunBrokerRemoteClient } from "./broker-remote-client";
 import { installElectrobunConfigStoreHost } from "./config-host";
@@ -89,6 +89,9 @@ async function boot() {
   const desktopWindowBridge = createDesktopWindowBridge(init.windowKind, init.paneId);
   const desktopApplicationMenuBridge = createApplicationMenuBridge();
   const webUiHost = createWebUiHost(init.desktopPlatform);
+  const remoteControlAdapter = init.windowKind === "main"
+    ? { registerHandler: setElectrobunRemoteRequestHandler }
+    : undefined;
   measurePerfAsync("startup.electrobun.root-render", async () => {
     root.render(
       <ElectrobunErrorBoundary>
@@ -102,6 +105,7 @@ async function boot() {
                   desktopApplicationMenuBridge={desktopApplicationMenuBridge}
                   desktopSnapshot={desktopSnapshot}
                   desktopThemePreview={init.desktopThemePreview}
+                  remoteControlAdapter={remoteControlAdapter}
                 />
               </WebDialogHostProvider>
             </WebToastHostProvider>

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -17,6 +17,8 @@ import { colors } from "../../theme/colors";
 import { startMainThreadMonitor } from "../../utils/main-thread-monitor";
 import { measurePerfAsync } from "../../utils/perf-marks";
 import type { CliLaunchRequest } from "../../types/plugin";
+import type { RemoteControlAdapter } from "../../remote/app-host";
+import { startRemoteControlServer, type RemoteControlServer } from "../../remote/server";
 
 export interface StartOpenTuiAppOptions {
   externalPlugins?: Awaited<ReturnType<typeof loadExternalPlugins>>;
@@ -31,6 +33,35 @@ export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Pro
 
   const appLog = debugLog.createLogger("app");
   appLog.info("Gloomberb starting");
+  const remoteControlAdapter: RemoteControlAdapter = {
+    startServer: ({ dataDir, handle }) => {
+      let closed = false;
+      const serverPromise: Promise<RemoteControlServer> = startRemoteControlServer({
+        dataDir,
+        appKind: "tui",
+        handle,
+      });
+      void serverPromise.then((server) => {
+        if (closed) {
+          void server.close();
+          return;
+        }
+        appLog.info("Remote control endpoint started", {
+          appKind: server.endpoint.appKind,
+          port: server.endpoint.port,
+        });
+      }).catch((error) => {
+        appLog.error("Remote control endpoint failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+      return () => {
+        closed = true;
+        void serverPromise.then((server) => server.close()).catch(() => {});
+      };
+    },
+  };
 
   const cliArgs = options.cliArgs ?? process.argv.slice(2);
   const externalPlugins = options.externalPlugins ?? await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins());
@@ -81,6 +112,7 @@ export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Pro
                 config={config}
                 externalPlugins={externalPlugins}
                 cliLaunchRequest={cliLaunchRequest}
+                remoteControlAdapter={remoteControlAdapter}
               />
             </OpenTuiDialogHostProvider>
           </ToastHostProvider>

--- a/src/state/app/context/index.tsx
+++ b/src/state/app/context/index.tsx
@@ -342,27 +342,24 @@ export function AppProvider({
   stateRef.current = state;
 
   const dispatch = useCallback((action: AppAction) => {
-    if (desktopBridge) {
-      rawDispatch(action);
-      return;
-    }
-
-    switch (action.type) {
-      case "SET_CONFIG":
-        rawDispatch({
+    const dispatchedAction = desktopBridge
+      ? action
+      : action.type === "SET_CONFIG"
+        ? {
           ...action,
           config: materializeDetachedConfig(action.config),
-        });
-        return;
-      case "UPDATE_LAYOUT":
-        rawDispatch({
-          ...action,
-          layout: materializeDetachedPanesAsFloating(action.layout),
-        });
-        return;
-      default:
-        rawDispatch(action);
+        } as AppAction
+        : action.type === "UPDATE_LAYOUT"
+          ? {
+            ...action,
+            layout: materializeDetachedPanesAsFloating(action.layout),
+          } as AppAction
+          : action;
+    stateRef.current = appReducer(stateRef.current, dispatchedAction);
+    for (const listener of listenersRef.current) {
+      listener();
     }
+    rawDispatch(dispatchedAction);
   }, [desktopBridge, rawDispatch]);
 
   const buildDesktopSnapshot = useCallback((currentState: AppState): DesktopSharedStateSnapshot => ({

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,6 +1,16 @@
-import { createElement, forwardRef, type ComponentProps } from "react";
+import { createElement, forwardRef, useCallback, useRef, type ComponentProps, type ForwardedRef } from "react";
 import { useForwardedScrollBoxRef, useRegisterPaneScrollBox } from "../state/pane-scroll-registry";
 import { useUiHost, type UiHost } from "./host";
+import { useRemoteUiNode } from "../remote/semantic-tree";
+import {
+  remoteChartEvent,
+  remoteEvent,
+  remoteMetadataFromProps,
+  remoteNumberValue,
+  remotePropLabel,
+  remotePropRole,
+  remoteStringValue,
+} from "../remote/semantic-helpers";
 export {
   RGBA,
   StyledText,
@@ -40,13 +50,50 @@ export type {
 
 export const Box = forwardRef<any, ComponentProps<UiHost["Box"]>>((props, ref) => {
   const { Box: HostBox } = useUiHost();
-  return createElement(HostBox as any, { ...props, ref });
+  const rawProps = props as Record<string, unknown>;
+  const onMouseDown = rawProps.onMouseDown as ((event?: unknown) => unknown) | undefined;
+  const onMouseUp = rawProps.onMouseUp as ((event?: unknown) => unknown) | undefined;
+  const onContextMenu = rawProps.onContextMenu as ((event?: unknown) => unknown) | undefined;
+  const remoteNodeId = useRemoteUiNode(
+    onMouseDown || onMouseUp || onContextMenu
+      ? {
+        role: remotePropRole(rawProps, "box"),
+        label: remotePropLabel(rawProps),
+        actions: {
+          press: onMouseDown ? (input) => onMouseDown(remoteEvent(input)) : undefined,
+          release: onMouseUp ? (input) => onMouseUp(remoteEvent(input)) : undefined,
+          contextMenu: onContextMenu ? (input) => onContextMenu(remoteEvent(input)) : undefined,
+        },
+        metadata: {
+          width: rawProps.width,
+          height: rawProps.height,
+        },
+      }
+      : null,
+  );
+  return createElement(HostBox as any, { ...props, ref, "data-gloom-remote-node-id": remoteNodeId ?? undefined });
 });
 Box.displayName = "Box";
 
 export const Text = forwardRef<any, ComponentProps<UiHost["Text"]>>((props, ref) => {
   const { Text: HostText } = useUiHost();
-  return createElement(HostText as any, { ...props, ref });
+  const rawProps = props as Record<string, unknown>;
+  const onMouseDown = rawProps.onMouseDown as ((event?: unknown) => unknown) | undefined;
+  const label = remotePropLabel(rawProps)
+    ?? (typeof rawProps.children === "string" ? rawProps.children : undefined)
+    ?? (typeof rawProps.content === "string" ? rawProps.content : undefined);
+  const remoteNodeId = useRemoteUiNode(
+    onMouseDown
+      ? {
+        role: remotePropRole(rawProps, "text"),
+        label,
+        actions: {
+          press: (input) => onMouseDown(remoteEvent(input)),
+        },
+      }
+      : null,
+  );
+  return createElement(HostText as any, { ...props, ref, "data-gloom-remote-node-id": remoteNodeId ?? undefined });
 });
 Text.displayName = "Text";
 
@@ -71,31 +118,160 @@ Underline.displayName = "Underline";
 export const ScrollBox = forwardRef<any, ComponentProps<UiHost["ScrollBox"]>>((props, ref) => {
   const { ScrollBox: HostScrollBox } = useUiHost();
   const localRef = useForwardedScrollBoxRef<any>(ref);
+  const rawProps = props as Record<string, unknown>;
+  const remoteNodeId = useRemoteUiNode(
+    props.scrollY === true
+      ? {
+        role: remotePropRole(rawProps, "scrollbox"),
+        label: remotePropLabel(rawProps),
+        actions: {
+          scrollTo: (input) => {
+            const top = remoteNumberValue(input, ["top", "index"]);
+            localRef.current?.scrollTo?.(Math.max(0, Math.round(top)));
+          },
+          scrollBy: (input) => {
+            const currentTop = Math.max(0, Math.round(localRef.current?.scrollTop ?? 0));
+            const delta = input && typeof input === "object" && (input as { direction?: unknown }).direction === "up"
+              ? remoteNumberValue(input, ["delta"], -1)
+              : remoteNumberValue(input, ["delta"], 1);
+            localRef.current?.scrollTo?.(Math.max(0, currentTop + Math.round(delta)));
+          },
+        },
+        metadata: {
+          ...remoteMetadataFromProps(rawProps),
+          width: rawProps.width,
+          height: rawProps.height,
+          scrollY: props.scrollY === true,
+          scrollTop: localRef.current?.scrollTop,
+          viewportHeight: localRef.current?.viewport?.height,
+        },
+      }
+      : null,
+  );
   useRegisterPaneScrollBox(localRef, {
     enabled: props.scrollY === true,
     onScrollActivity: typeof props.onMouseScroll === "function"
       ? props.onMouseScroll as (event: { scroll: { direction: "up" | "down"; delta: number } }) => void
       : undefined,
   });
-  return createElement(HostScrollBox as any, { ...props, ref: localRef });
+  return createElement(HostScrollBox as any, { ...props, ref: localRef, "data-gloom-remote-node-id": remoteNodeId ?? undefined });
 });
 ScrollBox.displayName = "ScrollBox";
 
 export const Input = forwardRef<any, ComponentProps<UiHost["Input"]>>((props, ref) => {
   const { Input: HostInput } = useUiHost();
-  return createElement(HostInput as any, { ...props, ref });
+  const rawProps = props as Record<string, unknown>;
+  const onInput = rawProps.onInput as ((value: string) => unknown) | undefined;
+  const onChange = rawProps.onChange as ((value: string) => unknown) | undefined;
+  const onSubmit = rawProps.onSubmit as ((value?: string) => unknown) | undefined;
+  const remoteNodeId = useRemoteUiNode({
+    role: remotePropRole(rawProps, "input"),
+    label: remotePropLabel(rawProps),
+    disabled: rawProps.disabled === true,
+    actions: {
+      setValue: (input) => {
+        const value = remoteStringValue(input);
+        onInput?.(value);
+        onChange?.(value);
+      },
+      submit: (input) => {
+        const value = remoteStringValue(input, undefined);
+        onSubmit?.(value);
+      },
+      focus: () => (ref && typeof ref === "object" ? ref.current?.focus?.() : undefined),
+    },
+    metadata: {
+      ...remoteMetadataFromProps(rawProps),
+      value: rawProps.value,
+      placeholder: rawProps.placeholder,
+      focused: rawProps.focused,
+    },
+  });
+  return createElement(HostInput as any, { ...props, ref, "data-gloom-remote-node-id": remoteNodeId ?? undefined });
 });
 Input.displayName = "Input";
 
 export const Textarea = forwardRef<any, ComponentProps<UiHost["Textarea"]>>((props, ref) => {
   const { Textarea: HostTextarea } = useUiHost();
-  return createElement(HostTextarea as any, { ...props, ref });
+  const rawProps = props as Record<string, unknown>;
+  const onInput = rawProps.onInput as ((value: string) => unknown) | undefined;
+  const onChange = rawProps.onChange as ((value: string) => unknown) | undefined;
+  const onSubmit = rawProps.onSubmit as (() => unknown) | undefined;
+  const remoteNodeId = useRemoteUiNode({
+    role: remotePropRole(rawProps, "textarea"),
+    label: remotePropLabel(rawProps),
+    disabled: rawProps.disabled === true,
+    actions: {
+      setValue: (input) => {
+        const value = remoteStringValue(input);
+        onInput?.(value);
+        onChange?.(value);
+      },
+      submit: () => onSubmit?.(),
+      focus: () => (ref && typeof ref === "object" ? ref.current?.focus?.() : undefined),
+    },
+    metadata: {
+      ...remoteMetadataFromProps(rawProps),
+      value: rawProps.value ?? rawProps.initialValue,
+      placeholder: rawProps.placeholder,
+      focused: rawProps.focused,
+    },
+  });
+  return createElement(HostTextarea as any, { ...props, ref, "data-gloom-remote-node-id": remoteNodeId ?? undefined });
 });
 Textarea.displayName = "Textarea";
 
+function assignForwardedRef(ref: ForwardedRef<any>, value: any): void {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
 export const ChartSurface = forwardRef<any, ComponentProps<UiHost["ChartSurface"]>>((props, ref) => {
   const { ChartSurface: HostChartSurface } = useUiHost();
-  return createElement(HostChartSurface as any, { ...props, ref });
+  const rawProps = props as Record<string, unknown>;
+  const localRef = useRef<any>(null);
+  const setSurfaceRef = useCallback((value: any) => {
+    localRef.current = value;
+    assignForwardedRef(ref, value);
+  }, [ref]);
+  const onMouseMove = rawProps.onMouseMove as ((event?: unknown) => unknown) | undefined;
+  const onMouseDown = rawProps.onMouseDown as ((event?: unknown) => unknown) | undefined;
+  const onMouseDrag = rawProps.onMouseDrag as ((event?: unknown) => unknown) | undefined;
+  const onMouseUp = rawProps.onMouseUp as ((event?: unknown) => unknown) | undefined;
+  const onMouseDragEnd = rawProps.onMouseDragEnd as ((event?: unknown) => unknown) | undefined;
+  const onMouseScroll = rawProps.onMouseScroll as ((event?: unknown) => unknown) | undefined;
+  const width = typeof rawProps.width === "number" ? rawProps.width : undefined;
+  const height = typeof rawProps.height === "number" ? rawProps.height : undefined;
+  const bitmap = rawProps.bitmap;
+  const bitmaps = Array.isArray(rawProps.bitmaps) ? rawProps.bitmaps : null;
+  const hasBitmap = !!bitmap || (bitmaps?.length ?? 0) > 0;
+  const visualRole = typeof rawProps["data-gloom-role"] === "string" ? rawProps["data-gloom-role"] : undefined;
+  const remoteNodeId = useRemoteUiNode({
+    role: "chart",
+    label: remotePropLabel(rawProps) ?? "Chart",
+    actions: {
+      moveCursor: onMouseMove ? (input) => onMouseMove(remoteChartEvent(input, localRef.current, width, height)) : undefined,
+      press: onMouseDown ? (input) => onMouseDown(remoteChartEvent(input, localRef.current, width, height)) : undefined,
+      drag: onMouseDrag ? (input) => onMouseDrag(remoteChartEvent(input, localRef.current, width, height)) : undefined,
+      release: onMouseUp ? (input) => onMouseUp(remoteChartEvent(input, localRef.current, width, height)) : undefined,
+      endDrag: onMouseDragEnd ? (input) => onMouseDragEnd(remoteChartEvent(input, localRef.current, width, height)) : undefined,
+      scroll: onMouseScroll ? (input) => onMouseScroll(remoteChartEvent(input, localRef.current, width, height)) : undefined,
+    },
+    metadata: {
+      ...remoteMetadataFromProps(rawProps),
+      width: rawProps.width,
+      height: rawProps.height,
+      hasBitmap,
+      bitmapCount: bitmaps?.length ?? (bitmap ? 1 : 0),
+      hasCrosshair: rawProps.crosshair != null,
+      interactive: !!(onMouseMove || onMouseDown || onMouseDrag || onMouseUp || onMouseScroll),
+      visualRole,
+    },
+  });
+  return createElement(HostChartSurface as any, { ...props, ref: setSurfaceRef, "data-gloom-remote-node-id": remoteNodeId ?? undefined });
 });
 ChartSurface.displayName = "ChartSurface";
 


### PR DESCRIPTION
## Summary

Adds a semantic remote-control API for both app surfaces, including endpoint discovery, authenticated local RPC, CLI access, schema/help resources, batching, included state snapshots, layout operations, command-bar result activation, and semantic UI node invocation.

The shared UI layer now exposes plugin-agnostic semantic controls for common surfaces, including lists, tabs, inputs, scrollboxes, and charts. Charts expose generic actions such as cursor movement, press, drag, release, and scroll through the shared ChartSurface rather than plugin-specific capability declarations.

The remote controller was split into smaller resource, layout, utility, and schema modules to keep the implementation easier to maintain.

## Validation

- `bun test src/remote/controller.test.ts src/remote/server.test.ts src/remote/json-patch.test.ts src/components/command-bar/surface/index.test.tsx`
- `bun test src/components/chart/static/chart/surface.test.tsx src/components/chart/static/bar-chart-surface.test.tsx`
- `bun test src/components/ui/ui.test.tsx src/components/ui/message-composer.test.tsx`
- touched-file TypeScript filter returned no errors

Note: the command-bar and shared UI test suites still emit existing React `act(...)` warnings while passing.