### PR TITLE
Add chat mention autocomplete

### DIFF
--- a/src/components/ui/message-composer.tsx
+++ b/src/components/ui/message-composer.tsx
@@ -17,6 +17,7 @@ export interface MessageComposerProps {
   terminalBottomInset?: number;
   onFocusRequest?: () => void;
   onInput?: (value: string) => void;
+  onCursorChange?: () => void;
   onSubmit?: () => void;
   keyBindings?: Array<Record<string, unknown>>;
   wrapText?: boolean;
@@ -52,6 +53,7 @@ export function MessageComposer({
   terminalBottomInset = 0,
   onFocusRequest,
   onInput,
+  onCursorChange,
   onSubmit,
   keyBindings,
   wrapText = false,
@@ -91,6 +93,7 @@ export function MessageComposer({
         terminalBottomInset={terminalBottomInset}
         onFocusRequest={onFocusRequest}
         onInput={onInput}
+        onCursorChange={onCursorChange}
         onSubmit={onSubmit}
         keyBindings={keyBindings}
         wrapText={wrapText}
@@ -149,6 +152,7 @@ export function MessageComposer({
             focusedBackgroundColor={colors.bg}
             cursorColor={colors.textBright}
             onInput={handleInput}
+            onCursorChange={onCursorChange}
             keyBindings={keyBindings}
             onSubmit={onSubmit}
             wrapText={wrapText}

--- a/src/plugins/builtin/chat/chat.test.tsx
+++ b/src/plugins/builtin/chat/chat.test.tsx
@@ -45,6 +45,55 @@ function makeOwnMessage(content = "typo", createdAt = recentChatTimestamp()): Ch
   };
 }
 
+const makeNamedMessage = (index: number, username: string): ChatMessage => ({
+  id: `named-${index}`,
+  channelId: "everyone",
+  content: `message from ${username}`,
+  replyToId: null,
+  createdAt: `2026-03-30T00:01:${String(index).padStart(2, "0")}.000Z`,
+  user: { id: `u-${username}`, username, displayName: username },
+});
+
+async function renderFocusedComposerWithDraft(
+  controller: ReturnType<typeof createController>,
+  draft: string,
+  options: Parameters<typeof createHarness>[1] = {},
+) {
+  const harnessOptions = {
+    width: 72,
+    height: 14,
+    ...options,
+  };
+  await act(async () => {
+    testSetup = await testRender(createHarness(controller, harnessOptions), {
+      width: harnessOptions.width ?? 72,
+      height: harnessOptions.height ?? 14,
+    });
+  });
+
+  await flushFrame();
+
+  const frameBeforeClick = setup().captureCharFrame().split("\n");
+  const inputRow = frameBeforeClick.findIndex((line) => line.includes("Type a message..."));
+  const inputCol = frameBeforeClick[inputRow]?.indexOf("Type a message...") ?? -1;
+
+  expect(inputRow).toBeGreaterThanOrEqual(0);
+  expect(inputCol).toBeGreaterThanOrEqual(0);
+
+  await act(async () => {
+    await setup().mockMouse.click(inputCol + 1, inputRow);
+    await setup().renderOnce();
+    await setup().renderOnce();
+  });
+
+  await act(async () => {
+    await setup().mockInput.typeText(draft);
+    await setup().renderOnce();
+    await setup().renderOnce();
+  });
+  await flushFrame();
+}
+
 beforeEach(() => {
   installChatApiTestDefaults();
 });
@@ -175,6 +224,82 @@ describe("ChatContent", () => {
     const frameAfterType = setup().captureCharFrame();
     expect(frameAfterType).toContain("> alphabeta");
     expect(frameAfterType).not.toContain("> betaalpha");
+  });
+
+  test("autocompletes recent user mentions from the focused composer", async () => {
+    const controller = createController({
+      messages: [
+        makeNamedMessage(1, "alpha"),
+        makeNamedMessage(2, "bravo"),
+        makeNamedMessage(3, "charlie"),
+      ],
+    });
+
+    await renderFocusedComposerWithDraft(controller, "@");
+
+    let frame = setup().captureCharFrame();
+    expect(frame).toContain("@charlie");
+    expect(frame).toContain("@bravo");
+
+    await emitKeypress({ name: "down", sequence: "\u001b[B" });
+
+    await act(async () => {
+      setup().mockInput.pressEnter();
+      await setup().renderOnce();
+      await setup().renderOnce();
+    });
+    await flushFrame();
+
+    frame = setup().captureCharFrame();
+    expect(frame).toContain("> @bravo");
+    expect(frame).not.toContain("@charlie");
+  });
+
+  test("tab accepts the current mention suggestion without pane cycling", async () => {
+    const controller = createController({
+      messages: [
+        makeNamedMessage(1, "alpha"),
+        makeNamedMessage(2, "bravo"),
+        makeNamedMessage(3, "charlie"),
+      ],
+    });
+
+    await renderFocusedComposerWithDraft(controller, "@");
+
+    const event = await emitKeypress({ name: "tab", sequence: "\t" });
+    await flushFrame();
+
+    const frame = setup().captureCharFrame();
+    expect(frame).toContain("> @charlie");
+    expect(frame).not.toContain("@bravo");
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.propagationStopped).toBe(true);
+  });
+
+  test("leaves tab for the command bar when mention suggestions are open behind it", async () => {
+    const controller = createController({
+      messages: [
+        makeNamedMessage(1, "alpha"),
+        makeNamedMessage(2, "bravo"),
+        makeNamedMessage(3, "charlie"),
+      ],
+    });
+
+    await renderFocusedComposerWithDraft(controller, "@", {
+      configureState: (state) => {
+        state.commandBarOpen = true;
+      },
+    });
+
+    const event = await emitKeypress({ name: "tab", sequence: "\t" });
+    await flushFrame();
+
+    const frame = setup().captureCharFrame();
+    expect(frame).toContain("@charlie");
+    expect(frame).toContain("> @");
+    expect(frame).not.toContain("> @charlie");
+    expect(event.defaultPrevented).toBe(false);
+    expect(event.propagationStopped).toBe(false);
   });
 
   test("up arrow selects the newest message first when nothing is selected", async () => {

--- a/src/plugins/builtin/chat/content/composer-cursor.ts
+++ b/src/plugins/builtin/chat/content/composer-cursor.ts
@@ -1,0 +1,29 @@
+import type { TextareaRenderable } from "../../../../ui";
+
+const clampCursorOffset = (offset: number, draft: string) => Math.max(0, Math.min(offset, draft.length));
+
+export function getComposerCursorOffset(
+  textarea: TextareaRenderable | null | undefined,
+  draft: string,
+): number {
+  const offset = textarea?.visualCursor?.offset ?? textarea?.cursorOffset ?? draft.length;
+  return clampCursorOffset(offset, draft);
+}
+
+export function moveComposerCursorToOffset(
+  textarea: TextareaRenderable,
+  draft: string,
+  offset: number,
+): void {
+  const nextOffset = clampCursorOffset(offset, draft);
+  const editBuffer = textarea.editBuffer as typeof textarea.editBuffer & {
+    setCursorByOffset?: (offset: number) => void;
+  };
+  if (typeof editBuffer.setCursorByOffset === "function") return editBuffer.setCursorByOffset(nextOffset);
+  if (typeof textarea.setCursorOffset === "function") return textarea.setCursorOffset(nextOffset);
+  try {
+    textarea.cursorOffset = nextOffset;
+  } catch {
+    // Some host renderers expose cursorOffset as read-only.
+  }
+}

--- a/src/plugins/builtin/chat/content/composer-runtime.ts
+++ b/src/plugins/builtin/chat/content/composer-runtime.ts
@@ -7,29 +7,10 @@ import {
 } from "../layout";
 import { parseChatComposerCommand } from "../composer-commands";
 import type { ChatContentController } from "./types";
+import { getComposerCursorOffset, moveComposerCursorToOffset } from "./composer-cursor";
 
 interface MutableRef<T> {
   current: T;
-}
-
-function moveComposerCursorToEnd(textarea: TextareaRenderable, draft: string) {
-  const offset = draft.length;
-  const editBuffer = textarea.editBuffer as typeof textarea.editBuffer & {
-    setCursorByOffset?: (offset: number) => void;
-  };
-  if (typeof editBuffer.setCursorByOffset === "function") {
-    editBuffer.setCursorByOffset(offset);
-    return;
-  }
-  if (typeof textarea.setCursorOffset === "function") {
-    textarea.setCursorOffset(offset);
-    return;
-  }
-  try {
-    textarea.cursorOffset = offset;
-  } catch {
-    // Some host renderers expose cursorOffset as read-only.
-  }
 }
 
 export function useChatComposerRuntime({
@@ -46,6 +27,7 @@ export function useChatComposerRuntime({
   inputRef,
   inputValueRef,
   messages,
+  onComposerStateChange,
   onChannelChange,
   editingMessage,
   latestEditableMessageId,
@@ -71,6 +53,7 @@ export function useChatComposerRuntime({
   inputRef: MutableRef<TextareaRenderable | null>;
   inputValueRef: MutableRef<string>;
   messages: ChatMessage[];
+  onComposerStateChange?: (draft: string, cursorOffset: number) => void;
   onChannelChange?: (channelId: string) => void;
   editingMessage: ChatMessage | null;
   latestEditableMessageId: string | null;
@@ -112,7 +95,7 @@ export function useChatComposerRuntime({
     }
   }, [channelId, controller, useDefaultControllerChannel]);
 
-  const replaceLocalComposer = useCallback((draft: string) => {
+  const replaceLocalComposer = useCallback((draft: string, cursorOffset = draft.length) => {
     inputValueRef.current = draft;
     updateComposerRows(draft);
     const textarea = inputRef.current;
@@ -120,14 +103,20 @@ export function useChatComposerRuntime({
       applyingExternalDraftRef.current = true;
       try {
         textarea.setText(draft);
-        moveComposerCursorToEnd(textarea, draft);
+        moveComposerCursorToOffset(textarea, draft, cursorOffset);
       } finally {
         applyingExternalDraftRef.current = false;
       }
     } else if (textarea) {
-      moveComposerCursorToEnd(textarea, draft);
+      moveComposerCursorToOffset(textarea, draft, cursorOffset);
     }
-  }, [applyingExternalDraftRef, inputRef, inputValueRef, updateComposerRows]);
+    onComposerStateChange?.(draft, cursorOffset);
+  }, [applyingExternalDraftRef, inputRef, inputValueRef, onComposerStateChange, updateComposerRows]);
+
+  const replaceComposerDraft = useCallback((draft: string, cursorOffset = draft.length) => {
+    replaceLocalComposer(draft, cursorOffset);
+    persistDraft(draft);
+  }, [persistDraft, replaceLocalComposer]);
 
   const beginReplyTo = useCallback((index: number, options?: { deferFocus?: boolean }) => {
     if (!canSend || index < 0 || index >= messages.length) return;
@@ -295,14 +284,22 @@ export function useChatComposerRuntime({
 
   const commitLocalDraft = useCallback((draft: string) => {
     if (applyingExternalDraftRef.current) return;
+    const previousDraft = inputValueRef.current;
     inputValueRef.current = draft;
     updateComposerRows(draft);
     persistDraft(draft);
+    const rawCursorOffset = getComposerCursorOffset(inputRef.current, draft);
+    const cursorOffset = rawCursorOffset === 0 && draft.length > previousDraft.length && draft.startsWith(previousDraft)
+      ? draft.length
+      : rawCursorOffset;
+    onComposerStateChange?.(draft, cursorOffset);
   }, [
     applyingExternalDraftRef,
     channelId,
     controller,
+    inputRef,
     inputValueRef,
+    onComposerStateChange,
     persistDraft,
     updateComposerRows,
     useDefaultControllerChannel,
@@ -376,6 +373,7 @@ export function useChatComposerRuntime({
     focusComposer,
     inputPlaceholder,
     replyPreview,
+    replaceComposerDraft,
     returnToComposer,
     sendMessage,
   };

--- a/src/plugins/builtin/chat/content/composer.tsx
+++ b/src/plugins/builtin/chat/content/composer.tsx
@@ -5,6 +5,7 @@ import type { ChatMessage } from "../../../../api-client";
 import { InlineAuthActions } from "../../cloud/auth-actions";
 import { ChatActionChip } from "../message/action-chip";
 import { COMPOSER_ACTION_WIDTH } from "../layout";
+import type { ChatMentionSuggestion } from "./mentions";
 
 const DESKTOP_CHAT_INPUT_TOP_MARGIN_PX = 6;
 
@@ -33,7 +34,71 @@ interface ChatComposerAreaProps {
   replyPreview: string;
   replyTo: ChatMessage | null;
   sendMessage: () => void;
+  mentionSuggestions: ChatMentionSuggestion[];
+  mentionSelectedIndex: number;
+  onMentionCursorChange: () => void;
+  onMentionSelect: (index?: number) => boolean;
   user: { id: string; username: string; emailVerified: boolean } | null;
+}
+
+function ChatMentionSuggestions({
+  contentWidth,
+  nativePaneChrome,
+  onSelect,
+  selectedIndex,
+  suggestions,
+}: {
+  contentWidth: number;
+  nativePaneChrome: boolean | undefined;
+  onSelect: (index?: number) => boolean;
+  selectedIndex: number;
+  suggestions: ChatMentionSuggestion[];
+}) {
+  if (suggestions.length === 0) return null;
+  const width = Math.max(18, Math.min(contentWidth, 44));
+  const menuStyle = nativePaneChrome
+    ? {
+      marginBottom: 4,
+      border: `1px solid ${colors.border}`,
+      borderRadius: 6,
+      overflow: "hidden",
+    }
+    : undefined;
+
+  return (
+    <Box
+      width={width}
+      height={suggestions.length}
+      flexDirection="column"
+      backgroundColor={nativePaneChrome ? colors.panel : colors.bg}
+      style={menuStyle}
+    >
+      {suggestions.map((suggestion, index) => {
+        const selected = index === selectedIndex;
+        return (
+          <Box
+            key={suggestion.username}
+            height={1}
+            width={width}
+            flexDirection="row"
+            backgroundColor={selected ? colors.selected : "transparent"}
+            onMouseDown={() => { onSelect(index); }}
+            style={{
+              cursor: "pointer",
+              paddingInline: nativePaneChrome ? 8 : undefined,
+            }}
+          >
+            <Text
+              fg={selected ? colors.selectedText : colors.positive}
+              attributes={selected ? TextAttributes.BOLD : 0}
+            >
+              {`@${suggestion.username}`}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
 }
 
 export function ChatComposerArea({
@@ -57,6 +122,10 @@ export function ChatComposerArea({
   replyPreview,
   replyTo,
   sendMessage,
+  mentionSuggestions,
+  mentionSelectedIndex,
+  onMentionCursorChange,
+  onMentionSelect,
   user,
 }: ChatComposerAreaProps) {
   if (!canSend) {
@@ -122,6 +191,14 @@ export function ChatComposerArea({
         </Box>
       )}
 
+      <ChatMentionSuggestions
+        contentWidth={contentWidth}
+        nativePaneChrome={nativePaneChrome}
+        onSelect={onMentionSelect}
+        selectedIndex={mentionSelectedIndex}
+        suggestions={mentionSuggestions}
+      />
+
       <MessageComposer
         inputRef={inputRef}
         initialValue={inputValueRef.current}
@@ -132,6 +209,7 @@ export function ChatComposerArea({
         height={composerHeight}
         onFocusRequest={focusComposer}
         onInput={commitLocalDraft}
+        onCursorChange={onMentionCursorChange}
         keyBindings={[
           { name: "return", action: "submit" },
           { name: "linefeed", action: "submit" },
@@ -141,6 +219,7 @@ export function ChatComposerArea({
           { name: "linefeed", meta: true, action: "submit" },
         ]}
         onSubmit={() => {
+          if (onMentionSelect()) return;
           if (inputValueRef.current.trim()) {
             sendMessage();
           }
@@ -157,13 +236,17 @@ export function getChatComposerAreaHeight({
   editingMessage,
   nativePaneChrome,
   replyTo,
+  mentionSuggestionCount,
 }: {
   canSend: boolean;
   composerHeight: number;
   editingMessage: ChatMessage | null;
   nativePaneChrome: boolean | undefined;
   replyTo: ChatMessage | null;
+  mentionSuggestionCount?: number;
 }) {
   if (!canSend) return 2;
-  return getMessageComposerBlockHeight({ height: composerHeight, nativePaneChrome }) + (editingMessage || replyTo ? 1 : 0);
+  return getMessageComposerBlockHeight({ height: composerHeight, nativePaneChrome })
+    + (editingMessage || replyTo ? 1 : 0)
+    + Math.max(0, mentionSuggestionCount ?? 0);
 }

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useUiCapabilities } from "../../../../ui";
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { type ScrollBoxRenderable, type TextareaRenderable } from "../../../../ui";
-import { useAppDispatch } from "../../../../state/app/context";
+import { useAppDispatch, useAppSelector } from "../../../../state/app/context";
 import { useInlineTickers } from "../../../../state/hooks/inline-tickers";
 import { blendHex, colors } from "../../../../theme/colors";
 import { chatController } from "../controller";
@@ -36,6 +36,13 @@ import {
   CHAT_MESSAGE_EDIT_WINDOW_MS,
   findLatestEditableChatMessage,
 } from "../edit-window";
+import {
+  applyMentionSuggestion,
+  buildRecentMentionSuggestions,
+  detectChatMentionTrigger,
+  filterMentionSuggestions,
+} from "./mentions";
+import { getComposerCursorOffset } from "./composer-cursor";
 
 interface ChatContentProps {
   width: number;
@@ -57,6 +64,7 @@ export function ChatContent({
   controller = chatController,
 }: ChatContentProps) {
   const dispatch = useAppDispatch();
+  const commandBarOpen = useAppSelector((state) => state.commandBarOpen);
   const channelId = normalizeChannelId(rawChannelId);
   const channelIdRef = useRef(channelId);
   channelIdRef.current = channelId;
@@ -82,6 +90,18 @@ export function ChatContent({
   });
   const composerTextWidthRef = useRef(initialWidthMetrics.composerTextWidth);
   const inputValueRef = useRef(initialSnapshot.draft);
+  const [composerDraft, setComposerDraft] = useState(initialSnapshot.draft);
+  const [composerCursorOffset, setComposerCursorOffset] = useState(initialSnapshot.draft.length);
+  const [mentionSelectedIndex, setMentionSelectedIndex] = useState(0);
+  const [dismissedMentionKey, setDismissedMentionKey] = useState<string | null>(null);
+  const syncComposerState = useCallback((draft: string, cursorOffset = getComposerCursorOffset(inputRef.current, draft)) => {
+    setComposerDraft((current) => (current === draft ? current : draft));
+    setComposerCursorOffset((current) => (current === cursorOffset ? current : cursorOffset));
+  }, []);
+  const syncComposerCursor = useCallback(() => {
+    const draft = inputRef.current?.editBuffer.getText() ?? inputValueRef.current;
+    syncComposerState(draft, getComposerCursorOffset(inputRef.current, draft));
+  }, [syncComposerState]);
   const [composerRows, setComposerRows] = useState(() => estimateComposerHeight(initialSnapshot.draft, initialWidthMetrics.composerTextWidth));
   const updateComposerRows = useCallback((draft: string) => {
     const nextRows = estimateComposerHeight(draft, composerTextWidthRef.current);
@@ -107,6 +127,7 @@ export function ChatContent({
     initialSnapshot,
     inputRef,
     inputValueRef,
+    onComposerStateChange: syncComposerState,
     prependAnchorRef,
     setFollowMessages,
     setSelectedIdx,
@@ -155,18 +176,6 @@ export function ChatContent({
   const latestEditableMessageId = useMemo(() => {
     return findLatestEditableChatMessage(messages, user?.id, editWindowNowMs)?.id ?? null;
   }, [editWindowNowMs, messages, user?.id]);
-  const {
-    composerHeight,
-    messageAreaHeight,
-  } = resolveChatContentHeightMetrics({
-    canSend,
-    composerRows,
-    editingMessage,
-    height,
-    nativePaneChrome,
-    replyTo,
-  });
-
   useEffect(() => {
     updateComposerRows(inputValueRef.current);
   }, [updateComposerRows]);
@@ -176,6 +185,44 @@ export function ChatContent({
   const userByUsername = useMemo(() => buildChatUserByUsername(channels, messages), [channels, messages]);
   const activeChannel = useMemo(() => channels.find((channel) => channel.id === channelId), [channelId, channels]);
   const activeChannelTitle = useMemo(() => formatChatPaneTitle(activeChannel, channelId), [activeChannel, channelId]);
+  const recentMentionSuggestions = useMemo(() => buildRecentMentionSuggestions({
+    activeChannel,
+    currentUserId: user?.id,
+    messages,
+  }), [activeChannel, messages, user?.id]);
+  const mentionDisabled = activeChannel?.kind === "direct" || (!activeChannel && channelId.startsWith("dm:"));
+  const mentionTrigger = useMemo(() => (
+    mentionDisabled ? null : detectChatMentionTrigger(composerDraft, composerCursorOffset)
+  ), [
+    mentionDisabled,
+    composerCursorOffset,
+    composerDraft,
+  ]);
+  const mentionTriggerKey = mentionTrigger
+    ? `${channelId}:${mentionTrigger.start}:${mentionTrigger.end}:${mentionTrigger.query}`
+    : null;
+  const mentionSuggestions = useMemo(() => {
+    if (!mentionTrigger || mentionTriggerKey === dismissedMentionKey) return [];
+    return filterMentionSuggestions(recentMentionSuggestions, mentionTrigger.query);
+  }, [dismissedMentionKey, mentionTrigger, mentionTriggerKey, recentMentionSuggestions]);
+  const mentionSelectedIndexSafe = mentionSuggestions.length > 0
+    ? Math.min(mentionSelectedIndex, mentionSuggestions.length - 1)
+    : 0;
+  useEffect(() => {
+    setMentionSelectedIndex(0);
+  }, [mentionTriggerKey]);
+  const {
+    composerHeight,
+    messageAreaHeight,
+  } = resolveChatContentHeightMetrics({
+    canSend,
+    composerRows,
+    editingMessage,
+    height,
+    mentionSuggestionCount: mentionSuggestions.length,
+    nativePaneChrome,
+    replyTo,
+  });
   const {
     cancelProfilePopoverClose,
     closeProfilePopover,
@@ -257,6 +304,7 @@ export function ChatContent({
     focusComposer,
     inputPlaceholder,
     replyPreview,
+    replaceComposerDraft,
     returnToComposer,
     sendMessage,
   } = useChatComposerRuntime({
@@ -273,6 +321,7 @@ export function ChatContent({
     inputRef,
     inputValueRef,
     messages,
+    onComposerStateChange: syncComposerState,
     onChannelChange,
     editingMessage,
     latestEditableMessageId,
@@ -285,6 +334,44 @@ export function ChatContent({
     updateComposerRows,
     useDefaultControllerChannel,
   });
+
+  const moveMentionSelection = useCallback((direction: "up" | "down") => {
+    if (mentionSuggestions.length === 0) return false;
+    setMentionSelectedIndex((current) => {
+      const safeCurrent = Math.max(0, Math.min(current, mentionSuggestions.length - 1));
+      if (direction === "up") {
+        return safeCurrent <= 0 ? mentionSuggestions.length - 1 : safeCurrent - 1;
+      }
+      return safeCurrent >= mentionSuggestions.length - 1 ? 0 : safeCurrent + 1;
+    });
+    return true;
+  }, [mentionSuggestions.length]);
+
+  const dismissMentionSuggestions = useCallback(() => {
+    if (!mentionTriggerKey || mentionSuggestions.length === 0) return false;
+    setDismissedMentionKey(mentionTriggerKey);
+    return true;
+  }, [mentionSuggestions.length, mentionTriggerKey]);
+
+  const commitMentionSelection = useCallback((index = mentionSelectedIndexSafe) => {
+    if (!mentionTrigger || mentionSuggestions.length === 0) return false;
+    const suggestion = mentionSuggestions[index] ?? mentionSuggestions[0];
+    if (!suggestion) return false;
+    const replacement = applyMentionSuggestion(composerDraft, mentionTrigger, suggestion);
+    replaceComposerDraft(replacement.draft, replacement.cursorOffset);
+    setMentionSelectedIndex(0);
+    setDismissedMentionKey(mentionTriggerKey);
+    queueMicrotask(() => focusInput());
+    return true;
+  }, [
+    composerDraft,
+    focusInput,
+    mentionSelectedIndexSafe,
+    mentionSuggestions,
+    mentionTrigger,
+    mentionTriggerKey,
+    replaceComposerDraft,
+  ]);
 
   const {
     handleTranscriptScrollActivity,
@@ -322,6 +409,7 @@ export function ChatContent({
     blurInput,
     canSend,
     cancelEditMessage,
+    commandBarOpen,
     clearReplyTarget,
     cycleChannel,
     focusChannelSidebar,
@@ -333,6 +421,10 @@ export function ChatContent({
     inputValueRef,
     loadingOlderMessages,
     messages,
+    mentionMenuOpen: mentionSuggestions.length > 0,
+    moveMentionSelection,
+    dismissMentionSuggestions,
+    commitMentionSelection,
     moveMessageSelection,
     moveSidebarChannelSelection,
     nativePaneChrome,
@@ -461,6 +553,10 @@ export function ChatContent({
         replyPreview={replyPreview}
         replyTo={replyTo}
         sendMessage={sendMessage}
+        mentionSuggestions={mentionSuggestions}
+        mentionSelectedIndex={mentionSelectedIndexSafe}
+        onMentionCursorChange={syncComposerCursor}
+        onMentionSelect={commitMentionSelection}
         user={user}
       />
       </Box>

--- a/src/plugins/builtin/chat/content/layout-metrics.ts
+++ b/src/plugins/builtin/chat/content/layout-metrics.ts
@@ -44,6 +44,7 @@ export function resolveChatContentHeightMetrics({
   composerRows,
   editingMessage,
   height,
+  mentionSuggestionCount,
   nativePaneChrome,
   replyTo,
 }: {
@@ -51,6 +52,7 @@ export function resolveChatContentHeightMetrics({
   composerRows: number;
   editingMessage: ChatMessage | null;
   height: number;
+  mentionSuggestionCount?: number;
   nativePaneChrome: boolean | undefined;
   replyTo: ChatMessage | null;
 }) {
@@ -59,7 +61,14 @@ export function resolveChatContentHeightMetrics({
       ? Math.min(CHAT_COMPOSER_MAX_ROWS + 1, Math.max(2, composerRows + 1))
       : composerRows
     : 0;
-  const inputAreaHeight = getChatComposerAreaHeight({ canSend, composerHeight, editingMessage, nativePaneChrome, replyTo });
+  const inputAreaHeight = getChatComposerAreaHeight({
+    canSend,
+    composerHeight,
+    editingMessage,
+    mentionSuggestionCount,
+    nativePaneChrome,
+    replyTo,
+  });
   const topSeparatorHeight = nativePaneChrome ? 0 : 1;
   const footerSeparatorHeight = !nativePaneChrome && !canSend ? 1 : 0;
   const messageAreaHeight = Math.max(1, height - topSeparatorHeight - footerSeparatorHeight - inputAreaHeight);

--- a/src/plugins/builtin/chat/content/mentions.test.ts
+++ b/src/plugins/builtin/chat/content/mentions.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatChannel, ChatMessage } from "../../../../api-client";
+import {
+  applyMentionSuggestion,
+  buildRecentMentionSuggestions,
+  detectChatMentionTrigger,
+  filterMentionSuggestions,
+} from "./mentions";
+
+const message = (id: string, username: string): ChatMessage => ({
+  id,
+  channelId: "everyone",
+  content: id,
+  replyToId: null,
+  createdAt: `2026-06-30T00:00:0${id}.000Z`,
+  user: { id: `u-${username}`, username, displayName: username },
+});
+
+describe("chat mention suggestions", () => {
+  test("detects an active mention trigger at the caret", () => {
+    expect(detectChatMentionTrigger("watch @al", "watch @al".length)).toEqual({
+      start: 6,
+      end: 9,
+      query: "al",
+    });
+    expect(detectChatMentionTrigger("email a@b", "email a@b".length)).toBeNull();
+    expect(detectChatMentionTrigger("done @al now", "done @al now".length)).toBeNull();
+  });
+
+  test("orders visible users by recent messages, filters by prefix, and skips direct channels", () => {
+    const activeChannel: ChatChannel = {
+      id: "everyone",
+      name: "everyone",
+      kind: "public",
+      created_at: "2026-06-30T00:00:00.000Z",
+    };
+    const suggestions = buildRecentMentionSuggestions({
+      activeChannel,
+      currentUserId: "u-me",
+      messages: [
+        message("1", "alpha"),
+        message("2", "bravo"),
+        { ...message("3", "me"), user: { id: "u-me", username: "me", displayName: "me" } },
+        message("4", "alpha"),
+        message("5", "charlie"),
+      ],
+    });
+
+    expect(suggestions.map((suggestion) => suggestion.username)).toEqual(["charlie", "alpha", "bravo"]);
+    expect(filterMentionSuggestions(suggestions, "a").map((suggestion) => suggestion.username)).toEqual(["alpha"]);
+    expect(buildRecentMentionSuggestions({
+      activeChannel: {
+        id: "dm:alpha",
+        name: "alpha",
+        kind: "direct",
+        created_at: "2026-06-30T00:00:00.000Z",
+      },
+      currentUserId: "u-me",
+      messages: [message("1", "alpha")],
+    })).toEqual([]);
+  });
+
+  test("replaces only the active mention fragment", () => {
+    const trigger = detectChatMentionTrigger("check @al", "check @al".length);
+    expect(trigger).not.toBeNull();
+
+    expect(applyMentionSuggestion("check @al", trigger!, {
+      username: "alpha",
+    })).toEqual({
+      draft: "check @alpha ",
+      cursorOffset: "check @alpha ".length,
+    });
+  });
+});

--- a/src/plugins/builtin/chat/content/mentions.ts
+++ b/src/plugins/builtin/chat/content/mentions.ts
@@ -1,0 +1,88 @@
+import type { ChatChannel, ChatMessage } from "../../../../api-client";
+
+export interface ChatMentionSuggestion {
+  username: string;
+}
+
+interface ChatMentionTrigger {
+  start: number;
+  end: number;
+  query: string;
+}
+
+const MENTION_TRIGGER_RE = /(^|[\s([{<,.;:!?])@([A-Za-z0-9_]{0,30})$/;
+const MAX_MENTION_SUGGESTIONS = 5;
+
+function normalizeUsername(username: string | null | undefined): string | null {
+  const normalized = username?.trim().replace(/^@+/, "");
+  return normalized ? normalized : null;
+}
+
+export function detectChatMentionTrigger(
+  draft: string,
+  cursorOffset: number,
+): ChatMentionTrigger | null {
+  const cursor = Math.max(0, Math.min(cursorOffset, draft.length));
+  const beforeCursor = draft.slice(0, cursor);
+  const match = beforeCursor.match(MENTION_TRIGGER_RE);
+  if (!match) return null;
+  const query = match[2] ?? "";
+  const start = beforeCursor.length - query.length - 1;
+  return { start, end: cursor, query };
+}
+
+export function buildRecentMentionSuggestions({
+  activeChannel,
+  currentUserId,
+  messages,
+  limit = MAX_MENTION_SUGGESTIONS,
+}: {
+  activeChannel: ChatChannel | undefined;
+  currentUserId: string | null | undefined;
+  messages: ChatMessage[];
+  limit?: number;
+}): ChatMentionSuggestion[] {
+  if (activeChannel?.kind === "direct") return [];
+  const seen = new Set<string>();
+  const suggestions: ChatMentionSuggestion[] = [];
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const user = messages[index]?.user;
+    const username = normalizeUsername(user?.username);
+    if (!user || !username || user.id === currentUserId) continue;
+    const key = username.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    suggestions.push({ username });
+    if (suggestions.length >= limit) break;
+  }
+
+  return suggestions;
+}
+
+export function filterMentionSuggestions(
+  suggestions: ChatMentionSuggestion[],
+  query: string,
+  limit = MAX_MENTION_SUGGESTIONS,
+): ChatMentionSuggestion[] {
+  const normalizedQuery = normalizeUsername(query)?.toLowerCase() ?? "";
+  return suggestions
+    .filter((suggestion) => !normalizedQuery || suggestion.username.toLowerCase().startsWith(normalizedQuery))
+    .slice(0, limit);
+}
+
+export function applyMentionSuggestion(
+  draft: string,
+  trigger: ChatMentionTrigger,
+  suggestion: ChatMentionSuggestion,
+): { draft: string; cursorOffset: number } {
+  const before = draft.slice(0, trigger.start);
+  const after = draft.slice(trigger.end);
+  const mention = `@${suggestion.username}`;
+  const suffix = after.length === 0 || !/^\s/.test(after) ? " " : "";
+  const nextDraft = `${before}${mention}${suffix}${after}`;
+  return {
+    draft: nextDraft,
+    cursorOffset: before.length + mention.length + suffix.length,
+  };
+}

--- a/src/plugins/builtin/chat/content/shortcuts.ts
+++ b/src/plugins/builtin/chat/content/shortcuts.ts
@@ -11,6 +11,7 @@ export function useChatContentShortcuts({
   blurInput,
   canSend,
   cancelEditMessage,
+  commandBarOpen,
   clearReplyTarget,
   cycleChannel,
   focusChannelSidebar,
@@ -22,6 +23,10 @@ export function useChatContentShortcuts({
   inputValueRef,
   loadingOlderMessages,
   messages,
+  mentionMenuOpen,
+  moveMentionSelection,
+  dismissMentionSuggestions,
+  commitMentionSelection,
   moveMessageSelection,
   moveSidebarChannelSelection,
   nativePaneChrome,
@@ -43,6 +48,7 @@ export function useChatContentShortcuts({
   blurInput: () => void;
   canSend: boolean;
   cancelEditMessage: () => void;
+  commandBarOpen: boolean;
   clearReplyTarget: () => void;
   cycleChannel: (direction: 1 | -1) => boolean;
   focusChannelSidebar: () => boolean;
@@ -54,6 +60,10 @@ export function useChatContentShortcuts({
   inputValueRef: MutableRefObject<string>;
   loadingOlderMessages: boolean;
   messages: ChatMessage[];
+  mentionMenuOpen: boolean;
+  moveMentionSelection: (direction: "up" | "down") => boolean;
+  dismissMentionSuggestions: () => boolean;
+  commitMentionSelection: () => boolean;
   moveMessageSelection: (direction: "up" | "down") => boolean;
   moveSidebarChannelSelection: (direction: "up" | "down") => boolean;
   nativePaneChrome?: boolean;
@@ -71,7 +81,25 @@ export function useChatContentShortcuts({
   sidebarFocusedRef: MutableRefObject<boolean>;
 }) {
   useShortcut((event) => {
-    if (!focused) return;
+    if (!focused || commandBarOpen || !inputFocused || !mentionMenuOpen) return;
+    if (
+      event.name !== "tab"
+      || event.ctrl
+      || event.meta
+      || event.super
+      || event.alt
+      || event.option
+    ) {
+      return;
+    }
+
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    commitMentionSelection();
+  }, { allowEditable: true, phase: "before" });
+
+  useShortcut((event) => {
+    if (!focused || commandBarOpen) return;
     const isEnterKey = event.name === "return" || event.name === "enter";
 
     if (sidebarFocusedRef.current && showChannelSidebar) {
@@ -117,6 +145,24 @@ export function useChatContentShortcuts({
     }
 
     if (inputFocused) {
+      if (mentionMenuOpen) {
+        if (event.name === "escape") {
+          event.preventDefault?.();
+          event.stopPropagation?.();
+          dismissMentionSuggestions();
+          return;
+        }
+
+        if (isPlainKey(event, "up", "down")) {
+          event.preventDefault?.();
+          event.stopPropagation?.();
+          if (event.name === "up" || event.name === "down") {
+            moveMentionSelection(event.name);
+          }
+          return;
+        }
+      }
+
       if (event.name === "escape") {
         event.preventDefault?.();
         event.stopPropagation?.();

--- a/src/plugins/builtin/chat/content/snapshot.ts
+++ b/src/plugins/builtin/chat/content/snapshot.ts
@@ -17,6 +17,7 @@ interface ChatSnapshotStateArgs {
   initialSnapshot: ChatSnapshot;
   inputRef: MutableRef<TextareaRenderable | null>;
   inputValueRef: MutableRef<string>;
+  onComposerStateChange?: (draft: string, cursorOffset: number) => void;
   prependAnchorRef: MutableRef<ChatPrependAnchor | null>;
   setFollowMessages: Dispatch<SetStateAction<boolean>>;
   setSelectedIdx: Dispatch<SetStateAction<number>>;
@@ -28,18 +29,21 @@ function syncDraftFromSnapshot({
   applyingExternalDraftRef,
   inputRef,
   inputValueRef,
+  onComposerStateChange,
   snapshot,
   updateComposerRows,
 }: {
   applyingExternalDraftRef: MutableRef<boolean>;
   inputRef: MutableRef<TextareaRenderable | null>;
   inputValueRef: MutableRef<string>;
+  onComposerStateChange?: (draft: string, cursorOffset: number) => void;
   snapshot: ChatSnapshot;
   updateComposerRows: (draft: string) => void;
 }) {
   if (inputValueRef.current !== snapshot.draft) {
     inputValueRef.current = snapshot.draft;
     updateComposerRows(snapshot.draft);
+    onComposerStateChange?.(snapshot.draft, snapshot.draft.length);
   }
   const textarea = inputRef.current;
   if (textarea && textarea.editBuffer.getText() !== snapshot.draft) {
@@ -62,6 +66,7 @@ export function useChatSnapshotState({
   initialSnapshot,
   inputRef,
   inputValueRef,
+  onComposerStateChange,
   prependAnchorRef,
   setFollowMessages,
   setSelectedIdx,
@@ -110,6 +115,7 @@ export function useChatSnapshotState({
         applyingExternalDraftRef,
         inputRef,
         inputValueRef,
+        onComposerStateChange,
         snapshot,
         updateComposerRows,
       });
@@ -130,6 +136,7 @@ export function useChatSnapshotState({
     controller,
     inputRef,
     inputValueRef,
+    onComposerStateChange,
     prependAnchorRef,
     setFollowMessages,
     setSelectedIdx,

--- a/src/plugins/builtin/chat/test-harness.tsx
+++ b/src/plugins/builtin/chat/test-harness.tsx
@@ -178,23 +178,33 @@ export function createChatTestControls(getSetup: () => ChatTestSetup) {
       sequence?: string;
       ctrl?: boolean;
       meta?: boolean;
+      super?: boolean;
+      alt?: boolean;
       shift?: boolean;
       option?: boolean;
     }) {
+      const keyEvent = {
+        ctrl: false,
+        meta: false,
+        option: false,
+        shift: false,
+        eventType: "press",
+        repeated: false,
+        defaultPrevented: false,
+        propagationStopped: false,
+        preventDefault() {
+          keyEvent.defaultPrevented = true;
+        },
+        stopPropagation() {
+          keyEvent.propagationStopped = true;
+        },
+        ...event,
+      };
       await act(async () => {
-        getSetup().renderer.keyInput.emit("keypress", {
-          ctrl: false,
-          meta: false,
-          option: false,
-          shift: false,
-          eventType: "press",
-          repeated: false,
-          stopPropagation: () => {},
-          preventDefault: () => {},
-          ...event,
-        } as any);
+        getSetup().renderer.keyInput.emit("keypress", keyEvent as any);
         await getSetup().renderOnce();
       });
+      return keyEvent;
     },
   };
 }

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -184,6 +184,7 @@ export function WebMessageComposer({
   height = 2,
   onFocusRequest,
   onInput,
+  onCursorChange,
   onSubmit,
   keyBindings,
   wrapText = false,
@@ -234,6 +235,7 @@ export function WebMessageComposer({
         onMouseDown={requestFocus}
         onFocus={requestFocus}
         onInput={handleInput}
+        onCursorChange={onCursorChange}
         keyBindings={keyBindings}
         onSubmit={onSubmit}
         wrapText={wrapText}


### PR DESCRIPTION
## Summary

- Add shared chat mention detection, recent-user suggestion filtering, and mention replacement logic.
- Wire the mention menu into the shared chat composer for both terminal and desktop renderers.
- Keep mention suggestions out of direct-message channels and keep only the mention Tab accept path at high keyboard priority so the command bar keeps ownership.

## Validation

- `bun test src/plugins/builtin/chat/content/mentions.test.ts src/plugins/builtin/chat/chat.test.tsx src/plugins/builtin/chat/sidebar.test.tsx src/app/global-shortcuts.test.tsx src/components/ui/message-composer.test.tsx src/plugins/builtin/chat/content/composer-runtime.test.tsx`
- `bun run desktop:view:build`
- `git diff --check`