### PR TITLE
Respect TUI chart renderer preference

### DIFF
--- a/src/plugins/ibkr/gateway/service/index.test.ts
+++ b/src/plugins/ibkr/gateway/service/index.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { BarSizeSetting, ConnectionState, SecType, type ContractDetails } from "@stoqey/ib";
 import { Subject, of } from "rxjs";
 import {
@@ -243,6 +246,25 @@ test("remote gateway snapshots are side-effect-free", async () => {
     setBrokerRemoteClient(null);
     setNativeIbkrGatewayModuleLoader(null);
     await ibkrGatewayManager.removeInstance(instanceId);
+  }
+});
+
+test("native gateway loader bundles without a runtime ./native specifier", async () => {
+  const outdir = mkdtempSync(join(tmpdir(), "gloomberb-ibkr-service-"));
+  try {
+    const result = await Bun.build({
+      entrypoints: [join(import.meta.dir, "index.ts")],
+      outdir,
+      target: "bun",
+    });
+
+    expect(result.success).toBe(true);
+    const entry = readFileSync(join(outdir, "index.js"), "utf8");
+    expect(entry).toContain("src/plugins/ibkr/gateway/service/native.ts");
+    expect(entry).not.toContain('"./native"');
+    expect(entry).not.toContain("'./native'");
+  } finally {
+    rmSync(outdir, { recursive: true, force: true });
   }
 });
 

--- a/src/plugins/ibkr/gateway/service/index.ts
+++ b/src/plugins/ibkr/gateway/service/index.ts
@@ -17,18 +17,18 @@ import type {
   IbkrSnapshot,
   ResolvedIbkrGatewayConnection,
 } from "../types";
+import {
+  loadNativeGatewayModule as loadDefaultNativeGatewayModule,
+  type NativeGatewayModule,
+} from "./native-loader";
 
 export type {
   IbkrGatewayConfig,
   ResolvedIbkrGatewayConnection,
 } from "../types";
 
-type NativeGatewayService = any;
 type NativeGatewayManager = any;
-type NativeGatewayModule = {
-  ibkrGatewayManager: NativeGatewayManager;
-  setResolvedIbkrGatewayListener(listener: ResolvedGatewayListener | null): void;
-};
+type NativeGatewayService = any;
 type Listener = () => void;
 type ResolvedGatewayListener = (
   instanceId: string | undefined,
@@ -47,9 +47,6 @@ let loadedNativeGatewayModule: NativeGatewayModule | null = null;
 let nativeGatewayModulePromise: Promise<NativeGatewayModule> | null = null;
 let nativeGatewayManager: NativeGatewayManager | null = null;
 let nativeGatewayModuleLoader: () => Promise<NativeGatewayModule>;
-const importNativeGatewayModule = new Function("specifier", "return import(specifier)") as (
-  specifier: string,
-) => Promise<NativeGatewayModule>;
 
 const snapshots = new Map<string, IbkrSnapshot>();
 const listeners = new Map<string, Set<Listener>>();
@@ -60,7 +57,7 @@ function getSnapshotEntry(instanceId?: string): IbkrSnapshot {
 }
 
 function defaultNativeGatewayModuleLoader(): Promise<NativeGatewayModule> {
-  return importNativeGatewayModule("./native");
+  return loadDefaultNativeGatewayModule();
 }
 
 nativeGatewayModuleLoader = defaultNativeGatewayModuleLoader;

--- a/src/plugins/ibkr/gateway/service/native-loader.ts
+++ b/src/plugins/ibkr/gateway/service/native-loader.ts
@@ -1,0 +1,12 @@
+import type { ResolvedIbkrGatewayConnection } from "../types";
+
+export type NativeGatewayModule = {
+  ibkrGatewayManager: any;
+  setResolvedIbkrGatewayListener(
+    listener: ((instanceId: string | undefined, connection: ResolvedIbkrGatewayConnection) => void | Promise<void>) | null,
+  ): void;
+};
+
+export function loadNativeGatewayModule(): Promise<NativeGatewayModule> {
+  return import("./native");
+}

--- a/src/renderers/electrobun/view/build-assets.ts
+++ b/src/renderers/electrobun/view/build-assets.ts
@@ -23,6 +23,7 @@ const COMMON_ALIAS_RULES: AliasRule[] = [
   ["./kitty/support", "components/chart/native/renderer-selection.ts", "native-stubs/chart/kitty-support.ts"],
   ["native/surface/manager", "native-stubs/chart/surface-manager.ts"],
   ["native/surface/sync", "native-stubs/chart/surface-sync.ts"],
+  ["./native-loader", "plugins/ibkr/gateway/service/index.ts", "native-stubs/ibkr-native-loader.ts"],
 ];
 
 export function electrobunViewPath(...parts: string[]): string {

--- a/src/renderers/electrobun/view/native-stubs/ibkr-native-loader.ts
+++ b/src/renderers/electrobun/view/native-stubs/ibkr-native-loader.ts
@@ -1,0 +1,3 @@
+export function loadNativeGatewayModule(): Promise<never> {
+  return Promise.reject(new Error("IBKR native gateway is unavailable in the desktop web renderer."));
+}

--- a/src/renderers/opentui/chart-surface.test.tsx
+++ b/src/renderers/opentui/chart-surface.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestRenderer } from "@opentui/core/testing";
+import { act } from "react";
+import { ChartSurface, Text } from "../../ui";
+import { getNativeSurfaceManager } from "../../components/chart/native/surface/manager";
+import type { ChartRendererPreference } from "../../components/chart/core/types";
+import { AppProvider } from "../../state/app/context";
+import { createDefaultConfig } from "../../types/config";
+import { createOpenTuiTestRoot } from "./test-utils";
+
+let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | undefined;
+let root: ReturnType<typeof createOpenTuiTestRoot> | undefined;
+const actEnvironment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+const bitmap = {
+  width: 4,
+  height: 4,
+  pixels: new Uint8Array(4 * 4 * 4).fill(255),
+};
+
+function setNativeRendererReady(): void {
+  (testSetup!.renderer as { _capabilities: unknown })._capabilities = { kitty_graphics: true };
+  (testSetup!.renderer as { _resolution: unknown })._resolution = { width: 800, height: 400 };
+}
+
+function surfaceCount(): number {
+  const manager = getNativeSurfaceManager(testSetup!.renderer as never) as unknown as {
+    surfaces: Map<string, unknown>;
+  };
+  return manager.surfaces.size;
+}
+
+async function flushFrames(): Promise<void> {
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await testSetup!.renderOnce();
+  });
+}
+
+function Harness({ preference }: { preference: ChartRendererPreference }) {
+  const config = createDefaultConfig(`/tmp/gloomberb-chart-surface-${preference}`);
+  config.chartPreferences.renderer = preference;
+
+  return (
+    <AppProvider config={config}>
+      <ChartSurface width={20} height={4} flexDirection="column" bitmaps={[bitmap]}>
+        <Text>fallback chart</Text>
+      </ChartSurface>
+    </AppProvider>
+  );
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root!.unmount();
+    });
+    root = undefined;
+  }
+  if (testSetup) {
+    testSetup.renderer.destroy();
+    testSetup = undefined;
+  }
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
+});
+
+describe("OpenTuiChartSurface", () => {
+  test("does not register kitty surfaces when the chart renderer is forced to braille", async () => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 40, height: 12 });
+    setNativeRendererReady();
+    root = createOpenTuiTestRoot(testSetup.renderer);
+
+    act(() => {
+      root!.render(<Harness preference="braille" />);
+    });
+
+    await flushFrames();
+
+    expect(testSetup.captureCharFrame()).toContain("fallback chart");
+    expect(surfaceCount()).toBe(0);
+  });
+
+  test("registers kitty surfaces when the chart renderer is forced to kitty and native graphics are ready", async () => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    testSetup = await createTestRenderer({ width: 40, height: 12 });
+    setNativeRendererReady();
+    root = createOpenTuiTestRoot(testSetup.renderer);
+
+    act(() => {
+      root!.render(<Harness preference="kitty" />);
+    });
+
+    await flushFrames();
+
+    expect(testSetup.captureCharFrame()).not.toContain("fallback chart");
+    expect(surfaceCount()).toBe(1);
+  });
+});

--- a/src/renderers/opentui/chart-surface.tsx
+++ b/src/renderers/opentui/chart-surface.tsx
@@ -5,14 +5,15 @@ import {
   type CellRect,
   type NativeChartBitmap,
 } from "../../components/chart/native/chart-rasterizer";
-import { getCachedKittySupport, ensureKittySupport } from "../../components/chart/native/kitty/support";
+import type { ChartRendererPreference } from "../../components/chart/core/types";
+import { useResolvedChartRendererState } from "../../components/chart/native/renderer-selection";
 import { getNativeSurfaceManager } from "../../components/chart/native/surface/manager";
 import {
   getRenderableCellRect,
   resolveNativeSurfaceVisibleRect,
   type NativeSurfaceRenderableNode,
 } from "../../components/chart/native/surface/visibility";
-import { useOptionalPaneInstanceId } from "../../state/app/context";
+import { useOptionalAppSelector, useOptionalPaneInstanceId } from "../../state/app/context";
 import { useNativeRenderer, type BoxRenderable, type ChartSurfaceProps } from "../../ui";
 
 interface NativeRenderableNode extends BoxRenderable, NativeSurfaceRenderableNode {
@@ -73,15 +74,20 @@ function bitmapKey(bitmap: NativeChartBitmap): string {
 }
 
 export const OpenTuiChartSurface = forwardRef<unknown, ChartSurfaceProps>(function OpenTuiChartSurface(
-  { children, bitmap, bitmaps, crosshair: _crosshair, ...props },
+  { children, bitmap, bitmaps, crosshair: _crosshair, nativeBitmapsEnabled = true, ...props },
   forwardedRef,
 ) {
   const renderer = useNativeRenderer();
   const paneId = useOptionalPaneInstanceId();
+  const preferredRenderer = useOptionalAppSelector<ChartRendererPreference>(
+    (state) => state.config.chartPreferences.renderer,
+    "braille",
+  );
+  const rendererState = useResolvedChartRendererState(preferredRenderer, renderer);
+  const nativeSurfacesEnabled = nativeBitmapsEnabled && rendererState.renderer === "kitty";
   const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);
   const surfaceId = useRef(`opentui-chart:${nextChartSurfaceId++}`).current;
   const renderableRef = useRef<NativeRenderableNode | null>(null);
-  const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
   const [target, setTarget] = useState<SurfaceTarget | null>(null);
   const nativeBitmap = (bitmaps?.[0] ?? bitmap ?? null) as NativeChartBitmap | null;
   const nativeBitmapKey = useMemo(() => (nativeBitmap ? bitmapKey(nativeBitmap) : null), [nativeBitmap]);
@@ -92,19 +98,8 @@ export const OpenTuiChartSurface = forwardRef<unknown, ChartSurfaceProps>(functi
   }, [forwardedRef]);
 
   useEffect(() => {
-    let cancelled = false;
-    setKittySupport(getCachedKittySupport(renderer));
-    ensureKittySupport(renderer).then((supported) => {
-      if (!cancelled) setKittySupport(supported);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [renderer]);
-
-  useEffect(() => {
     const renderable = renderableRef.current;
-    if (!renderable || !nativeBitmap || !nativeBitmapKey || kittySupport !== true) {
+    if (!renderable || !nativeBitmap || !nativeBitmapKey || !nativeSurfacesEnabled) {
       setTarget(null);
       return;
     }
@@ -148,7 +143,7 @@ export const OpenTuiChartSurface = forwardRef<unknown, ChartSurfaceProps>(functi
       }
       renderer.unregisterLifecyclePass(renderable);
     };
-  }, [kittySupport, nativeBitmap, nativeBitmapKey, renderer]);
+  }, [nativeBitmap, nativeBitmapKey, nativeSurfacesEnabled, renderer]);
 
   useEffect(() => {
     return () => {
@@ -157,7 +152,7 @@ export const OpenTuiChartSurface = forwardRef<unknown, ChartSurfaceProps>(functi
   }, [nativeSurfaceManager, surfaceId]);
 
   useEffect(() => {
-    if (kittySupport !== true || !target?.visibleRect || !nativeBitmap) {
+    if (!nativeSurfacesEnabled || !target?.visibleRect || !nativeBitmap) {
       nativeSurfaceManager.removeSurface(surfaceId);
       return;
     }
@@ -171,8 +166,8 @@ export const OpenTuiChartSurface = forwardRef<unknown, ChartSurfaceProps>(functi
       bitmapKey: target.bitmapKey,
     });
     renderer.requestRender();
-  }, [kittySupport, nativeBitmap, nativeSurfaceManager, paneId, renderer, surfaceId, target]);
+  }, [nativeBitmap, nativeSurfaceManager, nativeSurfacesEnabled, paneId, renderer, surfaceId, target]);
 
-  const showFallback = kittySupport !== true || !target || !nativeBitmap;
+  const showFallback = !nativeSurfacesEnabled || !target || !nativeBitmap;
   return createElement("box" as any, { ...props, ref: setRenderableRef }, showFallback ? children as ReactNode : null);
 });

--- a/src/state/app/context/index.tsx
+++ b/src/state/app/context/index.tsx
@@ -157,6 +157,39 @@ export function useAppSelector<T>(selector: (state: AppState) => T): T {
   return snapshot.selection;
 }
 
+export function useOptionalAppSelector<T>(selector: (state: AppState) => T, fallback: T): T {
+  const context = useContext(AppContext);
+  const selectorRef = useRef(selector);
+  selectorRef.current = selector;
+  const lastSnapshotRef = useRef<{ selection: T } | undefined>(undefined);
+
+  const readSelection = useCallback(() => {
+    if (!context) return fallback;
+    const state = isAppStoreContextValue(context) ? context.getState() : context.state;
+    return selectorRef.current(state);
+  }, [context, fallback]);
+
+  const snapshot = useSyncExternalStore(
+    useCallback((listener) => {
+      if (!context || !isAppStoreContextValue(context)) return () => {};
+      return context.subscribe(listener);
+    }, [context]),
+    () => {
+      const selection = readSelection();
+      const previous = lastSnapshotRef.current;
+      if (previous && Object.is(previous.selection, selection)) {
+        return previous;
+      }
+      const nextSnapshot = { selection };
+      lastSnapshotRef.current = nextSnapshot;
+      return nextSnapshot;
+    },
+    () => ({ selection: fallback }),
+  );
+
+  return snapshot.selection;
+}
+
 export function PaneInstanceProvider({ paneId, children }: { paneId: string; children: ReactNode }) {
   return <PaneContext.Provider value={paneId}>{children}</PaneContext.Provider>;
 }

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -206,6 +206,7 @@ export interface ChartSurfaceProps extends BoxProps {
   bitmap?: BitmapSurface | null;
   bitmaps?: readonly BitmapSurface[] | null;
   crosshair?: ChartCrosshairOverlay | null;
+  nativeBitmapsEnabled?: boolean;
 }
 export interface ImageSurfaceProps extends BoxProps {
   src?: string;


### PR DESCRIPTION
## Summary
- Make OpenTUI chart surfaces respect the configured chart renderer before registering native kitty surfaces.
- Keep braille/text fallback rendering active when the renderer is forced away from kitty.
- Use a bundle-safe static import for the IBKR native gateway service loader.

## Validation
- `bun test src/renderers/opentui/chart-surface.test.tsx src/plugins/ibkr/gateway/service/index.test.ts src/plugins/builtin/ticker-detail/chart-tab-switch.test.tsx src/components/chart/native/kitty/index.test.ts`
- tmux smoke with a temp config forcing `chartPreferences.renderer = "braille"` for ticker Graphs and Fear & Greed panes